### PR TITLE
feat(ci): unsigned iOS + tvOS IPA builds for sideloading

### DIFF
--- a/.github/workflows/sideload-ipa.yml
+++ b/.github/workflows/sideload-ipa.yml
@@ -1,0 +1,138 @@
+name: Sideload IPA Build
+
+# Builds UNSIGNED iOS and tvOS IPAs for third-party signing / sideloading.
+# These artifacts are not installable as-is: the end user re-signs them with
+# their own account (AltStore / Sideloadly / SideStore / etc.). No signing
+# certs, Match repo, or App Store Connect key is used — this workflow reads no
+# release secrets. See docs/release/sideloading.md.
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Marketing version (e.g. 1.4.0)'
+        required: true
+        type: string
+
+# Attach IPAs to the GitHub Release on tag builds; workflow_dispatch just
+# publishes artifacts, so it only needs read.
+permissions:
+  contents: write
+
+env:
+  XCODEGEN_VERSION: "2.43.0"
+
+jobs:
+  ios:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # tags + history for version resolution
+
+      - name: Select Xcode 26
+        run: sudo xcode-select -s /Applications/Xcode_26.3.app
+
+      - name: Install XcodeGen (pinned)
+        run: |
+          curl -fsSL -o /tmp/xcodegen.zip \
+            "https://github.com/yonaskolb/XcodeGen/releases/download/${XCODEGEN_VERSION}/xcodegen.zip"
+          unzip -q /tmp/xcodegen.zip -d /tmp/xcodegen-dist
+          sudo /tmp/xcodegen-dist/xcodegen/install.sh /usr/local
+          xcodegen --version
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Resolve marketing version
+        id: ver
+        env:
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_REF_NAME: ${{ github.ref_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          V="$(scripts/ci/resolve-marketing-version.sh \
+                "$GH_EVENT_NAME" "$GH_REF_NAME" "$INPUT_VERSION")"
+          {
+            echo "value<<EOF"
+            echo "$V"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "Resolved marketing version: $V"
+
+      - name: Build unsigned iOS IPA
+        run: bundle exec fastlane ios ipa_ios_unsigned
+        env:
+          MARKETING_VERSION: ${{ steps.ver.outputs.value }}
+
+      - name: Upload iOS IPA artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Silo-iOS-unsigned-ipa
+          path: build/ios-unsigned/Silo-unsigned.ipa
+          if-no-files-found: error
+
+      - name: Attach iOS IPA to release
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${GITHUB_REF_NAME}" build/ios-unsigned/Silo-unsigned.ipa --clobber
+
+  tvos:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Select Xcode 26
+        run: sudo xcode-select -s /Applications/Xcode_26.3.app
+
+      - name: Install XcodeGen (pinned)
+        run: |
+          curl -fsSL -o /tmp/xcodegen.zip \
+            "https://github.com/yonaskolb/XcodeGen/releases/download/${XCODEGEN_VERSION}/xcodegen.zip"
+          unzip -q /tmp/xcodegen.zip -d /tmp/xcodegen-dist
+          sudo /tmp/xcodegen-dist/xcodegen/install.sh /usr/local
+          xcodegen --version
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Resolve marketing version
+        id: ver
+        env:
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_REF_NAME: ${{ github.ref_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          V="$(scripts/ci/resolve-marketing-version.sh \
+                "$GH_EVENT_NAME" "$GH_REF_NAME" "$INPUT_VERSION")"
+          {
+            echo "value<<EOF"
+            echo "$V"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "Resolved marketing version: $V"
+
+      - name: Build unsigned tvOS IPA
+        run: bundle exec fastlane ios ipa_tvos_unsigned
+        env:
+          MARKETING_VERSION: ${{ steps.ver.outputs.value }}
+
+      - name: Upload tvOS IPA artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SiloTV-tvOS-unsigned-ipa
+          path: build/tvos-unsigned/SiloTV-unsigned.ipa
+          if-no-files-found: error
+
+      - name: Attach tvOS IPA to release
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${GITHUB_REF_NAME}" build/tvos-unsigned/SiloTV-unsigned.ipa --clobber

--- a/.github/workflows/sideload-ipa.yml
+++ b/.github/workflows/sideload-ipa.yml
@@ -16,21 +16,34 @@ on:
         required: true
         type: string
 
-# Attach IPAs to the GitHub Release on tag builds; workflow_dispatch just
-# publishes artifacts, so it only needs read.
-permissions:
-  contents: write
-
 env:
   XCODEGEN_VERSION: "2.43.0"
 
 jobs:
-  ios:
+  build:
     runs-on: macos-15
+    # Only the release-upload step (tag builds) needs write; scope it to the job
+    # rather than the whole workflow to keep the rest at least privilege.
+    permissions:
+      contents: write
+    strategy:
+      # Let one platform finish/publish even if the other fails.
+      fail-fast: false
+      matrix:
+        include:
+          - platform: iOS
+            lane: ipa_ios_unsigned
+            artifact: Silo-iOS-unsigned-ipa
+            ipa_path: build/ios-unsigned/Silo-unsigned.ipa
+          - platform: tvOS
+            lane: ipa_tvos_unsigned
+            artifact: SiloTV-tvOS-unsigned-ipa
+            ipa_path: build/tvos-unsigned/SiloTV-unsigned.ipa
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0   # tags + history for version resolution
+          fetch-depth: 0            # tags + history for version resolution
+          persist-credentials: false  # don't leave GITHUB_TOKEN in git config for xcodegen/SPM
 
       - name: Select Xcode 26
         run: sudo xcode-select -s /Applications/Xcode_26.3.app
@@ -63,76 +76,32 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "Resolved marketing version: $V"
 
-      - name: Build unsigned iOS IPA
-        run: bundle exec fastlane ios ipa_ios_unsigned
+      - name: Build unsigned ${{ matrix.platform }} IPA
+        run: bundle exec fastlane ios ${{ matrix.lane }}
         env:
           MARKETING_VERSION: ${{ steps.ver.outputs.value }}
 
-      - name: Upload iOS IPA artifact
+      - name: Upload ${{ matrix.platform }} IPA artifact
         uses: actions/upload-artifact@v4
         with:
-          name: Silo-iOS-unsigned-ipa
-          path: build/ios-unsigned/Silo-unsigned.ipa
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.ipa_path }}
           if-no-files-found: error
 
-      - name: Attach iOS IPA to release
+      - name: Attach ${{ matrix.platform }} IPA to release
         if: startsWith(github.ref, 'refs/tags/')
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${GITHUB_REF_NAME}" build/ios-unsigned/Silo-unsigned.ipa --clobber
-
-  tvos:
-    runs-on: macos-15
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Select Xcode 26
-        run: sudo xcode-select -s /Applications/Xcode_26.3.app
-
-      - name: Install XcodeGen (pinned)
+          IPA_PATH: ${{ matrix.ipa_path }}
         run: |
-          curl -fsSL -o /tmp/xcodegen.zip \
-            "https://github.com/yonaskolb/XcodeGen/releases/download/${XCODEGEN_VERSION}/xcodegen.zip"
-          unzip -q /tmp/xcodegen.zip -d /tmp/xcodegen-dist
-          sudo /tmp/xcodegen-dist/xcodegen/install.sh /usr/local
-          xcodegen --version
-
-      - uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-
-      - name: Resolve marketing version
-        id: ver
-        env:
-          GH_EVENT_NAME: ${{ github.event_name }}
-          GH_REF_NAME: ${{ github.ref_name }}
-          INPUT_VERSION: ${{ inputs.version }}
-        run: |
-          V="$(scripts/ci/resolve-marketing-version.sh \
-                "$GH_EVENT_NAME" "$GH_REF_NAME" "$INPUT_VERSION")"
-          {
-            echo "value<<EOF"
-            echo "$V"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-          echo "Resolved marketing version: $V"
-
-      - name: Build unsigned tvOS IPA
-        run: bundle exec fastlane ios ipa_tvos_unsigned
-        env:
-          MARKETING_VERSION: ${{ steps.ver.outputs.value }}
-
-      - name: Upload tvOS IPA artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: SiloTV-tvOS-unsigned-ipa
-          path: build/tvos-unsigned/SiloTV-unsigned.ipa
-          if-no-files-found: error
-
-      - name: Attach tvOS IPA to release
-        if: startsWith(github.ref, 'refs/tags/')
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${GITHUB_REF_NAME}" build/tvos-unsigned/SiloTV-unsigned.ipa --clobber
+          # release.yml (TestFlight) never creates a GitHub Release, so one may
+          # not exist for this tag. Create it if missing before uploading. Both
+          # matrix jobs can race here, so tolerate an "already exists" error and
+          # re-check that the release is present before uploading.
+          if ! gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release create "$GITHUB_REF_NAME" \
+              --title "$GITHUB_REF_NAME" \
+              --notes "Unsigned iOS/tvOS IPAs for third-party signing / sideloading. See docs/release/sideloading.md." \
+              || true
+          fi
+          gh release upload "$GITHUB_REF_NAME" "$IPA_PATH" --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ DerivedData/
 .build/
 iosApp/Pods/
 
+# Fastlane build outputs (IPAs, archives from the ipa_*_unsigned lanes)
+build/
+fastlane/README.md
+
 # Local signing and secrets
 iosApp/Signing/Local.xcconfig
 .env

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -78,6 +78,32 @@ def marketing_version_xcarg
   "MARKETING_VERSION=#{value} "
 end
 
+# Repackages a compiled .app from an unsigned .xcarchive into an unsigned .ipa.
+#
+# An .ipa is just a zip with the app under Payload/. We build the archive with
+# code signing disabled (no certs, no match, no ASC secrets needed) and wrap the
+# product here. The resulting IPA is NOT installable as-is — it is meant to be
+# re-signed by the end user with their own certificate via AltStore, Sideloadly,
+# SideStore, etc. before sideloading. See docs/release/sideloading.md.
+def package_unsigned_ipa(archive_path:, app_name:, output_dir:, output_ipa:)
+  app_path = "#{archive_path}/Products/Applications/#{app_name}.app"
+  UI.user_error!("Expected app not found at #{app_path}") unless File.exist?(app_path)
+
+  # zip must run from output_dir so the archive root is Payload/, not an
+  # absolute path. Rebuild Payload/ from scratch each run for idempotency.
+  sh(<<~SH)
+    set -euo pipefail
+    cd #{output_dir.shellescape}
+    rm -rf Payload #{output_ipa.shellescape}
+    mkdir Payload
+    cp -R #{app_path.shellescape} Payload/
+    zip -qry #{output_ipa.shellescape} Payload
+    rm -rf Payload
+  SH
+
+  UI.success("Unsigned IPA written to #{output_dir}/#{output_ipa}")
+end
+
 def testflight_distribution
   mode = ENV.fetch("TESTFLIGHT_DISTRIBUTION", "internal").strip.downcase
 
@@ -383,6 +409,85 @@ platform :ios do
       groups:                  testflight_upload[:groups],
       distribute_external:     testflight_upload[:distribute_external],
       notify_external_testers: testflight_upload[:notify_external_testers]
+    )
+  end
+
+  # ── Unsigned IPAs for third-party signing / sideloading ─────────────────────
+  #
+  # These lanes build an installable-once-re-signed IPA with NO code signing:
+  # no match, no distribution cert, no App Store Connect key. The user re-signs
+  # the artifact with their own account (AltStore / Sideloadly / SideStore / etc.)
+  # before sideloading. Because nothing is uploaded and no secrets are read, they
+  # run on any macOS runner without release credentials. See
+  # docs/release/sideloading.md for the caveats (entitlement remapping, 7-day
+  # free-account expiry, and the tvOS host-pairing / Top Shelf notes).
+
+  desc "Build an unsigned iOS IPA for third-party signing / sideloading (no upload)"
+  lane :ipa_ios_unsigned do
+    ios_app_dir  = File.expand_path("../iosApp", __dir__)
+    output_dir   = File.expand_path("../build/ios-unsigned", __dir__)
+    archive_path = "#{output_dir}/Silo.xcarchive"
+
+    sh("xcodegen generate --spec '#{ios_app_dir}/project.yml'")
+    sh("xcodebuild -project '#{ios_app_dir}/Silo.xcodeproj' " \
+       "-scheme Silo -resolvePackageDependencies")
+    sh("bash '#{ios_app_dir}/scripts/patch-libavutil-modulemap.sh'")
+
+    # Archive with signing disabled — no certs required. CURRENT_PROJECT_VERSION
+    # comes from CI when set; local runs fall back to the project.yml value.
+    xcodebuild(
+      archive:      true,
+      project:      "#{ios_app_dir}/Silo.xcodeproj",
+      scheme:       "Silo",
+      destination:  "generic/platform=iOS",
+      archive_path: archive_path,
+      xcargs:       "#{marketing_version_xcarg}" \
+                    "CODE_SIGNING_ALLOWED=NO " \
+                    "CODE_SIGNING_REQUIRED=NO " \
+                    "CODE_SIGN_IDENTITY='' " \
+                    "CODE_SIGN_ENTITLEMENTS=''"
+    )
+
+    package_unsigned_ipa(
+      archive_path: archive_path,
+      app_name:     "Silo",
+      output_dir:   output_dir,
+      output_ipa:   "Silo-unsigned.ipa"
+    )
+  end
+
+  desc "Build an unsigned tvOS IPA for third-party signing / sideloading (no upload)"
+  lane :ipa_tvos_unsigned do
+    ios_app_dir  = File.expand_path("../iosApp", __dir__)
+    output_dir   = File.expand_path("../build/tvos-unsigned", __dir__)
+    archive_path = "#{output_dir}/SiloTV.xcarchive"
+
+    sh("xcodegen generate --spec '#{ios_app_dir}/project.yml'")
+    sh("xcodebuild -project '#{ios_app_dir}/Silo.xcodeproj' " \
+       "-scheme SiloTV -resolvePackageDependencies")
+    sh("bash '#{ios_app_dir}/scripts/patch-libavutil-modulemap.sh'")
+
+    # The embedded Top Shelf extension is archived as part of SiloTV.app, so no
+    # per-target signing handling is needed here. Re-signers that cannot sign the
+    # extension (e.g. free accounts) can strip it before sideloading.
+    xcodebuild(
+      archive:      true,
+      project:      "#{ios_app_dir}/Silo.xcodeproj",
+      scheme:       "SiloTV",
+      destination:  "generic/platform=tvOS",
+      archive_path: archive_path,
+      xcargs:       "#{marketing_version_xcarg}" \
+                    "CODE_SIGNING_ALLOWED=NO " \
+                    "CODE_SIGNING_REQUIRED=NO " \
+                    "CODE_SIGN_IDENTITY='' " \
+                    "CODE_SIGN_ENTITLEMENTS=''"
+    )
+
+    package_unsigned_ipa(
+      archive_path: archive_path,
+      app_name:     "SiloTV",
+      output_dir:   output_dir,
+      output_ipa:   "SiloTV-unsigned.ipa"
     )
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -78,6 +78,22 @@ def marketing_version_xcarg
   "MARKETING_VERSION=#{value} "
 end
 
+# Regenerates Silo.xcodeproj from project.yml, resolves SPM packages for the
+# given scheme (populating DerivedData), and applies the FFmpeg module-map patch.
+# Shared by the unsigned IPA lanes. Returns the absolute iosApp directory.
+#
+# Note: beta_ios/beta_tvos intentionally do NOT use this helper — they interleave
+# match() and the build-number query between xcodegen and resolvePackageDependencies,
+# so the three steps are not contiguous there.
+def prepare_xcode_project(scheme:)
+  ios_app_dir = File.expand_path("../iosApp", __dir__)
+  sh("xcodegen generate --spec '#{ios_app_dir}/project.yml'")
+  sh("xcodebuild -project '#{ios_app_dir}/Silo.xcodeproj' " \
+     "-scheme #{scheme} -resolvePackageDependencies")
+  sh("bash '#{ios_app_dir}/scripts/patch-libavutil-modulemap.sh'")
+  ios_app_dir
+end
+
 # Repackages a compiled .app from an unsigned .xcarchive into an unsigned .ipa.
 #
 # An .ipa is just a zip with the app under Payload/. We build the archive with
@@ -424,14 +440,9 @@ platform :ios do
 
   desc "Build an unsigned iOS IPA for third-party signing / sideloading (no upload)"
   lane :ipa_ios_unsigned do
-    ios_app_dir  = File.expand_path("../iosApp", __dir__)
+    ios_app_dir  = prepare_xcode_project(scheme: "Silo")
     output_dir   = File.expand_path("../build/ios-unsigned", __dir__)
     archive_path = "#{output_dir}/Silo.xcarchive"
-
-    sh("xcodegen generate --spec '#{ios_app_dir}/project.yml'")
-    sh("xcodebuild -project '#{ios_app_dir}/Silo.xcodeproj' " \
-       "-scheme Silo -resolvePackageDependencies")
-    sh("bash '#{ios_app_dir}/scripts/patch-libavutil-modulemap.sh'")
 
     # Archive with signing disabled — no certs required. CURRENT_PROJECT_VERSION
     # comes from CI when set; local runs fall back to the project.yml value.
@@ -458,14 +469,9 @@ platform :ios do
 
   desc "Build an unsigned tvOS IPA for third-party signing / sideloading (no upload)"
   lane :ipa_tvos_unsigned do
-    ios_app_dir  = File.expand_path("../iosApp", __dir__)
+    ios_app_dir  = prepare_xcode_project(scheme: "SiloTV")
     output_dir   = File.expand_path("../build/tvos-unsigned", __dir__)
     archive_path = "#{output_dir}/SiloTV.xcarchive"
-
-    sh("xcodegen generate --spec '#{ios_app_dir}/project.yml'")
-    sh("xcodebuild -project '#{ios_app_dir}/Silo.xcodeproj' " \
-       "-scheme SiloTV -resolvePackageDependencies")
-    sh("bash '#{ios_app_dir}/scripts/patch-libavutil-modulemap.sh'")
 
     # The embedded Top Shelf extension is archived as part of SiloTV.app, so no
     # per-target signing handling is needed here. Re-signers that cannot sign the


### PR DESCRIPTION
## What

Adds a way to produce **unsigned** iOS and tvOS IPAs for third-party signing / sideloading (AltStore, Sideloadly, SideStore, etc.), alongside the existing TestFlight pipeline.

### Fastlane lanes (`fastlane/Fastfile`)
- `ipa_ios_unsigned` → `build/ios-unsigned/Silo-unsigned.ipa`
- `ipa_tvos_unsigned` → `build/tvos-unsigned/SiloTV-unsigned.ipa`

Both archive with `CODE_SIGNING_ALLOWED=NO` and repackage the `.app` into an unsigned IPA via a shared `package_unsigned_ipa` helper. **No match, distribution cert, or ASC key is used** — they run on any macOS runner with zero release secrets. The end user re-signs the artifact with their own account before sideloading.

### CI (`.github/workflows/sideload-ipa.yml`)
- Triggers on tag `v*` and manual `workflow_dispatch` (version input).
- Both platform jobs run in parallel (no build-number sequencing, nothing uploaded to Apple).
- Publishes IPAs as workflow artifacts; on tag builds also attaches them to the GitHub Release.

### Docs
- `docs/release/sideloading.md` documents the flow and caveats (entitlement remapping on re-sign, 7-day free-account expiry, tvOS host-pairing + Top Shelf stripping).

## Testing

Both lanes were run locally on macOS (Xcode 26.5.1):

| Lane | Artifact | Size | Signature | Structure |
|---|---|---|---|---|
| `ipa_ios_unsigned` | `Silo-unsigned.ipa` | 22 MB | not signed at all | `Payload/Silo.app/` |
| `ipa_tvos_unsigned` | `SiloTV-unsigned.ipa` | 28 MB | not signed at all | `Payload/SiloTV.app/` + embedded `PlugIns/SiloTVTopShelf.appex/` |

- Correct `Payload/<App>.app` layout, no `_CodeSignature` (confirmed unsigned).
- tvOS build includes the Top Shelf extension intact; archived cleanly with signing disabled.
- Not exercised locally: the GitHub-side artifact upload / release attachment (only runs in Actions).

## Note

The `v*` tag trigger is shared with the existing TestFlight `release.yml`, so a single `v*` tag fires both workflows. Say the word if you'd prefer a separate tag pattern or dispatch-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new build workflow to generate unsigned iOS and tvOS IPAs on tag pushes or manual runs.
  * Added support for packaging unsigned app archives into installable IPA files for sideloading.
  * Uploaded build artifacts automatically, and attached IPA files to GitHub Releases on tagged builds.

* **Chores**
  * Updated ignored files to keep generated build output and Fastlane-generated docs out of the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->