### PR TITLE
Add upcoming-media Calendar tab for iOS and tvOS

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -552,6 +552,9 @@ struct MainTabView: View {
         case .recommendations:
             RecommendationsView()
 
+        case .calendar:
+            CalendarView()
+
         case .settings:
             SettingsView()
 

--- a/iosApp/iosApp/Navigation/TabRouter.swift
+++ b/iosApp/iosApp/Navigation/TabRouter.swift
@@ -11,6 +11,7 @@ enum AppTab: String, CaseIterable, Identifiable {
     case search = "Search"
     case libraries = "Libraries"
     case recommendations = "For You"
+    case calendar = "Calendar"
     case settings = "Settings"
     case switchProfile = "Profile"
     case switchServer = "Server"
@@ -28,7 +29,7 @@ enum AppTab: String, CaseIterable, Identifiable {
         #if os(tvOS)
         return [.home, .libraries, .search, .recommendations, .settings, .switchProfile, .switchServer]
         #else
-        return [.home, .libraries, .recommendations, .settings]
+        return [.home, .libraries, .recommendations, .calendar, .settings]
         #endif
     }
 
@@ -39,6 +40,7 @@ enum AppTab: String, CaseIterable, Identifiable {
         case .libraries: return "rectangle.stack"
         case .search: return "magnifyingglass"
         case .recommendations: return "sparkles"
+        case .calendar: return "calendar"
         case .settings: return "gearshape"
         case .switchProfile: return "person.crop.circle"
         case .switchServer: return "server.rack"
@@ -52,6 +54,7 @@ enum AppTab: String, CaseIterable, Identifiable {
         case .libraries: return "rectangle.stack.fill"
         case .search: return "magnifyingglass"
         case .recommendations: return "sparkles"
+        case .calendar: return "calendar"
         case .settings: return "gearshape.fill"
         case .switchProfile: return "person.crop.circle.fill"
         case .switchServer: return "server.rack"

--- a/iosApp/iosApp/Networking/ContinuumAPI.swift
+++ b/iosApp/iosApp/Networking/ContinuumAPI.swift
@@ -456,6 +456,26 @@ actor ContinuumAPI {
         return SectionsResponse(sections: resolved)
     }
 
+    // --- Calendar ---
+
+    /// Upcoming releases/airings grouped by viewer-local day. `start` /
+    /// `end` are inclusive "YYYY-MM-DD" bounds (the server caps the
+    /// window at 31 days); `timezone` is the viewer's IANA identifier
+    /// used for day grouping.
+    func calendarEvents(
+        start: String,
+        end: String,
+        filter: String,
+        timezone: String
+    ) async throws -> CalendarResponse {
+        try await http.get("/api/v1/calendar", query: [
+            "start": start,
+            "end": end,
+            "filter": filter,
+            "timezone": timezone,
+        ])
+    }
+
     // --- Catalog ---
 
     func catalog(query: [String: String]) async throws -> CatalogResponse {

--- a/iosApp/iosApp/Networking/ResponseCache.swift
+++ b/iosApp/iosApp/Networking/ResponseCache.swift
@@ -81,6 +81,9 @@ enum CacheKey {
     }
     static func collectionItems(_ collectionId: String) -> String { "collection:\(collectionId):items" }
     static func similar(_ contentId: String) -> String { "item:\(contentId):similar" }
+    static func calendarWeek(_ weekStart: String, filter: String) -> String {
+        "calendar:\(weekStart):\(filter)"
+    }
 
     /// Per-profile data that must be dropped on profile switch.
     static let perProfilePrefixes: [String] = [
@@ -90,5 +93,6 @@ enum CacheKey {
         "item:",
         "collection:",
         "collections:",
+        "calendar:",
     ]
 }

--- a/iosApp/iosApp/Screens/Calendar/CalendarDayShelf.swift
+++ b/iosApp/iosApp/Screens/Calendar/CalendarDayShelf.swift
@@ -1,0 +1,153 @@
+import SwiftUI
+
+/// One day's row in the calendar agenda: a "Today" / "Monday, June 9"
+/// heading over a horizontal shelf of event cards, or a compact
+/// "Nothing scheduled" stub for event-less days so the week keeps its
+/// shape and day-strip taps always have a scroll target.
+struct CalendarDayShelf: View {
+    let heading: String
+    let events: [CalendarEvent]
+    let onEventTap: (CalendarEvent) -> Void
+    /// tvOS: route default focus to the first card on d-pad entry.
+    var prefersDefaultFocusOnFirstItem: Bool = false
+    /// tvOS: programmatic focus kick — when this changes to a new
+    /// non-zero token, focus jumps to the shelf's first card. Used by
+    /// the week strip's day selection to hand focus down to the row it
+    /// just scrolled to.
+    var focusRequest: Int = 0
+
+    @FocusState private var focusedItemId: String?
+    #if os(tvOS)
+    /// Each kick token claims focus exactly once, so `onAppear` re-fires
+    /// (this shelf lives in a `LazyVStack`) can't yank focus back to a
+    /// previously-selected row while the user is browsing elsewhere.
+    @State private var lastAppliedFocusRequest = 0
+    #endif
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: rowVerticalSpacing) {
+            Text(heading)
+                .font(.continuumHeadline)
+                .foregroundColor(events.isEmpty ? .continuumSecondaryText : .continuumOnSurface)
+                .padding(.horizontal, ContinuumTheme.safePadding)
+
+            if events.isEmpty {
+                emptyRow
+            } else {
+                shelfContent
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        #if os(tvOS)
+        .focusSection()
+        // `onAppear` covers the shelf being created lazily by the
+        // scroll-to-day jump; `onChange` covers shelves already realized.
+        .onAppear { applyFocusRequest(focusRequest) }
+        .onChange(of: focusRequest) { _, request in applyFocusRequest(request) }
+        #endif
+    }
+
+    #if os(tvOS)
+    private func applyFocusRequest(_ request: Int) {
+        guard request > 0, request != lastAppliedFocusRequest else { return }
+        lastAppliedFocusRequest = request
+        guard let firstId = events.first?.contentId else { return }
+        // Defer one runloop tick so a freshly-created shelf's cards are
+        // attached to the focus system before we claim focus.
+        DispatchQueue.main.async {
+            focusedItemId = firstId
+        }
+    }
+    #endif
+
+    private var shelfContent: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            LazyHStack(spacing: cardSpacing) {
+                ForEach(events) { event in
+                    CalendarEventCard(
+                        event: event,
+                        action: { onEventTap(event) },
+                        focusedItemId: shelfFocusBinding
+                    )
+                }
+            }
+            .padding(.horizontal, ContinuumTheme.safePadding)
+            .padding(.vertical, verticalCardPadding)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        #if os(tvOS)
+        .scrollClipDisabled()
+        .applyDefaultFirstEventFocus(
+            enabled: prefersDefaultFocusOnFirstItem,
+            binding: $focusedItemId,
+            firstItemId: events.first?.contentId
+        )
+        #endif
+    }
+
+    private var emptyRow: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "moon.stars")
+                .font(.continuumCaption)
+                .foregroundColor(.continuumSecondaryText.opacity(0.5))
+            Text("Nothing scheduled")
+                .font(.continuumCaption)
+                .foregroundColor(.continuumSecondaryText)
+        }
+        .padding(.horizontal, ContinuumTheme.safePadding)
+    }
+
+    private var shelfFocusBinding: FocusState<String?>.Binding? {
+        #if os(tvOS)
+        return $focusedItemId
+        #else
+        return nil
+        #endif
+    }
+
+    // MARK: - Metrics
+
+    private var rowVerticalSpacing: CGFloat {
+        #if os(tvOS)
+        return 20
+        #else
+        return ContinuumTheme.smallPadding
+        #endif
+    }
+
+    private var cardSpacing: CGFloat {
+        #if os(tvOS)
+        return 40
+        #else
+        return ContinuumTheme.spacing
+        #endif
+    }
+
+    /// Vertical breathing room so the tvOS focus lift doesn't clip.
+    private var verticalCardPadding: CGFloat {
+        #if os(tvOS)
+        return 24
+        #else
+        return 0
+        #endif
+    }
+}
+
+#if os(tvOS)
+private extension View {
+    /// Routes both initial and d-pad-entry focus to the shelf's first
+    /// card — same `.userInitiated` defaultFocus pattern as `MediaRow`.
+    @ViewBuilder
+    func applyDefaultFirstEventFocus(
+        enabled: Bool,
+        binding: FocusState<String?>.Binding,
+        firstItemId: String?
+    ) -> some View {
+        if enabled, let firstItemId {
+            self.defaultFocus(binding, firstItemId, priority: .userInitiated)
+        } else {
+            self
+        }
+    }
+}
+#endif

--- a/iosApp/iosApp/Screens/Calendar/CalendarEventCard.swift
+++ b/iosApp/iosApp/Screens/Calendar/CalendarEventCard.swift
@@ -1,0 +1,291 @@
+import SwiftUI
+
+/// Poster card for a single calendar event: badge pills, watched check,
+/// air-time caption, and an episode subtitle line. Purpose-built rather
+/// than wrapping `MediaCard` so badge overlays live inside the tvOS
+/// focus-lifted button and scale with the poster.
+struct CalendarEventCard: View {
+    let event: CalendarEvent
+    let action: () -> Void
+    /// tvOS-only: parent shelf's focus tracking, so the shelf can route
+    /// default focus to a specific card.
+    var focusedItemId: FocusState<String?>.Binding? = nil
+
+    private var cardWidth: CGFloat { ContinuumTheme.posterCardWidth }
+    private var cardHeight: CGFloat { ContinuumTheme.posterCardHeight }
+
+    var body: some View {
+        #if os(tvOS)
+        FocusableCalendarCard(
+            event: event,
+            cardWidth: cardWidth,
+            action: action,
+            focusedItemId: focusedItemId
+        ) {
+            posterImage
+        }
+        #else
+        Button(action: action) {
+            VStack(alignment: .leading, spacing: 4) {
+                posterImage
+                captionText
+            }
+        }
+        .buttonStyle(.plain)
+        .frame(width: cardWidth)
+        #endif
+    }
+
+    // MARK: - Poster
+
+    private var posterImage: some View {
+        ZStack {
+            AsyncImageView(
+                url: event.posterUrl ?? "",
+                thumbhash: event.posterThumbhash,
+                targetSize: CGSize(width: cardWidth, height: cardHeight),
+                contentMode: .fill
+            )
+            .frame(width: cardWidth, height: cardHeight)
+            .clipped()
+
+            // Badge pills (top-leading) and watched check (top-trailing)
+            // share the top edge; the server never sends more than two
+            // badges for one event.
+            VStack(alignment: .leading, spacing: badgeSpacing) {
+                ForEach(event.displayBadges, id: \.rawValue) { badge in
+                    CalendarBadgePill(badge: badge)
+                }
+            }
+            .padding(overlayPadding)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+
+            if event.isWatched {
+                ZStack {
+                    Circle()
+                        .fill(Color.continuumOnSurface)
+                        .frame(width: checkBadgeSize, height: checkBadgeSize)
+                        .shadow(color: .black.opacity(0.3), radius: 4)
+                    Image(systemName: "checkmark")
+                        .font(.system(size: checkIconSize, weight: .bold))
+                        .foregroundColor(.continuumBackground)
+                }
+                .padding(overlayPadding)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+            }
+
+            if let time = event.displayAirTime {
+                Text(time)
+                    .font(.system(size: timeFontSize, weight: .semibold))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, timePillHorizontalPadding)
+                    .padding(.vertical, timePillVerticalPadding)
+                    .background(Capsule().fill(Color.black.opacity(0.62)))
+                    .padding(overlayPadding)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+            }
+        }
+        .frame(width: cardWidth, height: cardHeight)
+        .clipShape(RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius))
+    }
+
+    // MARK: - Caption (shared layout, used directly on iOS)
+
+    @ViewBuilder
+    fileprivate var captionText: some View {
+        CalendarCardCaption(event: event, cardWidth: cardWidth)
+    }
+
+    // MARK: - Metrics
+
+    private var badgeSpacing: CGFloat {
+        #if os(tvOS)
+        return 8
+        #else
+        return 4
+        #endif
+    }
+
+    private var overlayPadding: CGFloat {
+        #if os(tvOS)
+        return 12
+        #else
+        return 6
+        #endif
+    }
+
+    private var checkBadgeSize: CGFloat {
+        #if os(tvOS)
+        return 40
+        #else
+        return 20
+        #endif
+    }
+
+    private var checkIconSize: CGFloat {
+        #if os(tvOS)
+        return 20
+        #else
+        return 10
+        #endif
+    }
+
+    private var timeFontSize: CGFloat {
+        #if os(tvOS)
+        return 20
+        #else
+        return 10
+        #endif
+    }
+
+    private var timePillHorizontalPadding: CGFloat {
+        #if os(tvOS)
+        return 12
+        #else
+        return 6
+        #endif
+    }
+
+    private var timePillVerticalPadding: CGFloat {
+        #if os(tvOS)
+        return 5
+        #else
+        return 2
+        #endif
+    }
+}
+
+// MARK: - Badge pill
+
+/// Monochrome editorial pill — white fill, black text — consistent with
+/// the app's Plezy mono palette (no accent colors).
+private struct CalendarBadgePill: View {
+    let badge: CalendarBadge
+
+    var body: some View {
+        Text(badge.label)
+            .font(.system(size: fontSize, weight: .bold))
+            .tracking(0.8)
+            .lineLimit(1)
+            .foregroundColor(.continuumBackground)
+            .padding(.horizontal, horizontalPadding)
+            .padding(.vertical, verticalPadding)
+            .background(Capsule().fill(Color.continuumOnSurface.opacity(0.92)))
+    }
+
+    private var fontSize: CGFloat {
+        #if os(tvOS)
+        return 18
+        #else
+        return 8
+        #endif
+    }
+
+    private var horizontalPadding: CGFloat {
+        #if os(tvOS)
+        return 12
+        #else
+        return 6
+        #endif
+    }
+
+    private var verticalPadding: CGFloat {
+        #if os(tvOS)
+        return 5
+        #else
+        return 2.5
+        #endif
+    }
+}
+
+// MARK: - Caption
+
+/// Title + context line under the poster. Reserves two title lines so
+/// cards in a shelf stay top-aligned regardless of wrapping.
+private struct CalendarCardCaption: View {
+    let event: CalendarEvent
+    let cardWidth: CGFloat
+    var isFocused: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(event.title)
+                .font(.continuumSubheadline)
+                .foregroundColor(isFocused ? .continuumOnSurface : .continuumOnSurface.opacity(0.85))
+                .lineLimit(2, reservesSpace: true)
+
+            if let subtitle {
+                Text(subtitle)
+                    .font(.continuumCaption)
+                    .foregroundColor(.continuumSecondaryText)
+                    .lineLimit(1)
+            }
+        }
+        .frame(width: cardWidth, alignment: .leading)
+    }
+
+    /// "S5 · E14 · Ozymandias" for episodes, "Season 2" for premieres,
+    /// "Movie" for film releases — mirrors the web calendar card.
+    private var subtitle: String? {
+        var parts: [String] = []
+        if let episodeSubtitle = event.episodeSubtitle {
+            parts.append(episodeSubtitle)
+        }
+        if event.type == "episode", let episodeTitle = event.episodeTitle, !episodeTitle.isEmpty {
+            parts.append(episodeTitle)
+        }
+        if event.type == "movie" {
+            parts.append("Movie")
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+}
+
+// MARK: - tvOS focusable wrapper
+
+#if os(tvOS)
+/// Mirrors `MediaCard`'s tvOS structure: the poster lives inside a
+/// `.card`-styled button (native focus lift + parallax) and the caption
+/// sits outside, brightening when the card is focused.
+private struct FocusableCalendarCard<Content: View>: View {
+    let event: CalendarEvent
+    let cardWidth: CGFloat
+    let action: () -> Void
+    let focusedItemId: FocusState<String?>.Binding?
+    @ViewBuilder var content: () -> Content
+
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Button(action: action) {
+                content()
+            }
+            .buttonStyle(.card)
+            .focused($isFocused)
+            .applyShelfFocus(focusedItemId, itemId: event.contentId)
+
+            CalendarCardCaption(event: event, cardWidth: cardWidth, isFocused: isFocused)
+                .animation(.easeOut(duration: 0.15), value: isFocused)
+        }
+        .frame(width: cardWidth)
+    }
+}
+
+private extension View {
+    /// Conditionally binds the card to the parent shelf's `@FocusState`
+    /// so the shelf's `defaultFocus(... priority: .userInitiated)` can
+    /// land focus here. No-op when the shelf doesn't manage focus.
+    @ViewBuilder
+    func applyShelfFocus(
+        _ binding: FocusState<String?>.Binding?,
+        itemId: String
+    ) -> some View {
+        if let binding {
+            self.focused(binding, equals: itemId)
+        } else {
+            self
+        }
+    }
+}
+#endif

