### PR TITLE
Redesign iOS Calendar UX: Trakt-style glass nav card

### DIFF
--- a/iosApp/iosApp/Screens/Calendar/CalendarFilterBar.swift
+++ b/iosApp/iosApp/Screens/Calendar/CalendarFilterBar.swift
@@ -1,33 +1,96 @@
 import SwiftUI
 
-/// Segmented Following / Trending / All preset control. Capsule segments
-/// matching the app's monochrome pill language; on tvOS each segment
-/// draws its own focus chrome (the app suppresses the system slab).
+/// Following / Trending / All scope control.
+///
+/// - iOS / macOS: a contained segmented control — a visible track holding a
+///   single near-white pill that slides between segments. The track is what
+///   keeps the control from reading as loose, clipped text against the black
+///   background (the previous glass capsule was invisible there).
+/// - tvOS: capsule glass segments that draw their own focus chrome (the app
+///   suppresses the system focus slab).
 struct CalendarFilterBar: View {
     let selected: CalendarFilter
     let onSelect: (CalendarFilter) -> Void
-    /// tvOS: programmatic focus kick from the root focus hand-down, so
-    /// the remote is never dead when the Calendar tab swaps in.
+    /// tvOS: programmatic focus kick from the root focus hand-down, so the
+    /// remote is never dead when the Calendar tab swaps in.
     var focusRequest: Int = 0
     /// tvOS: edge-up escape back to the top menu bar.
     var onMoveUp: (() -> Void)? = nil
 
-    @FocusState private var focusedFilter: CalendarFilter?
     #if os(tvOS)
+    @FocusState private var focusedFilter: CalendarFilter?
     /// Each hand-down token claims focus exactly once; guards against
     /// `onAppear` re-fires yanking focus on scroll recycling.
     @State private var lastAppliedFocusRequest = 0
+    #else
+    /// Drives the sliding selected pill across segments.
+    @Namespace private var pillNamespace
     #endif
 
     var body: some View {
+        #if os(tvOS)
+        tvBody
+        #else
+        phoneBody
+        #endif
+    }
+
+    // MARK: - iOS / macOS
+
+    #if !os(tvOS)
+    private var phoneBody: some View {
         HStack(spacing: segmentSpacing) {
             ForEach(CalendarFilter.allCases) { filter in
-                segmentButton(filter)
+                phoneSegment(filter)
+            }
+        }
+        .padding(containerPadding)
+        .background(
+            Capsule(style: .continuous).fill(Color.white.opacity(0.07))
+        )
+        .overlay(
+            Capsule(style: .continuous).strokeBorder(Color.white.opacity(0.10), lineWidth: 1)
+        )
+        .animation(ContinuumTheme.springAnimation, value: selected)
+        .accessibilityElement(children: .contain)
+    }
+
+    private func phoneSegment(_ filter: CalendarFilter) -> some View {
+        let isSelected = selected == filter
+        return Button {
+            onSelect(filter)
+        } label: {
+            Text(filter.displayLabel)
+                .font(segmentFont)
+                .lineLimit(1)
+                .foregroundColor(isSelected ? Color.continuumBackground : Color.continuumOnSurface.opacity(0.6))
+                .padding(.horizontal, segmentHorizontalPadding)
+                .frame(height: segmentHeight)
+                .background {
+                    if isSelected {
+                        Capsule(style: .continuous)
+                            .fill(Color.continuumOnSurface)
+                            .matchedGeometryEffect(id: "calendarFilterPill", in: pillNamespace)
+                    }
+                }
+                .contentShape(Capsule(style: .continuous))
+        }
+        .buttonStyle(.continuumFlat)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+    #endif
+
+    // MARK: - tvOS
+
+    #if os(tvOS)
+    private var tvBody: some View {
+        HStack(spacing: segmentSpacing) {
+            ForEach(CalendarFilter.allCases) { filter in
+                tvSegmentButton(filter)
             }
         }
         .padding(containerPadding)
         .siloGlass(in: .capsule)
-        #if os(tvOS)
         .focusSection()
         .onMoveCommand { direction in
             if direction == .up {
@@ -36,18 +99,15 @@ struct CalendarFilterBar: View {
         }
         .onAppear { applyFocusRequest(focusRequest) }
         .onChange(of: focusRequest) { _, request in applyFocusRequest(request) }
-        #endif
     }
 
-    #if os(tvOS)
     private func applyFocusRequest(_ request: Int) {
         guard request > 0, request != lastAppliedFocusRequest else { return }
         lastAppliedFocusRequest = request
         focusedFilter = selected
     }
-    #endif
 
-    private func segmentButton(_ filter: CalendarFilter) -> some View {
+    private func tvSegmentButton(_ filter: CalendarFilter) -> some View {
         let isSelected = selected == filter
         let isFocused = focusedFilter == filter
 
@@ -82,6 +142,7 @@ struct CalendarFilterBar: View {
         if isSelected { return Color.continuumOnSurface.opacity(0.88) }
         return .clear
     }
+    #endif
 
     // MARK: - Metrics
 
@@ -89,7 +150,7 @@ struct CalendarFilterBar: View {
         #if os(tvOS)
         return 6
         #else
-        return 2
+        return 4
         #endif
     }
 
@@ -97,7 +158,7 @@ struct CalendarFilterBar: View {
         #if os(tvOS)
         return 6
         #else
-        return 3
+        return 4
         #endif
     }
 
@@ -113,7 +174,7 @@ struct CalendarFilterBar: View {
         #if os(tvOS)
         return 26
         #else
-        return 14
+        return 16
         #endif
     }
 
@@ -121,7 +182,7 @@ struct CalendarFilterBar: View {
         #if os(tvOS)
         return 54
         #else
-        return 28
+        return 30
         #endif
     }
 }

--- a/iosApp/iosApp/Screens/Calendar/CalendarView.swift
+++ b/iosApp/iosApp/Screens/Calendar/CalendarView.swift
@@ -49,13 +49,72 @@ struct CalendarView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         #else
-        VStack(spacing: 0) {
-            HStack(spacing: 12) {
+        // No standalone title bar: the search / profile actions live inside
+        // the floating calendar card so the agenda reclaims that height.
+        phoneContent
+            .continuumBackground()
+        #if os(iOS)
+            .toolbar(.hidden, for: .navigationBar)
+        #endif
+        #endif
+    }
+
+    // MARK: - iOS / macOS
+
+    #if !os(tvOS)
+    private var phoneContent: some View {
+        ScrollViewReader { proxy in
+            ScrollView(.vertical, showsIndicators: false) {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    // The scope sits in the scrolling content so it slides
+                    // away as you read down the agenda — only the week rail
+                    // (pinned via the safe-area inset below) stays put. That
+                    // is the room win: one slim sticky bar instead of three.
+                    CalendarFilterBar(
+                        selected: viewModel.filter,
+                        onSelect: { viewModel.select(filter: $0) }
+                    )
+                    .padding(.horizontal, ContinuumTheme.safePadding)
+                    .padding(.top, ContinuumTheme.smallPadding)
+                    .padding(.bottom, ContinuumTheme.padding)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                    shelfArea
+                }
+                .padding(.bottom, ContinuumTheme.largePadding)
+            }
+            .safeAreaInset(edge: .top, spacing: 0) {
+                phoneWeekStrip(proxy: proxy)
+            }
+            .continuumScrollEdgeEffect()
+        }
+    }
+
+    /// The single pinned element: a floating Liquid-Glass calendar card. It
+    /// carries the relocated top-bar actions (so the agenda reclaims the old
+    /// title bar's height) and rides the scroll view's top safe-area inset —
+    /// the agenda scrolls *under* its glass. Tapping a day still lands its
+    /// shelf just below the card (the inset offsets `scrollTo`). No opaque
+    /// backing, so content refracts through the glass as it passes beneath.
+    private func phoneWeekStrip(proxy: ScrollViewProxy) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 10) {
                 SidebarToggleButton()
 
-                Text("Calendar")
-                    .font(.continuumTitle)
+                Text(monthLabel)
+                    .font(.system(size: 17, weight: .semibold))
                     .foregroundColor(.continuumOnSurface)
+
+                if !viewModel.isCurrentWeek {
+                    Button("Today") { returnToToday(proxy: proxy) }
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(.continuumOnSurface)
+                        .buttonStyle(.plain)
+                        .padding(.horizontal, 12)
+                        .frame(height: 30)
+                        .siloGlass(in: .capsule)
+                        .accessibilityLabel("Jump to today")
+                }
 
                 Spacer(minLength: 8)
 
@@ -71,53 +130,55 @@ struct CalendarView: View {
                     onSignOut: { router.signOutAndReset() }
                 )
             }
-            .padding(.horizontal, ContinuumTheme.padding)
-            .padding(.top, ContinuumTheme.smallPadding)
-            .padding(.bottom, ContinuumTheme.smallPadding)
 
-            phoneContent
+            CalendarWeekStrip(
+                week: viewModel.week,
+                selectedDay: viewModel.selectedDay,
+                isCurrentWeek: viewModel.isCurrentWeek,
+                hasEvents: { viewModel.hasEvents(on: $0) },
+                eventCount: { viewModel.events(on: $0).count },
+                onSelectDay: { selectDay($0, proxy: proxy) },
+                onPreviousWeek: { viewModel.goToPreviousWeek() },
+                onNextWeek: { viewModel.goToNextWeek() },
+                onToday: { returnToToday(proxy: proxy) }
+            )
         }
-        .continuumBackground()
-        #if os(iOS)
-        .toolbar(.hidden, for: .navigationBar)
-        #endif
-        #endif
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .siloGlass(in: RoundedRectangle(cornerRadius: 26, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 26, style: .continuous)
+                .strokeBorder(Color.white.opacity(0.08), lineWidth: 1)
+        )
+        .padding(.horizontal, ContinuumTheme.safePadding)
+        .padding(.top, ContinuumTheme.smallPadding)
+        .padding(.bottom, ContinuumTheme.smallPadding)
+        .frame(maxWidth: .infinity)
     }
 
-    // MARK: - iOS / macOS
+    /// "June 2026" for the visible week — Thursday anchor so a month-spanning
+    /// week shows the month that owns most of its days.
+    private var monthLabel: String {
+        let anchor = Calendar.current.date(byAdding: .day, value: 3, to: viewModel.week.startDate)
+            ?? viewModel.week.startDate
+        return anchor.formatted(.dateTime.month(.wide).year())
+    }
 
-    #if !os(tvOS)
-    private var phoneContent: some View {
-        ScrollViewReader { proxy in
-            ScrollView(.vertical, showsIndicators: false) {
-                LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
-                    Section {
-                        shelfArea
-                    } header: {
-                        VStack(alignment: .leading, spacing: ContinuumTheme.smallPadding) {
-                            CalendarFilterBar(
-                                selected: viewModel.filter,
-                                onSelect: { viewModel.select(filter: $0) }
-                            )
-                            .padding(.horizontal, ContinuumTheme.safePadding)
-
-                            CalendarWeekStrip(
-                                week: viewModel.week,
-                                selectedDay: viewModel.selectedDay,
-                                isCurrentWeek: viewModel.isCurrentWeek,
-                                hasEvents: { viewModel.hasEvents(on: $0) },
-                                onSelectDay: { selectDay($0, proxy: proxy) },
-                                onPreviousWeek: { viewModel.goToPreviousWeek() },
-                                onNextWeek: { viewModel.goToNextWeek() },
-                                onToday: { viewModel.goToToday() }
-                            )
-                        }
-                        .padding(.vertical, ContinuumTheme.smallPadding)
-                    }
-                }
-                .padding(.bottom, ContinuumTheme.largePadding)
+    /// "Today" returns to the current week *and* scrolls to today's shelf —
+    /// otherwise the user lands at the top of the week. The week reload is
+    /// awaited so today's shelf exists before we scroll, with a brief beat
+    /// for the reloaded shelves to lay out.
+    private func returnToToday(proxy: ScrollViewProxy) {
+        Task {
+            await viewModel.goToToday()
+            guard let today = viewModel.week.days.first(where: {
+                Calendar.current.isDateInToday($0)
+            }) else { return }
+            viewModel.selectDay(today)
+            try? await Task.sleep(for: .milliseconds(50))
+            withAnimation(ContinuumTheme.springAnimation) {
+                proxy.scrollTo(today, anchor: .top)
             }
-            .continuumScrollEdgeEffect()
         }
     }
     #endif
@@ -154,10 +215,11 @@ struct CalendarView: View {
                         selectedDay: viewModel.selectedDay,
                         isCurrentWeek: viewModel.isCurrentWeek,
                         hasEvents: { viewModel.hasEvents(on: $0) },
+                        eventCount: { viewModel.events(on: $0).count },
                         onSelectDay: { selectDay($0, proxy: proxy) },
                         onPreviousWeek: { viewModel.goToPreviousWeek() },
                         onNextWeek: { viewModel.goToNextWeek() },
-                        onToday: { viewModel.goToToday() }
+                        onToday: { Task { await viewModel.goToToday() } }
                     )
 
                     shelfArea

--- a/iosApp/iosApp/Screens/Calendar/CalendarView.swift
+++ b/iosApp/iosApp/Screens/Calendar/CalendarView.swift
@@ -101,7 +101,7 @@ struct CalendarView: View {
             HStack(spacing: 10) {
                 SidebarToggleButton()
 
-                Text(monthLabel)
+                Text(viewModel.week.monthLabel)
                     .font(.system(size: 17, weight: .semibold))
                     .foregroundColor(.continuumOnSurface)
 
@@ -156,18 +156,12 @@ struct CalendarView: View {
         .frame(maxWidth: .infinity)
     }
 
-    /// "June 2026" for the visible week — Thursday anchor so a month-spanning
-    /// week shows the month that owns most of its days.
-    private var monthLabel: String {
-        let anchor = Calendar.current.date(byAdding: .day, value: 3, to: viewModel.week.startDate)
-            ?? viewModel.week.startDate
-        return anchor.formatted(.dateTime.month(.wide).year())
-    }
-
     /// "Today" returns to the current week *and* scrolls to today's shelf —
     /// otherwise the user lands at the top of the week. The week reload is
-    /// awaited so today's shelf exists before we scroll, with a brief beat
-    /// for the reloaded shelves to lay out.
+    /// awaited so today's shelf exists, then the scroll is deferred one
+    /// runloop tick so the reloaded week's shelves are laid out first (the
+    /// same hand-off `CalendarDayShelf` uses for focus). Scrolling inline
+    /// would target the previous week's shelves, before SwiftUI re-renders.
     private func returnToToday(proxy: ScrollViewProxy) {
         Task {
             await viewModel.goToToday()
@@ -175,9 +169,10 @@ struct CalendarView: View {
                 Calendar.current.isDateInToday($0)
             }) else { return }
             viewModel.selectDay(today)
-            try? await Task.sleep(for: .milliseconds(50))
-            withAnimation(ContinuumTheme.springAnimation) {
-                proxy.scrollTo(today, anchor: .top)
+            DispatchQueue.main.async {
+                withAnimation(ContinuumTheme.springAnimation) {
+                    proxy.scrollTo(today, anchor: .top)
+                }
             }
         }
     }

--- a/iosApp/iosApp/Screens/Calendar/CalendarViewModel.swift
+++ b/iosApp/iosApp/Screens/Calendar/CalendarViewModel.swift
@@ -77,10 +77,12 @@ final class CalendarViewModel {
         Task { await load() }
     }
 
-    func goToToday() {
+    /// Returns to the current week and awaits its load so callers can scroll
+    /// to today's shelf once the data is in place.
+    func goToToday() async {
         week = CalendarWeek(containing: Date())
         selectedDay = Date()
-        Task { await load() }
+        await load()
     }
 
     // MARK: - Loading

--- a/iosApp/iosApp/Screens/Calendar/CalendarWeek.swift
+++ b/iosApp/iosApp/Screens/Calendar/CalendarWeek.swift
@@ -48,6 +48,13 @@ struct CalendarWeek: Equatable, Hashable {
     var startString: String { DateFormatters.isoDate.string(from: startDate) }
     var endString: String { DateFormatters.isoDate.string(from: endDate) }
 
+    /// "June 2026" — anchored on the week's Thursday so a month-spanning week
+    /// shows the month that owns most of its days.
+    var monthLabel: String {
+        let anchor = Self.isoCalendar.date(byAdding: .day, value: 3, to: startDate) ?? startDate
+        return anchor.formatted(.dateTime.month(.wide).year())
+    }
+
     func containsToday(_ today: Date = Date()) -> Bool {
         days.contains { Self.isoCalendar.isDate($0, inSameDayAs: today) }
     }

--- a/iosApp/iosApp/Screens/Calendar/CalendarWeekStrip.swift
+++ b/iosApp/iosApp/Screens/Calendar/CalendarWeekStrip.swift
@@ -1,13 +1,20 @@
 import SwiftUI
 
-/// Week navigator: prev/next chevrons around seven day buttons, plus a
-/// "Today" shortcut when viewing another week. Day buttons show an
-/// event-dot indicator and highlight the selected day.
+/// Week navigator.
+///
+/// - iOS / macOS: a Trakt-style two-row block meant to live inside the
+///   pinned calendar card — a month-year label and `‹ Today ›` controls on
+///   top, then a full-width row of rich day cells (weekday / boxed number /
+///   event-count) below.
+/// - tvOS: the original focus-driven strip (prev/next chevrons around seven
+///   day buttons, plus a `Today` shortcut), unchanged.
 struct CalendarWeekStrip: View {
     let week: CalendarWeek
     let selectedDay: Date
     let isCurrentWeek: Bool
     let hasEvents: (Date) -> Bool
+    /// Number of airings on a day — drives the per-cell count badge.
+    let eventCount: (Date) -> Int
     let onSelectDay: (Date) -> Void
     let onPreviousWeek: () -> Void
     let onNextWeek: () -> Void
@@ -18,6 +25,63 @@ struct CalendarWeekStrip: View {
     #endif
 
     var body: some View {
+        #if os(tvOS)
+        tvBody
+        #else
+        phoneBody
+        #endif
+    }
+
+    // MARK: - iOS / macOS
+
+    #if !os(tvOS)
+    /// The week-cells row: seven full-width rich cells flanked by prev/next
+    /// chevrons. The month label, Today button and top-bar actions live in
+    /// the card chrome above this (assembled by `CalendarView`).
+    private var phoneBody: some View {
+        HStack(spacing: 6) {
+            phoneNavButton(systemImage: "chevron.left", action: onPreviousWeek)
+                .accessibilityLabel("Previous week")
+
+            HStack(spacing: 0) {
+                ForEach(week.days, id: \.self) { date in
+                    CalendarRichDayCell(
+                        date: date,
+                        isSelected: Calendar.current.isDate(date, inSameDayAs: selectedDay),
+                        isToday: Calendar.current.isDateInToday(date),
+                        eventCount: eventCount(date),
+                        action: { onSelectDay(date) }
+                    )
+                    .frame(maxWidth: .infinity)
+                }
+            }
+
+            phoneNavButton(systemImage: "chevron.right", action: onNextWeek)
+                .accessibilityLabel("Next week")
+        }
+        .animation(ContinuumTheme.springAnimation, value: selectedDay)
+    }
+
+    private func phoneNavButton(
+        systemImage: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: systemImage)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(.continuumOnSurface.opacity(0.8))
+                .frame(width: 30, height: 30)
+                .background(Circle().fill(Color.white.opacity(0.07)))
+                .overlay(Circle().strokeBorder(Color.white.opacity(0.10), lineWidth: 1))
+        }
+        .buttonStyle(.continuumFlat)
+    }
+    #endif
+
+    // MARK: - tvOS
+
+    #if os(tvOS)
+    private var tvBody: some View {
         HStack(spacing: stripSpacing) {
             chevronButton(systemImage: "chevron.left", control: .previous, action: onPreviousWeek)
                 .accessibilityLabel("Previous week")
@@ -65,18 +129,8 @@ struct CalendarWeekStrip: View {
                 .foregroundColor(.continuumSecondaryText)
         }
         .padding(.horizontal, ContinuumTheme.safePadding)
-        #if os(tvOS)
         .focusSection()
-        #endif
         .animation(ContinuumTheme.springAnimation, value: isCurrentWeek)
-    }
-
-    /// "June 2026" — uses the Thursday so a week spanning two months
-    /// shows the month that owns most of its days.
-    private var monthLabel: String {
-        let anchor = Calendar.current.date(byAdding: .day, value: 3, to: week.startDate)
-            ?? week.startDate
-        return anchor.formatted(.dateTime.month(.wide).year())
     }
 
     private func chevronButton(
@@ -113,102 +167,126 @@ struct CalendarWeekStrip: View {
     }
 
     fileprivate func isFocused(_ control: StripControl) -> Bool {
-        #if os(tvOS)
         return focusedControl == control
-        #else
-        return false
-        #endif
     }
 
-    #if os(tvOS)
     fileprivate var focusBinding: FocusState<StripControl?>.Binding { $focusedControl }
-    #endif
+
+    /// "June 2026" — uses the Thursday so a week spanning two months shows
+    /// the month that owns most of its days.
+    private var monthLabel: String {
+        let anchor = Calendar.current.date(byAdding: .day, value: 3, to: week.startDate)
+            ?? week.startDate
+        return anchor.formatted(.dateTime.month(.wide).year())
+    }
 
     // MARK: - Metrics
 
-    private var stripSpacing: CGFloat {
-        #if os(tvOS)
-        return 18
-        #else
-        return 8
-        #endif
-    }
-
-    private var dayButtonSpacing: CGFloat {
-        #if os(tvOS)
-        return 10
-        #else
-        return 4
-        #endif
-    }
-
-    private var chevronFont: Font {
-        #if os(tvOS)
-        return .system(size: 24, weight: .semibold)
-        #else
-        return .system(size: 13, weight: .semibold)
-        #endif
-    }
-
-    private var chevronWidth: CGFloat {
-        #if os(tvOS)
-        return 64
-        #else
-        return 32
-        #endif
-    }
-
-    private var chevronHeight: CGFloat {
-        #if os(tvOS)
-        return 64
-        #else
-        return 32
-        #endif
-    }
-
-    private var todayFont: Font {
-        #if os(tvOS)
-        return .system(size: 22, weight: .semibold)
-        #else
-        return .system(size: 13, weight: .semibold)
-        #endif
-    }
-
-    private var todayHorizontalPadding: CGFloat {
-        #if os(tvOS)
-        return 24
-        #else
-        return 12
-        #endif
-    }
-
-    private var monthFont: Font {
-        #if os(tvOS)
-        return .system(size: 24, weight: .semibold)
-        #else
-        return .system(size: 13, weight: .semibold)
-        #endif
-    }
+    private var stripSpacing: CGFloat { 18 }
+    private var dayButtonSpacing: CGFloat { 10 }
+    private var chevronFont: Font { .system(size: 24, weight: .semibold) }
+    private var chevronWidth: CGFloat { 64 }
+    private var chevronHeight: CGFloat { 64 }
+    private var todayFont: Font { .system(size: 22, weight: .semibold) }
+    private var todayHorizontalPadding: CGFloat { 24 }
+    private var monthFont: Font { .system(size: 24, weight: .semibold) }
+    #endif
 }
 
+#if os(tvOS)
 private extension View {
-    /// tvOS: bind a strip control to the shared `@FocusState`; no-op on
-    /// other platforms.
+    /// tvOS: bind a strip control to the shared `@FocusState`.
     @ViewBuilder
     func applyStripFocus(
         _ strip: CalendarWeekStrip,
         control: CalendarWeekStrip.StripControl
     ) -> some View {
-        #if os(tvOS)
         self.focused(strip.focusBinding, equals: control)
-        #else
-        self
-        #endif
     }
 }
+#endif
 
-// MARK: - Day button
+// MARK: - iOS rich day cell
 
+#if !os(tvOS)
+/// Trakt-style day cell: weekday over a boxed day-number over an event-count
+/// badge. Selected fills the number box; today outlines it.
+private struct CalendarRichDayCell: View {
+    let date: Date
+    let isSelected: Bool
+    let isToday: Bool
+    let eventCount: Int
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: 5) {
+                Text(weekdayLabel)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(.continuumSecondaryText)
+
+                Text(dayNumber)
+                    .font(.system(size: 15, weight: .bold))
+                    .foregroundColor(isSelected ? .continuumBackground : .continuumOnSurface)
+                    .frame(width: 34, height: 34)
+                    .background(
+                        RoundedRectangle(cornerRadius: 11, style: .continuous)
+                            .fill(isSelected ? Color.continuumOnSurface : Color.clear)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 11, style: .continuous)
+                            .strokeBorder(
+                                isToday && !isSelected
+                                    ? Color.continuumOnSurface.opacity(0.45)
+                                    : Color.clear,
+                                lineWidth: 1.5
+                            )
+                    )
+
+                countIndicator
+            }
+            .frame(maxWidth: .infinity)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.continuumFlat)
+        .animation(.easeInOut(duration: 0.15), value: isSelected)
+        .accessibilityLabel(accessibilityDescription)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    @ViewBuilder
+    private var countIndicator: some View {
+        if eventCount > 0 {
+            Text("\(eventCount)")
+                .font(.system(size: 10, weight: .bold))
+                .foregroundColor(.continuumOnSurface.opacity(0.85))
+                .padding(.horizontal, 6)
+                .frame(height: 16)
+                .background(Capsule().fill(Color.white.opacity(0.10)))
+        } else {
+            Color.clear.frame(height: 16)
+        }
+    }
+
+    private var weekdayLabel: String {
+        date.formatted(.dateTime.weekday(.abbreviated))
+    }
+
+    private var dayNumber: String {
+        date.formatted(.dateTime.day())
+    }
+
+    private var accessibilityDescription: String {
+        let base = date.formatted(.dateTime.weekday(.wide).month(.wide).day())
+        guard eventCount > 0 else { return base }
+        return base + ", \(eventCount) event\(eventCount == 1 ? "" : "s")"
+    }
+}
+#endif
+
+// MARK: - tvOS day button
+
+#if os(tvOS)
 private struct CalendarDayButton: View {
     let date: Date
     let isSelected: Bool
@@ -290,51 +368,11 @@ private struct CalendarDayButton: View {
 
     // MARK: - Metrics
 
-    private var labelSpacing: CGFloat {
-        #if os(tvOS)
-        return 6
-        #else
-        return 3
-        #endif
-    }
-
-    private var weekdayFont: Font {
-        #if os(tvOS)
-        return .system(size: 18, weight: .semibold)
-        #else
-        return .system(size: 10, weight: .semibold)
-        #endif
-    }
-
-    private var numberFont: Font {
-        #if os(tvOS)
-        return .system(size: 26, weight: .bold)
-        #else
-        return .system(size: 15, weight: .bold)
-        #endif
-    }
-
-    private var dotSize: CGFloat {
-        #if os(tvOS)
-        return 8
-        #else
-        return 4
-        #endif
-    }
-
-    private var buttonWidth: CGFloat {
-        #if os(tvOS)
-        return 84
-        #else
-        return 42
-        #endif
-    }
-
-    private var buttonHeight: CGFloat {
-        #if os(tvOS)
-        return 96
-        #else
-        return 56
-        #endif
-    }
+    private var labelSpacing: CGFloat { 6 }
+    private var weekdayFont: Font { .system(size: 18, weight: .semibold) }
+    private var numberFont: Font { .system(size: 26, weight: .bold) }
+    private var dotSize: CGFloat { 8 }
+    private var buttonWidth: CGFloat { 84 }
+    private var buttonHeight: CGFloat { 96 }
 }
+#endif

--- a/iosApp/iosApp/Screens/Calendar/CalendarWeekStrip.swift
+++ b/iosApp/iosApp/Screens/Calendar/CalendarWeekStrip.swift
@@ -124,7 +124,7 @@ struct CalendarWeekStrip: View {
 
             Spacer(minLength: 0)
 
-            Text(monthLabel)
+            Text(week.monthLabel)
                 .font(monthFont)
                 .foregroundColor(.continuumSecondaryText)
         }
@@ -171,14 +171,6 @@ struct CalendarWeekStrip: View {
     }
 
     fileprivate var focusBinding: FocusState<StripControl?>.Binding { $focusedControl }
-
-    /// "June 2026" — uses the Thursday so a week spanning two months shows
-    /// the month that owns most of its days.
-    private var monthLabel: String {
-        let anchor = Calendar.current.date(byAdding: .day, value: 3, to: week.startDate)
-            ?? week.startDate
-        return anchor.formatted(.dateTime.month(.wide).year())
-    }
 
     // MARK: - Metrics
 


### PR DESCRIPTION
## What & why

The iOS Calendar tab's controls were cramped and heavy. The Following/Trending/All segmented control read as cut-off loose text against the black background (its glass capsule was invisible there), and the filter + week strip were **both** pinned on top of the title bar — three frozen bands that ate the top of the screen and left almost nothing scrolling.

This reworks the phone layout around a single **Trakt-inspired floating glass calendar card** plus a contained scope control. The tvOS focus paths are deliberately left untouched.

## Changes

- **`CalendarFilterBar`** — iOS now renders a *contained* segmented control: a visible track with a near-white pill that slides between segments (`matchedGeometryEffect`), so it no longer looks clipped. tvOS keeps its glass + focus chrome.
- **`CalendarView`** — removed the standalone "Calendar" title bar and folded its search / profile actions (and the iPad sidebar toggle) into the floating card's top row to reclaim that vertical space. The card uses Liquid Glass (`.siloGlass`) and rides the scroll view's top safe-area inset, so the agenda **refracts under it** as it scrolls. The scope control scrolls away with the content; only the card pins.
- **`CalendarWeekStrip`** — iOS week cells are now Trakt-style: weekday / boxed day number / event-count badge (selected fills the box, today outlines it), flanked by prev/next chevrons. tvOS strip unchanged.
- **Fix "Today"** — from another week it now `await`s the current-week reload and scrolls to today's shelf (mirroring a day-strip tap) instead of dumping the user at the top of the week. `goToToday()` is now `async`.

## Reviewer notes

- Monochrome by design: there's no brand accent, so Trakt's purple "today" highlight becomes a near-white outline; the card uses `continuumSurfaceElevated`/Liquid Glass.
- The "Today" scroll uses a 50ms beat after reload to let the new week's shelves lay out before `scrollTo` — flagged in case it needs tuning on slow loads.
- Scope: only the four `Screens/Calendar/` files. Built green on the **Silo** (iOS) and **SiloTV** (tvOS) schemes; not yet verified on macOS (`SiloMac` shares the iOS layout path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Refreshed the calendar UI with a pinned “glass” week strip and a smoother, more space-efficient agenda layout.
  * Added a Trakt-style week navigator on iOS/macOS with rich day cells and event-count badges.
* **Bug Fixes**
  * Improved the “Today” action to reliably navigate and scroll to the current day after data loads.
  * Enhanced TV focus behavior and consistent week-strip interaction styling across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->