### PR TITLE
fix(tvos): refine Skyline home navigation and rows

### DIFF
--- a/iosApp/iosApp/Components/EpisodeThumbCard.swift
+++ b/iosApp/iosApp/Components/EpisodeThumbCard.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
-/// Horizontal (16:9) media card for episode content — used in "Next Up",
-/// "Continue Watching" (when items are episodes), etc.
+/// Horizontal (16:9) media card for episode and resume content — used in
+/// "Next Up", "Continue Watching", etc.
 ///
 /// Shows the episode still / backdrop, the series title + episode code
 /// (e.g. "S2 · E3") as an overlay, and the episode title plus runtime beneath.
@@ -161,7 +161,7 @@ struct EpisodeThumbCard: View {
 
     // MARK: - Derived data
 
-    /// Prefer backdrop/still for episodes; fall back to poster.
+    /// Prefer backdrop/still artwork; fall back to poster.
     private var imageUrl: String {
         if let backdrop = item.backdropUrl, !backdrop.isEmpty {
             return backdrop
@@ -169,12 +169,12 @@ struct EpisodeThumbCard: View {
         return item.posterUrl ?? ""
     }
 
-    /// Series title if this is an episode, otherwise the item title.
+    /// Series title for episodes, otherwise the item title.
     private var displayTitle: String {
         item.seriesTitle ?? item.title
     }
 
-    /// Secondary line — episode title with a runtime or year.
+    /// Secondary line — episode title for episodes, otherwise year.
     private var subtitleLine: String? {
         if item.seriesTitle != nil {
             return item.title
@@ -196,7 +196,7 @@ struct EpisodeThumbCard: View {
     private var progressValue: Double? {
         // Watched items store position 0 server-side (the watched latch and
         // the resume point are independent), so a nonzero position is always
-        // a live resume point — including a rewatch of a played episode.
+        // a live resume point — including a rewatch of a played item.
         guard let pos = item.positionSeconds,
               let dur = item.durationSeconds,
               dur > 0, pos > 0 else { return nil }

--- a/iosApp/iosApp/Components/MediaRow.swift
+++ b/iosApp/iosApp/Components/MediaRow.swift
@@ -82,9 +82,10 @@ struct MediaRow: View {
     #if os(tvOS)
     private func applyFocusRequest(_ request: Int) {
         guard request > 0, request != lastAppliedFocusRequest,
-              let firstId = items.first?.contentId else { return }
+              let firstItem = items.first else { return }
         lastAppliedFocusRequest = request
-        focusedItemId = firstId
+        focusedItemId = firstItem.contentId
+        onItemFocus?(firstItem)
     }
     #endif
 

--- a/iosApp/iosApp/Components/MediaRow.swift
+++ b/iosApp/iosApp/Components/MediaRow.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// Layout mode for a horizontal media row.
 /// Poster rows use tall (2:3) poster cards; thumbnail rows use wide 16:9
 /// episode stills — pick thumbnail for episode-centric sections like
-/// "Next Up" and for Continue Watching entries that are episodes. Square
+/// "Next Up" and resume rows like Continue Watching. Square
 /// rows use 1:1 tiles for audiobook covers.
 enum MediaRowLayout {
     case poster

--- a/iosApp/iosApp/Components/StartupSplashView.swift
+++ b/iosApp/iosApp/Components/StartupSplashView.swift
@@ -28,8 +28,7 @@ struct StartupSplashView: View {
             Color.continuumBackground.ignoresSafeArea()
 
             if isVideoAvailable {
-                StartupSplashPlayerSurface(player: player)
-                    .ignoresSafeArea()
+                startupVideo
             } else {
                 fallbackContent
             }
@@ -37,6 +36,23 @@ struct StartupSplashView: View {
         .accessibilityLabel("Loading Continuum")
         .onAppear(perform: startPlayback)
         .onDisappear(perform: stopPlayback)
+    }
+
+    @ViewBuilder
+    private var startupVideo: some View {
+        #if os(tvOS)
+        GeometryReader { proxy in
+            let videoWidth = min(proxy.size.width * 0.25, 440)
+
+            StartupSplashPlayerSurface(player: player)
+                .frame(width: videoWidth, height: videoWidth * 9.0 / 16.0)
+                .position(x: proxy.size.width / 2, y: proxy.size.height / 2)
+        }
+        .ignoresSafeArea()
+        #else
+        StartupSplashPlayerSurface(player: player)
+            .ignoresSafeArea()
+        #endif
     }
 
     private var fallbackContent: some View {

--- a/iosApp/iosApp/Screens/Home/HomeView.swift
+++ b/iosApp/iosApp/Screens/Home/HomeView.swift
@@ -50,6 +50,7 @@ struct HomeView: View {
                     focusRequest: homeFocusRequest,
                     isTopMenuFocused: isTopMenuFocused,
                     onTopMenuFocusRequest: onTopMenuFocusRequest,
+                    resetsToFirstItemOnExit: true,
                     onItemTap: { navigateToDetail($0) }
                 )
             } else if let error = viewModel.error {

--- a/iosApp/iosApp/Screens/Home/HomeView.swift
+++ b/iosApp/iosApp/Screens/Home/HomeView.swift
@@ -50,7 +50,6 @@ struct HomeView: View {
                     focusRequest: homeFocusRequest,
                     isTopMenuFocused: isTopMenuFocused,
                     onTopMenuFocusRequest: onTopMenuFocusRequest,
-                    resetsToFirstItemOnExit: true,
                     onItemTap: { navigateToDetail($0) }
                 )
             } else if let error = viewModel.error {

--- a/iosApp/iosApp/Screens/Home/SectionRow.swift
+++ b/iosApp/iosApp/Screens/Home/SectionRow.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// A single section row on the home screen.
 /// Wraps MediaRow and handles "continue watching" progress display.
 /// Picks the thumbnail layout for episode-centric sections (Next Up,
-/// and Continue Watching when the items are episodes).
+/// and Continue Watching resume rows).
 struct SectionRow: View {
     let section: ResolvedSection
     let onItemTap: (String) -> Void
@@ -37,14 +37,19 @@ struct SectionRow: View {
     /// True when the row should render 16:9 episode stills instead of posters.
     /// A dedicated "Next Up" row always does. For other episode-bearing rows
     /// the platforms differ: tvOS Skyline keeps every episode row as a still,
-    /// while iOS/iPadOS/macOS reserve stills for the resume context (Continue
-    /// Watching) and render episode-discovery rows (e.g. "Recently Released
-    /// Episodes") as ordinary series posters with an S·E badge.
+    /// and keeps Continue Watching as a still-based resume row even when the
+    /// row currently contains movies only. iOS/iPadOS/macOS reserve stills for
+    /// Continue Watching rows that actually contain episodes and render
+    /// episode-discovery rows (e.g. "Recently Released Episodes") as ordinary
+    /// series posters with an S·E badge.
     private var isEpisodeRow: Bool {
         if section.sectionType.lowercased().contains("next") {
             return true
         }
         #if os(tvOS)
+        if isContinueWatching {
+            return true
+        }
         return hasEpisodeItems
         #else
         return isContinueWatching && hasEpisodeItems

--- a/iosApp/iosApp/Theme/ContinuumTheme.swift
+++ b/iosApp/iosApp/Theme/ContinuumTheme.swift
@@ -277,7 +277,7 @@ struct ContinuumTheme {
         /// space in standard scroll layouts.
         static let rowBandCardVerticalPadding: CGFloat = 14
         /// Duration for the vertical row-stack scroll when paging up/down.
-        static let rowBandScrollDuration: Double = 0.24
+        static let rowBandScrollDuration: Double = 0.18
         /// Passive row preview tint so it reads as available content without
         /// competing with the focused row.
         static let rowPreviewOpacity: Double = 0.74

--- a/iosApp/iosApp/Theme/ContinuumTheme.swift
+++ b/iosApp/iosApp/Theme/ContinuumTheme.swift
@@ -278,6 +278,9 @@ struct ContinuumTheme {
         static let rowBandCardVerticalPadding: CGFloat = 14
         /// Duration for the vertical row-stack scroll when paging up/down.
         static let rowBandScrollDuration: Double = 0.18
+        /// Distance the outgoing focused row travels as it fades behind the
+        /// marquee/title area during row paging.
+        static let rowBandExitOffset: CGFloat = 140
         /// Passive row preview tint so it reads as available content without
         /// competing with the focused row.
         static let rowPreviewOpacity: Double = 0.74

--- a/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
+++ b/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
@@ -8,9 +8,8 @@ import SwiftUI
 /// feeds in.
 ///
 /// Row movement is owned by tvOS focus + the vertical scroll view. Each row
-/// remains a native focus section whose first card is the user-initiated
-/// default focus target, so entering a new row starts at the left edge without
-/// custom page-section animation.
+/// remains a native focus section, so row-to-row movement preserves tvOS'
+/// geometric focus behavior instead of forcing the first item.
 struct TVSkylineSectionFeed: View {
     /// Section rows to page through, in order (already filtered to
     /// non-empty, non-featured by the caller).
@@ -18,8 +17,7 @@ struct TVSkylineSectionFeed: View {
     /// Marquee scale. Both call sites pass `.home` so the pages render
     /// identically; kept as a parameter only for call-site clarity.
     var marqueeScale: TVFocusMarquee.Scale = .home
-    /// Focus hand-down token from the shell — claims the first card on entry
-    /// and on every page change.
+    /// Focus hand-down token from the shell — claims the first card on entry.
     var focusRequest: Int = 0
     /// Whether the top menu currently holds focus. A late content load must
     /// not steal focus while the user is up in the menu.
@@ -115,7 +113,7 @@ struct TVSkylineSectionFeed: View {
         SectionRow(
             section: section,
             onItemTap: onItemTap,
-            prefersDefaultFocusOnFirstItem: true,
+            prefersDefaultFocusOnFirstItem: false,
             focusRequest: isFirstRow ? contentFocusToken : 0,
             onMoveUp: nil,
             onItemFocus: { item in

--- a/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
+++ b/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
@@ -9,8 +9,9 @@ import SwiftUI
 ///
 /// Paging: there is no scroll view, so the focus engine never moves the row
 /// while navigating across cards. Up/Down page the focused row explicitly and
-/// the next-row preview animates into the focused slot. Entry focus lands on
-/// the first row's first card, which the marquee previews immediately.
+/// the next-row preview animates into the focused slot while the outgoing row
+/// fades behind the marquee area. Entry focus lands on the first row's first
+/// card, which the marquee previews immediately.
 struct TVSkylineSectionFeed: View {
     /// Section rows to page through, in order (already filtered to
     /// non-empty, non-featured by the caller).
@@ -42,6 +43,13 @@ struct TVSkylineSectionFeed: View {
     /// async, so the initial hand-down would land on nothing.
     @State private var pendingFocusRequest: Int?
     @State private var lastAppliedRequest = 0
+    /// Direction of the most recent row page request. Drives only the outgoing
+    /// row fade direction; focus is still claimed by the newly-mounted row.
+    @State private var pageTransitionDelta = 0
+    /// The row that is leaving during the current page transition. Keeping this
+    /// separate from `pageIndex` lets the outgoing first row stay above the new
+    /// row long enough to visibly slide/fade out.
+    @State private var outgoingPageIndex: Int?
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Namespace private var rowPagingNamespace
@@ -82,6 +90,8 @@ struct TVSkylineSectionFeed: View {
             // would fall out of range and the band would render nothing,
             // stranding the page blank. Clamp it back into range and re-claim
             // focus so the now-visible row's first card re-primes the marquee.
+            pageTransitionDelta = 0
+            outgoingPageIndex = nil
             if !sections.isEmpty, pageIndex >= sections.count {
                 pageIndex = sections.count - 1
                 contentFocusToken += 1
@@ -118,7 +128,8 @@ struct TVSkylineSectionFeed: View {
                     }
                     .fixedSize(horizontal: false, vertical: true)
                     .id(section.id)
-                    .transition(.opacity)
+                    .zIndex(rowStackZIndex(for: section))
+                    .transition(rowStackTransition)
                 }
             }
             .frame(width: proxy.size.width, height: visibleBandHeight, alignment: .topLeading)
@@ -161,6 +172,23 @@ struct TVSkylineSectionFeed: View {
         return sections[nextIndex]
     }
 
+    private var rowStackTransition: AnyTransition {
+        guard !reduceMotion, pageTransitionDelta != 0 else {
+            return .opacity
+        }
+
+        let exitOffset = pageTransitionDelta > 0
+            ? -ContinuumTheme.Skyline.rowBandExitOffset
+            : ContinuumTheme.Skyline.rowBandExitOffset
+        let insertion: AnyTransition = pageTransitionDelta < 0
+            ? .offset(y: -ContinuumTheme.Skyline.rowBandExitOffset).combined(with: .opacity)
+            : .opacity
+        return .asymmetric(
+            insertion: insertion,
+            removal: .offset(y: exitOffset).combined(with: .opacity)
+        )
+    }
+
     private var rowPageAnimation: Animation {
         if reduceMotion {
             return .easeInOut(duration: ContinuumTheme.fastDuration)
@@ -176,6 +204,8 @@ struct TVSkylineSectionFeed: View {
     private func pageBand(by delta: Int) {
         let target = pageIndex + delta
         guard sections.indices.contains(target) else { return }
+        outgoingPageIndex = pageIndex
+        pageTransitionDelta = delta
         pageIndex = target
         contentFocusToken += 1
     }
@@ -198,6 +228,8 @@ struct TVSkylineSectionFeed: View {
         if isTopMenuFocused { return }
         guard request != lastAppliedRequest else { return }
         lastAppliedRequest = request
+        pageTransitionDelta = 0
+        outgoingPageIndex = nil
         pageIndex = 0
         contentFocusToken += 1
     }
@@ -209,6 +241,19 @@ struct TVSkylineSectionFeed: View {
             isEnabled: !reduceMotion
         )
     }
+
+    private func rowStackZIndex(for section: ResolvedSection) -> Double {
+        guard pageTransitionDelta != 0,
+              let index = sections.firstIndex(where: { $0.id == section.id }) else {
+            return 0
+        }
+
+        if pageTransitionDelta > 0 {
+            return index == outgoingPageIndex ? 1 : 0
+        }
+
+        return index == pageIndex ? 1 : 0
+    }
 }
 
 private struct TVRowPagingGeometry: ViewModifier {
@@ -219,7 +264,12 @@ private struct TVRowPagingGeometry: ViewModifier {
     @ViewBuilder
     func body(content: Content) -> some View {
         if isEnabled {
-            content.matchedGeometryEffect(id: id, in: namespace)
+            content.matchedGeometryEffect(
+                id: id,
+                in: namespace,
+                properties: .position,
+                anchor: .topLeading
+            )
         } else {
             content
         }

--- a/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
+++ b/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
@@ -9,8 +9,8 @@ import SwiftUI
 ///
 /// Paging: there is no scroll view, so the focus engine never moves the row
 /// while navigating across cards. Up/Down page the focused row explicitly and
-/// the stack crossfades. Entry focus lands on the first row's first card,
-/// which the marquee previews immediately.
+/// the next-row preview animates into the focused slot. Entry focus lands on
+/// the first row's first card, which the marquee previews immediately.
 struct TVSkylineSectionFeed: View {
     /// Section rows to page through, in order (already filtered to
     /// non-empty, non-featured by the caller).
@@ -42,11 +42,9 @@ struct TVSkylineSectionFeed: View {
     /// async, so the initial hand-down would land on nothing.
     @State private var pendingFocusRequest: Int?
     @State private var lastAppliedRequest = 0
-    /// Direction of the most recent row page request. Drives the visual
-    /// transition only; focus is still claimed by the newly-mounted row.
-    @State private var pageTransitionDelta = 0
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Namespace private var rowPagingNamespace
 
     var body: some View {
         ZStack(alignment: .top) {
@@ -84,7 +82,6 @@ struct TVSkylineSectionFeed: View {
             // would fall out of range and the band would render nothing,
             // stranding the page blank. Clamp it back into range and re-claim
             // focus so the now-visible row's first card re-primes the marquee.
-            pageTransitionDelta = 0
             if !sections.isEmpty, pageIndex >= sections.count {
                 pageIndex = sections.count - 1
                 contentFocusToken += 1
@@ -98,7 +95,7 @@ struct TVSkylineSectionFeed: View {
     /// One interactive section plus a non-focusable next-row preview in the
     /// lower half of the screen. No scroll view, so the focus engine can't
     /// move the row when navigating across cards. Up/Down page the featured
-    /// row and the stack crossfades.
+    /// row by animating the existing next-row preview into the focused slot.
     @ViewBuilder
     private var pagedBand: some View {
         GeometryReader { proxy in
@@ -116,11 +113,12 @@ struct TVSkylineSectionFeed: View {
                                 section: previewSection,
                                 cardWidth: ContinuumTheme.Skyline.densePosterCardWidth
                             )
+                            .modifier(rowPagingGeometry(for: previewSection))
                         }
                     }
                     .fixedSize(horizontal: false, vertical: true)
                     .id(section.id)
-                    .transition(rowStackTransition)
+                    .transition(.opacity)
                 }
             }
             .frame(width: proxy.size.width, height: visibleBandHeight, alignment: .topLeading)
@@ -154,25 +152,13 @@ struct TVSkylineSectionFeed: View {
         // Natural height so the row hugs its header and top-aligns in the
         // lower-half band rather than stretching.
         .fixedSize(horizontal: false, vertical: true)
+        .modifier(rowPagingGeometry(for: section))
     }
 
     private var nextPreviewSection: ResolvedSection? {
         let nextIndex = pageIndex + 1
         guard sections.indices.contains(nextIndex) else { return nil }
         return sections[nextIndex]
-    }
-
-    private var rowStackTransition: AnyTransition {
-        guard !reduceMotion, pageTransitionDelta != 0 else {
-            return .opacity
-        }
-
-        let insertionEdge: Edge = pageTransitionDelta > 0 ? .bottom : .top
-        let removalEdge: Edge = pageTransitionDelta > 0 ? .top : .bottom
-        return .asymmetric(
-            insertion: .move(edge: insertionEdge).combined(with: .opacity),
-            removal: .move(edge: removalEdge).combined(with: .opacity)
-        )
     }
 
     private var rowPageAnimation: Animation {
@@ -190,7 +176,6 @@ struct TVSkylineSectionFeed: View {
     private func pageBand(by delta: Int) {
         let target = pageIndex + delta
         guard sections.indices.contains(target) else { return }
-        pageTransitionDelta = delta
         pageIndex = target
         contentFocusToken += 1
     }
@@ -213,9 +198,31 @@ struct TVSkylineSectionFeed: View {
         if isTopMenuFocused { return }
         guard request != lastAppliedRequest else { return }
         lastAppliedRequest = request
-        pageTransitionDelta = 0
         pageIndex = 0
         contentFocusToken += 1
+    }
+
+    private func rowPagingGeometry(for section: ResolvedSection) -> TVRowPagingGeometry {
+        TVRowPagingGeometry(
+            id: section.id,
+            namespace: rowPagingNamespace,
+            isEnabled: !reduceMotion
+        )
+    }
+}
+
+private struct TVRowPagingGeometry: ViewModifier {
+    let id: String
+    let namespace: Namespace.ID
+    let isEnabled: Bool
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if isEnabled {
+            content.matchedGeometryEffect(id: id, in: namespace)
+        } else {
+            content
+        }
     }
 }
 

--- a/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
+++ b/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
@@ -2,16 +2,15 @@
 import SwiftUI
 
 /// Shared Skyline landing layout (§6.1): an ambient backdrop, a focus
-/// marquee that passively previews the focused card, and a lower-half row
-/// stack that shows the active section plus a clipped preview of the next
-/// section. Used by **both** Home and the library Browse tabs so the two stay
-/// pixel-identical — the only difference is the sections each feeds in.
+/// marquee that passively previews the focused card, and native vertically
+/// scrolling section rows. Used by **both** Home and the library Browse tabs
+/// so the two stay pixel-identical — the only difference is the sections each
+/// feeds in.
 ///
-/// Paging: there is no scroll view, so the focus engine never moves the row
-/// while navigating across cards. Up/Down page the focused row explicitly and
-/// the next-row preview animates into the focused slot while the outgoing row
-/// fades behind the marquee area. Entry focus lands on the first row's first
-/// card, which the marquee previews immediately.
+/// Row movement is owned by tvOS focus + the vertical scroll view. Each row
+/// remains a native focus section whose first card is the user-initiated
+/// default focus target, so entering a new row starts at the left edge without
+/// custom page-section animation.
 struct TVSkylineSectionFeed: View {
     /// Section rows to page through, in order (already filtered to
     /// non-empty, non-featured by the caller).
@@ -32,27 +31,15 @@ struct TVSkylineSectionFeed: View {
 
     /// Debounced focused-card state driving the marquee + backdrop.
     @State private var marqueeModel = TVFocusMarqueeModel()
-    /// The section currently featured at the top of the lower-half row stack.
-    /// The feed pages one at a time (no scroll view) so the focus engine never
-    /// scrolls the row.
-    @State private var pageIndex = 0
-    /// Token handed to the visible row so its first card claims focus on
-    /// entry and on every page change.
+    /// Token handed to row 1 so its first card claims focus on shell entry.
     @State private var contentFocusToken = 0
+    /// The row currently owning card focus. Bound to the vertical scroll view
+    /// so each focused row lands at the top of the clipped lower band.
+    @State private var focusedSectionID: String?
     /// Entry tokens that arrived before any row mounted — sections load
     /// async, so the initial hand-down would land on nothing.
     @State private var pendingFocusRequest: Int?
     @State private var lastAppliedRequest = 0
-    /// Direction of the most recent row page request. Drives only the outgoing
-    /// row fade direction; focus is still claimed by the newly-mounted row.
-    @State private var pageTransitionDelta = 0
-    /// The row that is leaving during the current page transition. Keeping this
-    /// separate from `pageIndex` lets the outgoing first row stay above the new
-    /// row long enough to visibly slide/fade out.
-    @State private var outgoingPageIndex: Int?
-
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @Namespace private var rowPagingNamespace
 
     var body: some View {
         ZStack(alignment: .top) {
@@ -64,10 +51,10 @@ struct TVSkylineSectionFeed: View {
                 crossfadeDuration: ContinuumTheme.Skyline.marqueeCrossfadeDuration
             )
 
-            // The lower half is a row stack: one interactive focused row plus
-            // a passive peek of the next row below it. It reaches into the
-            // bottom overscan and re-insets via rowBandBottomInset.
-            pagedBand
+            // Native scrolling lives only in the bottom row band. The viewport
+            // clips at its top edge so rows do not paint through the marquee
+            // title, description, and metadata while they scroll upward.
+            scrollingRows
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .ignoresSafeArea(edges: .bottom)
 
@@ -84,131 +71,63 @@ struct TVSkylineSectionFeed: View {
         // Rows mount only after the async section load; a deferred entry
         // token re-fires once they exist.
         .onChange(of: sections.map(\.id)) { _, _ in
-            // Home/library refresh their rows on return (e.g. player dismiss).
-            // If the user had paged down to a row that vanished (Continue
-            // Watching shrinks, permissions/data change), the stale pageIndex
-            // would fall out of range and the band would render nothing,
-            // stranding the page blank. Clamp it back into range and re-claim
-            // focus so the now-visible row's first card re-primes the marquee.
-            pageTransitionDelta = 0
-            outgoingPageIndex = nil
-            if !sections.isEmpty, pageIndex >= sections.count {
-                pageIndex = sections.count - 1
-                contentFocusToken += 1
-            }
             if let pending = pendingFocusRequest { requestEntryFocus(pending) }
         }
     }
 
-    // MARK: - Band
+    // MARK: - Rows
 
-    /// One interactive section plus a non-focusable next-row preview in the
-    /// lower half of the screen. No scroll view, so the focus engine can't
-    /// move the row when navigating across cards. Up/Down page the featured
-    /// row by animating the existing next-row preview into the focused slot.
+    /// Native vertical row scrolling, clipped to the lower band so rows always
+    /// appear from the same bottom area and disappear before the marquee text.
     @ViewBuilder
-    private var pagedBand: some View {
+    private var scrollingRows: some View {
         GeometryReader { proxy in
             let bandHeight = proxy.size.height * ContinuumTheme.Skyline.rowBandHeightFraction
-            let visibleBandHeight = max(0, bandHeight - ContinuumTheme.Skyline.rowBandBottomInset)
+            let visibleBandHeight = max(0, bandHeight)
+            let trailingPreviewPadding = max(
+                0,
+                visibleBandHeight - ContinuumTheme.Skyline.rowBandBottomInset
+            )
 
-            ZStack(alignment: .topLeading) {
-                if sections.indices.contains(pageIndex) {
-                    let section = sections[pageIndex]
-                    VStack(alignment: .leading, spacing: ContinuumTheme.Skyline.rowBandPreviewSpacing) {
-                        featuredRow(section)
-
-                        if let previewSection = nextPreviewSection {
-                            TVSectionRowPreview(
-                                section: previewSection,
-                                cardWidth: ContinuumTheme.Skyline.densePosterCardWidth
-                            )
-                            .modifier(rowPagingGeometry(for: previewSection))
-                        }
+            ScrollView(.vertical, showsIndicators: false) {
+                LazyVStack(alignment: .leading, spacing: ContinuumTheme.Skyline.rowBandPreviewSpacing) {
+                    ForEach(Array(sections.enumerated()), id: \.element.id) { index, section in
+                        featuredRow(section, isFirstRow: index == 0)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .id(section.id)
                     }
-                    .fixedSize(horizontal: false, vertical: true)
-                    .id(section.id)
-                    .zIndex(rowStackZIndex(for: section))
-                    .transition(rowStackTransition)
                 }
+                .scrollTargetLayout()
+                // Allows the final row to top-align like every prior row,
+                // with a blank preview area underneath instead of clamping.
+                .padding(.bottom, trailingPreviewPadding)
             }
+            .scrollTargetBehavior(.viewAligned)
+            .scrollPosition(id: $focusedSectionID, anchor: .top)
             .frame(width: proxy.size.width, height: visibleBandHeight, alignment: .topLeading)
             .clipped()
-            .padding(.bottom, ContinuumTheme.Skyline.rowBandBottomInset)
             .frame(width: proxy.size.width, height: proxy.size.height, alignment: .bottomLeading)
         }
-        .animation(
-            rowPageAnimation,
-            value: pageIndex
-        )
     }
 
     @ViewBuilder
-    private func featuredRow(_ section: ResolvedSection) -> some View {
-        // Row 1 is an items row so entry focus gives the marquee something
-        // rich to preview.
+    private func featuredRow(_ section: ResolvedSection, isFirstRow: Bool) -> some View {
         SectionRow(
             section: section,
             onItemTap: onItemTap,
             prefersDefaultFocusOnFirstItem: true,
-            focusRequest: contentFocusToken,
-            onMoveUp: pageIndex == 0 ? onTopMenuFocusRequest : { pageBand(by: -1) },
+            focusRequest: isFirstRow ? contentFocusToken : 0,
+            onMoveUp: nil,
             onItemFocus: { item in
-                marqueeModel.preview(TVMarqueeContent(item: item, rowTitle: section.title))
+                previewFocusedItem(item, in: section)
             },
             cardWidth: ContinuumTheme.Skyline.densePosterCardWidth,
             cardVerticalPadding: ContinuumTheme.Skyline.rowBandCardVerticalPadding,
-            onMoveDown: { pageBand(by: 1) }
-        )
-        // Natural height so the row hugs its header and top-aligns in the
-        // lower-half band rather than stretching.
-        .fixedSize(horizontal: false, vertical: true)
-        .modifier(rowPagingGeometry(for: section))
-    }
-
-    private var nextPreviewSection: ResolvedSection? {
-        let nextIndex = pageIndex + 1
-        guard sections.indices.contains(nextIndex) else { return nil }
-        return sections[nextIndex]
-    }
-
-    private var rowStackTransition: AnyTransition {
-        guard !reduceMotion, pageTransitionDelta != 0 else {
-            return .opacity
-        }
-
-        let exitOffset = pageTransitionDelta > 0
-            ? -ContinuumTheme.Skyline.rowBandExitOffset
-            : ContinuumTheme.Skyline.rowBandExitOffset
-        let insertion: AnyTransition = pageTransitionDelta < 0
-            ? .offset(y: -ContinuumTheme.Skyline.rowBandExitOffset).combined(with: .opacity)
-            : .opacity
-        return .asymmetric(
-            insertion: insertion,
-            removal: .offset(y: exitOffset).combined(with: .opacity)
+            onMoveDown: nil
         )
     }
 
-    private var rowPageAnimation: Animation {
-        if reduceMotion {
-            return .easeInOut(duration: ContinuumTheme.fastDuration)
-        }
-        return .easeInOut(duration: ContinuumTheme.Skyline.rowBandScrollDuration)
-    }
-
-    // MARK: - Paging & focus
-
-    /// Page the visible band by ±1. Clamps at the ends; Up past the first
-    /// row is handled by the row's onMoveUp (to the top bar). Each page hands
-    /// focus to the new row's first card via the focus token.
-    private func pageBand(by delta: Int) {
-        let target = pageIndex + delta
-        guard sections.indices.contains(target) else { return }
-        outgoingPageIndex = pageIndex
-        pageTransitionDelta = delta
-        pageIndex = target
-        contentFocusToken += 1
-    }
+    // MARK: - Focus
 
     /// Entry focus → the first row's first card. Tokens that arrive before
     /// the rows mount wait as a pending claim. A claim is dropped while the
@@ -228,327 +147,17 @@ struct TVSkylineSectionFeed: View {
         if isTopMenuFocused { return }
         guard request != lastAppliedRequest else { return }
         lastAppliedRequest = request
-        pageTransitionDelta = 0
-        outgoingPageIndex = nil
-        pageIndex = 0
         contentFocusToken += 1
     }
 
-    private func rowPagingGeometry(for section: ResolvedSection) -> TVRowPagingGeometry {
-        TVRowPagingGeometry(
-            id: section.id,
-            namespace: rowPagingNamespace,
-            isEnabled: !reduceMotion
-        )
-    }
+    private func previewFocusedItem(_ item: SectionItem, in section: ResolvedSection) {
+        marqueeModel.preview(TVMarqueeContent(item: item, rowTitle: section.title))
 
-    private func rowStackZIndex(for section: ResolvedSection) -> Double {
-        guard pageTransitionDelta != 0,
-              let index = sections.firstIndex(where: { $0.id == section.id }) else {
-            return 0
-        }
-
-        if pageTransitionDelta > 0 {
-            return index == outgoingPageIndex ? 1 : 0
-        }
-
-        return index == pageIndex ? 1 : 0
-    }
-}
-
-private struct TVRowPagingGeometry: ViewModifier {
-    let id: String
-    let namespace: Namespace.ID
-    let isEnabled: Bool
-
-    @ViewBuilder
-    func body(content: Content) -> some View {
-        if isEnabled {
-            content.matchedGeometryEffect(
-                id: id,
-                in: namespace,
-                properties: .position,
-                anchor: .topLeading
-            )
-        } else {
-            content
+        guard focusedSectionID != section.id else { return }
+        withAnimation(.easeOut(duration: ContinuumTheme.Skyline.rowBandScrollDuration)) {
+            focusedSectionID = section.id
         }
     }
 }
 
-private struct TVSectionRowPreview: View {
-    let section: ResolvedSection
-    let cardWidth: CGFloat
-
-    private var isContinueWatching: Bool {
-        section.sectionType == "continue_watching" || section.sectionType == "in_progress"
-    }
-
-    private var isEpisodeRow: Bool {
-        let type = section.sectionType.lowercased()
-        if type.contains("next") || type.contains("up_next") || type.contains("next_up") {
-            return true
-        }
-        return section.items.contains { $0.type.lowercased() == "episode" }
-    }
-
-    private var isAudiobookRow: Bool {
-        !section.items.isEmpty && section.items.allSatisfy(\.isAudiobook)
-    }
-
-    private var layout: MediaRowLayout {
-        if isContinueWatching { return .thumbnail }
-        if isEpisodeRow { return .thumbnail }
-        if isAudiobookRow { return .square }
-        return .poster
-    }
-
-    private var showProgress: Bool {
-        isContinueWatching || isEpisodeRow
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 20) {
-            header
-
-            HStack(spacing: 40) {
-                ForEach(Array(section.items.prefix(ContinuumTheme.Skyline.rowPreviewItemLimit))) { item in
-                    TVPassivePreviewCard(
-                        item: item,
-                        layout: layout,
-                        showProgress: showProgress,
-                        cardWidth: cardWidth
-                    )
-                }
-            }
-            .padding(.horizontal, ContinuumTheme.safePadding)
-            .padding(.vertical, 24)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .opacity(ContinuumTheme.Skyline.rowPreviewOpacity)
-        .allowsHitTesting(false)
-        .focusEffectDisabled()
-        .accessibilityHidden(true)
-    }
-
-    private var header: some View {
-        HStack(spacing: 14) {
-            if isContinueWatching {
-                Image(systemName: "play.circle.fill")
-                    .font(.system(size: 32, weight: .semibold))
-                    .foregroundColor(.continuumOnSurface)
-            }
-
-            Text(section.title)
-                .font(.continuumHeadline)
-                .foregroundColor(.continuumOnSurface)
-
-            Spacer()
-        }
-        .padding(.horizontal, ContinuumTheme.safePadding)
-    }
-}
-
-private struct TVPassivePreviewCard: View {
-    let item: SectionItem
-    let layout: MediaRowLayout
-    let showProgress: Bool
-    let cardWidth: CGFloat
-
-    var body: some View {
-        switch layout {
-        case .poster, .square:
-            posterCard
-        case .thumbnail:
-            thumbnailCard
-        }
-    }
-
-    private var posterCard: some View {
-        VStack(alignment: .leading, spacing: 22) {
-            posterArtwork
-
-            VStack(alignment: .leading, spacing: 4) {
-                Text(item.title)
-                    .font(.continuumSubheadline)
-                    .foregroundColor(.continuumOnSurface.opacity(0.85))
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-
-                if let year = item.year {
-                    Text(String(year))
-                        .font(.continuumCaption)
-                        .foregroundColor(.continuumSecondaryText)
-                }
-            }
-            .frame(width: posterWidth, alignment: .leading)
-        }
-        .frame(width: posterWidth)
-    }
-
-    private var thumbnailCard: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            thumbnailArtwork
-
-            VStack(alignment: .leading, spacing: 4) {
-                Text(thumbnailTitle)
-                    .font(.continuumSubheadline)
-                    .foregroundColor(.continuumOnSurface.opacity(0.85))
-                    .lineLimit(1)
-
-                if let subtitle = thumbnailSubtitle {
-                    Text(subtitle)
-                        .font(.continuumCaption)
-                        .foregroundColor(.continuumSecondaryText)
-                        .lineLimit(1)
-                }
-            }
-            .frame(width: ContinuumTheme.thumbnailCardWidth, alignment: .leading)
-        }
-        .frame(width: ContinuumTheme.thumbnailCardWidth)
-    }
-
-    private var posterArtwork: some View {
-        ZStack(alignment: .bottom) {
-            AsyncImageView(
-                url: item.posterUrl ?? "",
-                thumbhash: item.posterThumbhash,
-                targetSize: CGSize(width: posterWidth, height: posterHeight),
-                contentMode: .fill
-            )
-            .frame(width: posterWidth, height: posterHeight)
-            .clipped()
-            .clipShape(RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius))
-
-            if let progress = progressValue, progress > 0 {
-                VStack {
-                    Spacer()
-                    ProgressBar(value: progress)
-                }
-                .frame(width: posterWidth, height: posterHeight)
-                .clipShape(RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius))
-            }
-
-            if item.userState?.played == true {
-                watchedBadge
-                    .padding(12)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
-            }
-        }
-        .frame(width: posterWidth, height: posterHeight)
-    }
-
-    private var thumbnailArtwork: some View {
-        ZStack(alignment: .bottomLeading) {
-            AsyncImageView(
-                url: thumbnailImageURL,
-                thumbhash: item.backdropThumbhash ?? item.posterThumbhash,
-                targetSize: CGSize(width: ContinuumTheme.thumbnailCardWidth, height: ContinuumTheme.thumbnailCardHeight),
-                contentMode: .fill
-            )
-            .frame(width: ContinuumTheme.thumbnailCardWidth, height: ContinuumTheme.thumbnailCardHeight)
-            .clipped()
-            .clipShape(RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius))
-
-            LinearGradient(
-                colors: [.clear, .black.opacity(0.75)],
-                startPoint: .center,
-                endPoint: .bottom
-            )
-            .frame(width: ContinuumTheme.thumbnailCardWidth, height: ContinuumTheme.thumbnailCardHeight)
-            .clipShape(RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius))
-
-            if let badge = episodeBadge {
-                Text(badge)
-                    .font(.continuumCaption)
-                    .bold()
-                    .foregroundColor(.white)
-                    .padding(.horizontal, 14)
-                    .padding(.vertical, 7)
-                    .background(Capsule().fill(Color.black.opacity(0.65)))
-                    .padding(14)
-            }
-
-            if let progress = progressValue, progress > 0 {
-                VStack {
-                    Spacer()
-                    ProgressBar(value: progress)
-                }
-                .frame(width: ContinuumTheme.thumbnailCardWidth, height: ContinuumTheme.thumbnailCardHeight)
-                .clipShape(RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius))
-            }
-
-            if item.userState?.played == true {
-                watchedBadge
-                    .padding(14)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
-            }
-        }
-        .frame(width: ContinuumTheme.thumbnailCardWidth, height: ContinuumTheme.thumbnailCardHeight)
-    }
-
-    private var watchedBadge: some View {
-        ZStack {
-            Circle()
-                .fill(Color.continuumOnSurface)
-                .frame(width: 40, height: 40)
-                .shadow(color: .black.opacity(0.3), radius: 4)
-            Image(systemName: "checkmark")
-                .font(.system(size: 20, weight: .bold))
-                .foregroundColor(Color.continuumBackground)
-        }
-    }
-
-    private var posterWidth: CGFloat {
-        cardWidth
-    }
-
-    private var posterHeight: CGFloat {
-        switch layout {
-        case .square:
-            return cardWidth
-        case .poster, .thumbnail:
-            return cardWidth * (ContinuumTheme.posterCardHeight / ContinuumTheme.posterCardWidth)
-        }
-    }
-
-    private var thumbnailImageURL: String {
-        if let backdrop = item.backdropUrl, !backdrop.isEmpty {
-            return backdrop
-        }
-        return item.posterUrl ?? ""
-    }
-
-    private var thumbnailTitle: String {
-        item.seriesTitle ?? item.title
-    }
-
-    private var thumbnailSubtitle: String? {
-        if item.seriesTitle != nil {
-            return item.title
-        }
-        if let year = item.year {
-            return String(year)
-        }
-        return nil
-    }
-
-    private var episodeBadge: String? {
-        guard let season = item.seasonNumber, let episode = item.episodeNumber else {
-            return nil
-        }
-        return "S\(season) · E\(episode)"
-    }
-
-    private var progressValue: Double? {
-        guard showProgress,
-              let position = item.positionSeconds,
-              let duration = item.durationSeconds,
-              duration > 0,
-              position > 0 else {
-            return nil
-        }
-        return position / duration
-    }
-}
 #endif

--- a/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
+++ b/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
@@ -25,9 +25,6 @@ struct TVSkylineSectionFeed: View {
     var isTopMenuFocused: Bool = false
     /// Up at the first page hands focus to the top bar.
     let onTopMenuFocusRequest: (() -> Void)?
-    /// Home uses Back/Menu as a focus ladder: content -> first row/card ->
-    /// top menu. Other Skyline hosts keep the shell's default exit behavior.
-    var resetsToFirstItemOnExit: Bool = false
     /// Open a content item (detail).
     let onItemTap: (String) -> Void
 
@@ -38,9 +35,6 @@ struct TVSkylineSectionFeed: View {
     /// The row currently owning card focus. Bound to the vertical scroll view
     /// so each focused row lands at the top of the clipped lower band.
     @State private var focusedSectionID: String?
-    /// The card currently owning focus. Used by Home's Back/Menu focus ladder
-    /// to distinguish "already on row 1/card 1" from any other content focus.
-    @State private var focusedItemID: String?
     /// Entry tokens that arrived before any row mounted — sections load
     /// async, so the initial hand-down would land on nothing.
     @State private var pendingFocusRequest: Int?
@@ -79,10 +73,8 @@ struct TVSkylineSectionFeed: View {
             if let pending = pendingFocusRequest { requestEntryFocus(pending) }
         }
         .background(
-            TVSkylineRemotePressCatcher(
-                isExitActive: resetsToFirstItemOnExit && !isTopMenuFocused,
+            TVSkylineUpPressCatcher(
                 isUpActive: !isTopMenuFocused && isFocusedOnFirstSection,
-                onExit: handleExitCommand,
                 onMoveUp: { onTopMenuFocusRequest?() }
             )
             .frame(width: 0, height: 0)
@@ -165,24 +157,9 @@ struct TVSkylineSectionFeed: View {
 
     private func previewFocusedItem(_ item: SectionItem, in section: ResolvedSection) {
         marqueeModel.preview(TVMarqueeContent(item: item, rowTitle: section.title))
-        focusedItemID = item.contentId
 
         guard focusedSectionID != section.id else { return }
         focusedSectionID = section.id
-    }
-
-    private func handleExitCommand() {
-        guard !isFocusedOnFirstItem else {
-            onTopMenuFocusRequest?()
-            return
-        }
-        focusFirstItem()
-    }
-
-    private var isFocusedOnFirstItem: Bool {
-        guard let firstSection = sections.first,
-              let firstItem = firstSection.items.first else { return false }
-        return focusedSectionID == firstSection.id && focusedItemID == firstItem.contentId
     }
 
     private var isFocusedOnFirstSection: Bool {
@@ -190,50 +167,33 @@ struct TVSkylineSectionFeed: View {
         return focusedSectionID == firstSection.id
     }
 
-    private func focusFirstItem() {
-        guard let firstSection = sections.first else {
-            onTopMenuFocusRequest?()
-            return
-        }
-
-        focusedSectionID = firstSection.id
-        contentFocusToken += 1
-    }
-
 }
 
-private struct TVSkylineRemotePressCatcher: UIViewRepresentable {
-    var isExitActive: Bool
+private struct TVSkylineUpPressCatcher: UIViewRepresentable {
     var isUpActive: Bool
-    let onExit: () -> Void
     let onMoveUp: () -> Void
 
-    func makeUIView(context: Context) -> TVSkylineRemotePressUIView {
-        let view = TVSkylineRemotePressUIView()
+    func makeUIView(context: Context) -> TVSkylineUpPressUIView {
+        let view = TVSkylineUpPressUIView()
         apply(to: view)
         return view
     }
 
-    func updateUIView(_ uiView: TVSkylineRemotePressUIView, context: Context) {
+    func updateUIView(_ uiView: TVSkylineUpPressUIView, context: Context) {
         apply(to: uiView)
     }
 
-    private func apply(to view: TVSkylineRemotePressUIView) {
-        view.isExitActive = isExitActive
+    private func apply(to view: TVSkylineUpPressUIView) {
         view.isUpActive = isUpActive
-        view.onExit = onExit
         view.onMoveUp = onMoveUp
     }
 }
 
-private final class TVSkylineRemotePressUIView: UIView, UIGestureRecognizerDelegate {
-    var isExitActive = false
+private final class TVSkylineUpPressUIView: UIView, UIGestureRecognizerDelegate {
     var isUpActive = false
-    var onExit: () -> Void = {}
     var onMoveUp: () -> Void = {}
 
     private weak var attachedWindow: UIWindow?
-    private var exitRecognizer: UITapGestureRecognizer?
     private var upRecognizer: UITapGestureRecognizer?
 
     override func didMoveToWindow() {
@@ -251,38 +211,22 @@ private final class TVSkylineRemotePressUIView: UIView, UIGestureRecognizerDeleg
 
         guard let window else { return }
 
-        let exitRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleExitPress(_:)))
-        exitRecognizer.allowedPressTypes = [NSNumber(value: UIPress.PressType.menu.rawValue)]
-        exitRecognizer.cancelsTouchesInView = true
-        exitRecognizer.delegate = self
-
         let upRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleUpPress(_:)))
         upRecognizer.allowedPressTypes = [NSNumber(value: UIPress.PressType.upArrow.rawValue)]
         upRecognizer.cancelsTouchesInView = true
         upRecognizer.delegate = self
 
-        window.addGestureRecognizer(exitRecognizer)
         window.addGestureRecognizer(upRecognizer)
         attachedWindow = window
-        self.exitRecognizer = exitRecognizer
         self.upRecognizer = upRecognizer
     }
 
     private func detachRecognizers() {
-        if let exitRecognizer, let attachedWindow {
-            attachedWindow.removeGestureRecognizer(exitRecognizer)
-        }
         if let upRecognizer, let attachedWindow {
             attachedWindow.removeGestureRecognizer(upRecognizer)
         }
-        exitRecognizer = nil
         upRecognizer = nil
         attachedWindow = nil
-    }
-
-    @objc private func handleExitPress(_ recognizer: UITapGestureRecognizer) {
-        guard isExitActive, recognizer.state == .ended else { return }
-        onExit()
     }
 
     @objc private func handleUpPress(_ recognizer: UITapGestureRecognizer) {
@@ -291,9 +235,6 @@ private final class TVSkylineRemotePressUIView: UIView, UIGestureRecognizerDeleg
     }
 
     override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-        if gestureRecognizer === exitRecognizer {
-            return isExitActive
-        }
         if gestureRecognizer === upRecognizer {
             return isUpActive
         }

--- a/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
+++ b/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
@@ -1,5 +1,6 @@
 #if os(tvOS)
 import SwiftUI
+import UIKit
 
 /// Shared Skyline landing layout (§6.1): an ambient backdrop, a focus
 /// marquee that passively previews the focused card, and native vertically
@@ -77,9 +78,15 @@ struct TVSkylineSectionFeed: View {
         .onChange(of: sections.map(\.id)) { _, _ in
             if let pending = pendingFocusRequest { requestEntryFocus(pending) }
         }
-        .modifier(TVSkylineExitHandler(isEnabled: resetsToFirstItemOnExit) {
-            handleExitCommand()
-        })
+        .background(
+            TVSkylineRemotePressCatcher(
+                isExitActive: resetsToFirstItemOnExit && !isTopMenuFocused,
+                isUpActive: !isTopMenuFocused && isFocusedOnFirstSection,
+                onExit: handleExitCommand,
+                onMoveUp: { onTopMenuFocusRequest?() }
+            )
+            .frame(width: 0, height: 0)
+        )
     }
 
     // MARK: - Rows
@@ -110,7 +117,6 @@ struct TVSkylineSectionFeed: View {
                 .padding(.bottom, trailingPreviewPadding)
             }
             .scrollTargetBehavior(.viewAligned)
-            .scrollPosition(id: $focusedSectionID, anchor: .top)
             .frame(width: proxy.size.width, height: visibleBandHeight, alignment: .topLeading)
             .clipped()
             .frame(width: proxy.size.width, height: proxy.size.height, alignment: .bottomLeading)
@@ -162,9 +168,7 @@ struct TVSkylineSectionFeed: View {
         focusedItemID = item.contentId
 
         guard focusedSectionID != section.id else { return }
-        withAnimation(.easeOut(duration: ContinuumTheme.Skyline.rowBandScrollDuration)) {
-            focusedSectionID = section.id
-        }
+        focusedSectionID = section.id
     }
 
     private func handleExitCommand() {
@@ -181,30 +185,119 @@ struct TVSkylineSectionFeed: View {
         return focusedSectionID == firstSection.id && focusedItemID == firstItem.contentId
     }
 
+    private var isFocusedOnFirstSection: Bool {
+        guard let firstSection = sections.first else { return false }
+        return focusedSectionID == firstSection.id
+    }
+
     private func focusFirstItem() {
         guard let firstSection = sections.first else {
             onTopMenuFocusRequest?()
             return
         }
 
-        withAnimation(.easeOut(duration: ContinuumTheme.Skyline.rowBandScrollDuration)) {
-            focusedSectionID = firstSection.id
-        }
+        focusedSectionID = firstSection.id
         contentFocusToken += 1
+    }
+
+}
+
+private struct TVSkylineRemotePressCatcher: UIViewRepresentable {
+    var isExitActive: Bool
+    var isUpActive: Bool
+    let onExit: () -> Void
+    let onMoveUp: () -> Void
+
+    func makeUIView(context: Context) -> TVSkylineRemotePressUIView {
+        let view = TVSkylineRemotePressUIView()
+        apply(to: view)
+        return view
+    }
+
+    func updateUIView(_ uiView: TVSkylineRemotePressUIView, context: Context) {
+        apply(to: uiView)
+    }
+
+    private func apply(to view: TVSkylineRemotePressUIView) {
+        view.isExitActive = isExitActive
+        view.isUpActive = isUpActive
+        view.onExit = onExit
+        view.onMoveUp = onMoveUp
     }
 }
 
-private struct TVSkylineExitHandler: ViewModifier {
-    let isEnabled: Bool
-    let onExit: () -> Void
+private final class TVSkylineRemotePressUIView: UIView, UIGestureRecognizerDelegate {
+    var isExitActive = false
+    var isUpActive = false
+    var onExit: () -> Void = {}
+    var onMoveUp: () -> Void = {}
 
-    @ViewBuilder
-    func body(content: Content) -> some View {
-        if isEnabled {
-            content.onExitCommand(perform: onExit)
-        } else {
-            content
+    private weak var attachedWindow: UIWindow?
+    private var exitRecognizer: UITapGestureRecognizer?
+    private var upRecognizer: UITapGestureRecognizer?
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        attachRecognizersIfNeeded()
+    }
+
+    deinit {
+        detachRecognizers()
+    }
+
+    private func attachRecognizersIfNeeded() {
+        guard attachedWindow !== window else { return }
+        detachRecognizers()
+
+        guard let window else { return }
+
+        let exitRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleExitPress(_:)))
+        exitRecognizer.allowedPressTypes = [NSNumber(value: UIPress.PressType.menu.rawValue)]
+        exitRecognizer.cancelsTouchesInView = true
+        exitRecognizer.delegate = self
+
+        let upRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleUpPress(_:)))
+        upRecognizer.allowedPressTypes = [NSNumber(value: UIPress.PressType.upArrow.rawValue)]
+        upRecognizer.cancelsTouchesInView = true
+        upRecognizer.delegate = self
+
+        window.addGestureRecognizer(exitRecognizer)
+        window.addGestureRecognizer(upRecognizer)
+        attachedWindow = window
+        self.exitRecognizer = exitRecognizer
+        self.upRecognizer = upRecognizer
+    }
+
+    private func detachRecognizers() {
+        if let exitRecognizer, let attachedWindow {
+            attachedWindow.removeGestureRecognizer(exitRecognizer)
         }
+        if let upRecognizer, let attachedWindow {
+            attachedWindow.removeGestureRecognizer(upRecognizer)
+        }
+        exitRecognizer = nil
+        upRecognizer = nil
+        attachedWindow = nil
+    }
+
+    @objc private func handleExitPress(_ recognizer: UITapGestureRecognizer) {
+        guard isExitActive, recognizer.state == .ended else { return }
+        onExit()
+    }
+
+    @objc private func handleUpPress(_ recognizer: UITapGestureRecognizer) {
+        guard isUpActive, recognizer.state == .ended else { return }
+        onMoveUp()
+    }
+
+    override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        if gestureRecognizer === exitRecognizer {
+            return isExitActive
+        }
+        if gestureRecognizer === upRecognizer {
+            return isUpActive
+        }
+        return false
     }
 }
 

--- a/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
+++ b/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
@@ -24,6 +24,9 @@ struct TVSkylineSectionFeed: View {
     var isTopMenuFocused: Bool = false
     /// Up at the first page hands focus to the top bar.
     let onTopMenuFocusRequest: (() -> Void)?
+    /// Home uses Back/Menu as a focus ladder: content -> first row/card ->
+    /// top menu. Other Skyline hosts keep the shell's default exit behavior.
+    var resetsToFirstItemOnExit: Bool = false
     /// Open a content item (detail).
     let onItemTap: (String) -> Void
 
@@ -34,6 +37,9 @@ struct TVSkylineSectionFeed: View {
     /// The row currently owning card focus. Bound to the vertical scroll view
     /// so each focused row lands at the top of the clipped lower band.
     @State private var focusedSectionID: String?
+    /// The card currently owning focus. Used by Home's Back/Menu focus ladder
+    /// to distinguish "already on row 1/card 1" from any other content focus.
+    @State private var focusedItemID: String?
     /// Entry tokens that arrived before any row mounted — sections load
     /// async, so the initial hand-down would land on nothing.
     @State private var pendingFocusRequest: Int?
@@ -71,6 +77,9 @@ struct TVSkylineSectionFeed: View {
         .onChange(of: sections.map(\.id)) { _, _ in
             if let pending = pendingFocusRequest { requestEntryFocus(pending) }
         }
+        .modifier(TVSkylineExitHandler(isEnabled: resetsToFirstItemOnExit) {
+            handleExitCommand()
+        })
     }
 
     // MARK: - Rows
@@ -150,10 +159,51 @@ struct TVSkylineSectionFeed: View {
 
     private func previewFocusedItem(_ item: SectionItem, in section: ResolvedSection) {
         marqueeModel.preview(TVMarqueeContent(item: item, rowTitle: section.title))
+        focusedItemID = item.contentId
 
         guard focusedSectionID != section.id else { return }
         withAnimation(.easeOut(duration: ContinuumTheme.Skyline.rowBandScrollDuration)) {
             focusedSectionID = section.id
+        }
+    }
+
+    private func handleExitCommand() {
+        guard !isFocusedOnFirstItem else {
+            onTopMenuFocusRequest?()
+            return
+        }
+        focusFirstItem()
+    }
+
+    private var isFocusedOnFirstItem: Bool {
+        guard let firstSection = sections.first,
+              let firstItem = firstSection.items.first else { return false }
+        return focusedSectionID == firstSection.id && focusedItemID == firstItem.contentId
+    }
+
+    private func focusFirstItem() {
+        guard let firstSection = sections.first else {
+            onTopMenuFocusRequest?()
+            return
+        }
+
+        withAnimation(.easeOut(duration: ContinuumTheme.Skyline.rowBandScrollDuration)) {
+            focusedSectionID = firstSection.id
+        }
+        contentFocusToken += 1
+    }
+}
+
+private struct TVSkylineExitHandler: ViewModifier {
+    let isEnabled: Bool
+    let onExit: () -> Void
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if isEnabled {
+            content.onExitCommand(perform: onExit)
+        } else {
+            content
         }
     }
 }

--- a/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
+++ b/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
@@ -1,6 +1,5 @@
 #if os(tvOS)
 import SwiftUI
-import UIKit
 
 /// Shared Skyline landing layout (§6.1): an ambient backdrop, a focus
 /// marquee that passively previews the focused card, and native vertically
@@ -32,9 +31,6 @@ struct TVSkylineSectionFeed: View {
     @State private var marqueeModel = TVFocusMarqueeModel()
     /// Token handed to row 1 so its first card claims focus on shell entry.
     @State private var contentFocusToken = 0
-    /// The row currently owning card focus. Bound to the vertical scroll view
-    /// so each focused row lands at the top of the clipped lower band.
-    @State private var focusedSectionID: String?
     /// Entry tokens that arrived before any row mounted — sections load
     /// async, so the initial hand-down would land on nothing.
     @State private var pendingFocusRequest: Int?
@@ -72,13 +68,6 @@ struct TVSkylineSectionFeed: View {
         .onChange(of: sections.map(\.id)) { _, _ in
             if let pending = pendingFocusRequest { requestEntryFocus(pending) }
         }
-        .background(
-            TVSkylineUpPressCatcher(
-                isUpActive: !isTopMenuFocused && isFocusedOnFirstSection,
-                onMoveUp: { onTopMenuFocusRequest?() }
-            )
-            .frame(width: 0, height: 0)
-        )
     }
 
     // MARK: - Rows
@@ -122,7 +111,7 @@ struct TVSkylineSectionFeed: View {
             onItemTap: onItemTap,
             prefersDefaultFocusOnFirstItem: false,
             focusRequest: isFirstRow ? contentFocusToken : 0,
-            onMoveUp: nil,
+            onMoveUp: isFirstRow ? onTopMenuFocusRequest : nil,
             onItemFocus: { item in
                 previewFocusedItem(item, in: section)
             },
@@ -157,89 +146,8 @@ struct TVSkylineSectionFeed: View {
 
     private func previewFocusedItem(_ item: SectionItem, in section: ResolvedSection) {
         marqueeModel.preview(TVMarqueeContent(item: item, rowTitle: section.title))
-
-        guard focusedSectionID != section.id else { return }
-        focusedSectionID = section.id
     }
 
-    private var isFocusedOnFirstSection: Bool {
-        guard let firstSection = sections.first else { return false }
-        return focusedSectionID == firstSection.id
-    }
-
-}
-
-private struct TVSkylineUpPressCatcher: UIViewRepresentable {
-    var isUpActive: Bool
-    let onMoveUp: () -> Void
-
-    func makeUIView(context: Context) -> TVSkylineUpPressUIView {
-        let view = TVSkylineUpPressUIView()
-        apply(to: view)
-        return view
-    }
-
-    func updateUIView(_ uiView: TVSkylineUpPressUIView, context: Context) {
-        apply(to: uiView)
-    }
-
-    private func apply(to view: TVSkylineUpPressUIView) {
-        view.isUpActive = isUpActive
-        view.onMoveUp = onMoveUp
-    }
-}
-
-private final class TVSkylineUpPressUIView: UIView, UIGestureRecognizerDelegate {
-    var isUpActive = false
-    var onMoveUp: () -> Void = {}
-
-    private weak var attachedWindow: UIWindow?
-    private var upRecognizer: UITapGestureRecognizer?
-
-    override func didMoveToWindow() {
-        super.didMoveToWindow()
-        attachRecognizersIfNeeded()
-    }
-
-    deinit {
-        detachRecognizers()
-    }
-
-    private func attachRecognizersIfNeeded() {
-        guard attachedWindow !== window else { return }
-        detachRecognizers()
-
-        guard let window else { return }
-
-        let upRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleUpPress(_:)))
-        upRecognizer.allowedPressTypes = [NSNumber(value: UIPress.PressType.upArrow.rawValue)]
-        upRecognizer.cancelsTouchesInView = true
-        upRecognizer.delegate = self
-
-        window.addGestureRecognizer(upRecognizer)
-        attachedWindow = window
-        self.upRecognizer = upRecognizer
-    }
-
-    private func detachRecognizers() {
-        if let upRecognizer, let attachedWindow {
-            attachedWindow.removeGestureRecognizer(upRecognizer)
-        }
-        upRecognizer = nil
-        attachedWindow = nil
-    }
-
-    @objc private func handleUpPress(_ recognizer: UITapGestureRecognizer) {
-        guard isUpActive, recognizer.state == .ended else { return }
-        onMoveUp()
-    }
-
-    override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-        if gestureRecognizer === upRecognizer {
-            return isUpActive
-        }
-        return false
-    }
 }
 
 #endif

--- a/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
+++ b/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
@@ -240,6 +240,7 @@ private struct TVSectionRowPreview: View {
     }
 
     private var layout: MediaRowLayout {
+        if isContinueWatching { return .thumbnail }
         if isEpisodeRow { return .thumbnail }
         if isAudiobookRow { return .square }
         return .poster

--- a/iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift
@@ -411,7 +411,7 @@ struct TVTopMenuBar: View {
         !isFocusSuppressed
             && focusedItem != nil
             && !panelHasFocus
-            && (openPanel != nil || onExit != nil)
+            && (openPanel != nil || isFocusedAwayFromHome || onExit != nil)
     }
 
     private func handleExitPress() {
@@ -419,7 +419,20 @@ struct TVTopMenuBar: View {
             onDwell(nil)
             return
         }
+        if isFocusedAwayFromHome {
+            if selectedRoot == .home {
+                focusedItem = .root(.home)
+                isMenuFocused = true
+            } else {
+                onExit?()
+            }
+            return
+        }
         onExit?()
+    }
+
+    private var isFocusedAwayFromHome: Bool {
+        focusedItem != nil && focusedItem != .root(.home)
     }
 
     // MARK: - Dwell (§5.3, §5.8)

--- a/iosApp/scripts/strip-ffmpeg-framework-signatures.sh
+++ b/iosApp/scripts/strip-ffmpeg-framework-signatures.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${PLATFORM_NAME:-}" in
+  iphoneos|appletvos)
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+roots=()
+
+if [[ -n "${BUILD_DIR:-}" && "${BUILD_DIR}" == *"/Build/"* ]]; then
+  derived_data_root="${BUILD_DIR%%/Build/*}"
+  roots+=("${derived_data_root}/SourcePackages/artifacts/ffmpeg-build")
+fi
+
+if [[ -n "${SRCROOT:-}" ]]; then
+  roots+=("${SRCROOT}/build/SourcePackages/artifacts/ffmpeg-build")
+fi
+
+if [[ -n "${TARGET_BUILD_DIR:-}" && -n "${FRAMEWORKS_FOLDER_PATH:-}" ]]; then
+  roots+=("${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}")
+fi
+
+for root in "${roots[@]}"; do
+  [[ -d "${root}" ]] || continue
+  find "${root}" -type d -name _CodeSignature -prune -exec rm -rf {} +
+done


### PR DESCRIPTION
## Summary

- Replace the Skyline row pager with native vertical focus scrolling, clipped to the lower row band so rows disappear behind the marquee/title area.
- Tune row scroll behavior, row targets, preview spacing, and bottom padding so the focused row lands consistently and the final row still has a blank preview area below it.
- Fix tvOS Continue Watching resume rows so they keep the horizontal thumbnail layout, including movie-only resume rows.
- Restore native row focus behavior instead of forcing every row transition back to the first item.
- Refine top menu and Back/Menu behavior: Back from Home content returns to the top menu, top-menu Back can return to Home, and selecting Home hands focus back to the top-left content item.
- Reduce the tvOS startup splash video size.

## Why

The branch moves Home and library Skyline rows away from custom page-section animations toward native tvOS focus scrolling. That keeps row movement smoother and more predictable while preserving the clipped Skyline presentation where rows emerge from the bottom and hide behind the hero text area.

The earlier custom Back/Menu ladder depended on cached row focus state and was unreliable. The final behavior keeps Back simple: Home content returns to the top menu, and pressing Home from the menu is the path that re-enters the first content item.

## Validation

- `xcodebuild build -project Silo.xcodeproj -scheme SiloTV -destination 'generic/platform=tvOS Simulator' -derivedDataPath /tmp/silo-apple-derived CODE_SIGNING_ALLOWED=NO`

## Scope

Changed files:

- `iosApp/iosApp/Components/EpisodeThumbCard.swift`
- `iosApp/iosApp/Components/MediaRow.swift`
- `iosApp/iosApp/Components/StartupSplashView.swift`
- `iosApp/iosApp/Screens/Home/SectionRow.swift`
- `iosApp/iosApp/Theme/ContinuumTheme.swift`
- `iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift`
- `iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift`
