### PR TITLE
Person-detail metadata auto-refresh + tvOS cascade freeze fix

### DIFF
--- a/iosApp/iosApp/Components/MediaRow.swift
+++ b/iosApp/iosApp/Components/MediaRow.swift
@@ -1,4 +1,7 @@
 import SwiftUI
+#if os(tvOS)
+import os
+#endif
 
 /// Layout mode for a horizontal media row.
 /// Poster rows use tall (2:3) poster cards; thumbnail rows use wide 16:9
@@ -58,6 +61,10 @@ struct MediaRow: View {
     /// identity per page, so the kick has to land on `onAppear`, not only
     /// on a `focusRequest` change).
     @State private var lastAppliedFocusRequest = 0
+    private static let focusLogger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.continuum.app",
+        category: "TVFocus"
+    )
     #endif
 
     var body: some View {
@@ -74,6 +81,7 @@ struct MediaRow: View {
         .onChange(of: focusedItemId) { _, newValue in
             guard let newValue,
                   let item = items.first(where: { $0.contentId == newValue }) else { return }
+            Self.focusLogger.debug("mediaRow.focus item=\(newValue, privacy: .public)")
             onItemFocus?(item)
         }
         #endif
@@ -85,6 +93,7 @@ struct MediaRow: View {
               let firstItem = items.first else { return }
         lastAppliedFocusRequest = request
         focusedItemId = firstItem.contentId
+        Self.focusLogger.debug("mediaRow.applyFocus request=\(request, privacy: .public) first=\(firstItem.contentId, privacy: .public)")
         onItemFocus?(firstItem)
     }
     #endif

--- a/iosApp/iosApp/Networking/ContinuumAPI.swift
+++ b/iosApp/iosApp/Networking/ContinuumAPI.swift
@@ -227,6 +227,14 @@ actor ContinuumAPI {
                 isChild: request.isChild
             ))
         }
+        if components.count == 5,
+           components[0] == "api", components[1] == "v1",
+           components[2] == "people", components[4] == "refresh" {
+            guard let personId = Int(components[3]) else {
+                throw APIError.invalidPathParameter(name: "personId", value: components[3])
+            }
+            return try cast(try await refreshPerson(id: personId))
+        }
 
         throw APIError.unsupportedPath(path)
     }