--- a/iosApp/iosApp/Screens/Calendar/CalendarFilterBar.swift
+++ b/iosApp/iosApp/Screens/Calendar/CalendarFilterBar.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+
+/// Segmented Following / Trending / All preset control. Capsule segments
+/// matching the app's monochrome pill language; on tvOS each segment
+/// draws its own focus chrome (the app suppresses the system slab).
+struct CalendarFilterBar: View {
+    let selected: CalendarFilter
+    let onSelect: (CalendarFilter) -> Void
+    /// tvOS: programmatic focus kick from the root focus hand-down, so
+    /// the remote is never dead when the Calendar tab swaps in.
+    var focusRequest: Int = 0
+    /// tvOS: edge-up escape back to the top menu bar.
+    var onMoveUp: (() -> Void)? = nil
+
+    @FocusState private var focusedFilter: CalendarFilter?
+    #if os(tvOS)
+    /// Each hand-down token claims focus exactly once; guards against
+    /// `onAppear` re-fires yanking focus on scroll recycling.
+    @State private var lastAppliedFocusRequest = 0
+    #endif
+
+    var body: some View {
+        HStack(spacing: segmentSpacing) {
+            ForEach(CalendarFilter.allCases) { filter in
+                segmentButton(filter)
+            }
+        }
+        .padding(containerPadding)
+        .background(Capsule().fill(Color.white.opacity(0.06)))
+        .overlay(Capsule().stroke(Color.white.opacity(0.10), lineWidth: 1))
+        #if os(tvOS)
+        .focusSection()
+        .onMoveCommand { direction in
+            if direction == .up {
+                onMoveUp?()
+            }
+        }
+        .onAppear { applyFocusRequest(focusRequest) }
+        .onChange(of: focusRequest) { _, request in applyFocusRequest(request) }
+        #endif
+    }
+
+    #if os(tvOS)
+    private func applyFocusRequest(_ request: Int) {
+        guard request > 0, request != lastAppliedFocusRequest else { return }
+        lastAppliedFocusRequest = request
+        focusedFilter = selected
+    }
+    #endif
+
+    private func segmentButton(_ filter: CalendarFilter) -> some View {
+        let isSelected = selected == filter
+        let isFocused = focusedFilter == filter
+
+        return Button {
+            onSelect(filter)
+        } label: {
+            Text(filter.displayLabel)
+                .font(segmentFont)
+                .lineLimit(1)
+                .foregroundColor(foreground(isSelected: isSelected, isFocused: isFocused))
+                .padding(.horizontal, segmentHorizontalPadding)
+                .frame(height: segmentHeight)
+                .background(
+                    Capsule().fill(fill(isSelected: isSelected, isFocused: isFocused))
+                )
+                .scaleEffect(isFocused ? 1.05 : 1.0)
+        }
+        .buttonStyle(.continuumFlat)
+        .focused($focusedFilter, equals: filter)
+        .animation(ContinuumTheme.springAnimation, value: isFocused)
+        .animation(.easeInOut(duration: 0.15), value: isSelected)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    private func foreground(isSelected: Bool, isFocused: Bool) -> Color {
+        if isFocused || isSelected { return .continuumBackground }
+        return .continuumOnSurface.opacity(0.7)
+    }
+
+    private func fill(isSelected: Bool, isFocused: Bool) -> Color {
+        if isFocused { return Color.continuumOnSurface.opacity(0.96) }
+        if isSelected { return Color.continuumOnSurface.opacity(0.88) }
+        return .clear
+    }
+
+    // MARK: - Metrics
+
+    private var segmentSpacing: CGFloat {
+        #if os(tvOS)
+        return 6
+        #else
+        return 2
+        #endif
+    }
+
+    private var containerPadding: CGFloat {
+        #if os(tvOS)
+        return 6
+        #else
+        return 3
+        #endif
+    }
+
+    private var segmentFont: Font {
+        #if os(tvOS)
+        return .system(size: 22, weight: .semibold)
+        #else
+        return .system(size: 13, weight: .semibold)
+        #endif
+    }
+
+    private var segmentHorizontalPadding: CGFloat {
+        #if os(tvOS)
+        return 26
+        #else
+        return 14
+        #endif
+    }
+
+    private var segmentHeight: CGFloat {
+        #if os(tvOS)
+        return 54
+        #else
+        return 28
+        #endif
+    }
+}

--- a/iosApp/iosApp/Screens/Calendar/CalendarModels.swift
+++ b/iosApp/iosApp/Screens/Calendar/CalendarModels.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+
+// MARK: - Filter presets
+
+/// Server-side calendar presets surfaced in the UI. Raw values are the
+/// API `filter` query values.
+enum CalendarFilter: String, CaseIterable, Identifiable {
+    case following
+    case trending
+    case everything
+
+    var id: String { rawValue }
+
+    var displayLabel: String {
+        switch self {
+        case .following: return "Following"
+        case .trending: return "Trending"
+        case .everything: return "All"
+        }
+    }
+}
+
+// MARK: - Wire types
+
+/// Response from `GET /api/v1/calendar`. Snake_case keys are mapped by the
+/// shared decoder's `.convertFromSnakeCase` strategy.
+struct CalendarResponse: Codable {
+    let events: [CalendarDay]
+}
+
+/// One local day's worth of events. `date` is the viewer-local
+/// "YYYY-MM-DD" grouping key (`local_air_date` on each item).
+struct CalendarDay: Codable, Identifiable {
+    let date: String
+    let items: [CalendarEvent]
+
+    var id: String { date }
+}
+
+/// A single airing/release: a movie release, an episode airing, or a
+/// season premiere placeholder (used when episode 1 has no air date yet).
+struct CalendarEvent: Codable, Identifiable {
+    let contentId: String
+    let type: String // "movie" | "episode" | "season_premiere"
+    let title: String
+    let episodeTitle: String?
+    let seriesId: String?
+    let seasonNumber: Int?
+    let episodeNumber: Int?
+    let airDate: String?
+    let airTime: String?
+    let airAt: String?
+    let airTimezone: String?
+    let localAirDate: String?
+    let posterUrl: String?
+    let posterThumbhash: String?
+    let watched: Bool?
+    let badges: [String]?
+
+    var id: String { contentId }
+
+    /// Where tapping the event should land: episodes and season premieres
+    /// open their series; movies open themselves.
+    var navigationContentId: String {
+        type == "movie" ? contentId : (seriesId ?? contentId)
+    }
+
+    var isWatched: Bool { watched == true }
+
+    /// "S5 · E14" for episodes, "Season 2" for season premieres.
+    var episodeSubtitle: String? {
+        switch type {
+        case "episode":
+            guard let season = seasonNumber, let episode = episodeNumber else { return nil }
+            return "S\(season) · E\(episode)"
+        case "season_premiere":
+            guard let season = seasonNumber else { return nil }
+            return "Season \(season)"
+        default:
+            return nil
+        }
+    }
+
+    /// Localized air time for display ("9:00 PM"). Prefers the absolute
+    /// instant when the server knows the source timezone; falls back to
+    /// interpreting the wall-clock time in the viewer's timezone.
+    var displayAirTime: String? {
+        if let airAt {
+            return DateFormatters.localShortTime(fromRFC3339: airAt)
+        }
+        if let airTime {
+            return DateFormatters.localShortTime(fromWallClock: airTime)
+        }
+        return nil
+    }
+
+    var displayBadges: [CalendarBadge] {
+        (badges ?? []).compactMap(CalendarBadge.init)
+    }
+}
+
+/// Editorial badges the server attaches to calendar events.
+enum CalendarBadge: String {
+    case seriesPremiere = "series_premiere"
+    case seasonPremiere = "season_premiere"
+    case finale
+
+    var label: String {
+        switch self {
+        case .seriesPremiere: return "SERIES PREMIERE"
+        case .seasonPremiere: return "NEW SEASON"
+        case .finale: return "FINALE"
+        }
+    }
+}

--- a/iosApp/iosApp/Screens/Calendar/CalendarView.swift
+++ b/iosApp/iosApp/Screens/Calendar/CalendarView.swift
@@ -1,0 +1,322 @@
+import SwiftUI
+
+/// Upcoming-media calendar tab: a week-at-a-time agenda of movie
+/// releases, episode airings, and season premieres from the library,
+/// mirroring the server web UI's calendar.
+struct CalendarView: View {
+    /// Active focus hand-down token from `TVMainTabView`. When this
+    /// changes (the Calendar root was selected), focus is pushed onto
+    /// the filter bar so the screen never opens with a dead remote.
+    var focusRequest: Int = 0
+    var onTopMenuFocusRequest: (() -> Void)? = nil
+
+    @State private var viewModel = CalendarViewModel()
+    @State private var currentProfile: UserProfile?
+    @Environment(AppRouter.self) private var router
+    #if os(tvOS)
+    /// Focus hand-off for day selection: picking a day in the week strip
+    /// scrolls to that day's shelf and kicks focus onto its first card.
+    @State private var shelfFocusRequest = 0
+    @State private var shelfFocusDay: Date?
+    #endif
+
+    var body: some View {
+        rootLayout
+            .task {
+                await viewModel.load()
+                await loadCurrentProfile()
+            }
+        #if !os(tvOS)
+            .refreshable {
+                await viewModel.refresh()
+            }
+        #endif
+    }
+
+    @ViewBuilder
+    private var rootLayout: some View {
+        #if os(tvOS)
+        ZStack(alignment: .top) {
+            TVRootHeroBackdrop(
+                tintColor: .continuumBackground,
+                artworkURL: nil,
+                artworkThumbhash: nil,
+                isVisible: false
+            )
+
+            tvContent
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        #else
+        VStack(spacing: 0) {
+            HStack(spacing: 12) {
+                SidebarToggleButton()
+
+                Text("Calendar")
+                    .font(.continuumTitle)
+                    .foregroundColor(.continuumOnSurface)
+
+                Spacer(minLength: 8)
+
+                TabTopBarActions(
+                    profile: currentProfile,
+                    onSearch: { router.navigate(to: .search) },
+                    onSwitchProfile: {
+                        AuthService.shared.profileId = nil
+                        router.showProfileSelection()
+                    },
+                    onSwitchServer: { router.navigate(to: .serverList) },
+                    onSignOut: { router.signOutAndReset() }
+                )
+            }
+            .padding(.horizontal, ContinuumTheme.padding)
+            .padding(.top, ContinuumTheme.smallPadding)
+            .padding(.bottom, ContinuumTheme.smallPadding)
+
+            phoneContent
+        }
+        .continuumBackground()
+        #if os(iOS)
+        .toolbar(.hidden, for: .navigationBar)
+        #endif
+        #endif
+    }
+
+    // MARK: - iOS / macOS
+
+    #if !os(tvOS)
+    private var phoneContent: some View {
+        ScrollViewReader { proxy in
+            ScrollView(.vertical, showsIndicators: false) {
+                LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
+                    Section {
+                        shelfArea
+                    } header: {
+                        VStack(alignment: .leading, spacing: ContinuumTheme.smallPadding) {
+                            CalendarFilterBar(
+                                selected: viewModel.filter,
+                                onSelect: { viewModel.select(filter: $0) }
+                            )
+                            .padding(.horizontal, ContinuumTheme.safePadding)
+
+                            CalendarWeekStrip(
+                                week: viewModel.week,
+                                selectedDay: viewModel.selectedDay,
+                                isCurrentWeek: viewModel.isCurrentWeek,
+                                hasEvents: { viewModel.hasEvents(on: $0) },
+                                onSelectDay: { selectDay($0, proxy: proxy) },
+                                onPreviousWeek: { viewModel.goToPreviousWeek() },
+                                onNextWeek: { viewModel.goToNextWeek() },
+                                onToday: { viewModel.goToToday() }
+                            )
+                        }
+                        .padding(.vertical, ContinuumTheme.smallPadding)
+                        .background(Color.continuumBackground)
+                    }
+                }
+                .padding(.bottom, ContinuumTheme.largePadding)
+            }
+        }
+    }
+    #endif
+
+    // MARK: - tvOS
+
+    #if os(tvOS)
+    private var tvContent: some View {
+        ScrollViewReader { proxy in
+            ScrollView(.vertical, showsIndicators: false) {
+                LazyVStack(alignment: .leading, spacing: 30) {
+                    // Full-width focus section: the filter capsule only
+                    // occupies the leading corner, and a narrow section
+                    // can't catch up-moves from day buttons on the right
+                    // side of the strip below — the focus engine would
+                    // skip past it to the (full-width) top menu. The
+                    // spacer stretches the section across the row so
+                    // every up-move from the strip lands here first.
+                    HStack(spacing: 0) {
+                        CalendarFilterBar(
+                            selected: viewModel.filter,
+                            onSelect: { viewModel.select(filter: $0) },
+                            focusRequest: focusRequest,
+                            onMoveUp: onTopMenuFocusRequest
+                        )
+
+                        Spacer(minLength: 0)
+                    }
+                    .padding(.horizontal, ContinuumTheme.safePadding)
+                    .focusSection()
+
+                    CalendarWeekStrip(
+                        week: viewModel.week,
+                        selectedDay: viewModel.selectedDay,
+                        isCurrentWeek: viewModel.isCurrentWeek,
+                        hasEvents: { viewModel.hasEvents(on: $0) },
+                        onSelectDay: { selectDay($0, proxy: proxy) },
+                        onPreviousWeek: { viewModel.goToPreviousWeek() },
+                        onNextWeek: { viewModel.goToNextWeek() },
+                        onToday: { viewModel.goToToday() }
+                    )
+
+                    shelfArea
+                }
+                .padding(.top, TVTopMenuLayout.contentTopInset)
+                .padding(.bottom, ContinuumTheme.largePadding)
+            }
+        }
+    }
+    #endif
+
+    // MARK: - Shared shelf area
+
+    @ViewBuilder
+    private var shelfArea: some View {
+        if let error = viewModel.error {
+            ErrorView(state: error, onRetry: { Task { await viewModel.load() } })
+                .frame(minHeight: 320)
+        } else if viewModel.isLoading {
+            loadingState
+        } else if viewModel.isEmpty {
+            emptyState
+        } else {
+            let firstNonEmptyDay = viewModel.week.days.first { viewModel.hasEvents(on: $0) }
+            ForEach(viewModel.week.days, id: \.self) { day in
+                CalendarDayShelf(
+                    heading: viewModel.sectionHeading(for: day),
+                    events: viewModel.events(on: day),
+                    onEventTap: { event in
+                        router.navigate(to: .itemDetail(contentId: event.navigationContentId))
+                    },
+                    prefersDefaultFocusOnFirstItem: day == firstNonEmptyDay,
+                    focusRequest: shelfFocusRequest(for: day)
+                )
+                .id(day)
+                .padding(.bottom, shelfBottomPadding)
+            }
+        }
+    }
+
+    /// On tvOS the loading state must contain at least one focusable
+    /// element so Menu/Back keeps working — see `RecommendationsView`.
+    /// Here the always-rendered filter bar already provides one; the
+    /// clear spacer just keeps the layout from collapsing.
+    private var loadingState: some View {
+        Color.clear
+            .frame(minHeight: 320)
+            #if os(tvOS)
+            .focusable()
+            #endif
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "calendar.badge.exclamationmark")
+                .font(.system(size: 44))
+                .foregroundColor(.continuumOnSurface.opacity(0.3))
+
+            Text(emptyTitle)
+                .font(.continuumSubheadline)
+                .foregroundColor(.continuumOnSurface)
+
+            Text(emptySubtitle)
+                .font(.continuumCaption)
+                .foregroundColor(.continuumSecondaryText)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, ContinuumTheme.largePadding)
+
+            if viewModel.filter != .everything {
+                Button("Show Everything") {
+                    viewModel.select(filter: .everything)
+                }
+                .buttonStyle(ContinuumPrimaryButtonStyle())
+                .frame(width: emptyButtonWidth)
+                .padding(.top, ContinuumTheme.smallPadding)
+            } else {
+                // tvOS focus needs at least one target below the filter
+                // bar so d-pad down from it doesn't dead-end (see
+                // RecommendationsView's empty state).
+                #if os(tvOS)
+                Button("Refresh") {
+                    Task { await viewModel.refresh() }
+                }
+                .buttonStyle(ContinuumPrimaryButtonStyle())
+                .frame(width: emptyButtonWidth)
+                .padding(.top, ContinuumTheme.smallPadding)
+                #endif
+            }
+        }
+        .frame(maxWidth: .infinity, minHeight: 320)
+    }
+
+    private var emptyTitle: String {
+        viewModel.filter == .following
+            ? "Nothing from shows you follow"
+            : "Nothing scheduled this week"
+    }
+
+    private var emptySubtitle: String {
+        viewModel.filter == .following
+            ? "No upcoming releases this week from shows you watch, favorite, or watchlist."
+            : "No movie releases or episode airings in this week."
+    }
+
+    private var emptyButtonWidth: CGFloat {
+        #if os(tvOS)
+        return 360
+        #else
+        return 220
+        #endif
+    }
+
+    private var shelfBottomPadding: CGFloat {
+        #if os(tvOS)
+        return 6
+        #else
+        return ContinuumTheme.padding
+        #endif
+    }
+
+    // MARK: - Helpers
+
+    private func selectDay(_ day: Date, proxy: ScrollViewProxy) {
+        viewModel.selectDay(day)
+        withAnimation(ContinuumTheme.springAnimation) {
+            proxy.scrollTo(day, anchor: .top)
+        }
+        #if os(tvOS)
+        // Hand focus to the selected day's shelf so the remote lands on
+        // its first card instead of staying parked in the week strip.
+        // Day-less shelves have nothing to focus — leave focus on the
+        // strip so the user can pick another day.
+        if viewModel.hasEvents(on: day) {
+            shelfFocusDay = day
+            shelfFocusRequest += 1
+        }
+        #endif
+    }
+
+    /// Per-shelf kick token: only the most recently selected day sees a
+    /// non-zero, changing value, so exactly one shelf claims focus.
+    private func shelfFocusRequest(for day: Date) -> Int {
+        #if os(tvOS)
+        return day == shelfFocusDay ? shelfFocusRequest : 0
+        #else
+        return 0
+        #endif
+    }
+
+    /// Load the active profile so the iOS top bar can render its avatar.
+    /// Non-fatal on failure — the bar falls back to a generic icon.
+    private func loadCurrentProfile() async {
+        #if !os(tvOS)
+        guard let profileId = AuthService.shared.profileId else { return }
+        do {
+            let profiles = try await AuthService.shared.getProfiles()
+            currentProfile = profiles.first(where: { $0.id == profileId })
+        } catch {
+            // Leave currentProfile nil; the top bar renders a fallback.
+        }
+        #endif
+    }
+}

