### PR TITLE
feat(ci): reserve build numbers in preflight, build iOS+tvOS in parallel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,9 +57,37 @@ jobs:
           echo "platform=$P" >> "$GITHUB_OUTPUT"
           echo "Release platform: $P"
 
-  ios:
+  # Reserve the next build number per platform ONCE, before the platform builds
+  # fan out. The ios/tvos jobs then consume these fixed values instead of each
+  # querying latest_testflight_build_number concurrently — which lets them run in
+  # parallel with no build-number race. Query-only, so it runs on Linux with just
+  # the ASC API key (no signing/match/team secrets).
+  build-numbers:
     needs: setup
+    runs-on: ubuntu-latest
+    outputs:
+      ios_build: ${{ steps.bn.outputs.ios_build }}
+      tvos_build: ${{ steps.bn.outputs.tvos_build }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Reserve per-platform build numbers
+        id: bn
+        env:
+          APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
+        run: |
+          # The lane appends ios_build=/tvos_build= lines to BUILD_NUMBERS_FILE.
+          BUILD_NUMBERS_FILE="$GITHUB_OUTPUT" bundle exec fastlane ios reserve_build_numbers
+
+  ios:
+    needs: [setup, build-numbers]
     # Skip only when the selection is tvOS-only. 'both' and 'ios' both run iOS.
+    # No status function in the if -> implicit success() gate on needs, so a
+    # failed build-numbers job skips this build.
     if: ${{ needs.setup.outputs.platform != 'tvos' }}
     runs-on: macos-15
     steps:
@@ -102,6 +130,7 @@ jobs:
         run: bundle exec fastlane ios beta_ios
         env:
           MARKETING_VERSION: ${{ steps.ver.outputs.value }}
+          BUILD_NUMBER: ${{ needs.build-numbers.outputs.ios_build }}
           TEAM_ID: ${{ secrets.TEAM_ID }}
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
@@ -112,15 +141,13 @@ jobs:
           TESTFLIGHT_EXTERNAL_GROUPS: ${{ secrets.TESTFLIGHT_EXTERNAL_GROUPS }}
 
   tvos:
-    needs: [setup, ios]   # enforce iOS-before-tvOS build-number ordering when both run
-    # Run when the selection isn't iOS-only. `needs: ios` keeps the ordering for
-    # "both", but a skipped iOS job (tvOS-only) must not block tvOS — hence
-    # !cancelled() and the explicit "iOS didn't fail" check rather than the
-    # default success() gate (which would also skip on a skipped dependency).
-    if: >-
-      ${{ !cancelled()
-          && needs.ios.result != 'failure'
-          && needs.setup.outputs.platform != 'ios' }}
+    # No longer needs: ios — build numbers are reserved up front, so tvOS runs in
+    # parallel with iOS rather than after it. (Trade-off: on a both run, tvOS now
+    # releases even if iOS fails; the platforms' build-number sequences are
+    # independent, so a gap is harmless.)
+    needs: [setup, build-numbers]
+    # Skip only when the selection is iOS-only. Implicit success() gate on needs.
+    if: ${{ needs.setup.outputs.platform != 'ios' }}
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
@@ -162,6 +189,7 @@ jobs:
         run: bundle exec fastlane ios beta_tvos
         env:
           MARKETING_VERSION: ${{ steps.ver.outputs.value }}
+          BUILD_NUMBER: ${{ needs.build-numbers.outputs.tvos_build }}
           TEAM_ID: ${{ secrets.TEAM_ID }}
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}

--- a/docs/release/ci-release.md
+++ b/docs/release/ci-release.md
@@ -14,8 +14,11 @@
 On a both-platform run, tvOS is skipped if the iOS job fails (build-number
 ordering); a tvOS-only run builds tvOS on its own.
 
