### PR TITLE
feat(ci): platform selector for TestFlight releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,15 @@ on:
         description: 'Marketing version (e.g. 1.4.0)'
         required: true
         type: string
+      platform:
+        description: 'Which platform(s) to release'
+        required: true
+        type: choice
+        default: both
+        options:
+          - both
+          - ios
+          - tvos
 
 # Serialize releases: each run computes latest_testflight_build_number + 1,
 # so overlapping runs would collide. Let an in-flight release finish.
@@ -28,6 +37,9 @@ env:
 
 jobs:
   ios:
+    # Skip only when a manual dispatch explicitly selects tvOS. Tag pushes and
+    # the "both" default resolve to 'both', so iOS runs.
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.platform || 'both') != 'tvos' }}
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
@@ -79,7 +91,15 @@ jobs:
           TESTFLIGHT_EXTERNAL_GROUPS: ${{ secrets.TESTFLIGHT_EXTERNAL_GROUPS }}
 
   tvos:
-    needs: ios   # enforce iOS-before-tvOS build-number ordering
+    needs: ios   # enforce iOS-before-tvOS build-number ordering when both run
+    # Run when the selection isn't iOS-only. `needs: ios` keeps the ordering for
+    # "both", but a skipped iOS job (tvOS-only dispatch) must not block tvOS —
+    # hence !cancelled() and the explicit "iOS didn't fail" check rather than
+    # the default success() gate (which would also skip on a skipped dependency).
+    if: >-
+      ${{ !cancelled()
+          && needs.ios.result != 'failure'
+          && (github.event_name == 'workflow_dispatch' && inputs.platform || 'both') != 'ios' }}
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: TestFlight Release
 
 on:
   push:
+    # v* -> both platforms; the +ios / +tvos build-metadata suffix
+    # (v1.4.0+ios / v1.4.0+tvos) targets that platform only. Both match 'v*'.
     tags: ['v*']
   workflow_dispatch:
     inputs:
@@ -36,10 +38,29 @@ env:
   TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS: "true"
 
 jobs:
+  # Resolve the target platform from either the dispatch input or the tag's
+  # +ios / +tvos build-metadata suffix, so both trigger paths share one gate.
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      platform: ${{ steps.p.outputs.platform }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: p
+        env:
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_REF_NAME: ${{ github.ref_name }}
+          INPUT_PLATFORM: ${{ inputs.platform }}
+        run: |
+          P="$(scripts/ci/resolve-platform.sh \
+                "$GH_EVENT_NAME" "$GH_REF_NAME" "$INPUT_PLATFORM")"
+          echo "platform=$P" >> "$GITHUB_OUTPUT"
+          echo "Release platform: $P"
+
   ios:
-    # Skip only when a manual dispatch explicitly selects tvOS. Tag pushes and
-    # the "both" default resolve to 'both', so iOS runs.
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.platform || 'both') != 'tvos' }}
+    needs: setup
+    # Skip only when the selection is tvOS-only. 'both' and 'ios' both run iOS.
+    if: ${{ needs.setup.outputs.platform != 'tvos' }}
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
@@ -91,15 +112,15 @@ jobs:
           TESTFLIGHT_EXTERNAL_GROUPS: ${{ secrets.TESTFLIGHT_EXTERNAL_GROUPS }}
 
   tvos:
-    needs: ios   # enforce iOS-before-tvOS build-number ordering when both run
+    needs: [setup, ios]   # enforce iOS-before-tvOS build-number ordering when both run
     # Run when the selection isn't iOS-only. `needs: ios` keeps the ordering for
-    # "both", but a skipped iOS job (tvOS-only dispatch) must not block tvOS —
-    # hence !cancelled() and the explicit "iOS didn't fail" check rather than
-    # the default success() gate (which would also skip on a skipped dependency).
+    # "both", but a skipped iOS job (tvOS-only) must not block tvOS — hence
+    # !cancelled() and the explicit "iOS didn't fail" check rather than the
+    # default success() gate (which would also skip on a skipped dependency).
     if: >-
       ${{ !cancelled()
           && needs.ios.result != 'failure'
-          && (github.event_name == 'workflow_dispatch' && inputs.platform || 'both') != 'ios' }}
+          && needs.setup.outputs.platform != 'ios' }}
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4

--- a/docs/release/ci-release.md
+++ b/docs/release/ci-release.md
@@ -4,7 +4,10 @@
 - Push tag `vX.Y.Z` (e.g. `v1.4.0`) → builds iOS + tvOS, uploads to TestFlight,
   distributes to external groups, notifies testers.
 - Push prerelease tag `vX.Y.Z-beta.N` → same, marketing version `X.Y.Z`.