--- a/iosApp/iosApp/Screens/Calendar/CalendarViewModel.swift
+++ b/iosApp/iosApp/Screens/Calendar/CalendarViewModel.swift
@@ -1,0 +1,133 @@
+import SwiftUI
+
+/// Drives the Calendar tab: one Monday-anchored week of day-grouped
+/// events for the active filter preset, with stale-while-revalidate
+/// caching per (week, filter) pair.
+@Observable
+@MainActor
+final class CalendarViewModel {
+    private static let filterDefaultsKey = "calendar.filter"
+
+    var days: [CalendarDay] = []
+    var isLoading = false
+    var error: ErrorState?
+
+    var week = CalendarWeek(containing: Date())
+    /// Day highlighted in the week strip; drives scroll-to-day.
+    var selectedDay: Date = Date()
+
+    var filter: CalendarFilter
+
+    /// Monotonic token so a slow response for a week/filter the user has
+    /// already navigated away from can't clobber the visible state.
+    @ObservationIgnored private var requestToken = 0
+
+    init() {
+        let stored = UserDefaults.standard.string(forKey: Self.filterDefaultsKey) ?? ""
+        filter = CalendarFilter(rawValue: stored) ?? .following
+    }
+
+    // MARK: - Derived
+
+    var isCurrentWeek: Bool { week.containsToday() }
+
+    var isEmpty: Bool {
+        days.allSatisfy { $0.items.isEmpty }
+    }
+
+    func events(on date: Date) -> [CalendarEvent] {
+        let key = DateFormatters.isoDate.string(from: date)
+        return days.first(where: { $0.date == key })?.items ?? []
+    }
+
+    func hasEvents(on date: Date) -> Bool {
+        !events(on: date).isEmpty
+    }
+
+    /// Day-shelf heading: "Today" / "Tomorrow" / "Monday, June 9".
+    func sectionHeading(for date: Date) -> String {
+        let calendar = Calendar.current
+        if calendar.isDateInToday(date) { return "Today" }
+        if calendar.isDateInTomorrow(date) { return "Tomorrow" }
+        return date.formatted(.dateTime.weekday(.wide).month(.wide).day())
+    }
+
+    // MARK: - Actions
+
+    func selectDay(_ date: Date) {
+        selectedDay = date
+    }
+
+    func select(filter newFilter: CalendarFilter) {
+        guard newFilter != filter else { return }
+        filter = newFilter
+        UserDefaults.standard.set(newFilter.rawValue, forKey: Self.filterDefaultsKey)
+        Task { await load() }
+    }
+
+    func goToPreviousWeek() {
+        week = week.advanced(by: -1)
+        selectedDay = week.startDate
+        Task { await load() }
+    }
+
+    func goToNextWeek() {
+        week = week.advanced(by: 1)
+        selectedDay = week.startDate
+        Task { await load() }
+    }
+
+    func goToToday() {
+        week = CalendarWeek(containing: Date())
+        selectedDay = Date()
+        Task { await load() }
+    }
+
+    // MARK: - Loading
+
+    func load() async {
+        requestToken += 1
+        let token = requestToken
+        let week = week
+        let filter = filter
+        let key = CacheKey.calendarWeek(week.startString, filter: filter.rawValue)
+
+        if let cached: CalendarResponse = ResponseCache.shared.get(key) {
+            days = cached.events
+            isLoading = false
+        } else {
+            days = []
+            isLoading = true
+        }
+        error = nil
+
+        do {
+            let response = try await ContinuumAPI.shared.calendarEvents(
+                start: week.startString,
+                end: week.endString,
+                filter: filter.rawValue,
+                timezone: TimeZone.current.identifier
+            )
+            guard token == requestToken else { return }
+            ResponseCache.shared.set(response, for: key)
+            days = response.events
+        } catch let err {
+            guard token == requestToken else { return }
+            // A cancelled load (the tab was switched away mid-fetch) is
+            // not a failure — the next `.task` run reloads from scratch,
+            // so don't leave an error screen behind.
+            if err is CancellationError || (err as? URLError)?.code == .cancelled { return }
+            if days.isEmpty {
+                error = ErrorState(err)
+            }
+        }
+        isLoading = false
+    }
+
+    func refresh() async {
+        ResponseCache.shared.remove(
+            CacheKey.calendarWeek(week.startString, filter: filter.rawValue)
+        )
+        await load()
+    }
+}

