### PR TITLE
[codex] Use catalog API for iOS history

### DIFF
--- a/iosApp/iosApp/Networking/ContinuumAPI.swift
+++ b/iosApp/iosApp/Networking/ContinuumAPI.swift
@@ -482,6 +482,22 @@ actor ContinuumAPI {
         try await http.get("/api/v1/catalog", query: query)
     }
 
+    func historyCatalog(
+        offset: Int,
+        limit: Int,
+        snapshot: String? = nil,
+        includeTotal: Bool = true
+    ) async throws -> CatalogResponse {
+        var query: [String: String] = [
+            "source": "history",
+            "offset": String(offset),
+            "limit": String(limit),
+        ]
+        if let snapshot { query["snapshot"] = snapshot }
+        if !includeTotal { query["include_total"] = "false" }
+        return try await catalog(query: query)
+    }
+
     func itemDetail(contentId: String) async throws -> ItemDetail {
         try await http.get("/api/v1/catalog/items/\(contentId)")
     }

--- a/iosApp/iosApp/Screens/Personal/HistoryView.swift
+++ b/iosApp/iosApp/Screens/Personal/HistoryView.swift
@@ -2,24 +2,16 @@ import SwiftUI
 
 /// List of recently watched items from the user's history.
 struct HistoryView: View {
-    @State private var items: [BrowseItem] = []
-    @State private var isLoading = false
-    @State private var error: ErrorState?
-    @State private var hasMore = true
-    @State private var totalItems: Int?
-    @State private var nextOffset = 0
-    @State private var snapshot: String?
+    @State private var viewModel = HistoryViewModel()
     @Environment(AppRouter.self) private var router
-
-    private let pageSize = 60
 
     var body: some View {
         Group {
-            if !items.isEmpty {
+            if !viewModel.items.isEmpty {
                 gridContent
-            } else if let error {
-                ErrorView(state: error, onRetry: { Task { await loadHistory(reset: true) } })
-            } else if isLoading {
+            } else if let error = viewModel.error {
+                ErrorView(state: error, onRetry: { Task { await viewModel.load(reset: true) } })
+            } else if viewModel.isLoading {
                 // tvOS: this is a pushed destination, so the top menu bar
                 // isn't there to hold focus — without a focusable element
                 // the remote goes dead until the grid renders.
@@ -39,29 +31,29 @@ struct HistoryView: View {
         .navigationTitle("History")
         .continuumNavigationTitleDisplayMode(.large)
         .task {
-            await loadHistory(reset: true)
+            await viewModel.load(reset: true)
         }
         .refreshable {
-            await loadHistory(reset: true)
+            await viewModel.load(reset: true)
         }
     }
 
     private var gridContent: some View {
         ScrollView(.vertical, showsIndicators: false) {
             VStack(alignment: .leading, spacing: ContinuumTheme.padding) {
-                Text(countLabel)
+                Text(viewModel.countLabel)
                     .font(.continuumCaption)
                     .foregroundColor(.continuumSecondaryText)
 
                 CatalogGrid(
-                    items: items,
-                    isLoading: isLoading,
-                    hasMore: hasMore,
+                    items: viewModel.items,
+                    isLoading: viewModel.isLoading,
+                    hasMore: viewModel.hasMore,
                     onItemTap: { contentId in
                         router.navigate(to: .itemDetail(contentId: contentId))
                     },
                     onLoadMore: {
-                        Task { await loadMoreIfNeeded() }
+                        Task { await viewModel.load(reset: false) }
                     }
                 )
             }
@@ -69,69 +61,5 @@ struct HistoryView: View {
             .padding(.top, ContinuumTheme.smallPadding)
             .padding(.bottom, ContinuumTheme.largePadding)
         }
-    }
-
-    private var countLabel: String {
-        if let totalItems {
-            return "\(totalItems) item\(totalItems == 1 ? "" : "s")"
-        }
-        let suffix = hasMore ? "+" : ""
-        return "\(items.count)\(suffix) item\(items.count == 1 && !hasMore ? "" : "s")"
-    }
-
-    private func loadMoreIfNeeded() async {
-        guard hasMore, !isLoading else { return }
-        await loadHistory(reset: false)
-    }
-
-    private func loadHistory(reset: Bool) async {
-        guard !isLoading else { return }
-        if reset {
-            if items.isEmpty,
-               let cached: CatalogResponse = ResponseCache.shared.get(CacheKey.history) {
-                items = cached.items
-                hasMore = cached.hasMore ?? false
-                totalItems = cached.totalExact == false ? nil : cached.total
-                nextOffset = cached.items.count
-                snapshot = cached.snapshot
-            } else {
-                hasMore = true
-                nextOffset = 0
-                snapshot = nil
-            }
-        }
-        guard reset || hasMore else { return }
-
-        isLoading = true
-        error = nil
-        let requestOffset = reset ? 0 : nextOffset
-        let requestSnapshot = reset ? nil : snapshot
-        do {
-            let response = try await ContinuumAPI.shared.historyCatalog(
-                offset: requestOffset,
-                limit: pageSize,
-                snapshot: requestSnapshot,
-                includeTotal: reset
-            )
-            if reset {
-                items = response.items
-                ResponseCache.shared.set(response, for: CacheKey.history)
-            } else {
-                items.append(contentsOf: response.items)
-            }
-            if response.totalExact != false {
-                totalItems = response.total
-            }
-            hasMore = response.hasMore ?? false
-            nextOffset = requestOffset + response.items.count
-            if reset || snapshot == nil {
-                snapshot = response.snapshot
-            }
-        } catch let err {
-            if items.isEmpty {
-                self.error = ErrorState(err)
-            }
-        }
-        isLoading = false
     }
 }

--- a/iosApp/iosApp/Screens/Personal/HistoryView.swift
+++ b/iosApp/iosApp/Screens/Personal/HistoryView.swift
@@ -5,19 +5,20 @@ struct HistoryView: View {
     @State private var items: [BrowseItem] = []
     @State private var isLoading = false
     @State private var error: ErrorState?
+    @State private var hasMore = true
+    @State private var totalItems: Int?
+    @State private var nextOffset = 0
+    @State private var snapshot: String?
     @Environment(AppRouter.self) private var router
-    @Environment(\.horizontalSizeClass) private var hSize
 
-    private var columns: [GridItem] {
-        AdaptiveColumns.posters(for: hSize)
-    }
+    private let pageSize = 60
 
     var body: some View {
         Group {
             if !items.isEmpty {
                 gridContent
             } else if let error {
-                ErrorView(state: error, onRetry: { Task { await loadHistory() } })
+                ErrorView(state: error, onRetry: { Task { await loadHistory(reset: true) } })
             } else if isLoading {
                 // tvOS: this is a pushed destination, so the top menu bar
                 // isn't there to hold focus — without a focusable element
@@ -38,50 +39,94 @@ struct HistoryView: View {
         .navigationTitle("History")
         .continuumNavigationTitleDisplayMode(.large)
         .task {
-            await loadHistory()
+            await loadHistory(reset: true)
         }
         .refreshable {
-            await loadHistory()
+            await loadHistory(reset: true)
         }
     }
 
     private var gridContent: some View {
-        ScrollView {
-            LazyVGrid(columns: columns, spacing: 16) {
-                ForEach(items) { item in
-                    MediaCard(
-                        title: item.title,
-                        posterUrl: item.posterUrl ?? "",
-                        thumbhash: item.posterThumbhash,
-                        year: item.year,
-                        userState: item.userState,
-                        overlayData: OverlayData.from(item),
-                        action: {
-                            router.navigate(to: .itemDetail(contentId: item.contentId))
-                        }
-                    )
-                    .frame(maxWidth: .infinity)
-                }
+        ScrollView(.vertical, showsIndicators: false) {
+            VStack(alignment: .leading, spacing: ContinuumTheme.padding) {
+                Text(countLabel)
+                    .font(.continuumCaption)
+                    .foregroundColor(.continuumSecondaryText)
+
+                CatalogGrid(
+                    items: items,
+                    isLoading: isLoading,
+                    hasMore: hasMore,
+                    onItemTap: { contentId in
+                        router.navigate(to: .itemDetail(contentId: contentId))
+                    },
+                    onLoadMore: {
+                        Task { await loadMoreIfNeeded() }
+                    }
+                )
             }
-            .padding(ContinuumTheme.padding)
+            .padding(.horizontal, ContinuumTheme.padding)
+            .padding(.top, ContinuumTheme.smallPadding)
+            .padding(.bottom, ContinuumTheme.largePadding)
         }
     }
 
-    private func loadHistory() async {
-        if items.isEmpty,
-           let cached: CatalogResponse = ResponseCache.shared.get(CacheKey.history) {
-            items = cached.items
+    private var countLabel: String {
+        if let totalItems {
+            return "\(totalItems) item\(totalItems == 1 ? "" : "s")"
         }
-        if items.isEmpty {
-            isLoading = true
+        let suffix = hasMore ? "+" : ""
+        return "\(items.count)\(suffix) item\(items.count == 1 && !hasMore ? "" : "s")"
+    }
+
+    private func loadMoreIfNeeded() async {
+        guard hasMore, !isLoading else { return }
+        await loadHistory(reset: false)
+    }
+
+    private func loadHistory(reset: Bool) async {
+        guard !isLoading else { return }
+        if reset {
+            if items.isEmpty,
+               let cached: CatalogResponse = ResponseCache.shared.get(CacheKey.history) {
+                items = cached.items
+                hasMore = cached.hasMore ?? false
+                totalItems = cached.totalExact == false ? nil : cached.total
+                nextOffset = cached.items.count
+                snapshot = cached.snapshot
+            } else {
+                hasMore = true
+                nextOffset = 0
+                snapshot = nil
+            }
         }
+        guard reset || hasMore else { return }
+
+        isLoading = true
         error = nil
+        let requestOffset = reset ? 0 : nextOffset
+        let requestSnapshot = reset ? nil : snapshot
         do {
-            let response: CatalogResponse = try await ContinuumAPI.shared.get(
-                "/api/v1/history"
+            let response = try await ContinuumAPI.shared.historyCatalog(
+                offset: requestOffset,
+                limit: pageSize,
+                snapshot: requestSnapshot,
+                includeTotal: reset
             )
-            ResponseCache.shared.set(response, for: CacheKey.history)
-            items = response.items
+            if reset {
+                items = response.items
+                ResponseCache.shared.set(response, for: CacheKey.history)
+            } else {
+                items.append(contentsOf: response.items)
+            }
+            if response.totalExact != false {
+                totalItems = response.total
+            }
+            hasMore = response.hasMore ?? false
+            nextOffset = requestOffset + response.items.count
+            if reset || snapshot == nil {
+                snapshot = response.snapshot
+            }
         } catch let err {
             if items.isEmpty {
                 self.error = ErrorState(err)

--- a/iosApp/iosApp/Screens/Personal/HistoryViewModel.swift
+++ b/iosApp/iosApp/Screens/Personal/HistoryViewModel.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+/// Loads the user's watch history through the catalog `source=history`
+/// endpoint with offset/limit paging. A server-issued snapshot freezes the
+/// result set so paging stays consistent while the user scrolls.
+@Observable
+@MainActor
+class HistoryViewModel {
+    var items: [BrowseItem] = []
+    var isLoading = false
+    var error: ErrorState?
+    var hasMore = true
+
+    /// Exact catalog total when the server computed one (only the first page
+    /// asks for it); `nil` once we can only show a lower bound.
+    private(set) var totalItems: Int?
+
+    private var nextOffset = 0
+    /// Snapshot token issued by the first page that pins the history result
+    /// set. Held stable across subsequent pages so offset paging is consistent.
+    private var snapshot: String?
+    private let pageSize = 60
+
+    /// "523 items" when the exact total is known, otherwise a lower bound such
+    /// as "60+ items" while more pages remain.
+    var countLabel: String {
+        let count = totalItems ?? items.count
+        let isLowerBound = totalItems == nil && hasMore
+        let suffix = isLowerBound ? "+" : ""
+        let unit = (count == 1 && !isLowerBound) ? "item" : "items"
+        return "\(count)\(suffix) \(unit)"
+    }
+
+    func load(reset: Bool) async {
+        guard !isLoading else { return }
+
+        // Cold start: surface the cached first page instantly so the grid
+        // doesn't blank while the network call runs. Hydrating the cursor too
+        // means a load-more still resumes correctly if the refresh below fails.
+        if reset, items.isEmpty,
+           let cached: CatalogResponse = ResponseCache.shared.get(CacheKey.history) {
+            apply(firstPage: cached)
+        }
+
+        guard reset || hasMore else { return }
+
+        isLoading = true
+        error = nil
+
+        // A reset restarts at offset 0 with a fresh snapshot. Compute the
+        // request from locals and leave the live cursor untouched until the
+        // call succeeds — if it fails we keep the current page and its cursor,
+        // so a later load-more resumes instead of re-fetching (and duplicating)
+        // page 1.
+        let requestOffset = reset ? 0 : nextOffset
+        let requestSnapshot = reset ? nil : snapshot
+
+        do {
+            let response = try await ContinuumAPI.shared.historyCatalog(
+                offset: requestOffset,
+                limit: pageSize,
+                snapshot: requestSnapshot,
+                includeTotal: reset
+            )
+            if reset {
+                apply(firstPage: response)
+                ResponseCache.shared.set(response, for: CacheKey.history)
+            } else {
+                items.append(contentsOf: response.items)
+                advanceCursor(with: response, from: requestOffset)
+            }
+        } catch let err {
+            // Only surface an error when there's nothing on screen; otherwise
+            // keep the current page (and cursor) so the user can retry.
+            if items.isEmpty {
+                error = ErrorState(err)
+            }
+        }
+
+        isLoading = false
+    }
+
+    /// Replaces all paging state with a freshly-fetched (or cached) first page.
+    private func apply(firstPage response: CatalogResponse) {
+        items = response.items
+        hasMore = response.hasMore ?? false
+        // `total` is only authoritative when the server computed it; a
+        // `total_exact == false` response carries a placeholder we must ignore.
+        totalItems = response.totalExact == false ? nil : response.total
+        snapshot = response.snapshot
+        nextOffset = response.items.count
+    }
+
+    /// Folds a subsequent page into the cursor without disturbing the pinned
+    /// snapshot or a previously known-exact total (load-more pages skip the
+    /// count, so their `total_exact == false` placeholder is ignored).
+    private func advanceCursor(with response: CatalogResponse, from requestOffset: Int) {
+        if response.totalExact != false {
+            totalItems = response.total
+        }
+        hasMore = response.hasMore ?? false
+        nextOffset = requestOffset + response.items.count
+        if snapshot == nil {
+            snapshot = response.snapshot
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Route the iOS History screen through the catalog history source instead of the legacy personal history endpoint.
- Page results with `limit`, `offset`, and catalog snapshots so the full watch history loads while scrolling.
- Show the exact catalog total when available while preserving the cached first page behavior.

## Validation
- Regenerated the Xcode project with XcodeGen.
- Built the Silo iOS scheme for an iOS simulator with code signing disabled.
- Ran `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added paginated loading for watch history, with seamless “load more” as users scroll.
  * Improved history count display to reflect exact totals when available (and “+” lower-bound counts when not).
  * Added more responsive loading, empty, and error states, including pull-to-refresh and retry behavior.
* **Refactor**
  * Streamlined history screen logic by moving state management and paging behavior into a dedicated view model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->