### PR TITLE
feat(ci): platform selector for sideload IPA builds

### DIFF
--- a/.github/workflows/sideload-ipa.yml
+++ b/.github/workflows/sideload-ipa.yml
@@ -15,12 +15,43 @@ on:
         description: 'Marketing version (e.g. 1.4.0)'
         required: true
         type: string
+      platform:
+        description: 'Which platform(s) to build'
+        required: true
+        type: choice
+        default: both
+        options:
+          - both
+          - ios
+          - tvos
 
 env:
   XCODEGEN_VERSION: "2.43.0"
 
 jobs:
+  # Compute the build matrix from the dispatch input. Tag pushes (and any run
+  # without an explicit choice) build both platforms.
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+    steps:
+      - id: set
+        env:
+          PLATFORM: ${{ github.event_name == 'workflow_dispatch' && inputs.platform || 'both' }}
+        run: |
+          ios='{"platform":"iOS","lane":"ipa_ios_unsigned","artifact":"Silo-iOS-unsigned-ipa","ipa_path":"build/ios-unsigned/Silo-unsigned.ipa"}'
+          tvos='{"platform":"tvOS","lane":"ipa_tvos_unsigned","artifact":"SiloTV-tvOS-unsigned-ipa","ipa_path":"build/tvos-unsigned/SiloTV-unsigned.ipa"}'
+          case "$PLATFORM" in
+            ios)  include="[$ios]" ;;
+            tvos) include="[$tvos]" ;;
+            *)    include="[$ios,$tvos]" ;;
+          esac
+          echo "Building matrix for platform=$PLATFORM"
+          echo "matrix={\"include\":$include}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: setup
     runs-on: macos-15
     # Only the release-upload step (tag builds) needs write; scope it to the job
     # rather than the whole workflow to keep the rest at least privilege.
@@ -29,16 +60,7 @@ jobs:
     strategy:
       # Let one platform finish/publish even if the other fails.
       fail-fast: false
-      matrix:
-        include:
-          - platform: iOS
-            lane: ipa_ios_unsigned
-            artifact: Silo-iOS-unsigned-ipa
-            ipa_path: build/ios-unsigned/Silo-unsigned.ipa
-          - platform: tvOS
-            lane: ipa_tvos_unsigned
-            artifact: SiloTV-tvOS-unsigned-ipa
-            ipa_path: build/tvos-unsigned/SiloTV-unsigned.ipa
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/docs/release/sideloading.md
+++ b/docs/release/sideloading.md
@@ -1,0 +1,50 @@
+# Sideloading (unsigned IPA) builds
+
+The **Sideload IPA Build** workflow (`.github/workflows/sideload-ipa.yml`) produces
+**unsigned** iOS and tvOS IPAs. They are meant to be re-signed by the end user
+with their own Apple account and sideloaded via AltStore, SideStore, Sideloadly,
+or similar. This is separate from the TestFlight pipeline
+([ci-release.md](ci-release.md)).
+
+## How it differs from the TestFlight build
+- **No signing.** Archives are built with `CODE_SIGNING_ALLOWED=NO`; the IPA is
+  just `Payload/<App>.app` zipped. The user's sideloading tool strips the
+  (absent) signature and applies their own certificate.
+- **No secrets.** No Match repo, distribution cert, or App Store Connect key is
+  read. The workflow runs on any macOS runner without release credentials.
+- **No upload.** Nothing goes to Apple. Artifacts are published to the workflow
+  run and, on tag builds, attached to the GitHub Release.
+
+## How it triggers
+- Push tag `vX.Y.Z` → builds both IPAs and attaches them to that release.
+- Manual: Actions → "Sideload IPA Build" → Run workflow → enter `version` and
+  pick `platform` (`both` / `ios` / `tvos`); artifacts only, nothing attached to
+  a release. Tag pushes always build both platforms.
+
+The marketing version resolves the same way as the TestFlight workflow
+(`scripts/ci/resolve-marketing-version.sh`). The archives are unsigned, so no
+build-number sequencing against App Store Connect is needed and the two jobs
+run in parallel.
+
+## Fastlane lanes
+    bundle exec fastlane ios ipa_ios_unsigned    # -> build/ios-unsigned/Silo-unsigned.ipa
+    bundle exec fastlane ios ipa_tvos_unsigned   # -> build/tvos-unsigned/SiloTV-unsigned.ipa
+
+Both run locally with no credentials.
+
+## Caveats to communicate to users
+- **Re-signing changes entitlements.** When re-signed with a personal/free
+  account, the app's keychain-sharing group and any App Groups are remapped to
+  the user's team prefix. The app runs, but features that depend on a fixed
+  group identifier may behave differently.
+- **Free accounts expire in 7 days** and are limited to 3 active apps; a paid
+  developer account lasts ~1 year.
+- **tvOS needs a host machine.** Unlike iOS, Apple TV has no on-device
+  installer. Users pair the Apple TV with a host (Mac + AltServer/Xcode, or a
+  Linux box running atvloadly) over the network before installing, and the host
+  must be reachable for refreshes.
+- **tvOS Top Shelf extension.** It is embedded in `SiloTV.app` and archived
+  automatically. Re-signers who cannot sign the extension (common on free
+  accounts) can strip it before sideloading — the app installs without Top Shelf.
+- tvOS sideloading is more sensitive to OS version; new tvOS releases can
+  temporarily break the sideloading tools.


### PR DESCRIPTION
## What

Adds a `platform` choice to the **Sideload IPA Build** manual dispatch so you can build just one platform instead of always both.

- `workflow_dispatch` gains a `platform` input: **both** (default) / **ios** / **tvos**.
- A lightweight `setup` job computes the build matrix from the input; the `build` job consumes it via `fromJson`.
- **Tag pushes are unchanged** — they always build both platforms (tags can't carry inputs).

## Also fixes a dangling reference

`docs/*` is gitignored (only `tvos-focus.md` is negated; `ci-release.md` is force-tracked). As a result `docs/release/sideloading.md` — referenced by `fastlane/Fastfile` and `sideload-ipa.yml` — **was never committed in #36**. This PR force-adds it (same convention as `ci-release.md`) and documents the new selector.

## Testing

- Workflow YAML parses.
- Simulated the matrix-generation shell for every input value:

| input | matrix legs |
|---|---|
| `both` (or tag / empty) | iOS + tvOS |
| `ios` | iOS only |
| `tvos` | tvOS only |

All produce valid JSON. The actual build path per platform is unchanged from #36 (already verified end-to-end locally).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now choose which platform to build when starting a sideloading release manually: iOS, tvOS, or both.
  * Tag-based releases continue to build both platforms by default.

* **Documentation**
  * Added guidance for unsigned IPA sideloading builds, including what’s produced, when it runs, and key re-signing and device compatibility notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->