### PR TITLE
Prefetch library browse content after profile selection

### DIFF
--- a/iosApp/iosApp/Networking/ResponseCache.swift
+++ b/iosApp/iosApp/Networking/ResponseCache.swift
@@ -96,6 +96,9 @@ enum CacheKey {
     static func browse(libraryId: Int?, genre: String?, sort: String) -> String {
         "browse:\(libraryId.map(String.init) ?? "all"):\(genre ?? "all"):\(sort)"
     }
+    static func librarySections(_ libraryId: Int) -> String {
+        "library:\(libraryId):sections"
+    }
     static func tvLibrary(libraryId: Int, filterKey: String) -> String {
         "tvlibrary:\(libraryId):\(filterKey)"
     }

--- a/iosApp/iosApp/Networking/ResponseCache.swift
+++ b/iosApp/iosApp/Networking/ResponseCache.swift
@@ -112,6 +112,8 @@ enum CacheKey {
     static let perProfilePrefixes: [String] = [
         "home:",
         "recommendations:",
+        "browse:",
+        "library:",
         "personal:",
         "item:",
         "collection:",

--- a/iosApp/iosApp/Networking/ServerRegistry.swift
+++ b/iosApp/iosApp/Networking/ServerRegistry.swift
@@ -182,6 +182,7 @@ final class ServerRegistry {
         // not be able to land on the new server's token slot. See
         // `HTTPClient.cancelInFlightRequests` for the ordering contract.
         await HTTPClient.shared.cancelInFlightRequests()
+        await StartupContentPrefetcher.resetAllPrefetches()
 
         let entry = entries.first(where: { $0.id == serverId })!
         defaults.set(entry.url, forKey: "serverUrl")

--- a/iosApp/iosApp/Screens/Auth/AuthService.swift
+++ b/iosApp/iosApp/Screens/Auth/AuthService.swift
@@ -185,6 +185,7 @@ final class AuthService: @unchecked Sendable {
     /// watchlist, home recommendations) doesn't leak between accounts.
     @MainActor
     private func clearPerProfileCaches() {
+        StartupContentPrefetcher.resetProfileScopedPrefetches()
         for prefix in CacheKey.perProfilePrefixes {
             ResponseCache.shared.removeAll(withPrefix: prefix)
         }
@@ -265,6 +266,7 @@ final class AuthService: @unchecked Sendable {
     /// the next session must start clean.
     @MainActor
     private func clearAllCaches() {
+        StartupContentPrefetcher.resetAllPrefetches()
         ResponseCache.shared.clearAll()
         OverlayPrefsStore.shared.clear()
         ProfilePrefsStore.shared.clear()

--- a/iosApp/iosApp/Screens/Browse/BrowseView.swift
+++ b/iosApp/iosApp/Screens/Browse/BrowseView.swift
@@ -277,7 +277,7 @@ struct LibraryDetailView: View {
         guard initialTitle == nil else { return }
 
         do {
-            let response: LibrariesResponse = try await ContinuumAPI.shared.get("/api/v1/user/libraries")
+            let response = try await StartupContentPrefetcher.fetchUserLibraries()
             if let matchedLibrary = response.libraries.first(where: { $0.id == libraryId }) {
                 title = matchedLibrary.name
             }
@@ -300,7 +300,7 @@ private class LibraryRecommendedViewModel {
     }
 
     func loadSections(libraryId: Int) async {
-        let key = "library:\(libraryId):sections"
+        let key = CacheKey.librarySections(libraryId)
         if sections.isEmpty,
            let cached: SectionsResponse = ResponseCache.shared.get(key) {
             sections = cached.sections.filter { !$0.items.isEmpty }
@@ -313,10 +313,7 @@ private class LibraryRecommendedViewModel {
         error = nil
 
         do {
-            let response: SectionsResponse = try await ContinuumAPI.shared.get(
-                "/api/v1/library/\(libraryId)/sections"
-            )
-            ResponseCache.shared.set(response, for: key)
+            let response = try await StartupContentPrefetcher.fetchLibrarySections(libraryId: libraryId)
             sections = response.sections.filter { !$0.items.isEmpty }
         } catch let err {
             if sections.isEmpty {

--- a/iosApp/iosApp/Screens/Browse/BrowseViewModel.swift
+++ b/iosApp/iosApp/Screens/Browse/BrowseViewModel.swift
@@ -63,9 +63,18 @@ class BrowseViewModel {
                 query["genre"] = genre
             }
 
-            let response: CatalogResponse = try await ContinuumAPI.shared.get(
-                "/api/v1/catalog", query: query
-            )
+            let response: CatalogResponse
+            if reset && currentPage == 0 {
+                response = try await StartupContentPrefetcher.fetchBrowseFirstPage(
+                    libraryId: libraryId,
+                    genre: selectedGenre,
+                    sort: sortBy
+                )
+            } else {
+                response = try await ContinuumAPI.shared.get(
+                    "/api/v1/catalog", query: query
+                )
+            }
             if reset {
                 items = response.items
                 ResponseCache.shared.set(response, for: currentCacheKey)

--- a/iosApp/iosApp/Screens/Browse/LibrariesTabView.swift
+++ b/iosApp/iosApp/Screens/Browse/LibrariesTabView.swift
@@ -59,6 +59,7 @@ struct LibrariesTabView: View {
                     selectedLibraryId = id
                     storedLibraryId = id
                     showPicker = false
+                    StartupContentPrefetcher.prefetchLibraryLanding(libraryId: id)
                 }
             )
         }
@@ -128,7 +129,7 @@ struct LibrariesTabView: View {
         // Hydrate from cache so a returning visit paints last-known
         // libraries instantly while the refresh runs.
         if libraries.isEmpty,
-           let cached: LibrariesResponse = ResponseCache.shared.get("libraries:list") {
+           let cached: LibrariesResponse = ResponseCache.shared.get(CacheKey.userLibraries) {
             libraries = cached.libraries
             applyLibrarySelection()
         }
@@ -137,10 +138,12 @@ struct LibrariesTabView: View {
         }
         error = nil
         do {
-            let response: LibrariesResponse = try await ContinuumAPI.shared.get("/api/v1/user/libraries")
-            ResponseCache.shared.set(response, for: "libraries:list")
+            let response = try await StartupContentPrefetcher.fetchUserLibraries()
             libraries = response.libraries
             applyLibrarySelection()
+            if let selectedLibraryId {
+                StartupContentPrefetcher.prefetchLibraryLanding(libraryId: selectedLibraryId)
+            }
         } catch {
             if libraries.isEmpty {
                 self.error = ErrorState(error)

--- a/iosApp/iosApp/Screens/Profiles/ProfileSelectionViewModel.swift
+++ b/iosApp/iosApp/Screens/Profiles/ProfileSelectionViewModel.swift
@@ -49,7 +49,7 @@ class ProfileSelectionViewModel {
     func selectProfile(_ profile: UserProfile, router: AppRouter) async {
         do {
             try await auth.selectProfile(profileId: profile.id)
-            StartupContentPrefetcher.prefetchHomeSections()
+            StartupContentPrefetcher.prefetchAuthenticatedContent()
             await PlayerSettings.shared.refreshFromServer()
             router.resetToHome()
         } catch {
@@ -60,7 +60,7 @@ class ProfileSelectionViewModel {
     /// Select a profile with a PIN.
     func selectProfileWithPIN(_ profile: UserProfile, pin: String, router: AppRouter) async throws {
         try await auth.selectProfile(profileId: profile.id, pin: pin)
-        StartupContentPrefetcher.prefetchHomeSections()
+        StartupContentPrefetcher.prefetchAuthenticatedContent()
         await PlayerSettings.shared.refreshFromServer()
         router.resetToHome()
     }

--- a/iosApp/iosApp/Screens/Recommendations/RecommendationsViewModel.swift
+++ b/iosApp/iosApp/Screens/Recommendations/RecommendationsViewModel.swift
@@ -28,10 +28,7 @@ class RecommendationsViewModel {
         error = nil
 
         do {
-            let response: SectionsResponse = try await ContinuumAPI.shared.get(
-                "/api/v1/recommendations/discover"
-            )
-            ResponseCache.shared.set(response, for: CacheKey.recommendations)
+            let response = try await StartupContentPrefetcher.fetchRecommendations()
             sections = sortedNonEmptySections(from: response.sections)
         } catch let err {
             if sections.isEmpty {
@@ -48,10 +45,7 @@ class RecommendationsViewModel {
     func refresh() async {
         isRefreshing = true
         do {
-            let response: SectionsResponse = try await ContinuumAPI.shared.get(
-                "/api/v1/recommendations/discover"
-            )
-            ResponseCache.shared.set(response, for: CacheKey.recommendations)
+            let response = try await StartupContentPrefetcher.fetchRecommendations()
             sections = sortedNonEmptySections(from: response.sections)
             error = nil
         } catch let err {

--- a/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
+++ b/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
@@ -3,7 +3,11 @@ import Foundation
 @MainActor
 enum StartupContentPrefetcher {
     private static let maxHomeArtworkURLs = 12
+    private static let maxSectionArtworkURLs = 12
+    private static let maxBrowseArtworkURLs = 12
     private static let maxProfileArtworkURLs = 8
+    private static let browsePageSize = 60
+    private static let selectedLibraryDefaultsKey = "librariesTabSelectedLibraryId"
     private static let episodeSectionTypes: Set<String> = [
         "continue_watching",
         "in_progress",
@@ -12,6 +16,10 @@ enum StartupContentPrefetcher {
 
     private static var profilesTask: Task<[UserProfile], Error>?
     private static var homeSectionsTask: Task<SectionsResponse, Error>?
+    private static var recommendationsTask: Task<SectionsResponse, Error>?
+    private static var userLibrariesTask: Task<LibrariesResponse, Error>?
+    private static var librarySectionsTasks: [Int: Task<SectionsResponse, Error>] = [:]
+    private static var browseFirstPageTasks: [String: Task<CatalogResponse, Error>] = [:]
 
     static func prefetchProfiles() {
         Task {
@@ -71,18 +79,184 @@ enum StartupContentPrefetcher {
         }
     }
 
+    static func prefetchRecommendations() {
+        Task {
+            _ = try? await fetchRecommendations()
+        }
+    }
+
+    static func fetchRecommendations() async throws -> SectionsResponse {
+        let task: Task<SectionsResponse, Error>
+        if let recommendationsTask {
+            task = recommendationsTask
+        } else {
+            task = Task {
+                try await ContinuumAPI.shared.recommendationsDiscover()
+            }
+            recommendationsTask = task
+        }
+
+        do {
+            let response = try await task.value
+            recommendationsTask = nil
+            ResponseCache.shared.set(response, for: CacheKey.recommendations)
+            prefetchSectionArtwork(for: response, maxCount: maxSectionArtworkURLs)
+            return response
+        } catch {
+            recommendationsTask = nil
+            throw error
+        }
+    }
+
+    static func prefetchUserLibraries() {
+        Task {
+            _ = try? await fetchUserLibraries()
+        }
+    }
+
+    static func fetchUserLibraries() async throws -> LibrariesResponse {
+        let task: Task<LibrariesResponse, Error>
+        if let userLibrariesTask {
+            task = userLibrariesTask
+        } else {
+            task = Task {
+                try await ContinuumAPI.shared.libraries()
+            }
+            userLibrariesTask = task
+        }
+
+        do {
+            let response = try await task.value
+            userLibrariesTask = nil
+            ResponseCache.shared.set(response, for: CacheKey.userLibraries)
+            return response
+        } catch {
+            userLibrariesTask = nil
+            throw error
+        }
+    }
+
+    static func prefetchLibraryLanding(libraryId: Int) {
+        prefetchLibrarySections(libraryId: libraryId)
+        prefetchBrowseFirstPage(libraryId: libraryId)
+    }
+
+    static func prefetchLibrarySections(libraryId: Int) {
+        Task {
+            _ = try? await fetchLibrarySections(libraryId: libraryId)
+        }
+    }
+
+    static func fetchLibrarySections(libraryId: Int) async throws -> SectionsResponse {
+        let task: Task<SectionsResponse, Error>
+        if let existing = librarySectionsTasks[libraryId] {
+            task = existing
+        } else {
+            task = Task {
+                try await ContinuumAPI.shared.librarySections(libraryId: libraryId)
+            }
+            librarySectionsTasks[libraryId] = task
+        }
+
+        do {
+            let response = try await task.value
+            librarySectionsTasks[libraryId] = nil
+            ResponseCache.shared.set(response, for: CacheKey.librarySections(libraryId))
+            prefetchSectionArtwork(for: response, maxCount: maxSectionArtworkURLs)
+            return response
+        } catch {
+            librarySectionsTasks[libraryId] = nil
+            throw error
+        }
+    }
+
+    static func prefetchBrowseFirstPage(libraryId: Int?, genre: String? = nil, sort: String = "title") {
+        Task {
+            _ = try? await fetchBrowseFirstPage(libraryId: libraryId, genre: genre, sort: sort)
+        }
+    }
+
+    static func fetchBrowseFirstPage(
+        libraryId: Int?,
+        genre: String? = nil,
+        sort: String = "title"
+    ) async throws -> CatalogResponse {
+        let key = CacheKey.browse(libraryId: libraryId, genre: genre, sort: sort)
+        let task: Task<CatalogResponse, Error>
+        if let existing = browseFirstPageTasks[key] {
+            task = existing
+        } else {
+            task = Task {
+                var query: [String: String] = [
+                    "offset": "0",
+                    "limit": String(browsePageSize),
+                    "sort": sort,
+                ]
+                if let libraryId {
+                    query["library_id"] = String(libraryId)
+                }
+                if let genre {
+                    query["genre"] = genre
+                }
+
+                return try await ContinuumAPI.shared.catalog(query: query)
+            }
+            browseFirstPageTasks[key] = task
+        }
+
+        do {
+            let response = try await task.value
+            browseFirstPageTasks[key] = nil
+            ResponseCache.shared.set(response, for: key)
+            prefetchBrowseArtwork(for: response)
+            return response
+        } catch {
+            browseFirstPageTasks[key] = nil
+            throw error
+        }
+    }
+
+    static func prefetchAuthenticatedContent() {
+        prefetchHomeSections()
+        prefetchRecommendations()
+        prefetchActiveLibraryLanding()
+        Task {
+            await OverlayPrefsStore.shared.hydrateIfNeeded()
+        }
+    }
+
     static func prefetchForInitialRoute(_ state: AppRouter.AuthState) {
         switch state {
         case .authenticated:
-            prefetchHomeSections()
-            Task {
-                await OverlayPrefsStore.shared.hydrateIfNeeded()
-            }
+            prefetchAuthenticatedContent()
         case .needsProfile:
             prefetchProfiles()
         case .loading, .needsServerSetup, .needsLogin:
             break
         }
+    }
+
+    private static func prefetchActiveLibraryLanding() {
+        Task {
+            guard let response = try? await fetchUserLibraries(),
+                  let library = preferredLibrary(from: response.libraries) else {
+                return
+            }
+            prefetchLibraryLanding(libraryId: library.id)
+        }
+    }
+
+    private static func preferredLibrary(from libraries: [Library]) -> Library? {
+        AppNavPreferences.shared.refresh()
+        let visibleLibraries = libraries.filter {
+            AppNavPreferences.shared.showAudiobooks || !$0.isAudiobookLibrary
+        }
+        let storedId = UserDefaults.standard.integer(forKey: selectedLibraryDefaultsKey)
+        if storedId != 0,
+           let stored = visibleLibraries.first(where: { $0.id == storedId }) {
+            return stored
+        }
+        return visibleLibraries.first
     }
 
     private static func prefetchHomeArtwork(for response: SectionsResponse) {
@@ -130,6 +304,54 @@ enum StartupContentPrefetcher {
                 if urls.count >= maxHomeArtworkURLs { break }
             }
             if urls.count >= maxHomeArtworkURLs { break }
+        }
+
+        guard !urls.isEmpty else { return }
+        PosterImageCache.prefetcher.startPrefetching(with: urls)
+    }
+
+    private static func prefetchSectionArtwork(for response: SectionsResponse, maxCount: Int) {
+        var urls: [URL] = []
+        var seen = Set<String>()
+
+        func append(_ urlString: String?) {
+            guard urls.count < maxCount,
+                  let url = normalizedURL(from: urlString) else {
+                return
+            }
+            let key = url.absoluteString
+            guard seen.insert(key).inserted else { return }
+            urls.append(url)
+        }
+
+        for section in response.sections where !section.isFeatured && !section.items.isEmpty {
+            for item in section.items {
+                if episodeSectionTypes.contains(section.sectionType) {
+                    append(item.backdropUrl ?? item.posterUrl)
+                } else {
+                    append(item.posterUrl)
+                }
+                if urls.count >= maxCount { break }
+            }
+            if urls.count >= maxCount { break }
+        }
+
+        guard !urls.isEmpty else { return }
+        PosterImageCache.prefetcher.startPrefetching(with: urls)
+    }
+
+    private static func prefetchBrowseArtwork(for response: CatalogResponse) {
+        var urls: [URL] = []
+        var seen = Set<String>()
+
+        for item in response.items {
+            guard urls.count < maxBrowseArtworkURLs,
+                  let url = normalizedURL(from: item.posterUrl) else {
+                continue
+            }
+            let key = url.absoluteString
+            guard seen.insert(key).inserted else { continue }
+            urls.append(url)
         }
 
         guard !urls.isEmpty else { return }

--- a/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
+++ b/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
@@ -20,6 +20,31 @@ enum StartupContentPrefetcher {
     private static var userLibrariesTask: Task<LibrariesResponse, Error>?
     private static var librarySectionsTasks: [Int: Task<SectionsResponse, Error>] = [:]
     private static var browseFirstPageTasks: [String: Task<CatalogResponse, Error>] = [:]
+    private static var profileScopedGeneration = 0
+    private static var profilesGeneration = 0
+
+    static func resetProfileScopedPrefetches() {
+        profileScopedGeneration += 1
+
+        homeSectionsTask?.cancel()
+        recommendationsTask?.cancel()
+        userLibrariesTask?.cancel()
+        librarySectionsTasks.values.forEach { $0.cancel() }
+        browseFirstPageTasks.values.forEach { $0.cancel() }
+
+        homeSectionsTask = nil
+        recommendationsTask = nil
+        userLibrariesTask = nil
+        librarySectionsTasks.removeAll()
+        browseFirstPageTasks.removeAll()
+    }
+
+    static func resetAllPrefetches() {
+        profilesGeneration += 1
+        profilesTask?.cancel()
+        profilesTask = nil
+        resetProfileScopedPrefetches()
+    }
 
     static func prefetchProfiles() {
         Task {
@@ -28,6 +53,7 @@ enum StartupContentPrefetcher {
     }
 
     static func fetchProfiles() async throws -> [UserProfile] {
+        let generation = profilesGeneration
         let task: Task<[UserProfile], Error>
         if let profilesTask {
             task = profilesTask
@@ -40,12 +66,17 @@ enum StartupContentPrefetcher {
 
         do {
             let profiles = try await task.value
-            profilesTask = nil
+            try validateProfilesGeneration(generation)
+            if profilesGeneration == generation {
+                profilesTask = nil
+            }
             ResponseCache.shared.set(profiles, for: CacheKey.profiles)
             prefetchProfileArtwork(for: profiles)
             return profiles
         } catch {
-            profilesTask = nil
+            if profilesGeneration == generation {
+                profilesTask = nil
+            }
             throw error
         }
     }
@@ -57,6 +88,7 @@ enum StartupContentPrefetcher {
     }
 
     static func fetchHomeSections() async throws -> SectionsResponse {
+        let generation = profileScopedGeneration
         let task: Task<SectionsResponse, Error>
         if let homeSectionsTask {
             task = homeSectionsTask
@@ -69,12 +101,17 @@ enum StartupContentPrefetcher {
 
         do {
             let response = try await task.value
-            homeSectionsTask = nil
+            try validateProfileScopedGeneration(generation)
+            if profileScopedGeneration == generation {
+                homeSectionsTask = nil
+            }
             ResponseCache.shared.set(response, for: CacheKey.homeSections)
             prefetchHomeArtwork(for: response)
             return response
         } catch {
-            homeSectionsTask = nil
+            if profileScopedGeneration == generation {
+                homeSectionsTask = nil
+            }
             throw error
         }
     }
@@ -86,6 +123,7 @@ enum StartupContentPrefetcher {
     }
 
     static func fetchRecommendations() async throws -> SectionsResponse {
+        let generation = profileScopedGeneration
         let task: Task<SectionsResponse, Error>
         if let recommendationsTask {
             task = recommendationsTask
@@ -98,12 +136,17 @@ enum StartupContentPrefetcher {
 
         do {
             let response = try await task.value
-            recommendationsTask = nil
+            try validateProfileScopedGeneration(generation)
+            if profileScopedGeneration == generation {
+                recommendationsTask = nil
+            }
             ResponseCache.shared.set(response, for: CacheKey.recommendations)
             prefetchSectionArtwork(for: response, maxCount: maxSectionArtworkURLs)
             return response
         } catch {
-            recommendationsTask = nil
+            if profileScopedGeneration == generation {
+                recommendationsTask = nil
+            }
             throw error
         }
     }
@@ -115,6 +158,7 @@ enum StartupContentPrefetcher {
     }
 
     static func fetchUserLibraries() async throws -> LibrariesResponse {
+        let generation = profileScopedGeneration
         let task: Task<LibrariesResponse, Error>
         if let userLibrariesTask {
             task = userLibrariesTask
@@ -127,11 +171,16 @@ enum StartupContentPrefetcher {
 
         do {
             let response = try await task.value
-            userLibrariesTask = nil
+            try validateProfileScopedGeneration(generation)
+            if profileScopedGeneration == generation {
+                userLibrariesTask = nil
+            }
             ResponseCache.shared.set(response, for: CacheKey.userLibraries)
             return response
         } catch {
-            userLibrariesTask = nil
+            if profileScopedGeneration == generation {
+                userLibrariesTask = nil
+            }
             throw error
         }
     }
@@ -148,6 +197,7 @@ enum StartupContentPrefetcher {
     }
 
     static func fetchLibrarySections(libraryId: Int) async throws -> SectionsResponse {
+        let generation = profileScopedGeneration
         let task: Task<SectionsResponse, Error>
         if let existing = librarySectionsTasks[libraryId] {
             task = existing
@@ -160,12 +210,17 @@ enum StartupContentPrefetcher {
 
         do {
             let response = try await task.value
-            librarySectionsTasks[libraryId] = nil
+            try validateProfileScopedGeneration(generation)
+            if profileScopedGeneration == generation {
+                librarySectionsTasks[libraryId] = nil
+            }
             ResponseCache.shared.set(response, for: CacheKey.librarySections(libraryId))
             prefetchSectionArtwork(for: response, maxCount: maxSectionArtworkURLs)
             return response
         } catch {
-            librarySectionsTasks[libraryId] = nil
+            if profileScopedGeneration == generation {
+                librarySectionsTasks[libraryId] = nil
+            }
             throw error
         }
     }
@@ -181,6 +236,7 @@ enum StartupContentPrefetcher {
         genre: String? = nil,
         sort: String = "title"
     ) async throws -> CatalogResponse {
+        let generation = profileScopedGeneration
         let key = CacheKey.browse(libraryId: libraryId, genre: genre, sort: sort)
         let task: Task<CatalogResponse, Error>
         if let existing = browseFirstPageTasks[key] {
@@ -206,12 +262,17 @@ enum StartupContentPrefetcher {
 
         do {
             let response = try await task.value
-            browseFirstPageTasks[key] = nil
+            try validateProfileScopedGeneration(generation)
+            if profileScopedGeneration == generation {
+                browseFirstPageTasks[key] = nil
+            }
             ResponseCache.shared.set(response, for: key)
             prefetchBrowseArtwork(for: response)
             return response
         } catch {
-            browseFirstPageTasks[key] = nil
+            if profileScopedGeneration == generation {
+                browseFirstPageTasks[key] = nil
+            }
             throw error
         }
     }
@@ -248,9 +309,13 @@ enum StartupContentPrefetcher {
 
     private static func preferredLibrary(from libraries: [Library]) -> Library? {
         AppNavPreferences.shared.refresh()
-        let visibleLibraries = libraries.filter {
-            AppNavPreferences.shared.showAudiobooks || !$0.isAudiobookLibrary
-        }
+        let visibleLibraries = libraries
+            .filter {
+                AppNavPreferences.shared.showAudiobooks || !$0.isAudiobookLibrary
+            }
+            .sorted {
+                ($0.sortOrder ?? Int.max, $0.id) < ($1.sortOrder ?? Int.max, $1.id)
+            }
         let storedId = UserDefaults.standard.integer(forKey: selectedLibraryDefaultsKey)
         if storedId != 0,
            let stored = visibleLibraries.first(where: { $0.id == storedId }) {
@@ -378,6 +443,18 @@ enum StartupContentPrefetcher {
 
         guard !urls.isEmpty else { return }
         PosterImageCache.prefetcher.startPrefetching(with: urls)
+    }
+
+    private static func validateProfileScopedGeneration(_ generation: Int) throws {
+        guard profileScopedGeneration == generation else {
+            throw CancellationError()
+        }
+    }
+
+    private static func validateProfilesGeneration(_ generation: Int) throws {
+        guard profilesGeneration == generation else {
+            throw CancellationError()
+        }
     }
 
     private static func normalizedURL(from urlString: String?) -> URL? {

--- a/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
@@ -700,8 +700,7 @@ struct TVMainTabView: View {
         }
 
         do {
-            let response: LibrariesResponse = try await ContinuumAPI.shared.get("/api/v1/user/libraries")
-            ResponseCache.shared.set(response, for: CacheKey.userLibraries)
+            let response = try await StartupContentPrefetcher.fetchUserLibraries()
             libraries = response.libraries
             ensureSelectedRootIsVisible()
         } catch {

--- a/iosApp/iosApp/tvOS/Screens/Libraries/TVLibraryBrowseView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Libraries/TVLibraryBrowseView.swift
@@ -78,10 +78,14 @@ struct TVLibraryBrowseView: View {
     // MARK: - Data
 
     private func loadContent() async {
+        if sections.isEmpty,
+           let cached: SectionsResponse = ResponseCache.shared.get(CacheKey.librarySections(library.id)) {
+            sections = cached.sections
+        }
         isLoadingSections = true
         sectionsError = nil
         do {
-            let response = try await ContinuumAPI.shared.librarySections(libraryId: library.id)
+            let response = try await StartupContentPrefetcher.fetchLibrarySections(libraryId: library.id)
             sections = response.sections
         } catch {
             sectionsError = ErrorState(error)


### PR DESCRIPTION
## Summary
- Prefetch authenticated startup content beyond home sections, including recommendations, user libraries, and the active library landing page.
- Share fetch/cache paths for recommendations, libraries, library sections, and first-page browse results to avoid duplicate requests.
- Hydrate iOS and tvOS library views from cached prefetched content and prefetch artwork for faster first paint.

## Testing
- Not run; PR content generated from the provided commit and diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded background prefetching for improved startup and browsing: recommendations, user libraries, library sections, and the first browse page.
  * Switching libraries now proactively refreshes the associated landing content and related sections.

* **Bug Fixes**
  * Improved cache reuse across browse and library views, including faster hydration from cached library section data.
  * Profile changes now preload authenticated content more consistently after selection.

* **Chores**
  * Reset/cleanup of prefetch state is now more thorough during server switches and cache-wipe flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->