### PR TITLE
Redesign iOS audiobook detail page

### DIFF
--- a/docs/audiobook-detail-redesign/mockup.html
+++ b/docs/audiobook-detail-redesign/mockup.html
@@ -169,9 +169,7 @@
       </button>
       <div class="abk-secondary">
         <div class="abk-sbtn"><div class="abk-circ"><i class="ti ti-refresh"></i></div><small>Start over</small></div>
-        <div class="abk-sbtn"><div class="abk-circ"><i class="ti ti-download"></i></div><small>Download</small></div>
         <div class="abk-sbtn"><div class="abk-circ speed">1.0×</div><small>Speed</small></div>
-        <div class="abk-sbtn"><div class="abk-circ"><i class="ti ti-check"></i></div><small>Finished</small></div>
       </div>
     </div>
 

--- a/docs/audiobook-detail-redesign/mockup.html
+++ b/docs/audiobook-detail-redesign/mockup.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Silo — Audiobook detail redesign</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@3.30.0/dist/tabler-icons.min.css" />
+<style>
+  html,body{margin:0;background:#101012;-webkit-font-smoothing:antialiased;}
+  body{font-family:-apple-system,"SF Pro Display","SF Pro Text",system-ui,sans-serif;padding:28px 0 48px;display:flex;justify-content:center;}
+</style>
+</head>
+<body>
+
+<div class="abk-stage">
+<style>
+  .abk-stage{font-family:-apple-system,"SF Pro Display","SF Pro Text",system-ui,sans-serif;display:flex;justify-content:center;width:100%;}
+  .abk-phone{width:372px;background:#1a1a1d;border-radius:48px;padding:9px;box-shadow:0 0 0 1.5px #3a3a40,0 30px 70px rgba(0,0,0,.55);}
+  .abk-screen{--ink:#EDEDED;--mut:rgba(237,237,237,.6);--mut2:rgba(237,237,237,.38);--line:rgba(255,255,255,.12);--rest:rgba(255,255,255,.07);--restbd:rgba(255,255,255,.10);--elev:#15171C;
+    position:relative;width:100%;background:#000;border-radius:40px;overflow:hidden;color:var(--ink);}
+  .abk-screen *{box-sizing:border-box;}
+  .abk-status{position:relative;z-index:5;display:flex;align-items:center;justify-content:space-between;padding:14px 26px 4px;font-size:15px;font-weight:600;letter-spacing:.2px;}
+  .abk-island{position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:6;}
+  .abk-sigwrap{display:flex;align-items:center;gap:7px;}
+  .abk-batt{width:23px;height:12px;border:1.3px solid var(--ink);border-radius:3px;position:relative;opacity:.95;}
+  .abk-batt::after{content:"";position:absolute;top:2px;left:1.4px;bottom:2px;width:15px;background:var(--ink);border-radius:1px;}
+  .abk-batt::before{content:"";position:absolute;right:-3px;top:3.5px;width:1.6px;height:5px;background:var(--ink);border-radius:1px;}
+
+  .abk-backdrop{position:absolute;top:0;left:0;right:0;height:540px;z-index:0;overflow:hidden;}
+  .abk-backdrop .art{position:absolute;inset:-90px -60px auto -60px;height:560px;filter:blur(54px) saturate(135%);opacity:.62;transform:scale(1.15);}
+  .abk-backdrop::after{content:"";position:absolute;inset:0;background:linear-gradient(to bottom,rgba(0,0,0,.30) 0%,rgba(0,0,0,.58) 46%,#000 80%);}
+
+  .abk-art{background:
+      radial-gradient(120% 88% at 50% 60%,rgba(255,184,86,.92) 0%,rgba(255,138,48,.34) 17%,rgba(255,138,48,0) 41%),
+      radial-gradient(95% 72% at 73% 13%,rgba(166,74,196,.72) 0%,rgba(120,50,150,0) 48%),
+      radial-gradient(105% 80% at 22% 98%,rgba(74,166,206,.6) 0%,rgba(40,110,150,0) 52%),
+      linear-gradient(168deg,#3a2360 0%,#23284f 44%,#0d2233 100%);}
+
+  .abk-hero{position:relative;z-index:2;padding:6px 20px 0;}
+  .abk-back{position:absolute;top:2px;left:16px;width:38px;height:38px;border-radius:50%;display:flex;align-items:center;justify-content:center;background:rgba(20,20,22,.62);backdrop-filter:blur(14px);border:.5px solid var(--restbd);font-size:20px;z-index:3;}
+
+  .abk-cover{width:194px;height:194px;margin:30px auto 0;border-radius:9px;position:relative;overflow:hidden;
+    box-shadow:0 26px 52px rgba(0,0,0,.62),0 6px 18px rgba(0,0,0,.5);border:.5px solid rgba(255,255,255,.10);}
+  .abk-cover .cc{position:absolute;inset:0;padding:11px 11px 9px;display:flex;flex-direction:column;align-items:center;color:#fff;text-shadow:0 1px 3px rgba(0,0,0,.55);}
+  .abk-cv-top{width:100%;display:flex;justify-content:space-between;align-items:flex-start;}
+  .abk-cv-ga{font-size:11px;font-weight:800;letter-spacing:.2px;color:#dff0ff;}
+  .abk-cv-fc{font-size:8px;font-weight:800;letter-spacing:.4px;color:#ffd9b0;text-align:right;line-height:1.25;}
+  .abk-cv-title{margin-top:9px;text-align:center;font-family:Georgia,"Times New Roman",var(--font-serif),serif;}
+  .abk-cv-the{font-size:9px;letter-spacing:3px;color:#cfe6ff;}
+  .abk-cv-sl{font-size:21px;font-weight:800;line-height:.96;letter-spacing:.5px;color:#eaf4ff;margin-top:1px;}
+  .abk-cv-wt{font-size:11px;font-weight:700;letter-spacing:1px;color:#ffe9c7;margin-top:5px;}
+  .abk-cv-of{font-size:8px;letter-spacing:2px;color:#ffe9c7;opacity:.9;}
+  .abk-cv-auth{margin-top:auto;font-size:12px;font-weight:800;letter-spacing:1.2px;color:#fff;}
+
+  .abk-eyebrow{display:flex;justify-content:center;margin-top:20px;}
+  .abk-eyebrow span{font-size:11px;font-weight:700;letter-spacing:1.6px;color:var(--ink);padding:5px 12px;border-radius:999px;background:var(--elev);border:.5px solid var(--restbd);}
+  .abk-title{margin:13px 0 0;text-align:center;font-size:28px;font-weight:800;letter-spacing:-.4px;line-height:1.04;}
+  .abk-series{margin:7px 0 0;text-align:center;font-size:11px;font-weight:700;letter-spacing:1.7px;color:var(--mut);}
+  .abk-author{margin:12px 0 0;text-align:center;font-size:16px;font-weight:600;color:var(--ink);}
+  .abk-narr{margin:4px 0 0;text-align:center;font-size:13px;color:var(--mut);}
+  .abk-meta{margin:11px 0 0;display:flex;justify-content:center;align-items:center;gap:8px;font-size:12.5px;color:var(--mut);flex-wrap:wrap;}
+  .abk-meta .dot{color:var(--mut2);}
+  .abk-meta .rate{color:#FFC107;font-weight:600;display:inline-flex;align-items:center;gap:3px;}
+
+  .abk-progcap{margin:22px 20px 0;display:flex;justify-content:space-between;font-size:12px;}
+  .abk-progcap .l{color:var(--ink);font-weight:600;}
+  .abk-progcap .r{color:var(--mut);}
+
+  .abk-actions{padding:9px 20px 0;}
+  .abk-resume{position:relative;width:100%;height:54px;border:none;border-radius:999px;background:#EDEDED;color:#000;font-size:16.5px;font-weight:700;display:flex;align-items:center;justify-content:center;gap:9px;overflow:hidden;cursor:pointer;}
+  .abk-resume .ptrack{position:absolute;left:16px;right:16px;bottom:8px;height:5px;border-radius:3px;background:rgba(0,0,0,.18);}
+  .abk-resume .pfill{position:absolute;left:0;top:0;bottom:0;width:57%;border-radius:3px;background:rgba(0,0,0,.82);}
+  .abk-resume i{font-size:19px;}
+  .abk-secondary{margin-top:16px;display:flex;justify-content:space-between;padding:0 4px;}
+  .abk-sbtn{display:flex;flex-direction:column;align-items:center;gap:7px;width:62px;}
+  .abk-circ{width:52px;height:52px;border-radius:50%;background:var(--rest);border:.5px solid var(--restbd);display:flex;align-items:center;justify-content:center;font-size:21px;color:var(--ink);}
+  .abk-circ.speed{font-size:15px;font-weight:700;}
+  .abk-sbtn small{font-size:11px;color:var(--mut);font-weight:500;}
+
+  .abk-sec{padding:30px 20px 0;}
+  .abk-sec h3{margin:0 0 12px;font-size:17px;font-weight:600;color:var(--ink);}
+  .abk-sechead{display:flex;align-items:baseline;justify-content:space-between;margin-bottom:12px;}
+  .abk-sechead h3{margin:0;}
+  .abk-sechead .all{font-size:13px;color:var(--mut);display:inline-flex;align-items:center;gap:2px;}
+  .abk-about{font-size:14px;line-height:1.5;color:var(--mut);}
+  .abk-about .more{color:var(--ink);font-weight:600;}
+
+  .abk-chap{display:flex;align-items:center;gap:13px;padding:11px 0;border-top:.5px solid var(--line);}
+  .abk-chap:first-of-type{border-top:none;}
+  .abk-chap .ix{width:26px;height:26px;border-radius:50%;flex:none;background:var(--rest);border:.5px solid var(--restbd);display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:600;color:var(--mut);}
+  .abk-chap .nm{flex:1;font-size:14px;color:var(--ink);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+  .abk-chap .tm{font-size:12px;color:var(--mut);font-variant-numeric:tabular-nums;font-feature-settings:"tnum";}
+  .abk-chap.playing .ix{background:#EDEDED;border-color:#EDEDED;color:#000;}
+  .abk-chap.playing .nm{font-weight:600;}
+
+  .abk-rail{display:flex;gap:12px;margin-top:2px;}
+  .abk-bk{width:104px;flex:none;}
+  .abk-bk .sq{width:104px;height:104px;border-radius:8px;position:relative;overflow:hidden;border:.5px solid rgba(255,255,255,.10);display:flex;align-items:center;justify-content:center;}
+  .abk-bk .sq .n{font-family:Georgia,serif;font-size:34px;font-weight:800;color:rgba(255,255,255,.92);text-shadow:0 1px 4px rgba(0,0,0,.5);}
+  .abk-bk.cur .sq{box-shadow:0 0 0 2px #EDEDED;}
+  .abk-bk .lab{margin-top:7px;font-size:12px;font-weight:600;color:var(--ink);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+  .abk-bk .sub{font-size:11px;color:var(--mut);}
+  .abk-bdg{position:absolute;top:6px;right:6px;width:18px;height:18px;border-radius:50%;background:#EDEDED;color:#000;display:flex;align-items:center;justify-content:center;font-size:11px;}
+  .abk-pbar{position:absolute;left:0;right:0;bottom:0;height:4px;background:rgba(0,0,0,.4);}
+  .abk-pbar i{position:absolute;left:0;top:0;bottom:0;background:#EDEDED;}
+
+  .abk-details{margin:26px 20px 0;font-size:12px;color:var(--mut2);display:flex;align-items:center;gap:8px;}
+  .abk-details .dot{opacity:.7;}
+  .abk-home{height:30px;display:flex;align-items:flex-end;justify-content:center;padding-bottom:9px;margin-top:14px;}
+  .abk-home::after{content:"";width:134px;height:5px;border-radius:3px;background:rgba(255,255,255,.32);}
+
+  .abk-art1{background:linear-gradient(160deg,#2b3a6b,#0f2030);}
+  .abk-art2{background:linear-gradient(160deg,#5a2c4a,#1a1228);}
+  .abk-art3{background:linear-gradient(160deg,#2c5a4a,#0f2420);}
+  .abk-art4{background:linear-gradient(160deg,#6b4a2c,#281c10);}
+</style>
+
+<h2 class="sr-only" style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0 0 0 0);">Redesigned Silo audiobook detail screen mockup, shown in an iPhone frame.</h2>
+
+<div class="abk-phone">
+  <div class="abk-screen">
+    <div class="abk-island"></div>
+    <div class="abk-status">
+      <div>2:21</div>
+      <div class="abk-sigwrap"><i class="ti ti-wifi" style="font-size:16px"></i><div class="abk-batt"></div></div>
+    </div>
+
+    <div class="abk-backdrop"><div class="art abk-art"></div></div>
+
+    <div class="abk-hero">
+      <div class="abk-back"><i class="ti ti-chevron-left"></i></div>
+
+      <div class="abk-cover">
+        <div class="abk-art" style="position:absolute;inset:0;"></div>
+        <div class="cc">
+          <div class="abk-cv-top">
+            <div class="abk-cv-ga">GraphicAudio<span style="font-weight:400">))</span></div>
+            <div class="abk-cv-fc">FULL CAST<br>CINEMATIC MUSIC<br>SOUND EFFECTS</div>
+          </div>
+          <div class="abk-cv-title">
+            <div class="abk-cv-the">THE</div>
+            <div class="abk-cv-sl">STORMLIGHT<br>ARCHIVE</div>
+            <div class="abk-cv-wt">WIND AND TRUTH</div>
+            <div class="abk-cv-of">(5 OF 5)</div>
+          </div>
+          <div class="abk-cv-auth">BRANDON SANDERSON</div>
+        </div>
+      </div>
+
+      <div class="abk-eyebrow"><span>AUDIOBOOK</span></div>
+      <h1 class="abk-title">Wind and Truth</h1>
+      <div class="abk-series">THE STORMLIGHT ARCHIVE · BOOK 5 OF 5</div>
+      <div class="abk-author">Brandon Sanderson</div>
+      <div class="abk-narr">Narrated by Danny Montooth, James Konicek &amp; 3 more</div>
+      <div class="abk-meta">
+        <span class="rate"><i class="ti ti-star" style="font-size:12px"></i>4.8</span>
+        <span class="dot">·</span><span>9h 51m</span>
+        <span class="dot">·</span><span>Full cast</span>
+        <span class="dot">·</span><span>2024</span>
+      </div>
+    </div>
+
+    <div class="abk-progcap"><div class="l">57% complete</div><div class="r">4h 14m left</div></div>
+
+    <div class="abk-actions">
+      <button class="abk-resume">
+        <i class="ti ti-player-play"></i>Resume
+        <div class="ptrack"><div class="pfill"></div></div>
+      </button>
+      <div class="abk-secondary">
+        <div class="abk-sbtn"><div class="abk-circ"><i class="ti ti-refresh"></i></div><small>Start over</small></div>
+        <div class="abk-sbtn"><div class="abk-circ"><i class="ti ti-download"></i></div><small>Download</small></div>
+        <div class="abk-sbtn"><div class="abk-circ speed">1.0×</div><small>Speed</small></div>
+        <div class="abk-sbtn"><div class="abk-circ"><i class="ti ti-check"></i></div><small>Finished</small></div>
+      </div>
+    </div>
+
+    <div class="abk-sec">
+      <h3>About</h3>
+      <div class="abk-about">The long-awaited explosive climax to the first arc of the #1 New York Times bestselling Stormlight Archive — the iconic epic fantasy masterpiece that has sold more than 10 million copies, from acclaimed author Brandon&nbsp;Sanderson. <span class="more">more</span></div>
+    </div>
+
+    <div class="abk-sec">
+      <div class="abk-sechead"><h3>Chapters</h3><span class="all">Show all 31<i class="ti ti-chevron-right" style="font-size:15px"></i></span></div>
+      <div class="abk-chap"><div class="ix"><i class="ti ti-player-play" style="font-size:12px"></i></div><div class="nm">Prologue — To Pierce the Sky</div><div class="tm">0:00</div></div>
+      <div class="abk-chap playing"><div class="ix">1</div><div class="nm">Knit the Land</div><div class="tm">18:42</div></div>
+      <div class="abk-chap"><div class="ix">2</div><div class="nm">The Spear That Would Not Break</div><div class="tm">1:04:18</div></div>
+      <div class="abk-chap"><div class="ix">3</div><div class="nm">A Debt Repaid in Storms</div><div class="tm">1:51:07</div></div>
+      <div class="abk-chap"><div class="ix">4</div><div class="nm">Words of Radiance</div><div class="tm">2:39:55</div></div>
+    </div>
+
+    <div class="abk-sec">
+      <div class="abk-sechead"><h3>The Stormlight Archive</h3><span class="all">See series<i class="ti ti-chevron-right" style="font-size:15px"></i></span></div>
+      <div class="abk-rail">
+        <div class="abk-bk"><div class="sq abk-art1"><span class="n">1</span><div class="abk-bdg"><i class="ti ti-check" style="font-size:11px"></i></div></div><div class="lab">The Way of Kings</div><div class="sub">Book 1</div></div>
+        <div class="abk-bk"><div class="sq abk-art2"><span class="n">2</span><div class="abk-bdg"><i class="ti ti-check" style="font-size:11px"></i></div></div><div class="lab">Words of Radiance</div><div class="sub">Book 2</div></div>
+        <div class="abk-bk cur"><div class="sq abk-art"><span class="n">5</span><div class="abk-pbar"><i style="width:57%"></i></div></div><div class="lab">Wind and Truth</div><div class="sub">Book 5 · 57%</div></div>
+        <div class="abk-bk"><div class="sq abk-art3"><span class="n">3</span></div><div class="lab">Oathbringer</div><div class="sub">Book 3</div></div>
+      </div>
+    </div>
+
+    <div class="abk-details">
+      <span>Audio</span><span class="dot">·</span><span>AAC</span><span class="dot">·</span><span>MP4</span><span class="dot">·</span><span>Single file · 9h 51m</span>
+    </div>
+
+    <div class="abk-home"></div>
+  </div>
+</div>
+</div>
+
+</body>
+</html>

--- a/iosApp/Tests/AudiobookDetailFormattingTests.swift
+++ b/iosApp/Tests/AudiobookDetailFormattingTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+@testable import Silo
+
+final class AudiobookDetailFormattingTests: XCTestCase {
+
+    // MARK: - Title cleanup
+
+    func testStripsSeriesPrefixAndTrailingVolume() {
+        let title = AudiobookDetailFormatting.cleanTitle(
+            "Stormlight Archive 5 - Wind and Truth (5 of 5)",
+            seriesName: "The Stormlight Archive"
+        )
+        XCTAssertEqual(title, "Wind and Truth")
+    }
+
+    func testLeavesStandaloneTitleUntouched() {
+        XCTAssertEqual(
+            AudiobookDetailFormatting.cleanTitle("Project Hail Mary", seriesName: nil),
+            "Project Hail Mary"
+        )
+    }
+
+    func testTitleNotMangledWhenItDoesNotStartWithSeries() {
+        // Book 1's title doesn't repeat the series name, so nothing should
+        // be stripped from it even though series data is present.
+        XCTAssertEqual(
+            AudiobookDetailFormatting.cleanTitle("The Way of Kings", seriesName: "The Stormlight Archive"),
+            "The Way of Kings"
+        )
+    }
+
+    func testTrailingVolumeStrippedWithoutSeries() {
+        XCTAssertEqual(
+            AudiobookDetailFormatting.cleanTitle("Some Story (2 of 3)", seriesName: nil),
+            "Some Story"
+        )
+    }
+
+    // MARK: - Volume locator
+
+    func testVolumeLocatorParsesIndexAndTotal() {
+        let volume = AudiobookDetailFormatting.volume(in: "Stormlight Archive 5 - Wind and Truth (5 of 5)")
+        XCTAssertEqual(volume.index, 5)
+        XCTAssertEqual(volume.total, 5)
+    }
+
+    func testVolumeLocatorAbsentReturnsNils() {
+        let volume = AudiobookDetailFormatting.volume(in: "Project Hail Mary")
+        XCTAssertNil(volume.index)
+        XCTAssertNil(volume.total)
+    }
+
+    // MARK: - Series line
+
+    func testSeriesLineUsesParsedTotalNotEntryCount() {
+        // Regression: the series grouping reported 19 entries (alternate
+        // editions), but the book is 5 of 5.
+        XCTAssertEqual(
+            AudiobookDetailFormatting.seriesLine(name: "The Stormlight Archive", index: 5, total: 5),
+            "The Stormlight Archive · Book 5 of 5"
+        )
+    }
+
+    func testSeriesLineFallsBackToNameOnlyWithoutIndex() {
+        XCTAssertEqual(
+            AudiobookDetailFormatting.seriesLine(name: "Mistborn", index: nil, total: nil),
+            "Mistborn"
+        )
+        XCTAssertEqual(
+            AudiobookDetailFormatting.seriesLine(name: "Mistborn", index: 2, total: nil),
+            "Mistborn · Book 2"
+        )
+    }
+
+    // MARK: - Credit summaries
+
+    func testNarratorSummaryRollsUpDiscretePeople() {
+        let summary = AudiobookDetailFormatting.peopleSummary(
+            ["Danny Montooth", "James Konicek", "Drew Kopas", "Andy Clemence", "Bradley Foster Smith"],
+            visible: 2
+        )
+        XCTAssertEqual(summary, "Danny Montooth, James Konicek & 3 more")
+    }
+
+    func testNarratorSummaryRollsUpCombinedString() {
+        // Regression: the server delivers the whole cast as one comma-joined
+        // string, which must still summarise rather than wrap to many lines.
+        let summary = AudiobookDetailFormatting.peopleSummary(
+            ["Danny Montooth, James Konicek, Drew Kopas, Andy Clemence, Bradley Foster Smith"],
+            visible: 2
+        )
+        XCTAssertEqual(summary, "Danny Montooth, James Konicek & 3 more")
+    }
+
+    func testSmallCreditListsJoinNaturally() {
+        XCTAssertEqual(AudiobookDetailFormatting.peopleSummary(["Brandon Sanderson"]), "Brandon Sanderson")
+        XCTAssertEqual(AudiobookDetailFormatting.peopleSummary(["A", "B"]), "A & B")
+        XCTAssertEqual(AudiobookDetailFormatting.peopleSummary(["A", "B", "C"]), "A, B & C")
+    }
+
+    func testEmptyCreditListIsNil() {
+        XCTAssertNil(AudiobookDetailFormatting.peopleSummary([]))
+        XCTAssertNil(AudiobookDetailFormatting.peopleSummary(["", "  "]))
+    }
+}

--- a/iosApp/iosApp/Screens/Detail/AudiobookDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/AudiobookDetailContent.swift
@@ -6,19 +6,64 @@ struct AudiobookDetailContent: View {
 
     @Environment(AudioPlaybackStore.self) private var audioStore
 
+    #if !os(tvOS)
+    @State private var showAllChapters = false
+    #endif
+
     var body: some View {
+        #if os(tvOS)
+        tvBody
+        #else
+        phoneBody
+        #endif
+    }
+
+    @ViewBuilder
+    private var aboutSection: some View {
+        if let overview = detail.overview, !overview.isEmpty {
+            detailSection(title: "About") {
+                Text(overview)
+                    .font(aboutFont)
+                    .foregroundStyle(.secondary)
+                    .lineSpacing(3)
+            }
+        }
+    }
+
+    /// Series / narration / recommendation rails — identical on every
+    /// platform, so both layouts share them.
+    @ViewBuilder
+    private var commonSections: some View {
+        if let series = detail.audiobook?.series, !series.entries.isEmpty {
+            detailSection(title: series.name ?? "Series") {
+                relatedRail(items: series.entries)
+            }
+        }
+
+        if !otherNarrations.isEmpty {
+            narrationsSection
+        }
+
+        if let related = detail.audiobook?.related {
+            if !related.alsoByAuthor.isEmpty {
+                detailSection(title: "More by Author") {
+                    relatedRail(items: related.alsoByAuthor)
+                }
+            }
+            if !related.similar.isEmpty {
+                detailSection(title: "Related") {
+                    relatedRail(items: related.similar)
+                }
+            }
+        }
+    }
+
+    #if os(tvOS)
+    private var tvBody: some View {
         ScrollView(.vertical, showsIndicators: false) {
             VStack(alignment: .leading, spacing: sectionSpacing) {
                 header
-
-                if let overview = detail.overview, !overview.isEmpty {
-                    detailSection(title: "About") {
-                        Text(overview)
-                            .font(.body)
-                            .foregroundStyle(.secondary)
-                            .lineSpacing(3)
-                    }
-                }
+                aboutSection
 
                 if !parts.isEmpty {
                     detailSection(title: "Parts") {
@@ -40,58 +85,7 @@ struct AudiobookDetailContent: View {
                     }
                 }
 
-                if let series = detail.audiobook?.series, !series.entries.isEmpty {
-                    detailSection(title: series.name ?? "Series") {
-                        relatedRail(items: series.entries)
-                    }
-                }
-
-                if !otherNarrations.isEmpty {
-                    detailSection(title: "Alternate Narrations") {
-                        VStack(spacing: 10) {
-                            ForEach(otherNarrations) { narration in
-                                Button {
-                                    onNavigateToItem(narration.contentId)
-                                } label: {
-                                    HStack(spacing: 12) {
-                                        Image(systemName: "person.wave.2")
-                                            .frame(width: 28)
-                                        VStack(alignment: .leading, spacing: 2) {
-                                            Text(narration.title)
-                                                .font(.headline)
-                                                .lineLimit(1)
-                                            if !narration.narrators.isEmpty {
-                                                Text(narration.narrators.joined(separator: ", "))
-                                                    .font(.subheadline)
-                                                    .foregroundStyle(.secondary)
-                                                    .lineLimit(1)
-                                            }
-                                        }
-                                        Spacer()
-                                        Image(systemName: "chevron.right")
-                                            .foregroundStyle(.secondary)
-                                    }
-                                    .contentShape(Rectangle())
-                                }
-                                .buttonStyle(.plain)
-                            }
-                        }
-                    }
-                }
-
-                if let related = detail.audiobook?.related {
-                    if !related.alsoByAuthor.isEmpty {
-                        detailSection(title: "More by Author") {
-                            relatedRail(items: related.alsoByAuthor)
-                        }
-                    }
-                    if !related.similar.isEmpty {
-                        detailSection(title: "Related") {
-                            relatedRail(items: related.similar)
-                        }
-                    }
-                }
-
+                commonSections
             }
             .padding(.horizontal, ContinuumTheme.safePadding)
             .padding(.top, topPadding)
@@ -100,9 +94,7 @@ struct AudiobookDetailContent: View {
         .continuumBackground()
     }
 
-    @ViewBuilder
     private var header: some View {
-        #if os(tvOS)
         ZStack(alignment: .bottomLeading) {
             audiobookBackdrop
             HStack(alignment: .center, spacing: 56) {
@@ -116,21 +108,48 @@ struct AudiobookDetailContent: View {
             .padding(.top, 120)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        #else
-        VStack(spacing: 22) {
-            cover(size: coverSize)
-            headerText
-                .frame(maxWidth: 620)
+    }
+    #endif
+
+    private var narrationsSection: some View {
+        detailSection(title: "Alternate Narrations") {
+            VStack(spacing: 10) {
+                ForEach(otherNarrations) { narration in
+                    Button {
+                        onNavigateToItem(narration.contentId)
+                    } label: {
+                        HStack(spacing: 12) {
+                            Image(systemName: "person.wave.2")
+                                .frame(width: 28)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(narration.title)
+                                    .font(.headline)
+                                    .lineLimit(1)
+                                if !narration.narrators.isEmpty {
+                                    Text(narration.narrators.joined(separator: ", "))
+                                        .font(.subheadline)
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(1)
+                                }
+                            }
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .foregroundStyle(.secondary)
+                        }
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
         }
-        .frame(maxWidth: .infinity)
-        #endif
     }
 
+    // MARK: - tvOS header (10-foot cinematic layout)
+
+    #if os(tvOS)
     private var headerText: some View {
         VStack(alignment: headerAlignment, spacing: 14) {
-            #if os(tvOS)
             audiobookEyebrow
-            #endif
             Text(detail.title)
                 .font(titleFont)
                 .fontWeight(.bold)
@@ -157,7 +176,6 @@ struct AudiobookDetailContent: View {
 
     @ViewBuilder
     private var actionRow: some View {
-        #if os(tvOS)
         // The hero pills own their focus appearance — system bordered
         // styles render white-on-white here because the tvOS root tints
         // controls with `.continuumOnSurface`.
@@ -194,30 +212,8 @@ struct AudiobookDetailContent: View {
                 .buttonStyle(TVPillButtonStyle(kind: .secondary))
             }
         }
-        #else
-        HStack(spacing: 12) {
-            Button {
-                audioStore.play(
-                    contentId: detail.contentId,
-                    restart: false,
-                    startPosition: resumePosition
-                )
-            } label: {
-                Label(primaryPlayLabel, systemImage: "play.fill")
-            }
-            .buttonStyle(.borderedProminent)
-
-            Button {
-                audioStore.play(contentId: detail.contentId, restart: true)
-            } label: {
-                Label("Start Over", systemImage: "arrow.counterclockwise")
-            }
-            .buttonStyle(.bordered)
-        }
-        #endif
     }
 
-    #if os(tvOS)
     /// A blurred, darkened wash of the square cover stands in for a 16:9
     /// backdrop, keeping the audiobook page in the cinematic family.
     @ViewBuilder
@@ -257,84 +253,6 @@ struct AudiobookDetailContent: View {
                 .foregroundColor(.white.opacity(0.78))
         }
     }
-    #endif
-
-    @ViewBuilder
-    private func cover(size: CGFloat) -> some View {
-        if let url = detail.posterUrl, !url.isEmpty {
-            AsyncImageView(
-                url: url,
-                thumbhash: detail.posterThumbhash,
-                targetSize: CGSize(width: size, height: size),
-                contentMode: .fill
-            )
-            .frame(width: size, height: size)
-            .clipShape(RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius))
-        } else {
-            RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius)
-                .fill(Color.continuumSurfaceElevated)
-                .frame(width: size, height: size)
-                .overlay {
-                    Image(systemName: "book.closed")
-                        .font(.system(size: size * 0.22, weight: .semibold))
-                        .foregroundStyle(.secondary)
-                }
-        }
-    }
-
-    private func detailSection<Content: View>(
-        title: String,
-        @ViewBuilder content: () -> Content
-    ) -> some View {
-        VStack(alignment: .leading, spacing: 14) {
-            Text(title)
-                .font(sectionTitleFont)
-                .fontWeight(.semibold)
-                .foregroundColor(.continuumOnSurface)
-            content()
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    private func partRow(part: FileVersion, fallbackIndex: Int) -> some View {
-        HStack(spacing: 14) {
-            Image(systemName: "waveform")
-                .foregroundStyle(.secondary)
-                .frame(width: 28)
-            VStack(alignment: .leading, spacing: 2) {
-                Text(partTitle(part, fallbackIndex: fallbackIndex))
-                    .font(rowTitleFont)
-                    .lineLimit(1)
-                Text(partSubtitle(part))
-                    .font(rowMetaFont)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-            }
-            Spacer()
-            Text(PlayerTimeFormatter.formatRuntime(partDuration(part)))
-                .font(rowMetaFont)
-                .foregroundStyle(.secondary)
-        }
-        .padding(.vertical, 4)
-    }
-
-    /// Row typography: tvOS uses the 10-foot scale instead of letting
-    /// iOS semantic fonts balloon at TV sizes.
-    private var rowTitleFont: Font {
-        #if os(tvOS)
-        return .continuumBody
-        #else
-        return .headline
-        #endif
-    }
-
-    private var rowMetaFont: Font {
-        #if os(tvOS)
-        return .continuumCaption
-        #else
-        return .subheadline
-        #endif
-    }
 
     private func chapterRow(_ chapter: DisplayChapter) -> some View {
         Button {
@@ -349,25 +267,472 @@ struct AudiobookDetailContent: View {
                     .foregroundStyle(.secondary)
                     .frame(width: 28)
                 Text(chapter.title)
-                    .font(rowTitleFont)
+                    .font(.continuumBody)
                     .lineLimit(1)
                 Spacer()
                 Text(PlayerTimeFormatter.formatHMS(chapter.startSeconds))
-                    .font(rowMetaFont)
+                    .font(.continuumCaption)
                     .monospacedDigit()
                     .foregroundStyle(.secondary)
             }
             .contentShape(Rectangle())
-            #if os(tvOS)
             .padding(.horizontal, 28)
             .padding(.vertical, 18)
-            #endif
         }
-        #if os(tvOS)
         .buttonStyle(TVAudiobookRowStyle())
-        #else
+    }
+
+    private func partRow(part: FileVersion, fallbackIndex: Int) -> some View {
+        HStack(spacing: 14) {
+            Image(systemName: "waveform")
+                .foregroundStyle(.secondary)
+                .frame(width: 28)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(partTitle(part, fallbackIndex: fallbackIndex))
+                    .font(.continuumBody)
+                    .lineLimit(1)
+                Text(partSubtitle(part))
+                    .font(.continuumCaption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer()
+            Text(PlayerTimeFormatter.formatRuntime(partDuration(part)))
+                .font(.continuumCaption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 4)
+    }
+    #endif
+
+    // MARK: - iOS / macOS hero
+
+    #if !os(tvOS)
+    private var phoneBody: some View {
+        // The GeometryReader captures the real top safe-area inset *before*
+        // the ScrollView ignores it, so the hero column can clear the status
+        // bar while the backdrop still bleeds to the physical top edge.
+        GeometryReader { proxy in
+            let topInset = proxy.safeAreaInsets.top
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 0) {
+                    phoneHero(topInset: topInset)
+                    phoneSections
+                        .padding(.horizontal, ContinuumTheme.safePadding)
+                        .padding(.top, sectionSpacing)
+                        .padding(.bottom, bottomPadding)
+                }
+            }
+            .ignoresSafeArea(edges: .top)
+        }
+        .continuumBackground()
+    }
+
+    private var phoneSections: some View {
+        VStack(alignment: .leading, spacing: sectionSpacing) {
+            aboutSection
+
+            if !displayChapters.isEmpty {
+                phoneChaptersSection
+            }
+
+            if parts.count > 1 {
+                phonePartsSection
+            }
+
+            commonSections
+            phoneDetailsLine
+        }
+    }
+
+    /// Identity-first hero in the house style: the square cover floats on a
+    /// blurred, color-extracted wash of itself (the §5.5 detail backdrop the
+    /// movie hero already uses, adapted for square art), with a clear
+    /// Title → Author → Narrator hierarchy and a progress-forward CTA. The
+    /// backdrop is a top-pinned background so it fills up under the status
+    /// bar; the cover is inset past the safe area so it clears it.
+    private func phoneHero(topInset: CGFloat) -> some View {
+        VStack(spacing: 0) {
+            phoneCover
+                .padding(.top, topInset + 14)
+            phoneIdentity
+                .padding(.top, 20)
+            phoneProgressActions
+                .padding(.top, 22)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, ContinuumTheme.safePadding)
+        .background(alignment: .top) {
+            phoneBackdrop
+        }
+    }
+
+    private var phoneBackdrop: some View {
+        ZStack {
+            if let url = detail.posterUrl, !url.isEmpty {
+                AsyncImageView(
+                    url: url,
+                    thumbhash: detail.posterThumbhash,
+                    targetSize: CGSize(width: 420, height: 420),
+                    contentMode: .fill
+                )
+                .frame(height: phoneBackdropHeight)
+                .frame(maxWidth: .infinity)
+                .clipped()
+                .blur(radius: 48, opaque: true)
+                .opacity(0.55)
+            } else {
+                Color.continuumSurface.frame(height: phoneBackdropHeight)
+            }
+            LinearGradient(
+                stops: [
+                    .init(color: Color.continuumBackground.opacity(0.30), location: 0.0),
+                    .init(color: Color.continuumBackground.opacity(0.72), location: 0.55),
+                    .init(color: Color.continuumBackground, location: 0.95),
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .frame(height: phoneBackdropHeight)
+        }
+        .frame(maxWidth: .infinity, alignment: .top)
+        .allowsHitTesting(false)
+    }
+
+    @ViewBuilder
+    private var phoneCover: some View {
+        Group {
+            if let url = detail.posterUrl, !url.isEmpty {
+                AsyncImageView(
+                    url: url,
+                    thumbhash: detail.posterThumbhash,
+                    targetSize: CGSize(width: phoneCoverSize, height: phoneCoverSize),
+                    contentMode: .fill
+                )
+            } else {
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(Color.continuumSurfaceElevated)
+                    .overlay {
+                        Image(systemName: "headphones")
+                            .font(.system(size: phoneCoverSize * 0.2, weight: .semibold))
+                            .foregroundStyle(.secondary)
+                    }
+            }
+        }
+        .frame(width: phoneCoverSize, height: phoneCoverSize)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(Color.white.opacity(0.08), lineWidth: 0.5)
+        )
+        .shadow(color: .black.opacity(0.5), radius: 26, x: 0, y: 16)
+    }
+
+    private var phoneIdentity: some View {
+        VStack(spacing: 0) {
+            Text("AUDIOBOOK")
+                .font(.system(size: 11, weight: .semibold))
+                .tracking(1.6)
+                .foregroundColor(.continuumOnSurface)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 5)
+                .background(Capsule().fill(Color.continuumSurfaceElevated))
+
+            Text(displayTitle)
+                .font(.system(size: 28, weight: .bold))
+                .tracking(-0.4)
+                .multilineTextAlignment(.center)
+                .foregroundColor(.continuumOnSurface)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.top, 14)
+
+            if let seriesLineText {
+                Text(seriesLineText.uppercased())
+                    .font(.system(size: 11, weight: .semibold))
+                    .tracking(1.6)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.top, 7)
+            }
+
+            if let authorSummary {
+                Text(authorSummary)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundColor(.continuumOnSurface)
+                    .multilineTextAlignment(.center)
+                    .padding(.top, 12)
+            }
+
+            if let narratorSummary {
+                Text("Narrated by \(narratorSummary)")
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(2)
+                    .padding(.top, 4)
+            }
+
+            if !metaTokens.isEmpty {
+                Text(metaTokens.joined(separator: "  ·  "))
+                    .font(.system(size: 12.5))
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.top, 11)
+            }
+        }
+        .frame(maxWidth: 560)
+    }
+
+    private var phoneProgressActions: some View {
+        VStack(spacing: 14) {
+            if resumeFraction != nil {
+                HStack {
+                    Text("\(percentComplete)% complete")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundColor(.continuumOnSurface)
+                    Spacer()
+                    Text("\(PlayerTimeFormatter.formatRuntime(timeLeftSeconds)) left")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, 4)
+            }
+
+            AudiobookResumePill(
+                icon: primaryActionIcon,
+                title: primaryActionLabel,
+                progress: resumeFraction
+            ) {
+                primaryAction()
+            }
+
+            phoneSecondaryControls
+        }
+        .frame(maxWidth: 420)
+    }
+
+    private var phoneSecondaryControls: some View {
+        HStack(alignment: .top, spacing: 26) {
+            phoneControl("Start Over") {
+                PhoneCircleActionButton(
+                    icon: "arrow.counterclockwise",
+                    accessibilityLabel: "Start Over"
+                ) {
+                    audioStore.play(contentId: detail.contentId, restart: true)
+                }
+            }
+
+            phoneControl("Speed") {
+                phoneSpeedControl
+            }
+
+            if !otherNarrations.isEmpty {
+                phoneControl("Narration") {
+                    PhoneCircleMenuButton(icon: "person.wave.2", accessibilityLabel: "Narration") {
+                        ForEach(otherNarrations) { narration in
+                            Button {
+                                onNavigateToItem(narration.contentId)
+                            } label: {
+                                Text(narration.narrators.isEmpty
+                                     ? narration.title
+                                     : narration.narrators.joined(separator: ", "))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var phoneSpeedControl: some View {
+        Menu {
+            ForEach(speedOptions, id: \.self) { rate in
+                Button {
+                    audioStore.player.setPlaybackRate(rate)
+                } label: {
+                    if abs(audioStore.player.playbackRate - rate) < 0.01 {
+                        Label(speedLabel(rate), systemImage: "checkmark")
+                    } else {
+                        Text(speedLabel(rate))
+                    }
+                }
+            }
+        } label: {
+            Text(speedLabel(audioStore.player.playbackRate))
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(.white)
+                .frame(width: 44, height: 44)
+                .background(
+                    Circle()
+                        .fill(Color.white.opacity(0.10))
+                        .overlay(Circle().stroke(Color.white.opacity(0.25), lineWidth: 1))
+                )
+        }
+        .accessibilityLabel("Playback Speed")
+    }
+
+    @ViewBuilder
+    private func phoneControl<Content: View>(
+        _ caption: String,
+        @ViewBuilder _ content: () -> Content
+    ) -> some View {
+        VStack(spacing: 7) {
+            content()
+            Text(caption)
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var phoneChaptersSection: some View {
+        detailSection(title: "Chapters") {
+            VStack(spacing: 0) {
+                ForEach(Array(visibleChapters.enumerated()), id: \.element.id) { index, chapter in
+                    phoneChapterRow(chapter, showsDivider: index > 0)
+                }
+
+                if displayChapters.count > chapterCollapseLimit {
+                    Button {
+                        withAnimation(.easeInOut(duration: ContinuumTheme.normalDuration)) {
+                            showAllChapters.toggle()
+                        }
+                    } label: {
+                        HStack(spacing: 6) {
+                            Text(showAllChapters
+                                 ? "Show less"
+                                 : "Show all \(displayChapters.count) chapters")
+                            Image(systemName: showAllChapters ? "chevron.up" : "chevron.down")
+                                .font(.system(size: 12, weight: .semibold))
+                        }
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.top, 12)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    private func phoneChapterRow(_ chapter: DisplayChapter, showsDivider: Bool) -> some View {
+        Button {
+            audioStore.play(
+                contentId: detail.contentId,
+                restart: false,
+                startPosition: chapter.startSeconds
+            )
+        } label: {
+            HStack(spacing: 13) {
+                Image(systemName: "play.fill")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundColor(.continuumOnSurface)
+                    .frame(width: 26, height: 26)
+                    .background(
+                        Circle()
+                            .fill(Color.white.opacity(0.07))
+                            .overlay(Circle().stroke(Color.white.opacity(0.10), lineWidth: 0.5))
+                    )
+                Text(chapter.title)
+                    .font(.system(size: 15))
+                    .foregroundColor(.continuumOnSurface)
+                    .lineLimit(1)
+                Spacer()
+                Text(PlayerTimeFormatter.formatHMS(chapter.startSeconds))
+                    .font(.system(size: 13))
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.vertical, 11)
+            .contentShape(Rectangle())
+            .overlay(alignment: .top) {
+                if showsDivider {
+                    Rectangle()
+                        .fill(Color.continuumDivider)
+                        .frame(height: 0.5)
+                }
+            }
+        }
         .buttonStyle(.plain)
-        #endif
+    }
+
+    private var phonePartsSection: some View {
+        detailSection(title: "Parts") {
+            VStack(spacing: 0) {
+                ForEach(parts.indices, id: \.self) { index in
+                    phonePartRow(parts[index], index: index, showsDivider: index > 0)
+                }
+            }
+        }
+    }
+
+    private func phonePartRow(_ part: FileVersion, index: Int, showsDivider: Bool) -> some View {
+        Button {
+            audioStore.play(
+                contentId: detail.contentId,
+                restart: false,
+                startPosition: partStartOffset(index)
+            )
+        } label: {
+            HStack(spacing: 13) {
+                Image(systemName: "waveform")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(.continuumOnSurface)
+                    .frame(width: 26, height: 26)
+                    .background(
+                        Circle()
+                            .fill(Color.white.opacity(0.07))
+                            .overlay(Circle().stroke(Color.white.opacity(0.10), lineWidth: 0.5))
+                    )
+                Text(partTitle(part, fallbackIndex: index))
+                    .font(.system(size: 15))
+                    .foregroundColor(.continuumOnSurface)
+                    .lineLimit(1)
+                Spacer()
+                Text(PlayerTimeFormatter.formatRuntime(partDuration(part)))
+                    .font(.system(size: 13))
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.vertical, 11)
+            .contentShape(Rectangle())
+            .overlay(alignment: .top) {
+                if showsDivider {
+                    Rectangle()
+                        .fill(Color.continuumDivider)
+                        .frame(height: 0.5)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private var phoneDetailsLine: some View {
+        if !formatTokens.isEmpty {
+            Text(formatTokens.joined(separator: "  ·  "))
+                .font(.system(size: 12))
+                .foregroundColor(.continuumOnSurface.opacity(0.4))
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+    #endif
+
+    // MARK: - Shared section scaffolding
+
+    private func detailSection<Content: View>(
+        title: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text(title)
+                .font(sectionTitleFont)
+                .fontWeight(.semibold)
+                .foregroundColor(.continuumOnSurface)
+            content()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private func relatedRail(items: [AudiobookRelatedItem]) -> some View {
@@ -424,6 +789,31 @@ struct AudiobookDetailContent: View {
         }
     }
 
+    @ViewBuilder
+    private func cover(size: CGFloat) -> some View {
+        if let url = detail.posterUrl, !url.isEmpty {
+            AsyncImageView(
+                url: url,
+                thumbhash: detail.posterThumbhash,
+                targetSize: CGSize(width: size, height: size),
+                contentMode: .fill
+            )
+            .frame(width: size, height: size)
+            .clipShape(RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius))
+        } else {
+            RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius)
+                .fill(Color.continuumSurfaceElevated)
+                .frame(width: size, height: size)
+                .overlay {
+                    Image(systemName: "book.closed")
+                        .font(.system(size: size * 0.22, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                }
+        }
+    }
+
+    // MARK: - Audiobook timeline data
+
     private var parts: [FileVersion] {
         AudiobookPlaybackContext.audioParts(of: detail)
     }
@@ -455,6 +845,40 @@ struct AudiobookDetailContent: View {
         detail.audiobook?.otherNarrations ?? []
     }
 
+    private var resumePosition: Double? {
+        guard let position = detail.userData?.positionSeconds,
+              position.isFinite,
+              position > 30 else { return nil }
+        if let duration = detail.userData?.durationSeconds,
+           duration.isFinite,
+           duration > 0,
+           position >= duration - 5 {
+            return nil
+        }
+        return position
+    }
+
+    private func partTitle(_ part: FileVersion, fallbackIndex: Int) -> String {
+        if let fileName = part.fileName, !fileName.isEmpty {
+            return fileName
+        }
+        let rawIndex = part.presentationPartIndex ?? fallbackIndex
+        let displayIndex = rawIndex <= 0 ? rawIndex + 1 : rawIndex
+        return "Part \(displayIndex)"
+    }
+
+    private func partDuration(_ part: FileVersion) -> Double {
+        AudiobookPlaybackContext.partDuration(part)
+    }
+
+    private func joinedNames(_ people: [AudiobookPerson]?) -> String? {
+        people?
+            .map(\.name)
+            .filter { !$0.isEmpty }
+            .joined(separator: ", ")
+    }
+
+    #if os(tvOS)
     private var currentNarratorLabel: String {
         guard let names = joinedNames(detail.audiobook?.narrators), !names.isEmpty else {
             return "Default"
@@ -470,27 +894,11 @@ struct AudiobookDetailContent: View {
         if let narrators = joinedNames(detail.audiobook?.narrators), !narrators.isEmpty {
             tokens.append("Narrated by \(narrators)")
         }
-        let totalDuration = detail.audiobook?.totalDurationSeconds.map(Double.init)
-            ?? detail.userData?.durationSeconds
-            ?? parts.reduce(0) { $0 + partDuration($1) }
-        let runtime = PlayerTimeFormatter.formatRuntime(totalDuration)
+        let runtime = PlayerTimeFormatter.formatRuntime(totalDurationSeconds)
         if !runtime.isEmpty {
             tokens.append(runtime)
         }
         return tokens.joined(separator: "  ")
-    }
-
-    private var resumePosition: Double? {
-        guard let position = detail.userData?.positionSeconds,
-              position.isFinite,
-              position > 30 else { return nil }
-        if let duration = detail.userData?.durationSeconds,
-           duration.isFinite,
-           duration > 0,
-           position >= duration - 5 {
-            return nil
-        }
-        return position
     }
 
     private var primaryPlayLabel: String {
@@ -499,16 +907,23 @@ struct AudiobookDetailContent: View {
         }
         return "Play"
     }
+    #endif
 
-    private func partTitle(_ part: FileVersion, fallbackIndex: Int) -> String {
-        if let fileName = part.fileName, !fileName.isEmpty {
-            return fileName
+    /// Total book duration, preferring the server's authoritative value and
+    /// falling back to the stitched part durations.
+    private var totalDurationSeconds: Double {
+        if let total = detail.audiobook?.totalDurationSeconds, total > 0 {
+            return Double(total)
         }
-        let rawIndex = part.presentationPartIndex ?? fallbackIndex
-        let displayIndex = rawIndex <= 0 ? rawIndex + 1 : rawIndex
-        return "Part \(displayIndex)"
+        if let duration = detail.userData?.durationSeconds, duration > 0 {
+            return duration
+        }
+        return parts.reduce(0) { $0 + partDuration($1) }
     }
 
+    /// Codec / container metadata is server-tooling detail — kept off the
+    /// hero entirely and shown without bitrate (the old "0 kbps" came from
+    /// integer-dividing a kbps value by 1000).
     private func partSubtitle(_ part: FileVersion) -> String {
         var tokens: [String] = []
         if let codec = part.codecAudio, !codec.isEmpty {
@@ -517,28 +932,163 @@ struct AudiobookDetailContent: View {
         if let container = part.container, !container.isEmpty {
             tokens.append(container.uppercased())
         }
-        if let bitrate = part.bitrate, bitrate > 0 {
-            tokens.append("\(bitrate / 1000) kbps")
-        }
         return tokens.isEmpty ? "Audio part" : tokens.joined(separator: "  ")
     }
 
-    private func partDuration(_ part: FileVersion) -> Double {
-        AudiobookPlaybackContext.partDuration(part)
+    // MARK: - iOS / macOS hero data
+
+    #if !os(tvOS)
+    private var displayTitle: String {
+        AudiobookDetailFormatting.cleanTitle(detail.title, seriesName: detail.audiobook?.series?.name)
     }
 
-    private func joinedNames(_ people: [AudiobookPerson]?) -> String? {
-        people?
-            .map(\.name)
-            .filter { !$0.isEmpty }
-            .joined(separator: ", ")
+    /// The series total comes from the title's "(N of M)" locator rather
+    /// than the series grouping's entry count — the grouping can include
+    /// alternate editions/narrations, which inflates the count (e.g. "of 19"
+    /// for a 5-book series).
+    private var seriesLineText: String? {
+        let volume = AudiobookDetailFormatting.volume(in: detail.title)
+        return AudiobookDetailFormatting.seriesLine(
+            name: detail.audiobook?.series?.name,
+            index: currentSeriesIndex ?? volume.index,
+            total: volume.total
+        )
     }
 
-    private var coverSize: CGFloat {
+    private var currentSeriesIndex: Int? {
+        detail.audiobook?.series?.entries
+            .first(where: { $0.contentId == detail.contentId })?
+            .seriesIndex
+    }
+
+    private var authorSummary: String? {
+        AudiobookDetailFormatting.peopleSummary(
+            detail.audiobook?.authors.map(\.name) ?? [],
+            visible: 3
+        )
+    }
+
+    private var narratorSummary: String? {
+        AudiobookDetailFormatting.peopleSummary(
+            detail.audiobook?.narrators.map(\.name) ?? [],
+            visible: 2
+        )
+    }
+
+    /// Compact, content-y metadata for the hero (interpunct-joined): runtime,
+    /// publisher, year. Codec/bitrate intentionally excluded.
+    private var metaTokens: [String] {
+        var tokens: [String] = []
+        let runtime = PlayerTimeFormatter.formatRuntime(totalDurationSeconds)
+        if !runtime.isEmpty { tokens.append(runtime) }
+        if let publisher = detail.audiobook?.publisher, !publisher.isEmpty {
+            tokens.append(publisher)
+        }
+        if let year = detail.year { tokens.append(String(year)) }
+        return tokens
+    }
+
+    /// Quiet, deemphasised technical line at the foot of the page.
+    private var formatTokens: [String] {
+        guard let primary = parts.first else { return [] }
+        var tokens: [String] = []
+        if let codec = primary.codecAudio, !codec.isEmpty {
+            tokens.append(codec.uppercased())
+        }
+        if let container = primary.container, !container.isEmpty {
+            tokens.append(container.uppercased())
+        }
+        if parts.count > 1 {
+            tokens.append("\(parts.count) parts")
+        }
+        let runtime = PlayerTimeFormatter.formatRuntime(totalDurationSeconds)
+        if !runtime.isEmpty { tokens.append(runtime) }
+        return tokens
+    }
+
+    private var positionSeconds: Double {
+        max(0, detail.userData?.positionSeconds ?? 0)
+    }
+
+    /// Listening progress 0...1, only when there's a meaningful resume point.
+    private var resumeFraction: Double? {
+        guard resumePosition != nil, totalDurationSeconds > 0 else { return nil }
+        return min(1, max(0, positionSeconds / totalDurationSeconds))
+    }
+
+    private var percentComplete: Int {
+        Int((resumeFraction ?? 0) * 100 + 0.5)
+    }
+
+    private var timeLeftSeconds: Double {
+        max(0, totalDurationSeconds - positionSeconds)
+    }
+
+    private var isFinished: Bool {
+        if detail.userData?.played == true { return true }
+        guard totalDurationSeconds > 0, positionSeconds > 0 else { return false }
+        return positionSeconds >= totalDurationSeconds - 5
+    }
+
+    private var primaryActionLabel: String {
+        if resumePosition != nil { return "Resume" }
+        if isFinished { return "Play Again" }
+        return "Play"
+    }
+
+    private var primaryActionIcon: String {
+        resumePosition == nil && isFinished ? "arrow.counterclockwise" : "play.fill"
+    }
+
+    private func primaryAction() {
+        if let resumePosition {
+            audioStore.play(contentId: detail.contentId, restart: false, startPosition: resumePosition)
+        } else if isFinished {
+            audioStore.play(contentId: detail.contentId, restart: true)
+        } else {
+            audioStore.play(contentId: detail.contentId, restart: false)
+        }
+    }
+
+    private func partStartOffset(_ index: Int) -> Double {
+        var offset = 0.0
+        for position in 0..<index where parts.indices.contains(position) {
+            offset += partDuration(parts[position])
+        }
+        return offset
+    }
+
+    private var visibleChapters: [DisplayChapter] {
+        showAllChapters ? displayChapters : Array(displayChapters.prefix(chapterCollapseLimit))
+    }
+
+    private let chapterCollapseLimit = 8
+
+    private let speedOptions: [Double] = [0.75, 1.0, 1.25, 1.5, 1.75, 2.0]
+
+    private func speedLabel(_ rate: Double) -> String {
+        let value = rate.truncatingRemainder(dividingBy: 1) == 0
+            ? String(Int(rate))
+            : String(format: "%g", rate)
+        return "\(value)×"
+    }
+    #endif
+
+    // MARK: - Platform metrics
+
+    private var sectionTitleFont: Font {
         #if os(tvOS)
-        return 360
+        return .title2
         #else
-        return 220
+        return .headline
+        #endif
+    }
+
+    private var aboutFont: Font {
+        #if os(tvOS)
+        return .body
+        #else
+        return .system(size: 15)
         #endif
     }
 
@@ -576,7 +1126,7 @@ struct AudiobookDetailContent: View {
         #if os(tvOS)
         return 0
         #else
-        return 24
+        return 0
         #endif
     }
 
@@ -588,37 +1138,19 @@ struct AudiobookDetailContent: View {
         #endif
     }
 
-    private var titleFont: Font {
-        #if os(tvOS)
-        return .system(size: 56, weight: .bold)
-        #else
-        return .title2
-        #endif
-    }
+    #if os(tvOS)
+    private var coverSize: CGFloat { 360 }
 
-    private var sectionTitleFont: Font {
-        #if os(tvOS)
-        return .title2
-        #else
-        return .headline
-        #endif
-    }
+    private var titleFont: Font { .system(size: 56, weight: .bold) }
 
-    private var headerAlignment: HorizontalAlignment {
-        #if os(tvOS)
-        return .leading
-        #else
-        return .center
-        #endif
-    }
+    private var headerAlignment: HorizontalAlignment { .leading }
 
-    private var headerTextAlignment: TextAlignment {
-        #if os(tvOS)
-        return .leading
-        #else
-        return .center
-        #endif
-    }
+    private var headerTextAlignment: TextAlignment { .leading }
+    #else
+    private var phoneCoverSize: CGFloat { 196 }
+
+    private var phoneBackdropHeight: CGFloat { 470 }
+    #endif
 }
 
 private struct DisplayChapter: Identifiable, Hashable {
@@ -627,6 +1159,54 @@ private struct DisplayChapter: Identifiable, Hashable {
     let startSeconds: Double
     let partTitle: String
 }
+
+#if !os(tvOS)
+/// Solid-white capsule resume/play button with the in-pill progress bar
+/// the design language specifies for in-progress items (§5.5): a thin black
+/// track + fill hugging the bottom of the pill.
+private struct AudiobookResumePill: View {
+    let icon: String
+    let title: String
+    let progress: Double?
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 10) {
+                Image(systemName: icon)
+                    .font(.system(size: 17, weight: .bold))
+                Text(title)
+                    .font(.system(size: 17, weight: .semibold))
+                    .lineLimit(1)
+            }
+            .foregroundColor(.black)
+            .frame(maxWidth: .infinity)
+            .frame(height: 54)
+            .background {
+                ZStack {
+                    Capsule().fill(Color.white)
+                    if let progress, progress > 0 {
+                        GeometryReader { geo in
+                            ZStack(alignment: .leading) {
+                                Capsule()
+                                    .fill(Color.black.opacity(0.16))
+                                    .frame(height: 5)
+                                Capsule()
+                                    .fill(Color.black.opacity(0.82))
+                                    .frame(width: max(6, geo.size.width * progress), height: 5)
+                            }
+                            .frame(maxHeight: .infinity, alignment: .bottom)
+                            .padding(.horizontal, 16)
+                            .padding(.bottom, 8)
+                        }
+                    }
+                }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+}
+#endif
 
 #if os(tvOS)
 /// Native list-row focus grammar for chapter rows (mirrors

--- a/iosApp/iosApp/Screens/Detail/AudiobookDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/AudiobookDetailContent.swift
@@ -180,12 +180,8 @@ struct AudiobookDetailContent: View {
         // styles render white-on-white here because the tvOS root tints
         // controls with `.continuumOnSurface`.
         HStack(spacing: 24) {
-            TVPrimaryPillButton(icon: "play.fill", title: primaryPlayLabel) {
-                audioStore.play(
-                    contentId: detail.contentId,
-                    restart: false,
-                    startPosition: resumePosition
-                )
+            TVPrimaryPillButton(icon: primaryActionIcon, title: primaryPlayLabel) {
+                primaryAction()
             }
 
             TVSecondaryPillButton(icon: "arrow.counterclockwise", title: "Start Over") {
@@ -849,13 +845,43 @@ struct AudiobookDetailContent: View {
         guard let position = detail.userData?.positionSeconds,
               position.isFinite,
               position > 30 else { return nil }
-        if let duration = detail.userData?.durationSeconds,
-           duration.isFinite,
+        // Use the same duration source that drives the finished-state logic,
+        // so a completed book with a missing/stale userData duration still
+        // suppresses Resume and routes to Play Again.
+        let duration = totalDurationSeconds
+        if duration.isFinite,
            duration > 0,
            position >= duration - 5 {
             return nil
         }
         return position
+    }
+
+    private var positionSeconds: Double {
+        max(0, detail.userData?.positionSeconds ?? 0)
+    }
+
+    /// Whether the book is effectively finished. Shared so every platform
+    /// can route completed titles to "Play Again" (restart) instead of
+    /// resuming near the end.
+    private var isFinished: Bool {
+        if detail.userData?.played == true { return true }
+        guard totalDurationSeconds > 0, positionSeconds > 0 else { return false }
+        return positionSeconds >= totalDurationSeconds - 5
+    }
+
+    private var primaryActionIcon: String {
+        resumePosition == nil && isFinished ? "arrow.counterclockwise" : "play.fill"
+    }
+
+    private func primaryAction() {
+        if let resumePosition {
+            audioStore.play(contentId: detail.contentId, restart: false, startPosition: resumePosition)
+        } else if isFinished {
+            audioStore.play(contentId: detail.contentId, restart: true)
+        } else {
+            audioStore.play(contentId: detail.contentId, restart: false)
+        }
     }
 
     private func partTitle(_ part: FileVersion, fallbackIndex: Int) -> String {
@@ -904,6 +930,9 @@ struct AudiobookDetailContent: View {
     private var primaryPlayLabel: String {
         if let resumePosition {
             return "Resume \(PlayerTimeFormatter.formatHMS(resumePosition))"
+        }
+        if isFinished {
+            return "Play Again"
         }
         return "Play"
     }
@@ -1006,10 +1035,6 @@ struct AudiobookDetailContent: View {
         return tokens
     }
 
-    private var positionSeconds: Double {
-        max(0, detail.userData?.positionSeconds ?? 0)
-    }
-
     /// Listening progress 0...1, only when there's a meaningful resume point.
     private var resumeFraction: Double? {
         guard resumePosition != nil, totalDurationSeconds > 0 else { return nil }
@@ -1024,30 +1049,10 @@ struct AudiobookDetailContent: View {
         max(0, totalDurationSeconds - positionSeconds)
     }
 
-    private var isFinished: Bool {
-        if detail.userData?.played == true { return true }
-        guard totalDurationSeconds > 0, positionSeconds > 0 else { return false }
-        return positionSeconds >= totalDurationSeconds - 5
-    }
-
     private var primaryActionLabel: String {
         if resumePosition != nil { return "Resume" }
         if isFinished { return "Play Again" }
         return "Play"
-    }
-
-    private var primaryActionIcon: String {
-        resumePosition == nil && isFinished ? "arrow.counterclockwise" : "play.fill"
-    }
-
-    private func primaryAction() {
-        if let resumePosition {
-            audioStore.play(contentId: detail.contentId, restart: false, startPosition: resumePosition)
-        } else if isFinished {
-            audioStore.play(contentId: detail.contentId, restart: true)
-        } else {
-            audioStore.play(contentId: detail.contentId, restart: false)
-        }
     }
 
     private func partStartOffset(_ index: Int) -> Double {

--- a/iosApp/iosApp/Screens/Detail/AudiobookDetailFormatting.swift
+++ b/iosApp/iosApp/Screens/Detail/AudiobookDetailFormatting.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+/// Pure formatting helpers for the audiobook detail screen. Kept free of
+/// SwiftUI so the title-cleanup and credit-summarisation rules — the bits
+/// most likely to mangle real-world catalog strings — can be unit tested.
+///
+/// Everything here is deliberately conservative: it only rewrites patterns
+/// it positively recognises and otherwise returns the input untouched, so a
+/// title it doesn't understand can never come out worse than it went in.
+enum AudiobookDetailFormatting {
+
+    /// Cleans redundant series locators out of a raw audiobook title. Server
+    /// titles frequently bake the series name and volume into the title
+    /// ("Stormlight Archive 5 - Wind and Truth (5 of 5)"); we lift those out
+    /// so the title can read as just "Wind and Truth".
+    static func cleanTitle(_ rawTitle: String, seriesName: String?) -> String {
+        let original = rawTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        var title = original
+
+        if let seriesName, !seriesName.isEmpty {
+            title = strippingSeriesPrefix(title, seriesName: seriesName)
+        }
+        title = strippingTrailingVolume(title)
+        title = title.trimmingCharacters(in: trimEdges)
+
+        return title.isEmpty ? original : title
+    }
+
+    /// Parses a trailing "(N of M)" volume locator from a raw title. This is
+    /// the most reliable source of the series *total* — the structured
+    /// series grouping can lump in alternate editions/narrations, so its
+    /// entry count overstates how many books are in the series.
+    static func volume(in rawTitle: String) -> (index: Int?, total: Int?) {
+        let pattern = #"\(\s*(\d+)\s+of\s+(\d+)\s*\)\s*$"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+            return (nil, nil)
+        }
+        let range = NSRange(rawTitle.startIndex..., in: rawTitle)
+        guard let match = regex.firstMatch(in: rawTitle, range: range),
+              let indexRange = Range(match.range(at: 1), in: rawTitle),
+              let totalRange = Range(match.range(at: 2), in: rawTitle) else {
+            return (nil, nil)
+        }
+        return (Int(rawTitle[indexRange]), Int(rawTitle[totalRange]))
+    }
+
+    /// "The Stormlight Archive · Book 5 of 5" / "… · Book 5" / "…".
+    static func seriesLine(name: String?, index: Int?, total: Int?) -> String? {
+        guard let name = name?.trimmingCharacters(in: .whitespaces), !name.isEmpty else {
+            return nil
+        }
+        guard let index, index > 0 else { return name }
+        if let total, total >= index, total > 1 {
+            return "\(name) · Book \(index) of \(total)"
+        }
+        return "\(name) · Book \(index)"
+    }
+
+    /// Summarises a credit list: keeps the first `visible` names and rolls
+    /// the rest into "& N more". Splits on commas first, because servers
+    /// sometimes deliver a whole cast as one comma-joined string rather than
+    /// discrete people. Small lists join naturally with "&" so we never
+    /// print the awkward "& 1 more".
+    ///
+    /// - `["Brandon Sanderson"]` → "Brandon Sanderson"
+    /// - `["A", "B", "C"]` → "A, B & C"
+    /// - `["A, B, C, D, E"]` (one combined string, visible 2) → "A, B & 3 more"
+    static func peopleSummary(_ names: [String], visible: Int = 2) -> String? {
+        let cleaned = names
+            .flatMap { $0.components(separatedBy: ",") }
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard !cleaned.isEmpty else { return nil }
+
+        if cleaned.count <= visible + 1 {
+            return naturalJoin(cleaned)
+        }
+        let shown = cleaned.prefix(visible).joined(separator: ", ")
+        let remaining = cleaned.count - visible
+        return "\(shown) & \(remaining) more"
+    }
+
+    // MARK: - Internals
+
+    private static let trimEdges = CharacterSet(charactersIn: " -–—:·,").union(.whitespacesAndNewlines)
+
+    private static func naturalJoin(_ names: [String]) -> String {
+        switch names.count {
+        case 0: return ""
+        case 1: return names[0]
+        case 2: return "\(names[0]) & \(names[1])"
+        default: return names.dropLast().joined(separator: ", ") + " & " + (names.last ?? "")
+        }
+    }
+
+    /// Drops a leading "<Series>[ N][ -:–] " prefix when the title opens
+    /// with the series name (ignoring a leading article on either side).
+    private static func strippingSeriesPrefix(_ title: String, seriesName: String) -> String {
+        let core = droppingLeadingArticle(seriesName).trimmingCharacters(in: .whitespaces)
+        guard !core.isEmpty else { return title }
+
+        let hay = droppingLeadingArticle(title)
+        guard hay.lowercased().hasPrefix(core.lowercased()) else { return title }
+
+        var rest = Substring(hay.dropFirst(core.count))
+        // Eat the volume number and separators that sit between the series
+        // name and the actual title ("Stormlight Archive" → " 5 - " → title).
+        rest = rest.drop { ch in
+            ch == " " || ch.isNumber || ch == "-" || ch == "–" || ch == "—" || ch == ":" || ch == "#"
+        }
+        let candidate = rest.trimmingCharacters(in: .whitespaces)
+        // Bail out if we'd consume the whole thing — that means the "prefix"
+        // was actually the title.
+        return candidate.isEmpty ? title : candidate
+    }
+
+    /// Removes a trailing volume locator: "(5 of 5)", "(Book 5)",
+    /// "(Volume 5)". These are pure series metadata the series line carries.
+    private static func strippingTrailingVolume(_ title: String) -> String {
+        let patterns = [
+            #"\s*\(\s*\d+\s+of\s+\d+\s*\)$"#,
+            #"\s*\(\s*book\s+\d+\s*\)$"#,
+            #"\s*\(\s*vol(?:ume)?\.?\s*\d+\s*\)$"#,
+        ]
+        var result = title
+        for pattern in patterns {
+            if let range = result.range(
+                of: pattern,
+                options: [.regularExpression, .caseInsensitive]
+            ) {
+                result.removeSubrange(range)
+            }
+        }
+        return result
+    }
+
+    private static func droppingLeadingArticle(_ s: String) -> String {
+        let lower = s.lowercased()
+        for article in ["the ", "a ", "an "] where lower.hasPrefix(article) {
+            return String(s.dropFirst(article.count))
+        }
+        return s
+    }
+}


### PR DESCRIPTION
## What & why

The iOS/macOS audiobook detail page didn't follow the app's own design language (`DESIGN_LANGUAGE.md` §5.5). Movies get the blurred-art hero + inverted play pill; audiobooks got a centered square on flat black with author, all narrators, and runtime jammed into one centered run-on line. This redesign brings audiobooks up to the same bar and adds the audiobook-specific affordances (narrator hierarchy, chapters, progress, speed).

Design research + an HTML mockup of the direction live in `docs/audiobook-detail-redesign/mockup.html`.

## Changes (iOS/macOS — tvOS layout preserved verbatim)

- **Ambient hero** — the square cover floats on a blurred, color-extracted wash of itself that bleeds under the status bar (the ScrollView ignores the top safe area; the backdrop is a top-pinned background and the cover is inset past it).
- **Clear hierarchy** — cleaned Title → Series line → Author → Narrator, replacing the single run-on metadata string.
- **Progress-forward CTA** — white Resume pill with an in-pill progress bar + "% complete / time left" for in-progress books; falls back to Play / Play Again. Secondary controls: Start Over, Speed (wired to `AudioPlayerViewModel.setPlaybackRate`), and Narration (when alternates exist).
- **Chapters first-class** (collapsible); **Parts** only renders for genuine multi-file books; codec/container demoted to a quiet details line.

## Bug fixes

- **`0 kbps`** — dropped bitrate from the part subtitle (it was integer-dividing a kbps value by 1000).
- **"Book 5 of 19"** — the series grouping includes alternate editions, so the total now comes from the title's `(N of M)` locator, not the entry count.
- **Narrator pile-up** — the server returns the cast as one comma-joined string, so the summariser splits on commas before rolling up to "& N more".

## Notes for reviewers

- New `AudiobookDetailFormatting` holds the pure title-cleanup / credit-summary logic, covered by `AudiobookDetailFormattingTests` (regression cases for the series-total and combined-narrator-string bugs).
- New Swift files are picked up via `project.yml` globbing — run `xcodegen generate` before building.
- **Intentionally deferred:** the mockup's *Download* and *Mark finished* controls have no client/server backing yet, so they were left out rather than shipped as dead buttons.

## Verification

- `Silo` (iOS) and `SiloTV` (tvOS) builds succeed.
- Formatter logic verified (the in-sim `.xctest` bundle wouldn't load in this environment, so the pure logic was checked out-of-band; the XCTest cases are included).
- Confirmed rendering in the iOS simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Redesigned the audiobook detail screen with an updated hero layout, improved playback controls (including an in-pill resume with progress), richer chapters/series rail sections, and clearer audio metadata.
- **Bug Fixes**
  - Cleaned up audiobook titles and series labels by removing redundant series prefixes and trailing volume markers.
  - Improved narrator/credit summarization and standardized part/section subtitle formatting, removing technical bitrate-style details.
- **Tests**
  - Added coverage to ensure consistent title, series, and credit formatting across edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->