### PR TITLE
fix(tvos): match Top Shelf bundle version to host app for TestFlight

### DIFF
--- a/iosApp/TopShelf/Info.plist
+++ b/iosApp/TopShelf/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>ContinuumKeychainAccessGroup</key>
 	<string>$(AppIdentifierPrefix)org.siloserver.silo.shared</string>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
## Problem

The embedded **SiloTVTopShelf** extension hard-coded its version keys in `iosApp/TopShelf/Info.plist`:

```xml
<key>CFBundleShortVersionString</key><string>0.1.0</string>
<key>CFBundleVersion</key><string>1</string>
```

The tvOS release lane (added in #31) injects `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` as **global** `xcargs` overrides. Those only reach a target's bundle if its plist references the variable. The host tvOS app does (`tvOS-Info.plist` uses `$(MARKETING_VERSION)`/`$(CURRENT_PROJECT_VERSION)`), so it gets e.g. `1.4.0 (5)`. The Top Shelf `.appex` ignored them and shipped `0.1.0 (1)`.

App Store Connect requires an embedded extension's **short version and build number to match the containing app**, so every tvOS upload would be rejected with a bundle-version mismatch. (Latent only because CI hasn't run a real tvOS build yet — and it affects the build number even at marketing version `0.1.0`.)

Credit: caught by the Codex review on #31.

## Fix

Reference the same build-setting variables as the host app:

```xml
<key>CFBundleShortVersionString</key><string>$(MARKETING_VERSION)</string>
<key>CFBundleVersion</key><string>$(CURRENT_PROJECT_VERSION)</string>
```

`SiloTVTopShelf` already defines `MARKETING_VERSION: "0.1.0"` and `CURRENT_PROJECT_VERSION: 1` in `project.yml`, so local/default builds keep `0.1.0 (1)` exactly as before; CI's global overrides now apply to the host app and the extension in lockstep.

## Test
- Local/default build: appex resolves to `0.1.0 (1)` (unchanged).
- CI release build: appex inherits the tag-derived `MARKETING_VERSION` and the `latest_testflight_build_number + 1`, matching the host SiloTV app → no ASC mismatch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated app version settings to use project-managed version values instead of fixed numbers, making releases easier to keep in sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->