@@ -528,6 +536,10 @@ actor ContinuumAPI {
 
     func person(id: Int) async throws -> Person {
         try await http.get("/api/v1/people/\(id)")
+    }
+
+    func refreshPerson(id: Int) async throws -> PersonRefreshQueuedResponse {
+        try await http.post("/api/v1/people/\(id)/refresh")
     }
 
     func personCatalogItems(

--- a/iosApp/iosApp/Networking/Models.swift
+++ b/iosApp/iosApp/Networking/Models.swift
@@ -513,6 +513,11 @@ struct Person: Codable, Identifiable, Hashable {
     let plexGuid: String?
 }
 
+struct PersonRefreshQueuedResponse: Codable, Hashable {
+    let status: String
+    let personId: Int
+}
+
 struct Season: Codable, Identifiable, Hashable {
     let contentId: String
     let seasonNumber: Int

--- a/iosApp/iosApp/Screens/People/PersonDetailView.swift
+++ b/iosApp/iosApp/Screens/People/PersonDetailView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import os
 
 enum PersonMediaFilter: String, CaseIterable, Identifiable {
     case all
@@ -36,11 +37,20 @@ final class PersonDetailViewModel {
     var hasMore = true
     var selectedFilter: PersonMediaFilter = .all
     var totalItems: Int?
+    var isRefreshingMetadata = false
 
+    private static let metadataRefreshWindowSeconds: TimeInterval = 120
+    private static let metadataRefreshPollInterval: Duration = .seconds(3)
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.continuum.app",
+        category: "PersonDetail"
+    )
     private let pageSize = 60
     private var nextOffset = 0
     private var snapshot: String?
     private var generation = 0
+    private var metadataRefreshTask: Task<Void, Never>?
+    private var autoRefreshRequestedPersonId: Int?
 
     #if os(tvOS)
     private var prefetchedPosterURLs: Set<URL> = []
@@ -48,6 +58,21 @@ final class PersonDetailViewModel {
 
     init(personId: Int) {
         self.personId = personId
+    }
+
+    /// Cancel the manually-spawned refresh poll when this page leaves the
+    /// nav stack. SwiftUI only auto-cancels `.task`; this task otherwise
+    /// retains the view model and keeps mutating state after the route pops.
+    func stopMetadataRefresh() {
+        guard metadataRefreshTask != nil || isRefreshingMetadata else { return }
+        Self.logger.debug("stopMetadataRefresh personId=\(self.personId, privacy: .public)")
+        metadataRefreshTask?.cancel()
+        metadataRefreshTask = nil
+        isRefreshingMetadata = false
+    }
+
+    func resumeMetadataRefreshIfNeeded() {
+        scheduleMetadataRefreshIfNeeded(for: person)
     }
 
     var isInitialLoading: Bool {
@@ -72,6 +97,7 @@ final class PersonDetailViewModel {
             if person == nil {
                 person = try await ContinuumAPI.shared.person(id: personId)
             }
+            scheduleMetadataRefreshIfNeeded(for: person)
             await fetchPage(reset: true, generation: currentGeneration)
         } catch {
             guard currentGeneration == generation else { return }
@@ -105,6 +131,72 @@ final class PersonDetailViewModel {
         PosterImageCache.prefetcher.startPrefetching(with: newURLs)
     }
     #endif
+
+    private func scheduleMetadataRefreshIfNeeded(for person: Person?) {
+        guard let person else { return }
+        guard person.isMetadataIncomplete else {
+            metadataRefreshTask?.cancel()
+            metadataRefreshTask = nil
+            isRefreshingMetadata = false
+            return
+        }
+        guard metadataRefreshTask == nil else { return }
+
+        let shouldQueueRefresh = autoRefreshRequestedPersonId != person.id
+        if shouldQueueRefresh {
+            autoRefreshRequestedPersonId = person.id
+        }
+        isRefreshingMetadata = true
+        Self.logger.debug("startMetadataRefresh personId=\(person.id, privacy: .public) queue=\(shouldQueueRefresh, privacy: .public)")
+        metadataRefreshTask = Task { [weak self] in
+            await self?.runMetadataAutoRefresh(
+                for: person.id,
+                shouldQueueRefresh: shouldQueueRefresh
+            )
+        }
+    }
+
+    private func runMetadataAutoRefresh(for personId: Int, shouldQueueRefresh: Bool) async {
+        defer {
+            let wasCancelled = Task.isCancelled
+            metadataRefreshTask = nil
+            isRefreshingMetadata = false
+            if !wasCancelled, person?.isMetadataIncomplete == true {
+                autoRefreshRequestedPersonId = nil
+            }
+            Self.logger.debug("finishMetadataRefresh personId=\(personId, privacy: .public) cancelled=\(wasCancelled, privacy: .public)")
+        }
+
+        if shouldQueueRefresh,
+           let token = await ContinuumAPI.shared.currentAccessToken(),
+           !token.isEmpty {
+            _ = try? await ContinuumAPI.shared.refreshPerson(id: personId)
+        }
+
+        let deadline = Date.now.addingTimeInterval(Self.metadataRefreshWindowSeconds)
+        while !Task.isCancelled && Date.now < deadline {
+            do {
+                try await Task.sleep(for: Self.metadataRefreshPollInterval)
+            } catch {
+                return
+            }
+
+            guard !Task.isCancelled else { return }
+
+            do {
+                let updatedPerson = try await ContinuumAPI.shared.person(id: personId)
+                guard personId == self.personId else { return }
+                person = updatedPerson
+                if !updatedPerson.isMetadataIncomplete {
+                    Self.logger.debug("completeMetadataRefresh personId=\(personId, privacy: .public)")
+                    isRefreshingMetadata = false
+                    return
+                }
+            } catch {
+                continue
+            }
+        }
+    }
 
     private func fetchPage(reset: Bool, generation currentGeneration: Int) async {
         guard hasMore, !isLoadingItems else { return }
@@ -162,8 +254,14 @@ struct PersonDetailView: View {
         rootContent
             .navigationTitle(viewModel.person?.name ?? "Person")
             .continuumNavigationTitleDisplayMode(.inline)
+            .onAppear {
+                viewModel.resumeMetadataRefreshIfNeeded()
+            }
             .task {
                 await viewModel.loadInitial()
+            }
+            .onDisappear {
+                viewModel.stopMetadataRefresh()
             }
     }
 
@@ -284,6 +382,10 @@ private struct TVPersonDetailContent: View {
                         Capsule()
                             .fill(Color.continuumSurfaceVariant)
                     )
+            }
+
+            if viewModel.isRefreshingMetadata {
+                PersonMetadataRefreshIndicator()
             }
         }
     }
@@ -406,6 +508,10 @@ private struct PhonePersonDetailContent: View {
                             .fill(Color.continuumSurfaceVariant)
                     )
             }
+
+            if viewModel.isRefreshingMetadata {
+                PersonMetadataRefreshIndicator()
+            }
         }
     }
 
@@ -468,6 +574,51 @@ private struct PersonPortrait: View {
             RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius)
                 .stroke(Color.white.opacity(0.10), lineWidth: 1)
         )
+    }
+}
+
+private struct PersonMetadataRefreshIndicator: View {
+    var body: some View {
+        HStack(spacing: 8) {
+            ProgressView()
+                .controlSize(controlSize)
+                .tint(.continuumOnSurface)
+
+            Text("Loading metadata")
+                .font(.continuumSmall)
+                .foregroundColor(.continuumSecondaryText)
+        }
+        .padding(.horizontal, horizontalPadding)
+        .padding(.vertical, verticalPadding)
+        .background(
+            Capsule()
+                .fill(Color.continuumSurfaceVariant.opacity(0.72))
+        )
+        .accessibilityElement(children: .combine)
+    }
+
+    private var controlSize: ControlSize {
+        #if os(tvOS)
+        .regular
+        #else
+        .small
+        #endif
+    }
+
+    private var horizontalPadding: CGFloat {
+        #if os(tvOS)
+        16
+        #else
+        9
+        #endif
+    }
+
+    private var verticalPadding: CGFloat {
+        #if os(tvOS)
+        8
+        #else
+        5
+        #endif
     }
 }
 