-The git tag is the marketing version. Build numbers auto-increment per platform
-from App Store Connect. iOS builds before tvOS (build-number ordering).
+The git tag is the marketing version. A preflight `build-numbers` job reserves
+the next per-platform build number from App Store Connect once, then the iOS and
+tvOS jobs **build in parallel** consuming those fixed numbers (no build-number
+race). On a both-platform run the two are independent — tvOS still releases even
+if iOS fails; their build-number sequences are separate, so a gap is harmless.
 
 ## Required repository secrets
 | Secret | Purpose |

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -78,6 +78,34 @@ def marketing_version_xcarg
   "MARKETING_VERSION=#{value} "
 end
 
+# Returns the build number to stamp on a TestFlight build.
+#
+# In CI the reserve_build_numbers job computes the next number per platform once
+# and passes it to the (parallel) ios/tvos jobs via BUILD_NUMBER — so the two
+# jobs never race latest_testflight_build_number against each other. Local and
+# ad-hoc runs leave BUILD_NUMBER unset and fall back to querying App Store
+# Connect directly.
+#
+# BUILD_NUMBER is validated as a positive integer before use: it flows into
+# xcodebuild's xcargs as CURRENT_PROJECT_VERSION, so it must never carry spaces
+# or shell metacharacters (same threat model as marketing_version_xcarg).
+def resolve_build_number(api_key:, app_identifier:, platform:)
+  injected = ENV["BUILD_NUMBER"].to_s.strip
+  unless injected.empty?
+    unless injected.match?(/\A\d+\z/)
+      UI.user_error!("Invalid BUILD_NUMBER #{injected.inspect}; expected a positive integer")
+    end
+    UI.message("Using injected BUILD_NUMBER=#{injected} for #{platform}")
+    return injected.to_i
+  end
+
+  latest_testflight_build_number(
+    api_key:        api_key,
+    app_identifier: app_identifier,
+    platform:       platform
+  ) + 1
+end
+
 # Regenerates Silo.xcodeproj from project.yml, resolves SPM packages for the
 # given scheme (populating DerivedData), and applies the FFmpeg module-map patch.
 # Shared by the unsigned IPA lanes. Returns the absolute iosApp directory.
@@ -255,14 +283,15 @@ platform :ios do
       api_key:        api_key
     )
 
-    # Query the iOS-specific build number and increment by 1.
-    # platform: "ios" scopes the query to iOS builds only — tvOS tracks
-    # its own build sequence independently under Universal Purchase.
-    build_number = latest_testflight_build_number(
+    # iOS-specific build number (injected by CI's reserve_build_numbers job, or
+    # queried directly for local runs). platform: "ios" scopes the query to iOS
+    # builds only — tvOS tracks its own sequence independently under Universal
+    # Purchase.
+    build_number = resolve_build_number(
       api_key:        api_key,
       app_identifier: app_id,
       platform:       "ios"
-    ) + 1
+    )
 
     # Resolve SPM packages so DerivedData is populated before the FFmpeg patch.
     sh("xcodebuild -project '#{ios_app_dir}/Silo.xcodeproj' " \
@@ -344,14 +373,14 @@ platform :ios do
       api_key:        api_key
     )
 
-    # Query the tvOS-specific build number and increment by 1.
-    # platform: "appletvos" scopes the query to tvOS builds only — independent
-    # from the iOS sequence under Universal Purchase.
-    build_number = latest_testflight_build_number(
+    # tvOS-specific build number (injected by CI's reserve_build_numbers job, or
+    # queried directly for local runs). platform: "appletvos" scopes the query to
+    # tvOS builds only — independent from the iOS sequence under Universal Purchase.
+    build_number = resolve_build_number(
       api_key:        api_key,
       app_identifier: app_id,
       platform:       "appletvos"
-    ) + 1
+    )
 
     # Resolve SPM packages for DerivedData population.
     sh("xcodebuild -project '#{ios_app_dir}/Silo.xcodeproj' " \
@@ -426,6 +455,34 @@ platform :ios do
       distribute_external:     testflight_upload[:distribute_external],
       notify_external_testers: testflight_upload[:notify_external_testers]
     )
