### PR TITLE
fix(components): align progress helpers with the new watch-progress model

### DIFF
--- a/iosApp/iosApp/Components/EpisodeThumbCard.swift
+++ b/iosApp/iosApp/Components/EpisodeThumbCard.swift
@@ -194,9 +194,12 @@ struct EpisodeThumbCard: View {
     }
 
     private var progressValue: Double? {
+        // Watched items store position 0 server-side (the watched latch and
+        // the resume point are independent), so a nonzero position is always
+        // a live resume point — including a rewatch of a played episode.
         guard let pos = item.positionSeconds,
               let dur = item.durationSeconds,
-              dur > 0 else { return nil }
+              dur > 0, pos > 0 else { return nil }
         return pos / dur
     }
 

--- a/iosApp/iosApp/Components/MediaRow.swift
+++ b/iosApp/iosApp/Components/MediaRow.swift
@@ -143,10 +143,13 @@ struct MediaRow: View {
     }
 
     private func progressValue(for item: SectionItem) -> Double? {
+        // Watched items store position 0 server-side (the watched latch and
+        // the resume point are independent), so a nonzero position is always
+        // a live resume point — including a rewatch of a played item.
         guard showProgress,
               let pos = item.positionSeconds,
               let dur = item.durationSeconds,
-              dur > 0 else { return nil }
+              dur > 0, pos > 0 else { return nil }
         return pos / dur
     }
 


### PR DESCRIPTION
## Context

Server PR [silo-server#117](https://github.com/Silo-Server/silo-server/pull/117) changes the watch-progress model: `played`/`completed` becomes a one-way watched latch and **watched items now report `position_seconds: 0`** instead of position pinned to the duration. A rewatch of a watched item reports `played: true` **with** a live nonzero position, and such items now appear in the Continue Watching source, which keys on `position > 0`.

## Audit result: client already compatible

A full sweep of progress consumers found this app position-driven throughout, so the model change is transparent:

- Resume helpers (`resumePositionSeconds` in Movie/Season/Series/TV detail views) are gated on `pos > 30` / `pos < dur − 5`, never on `played` — watched items (position 0) get "Play", rewatches get "Resume".
- `PlaybackSessionBridge.resolvedStartPosition` consumes the stored position directly; watched items start from the beginning, rewatches resume.
- Watched badges (`MediaCard`, `EpisodeThumbCard`, `TVMediaCard`, `PhoneEpisodeRail`) key on the `played` flag, never derive it from position.
- Next-up selection prefers `isInProgress` then first `!played` — a rewatch in flight correctly becomes the season's next-up.
- No local cache derives `played` from position (`playedOverride` is server-synced optimistic state only).
- Top Shelf computes progress from position/duration on continue-watching items only.

## Change

The one wrinkle: `EpisodeThumbCard.progressValue` and `MediaRow.progressValue(for:)` returned `0.0` (not `nil`) for watched items under the new model, relying on render-site `> 0` guards to avoid drawing an empty progress track. This PR adds the `pos > 0` guard inside the helpers themselves (matching `PhoneEpisodeRail`), so "no live resume point" is `nil` everywhere regardless of future render sites, and documents the new model invariant at both spots.

New behavior users will see (no client code drives this — it falls out of the server change): rewatching a watched item puts it back in Continue Watching with its progress bar **and** the watched checkmark, matching the web app, Plex, and current Jellyfin.

## Testing

`swiftc -parse` clean on both files. A full `xcodebuild` of `origin/main` is currently blocked on this machine by an upstream binary checksum mismatch (`Libuavs3d` via the mpvkit dependency) — the local vendoring work addresses this but isn't pushed yet; the change here is two guard clauses on existing optionals, so type-level risk is nil. Recommend a normal build once the vendored package lands.

---
AI-use disclosure: implemented with Claude (Claude Code), reviewed by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resume progress calculation for watched episodes and media. Resume points now display only when an actual playback position exists, preventing incorrect progress indicators when items are marked as watched without a valid resume point.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->