### PR TITLE
iOS push notifications: APNs registration, enriched alerts, deep links

### DIFF
--- a/iosApp/NotificationService/Info.plist
+++ b/iosApp/NotificationService/Info.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>Silo</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ContinuumKeychainAccessGroup</key>
+	<string>$(AppIdentifierPrefix)org.siloserver.silo.shared</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.usernotifications.service</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).NotificationService</string>
+	</dict>
+</dict>
+</plist>

--- a/iosApp/NotificationService/NotificationService.entitlements
+++ b/iosApp/NotificationService/NotificationService.entitlements
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>aps-environment</key>
-	<string>$(APS_ENVIRONMENT)</string>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.siloserver.silo</string>

--- a/iosApp/NotificationService/NotificationService.personal.entitlements
+++ b/iosApp/NotificationService/NotificationService.personal.entitlements
@@ -2,12 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>aps-environment</key>
-	<string>$(APS_ENVIRONMENT)</string>
-	<key>com.apple.security.application-groups</key>
-	<array>
-		<string>group.org.siloserver.silo</string>
-	</array>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)org.siloserver.silo.shared</string>

--- a/iosApp/NotificationService/NotificationService.swift
+++ b/iosApp/NotificationService/NotificationService.swift
@@ -1,0 +1,77 @@
+import UserNotifications
+
+final class NotificationService: UNNotificationServiceExtension {
+    /// Guards all mutable state below. `didReceive` and
+    /// `serviceExtensionTimeWillExpire` arrive on system-owned threads while
+    /// the enrichment task completes on the Swift concurrency pool, and the
+    /// system's content handler must be invoked exactly once.
+    private let stateLock = NSLock()
+    private var contentHandler: ((UNNotificationContent) -> Void)?
+    private var bestAttemptContent: UNMutableNotificationContent?
+    private var enrichmentTask: Task<Void, Never>?
+
+    override func didReceive(
+        _ request: UNNotificationRequest,
+        withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
+    ) {
+        stateLock.lock()
+        self.contentHandler = contentHandler
+        stateLock.unlock()
+
+        guard let bestAttemptContent = request.content.mutableCopy() as? UNMutableNotificationContent else {
+            complete(with: request.content)
+            return
+        }
+        stateLock.lock()
+        self.bestAttemptContent = bestAttemptContent
+        stateLock.unlock()
+
+        guard let deliveryID = ApplePushDisplayWire.deliveryID(from: bestAttemptContent.userInfo),
+              let state = ApplePushDisplayStateReader().currentState() else {
+            complete(with: bestAttemptContent)
+            return
+        }
+
+        let client = ApplePushDisplayClient()
+        let task = Task { [weak self, bestAttemptContent] in
+            do {
+                let response = try await client.fetchDisplay(deliveryID: deliveryID, state: state)
+                response.apply(to: bestAttemptContent)
+            } catch {
+                // The generic APNs fallback remains the notification content.
+            }
+            self?.complete(with: bestAttemptContent)
+        }
+        stateLock.lock()
+        if self.contentHandler == nil {
+            // Already completed (expiry raced ahead); the task's own
+            // complete(with:) will no-op, so just stop the fetch.
+            stateLock.unlock()
+            task.cancel()
+        } else {
+            self.enrichmentTask = task
+            stateLock.unlock()
+        }
+    }
+
+    override func serviceExtensionTimeWillExpire() {
+        stateLock.lock()
+        let task = enrichmentTask
+        let content = bestAttemptContent
+        stateLock.unlock()
+        task?.cancel()
+        if let content {
+            complete(with: content)
+        }
+    }
+
+    private func complete(with content: UNNotificationContent) {
+        stateLock.lock()
+        let handler = contentHandler
+        contentHandler = nil
+        bestAttemptContent = nil
+        enrichmentTask = nil
+        stateLock.unlock()
+        handler?(content)
+    }
+}

--- a/iosApp/Signing/Local.xcconfig.sample
+++ b/iosApp/Signing/Local.xcconfig.sample
@@ -1,13 +1,15 @@
 // Copy this file to `Local.xcconfig` (gitignored) to override the signing
-// defaults in `Silo.xcconfig`, `SiloTV.xcconfig`, and
-// `SiloTVTopShelf.xcconfig`. Use this when you don't have access to
-// the Silo Media L.L.C Apple Developer team that owns
-// `org.siloserver.silo` and the `group.org.siloserver.silo` App Group.
+// defaults in `Silo.xcconfig`, `SiloTV.xcconfig`,
+// `SiloTVTopShelf.xcconfig`, and `SiloNotificationService.xcconfig`. Use
+// this when you don't have access to the Silo Media L.L.C Apple Developer
+// team that owns `org.siloserver.silo` and the `group.org.siloserver.silo`
+// App Group.
 //
 // Every target xcconfig ends with `#include? "Local.xcconfig"`, so any
 // variable you redefine here wins. Each target reads its own indirection
 // variable (SILO_IOS_BUNDLE_ID / SILO_TV_BUNDLE_ID /
-// SILO_MAC_BUNDLE_ID / SILO_TOPSHELF_BUNDLE_ID, plus the
+// SILO_MAC_BUNDLE_ID / SILO_TOPSHELF_BUNDLE_ID /
+// SILO_NOTIFICATION_SERVICE_BUNDLE_ID, plus the
 // `_ENTITLEMENTS` variables), so
 // you can change one target without affecting the others.
 //
@@ -26,18 +28,28 @@
 // SILO_MAC_BUNDLE_ID      = com.example.silo.mac
 // SILO_TOPSHELF_BUNDLE_ID = com.example.silo.topshelf
 //
+// The Notification Service extension is embedded in the iOS app, so its
+// bundle ID must be prefixed by SILO_IOS_BUNDLE_ID or embedded-binary
+// validation fails at install:
+//
+// SILO_NOTIFICATION_SERVICE_BUNDLE_ID = com.example.silo.NotificationService
+//
 // ----- Entitlements -------------------------------------------------------
 //