-- Manual: Actions tab → "TestFlight Release" → Run workflow → enter `version`.
+- Manual: Actions tab → "TestFlight Release" → Run workflow → enter `version`
+  and pick `platform` (`both` / `ios` / `tvos`). Tag pushes always release both.
+  On a `both` run, tvOS is skipped if the iOS job fails (build-number ordering);
+  a `tvos`-only run builds tvOS on its own.
 
 The git tag is the marketing version. Build numbers auto-increment per platform
 from App Store Connect. iOS builds before tvOS (build-number ordering).

--- a/docs/release/ci-release.md
+++ b/docs/release/ci-release.md
@@ -4,10 +4,15 @@
 - Push tag `vX.Y.Z` (e.g. `v1.4.0`) → builds iOS + tvOS, uploads to TestFlight,
   distributes to external groups, notifies testers.
 - Push prerelease tag `vX.Y.Z-beta.N` → same, marketing version `X.Y.Z`.
+- **Single platform via tag:** append a `+ios` or `+tvos` build-metadata suffix
+  — `vX.Y.Z+ios` releases iOS only, `vX.Y.Z+tvos` tvOS only. Plain `vX.Y.Z`
+  releases both. Works with prereleases too (`vX.Y.Z-beta.N+ios`). The marketing
+  version stays `X.Y.Z` (the suffix is stripped).
 - Manual: Actions tab → "TestFlight Release" → Run workflow → enter `version`
-  and pick `platform` (`both` / `ios` / `tvos`). Tag pushes always release both.
-  On a `both` run, tvOS is skipped if the iOS job fails (build-number ordering);
-  a `tvos`-only run builds tvOS on its own.
+  and pick `platform` (`both` / `ios` / `tvos`).
+
+On a both-platform run, tvOS is skipped if the iOS job fails (build-number
+ordering); a tvOS-only run builds tvOS on its own.
 
 The git tag is the marketing version. Build numbers auto-increment per platform
 from App Store Connect. iOS builds before tvOS (build-number ordering).

--- a/scripts/ci/resolve-marketing-version.sh
+++ b/scripts/ci/resolve-marketing-version.sh
@@ -3,8 +3,11 @@
 #
 # Usage: resolve-marketing-version.sh <event_name> <ref_name> <dispatch_input>
 #   workflow_dispatch -> echoes <dispatch_input> verbatim
-#   anything else     -> strips leading 'v' and any '-<suffix>' from <ref_name>
-#                        (v1.4.0 -> 1.4.0 ; v1.4.0-beta.2 -> 1.4.0)
+#   anything else     -> strips the leading 'v', any '+<metadata>' build suffix
+#                        (e.g. the +ios / +tvos platform marker), and any
+#                        '-<prerelease>' suffix from <ref_name>
+#                        (v1.4.0 -> 1.4.0 ; v1.4.0-beta.2 -> 1.4.0 ;
+#                         v1.4.0+ios -> 1.4.0 ; v2.0.0-rc.1+tvos -> 2.0.0)
 set -euo pipefail
 
 event_name="${1:-}"
@@ -14,8 +17,9 @@ dispatch_input="${3:-}"
 if [[ "$event_name" == "workflow_dispatch" ]]; then
   version="$dispatch_input"
 else
-  version="${ref_name#v}"     # strip leading v
-  version="${version%%-*}"    # strip -beta.N / -rc.N suffix
+  version="${ref_name#v}"      # strip leading v
+  version="${version%%+*}"     # strip +ios / +tvos (semver build metadata)
+  version="${version%%-*}"     # strip -beta.N / -rc.N suffix
 fi
 
 if [[ -z "$version" ]]; then

