### PR TITLE
[codex] Fix tvOS Home wake recovery

### DIFF
--- a/iosApp/iosApp/Components/ErrorView.swift
+++ b/iosApp/iosApp/Components/ErrorView.swift
@@ -85,7 +85,7 @@ struct ErrorView: View {
         if let goBack = resolvedOnGoBack {
             return Action(title: "Go Back", run: goBack)
         }
-        return Action(title: "Sign In Again", run: resolvedOnSignOut)
+        return nil
     }
 
     private var secondaryAction: Action? {
@@ -94,8 +94,8 @@ struct ErrorView: View {
         }
         if state.isNotFound, resolvedOnGoBack != nil {
             if let onRetry { return Action(title: "Try Again", run: onRetry) }
-            return Action(title: "Sign Out", run: resolvedOnSignOut)
+            return nil
         }
-        return Action(title: "Sign Out", run: resolvedOnSignOut)
+        return nil
     }
 }

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -92,6 +92,9 @@ struct ContentView: View {
             guard newPhase == .active,
                   router.authState == .authenticated else { return }
             Task { await overlayPrefs.hydrateIfNeeded() }
+            #if os(tvOS)
+            NotificationCenter.default.post(name: .homeSectionsShouldRefresh, object: nil)
+            #endif
         }
     }
 

--- a/iosApp/iosApp/Screens/Home/HomeViewModel.swift
+++ b/iosApp/iosApp/Screens/Home/HomeViewModel.swift
@@ -37,17 +37,38 @@ class HomeViewModel {
         error = nil
 
         do {
-            let response = try await StartupContentPrefetcher.fetchHomeSections()
-            sections = response.sections.filter { !$0.items.isEmpty }
+            try await fetchAndApplySections()
         } catch let err {
             // Don't blow away painted content on a transient failure —
             // surface the error only when there's nothing to show.
             if sections.isEmpty {
-                self.error = ErrorState(err)
+                let state = ErrorState(err)
+                if state.isTransient {
+                    await retryTransientInitialLoad()
+                } else {
+                    self.error = state
+                }
             }
         }
 
         isLoading = false
         isRefreshing = false
+    }
+
+    private func fetchAndApplySections() async throws {
+        let response = try await StartupContentPrefetcher.fetchHomeSections()
+        sections = response.sections.filter { !$0.items.isEmpty }
+        error = nil
+    }
+
+    private func retryTransientInitialLoad() async {
+        try? await Task.sleep(nanoseconds: 750_000_000)
+        guard !Task.isCancelled else { return }
+
+        do {
+            try await fetchAndApplySections()
+        } catch {
+            self.error = ErrorState(error)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Retry one transient empty Home load before surfacing the generic server error.
- Refresh Home on tvOS foreground/wake while the app is authenticated.
- Remove the sign-out fallback from generic retryable errors so users are not steered toward signing out for a network hiccup.

## Verification
- Built `SiloTV` for the tvOS simulator.
- Paired the tvOS simulator app to the dev server through the TV pairing flow, selected a profile, and confirmed Home loaded media content.
- Simulated display sleep/wake in the tvOS simulator and confirmed authenticated Home remained visible without the generic server/sign-out error.
- Ran `git diff --check`.
- Ran `privacy-leak-check` on the staged diff, commit message, and PR body.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added automatic retry mechanism for temporary loading failures, improving app resilience
  * Enhanced home content refresh behavior on tvOS when returning to the app from the background

* **User Experience**
  * Simplified error dialogs with streamlined action buttons

<!-- end of auto-generated comment: release notes by coderabbit.ai -->