-// Personal Teams can't join App Groups. Only the tvOS app and Top Shelf
-// extension need that shared container, so point just those targets at
-// the stripped `.personal.entitlements` variants:
+// Personal Teams can't join App Groups or sign the `aps-environment` push
+// entitlement. The iOS app, the Notification Service extension, the tvOS
+// app, and Top Shelf all need stripped `.personal.entitlements` variants:
 //
-// SILO_TV_ENTITLEMENTS       = SiloTV.personal.entitlements
-// SILO_TOPSHELF_ENTITLEMENTS = TopShelf/TopShelf.personal.entitlements
+// SILO_IOS_ENTITLEMENTS                  = Silo.personal.entitlements
+// SILO_NOTIFICATION_SERVICE_ENTITLEMENTS = NotificationService/NotificationService.personal.entitlements
+// SILO_TV_ENTITLEMENTS                   = SiloTV.personal.entitlements
+// SILO_TOPSHELF_ENTITLEMENTS             = TopShelf/TopShelf.personal.entitlements
 //
 // Note: Top Shelf → host-app state handoff uses that App Group, so the
 // Apple TV Home Screen rows stay empty when you build under a Personal
-// Team. Everything else (playback, auth, library browsing) works.
+// Team. Likewise, push notifications and notification enrichment are
+// unavailable on Personal Team iOS builds (registration fails gracefully).
+// Everything else (playback, auth, library browsing) works.
 //
 // ----- Development team --------------------------------------------------
 //

--- a/iosApp/Signing/SiloNotificationService.xcconfig
+++ b/iosApp/Signing/SiloNotificationService.xcconfig
@@ -1,0 +1,12 @@
+// iOS Notification Service extension signing defaults. CI and the paid
+// team use these as-is. Local contributors without access to the paid team
+// can override any of these by dropping a `Local.xcconfig` into this
+// directory.
+
+SILO_NOTIFICATION_SERVICE_BUNDLE_ID = org.siloserver.silo.NotificationService
+SILO_NOTIFICATION_SERVICE_ENTITLEMENTS = NotificationService/NotificationService.entitlements
+
+PRODUCT_BUNDLE_IDENTIFIER = $(SILO_NOTIFICATION_SERVICE_BUNDLE_ID)
+CODE_SIGN_ENTITLEMENTS = $(SILO_NOTIFICATION_SERVICE_ENTITLEMENTS)
+
+#include? "Local.xcconfig"