--- a/iosApp/iosApp/Screens/Calendar/CalendarWeek.swift
+++ b/iosApp/iosApp/Screens/Calendar/CalendarWeek.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// A single Monday-anchored 7-day window. The Monday anchor is fixed
+/// (matching the server web UI's week convention) regardless of the
+/// device locale's first weekday, so the same week of data renders
+/// identically everywhere.
+struct CalendarWeek: Equatable, Hashable {
+    /// ISO 8601 weeks start on Monday by definition; using one calendar
+    /// for every operation keeps the anchor and the day arithmetic from
+    /// disagreeing (the device calendar may not even be Gregorian).
+    private static let isoCalendar: Calendar = {
+        var calendar = Calendar(identifier: .iso8601)
+        calendar.timeZone = .current
+        return calendar
+    }()
+
+    /// Midnight on the week's Monday, in the device timezone.
+    let startDate: Date
+
+    /// The week containing `date`.
+    init(containing date: Date) {
+        let components = Self.isoCalendar.dateComponents(
+            [.yearForWeekOfYear, .weekOfYear],
+            from: date
+        )
+        self.startDate = Self.isoCalendar.date(from: components) ?? date
+    }
+
+    /// All 7 day dates, Monday through Sunday.
+    var days: [Date] {
+        (0..<7).compactMap {
+            Self.isoCalendar.date(byAdding: .day, value: $0, to: startDate)
+        }
+    }
+
+    var endDate: Date {
+        Self.isoCalendar.date(byAdding: .day, value: 6, to: startDate) ?? startDate
+    }
+
+    func advanced(by weeks: Int) -> CalendarWeek {
+        guard let shifted = Self.isoCalendar.date(
+            byAdding: .weekOfYear, value: weeks, to: startDate
+        ) else { return self }
+        return CalendarWeek(containing: shifted)
+    }
+
+    /// "YYYY-MM-DD" API strings.
+    var startString: String { DateFormatters.isoDate.string(from: startDate) }
+    var endString: String { DateFormatters.isoDate.string(from: endDate) }
+
+    func containsToday(_ today: Date = Date()) -> Bool {
+        days.contains { Self.isoCalendar.isDate($0, inSameDayAs: today) }
+    }
+}