--- a/scripts/ci/resolve-marketing-version.test.sh
+++ b/scripts/ci/resolve-marketing-version.test.sh
@@ -15,6 +15,9 @@ assert_eq() {
 assert_eq "final tag"      "1.4.0" "$("$script" push          v1.4.0        "")"
 assert_eq "prerelease tag" "1.4.0" "$("$script" push          v1.4.0-beta.2 "")"
 assert_eq "rc tag"         "2.0.0" "$("$script" push          v2.0.0-rc.1   "")"
+assert_eq "ios-suffixed"   "1.4.0" "$("$script" push          v1.4.0+ios    "")"
+assert_eq "tvos-suffixed"  "1.4.0" "$("$script" push          v1.4.0+tvos   "")"
+assert_eq "prerelease+meta" "2.0.0" "$("$script" push         v2.0.0-rc.1+tvos "")"
 assert_eq "dispatch input" "1.4.0" "$("$script" workflow_dispatch ""        1.4.0)"
 
 assert_reject() {

--- a/scripts/ci/resolve-platform.sh
+++ b/scripts/ci/resolve-platform.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Resolve which platform(s) a TestFlight release targets.
+#
+# Usage: resolve-platform.sh <event_name> <ref_name> <dispatch_input>
+#   workflow_dispatch -> uses <dispatch_input> (both|ios|tvos; empty -> both)
+#   tag push          -> *+ios  -> ios   (e.g. v1.4.0+ios, v1.4.0-beta.1+ios)
+#                        *+tvos -> tvos  (e.g. v1.4.0+tvos)
+#                        v*     -> both  (no +platform metadata)
+# Output is always one of: both | ios | tvos (invalid input exits non-zero).
+set -euo pipefail
+
+event_name="${1:-}"
+ref_name="${2:-}"
+dispatch_input="${3:-}"
+
+if [[ "$event_name" == "workflow_dispatch" ]]; then
+  platform="${dispatch_input:-both}"
+else
+  case "$ref_name" in
+    *+ios)  platform="ios" ;;
+    *+tvos) platform="tvos" ;;
+    *)      platform="both" ;;   # plain v* (no +platform suffix) -> both
+  esac
+fi
+
+case "$platform" in
+  both|ios|tvos) echo "$platform" ;;
+  *)
+    echo "resolve-platform: invalid platform '${platform}' " \
+         "(event='${event_name}' ref='${ref_name}' input='${dispatch_input}')" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/ci/resolve-platform.test.sh
+++ b/scripts/ci/resolve-platform.test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+here="$(cd "$(dirname "$0")" && pwd)"
+script="${here}/resolve-platform.sh"
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" != "$actual" ]]; then
+    echo "FAIL: ${desc}: expected '${expected}', got '${actual}'" >&2
+    exit 1
+  fi
+  echo "ok: ${desc}"
+}
+
+assert_eq "plain tag -> both"        "both" "$("$script" push             v1.4.0        "")"
+assert_eq "prerelease tag -> both"   "both" "$("$script" push             v1.4.0-beta.2 "")"
+assert_eq "ios-suffixed tag"         "ios"  "$("$script" push             v1.4.0+ios    "")"
+assert_eq "tvos-suffixed tag"        "tvos" "$("$script" push             v2.0.0+tvos   "")"
+assert_eq "ios-suffixed prerelease"  "ios"  "$("$script" push             v1.4.0-rc.1+ios "")"
+assert_eq "dispatch both"            "both" "$("$script" workflow_dispatch ""           both)"
+assert_eq "dispatch ios"             "ios"  "$("$script" workflow_dispatch ""           ios)"
+assert_eq "dispatch tvos"            "tvos" "$("$script" workflow_dispatch ""           tvos)"
+assert_eq "dispatch empty -> both"   "both" "$("$script" workflow_dispatch ""           "")"
+
+assert_reject() {
+  local desc="$1"; shift
+  if "$script" "$@" 2>/dev/null; then
+    echo "FAIL: ${desc}: expected non-zero exit, got success" >&2
+    exit 1
+  fi
+  echo "ok: ${desc}"
+}
+
+assert_reject "invalid dispatch input" workflow_dispatch "" macos
+
+echo "ALL PASS"


### PR DESCRIPTION
## What

Adds a `platform` choice to the **TestFlight Release** manual dispatch so a release can target a single platform instead of always both. Companion to #37 (which added the same to the unsigned *sideload* workflow); this one covers the App Store / TestFlight path.

- `workflow_dispatch` gains a `platform` input: **both** (default) / **ios** / **tvos**.
- Each job is guarded by an `if:` expression driven by the input.
- **Tag pushes are unchanged** — they always release both platforms.

## The build-number-ordering wrinkle

The `tvos` job keeps `needs: ios` so on a **both** run iOS still allocates its build number before tvOS. But a naive guard would break tvOS-only runs, because a *skipped* `ios` job makes a `needs: ios` job skip under the default `success()` gate. So the tvos `if:` uses:

```
!cancelled() && needs.ios.result != 'failure' && (platform) != 'ios'
```

Behavior:

| Trigger | ios job | tvos job |
|---|---|---|
| tag push / dispatch `both` | runs | runs — **skipped if iOS fails** |
| dispatch `ios` | runs | skipped |
| dispatch `tvos` | skipped | runs (iOS skipped ≠ failed) |

## Note worth confirming

The `needs: ios` ordering comment says it's for build-number ordering, but the Fastfile queries **platform-specific** build numbers (`ios` vs `appletvos`), which are independent under Universal Purchase. So the ordering may be conservative rather than strictly required — flagging in case tvOS-only runs surface anything. The concurrency group still serializes overlapping releases regardless.

## Testing

- `release.yml` YAML parses; both `if:` expressions parse and were walked through the truth table above.
- No change to the actual `beta_ios` / `beta_tvos` lanes or the signed build path.