--- a/iosApp/Tests/ApplePushRegistrationTests.swift
+++ b/iosApp/Tests/ApplePushRegistrationTests.swift
@@ -1,0 +1,183 @@
+import Foundation
+import UserNotifications
+import XCTest
+@testable import Silo
+
+final class ApplePushRegistrationTests: XCTestCase {
+    func testTokenHexEncodesToLowercasePaddedHex() {
+        let data = Data([0x00, 0x01, 0x0f, 0x10, 0xab, 0xff])
+
+        XCTAssertEqual(ApplePushRegistrationWire.tokenHex(from: data), "00010f10abff")
+    }
+
+    func testEmptyBundleIdentifiersFallBackToSiloTopic() {
+        XCTAssertEqual(ApplePushRegistrationWire.topic(bundleIdentifier: nil), "org.siloserver.silo")
+        XCTAssertEqual(ApplePushRegistrationWire.topic(bundleIdentifier: "   "), "org.siloserver.silo")
+        XCTAssertEqual(ApplePushRegistrationWire.topic(bundleIdentifier: "org.example.app"), "org.example.app")
+    }
+
+    func testAPNsEnvironmentParsesFromProvisioningProfile() {
+        XCTAssertEqual(
+            ApplePushRegistrationWire.apnsEnvironment(
+                fromProvisioningProfile: Self.provisioningProfileData(apsEnvironment: "development")
+            ),
+            "sandbox"
+        )
+        XCTAssertEqual(
+            ApplePushRegistrationWire.apnsEnvironment(
+                fromProvisioningProfile: Self.provisioningProfileData(apsEnvironment: "production")
+            ),
+            "production"
+        )
+    }
+
+    func testAPNsEnvironmentIsNilWithoutPushEntitlement() {
+        XCTAssertNil(
+            ApplePushRegistrationWire.apnsEnvironment(
+                fromProvisioningProfile: Self.provisioningProfileData(apsEnvironment: nil)
+            )
+        )
+        XCTAssertNil(ApplePushRegistrationWire.apnsEnvironment(fromProvisioningProfile: Data([0x30, 0x82, 0x01])))
+        XCTAssertNil(
+            ApplePushRegistrationWire.apnsEnvironment(
+                fromProvisioningProfile: Self.provisioningProfileData(apsEnvironment: "bogus")
+            )
+        )
+    }
+
+    func testNotificationSyncQueryIncludesLimitAndOptionalCursor() {
+        XCTAssertEqual(ApplePushNotificationSyncWire.query(since: nil), ["limit": "50"])
+        XCTAssertEqual(ApplePushNotificationSyncWire.query(since: "cursor"), [
+            "limit": "50",
+            "since": "cursor"
+        ])
+    }
+
+    func testNotificationSyncResponseDecodesSnakeCasePayload() throws {
+        let json = """
+        {
+          "notifications": [
+            {
+              "id": "delivery-1",
+              "type": "new_episode",
+              "profile_id": "profile-1",
+              "series_title": "Example",
+              "reason_flags": {"watchlist": true},
+              "created_at": "2026-07-01T12:30:00Z",
+              "read_at": null
+            }
+          ],
+          "next_cursor": "cursor-1",
+          "unread_count": 3
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        decoder.dateDecodingStrategy = .iso8601
+
+        let response = try decoder.decode(ApplePushNotificationSyncResponse.self, from: json)
+
+        XCTAssertEqual(response.notifications.count, 1)
+        XCTAssertEqual(response.notifications.first?.id, "delivery-1")
+        XCTAssertEqual(response.notifications.first?.profileId, "profile-1")
+        XCTAssertEqual(response.nextCursor, "cursor-1")
+        XCTAssertEqual(response.unreadCount, 3)
+    }
+
+    func testNotificationDisplayDeliveryIDParsesFromAPNsPayload() {
+        XCTAssertEqual(ApplePushDisplayWire.deliveryID(from: ["silo_delivery_id": "  delivery-1  "]), "delivery-1")
+        XCTAssertNil(ApplePushDisplayWire.deliveryID(from: ["silo_delivery_id": "   "]))
+        XCTAssertNil(ApplePushDisplayWire.deliveryID(from: [:]))
+    }
+
+    func testNotificationDisplayEndpointURLAppendsDeliveryID() throws {
+        let url = try XCTUnwrap(ApplePushDisplayWire.displayURL(
+            serverURL: "https://silo.example.test/",
+            deliveryID: "delivery-1"
+        ))
+
+        XCTAssertEqual(url.absoluteString, "https://silo.example.test/api/v1/notifications/push/apple/display/delivery-1")
+    }
+
+    func testNotificationDisplayResponseDecodesAndMutatesNotificationContent() throws {
+        let json = """
+        {
+          "delivery_id": "delivery-1",
+          "title": "New episode of Example",
+          "body": "S1E2 - Pilot",
+          "thread_id": "series:series-1",
+          "category": "episode_available",
+          "url": "/item/episode-1"
+        }
+        """.data(using: .utf8)!
+        let response = try JSONDecoder().decode(ApplePushDisplayResponse.self, from: json)
+        let content = UNMutableNotificationContent()
+        content.title = "Silo"
+        content.body = "New notification available"
+        content.userInfo = ["silo_delivery_id": "delivery-1"]
+
+        response.apply(to: content)
+
+        XCTAssertEqual(content.title, "New episode of Example")
+        XCTAssertEqual(content.body, "S1E2 - Pilot")
+        XCTAssertEqual(content.threadIdentifier, "series:series-1")
+        XCTAssertEqual(content.categoryIdentifier, "episode_available")
+        XCTAssertEqual(content.userInfo["silo_delivery_id"] as? String, "delivery-1")
+        XCTAssertEqual(content.userInfo["silo_url"] as? String, "/item/episode-1")
+    }
+
+    func testNotificationDisplayURLMapsToAppDeepLink() throws {
+        let itemURL = try XCTUnwrap(ApplePushDeepLinkCoordinator.deepLinkURL(from: [
+            "silo_url": "/item/episode-1"
+        ]))
+        XCTAssertEqual(itemURL.absoluteString, "continuum://item/episode-1")
+
+        let absoluteURL = try XCTUnwrap(
+            ApplePushDeepLinkCoordinator.deepLinkURL(fromDisplayURL: "https://silo.example.test/item/movie-123?from=push")
+        )
+        XCTAssertEqual(absoluteURL.absoluteString, "continuum://item/movie-123")
+
+        let existingURL = try XCTUnwrap(
+            ApplePushDeepLinkCoordinator.deepLinkURL(fromDisplayURL: "continuum://play/episode-1")
+        )
+        XCTAssertEqual(existingURL.absoluteString, "continuum://play/episode-1")
+
+        // Routes are forwarded without an allowlist — ContentView's
+        // handleDeepLink owns validity and ignores unknown hosts — so new
+        // push destinations can't silently drift out of sync here.
+        let forwardedURL = try XCTUnwrap(
+            ApplePushDeepLinkCoordinator.deepLinkURL(fromDisplayURL: "/settings/notifications")
+        )
+        XCTAssertEqual(forwardedURL.absoluteString, "continuum://settings/notifications")
+
+        XCTAssertNil(ApplePushDeepLinkCoordinator.deepLinkURL(fromDisplayURL: "/item"))
+        XCTAssertNil(ApplePushDeepLinkCoordinator.deepLinkURL(fromDisplayURL: "   "))
+    }
+
+    /// Builds a fake `embedded.mobileprovision`: an XML plist wrapped in
+    /// leading/trailing binary junk, like the real CMS envelope.
+    private static func provisioningProfileData(apsEnvironment: String?) -> Data {
+        let entitlement = apsEnvironment.map {
+            "<key>aps-environment</key><string>\($0)</string>"
+        } ?? ""
+        let plist = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>Name</key><string>Test Profile</string>
+            <key>Entitlements</key>
+            <dict>
+                <key>application-identifier</key><string>TEAMID.org.example.app</string>
+                \(entitlement)
+            </dict>
+        </dict>
+        </plist>
+        """
+        var data = Data([0x30, 0x82, 0x0a, 0x0b])
+        data.append(Data(plist.utf8))
+        data.append(Data([0x00, 0x01, 0x02]))
+        return data
+    }
+}