--- a/iosApp/iosApp/Screens/Calendar/CalendarWeekStrip.swift
+++ b/iosApp/iosApp/Screens/Calendar/CalendarWeekStrip.swift
@@ -1,0 +1,340 @@
+import SwiftUI
+
+/// Week navigator: prev/next chevrons around seven day buttons, plus a
+/// "Today" shortcut when viewing another week. Day buttons show an
+/// event-dot indicator and highlight the selected day.
+struct CalendarWeekStrip: View {
+    let week: CalendarWeek
+    let selectedDay: Date
+    let isCurrentWeek: Bool
+    let hasEvents: (Date) -> Bool
+    let onSelectDay: (Date) -> Void
+    let onPreviousWeek: () -> Void
+    let onNextWeek: () -> Void
+    let onToday: () -> Void
+
+    #if os(tvOS)
+    @FocusState private var focusedControl: StripControl?
+    #endif
+
+    var body: some View {
+        HStack(spacing: stripSpacing) {
+            chevronButton(systemImage: "chevron.left", control: .previous, action: onPreviousWeek)
+                .accessibilityLabel("Previous week")
+
+            HStack(spacing: dayButtonSpacing) {
+                ForEach(week.days, id: \.self) { date in
+                    CalendarDayButton(
+                        date: date,
+                        isSelected: Calendar.current.isDate(date, inSameDayAs: selectedDay),
+                        isToday: Calendar.current.isDateInToday(date),
+                        hasEvents: hasEvents(date),
+                        isFocused: isFocused(.day(date)),
+                        action: { onSelectDay(date) }
+                    )
+                    .applyStripFocus(self, control: .day(date))
+                }
+            }
+
+            chevronButton(systemImage: "chevron.right", control: .next, action: onNextWeek)
+                .accessibilityLabel("Next week")
+
+            if !isCurrentWeek {
+                Button("Today", action: onToday)
+                    .font(todayFont)
+                    .foregroundColor(isFocused(.today) ? .continuumBackground : .continuumOnSurface)
+                    .buttonStyle(.continuumFlat)
+                    .padding(.horizontal, todayHorizontalPadding)
+                    .frame(height: chevronHeight)
+                    .background(
+                        Capsule().fill(
+                            isFocused(.today)
+                                ? Color.continuumOnSurface.opacity(0.94)
+                                : Color.white.opacity(0.08)
+                        )
+                    )
+                    .overlay(Capsule().stroke(Color.white.opacity(0.18), lineWidth: 1))
+                    .applyStripFocus(self, control: .today)
+                    .accessibilityLabel("Jump to today")
+            }
+
+            Spacer(minLength: 0)
+
+            Text(monthLabel)
+                .font(monthFont)
+                .foregroundColor(.continuumSecondaryText)
+        }
+        .padding(.horizontal, ContinuumTheme.safePadding)
+        #if os(tvOS)
+        .focusSection()
+        #endif
+        .animation(ContinuumTheme.springAnimation, value: isCurrentWeek)
+    }
+
+    /// "June 2026" — uses the Thursday so a week spanning two months
+    /// shows the month that owns most of its days.
+    private var monthLabel: String {
+        let anchor = Calendar.current.date(byAdding: .day, value: 3, to: week.startDate)
+            ?? week.startDate
+        return anchor.formatted(.dateTime.month(.wide).year())
+    }
+
+    private func chevronButton(
+        systemImage: String,
+        control: StripControl,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: systemImage)
+                .font(chevronFont)
+                .foregroundColor(
+                    isFocused(control) ? .continuumBackground : .continuumOnSurface.opacity(0.7)
+                )
+                .frame(width: chevronWidth, height: chevronHeight)
+                .background(
+                    Circle().fill(
+                        isFocused(control)
+                            ? Color.continuumOnSurface.opacity(0.94)
+                            : Color.white.opacity(0.08)
+                    )
+                )
+        }
+        .buttonStyle(.continuumFlat)
+        .applyStripFocus(self, control: control)
+    }
+
+    // MARK: - Focus plumbing
+
+    enum StripControl: Hashable {
+        case previous
+        case next
+        case today
+        case day(Date)
+    }
+
+    fileprivate func isFocused(_ control: StripControl) -> Bool {
+        #if os(tvOS)
+        return focusedControl == control
+        #else
+        return false
+        #endif
+    }
+
+    #if os(tvOS)
+    fileprivate var focusBinding: FocusState<StripControl?>.Binding { $focusedControl }
+    #endif
+
+    // MARK: - Metrics
+
+    private var stripSpacing: CGFloat {
+        #if os(tvOS)
+        return 18
+        #else
+        return 8
+        #endif
+    }
+
+    private var dayButtonSpacing: CGFloat {
+        #if os(tvOS)
+        return 10
+        #else
+        return 4
+        #endif
+    }
+
+    private var chevronFont: Font {
+        #if os(tvOS)
+        return .system(size: 24, weight: .semibold)
+        #else
+        return .system(size: 13, weight: .semibold)
+        #endif
+    }
+
+    private var chevronWidth: CGFloat {
+        #if os(tvOS)
+        return 64
+        #else
+        return 32
+        #endif
+    }
+
+    private var chevronHeight: CGFloat {
+        #if os(tvOS)
+        return 64
+        #else
+        return 32
+        #endif
+    }
+
+    private var todayFont: Font {
+        #if os(tvOS)
+        return .system(size: 22, weight: .semibold)
+        #else
+        return .system(size: 13, weight: .semibold)
+        #endif
+    }
+
+    private var todayHorizontalPadding: CGFloat {
+        #if os(tvOS)
+        return 24
+        #else
+        return 12
+        #endif
+    }
+
+    private var monthFont: Font {
+        #if os(tvOS)
+        return .system(size: 24, weight: .semibold)
+        #else
+        return .system(size: 13, weight: .semibold)
+        #endif
+    }
+}
+
+private extension View {
+    /// tvOS: bind a strip control to the shared `@FocusState`; no-op on
+    /// other platforms.
+    @ViewBuilder
+    func applyStripFocus(
+        _ strip: CalendarWeekStrip,
+        control: CalendarWeekStrip.StripControl
+    ) -> some View {
+        #if os(tvOS)
+        self.focused(strip.focusBinding, equals: control)
+        #else
+        self
+        #endif
+    }
+}
+
+// MARK: - Day button
+
+private struct CalendarDayButton: View {
+    let date: Date
+    let isSelected: Bool
+    let isToday: Bool
+    let hasEvents: Bool
+    let isFocused: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: labelSpacing) {
+                Text(weekdayLabel)
+                    .font(weekdayFont)
+                    .foregroundColor(secondaryColor)
+
+                Text(dayNumber)
+                    .font(numberFont)
+                    .foregroundColor(primaryColor)
+
+                Circle()
+                    .fill(hasEvents ? dotColor : .clear)
+                    .frame(width: dotSize, height: dotSize)
+            }
+            .frame(width: buttonWidth, height: buttonHeight)
+            .background(
+                RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius, style: .continuous)
+                    .fill(backgroundFill)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius, style: .continuous)
+                    .stroke(
+                        isToday && !isSelected && !isFocused
+                            ? Color.white.opacity(0.35)
+                            : .clear,
+                        lineWidth: 1
+                    )
+            )
+            .scaleEffect(isFocused ? 1.06 : 1.0)
+        }
+        .buttonStyle(.continuumFlat)
+        .animation(ContinuumTheme.springAnimation, value: isFocused)
+        .animation(.easeInOut(duration: 0.15), value: isSelected)
+        .accessibilityLabel(accessibilityDescription)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    private var weekdayLabel: String {
+        date.formatted(.dateTime.weekday(.abbreviated))
+    }
+
+    private var dayNumber: String {
+        date.formatted(.dateTime.day())
+    }
+
+    private var accessibilityDescription: String {
+        date.formatted(.dateTime.weekday(.wide).month(.wide).day())
+            + (hasEvents ? ", has events" : "")
+    }
+
+    private var inverted: Bool { isSelected || isFocused }
+
+    private var primaryColor: Color {
+        inverted ? .continuumBackground : .continuumOnSurface
+    }
+
+    private var secondaryColor: Color {
+        inverted ? Color.continuumBackground.opacity(0.7) : .continuumSecondaryText
+    }
+
+    private var dotColor: Color {
+        inverted ? .continuumBackground : .continuumOnSurface.opacity(0.8)
+    }
+
+    private var backgroundFill: Color {
+        if isFocused { return Color.continuumOnSurface.opacity(0.94) }
+        if isSelected { return Color.continuumOnSurface.opacity(0.88) }
+        return Color.white.opacity(0.05)
+    }
+
+    // MARK: - Metrics
+
+    private var labelSpacing: CGFloat {
+        #if os(tvOS)
+        return 6
+        #else
+        return 3
+        #endif
+    }
+
+    private var weekdayFont: Font {
+        #if os(tvOS)
+        return .system(size: 18, weight: .semibold)
+        #else
+        return .system(size: 10, weight: .semibold)
+        #endif
+    }
+
+    private var numberFont: Font {
+        #if os(tvOS)
+        return .system(size: 26, weight: .bold)
+        #else
+        return .system(size: 15, weight: .bold)
+        #endif
+    }
+
+    private var dotSize: CGFloat {
+        #if os(tvOS)
+        return 8
+        #else
+        return 4
+        #endif
+    }
+
+    private var buttonWidth: CGFloat {
+        #if os(tvOS)
+        return 84
+        #else
+        return 42
+        #endif
+    }
+
+    private var buttonHeight: CGFloat {
+        #if os(tvOS)
+        return 96
+        #else
+        return 56
+        #endif
+    }
+}