@@ -564,6 +715,10 @@ private struct PersonFilterButton: View {
 }
 
 private extension Person {
+    var isMetadataIncomplete: Bool {
+        clean(bio) == nil || clean(photoUrl) == nil || clean(birthDate) == nil
+    }
+
     var initials: String {
         let parts = name
             .split(separator: " ")

--- a/iosApp/iosApp/tvOS/Navigation/TVCascadeSelector.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVCascadeSelector.swift
@@ -145,9 +145,15 @@ struct TVCascadeSelector: View {
                 .frame(width: ContinuumTheme.Skyline.flyoutWidth, alignment: .top)
                 .opacity(flyoutAnchorId != nil ? 1 : 0)
                 .padding(.top, flyoutTopPadding)
+                // Animate the follow on the *discrete* anchor change, never on
+                // `flyoutTopPadding` itself. `flyoutTopPadding` is derived from
+                // live GeometryReader→preference measurements; animating on it
+                // makes sub-pixel re-measure jitter re-arm the animation every
+                // layout pass, so `AnimatorState.combine` accumulates without
+                // bound and the CA transaction never commits (hard UI freeze).
                 .animation(
                     reduceMotion ? nil : .easeInOut(duration: ContinuumTheme.Skyline.flyoutOpenDuration),
-                    value: flyoutTopPadding
+                    value: flyoutAnchorId
                 )
         }
         .coordinateSpace(name: Self.cascadeSpace)

--- a/iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift
@@ -1,6 +1,7 @@
 #if os(tvOS)
 import SwiftUI
 import UIKit
+import os
 
 enum TVTopMenuLayout {
     /// Vertical clearance needed when a root tvOS page does not render a
@@ -162,6 +163,10 @@ struct TVTopMenuBar: View {
     @State private var dwellSuppressedElement: TVTopMenuFocus?
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.continuum.app",
+        category: "TVFocus"
+    )
 
     var body: some View {
         ZStack(alignment: .top) {
@@ -209,6 +214,8 @@ struct TVTopMenuBar: View {
             }
         }
         .onChange(of: focusRequest) { _, _ in
+            let target = focusRequestTarget.map { String(describing: $0) } ?? "nil"
+            Self.logger.debug("topMenu.focusRequest request=\(focusRequest, privacy: .public) suppressed=\(isFocusSuppressed, privacy: .public) target=\(target, privacy: .public)")
             requestMenuFocus()
         }
         .onChange(of: isMenuFocused) { _, newValue in
@@ -226,6 +233,8 @@ struct TVTopMenuBar: View {
             isMenuFocused = focusedItem != nil && !newValue
         }
         .onChange(of: focusedItem) { _, newValue in
+            let item = newValue.map { String(describing: $0) } ?? "nil"
+            Self.logger.debug("topMenu.focus item=\(item, privacy: .public) panelHasFocus=\(panelHasFocus, privacy: .public) panelEntersFocus=\(panelEntersFocus, privacy: .public)")
             if let newValue {
                 lastBarFocus = newValue
                 refocusAfterClose = false
@@ -376,7 +385,10 @@ struct TVTopMenuBar: View {
     }
 
     private func requestMenuFocus() {
-        guard !isFocusSuppressed else { return }
+        guard !isFocusSuppressed else {
+            Self.logger.debug("topMenu.requestMenuFocus blocked suppressed=true")
+            return
+        }
         switch focusRequestTarget {
         // A non-nil target means focus is returning from an explicit panel
         // close (focusTopMenuIfVisible(focusing:) is only called that way).
@@ -392,6 +404,8 @@ struct TVTopMenuBar: View {
         case .none:
             focusedItem = .root(selectedRoot)
         }
+        let item = focusedItem.map { String(describing: $0) } ?? "nil"
+        Self.logger.debug("topMenu.requestMenuFocus focusedItem=\(item, privacy: .public)")
     }
 
     // MARK: - Search
@@ -465,6 +479,8 @@ struct TVTopMenuBar: View {
     }
 
     private func handleExitPress() {
+        let item = focusedItem.map { String(describing: $0) } ?? "nil"
+        Self.logger.debug("topMenu.exitPress focusedItem=\(item, privacy: .public) openPanel=\(openPanel != nil, privacy: .public) selectedRoot=\(String(describing: selectedRoot), privacy: .public)")
         if openPanel != nil {
             onDwell(nil)
             return

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
@@ -7,12 +7,12 @@ import SwiftUI
 /// start playback — the rail is a browsing surface, not a direct play
 /// launcher.
 ///
-/// When rendered on an episode detail page, pass `currentContentId` to
-/// highlight the episode the user is currently viewing. The rail will
-/// also scroll that card to the horizontal center on first appearance
-/// and make it the default focus target when the user d-pads down into
-/// the rail, so they land on the episode they're already on rather than
-/// the first card in the season.
+/// Pass `currentContentId` to highlight the episode currently represented
+/// by the surrounding detail experience. The rail will also scroll that
+/// card to the horizontal center on first appearance and make it the
+/// default focus target when the user d-pads down into the rail, so they
+/// land on the episode represented by the page's primary action rather
+/// than the first card in the season.
 struct TVEpisodeRail: View {
     let episodes: [EpisodeListItem]
     let onSelect: (String) -> Void

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
@@ -1,5 +1,6 @@
 #if os(tvOS)
 import SwiftUI
+import os
 
 /// Cinematic item-detail screen for tvOS. Replaces the shared
 /// `MovieDetailContent` / `SeriesDetailContent` layouts on tvOS only; the
@@ -22,6 +23,10 @@ struct TVItemDetailView: View {
     @State private var isLoadingNextUpPlaybackDetail = false
     @State private var didLoadNextUpPlaybackDetail = false
     @Environment(AppRouter.self) private var router
+    private static let focusLogger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.continuum.app",
+        category: "TVFocus"
+    )
 
     init(contentId: String) {
         self.contentId = contentId
@@ -48,6 +53,12 @@ struct TVItemDetailView: View {
         .continuumBackground()
         .continuumNavigationTitleDisplayMode(.inline)
         .continuumNavigationBarBackgroundHidden()
+        .onAppear {
+            Self.focusLogger.debug("itemDetail.appear contentId=\(contentId, privacy: .public) pathDepth=\(router.path.count, privacy: .public)")
+        }
+        .onDisappear {
+            Self.focusLogger.debug("itemDetail.disappear contentId=\(contentId, privacy: .public) pathDepth=\(router.path.count, privacy: .public)")
+        }
         .task(id: contentId) {
             preferredVersionFileId = nil
             preferredAudioTrackIndex = nil

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
@@ -248,7 +248,11 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
                     .font(.system(size: 22, weight: .regular))
                     .foregroundColor(.continuumSecondaryText)
             } else {
-                TVEpisodeRail(episodes: episodes, onSelect: onEpisodeTap)
+                TVEpisodeRail(
+                    episodes: episodes,
+                    onSelect: onEpisodeTap,
+                    currentContentId: nextUpEpisode?.contentId
+                )
             }
         }
     }

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -256,7 +256,8 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         } else {
             TVEpisodeRail(
                 episodes: episodes,
-                onSelect: onEpisodeTap
+                onSelect: onEpisodeTap,
+                currentContentId: nextUpEpisode?.contentId
             )
         }
     }


### PR DESCRIPTION
## Summary
- **Person-detail metadata auto-refresh (iOS + tvOS).** When a person page opens with incomplete metadata (missing bio / photo / birth date), queue a server-side refresh (`POST /api/v1/people/{id}/refresh`) and poll `GET /api/v1/people/{id}` every 3s for up to 120s, swapping in the enriched record when it lands. A "Loading metadata" indicator shows while in flight; the poll task is cancelled on disappear so it can't outlive the route.
- **tvOS episode rail** highlights + scrolls to the next-up episode via `currentContentId` on series/season detail.
- **tvOS cascade-selector freeze fix.** The Skyline top-menu cascade animated the flyout alignment padding on a live `GeometryReader`→preference value (`flyoutTopPadding`), which re-armed a SwiftUI animation every layout pass — `AnimatorState.combine` accumulated without bound, the CoreAnimation transaction never committed, and the app hard-froze on the way back to Home (repro: item detail → cast member → back → back; Home never paints). Now animates on the discrete `flyoutAnchorId`. Root-caused by sampling the hung simulator process (main thread pegged in `AnimatorState.combine`).
- Adds `TVFocus` debug logging across a few detail/navigation components.

## Server dependency
The metadata refresh assumes the server exposes `POST /api/v1/people/{id}/refresh` returning `PersonRefreshQueuedResponse`. Confirm it's implemented/deployed before relying on the feature.

## Testing
- ✅ Builds: `SiloTV` (tvOS sim) and `Silo` (iOS sim) both succeed.
- ✅ Cascade freeze fix verified on the tvOS simulator — item detail → actor → back → back now returns to Home instead of locking up.
- ⚠️ Person metadata refresh not yet validated end-to-end against a live server returning incomplete metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic metadata refresh for person details when key info is missing, with an on-screen refresh indicator.
  * Improved tvOS focus behavior so the currently relevant episode is highlighted and centered more consistently.
* **Bug Fixes**
  * Reduced accidental tvOS flyout re-animation caused by layout jitter.
  * Added additional tvOS focus logging to help diagnose navigation issues without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->