+  end
+
+  # ── Build-number reservation ────────────────────────────────────────────────
+
+  desc "Reserve the next per-platform TestFlight build numbers (CI preflight)"
+  lane :reserve_build_numbers do
+    # Query-only: no keychain/signing setup needed, so this runs on a plain
+    # Linux runner. Computes the next iOS and tvOS build numbers once so the
+    # parallel beta_ios / beta_tvos jobs consume fixed values instead of each
+    # racing latest_testflight_build_number.
+    api_key = setup_api_key
+    app_id  = "org.siloserver.silo"
+
+    ios_build = latest_testflight_build_number(
+      api_key: api_key, app_identifier: app_id, platform: "ios"
+    ) + 1
+    tvos_build = latest_testflight_build_number(
+      api_key: api_key, app_identifier: app_id, platform: "appletvos"
+    ) + 1
+
+    # Emit key=value lines to BUILD_NUMBERS_FILE (CI points this at
+    # $GITHUB_OUTPUT). Append so we never clobber other outputs already there.
+    out = ENV.fetch("BUILD_NUMBERS_FILE", "build_numbers.env")
+    File.open(out, "a") do |f|
+      f.puts "ios_build=#{ios_build}"
+      f.puts "tvos_build=#{tvos_build}"
+    end
+    UI.success("Reserved build numbers — iOS: #{ios_build}, tvOS: #{tvos_build}")
   end
 
   # ── Unsigned IPAs for third-party signing / sideloading ─────────────────────


### PR DESCRIPTION
Follow-up to #38 (now merged). Makes the TestFlight iOS and tvOS builds run in **parallel** instead of iOS-before-tvOS, without a build-number race.

## What

**Reserve-then-fan-out:**

```
setup (resolve platform)
  └─ build-numbers  ← query ASC once, output ios_build + tvos_build
       ├── ios   (parallel, BUILD_NUMBER=ios_build)
       └── tvos  (parallel, BUILD_NUMBER=tvos_build)
```

### Why it's race-free
The old `needs: ios` existed so the jobs didn't both run `latest_testflight_build_number + 1` concurrently. Computing both numbers **once** in a preflight job removes the concurrent query entirely — safe regardless of whether the per-platform sequences are independent. Both builds then run fully in parallel.

## Changes

**Fastfile**
- `resolve_build_number` helper — uses injected `BUILD_NUMBER` (validated as a positive integer; same injection threat model as `marketing_version_xcarg`) when present, else queries ASC as before. Local/ad-hoc runs keep working.
- `reserve_build_numbers` lane — query-only, appends `ios_build=`/`tvos_build=` to `BUILD_NUMBERS_FILE` (CI points it at `$GITHUB_OUTPUT`). Runs on Linux with just the ASC API key (no match/team secrets).
- `beta_ios` / `beta_tvos` call `resolve_build_number`.

**release.yml**
- New `build-numbers` job (`needs: setup`) reserving both numbers on `ubuntu-latest`.
- `ios` / `tvos` now `needs: [setup, build-numbers]` and run in parallel; `tvos` no longer needs `ios`.

## Trade-off (intentional)

On a both-platform run, tvOS now releases **even if iOS fails**. Per-platform build-number sequences are independent, so a gap is harmless — and a tvOS fix shouldn't be blocked by an iOS problem. Flagging in case you'd rather keep the abort-tvOS-if-iOS-fails behavior.

## Testing

- Fastfile parses; `reserve_build_numbers` + `beta_*` lanes register.
- `BUILD_NUMBER` validation unit-checked (accepts `42`/` 7 `; rejects `1.2`, `12 EXTRA=9`, `$(id)`, `-3`; empty → falls back to ASC query).
- `release.yml` YAML + job graph verified (`setup → build-numbers → ios ∥ tvos`, BUILD_NUMBER wired per platform).
- **Not run:** a live CI release — `reserve_build_numbers` needs real ASC credentials, so the ASC query + parallel upload is only exercised on GitHub.