--- a/iosApp/iosApp/Screens/Personal/FavoritesView.swift
+++ b/iosApp/iosApp/Screens/Personal/FavoritesView.swift
@@ -25,7 +25,13 @@ struct FavoritesView: View {
             } else if let error {
                 ErrorView(state: error, onRetry: { Task { await loadFavorites() } })
             } else if isLoading {
+                // tvOS: this is a pushed destination, so the top menu bar
+                // isn't there to hold focus — without a focusable element
+                // the remote goes dead until the grid renders.
                 Color.clear
+                #if os(tvOS)
+                    .focusable()
+                #endif
             } else {
                 EmptyStateView(
                     icon: "heart",

--- a/iosApp/iosApp/Screens/Personal/HistoryView.swift
+++ b/iosApp/iosApp/Screens/Personal/HistoryView.swift
@@ -19,7 +19,13 @@ struct HistoryView: View {
             } else if let error {
                 ErrorView(state: error, onRetry: { Task { await loadHistory() } })
             } else if isLoading {
+                // tvOS: this is a pushed destination, so the top menu bar
+                // isn't there to hold focus — without a focusable element
+                // the remote goes dead until the grid renders.
                 Color.clear
+                #if os(tvOS)
+                    .focusable()
+                #endif
             } else {
                 EmptyStateView(
                     icon: "clock",

--- a/iosApp/iosApp/Screens/Personal/WatchlistView.swift
+++ b/iosApp/iosApp/Screens/Personal/WatchlistView.swift
@@ -25,7 +25,13 @@ struct WatchlistView: View {
             } else if let error {
                 ErrorView(state: error, onRetry: { Task { await loadWatchlist() } })
             } else if isLoading {
+                // tvOS: this is a pushed destination, so the top menu bar
+                // isn't there to hold focus — without a focusable element
+                // the remote goes dead until the grid renders.
                 Color.clear
+                #if os(tvOS)
+                    .focusable()
+                #endif
             } else {
                 EmptyStateView(
                     icon: "bookmark",

--- a/iosApp/iosApp/Screens/Search/SearchView.swift
+++ b/iosApp/iosApp/Screens/Search/SearchView.swift
@@ -16,6 +16,15 @@ struct SearchView: View {
                 if shouldShowFilters {
                     mediaTypePicker
                         .padding(.horizontal, ContinuumTheme.padding)
+                    #if os(tvOS)
+                        // The picker is a centered 760pt pill inside a
+                        // 1600pt column. Stretch its focus section across
+                        // the full row so up-moves from the grid's outer
+                        // columns land here instead of skipping straight
+                        // to the search field above.
+                        .frame(maxWidth: .infinity)
+                        .focusSection()
+                    #endif
                 }
 
                 content

--- a/iosApp/iosApp/Shared/DateFormatters.swift
+++ b/iosApp/iosApp/Shared/DateFormatters.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Process-wide reusable date/time formatters. `DateFormatter` construction
+/// is expensive — share instances instead of building them per render.
+enum DateFormatters {
+    /// "yyyy-MM-dd" in the device's current timezone. Used for calendar API
+    /// request params and for matching server `local_air_date` strings,
+    /// which the server computes in the same timezone the client sends.
+    static let isoDate: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = .current
+        return formatter
+    }()
+
+    /// Wall-clock time parser for the server's "HH:mm" / "HH:mm:ss" strings.
+    static func parseWallClockTime(_ raw: String) -> DateComponents? {
+        let parts = raw.split(separator: ":").compactMap { Int($0) }
+        guard parts.count >= 2, (0..<24).contains(parts[0]), (0..<60).contains(parts[1]) else {
+            return nil
+        }
+        return DateComponents(hour: parts[0], minute: parts[1])
+    }
+
+    /// Localized short time ("9:00 PM" / "21:00" per locale) from an
+    /// RFC3339 instant string. Returns nil when parsing fails.
+    static func localShortTime(fromRFC3339 raw: String) -> String? {
+        guard let date = rfc3339.date(from: raw) ?? rfc3339Fractional.date(from: raw) else {
+            return nil
+        }
+        return date.formatted(date: .omitted, time: .shortened)
+    }
+
+    /// Localized short time from a wall-clock "HH:mm" string, interpreted
+    /// in the device timezone.
+    static func localShortTime(fromWallClock raw: String) -> String? {
+        guard let components = parseWallClockTime(raw),
+              let date = Calendar.current.date(
+                bySettingHour: components.hour ?? 0,
+                minute: components.minute ?? 0,
+                second: 0,
+                of: Date()
+              ) else {
+            return nil
+        }
+        return date.formatted(date: .omitted, time: .shortened)
+    }
+
+    private static let rfc3339: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    private static let rfc3339Fractional: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+}

--- a/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
@@ -130,6 +130,11 @@ struct TVMainTabView: View {
                 focusRequest: contentFocusRequest,
                 onTopMenuFocusRequest: focusTopMenuIfVisible
             )
+        case .calendar:
+            CalendarView(
+                focusRequest: contentFocusRequest,
+                onTopMenuFocusRequest: focusTopMenuIfVisible
+            )
         }
     }
 

--- a/iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift
@@ -13,6 +13,7 @@ enum TVTopMenuLayout {
     static let homeButtonWidth: CGFloat = 136
     static let librariesButtonWidth: CGFloat = 196
     static let forYouButtonWidth: CGFloat = 164
+    static let calendarButtonWidth: CGFloat = 186
     static let librarySwitcherWidth: CGFloat = 218
     static let librarySwitcherHeight: CGFloat = 46
     static let librarySwitcherFocusPadding: CGFloat = 14
@@ -28,6 +29,7 @@ enum TVRootDestination: String, CaseIterable, Identifiable, Hashable {
     case search = "Search"
     case libraries = "Libraries"
     case forYou = "For You"
+    case calendar = "Calendar"
 
     var id: String { rawValue }
 }
@@ -87,6 +89,8 @@ struct TVTopMenuBar: View {
                 rootButton(.libraries)
 
                 rootButton(.forYou)
+
+                rootButton(.calendar)
             }
             .frame(height: TVTopMenuLayout.primaryRowHeight, alignment: .top)
             .padding(.top, TVTopMenuLayout.primaryTopInset)
@@ -295,6 +299,8 @@ struct TVTopMenuBar: View {
             return TVTopMenuLayout.librariesButtonWidth
         case .forYou:
             return TVTopMenuLayout.forYouButtonWidth
+        case .calendar:
+            return TVTopMenuLayout.calendarButtonWidth
         }
     }
 

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVCardOverlaySettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVCardOverlaySettingsView.swift
@@ -565,6 +565,11 @@ private struct TVOverlayDetailSheet: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(.horizontal, 40)
+        // Full-width focus section per settings row: the visibility /
+        // position / icon clusters are narrow and left-aligned, so
+        // without this, vertical moves from the wide accent grid (or
+        // from right-side position buttons) skip past them.
+        .focusSection()
     }
 
     private func setEnabled(_ enabled: Bool) {


### PR DESCRIPTION
## What

Implements the server's Calendar feature (`GET /api/v1/calendar`) in the Apple clients as a new top-level tab on both iOS (5th tab / iPad sidebar entry) and tvOS (new top-menu destination), mirroring the web UI's week-agenda UX.

- **Week navigator**: Monday-anchored 7-day strip with event-dot indicators, prev/next week chevrons, month label, and a Today shortcut when off the current week. Tapping a day scrolls to its shelf; the strip is sticky (pinned header) on iOS.
- **Day shelves**: one labeled horizontal poster shelf per day ("Today" / "Tomorrow" / "Monday, June 9"); event-less days show a compact "Nothing scheduled" stub so the week keeps its shape.
- **Event cards**: purpose-built poster cards with monochrome badge pills (SERIES PREMIERE / NEW SEASON / FINALE), watched checkmark, localized air-time pill, and an "S5 · E14 · Episode Title" caption. Episodes/season premieres navigate to their series; movies to themselves.
- **Filters**: Following / Trending / All presets (server values `following` / `trending` / `everything`), defaulting to Following, persisted in UserDefaults.
- **Data layer**: typed `ContinuumAPI.calendarEvents(...)`, per-(week, filter) `ResponseCache` keys with stale-while-revalidate, cleared on profile switch; stale-request token guard; viewer timezone sent as `TimeZone.current.identifier` so server-side day grouping matches the device. New shared `DateFormatters` utility.

### tvOS focus work

- Focus hand-down from the top menu to the filter bar on tab entry; default focus on the first non-empty shelf; selecting a date in the strip kicks focus onto that day's first card.
- Vertical focus walks rows in order (menu ↔ filters ↔ dates ↔ shelves) — the filter row is stretched to a full-width focus section so up-moves from the right side of the date strip can't skip to the top menu.

### Drive-by fixes from a focus-geometry audit

Auditing the rest of the app for the same bug class turned up three real instances, fixed here:

- **Search (tvOS)**: the centered 760pt media-type picker above the 1600pt results grid now has a full-width focus section, so up-moves from outer grid columns no longer skip it.
- **Card-overlay settings detail sheet (tvOS)**: each settings row (`sectionWrap`) now has a full-width focus section; narrow On/Off and position clusters were previously skippable from the wide accent grid.
- **Favorites / Watchlist / History**: loading states keep a tvOS-focusable element — these are pushed screens where the top menu isn't present to hold focus, so a slow load left the remote dead.

## Why

The web admin UI already ships this calendar; this brings the Apple clients to parity (Android has no calendar yet — this sets the cross-platform precedent).

## Notes for review

- New source files are picked up by the existing `project.yml` directory globs; `Silo.xcodeproj` regenerated with XcodeGen.
- All three schemes build: `Silo` (iOS), `SiloTV` (tvOS), `SiloMac` (macOS — compiles the iOS layout; not a target of this feature).
- Post-implementation review (3 reviewer passes) findings were addressed: cancellation errors no longer surface as error screens, `CalendarWeek` uses a single ISO-8601 calendar for all date math, dead focus params pruned, tvOS empty state always has a focus target.
- No tests added per repo guidelines (UI feature); `CalendarWeek` year-boundary math is the one spot worth a focused XCTest later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Calendar tab with weekly event agenda view
  * Events grouped by day with filter options
  * Week navigation and day selection controls
  * Event cards display poster images with episode/season details and air times
  * Pull-to-refresh support on iOS

* **Improvements**
  * Enhanced tvOS focus management and navigation across multiple screens

<!-- end of auto-generated comment: release notes by coderabbit.ai -->