### PR TITLE
[codex] Fix movie version metadata badges

### DIFF
--- a/iosApp/iosApp/Screens/Detail/MovieDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/MovieDetailContent.swift
@@ -67,7 +67,7 @@ struct MovieDetailContent: View {
             sourceTokens: PhoneHeroMetadata.movieSourceTokens(from: detail),
             ratingChip: PhoneHeroMetadata.contentRatingChip(from: detail),
             overview: detail.overview,
-            factsLine: PhoneHeroMetadata.movieFactsLine(from: detail),
+            factsLine: PhoneHeroMetadata.movieFactsLine(from: detail, version: effectiveVersion),
             overlayData: OverlayData.from(detail),
             actions: { actionStack }
         )

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneHeroMetadata.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneHeroMetadata.swift
@@ -61,7 +61,7 @@ enum PhoneHeroMetadata {
 
     // MARK: - Facts row
 
-    static func movieFactsLine(from detail: ItemDetail) -> [PhoneHeroFactToken] {
+    static func movieFactsLine(from detail: ItemDetail, version selectedVersion: FileVersion? = nil) -> [PhoneHeroFactToken] {
         var tokens: [PhoneHeroFactToken] = []
         if let year = detail.year, year > 0 { tokens.append(.text(String(year))) }
         if let runtime = detail.runtime, runtime > 0 {
@@ -70,7 +70,7 @@ enum PhoneHeroMetadata {
         if let imdb = detail.ratingImdb {
             tokens.append(.text(String(format: "★ %.1f", imdb)))
         }
-        tokens.append(contentsOf: qualityTokens(from: detail))
+        tokens.append(contentsOf: qualityTokens(from: detail, version: selectedVersion))
         return tokens
     }
 
@@ -165,8 +165,8 @@ enum PhoneHeroMetadata {
         }
     }
 
-    private static func qualityTokens(from detail: ItemDetail) -> [PhoneHeroFactToken] {
-        guard let version = preferredVersion(from: detail) else { return [] }
+    private static func qualityTokens(from detail: ItemDetail, version selectedVersion: FileVersion? = nil) -> [PhoneHeroFactToken] {
+        guard let version = selectedVersion ?? preferredVersion(from: detail) else { return [] }
         var tokens: [PhoneHeroFactToken] = []
         if let res = resolutionLabel(version.resolution) { tokens.append(.chip(res)) }
         if version.hdr == true {

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVDetailHero.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVDetailHero.swift
@@ -480,7 +480,7 @@ enum TVHeroMetadata {
 
     // Facts line (year · runtime · maturity · quality chips)
 
-    static func movieFactsLine(from detail: ItemDetail) -> [TVHeroFactToken] {
+    static func movieFactsLine(from detail: ItemDetail, version selectedVersion: FileVersion? = nil) -> [TVHeroFactToken] {
         var tokens: [TVHeroFactToken] = []
         if let year = detail.year, year > 0 {
             tokens.append(.text(String(year)))
@@ -491,7 +491,7 @@ enum TVHeroMetadata {
         if let imdb = detail.ratingImdb {
             tokens.append(.text(String(format: "★ %.1f", imdb)))
         }
-        tokens.append(contentsOf: qualityTokens(from: detail))
+        tokens.append(contentsOf: qualityTokens(from: detail, version: selectedVersion))
         return tokens
     }
 
@@ -559,8 +559,8 @@ enum TVHeroMetadata {
         }
     }
 
-    private static func qualityTokens(from detail: ItemDetail) -> [TVHeroFactToken] {
-        guard let version = preferredVersion(from: detail) else { return [] }
+    private static func qualityTokens(from detail: ItemDetail, version selectedVersion: FileVersion? = nil) -> [TVHeroFactToken] {
+        guard let version = selectedVersion ?? preferredVersion(from: detail) else { return [] }
         var tokens: [TVHeroFactToken] = []
         if let res = resolutionLabel(version.resolution) {
             tokens.append(.chip(res))

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
@@ -281,7 +281,8 @@ struct TVMovieDetailView: View {
         DetailVersionSelection.displayVersion(
             versions: availableVersions,
             selectedFileId: selectedVersionFileId,
-            lastFileId: detail.userData?.lastFileId
+            lastFileId: detail.userData?.lastFileId,
+            preferredQualityId: PlayerSettings.shared.preferredQuality
         )
     }
 }

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
@@ -46,7 +46,7 @@ struct TVMovieDetailView: View {
                     ratingChip: TVHeroMetadata.contentRatingChip(from: detail),
                     overview: detail.overview,
                     tagline: detail.tagline,
-                    factsLine: TVHeroMetadata.movieFactsLine(from: detail),
+                    factsLine: TVHeroMetadata.movieFactsLine(from: detail, version: currentVersion),
                     starringText: TVHeroMetadata.starringText(from: detail),
                     actions: { actionColumn }
                 )
@@ -80,11 +80,7 @@ struct TVMovieDetailView: View {
             actionRow
             TVPlaybackSelectorRow(
                 versions: availableVersions,
-                currentVersion: DetailVersionSelection.displayVersion(
-                    versions: availableVersions,
-                    selectedFileId: selectedVersionFileId,
-                    lastFileId: detail.userData?.lastFileId
-                ),
+                currentVersion: currentVersion,
                 selectedVersionFileId: selectedVersionFileId,
                 selectedAudioTrackIndex: selectedAudioTrackIndex,
                 selectedSubtitleTrackIndex: selectedSubtitleTrackIndex,
@@ -279,6 +275,14 @@ struct TVMovieDetailView: View {
 
     private var availableVersions: [FileVersion] {
         detail.versions ?? []
+    }
+
+    private var currentVersion: FileVersion? {
+        DetailVersionSelection.displayVersion(
+            versions: availableVersions,
+            selectedFileId: selectedVersionFileId,
+            lastFileId: detail.userData?.lastFileId
+        )
     }
 }
 #endif

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVPlaybackSelectorRow.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVPlaybackSelectorRow.swift
@@ -72,7 +72,10 @@ struct TVPlaybackSelectorRow: View {
                 ForEach(editions) { edition in
                     Button {
                         let best = DetailVersionSelection.displayVersion(
-                            versions: edition.versions, selectedFileId: nil, lastFileId: nil
+                            versions: edition.versions,
+                            selectedFileId: nil,
+                            lastFileId: nil,
+                            preferredQualityId: PlayerSettings.shared.preferredQuality
                         )
                         onSelectVersion(best?.fileId)
                     } label: {


### PR DESCRIPTION
## Summary
- Use the selected movie file version when building phone and tvOS hero quality badges.
- Keep the existing preferred-version fallback when no explicit selection exists.
- Reuse the tvOS current-version calculation so the selector and hero metadata stay in sync.

## Root cause
The movie hero metadata rows computed quality chips from the preferred file version instead of the currently selected/displayed version. Changing the playback version could update the selector while leaving the hero badges on the original file.

## Validation
- `xcodegen generate`
- `xcodebuild build -project Silo.xcodeproj -scheme Silo -destination 'platform=iOS Simulator,name=iPhone 17 Pro' CODE_SIGNING_ALLOWED=NO`
- `xcodebuild build -project Silo.xcodeproj -scheme SiloTV -destination 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=26.5' CODE_SIGNING_ALLOWED=NO`
- iOS simulator fixture run against the real movie detail UI: after selecting a 2160p HDR version, the selector, audio row, and hero badges updated to the selected version.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Movie detail facts and quality information (resolution, HDR, audio, captions) now correctly reflect the selected file version on both iPhone and Apple TV.
  * The TV hero “facts” row and the playback edition selector’s “best” version are now computed using the currently preferred quality setting, ensuring the displayed quality chips match what will be played.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->