--- a/iosApp/Tests/ApplePushRegistrationTests.swift
+++ b/iosApp/Tests/ApplePushRegistrationTests.swift
@@ -81,6 +81,8 @@ final class ApplePushRegistrationTests: XCTestCase {
         XCTAssertEqual(response.notifications.count, 1)
         XCTAssertEqual(response.notifications.first?.id, "delivery-1")
         XCTAssertEqual(response.notifications.first?.profileId, "profile-1")
+        XCTAssertNotNil(response.notifications.first?.createdAt)
+        XCTAssertNil(response.notifications.first?.readAt)
         XCTAssertEqual(response.nextCursor, "cursor-1")
         XCTAssertEqual(response.unreadCount, 3)
     }

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -42,7 +42,17 @@ struct ContentView: View {
         ))
         .onReceive(NotificationCenter.default.publisher(for: .continuumDeepLink)) { notification in
             guard let url = notification.userInfo?["url"] as? URL else { return }
+            #if os(iOS)
+            ApplePushDeepLinkCoordinator.shared.clearPendingDeepLink(matching: url)
+            #endif
             handleDeepLink(url)
+        }
+        .onAppear {
+            #if os(iOS)
+            if let url = ApplePushDeepLinkCoordinator.shared.consumePendingDeepLink() {
+                handleDeepLink(url)
+            }
+            #endif
         }
         .onReceive(NotificationCenter.default.publisher(for: .continuumSessionExpired)) { _ in
             audioStore.dismissFullPlayer()
@@ -72,6 +82,9 @@ struct ContentView: View {
                 // features stay hidden until a profile switch. Idempotent and
                 // failure-tolerant, so double-calling with `selectProfile` is safe.
                 await AICapabilities.shared.refresh()
+                #if os(iOS)
+                await ApplePushRegistrationCoordinator.shared.prepareForAuthenticatedProfile()
+                #endif
             }
         }
         .onChange(of: scenePhase) { _, newPhase in
@@ -103,6 +116,12 @@ struct ContentView: View {
             // natural retry on foreground. `refresh()` is idempotent, so the
             // happy path costs nothing.
             Task { await AICapabilities.shared.refresh() }
+            #if os(iOS)
+            Task {
+                await ApplePushRegistrationCoordinator.shared.prepareForAuthenticatedProfile()
+                await ApplePushRegistrationCoordinator.shared.registerCurrentDeviceTokenIfPossible()
+            }
+            #endif
             #if os(tvOS)
             NotificationCenter.default.post(name: .homeSectionsShouldRefresh, object: nil)
             #endif

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -62,6 +62,7 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
+		<string>remote-notification</string>
 	</array>
 	<key>UILaunchScreen</key>
 	<dict/>

--- a/iosApp/iosApp/Notifications/ApplePushDeepLinkCoordinator.swift
+++ b/iosApp/iosApp/Notifications/ApplePushDeepLinkCoordinator.swift
@@ -1,0 +1,66 @@
+#if os(iOS)
+import Foundation
+
+@MainActor
+final class ApplePushDeepLinkCoordinator {
+    static let shared = ApplePushDeepLinkCoordinator()
+
+    private var pendingDeepLink: URL?
+
+    private init() {}
+
+    func postDeepLink(from userInfo: [AnyHashable: Any]) {
+        guard let url = Self.deepLinkURL(from: userInfo) else { return }
+        pendingDeepLink = url
+        NotificationCenter.default.post(
+            name: .continuumDeepLink,
+            object: nil,
+            userInfo: ["url": url]
+        )
+    }
+
+    func consumePendingDeepLink() -> URL? {
+        defer { pendingDeepLink = nil }
+        return pendingDeepLink
+    }
+
+    func clearPendingDeepLink(matching url: URL) {
+        guard pendingDeepLink?.absoluteString == url.absoluteString else { return }
+        pendingDeepLink = nil
+    }
+
+    nonisolated static func deepLinkURL(from userInfo: [AnyHashable: Any]) -> URL? {
+        guard let raw = userInfo[ApplePushDisplayWire.urlUserInfoKey] as? String else { return nil }
+        return deepLinkURL(fromDisplayURL: raw)
+    }
+
+    nonisolated static func deepLinkURL(fromDisplayURL rawValue: String) -> URL? {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        if let url = URL(string: trimmed), url.scheme == "continuum" {
+            return url
+        }
+
+        let parsedURL = URL(string: trimmed)
+        let path = parsedURL?.path.isEmpty == false ? parsedURL?.path : trimmed
+        let components = path?
+            .split(separator: "/", omittingEmptySubsequences: true)
+            .map(String.init) ?? []
+        guard components.count >= 2 else { return nil }
+
+        // The route is forwarded as-is: ContentView.handleDeepLink owns
+        // route validity and safely ignores unknown hosts, so new push
+        // destinations work without a second allowlist to keep in sync.
+        let route = components[0]
+        let contentID = components[1].trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !contentID.isEmpty else { return nil }
+
+        var deepLink = URLComponents()
+        deepLink.scheme = "continuum"
+        deepLink.host = route
+        deepLink.path = "/" + contentID
+        return deepLink.url
+    }
+}
+#endif

--- a/iosApp/iosApp/Notifications/ApplePushDisplayMetadata.swift
+++ b/iosApp/iosApp/Notifications/ApplePushDisplayMetadata.swift
@@ -1,0 +1,146 @@
+#if os(iOS)
+import Foundation
+import UserNotifications
+
+struct ApplePushDisplayResponse: Decodable, Equatable {
+    let deliveryID: String
+    let title: String
+    let body: String?
+    let threadID: String?
+    let category: String
+    let url: String
+
+    enum CodingKeys: String, CodingKey {
+        case deliveryID = "delivery_id"
+        case title
+        case body
+        case threadID = "thread_id"
+        case category
+        case url
+    }
+
+    func apply(to content: UNMutableNotificationContent) {
+        if !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            content.title = title
+        }
+        if let body {
+            content.body = body
+        }
+        if let threadID, !threadID.isEmpty {
+            content.threadIdentifier = threadID
+        }
+        if !category.isEmpty {
+            content.categoryIdentifier = category
+        }
+        var userInfo = content.userInfo
+        userInfo[ApplePushDisplayWire.deliveryIDUserInfoKey] = deliveryID
+        userInfo[ApplePushDisplayWire.urlUserInfoKey] = url
+        content.userInfo = userInfo
+    }
+}
+
+struct ApplePushDisplayAuthState: Equatable {
+    let serverURL: String
+    let profileID: String
+    let accessToken: String
+    /// Mirrored profile-verification token. Empty when the active profile
+    /// has no PIN; required by the server for PIN-protected profiles, whose
+    /// display fetches otherwise 403 with `profile_unverified`.
+    let profileToken: String
+
+    var isUsable: Bool {
+        !serverURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !profileID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !accessToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+}
+
+enum ApplePushDisplayWire {
+    static let deliveryIDUserInfoKey = "silo_delivery_id"
+    static let urlUserInfoKey = "silo_url"
+
+    static func deliveryID(from userInfo: [AnyHashable: Any]) -> String? {
+        guard let raw = userInfo[deliveryIDUserInfoKey] as? String else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    static func displayURL(serverURL: String, deliveryID: String) -> URL? {
+        let trimmedServerURL = serverURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedDeliveryID = deliveryID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedServerURL.isEmpty,
+              !trimmedDeliveryID.isEmpty,
+              let baseURL = URL(string: trimmedServerURL) else {
+            return nil
+        }
+        return baseURL
+            .appendingPathComponent("api")
+            .appendingPathComponent("v1")
+            .appendingPathComponent("notifications")
+            .appendingPathComponent("push")
+            .appendingPathComponent("apple")
+            .appendingPathComponent("display")
+            .appendingPathComponent(trimmedDeliveryID)
+    }
+}
+
+struct ApplePushDisplayStateReader {
+    var defaults: SharedDefaults = .shared
+    var keychain: SharedKeychain = SharedKeychain()
+
+    func currentState() -> ApplePushDisplayAuthState? {
+        let state = ApplePushDisplayAuthState(
+            serverURL: defaults.string(forKey: SharedStorage.serverUrlKey) ?? "",
+            profileID: defaults.string(forKey: SharedStorage.profileIdKey) ?? "",
+            accessToken: keychain.get(SharedStorage.mirroredAccessTokenAccount) ?? "",
+            profileToken: keychain.get(SharedStorage.mirroredProfileTokenAccount) ?? ""
+        )
+        return state.isUsable ? state : nil
+    }
+}
+
+enum ApplePushDisplayClientError: Error, Equatable {
+    case invalidURL
+    case badStatus(Int)
+}
+
+final class ApplePushDisplayClient {
+    private let session: URLSession
+
+    init(session: URLSession = ApplePushDisplayClient.makeSession()) {
+        self.session = session
+    }
+
+    func fetchDisplay(deliveryID: String, state: ApplePushDisplayAuthState) async throws -> ApplePushDisplayResponse {
+        guard let url = ApplePushDisplayWire.displayURL(serverURL: state.serverURL, deliveryID: deliveryID) else {
+            throw ApplePushDisplayClientError.invalidURL
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 4
+        request.setValue("Bearer \(state.accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue(state.profileID, forHTTPHeaderField: "X-Profile-Id")
+        if !state.profileToken.isEmpty {
+            request.setValue(state.profileToken, forHTTPHeaderField: "X-Profile-Token")
+        }
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw ApplePushDisplayClientError.badStatus(0)
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw ApplePushDisplayClientError.badStatus(http.statusCode)
+        }
+        return try JSONDecoder().decode(ApplePushDisplayResponse.self, from: data)
+    }
+
+    private static func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = 4
+        configuration.timeoutIntervalForResource = 5
+        configuration.waitsForConnectivity = false
+        return URLSession(configuration: configuration)
+    }
+}
+#endif

--- a/iosApp/iosApp/Notifications/ApplePushNotificationSync.swift
+++ b/iosApp/iosApp/Notifications/ApplePushNotificationSync.swift
@@ -52,6 +52,11 @@ final class ApplePushNotificationSyncCoordinator {
         guard !inFlight else {
             return false
         }
+        // Claimed before the first await: the retarget below suspends, and a
+        // second push/foreground/tap sync re-entering during that window
+        // would pass the guard and race the cursor bookkeeping.
+        inFlight = true
+        defer { inFlight = false }
 
         // A background remote-notification wake can launch a killed app and
         // land here before ContentView.checkInitialState() has pointed
@@ -73,9 +78,6 @@ final class ApplePushNotificationSyncCoordinator {
             cursorContext = context
             nextCursor = nil
         }
-
-        inFlight = true
-        defer { inFlight = false }
 
         do {
             let response: ApplePushNotificationSyncResponse = try await HTTPClient.shared.get(

--- a/iosApp/iosApp/Notifications/ApplePushNotificationSync.swift
+++ b/iosApp/iosApp/Notifications/ApplePushNotificationSync.swift
@@ -1,0 +1,93 @@
+#if os(iOS)
+import Foundation
+import OSLog
+
+struct ApplePushNotificationSyncResponse: Decodable, Equatable {
+    let notifications: [ApplePushNotificationSyncItem]
+    let nextCursor: String?
+    let unreadCount: Int
+}
+
+struct ApplePushNotificationSyncItem: Decodable, Equatable, Identifiable {
+    let id: String
+    let type: String?
+    let profileId: String?
+    let createdAt: Date?
+    let readAt: Date?
+}
+
+enum ApplePushNotificationSyncWire {
+    static let endpoint = "/api/v1/notifications/sync"
+    static let defaultLimit = 50
+
+    static func query(since: String?) -> [String: String] {
+        var query = ["limit": String(defaultLimit)]
+        if let since, !since.isEmpty {
+            query["since"] = since
+        }
+        return query
+    }
+}
+
+@MainActor
+final class ApplePushNotificationSyncCoordinator {
+    static let shared = ApplePushNotificationSyncCoordinator()
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "org.siloserver.silo",
+        category: "ApplePushSync"
+    )
+
+    private var inFlight = false
+    private var nextCursor: String?
+    private var cursorContext: String?
+
+    private init() {}
+
+    @discardableResult
+    func refreshFromRemoteNotification() async -> Bool {
+        guard AuthService.shared.hasServer, AuthService.shared.hasProfile else {
+            return false
+        }
+        guard !inFlight else {
+            return false
+        }
+
+        // The cursor is only meaningful for the server+profile that minted
+        // it; a cursor from server A sent as ?since= to server B silently
+        // skips B's older notifications.
+        let context = [
+            ServerRegistry.shared.activeServerId ?? "",
+            AuthService.shared.profileId ?? ""
+        ].joined(separator: "|")
+        if context != cursorContext {
+            cursorContext = context
+            nextCursor = nil
+        }
+
+        inFlight = true
+        defer { inFlight = false }
+
+        do {
+            let response: ApplePushNotificationSyncResponse = try await HTTPClient.shared.get(
+                ApplePushNotificationSyncWire.endpoint,
+                query: ApplePushNotificationSyncWire.query(since: nextCursor)
+            )
+            if let cursor = response.nextCursor, !cursor.isEmpty {
+                nextCursor = cursor
+            }
+            if !response.notifications.isEmpty {
+                NotificationCenter.default.post(name: .homeSectionsShouldRefresh, object: nil)
+            }
+            Self.logger.info("Synced Silo notifications after APNs wake count=\(response.notifications.count, privacy: .public) unread=\(response.unreadCount, privacy: .public)")
+            return true
+        } catch HTTPError.http(let statusCode, _) where statusCode == 404 || statusCode == 405 {
+            Self.logger.info("Notification sync endpoint is not available on this Silo server yet")
+            return false
+        } catch {
+            Self.logger.error("Notification sync after APNs wake failed: \(String(describing: error), privacy: .public)")
+            return false
+        }
+    }
+}
+#endif

--- a/iosApp/iosApp/Notifications/ApplePushNotificationSync.swift
+++ b/iosApp/iosApp/Notifications/ApplePushNotificationSync.swift
@@ -53,6 +53,15 @@ final class ApplePushNotificationSyncCoordinator {
             return false
         }
 
+        // A background remote-notification wake can launch a killed app and
+        // land here before ContentView.checkInitialState() has pointed
+        // TokenStore at the active registry server — HTTPClient would then
+        // send this sync unauthenticated and 401. Retarget first; it's an
+        // idempotent no-op on every subsequent call.
+        if let serverId = ServerRegistry.shared.activeServerId, !serverId.isEmpty {
+            await TokenStore.shared.retargetActiveServer(serverId: serverId)
+        }
+
         // The cursor is only meaningful for the server+profile that minted
         // it; a cursor from server A sent as ?since= to server B silently
         // skips B's older notifications.

--- a/iosApp/iosApp/Notifications/ApplePushRegistration.swift
+++ b/iosApp/iosApp/Notifications/ApplePushRegistration.swift
@@ -1,0 +1,198 @@
+#if os(iOS)
+import Foundation
+import OSLog
+import UIKit
+import UserNotifications
+
+struct ApplePushRegistrationRequest: Encodable, Equatable {
+    let deviceId: String
+    let apnsToken: String
+    let apnsEnvironment: String
+    let apnsTopic: String
+    let pushMode: String
+}
+
+struct ApplePushRegistrationResponse: Decodable {
+    let id: String
+    let serverDeviceId: String
+    let enabled: Bool
+    let pushMode: String
+}
+
+enum ApplePushRegistrationWire {
+    static let endpoint = "/api/v1/devices/push/apple"
+    static let defaultTopic = "org.siloserver.silo"
+    static let privatePushMode = "private_push"
+
+    /// The APNs environment is a *signing-time* decision (the
+    /// `aps-environment` entitlement from the provisioning profile), not a
+    /// compile-time one: the repo ships Release IPAs for sideloading that
+    /// get re-signed with development profiles, and a `#if DEBUG` guess
+    /// would register those sandbox tokens as "production" — every push
+    /// would then fail with BadDeviceToken. Read the embedded profile
+    /// instead; App Store installs carry no embedded profile and are
+    /// production by definition.
+    static var currentAPNsEnvironment: String {
+        #if targetEnvironment(simulator)
+        return "sandbox"
+        #else
+        if let url = Bundle.main.url(forResource: "embedded", withExtension: "mobileprovision"),
+           let data = try? Data(contentsOf: url),
+           let environment = apnsEnvironment(fromProvisioningProfile: data) {
+            return environment
+        }
+        return "production"
+        #endif
+    }
+
+    /// Extracts `Entitlements.aps-environment` from a raw
+    /// `embedded.mobileprovision` (a CMS blob wrapping an XML plist) and
+    /// maps it to the server's wire values. Returns nil when the profile
+    /// has no push entitlement or cannot be parsed.
+    static func apnsEnvironment(fromProvisioningProfile data: Data) -> String? {
+        guard let plistStart = data.range(of: Data("<plist".utf8)),
+              let plistEnd = data.range(of: Data("</plist>".utf8), in: plistStart.upperBound..<data.endIndex) else {
+            return nil
+        }
+        let plistData = data.subdata(in: plistStart.lowerBound..<plistEnd.upperBound)
+        guard let plist = try? PropertyListSerialization.propertyList(from: plistData, options: [], format: nil) as? [String: Any],
+              let entitlements = plist["Entitlements"] as? [String: Any],
+              let value = entitlements["aps-environment"] as? String else {
+            return nil
+        }
+        switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "development":
+            return "sandbox"
+        case "production":
+            return "production"
+        default:
+            return nil
+        }
+    }
+
+    static func tokenHex(from data: Data) -> String {
+        data.map { byte in
+            let hex = String(byte, radix: 16)
+            return hex.count == 1 ? "0" + hex : hex
+        }
+        .joined()
+    }
+
+    static func topic(bundleIdentifier: String?) -> String {
+        let trimmed = bundleIdentifier?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? defaultTopic : trimmed
+    }
+}
+
+@MainActor
+final class ApplePushRegistrationCoordinator {
+    static let shared = ApplePushRegistrationCoordinator()
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "org.siloserver.silo",
+        category: "ApplePush"
+    )
+
+    private var lastDeviceToken: Data?
+    private var inFlightFingerprint: String?
+    private var lastSuccessfulFingerprint: String?
+    private var endpointUnsupportedForContext: String?
+
+    private init() {}
+
+    func prepareForAuthenticatedProfile() async {
+        guard AuthService.shared.hasServer, AuthService.shared.hasProfile else {
+            return
+        }
+
+        let center = UNUserNotificationCenter.current()
+        let settings = await center.notificationSettings()
+        switch settings.authorizationStatus {
+        case .authorized, .provisional, .ephemeral:
+            UIApplication.shared.registerForRemoteNotifications()
+        case .notDetermined:
+            do {
+                let granted = try await center.requestAuthorization(options: [.alert, .sound, .badge])
+                guard granted else {
+                    Self.logger.info("User declined Apple push notification authorization")
+                    return
+                }
+                UIApplication.shared.registerForRemoteNotifications()
+            } catch {
+                Self.logger.error("Apple push authorization request failed: \(String(describing: error), privacy: .public)")
+            }
+        case .denied:
+            Self.logger.info("Apple push notification authorization is denied")
+        @unknown default:
+            Self.logger.info("Apple push notification authorization is in an unknown state")
+        }
+    }
+
+    func didRegisterForRemoteNotifications(deviceToken: Data) async {
+        lastDeviceToken = deviceToken
+        await registerCurrentDeviceTokenIfPossible()
+    }
+
+    func didFailToRegisterForRemoteNotifications(error: Error) {
+        Self.logger.error("APNs device-token registration failed: \(String(describing: error), privacy: .public)")
+    }
+
+    func registerCurrentDeviceTokenIfPossible() async {
+        guard AuthService.shared.hasServer, AuthService.shared.hasProfile else {
+            return
+        }
+        guard let lastDeviceToken else {
+            return
+        }
+
+        let request = makeRegistrationRequest(deviceToken: lastDeviceToken)
+        let fingerprint = registrationFingerprint(for: request)
+        guard fingerprint != lastSuccessfulFingerprint,
+              fingerprint != inFlightFingerprint,
+              fingerprint != endpointUnsupportedForContext else {
+            return
+        }
+
+        inFlightFingerprint = fingerprint
+        defer { inFlightFingerprint = nil }
+
+        do {
+            let response: ApplePushRegistrationResponse = try await HTTPClient.shared.post(
+                ApplePushRegistrationWire.endpoint,
+                body: request
+            )
+            lastSuccessfulFingerprint = fingerprint
+            endpointUnsupportedForContext = nil
+            Self.logger.info("Registered APNs token with Silo server_device_id=\(response.serverDeviceId, privacy: .private) enabled=\(response.enabled, privacy: .public)")
+        } catch HTTPError.http(let statusCode, _) where statusCode == 404 || statusCode == 405 {
+            endpointUnsupportedForContext = fingerprint
+            Self.logger.info("Apple push device endpoint is not available on this Silo server yet")
+        } catch {
+            Self.logger.error("Apple push device registration failed: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    private func makeRegistrationRequest(deviceToken: Data) -> ApplePushRegistrationRequest {
+        ApplePushRegistrationRequest(
+            deviceId: AppleDeviceIdentity.current.id,
+            apnsToken: ApplePushRegistrationWire.tokenHex(from: deviceToken),
+            apnsEnvironment: ApplePushRegistrationWire.currentAPNsEnvironment,
+            apnsTopic: ApplePushRegistrationWire.topic(bundleIdentifier: Bundle.main.bundleIdentifier),
+            pushMode: ApplePushRegistrationWire.privatePushMode
+        )
+    }
+
+    private func registrationFingerprint(for request: ApplePushRegistrationRequest) -> String {
+        [
+            ServerRegistry.shared.activeServerId ?? "",
+            AuthService.shared.profileId ?? "",
+            request.deviceId,
+            request.apnsToken,
+            request.apnsEnvironment,
+            request.apnsTopic,
+            request.pushMode
+        ]
+        .joined(separator: "|")
+    }
+}
+#endif

--- a/iosApp/iosApp/Notifications/ApplePushRegistration.swift
+++ b/iosApp/iosApp/Notifications/ApplePushRegistration.swift
@@ -144,6 +144,16 @@ final class ApplePushRegistrationCoordinator {
         guard let lastDeviceToken else {
             return
         }
+        // The cached token can outlive the user's permission: if they revoke
+        // notification authorization in Settings, a later foreground or
+        // profile switch must not re-upload the token for the new context.
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        switch settings.authorizationStatus {
+        case .authorized, .provisional, .ephemeral:
+            break
+        default:
+            return
+        }
 
         let request = makeRegistrationRequest(deviceToken: lastDeviceToken)
         let fingerprint = registrationFingerprint(for: request)

--- a/iosApp/iosApp/Notifications/SiloAppDelegate+Push.swift
+++ b/iosApp/iosApp/Notifications/SiloAppDelegate+Push.swift
@@ -1,0 +1,92 @@
+#if os(iOS)
+import UIKit
+import UserNotifications
+
+extension SiloAppDelegate: UNUserNotificationCenterDelegate {
+    /// iOS gives background remote-notification wakes roughly 30 seconds to
+    /// call the completion handler, while HTTPClient's default URLSession
+    /// request timeout is 60 seconds — so the sync is raced against a
+    /// deadline that leaves the system budget intact.
+    private static let backgroundSyncDeadlineSeconds: TimeInterval = 15
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        UNUserNotificationCenter.current().delegate = self
+        return true
+    }
+
+    func application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        Task { @MainActor in
+            await ApplePushRegistrationCoordinator.shared.didRegisterForRemoteNotifications(deviceToken: deviceToken)
+        }
+    }
+
+    func application(
+        _ application: UIApplication,
+        didFailToRegisterForRemoteNotificationsWithError error: Error
+    ) {
+        ApplePushRegistrationCoordinator.shared.didFailToRegisterForRemoteNotifications(error: error)
+    }
+
+    func application(
+        _ application: UIApplication,
+        didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+        fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+    ) {
+        Task { @MainActor in
+            let synced = await Self.syncWithDeadline(Self.backgroundSyncDeadlineSeconds)
+            completionHandler(synced ? .newData : .noData)
+        }
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification
+    ) async -> UNNotificationPresentationOptions {
+        // Present immediately: the inbox sync must never delay the banner,
+        // and the system only waits a few seconds for this return value.
+        Task { @MainActor in
+            await ApplePushNotificationSyncCoordinator.shared.refreshFromRemoteNotification()
+        }
+        return [.banner, .list, .sound]
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse
+    ) async {
+        // Navigation depends only on the payload already in hand — post the
+        // deep link before any network work so the tap routes instantly.
+        let userInfo = response.notification.request.content.userInfo
+        await ApplePushDeepLinkCoordinator.shared.postDeepLink(from: userInfo)
+        Task { @MainActor in
+            await ApplePushNotificationSyncCoordinator.shared.refreshFromRemoteNotification()
+        }
+    }
+
+    /// Runs the notification sync but returns `false` once the deadline
+    /// passes, cancelling the underlying request. The completion handler for
+    /// a background wake must be called inside the system budget even when
+    /// the server is unreachable.
+    @MainActor
+    private static func syncWithDeadline(_ seconds: TimeInterval) async -> Bool {
+        await withTaskGroup(of: Bool.self) { group in
+            group.addTask { @MainActor in
+                await ApplePushNotificationSyncCoordinator.shared.refreshFromRemoteNotification()
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+                return false
+            }
+            let first = await group.next() ?? false
+            group.cancelAll()
+            return first
+        }
+    }
+}
+#endif

--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -71,6 +71,11 @@ targets:
         SDKROOT: iphoneos
         SUPPORTED_PLATFORMS: "iphoneos iphonesimulator"
         SWIFT_OBJC_BRIDGING_HEADER: iosApp/Screens/Player/CoreMedia/SiloPlayerBridging.h
+      configs:
+        Debug:
+          APS_ENVIRONMENT: development
+        Release:
+          APS_ENVIRONMENT: production
     dependencies:
       - package: FFmpeg
         product: FFmpeg
@@ -78,6 +83,8 @@ targets:
         product: Nuke
       - package: Nuke
         product: NukeUI
+      - target: SiloNotificationService
+        embed: true
 
   # NOTE: tvOS-specific source files live under iosApp/tvOS/. They are guarded
   # by #if os(tvOS) so they compile out on the iOS target even though the
@@ -203,6 +210,31 @@ targets:
         SUPPORTED_PLATFORMS: "appletvos appletvsimulator"
     dependencies:
       - sdk: TVServices.framework
+
+  # iOS Notification Service extension: enriches generic APNs alerts by
+  # fetching compact display metadata directly from the user's Silo server.
+  # Shares active server/profile/token state via the App Group + shared
+  # Keychain access group, but does not link the main app's AuthService.
+  SiloNotificationService:
+    type: app-extension
+    platform: iOS
+    sources:
+      - path: NotificationService
+      - path: iosApp/Notifications/ApplePushDisplayMetadata.swift
+      - path: iosApp/Shared/SharedStorage.swift
+    configFiles:
+      Debug: Signing/SiloNotificationService.xcconfig
+      Release: Signing/SiloNotificationService.xcconfig
+    settings:
+      base:
+        PRODUCT_NAME: SiloNotificationService
+        INFOPLIST_FILE: NotificationService/Info.plist
+        MARKETING_VERSION: "0.1.0"
+        CURRENT_PROJECT_VERSION: 1
+        SDKROOT: iphoneos
+        SUPPORTED_PLATFORMS: "iphoneos iphonesimulator"
+    dependencies:
+      - sdk: UserNotifications.framework
 
   # Unit-test bundle for the iOS Silo app. Hosts the XCTest cases under
   # Tests/ and loads the Silo.app binary so `@testable import Silo` can


### PR DESCRIPTION
## What

End-to-end APNs push support for the iOS app:

- **Registration** (`Notifications/ApplePushRegistration.swift`): requests notification authorization once a server+profile is active, registers the device token with `POST /api/v1/devices/push/apple`, dedupes by a server|profile|token fingerprint, and tolerates older servers (404/405 → marked unsupported for that context). The reported `apns_environment` is parsed from the embedded provisioning profile's `aps-environment` entitlement at runtime rather than `#if DEBUG`, so the CI sideload IPAs re-signed with development profiles register sandbox tokens as sandbox.
- **Notification Service extension** (`NotificationService/`, new `SiloNotificationService` target): enriches the generic APNs alert with display metadata from `GET /api/v1/notifications/push/apple/display/{delivery_id}`, authenticated with the App Group + shared-keychain mirrored credentials — including `X-Profile-Token`, which PIN-protected profiles require. Handler state is `NSLock`-guarded so the system content handler is invoked exactly once even when the fetch races `serviceExtensionTimeWillExpire`. Requests use a dedicated 4s/5s-timeout ephemeral session; failures fall back to the generic alert.
- **Deep links** (`Notifications/ApplePushDeepLinkCoordinator.swift`): notification taps map the payload's `silo_url` to `continuum://` URLs through the existing `.continuumDeepLink` channel, with a pending buffer for cold launches. Routes are forwarded without an allowlist — `ContentView.handleDeepLink` stays the single owner of route validity.
- **Inbox sync** (`Notifications/ApplePushNotificationSync.swift`): push wakes trigger a cursor-based `GET /api/v1/notifications/sync`; the cursor is scoped per server+profile so switching contexts can't skip notifications. None of the delegate callbacks block on the network: banners present immediately, taps navigate before syncing, and background wakes race the sync against a 15s deadline so the completion handler always lands inside the ~30s system budget.
- **Signing/config**: `aps-environment` entitlement driven by a per-config `APS_ENVIRONMENT` build setting (Debug=development, Release=production); new extension xcconfig follows the existing team-default + `Local.xcconfig` override pattern; `.personal.entitlements` variants and updated `Local.xcconfig.sample` keep the Personal Team workflow signable (push is unavailable there and fails gracefully).

## Why

Server-side notification delivery (relay + `push_devices` + display endpoint) already exists in silo-server; this adds the iOS client half so users get enriched, tappable alerts for new content.

## Reviewer notes

- A high-effort multi-agent code review ran on this diff; all confirmed findings are fixed in this branch (blocking delegate callbacks, PIN-profile 403 on enrichment, APNs environment mismatch on re-signed builds, extension content-handler race, cross-context sync cursor, personal-team signing gap, XCTest convention, deep-link allowlist drift).
- Two gaps need **silo-server** coordination and are tracked separately: no deregistration endpoint (sign-out/profile-switch leaves the device registered — the server upserts per `(profile_id, device_id)`), and the extension's mirrored access token expires ~8h after the app last ran, after which enrichment falls back to the generic alert until the app is opened.
- Tests: `Tests/ApplePushRegistrationTests.swift` (XCTest, 10 cases) covers wire encoding, provisioning-profile parsing, sync/display decoding, and deep-link mapping. iOS build green (`Silo` scheme, iPhone 17 Pro sim); tvOS/macOS untouched (all new app code is `#if os(iOS)`).
- Run `xcodegen generate` after checkout — `project.yml` adds the extension target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an iOS Notification Service Extension for enriching incoming push content.
  * Introduced coordinated push registration, notification sync after background wake, and push-driven deep-link routing.
* **Bug Fixes**
  * Improved deep-link queue consumption so taps and launches route consistently.
  * Added safer time-expiry handling during notification enrichment and sync.
* **Documentation**
  * Expanded iOS signing guidance for the extension and entitlements.
* **Tests**
  * Added coverage for push registration, deep-link parsing, notification sync, and push display decoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->