### PR TITLE
iOS offline downloads: monitoring, background refresh, push-triggered auto-download

### DIFF
--- a/iosApp/DownloadsActivity/DownloadsLiveActivity.swift
+++ b/iosApp/DownloadsActivity/DownloadsLiveActivity.swift
@@ -1,0 +1,169 @@
+import ActivityKit
+import SwiftUI
+import WidgetKit
+
+@main
+struct SiloDownloadsActivityBundle: WidgetBundle {
+    var body: some Widget {
+        DownloadsLiveActivity()
+    }
+}
+
+/// Renders the downloads Live Activity started by the host app's
+/// `DownloadLiveActivityController`: a lock-screen card and the Dynamic
+/// Island treatments. Tapping anywhere deep-links to the Downloads tab via
+/// the `continuum://downloads` route the app already handles.
+struct DownloadsLiveActivity: Widget {
+    private static let deepLink = URL(string: "continuum://downloads")
+
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: DownloadActivityAttributes.self) { context in
+            DownloadsLockScreenView(state: context.state, isStale: context.isStale)
+                .padding(16)
+                .widgetURL(Self.deepLink)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    Image(systemName: context.state.phase.symbolName)
+                        .font(.title2)
+                        .foregroundStyle(.tint)
+                        .padding(.leading, 4)
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    Text(context.state.percentText)
+                        .font(.title3.weight(.semibold))
+                        .monospacedDigit()
+                        .padding(.trailing, 4)
+                }
+                DynamicIslandExpandedRegion(.center) {
+                    VStack(spacing: 2) {
+                        Text(context.state.title)
+                            .font(.headline)
+                            .lineLimit(1)
+                        if let line = context.state.contextLine {
+                            Text(line)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                    }
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        ProgressView(value: context.state.fraction)
+                            .progressViewStyle(.linear)
+                        Text(context.state.statusText(isStale: context.isStale))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
+                    }
+                    .padding(.horizontal, 4)
+                }
+            } compactLeading: {
+                Image(systemName: context.state.phase.symbolName)
+                    .foregroundStyle(.tint)
+            } compactTrailing: {
+                ProgressView(value: context.state.fraction)
+                    .progressViewStyle(.circular)
+                    .tint(.blue)
+            } minimal: {
+                ProgressView(value: context.state.fraction)
+                    .progressViewStyle(.circular)
+                    .tint(.blue)
+            }
+            .widgetURL(Self.deepLink)
+        }
+    }
+}
+
+private struct DownloadsLockScreenView: View {
+    let state: DownloadActivityAttributes.ContentState
+    let isStale: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 12) {
+                Image(systemName: state.phase.symbolName)
+                    .font(.title2)
+                    .foregroundStyle(.tint)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(state.title)
+                        .font(.headline)
+                        .lineLimit(1)
+                    if let line = state.contextLine {
+                        Text(line)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+                Spacer(minLength: 8)
+                if state.phase != .completed {
+                    Text(state.percentText)
+                        .font(.title3.weight(.semibold))
+                        .monospacedDigit()
+                }
+            }
+            if state.phase != .completed {
+                ProgressView(value: state.fraction)
+                    .progressViewStyle(.linear)
+                Text(state.statusText(isStale: isStale))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+        }
+    }
+}
+
+private extension DownloadActivityAttributes.ContentState.Phase {
+    var symbolName: String {
+        switch self {
+        case .downloading: return "arrow.down.circle.fill"
+        case .paused: return "pause.circle.fill"
+        case .preparing: return "clock.arrow.circlepath"
+        case .completed: return "checkmark.circle.fill"
+        }
+    }
+}
+
+private extension DownloadActivityAttributes.ContentState {
+    var percentText: String {
+        fraction.formatted(.percent.precision(.fractionLength(0)))
+    }
+
+    /// Secondary line under the title: item context plus queue position,
+    /// e.g. "Severance · S1 · E4 · 2 of 5".
+    var contextLine: String? {
+        var parts: [String] = []
+        if let subtitle { parts.append(subtitle) }
+        if totalCount > 1, phase != .completed {
+            parts.append("\(min(completedCount + 1, totalCount)) of \(totalCount)")
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    func statusText(isStale: Bool) -> String {
+        switch phase {
+        case .completed:
+            return "Complete"
+        case .paused:
+            return "Paused"
+        case .preparing:
+            return "Preparing…"
+        case .downloading:
+            // Past the stale date the app was suspended mid-transfer and
+            // these numbers stopped ticking; say so instead of freezing a
+            // live-looking counter.
+            if isStale { return "Continuing in background…" }
+            guard bytesExpected > 0 else { return "Downloading…" }
+            var text = bytesDownloaded.formatted(.byteCount(style: .file))
+                + " of "
+                + bytesExpected.formatted(.byteCount(style: .file))
+            if let bytesPerSecond, bytesPerSecond > 0 {
+                text += " · " + Int64(bytesPerSecond).formatted(.byteCount(style: .file)) + "/s"
+            }
+            return text
+        }
+    }
+}

--- a/iosApp/DownloadsActivity/Info.plist
+++ b/iosApp/DownloadsActivity/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>Silo Downloads</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/iosApp/Signing/Local.xcconfig.sample
+++ b/iosApp/Signing/Local.xcconfig.sample
@@ -9,7 +9,8 @@
 // variable you redefine here wins. Each target reads its own indirection
 // variable (SILO_IOS_BUNDLE_ID / SILO_TV_BUNDLE_ID /
 // SILO_MAC_BUNDLE_ID / SILO_TOPSHELF_BUNDLE_ID /
-// SILO_NOTIFICATION_SERVICE_BUNDLE_ID, plus the
+// SILO_NOTIFICATION_SERVICE_BUNDLE_ID /
+// SILO_DOWNLOADS_ACTIVITY_BUNDLE_ID, plus the
 // `_ENTITLEMENTS` variables), so
 // you can change one target without affecting the others.
 //
@@ -28,11 +29,15 @@
 // SILO_MAC_BUNDLE_ID      = com.example.silo.mac
 // SILO_TOPSHELF_BUNDLE_ID = com.example.silo.topshelf
 //
-// The Notification Service extension is embedded in the iOS app, so its
-// bundle ID must be prefixed by SILO_IOS_BUNDLE_ID or embedded-binary
-// validation fails at install:
+// The Notification Service and Downloads Live Activity extensions are
+// embedded in the iOS app, so their bundle IDs must be prefixed by
+// SILO_IOS_BUNDLE_ID or embedded-binary validation fails at install:
 //
 // SILO_NOTIFICATION_SERVICE_BUNDLE_ID = com.example.silo.NotificationService
+// SILO_DOWNLOADS_ACTIVITY_BUNDLE_ID   = com.example.silo.DownloadsActivity
+//
+// (The Downloads Live Activity extension has no entitlements, so it needs
+// no `.personal.entitlements` variant and works on Personal Teams.)
 //
 // ----- Entitlements -------------------------------------------------------
 //

--- a/iosApp/Signing/SiloDownloadsActivity.xcconfig
+++ b/iosApp/Signing/SiloDownloadsActivity.xcconfig
@@ -1,0 +1,11 @@
+// iOS Downloads Live Activity widget extension signing defaults. CI and
+// the paid team use these as-is. Local contributors without access to the
+// paid team can override any of these by dropping a `Local.xcconfig` into
+// this directory. The extension needs no entitlements (no App Group or
+// keychain access — the host app pushes all content via ActivityKit).
+
+SILO_DOWNLOADS_ACTIVITY_BUNDLE_ID = org.siloserver.silo.DownloadsActivity
+
+PRODUCT_BUNDLE_IDENTIFIER = $(SILO_DOWNLOADS_ACTIVITY_BUNDLE_ID)
+
+#include? "Local.xcconfig"

--- a/iosApp/Tests/DownloadGroupingTests.swift
+++ b/iosApp/Tests/DownloadGroupingTests.swift
@@ -1,0 +1,210 @@
+import XCTest
+import Foundation
+@testable import Silo
+
+/// Pure-logic coverage for the Downloads redesign grouping/sorting rules
+/// (`DownloadGroupBuilder`). These are the highest-risk new behaviors:
+/// season ordering (newest-first, specials last), episode ordering, watched
+/// counts, title resolution, and list sort options.
+final class DownloadGroupingTests: XCTestCase {
+
+    // MARK: - Factories
+
+    private func episode(
+        _ id: String,
+        series: String,
+        season: Int,
+        number: Int,
+        bytes: Int64,
+        title: String? = nil,
+        seriesTitle: String? = nil,
+        status: LocalDownloadStatus = .completed
+    ) -> DownloadRecord {
+        DownloadRecord(
+            id: id,
+            contentId: series,
+            episodeId: "\(id)-leaf",
+            batchId: nil,
+            mediaFileId: 0,
+            format: "original",
+            serverStatus: "ready",
+            localStatus: status,
+            fileSize: bytes,
+            bytesDownloaded: bytes,
+            mediaFilename: "media.mp4",
+            manifestFilename: "manifest.json",
+            posterFilename: nil,
+            backdropFilename: nil,
+            logoFilename: nil,
+            subtitleFilenames: [:],
+            title: title ?? "Episode \(number)",
+            subtitle: "S\(season) · E\(number)",
+            type: "episode",
+            seriesId: series,
+            seriesTitle: seriesTitle,
+            seasonNumber: season,
+            episodeNumber: number,
+            posterThumbhash: nil,
+            container: "mp4",
+            stableIdentity: nil,
+            registeredAt: Date(timeIntervalSince1970: 1_000_000 + Double(season * 100 + number)),
+            downloadedAt: nil,
+            lastError: nil,
+            retryCount: 0,
+            taskIdentifier: nil
+        )
+    }
+
+    private func movie(_ id: String, bytes: Int64, title: String) -> DownloadRecord {
+        DownloadRecord(
+            id: id,
+            contentId: id,
+            episodeId: nil,
+            batchId: nil,
+            mediaFileId: 0,
+            format: "original",
+            serverStatus: "ready",
+            localStatus: .completed,
+            fileSize: bytes,
+            bytesDownloaded: bytes,
+            mediaFilename: "media.mp4",
+            manifestFilename: "manifest.json",
+            posterFilename: nil,
+            backdropFilename: nil,
+            logoFilename: nil,
+            subtitleFilenames: [:],
+            title: title,
+            subtitle: "2024",
+            type: "movie",
+            seriesId: nil,
+            seriesTitle: nil,
+            seasonNumber: nil,
+            episodeNumber: nil,
+            posterThumbhash: nil,
+            container: "mp4",
+            stableIdentity: nil,
+            registeredAt: Date(timeIntervalSince1970: 1_000_000),
+            downloadedAt: nil,
+            lastError: nil,
+            retryCount: 0,
+            taskIdentifier: nil
+        )
+    }
+
+    private func groups(
+        _ records: [DownloadRecord],
+        watched: Set<String> = [],
+        seriesTitle: @escaping (String) -> String? = { _ in nil },
+        monitored: Set<String> = []
+    ) -> [DownloadSeriesGroup] {
+        DownloadGroupBuilder.seriesGroups(
+            from: records,
+            isWatched: { watched.contains($0.leafMediaItemId) },
+            seriesTitle: seriesTitle,
+            isMonitored: { monitored.contains($0) }
+        )
+    }
+
+    // MARK: - Grouping
+
+    func testGroupsEpisodesBySeriesAndExcludesMovies() {
+        let records = [
+            episode("a", series: "show", season: 1, number: 1, bytes: 100),
+            episode("b", series: "show", season: 1, number: 2, bytes: 200),
+            movie("m", bytes: 999, title: "A Movie"),
+        ]
+        let result = groups(records)
+        XCTAssertEqual(result.count, 1, "movies must not produce a series group")
+        XCTAssertEqual(result.first?.seriesId, "show")
+        XCTAssertEqual(result.first?.episodeCount, 2)
+        XCTAssertEqual(result.first?.totalBytes, 300)
+    }
+
+    func testSeasonsAreNewestFirstWithSpecialsLast() {
+        let records = [
+            episode("a", series: "s", season: 1, number: 1, bytes: 1),
+            episode("b", series: "s", season: 2, number: 1, bytes: 1),
+            episode("c", series: "s", season: 0, number: 1, bytes: 1),
+        ]
+        let group = groups(records).first
+        XCTAssertEqual(group?.seasons.map(\.seasonNumber), [2, 1, 0])
+    }
+
+    func testEpisodesWithinSeasonSortedByNumber() {
+        let records = [
+            episode("a", series: "s", season: 1, number: 3, bytes: 1),
+            episode("b", series: "s", season: 1, number: 1, bytes: 1),
+            episode("c", series: "s", season: 1, number: 2, bytes: 1),
+        ]
+        let season = groups(records).first?.seasons.first
+        XCTAssertEqual(season?.records.map { $0.episodeNumber }, [1, 2, 3])
+    }
+
+    func testWatchedCountsAndAllWatched() {
+        let records = [
+            episode("a", series: "s", season: 1, number: 1, bytes: 1),
+            episode("b", series: "s", season: 1, number: 2, bytes: 1),
+        ]
+        let partial = groups(records, watched: ["a-leaf"]).first
+        XCTAssertEqual(partial?.watchedCount, 1)
+        XCTAssertFalse(partial?.allWatched ?? true)
+
+        let all = groups(records, watched: ["a-leaf", "b-leaf"]).first
+        XCTAssertTrue(all?.allWatched ?? false)
+    }
+
+    func testPerSeasonTotalsAndCounts() {
+        let records = [
+            episode("a", series: "s", season: 2, number: 1, bytes: 100),
+            episode("b", series: "s", season: 2, number: 2, bytes: 150),
+            episode("c", series: "s", season: 1, number: 1, bytes: 300),
+        ]
+        let group = groups(records).first
+        XCTAssertEqual(group?.totalBytes, 550)
+        XCTAssertEqual(group?.seasons.first?.seasonNumber, 2)
+        XCTAssertEqual(group?.seasons.first?.totalBytes, 250)
+        XCTAssertEqual(group?.seasons.first?.episodeCount, 2)
+    }
+
+    // MARK: - Title resolution
+
+    func testTitlePrefersRecordSeriesTitleThenSubscription() {
+        let withRecordTitle = [episode("a", series: "sid", season: 1, number: 1, bytes: 1, seriesTitle: "The Show")]
+        XCTAssertEqual(groups(withRecordTitle, seriesTitle: { _ in "Fallback" }).first?.title, "The Show")
+
+        let withoutRecordTitle = [episode("a", series: "sid", season: 1, number: 1, bytes: 1)]
+        XCTAssertEqual(groups(withoutRecordTitle, seriesTitle: { _ in "Sub Title" }).first?.title, "Sub Title")
+    }
+
+    func testMonitoredFlagThreadedThrough() {
+        let records = [episode("a", series: "sid", season: 1, number: 1, bytes: 1)]
+        XCTAssertTrue(groups(records, monitored: ["sid"]).first?.isMonitored ?? false)
+        XCTAssertFalse(groups(records).first?.isMonitored ?? true)
+    }
+
+    // MARK: - List sorting
+
+    func testSortLargestFirst() {
+        let items: [DownloadListItem] = [
+            .movie(movie("a", bytes: 100, title: "A")),
+            .movie(movie("b", bytes: 300, title: "B")),
+            .movie(movie("c", bytes: 200, title: "C")),
+        ]
+        XCTAssertEqual(
+            DownloadGroupBuilder.sorted(items, by: .largestFirst).map(\.totalBytes),
+            [300, 200, 100]
+        )
+    }
+
+    func testSortAlphabeticalIsCaseInsensitive() {
+        let items: [DownloadListItem] = [
+            .movie(movie("a", bytes: 1, title: "Zodiac")),
+            .movie(movie("b", bytes: 1, title: "arrival")),
+            .movie(movie("c", bytes: 1, title: "Dune")),
+        ]
+        XCTAssertEqual(
+            DownloadGroupBuilder.sorted(items, by: .alphabetical).map(\.sortTitle),
+            ["arrival", "Dune", "Zodiac"]
+        )
+    }
+}

--- a/iosApp/iosApp/Components/DownloadedBadge.swift
+++ b/iosApp/iosApp/Components/DownloadedBadge.swift
@@ -1,0 +1,21 @@
+#if !os(tvOS)
+import SwiftUI
+
+/// Corner indicator marking catalog cards whose media is fully on device.
+/// Completed downloads only — in-flight state lives on the detail screens,
+/// so cards never re-render on transfer progress. Green to match the
+/// download button's completed state; the arrow glyph (Downloads tab
+/// iconography) keeps it distinct from the white watched check that owns
+/// the opposite corner.
+struct DownloadedBadge: View {
+    var size: CGFloat = 18
+
+    var body: some View {
+        Image(systemName: "arrow.down.circle.fill")
+            .font(.system(size: size, weight: .semibold))
+            .symbolRenderingMode(.palette)
+            .foregroundStyle(.white, .green)
+            .shadow(color: .black.opacity(0.3), radius: 4)
+    }
+}
+#endif

--- a/iosApp/iosApp/Components/DownloadedBadge.swift
+++ b/iosApp/iosApp/Components/DownloadedBadge.swift
@@ -18,4 +18,21 @@ struct DownloadedBadge: View {
             .shadow(color: .black.opacity(0.3), radius: 4)
     }
 }
+
+/// Card ZStack layer pinning the downloaded indicator bottom-trailing —
+/// clear of the watched check (top-trailing) and episode badges
+/// (bottom-leading). Gated by the manager's capability-aware lookup so
+/// nothing renders on servers without downloads.
+struct DownloadedBadgeOverlay: View {
+    let contentId: String?
+    let padding: CGFloat
+
+    var body: some View {
+        if let contentId, DownloadManager.shared.isDownloaded(contentId: contentId) {
+            DownloadedBadge()
+                .padding(padding)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+        }
+    }
+}
 #endif

--- a/iosApp/iosApp/Components/EpisodeThumbCard.swift
+++ b/iosApp/iosApp/Components/EpisodeThumbCard.swift
@@ -168,15 +168,7 @@ struct EpisodeThumbCard: View {
             }
 
             #if !os(tvOS)
-            // Downloaded indicator — bottom-trailing keeps clear of the S/E
-            // badge (bottom-leading) and watched check (top-trailing). Gated
-            // by the manager's capability-aware lookup so nothing renders on
-            // servers without downloads.
-            if DownloadManager.shared.isDownloaded(contentId: item.contentId) {
-                DownloadedBadge()
-                    .padding(badgeInset)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
-            }
+            DownloadedBadgeOverlay(contentId: item.contentId, padding: badgeInset)
             #endif
         }
         .frame(width: cardWidth, height: cardHeight)

--- a/iosApp/iosApp/Components/EpisodeThumbCard.swift
+++ b/iosApp/iosApp/Components/EpisodeThumbCard.swift
@@ -166,6 +166,18 @@ struct EpisodeThumbCard: View {
                 .padding(badgeInset)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
             }
+
+            #if !os(tvOS)
+            // Downloaded indicator — bottom-trailing keeps clear of the S/E
+            // badge (bottom-leading) and watched check (top-trailing). Gated
+            // by the manager's capability-aware lookup so nothing renders on
+            // servers without downloads.
+            if DownloadManager.shared.isDownloaded(contentId: item.contentId) {
+                DownloadedBadge()
+                    .padding(badgeInset)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+            }
+            #endif
         }
         .frame(width: cardWidth, height: cardHeight)
     }

--- a/iosApp/iosApp/Components/MediaCard.swift
+++ b/iosApp/iosApp/Components/MediaCard.swift
@@ -190,6 +190,18 @@ struct MediaCard: View {
                 .padding(checkBadgePadding)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
             }
+
+            #if !os(tvOS)
+            // Downloaded indicator — bottom-trailing so it never fights the
+            // watched check (top-trailing) or the episode badge (bottom-
+            // leading). Gated by the manager's capability-aware lookup so
+            // nothing renders on servers without downloads.
+            if let contentId, DownloadManager.shared.isDownloaded(contentId: contentId) {
+                DownloadedBadge()
+                    .padding(checkBadgePadding)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+            }
+            #endif
         }
         .frame(width: cardWidth, height: cardHeight)
     }

--- a/iosApp/iosApp/Components/MediaCard.swift
+++ b/iosApp/iosApp/Components/MediaCard.swift
@@ -192,15 +192,7 @@ struct MediaCard: View {
             }
 
             #if !os(tvOS)
-            // Downloaded indicator — bottom-trailing so it never fights the
-            // watched check (top-trailing) or the episode badge (bottom-
-            // leading). Gated by the manager's capability-aware lookup so
-            // nothing renders on servers without downloads.
-            if let contentId, DownloadManager.shared.isDownloaded(contentId: contentId) {
-                DownloadedBadge()
-                    .padding(checkBadgePadding)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
-            }
+            DownloadedBadgeOverlay(contentId: contentId, padding: checkBadgePadding)
             #endif
         }
         .frame(width: cardWidth, height: cardHeight)

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -215,6 +215,10 @@ struct ContentView: View {
                 pendingDeepLink = url
                 return
             }
+            // The tab only exists while downloads are enabled — a stale
+            // download notification tapped after a profile/capability
+            // change must not select a tab that never renders.
+            guard DownloadManager.shared.downloadsEnabled else { return }
             // Select the tab rather than pushing the route — a push stacks
             // a duplicate Downloads screen when that tab is already showing,
             // and hides the tab context from anywhere else.
@@ -852,10 +856,11 @@ struct MainTabView: View {
             #else
             DownloadsView()
             #endif
-        case .offlinePlayer(let downloadId, let contentId, let resumePosition):
+        case .offlinePlayer(let downloadId, let contentId, let startFromBeginning, let resumePosition):
             #if os(macOS)
             PlayerView(
                 contentId: contentId,
+                startFromBeginning: startFromBeginning,
                 resumePositionOverride: resumePosition,
                 offlineDownloadId: downloadId
             )

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -57,6 +57,9 @@ struct ContentView: View {
         .onReceive(NotificationCenter.default.publisher(for: .continuumSessionExpired)) { _ in
             audioStore.dismissFullPlayer()
             Task { await audioStore.player.close() }
+            #if !os(tvOS)
+            DownloadManager.shared.clearForSignOut()
+            #endif
             router.expiredSession()
         }
         .task {
@@ -84,6 +87,9 @@ struct ContentView: View {
                 await AICapabilities.shared.refresh()
                 #if os(iOS)
                 await ApplePushRegistrationCoordinator.shared.prepareForAuthenticatedProfile()
+                #endif
+                #if !os(tvOS)
+                await DownloadManager.shared.onAppActive()
                 #endif
             }
         }
@@ -124,6 +130,9 @@ struct ContentView: View {
             #endif
             #if os(tvOS)
             NotificationCenter.default.post(name: .homeSectionsShouldRefresh, object: nil)
+            #endif
+            #if !os(tvOS)
+            Task { await DownloadManager.shared.onAppActive() }
             #endif
         }
     }
@@ -568,6 +577,7 @@ struct MainTabView: View {
                 preferredSubtitleTrackIndex: payload.subtitleTrackIndex,
                 startFromBeginning: payload.startFromBeginning,
                 resumePositionOverride: payload.resumePosition,
+                offlineDownloadId: payload.offlineDownloadId,
                 posterURLHint: payload.posterURL,
                 backdropURLHint: payload.backdropURL
             )
@@ -597,11 +607,25 @@ struct MainTabView: View {
         #endif
     }
 
+    /// Visible tabs, plus a Downloads tab when the server advertises the
+    /// downloads capability for this profile. Reading
+    /// `DownloadManager.shared.downloadsEnabled` here registers the tab bar
+    /// as an observer, so the tab appears as soon as capability loads.
+    private var visibleTabs: [AppTab] {
+        var tabs = AppTab.visibleCases
+        #if !os(tvOS)
+        if DownloadManager.shared.downloadsEnabled {
+            tabs.append(.downloads)
+        }
+        #endif
+        return tabs
+    }
+
     /// iPhone + iPad compact width: bottom tab bar, single navigation stack.
     private var tabLayout: some View {
         NavigationStack(path: $router.path) {
             TabView(selection: $selectedTab) {
-                ForEach(AppTab.visibleCases) { tab in
+                ForEach(visibleTabs) { tab in
                     #if os(tvOS)
                     // Text-only tabs on tvOS keep the top bar compact — adding an
                     // icon blows up each tab's focus pill. The value-based `Tab`
@@ -648,7 +672,7 @@ struct MainTabView: View {
                 get: { selectedTab },
                 set: { if let v = $0 { selectedTab = v } }
             )) {
-                ForEach(AppTab.visibleCases) { tab in
+                ForEach(visibleTabs) { tab in
                     Label(
                         tab.rawValue,
                         systemImage: selectedTab == tab ? tab.selectedIcon : tab.icon
@@ -697,6 +721,13 @@ struct MainTabView: View {
 
         case .calendar:
             CalendarView()
+
+        case .downloads:
+            #if os(tvOS)
+            EmptyView()
+            #else
+            DownloadsView()
+            #endif
 
         case .settings:
             SettingsView()
@@ -787,6 +818,39 @@ struct MainTabView: View {
             RecommendationsView()
         case .serverList:
             ServerListView()
+        case .downloads:
+            #if os(tvOS)
+            EmptyStateView(icon: "questionmark.circle", title: "Unknown", subtitle: nil)
+                .continuumBackground()
+            #else
+            DownloadsView()
+            #endif
+        case .offlinePlayer(let downloadId, let contentId, let resumePosition):
+            #if os(macOS)
+            PlayerView(
+                contentId: contentId,
+                resumePositionOverride: resumePosition,
+                offlineDownloadId: downloadId
+            )
+            #else
+            // Presented as a full-screen cover (see MainTabView). This arm
+            // exists only for switch exhaustiveness.
+            EmptyView()
+            #endif
+        case .offlineSeriesBrowse(let seriesId):
+            #if os(tvOS)
+            EmptyStateView(icon: "questionmark.circle", title: "Unknown", subtitle: nil)
+                .continuumBackground()
+            #else
+            OfflineSeriesBrowseView(seriesId: seriesId)
+            #endif
+        case .offlineDownloadDetail(let downloadId):
+            #if os(tvOS)
+            EmptyStateView(icon: "questionmark.circle", title: "Unknown", subtitle: nil)
+                .continuumBackground()
+            #else
+            OfflineDownloadDetailView(downloadId: downloadId)
+            #endif
         default:
             EmptyStateView(icon: "questionmark.circle", title: "Unknown", subtitle: nil)
                 .continuumBackground()

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -100,6 +100,11 @@ struct ContentView: View {
                 castController.appDidBecomeActive()
             case .background:
                 castController.appDidEnterBackground()
+                // Keep series monitoring alive while backgrounded; only
+                // worth a wake when the profile can download at all.
+                if DownloadManager.shared.downloadsEnabled {
+                    DownloadBackgroundRefresh.schedule()
+                }
             default:
                 break
             }
@@ -196,12 +201,29 @@ struct ContentView: View {
     /// - `continuum://item/{contentId}` — push the detail screen
     /// - `continuum://play/{contentId}` — push the player (resume from
     ///   last known position)
+    /// - `continuum://downloads` — select the Downloads tab (local
+    ///   download notifications)
     ///
     /// If the auth state isn't ready yet, the link is queued in
     /// `pendingDeepLink` and drained on the next `.authenticated`
     /// transition.
     private func handleDeepLink(_ url: URL) {
-        guard let host = url.host, !url.pathComponents.isEmpty else { return }
+        guard let host = url.host else { return }
+
+        if host == "downloads" {
+            guard router.authState == .authenticated else {
+                pendingDeepLink = url
+                return
+            }
+            // Select the tab rather than pushing the route — a push stacks
+            // a duplicate Downloads screen when that tab is already showing,
+            // and hides the tab context from anywhere else.
+            router.popToRoot()
+            router.switchTab(to: .downloads)
+            return
+        }
+
+        guard !url.pathComponents.isEmpty else { return }
         let contentId = url.pathComponents
             .dropFirst()
             .first?
@@ -562,6 +584,11 @@ struct MainTabView: View {
             }
         }
         .tint(.continuumOnSurface)
+        .onChange(of: router.requestedTab) { _, tab in
+            guard let tab else { return }
+            selectedTab = tab
+            router.requestedTab = nil
+        }
         #if !os(macOS)
         .fullScreenCover(isPresented: Binding(
             get: { audioStore.isShowingFullPlayer },

--- a/iosApp/iosApp/Downloads/DownloadAPI.swift
+++ b/iosApp/iosApp/Downloads/DownloadAPI.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+/// Typed download / offline-sync endpoints, grouped as an extension on the
+/// existing `ContinuumAPI` facade. These reuse the facade's injected `http`
+/// transport (auth injection, 401 refresh, snake_case JSON coders) rather
+/// than the legacy path dispatcher. Contract: server `docs/downloads-api.md`.
+extension ContinuumAPI {
+
+    // MARK: - Capability
+
+    func downloadCapability() async throws -> DownloadCapability {
+        try await http.get("/api/v1/downloads/capability")
+    }
+
+    // MARK: - Download registry
+
+    /// Register a managed download. Returns one row for a single item, or
+    /// every batch member for a series/season request.
+    func createDownload(_ request: CreateDownloadRequest) async throws -> [ServerDownloadRow] {
+        let response: CreateDownloadResponse = try await http.post(
+            "/api/v1/downloads",
+            body: request
+        )
+        return response.downloads
+    }
+
+    /// The calling device's managed entries. Primary poll-for-readiness and
+    /// reconcile-on-launch call.
+    func listDownloads() async throws -> [ServerDownloadRow] {
+        let response: ServerDownloadsResponse = try await http.get("/api/v1/downloads")
+        return response.downloads
+    }
+
+    /// Report local progression so the server row reflects reality. Only
+    /// `downloading` / `completed` are accepted.
+    func patchDownloadStatus(id: String, status: String) async throws {
+        try await http.patchVoid(
+            "/api/v1/downloads/\(id)",
+            body: DownloadStatusUpdate(status: status)
+        )
+    }
+
+    func deleteDownloadRow(id: String) async throws {
+        try await http.delete("/api/v1/downloads/\(id)")
+    }
+
+    func fetchManifest(downloadId: String) async throws -> OfflineManifest {
+        try await http.get("/api/v1/downloads/\(downloadId)/manifest")
+    }
+
+    func fetchBatchManifests(batchId: String) async throws -> [OfflineManifest] {
+        let response: BatchManifestResponse = try await http.get(
+            "/api/v1/downloads/batches/\(batchId)/manifests"
+        )
+        return response.manifests
+    }
+
+    /// Fetch the raw bytes of an authenticated proxy asset (artwork or
+    /// subtitle). `path` is an API-relative path taken from the manifest
+    /// (`artwork_urls.*` / `subtitles[].fetch_url`).
+    func fetchDownloadAssetData(path: String) async throws -> Data {
+        try await http.getData(path)
+    }
+
+    /// Build the absolute file-endpoint URL for a download, resolved
+    /// against the active server origin. Used by the background downloader.
+    func downloadFileURL(downloadId: String) async -> URL? {
+        let base = await currentServerUrl()
+        guard !base.isEmpty else { return nil }
+        let trimmed = base.hasSuffix("/") ? String(base.dropLast()) : base
+        return URL(string: "\(trimmed)/api/v1/downloads/\(downloadId)/file")
+    }
+
+    // MARK: - Subscriptions
+
+    func createSubscription(_ request: CreateSubscriptionRequest) async throws -> CreateSubscriptionResponse {
+        try await http.post("/api/v1/downloads/subscriptions", body: request)
+    }
+
+    /// Register newly in-scope episodes across all of this device's
+    /// monitors. Returns how many were registered.
+    @discardableResult
+    func syncSubscriptions() async throws -> Int {
+        let response: SubscriptionSyncResponse = try await http.post(
+            "/api/v1/downloads/subscriptions/sync"
+        )
+        return response.registered
+    }
+
+    func listSubscriptions() async throws -> [ServerSubscription] {
+        let response: SubscriptionsListResponse = try await http.get(
+            "/api/v1/downloads/subscriptions"
+        )
+        return response.subscriptions
+    }
+
+    func updateSubscription(
+        id: String,
+        _ request: UpdateSubscriptionRequest
+    ) async throws -> CreateSubscriptionResponse {
+        try await http.patch("/api/v1/downloads/subscriptions/\(id)", body: request)
+    }
+
+    func deleteSubscription(id: String) async throws {
+        try await http.delete("/api/v1/downloads/subscriptions/\(id)")
+    }
+
+    // MARK: - Progress reconciliation
+
+    /// Flush a batch of queued offline progress events. Returns per-item
+    /// results so the caller can drop acked items from its queue.
+    func syncProgressBatch(items: [SyncProgressItem]) async throws -> [SyncProgressResult] {
+        guard !items.isEmpty else { return [] }
+        let response: SyncProgressResultsResponse = try await http.post(
+            "/api/v1/sync/progress",
+            body: SyncProgressRequest(items: items)
+        )
+        return response.results
+    }
+
+    /// Pull watch-state changes made on any device after `cursor`,
+    /// server-ordered. Pass `nil` for the initial pull.
+    func pullProgressDeltas(since cursor: String?) async throws -> ProgressPullResponse {
+        var query: [String: String] = [:]
+        if let cursor, !cursor.isEmpty { query["since"] = cursor }
+        return try await http.get("/api/v1/progress", query: query)
+    }
+}
+
+// MARK: - Request/response helpers
+
+private struct DownloadStatusUpdate: Encodable {
+    let status: String
+}
+
+/// `POST /api/v1/downloads` returns either a bare row (single item) or a
+/// `{ "downloads": [...] }` batch. This decodes both into a row list.
+struct CreateDownloadResponse: Decodable, Sendable {
+    let downloads: [ServerDownloadRow]
+
+    private enum CodingKeys: String, CodingKey {
+        case downloads
+    }
+
+    init(from decoder: Decoder) throws {
+        if let keyed = try? decoder.container(keyedBy: CodingKeys.self),
+           let rows = try? keyed.decode([ServerDownloadRow].self, forKey: .downloads) {
+            self.downloads = rows
+            return
+        }
+        let single = try ServerDownloadRow(from: decoder)
+        self.downloads = [single]
+    }
+}
+
+struct BatchManifestResponse: Decodable, Sendable {
+    let manifests: [OfflineManifest]
+}
+
+/// Per-item result envelope from `POST /api/v1/sync/progress` (§5.1).
+struct SyncProgressResultsResponse: Codable, Sendable {
+    let results: [SyncProgressResult]
+}
+
+struct SyncProgressResult: Codable, Sendable {
+    let mediaItemId: String
+    let status: String
+    let error: String?
+
+    var isOK: Bool { status == "ok" }
+}

--- a/iosApp/iosApp/Downloads/DownloadActionButton.swift
+++ b/iosApp/iosApp/Downloads/DownloadActionButton.swift
@@ -1,0 +1,187 @@
+#if !os(tvOS)
+import SwiftUI
+
+/// Per-item download control for the movie / episode detail screen. Reads
+/// the live record straight from `DownloadManager.shared` (an `@Observable`
+/// singleton), so it reflects download progress without the detail view
+/// model having to thread any state through. Matches the 44pt circle
+/// styling of the neighboring favorite / watchlist buttons.
+struct DownloadActionButton: View {
+    let detail: ItemDetail
+    let versions: [FileVersion]
+    let selectedVersionFileId: Int?
+
+    private var manager: DownloadManager { DownloadManager.shared }
+    private var record: DownloadRecord? { manager.record(forContentId: detail.contentId) }
+    @State private var showOptions = false
+
+    var body: some View {
+        content
+            .sheet(isPresented: $showOptions) {
+                DownloadOptionsSheet(
+                    title: detail.title,
+                    versions: versions,
+                    selectedVersionFileId: selectedVersionFileId,
+                    lastVersionFileId: detail.userData?.lastFileId,
+                    onStart: startDownload
+                )
+            }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch record?.localStatus {
+        case .none:
+            Button { showOptions = true } label: {
+                circleLabel(icon: "arrow.down.to.line", active: false)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Download")
+
+        case .downloading:
+            Menu {
+                Button(role: .destructive, action: cancel) {
+                    Label("Cancel Download", systemImage: "xmark.circle")
+                }
+            } label: {
+                progressLabel(fraction: record?.progressFraction ?? 0)
+            }
+            .accessibilityLabel("Downloading")
+
+        case .registering, .preparing, .queued, .fetchingAssets:
+            Menu {
+                Button(role: .destructive, action: cancel) {
+                    Label("Cancel Download", systemImage: "xmark.circle")
+                }
+            } label: {
+                circleLabel(icon: "arrow.down.circle", active: true, showSpinner: true)
+            }
+            .accessibilityLabel("Preparing download")
+
+        case .completed:
+            Menu {
+                Button(role: .destructive, action: delete) {
+                    Label("Delete Download", systemImage: "trash")
+                }
+            } label: {
+                circleLabel(icon: "checkmark.circle.fill", active: true, tint: .green)
+            }
+            .accessibilityLabel("Downloaded")
+
+        case .revoked:
+            Menu {
+                Button(role: .destructive, action: delete) {
+                    Label("Delete Download", systemImage: "trash")
+                }
+            } label: {
+                circleLabel(icon: "checkmark.circle", active: true, tint: .yellow)
+            }
+            .accessibilityLabel("Downloaded (re-download no longer allowed)")
+
+        case .failed:
+            Menu {
+                Button { showOptions = true } label: {
+                    Label("Retry With Options", systemImage: "arrow.clockwise")
+                }
+                Button(role: .destructive, action: delete) {
+                    Label("Remove", systemImage: "trash")
+                }
+            } label: {
+                circleLabel(icon: "exclamationmark.triangle", active: true, tint: .orange)
+            }
+            .accessibilityLabel("Download failed")
+        }
+    }
+
+    // MARK: - Actions
+
+    private func startDownload(_ options: DownloadRequestOptions) {
+        Task {
+            do {
+                if detail.type == "episode" {
+                    try await manager.downloadEpisode(
+                        seriesId: detail.seriesId ?? detail.contentId,
+                        episodeId: detail.contentId,
+                        displayTitle: detail.title,
+                        displaySubtitle: episodeSubtitle,
+                        posterThumbhash: detail.posterThumbhash,
+                        fileId: options.fileId,
+                        quality: options.quality
+                    )
+                } else {
+                    try await manager.downloadMovie(
+                        contentId: detail.contentId,
+                        displayTitle: detail.title,
+                        year: detail.year,
+                        posterThumbhash: detail.posterThumbhash,
+                        fileId: options.fileId,
+                        quality: options.quality
+                    )
+                }
+            } catch {
+                // The record (if any) reflects failure; nothing else to do.
+            }
+        }
+    }
+
+    private func cancel() {
+        if let id = record?.id { manager.deleteDownload(id: id) }
+    }
+
+    private func delete() {
+        if let id = record?.id { manager.deleteDownload(id: id) }
+    }
+
+    private var episodeSubtitle: String? {
+        let season = detail.seasonNumber.map { "S\($0)" }
+        let episode = detail.episodeNumber.map { "E\($0)" }
+        let tag = [season, episode].compactMap { $0 }.joined(separator: " · ")
+        return tag.isEmpty ? detail.seriesTitle : tag
+    }
+
+    // MARK: - Labels
+
+    private func circleLabel(
+        icon: String,
+        active: Bool,
+        tint: Color = .white,
+        showSpinner: Bool = false
+    ) -> some View {
+        ZStack {
+            Circle()
+                .fill(Color.white.opacity(active ? 0.18 : 0.10))
+                .overlay(
+                    Circle().stroke(Color.white.opacity(active ? 0.55 : 0.25), lineWidth: 1)
+                )
+            if showSpinner {
+                ProgressView()
+                    .controlSize(.small)
+                    .tint(.white)
+            } else {
+                Image(systemName: icon)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundColor(tint)
+                    .contentTransition(.symbolEffect(.replace.magic(fallback: .replace)))
+            }
+        }
+        .frame(width: 44, height: 44)
+    }
+
+    private func progressLabel(fraction: Double) -> some View {
+        ZStack {
+            Circle()
+                .fill(Color.white.opacity(0.10))
+                .overlay(Circle().stroke(Color.white.opacity(0.25), lineWidth: 1))
+            Circle()
+                .trim(from: 0, to: max(0.02, fraction))
+                .stroke(Color.white, style: StrokeStyle(lineWidth: 2.5, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+                .padding(4)
+            Image(systemName: "stop.fill")
+                .font(.system(size: 10, weight: .bold))
+                .foregroundColor(.white)
+        }
+        .frame(width: 44, height: 44)
+    }
+}
+#endif

--- a/iosApp/iosApp/Downloads/DownloadActionButton.swift
+++ b/iosApp/iosApp/Downloads/DownloadActionButton.swift
@@ -1,30 +1,149 @@
 #if !os(tvOS)
 import SwiftUI
 
-/// Per-item download control for the movie / episode detail screen. Reads
-/// the live record straight from `DownloadManager.shared` (an `@Observable`
-/// singleton), so it reflects download progress without the detail view
-/// model having to thread any state through. Matches the 44pt circle
-/// styling of the neighboring favorite / watchlist buttons.
+/// Series-scope inputs an episode card needs to start a download for one of
+/// its episodes; built once per episode rail by the owning detail screen.
+struct EpisodeDownloadContext {
+    let seriesId: String
+    let posterThumbhash: String?
+}
+
+/// Per-item download control. Reads the live record straight from
+/// `DownloadManager.shared` (an `@Observable` singleton), so it reflects
+/// download progress without the detail view model having to thread any
+/// state through.
+///
+/// Two placements share the state machine: the `.regular` style matches the
+/// 44pt circle styling of the neighboring favorite / watchlist buttons on
+/// the movie / episode detail screen, and the `.compact` style is the small
+/// circle drawn over episode-card stills, where a full detail navigation per
+/// episode would be the only alternative.
 struct DownloadActionButton: View {
-    let detail: ItemDetail
-    let versions: [FileVersion]
-    let selectedVersionFileId: Int?
+    enum Style {
+        case regular
+        case compact
+    }
+
+    /// Card layouts position the compact control over the still's corner,
+    /// so they need its footprint at layout time.
+    static let compactDiameter: CGFloat = 30
+
+    private let style: Style
+    private let contentId: String
+    private let isEpisode: Bool
+    private let seriesId: String?
+    private let displayTitle: String
+    private let displaySubtitle: String?
+    private let year: Int?
+    private let posterThumbhash: String?
+    /// Full version metadata for the options sheet; empty in compact style,
+    /// which never presents the sheet.
+    private let versions: [FileVersion]
+    /// Candidate file sizes feeding the pre-download large-file guard.
+    private let candidateFileSizes: [Int64]
+    private let selectedVersionFileId: Int?
+    private let lastVersionFileId: Int?
+    /// Owned by the detail screen so its overflow menu can open the same
+    /// options sheet — one-tap made the sheet a secondary path, and it must
+    /// stay discoverable somewhere visible. Compact placements have no
+    /// options sheet, so they bind a constant that never presents.
+    @Binding private var showOptions: Bool
 
     private var manager: DownloadManager { DownloadManager.shared }
-    private var record: DownloadRecord? { manager.record(forContentId: detail.contentId) }
-    @State private var showOptions = false
+    private var record: DownloadRecord? { manager.record(forContentId: contentId) }
+    @State private var confirmingCancel = false
+    /// Guard text for the pre-download confirmation; non-nil presents it.
+    @State private var largeDownloadWarning: String?
+    /// Short-lived caption above the button; non-nil shows it.
+    @State private var startNotice: String?
+    @State private var startFeedbackCount = 0
+    @State private var failFeedbackCount = 0
+
+    /// Detail action-row button, driven by the screen's `ItemDetail`.
+    init(
+        detail: ItemDetail,
+        versions: [FileVersion],
+        selectedVersionFileId: Int?,
+        showOptions: Binding<Bool>
+    ) {
+        style = .regular
+        contentId = detail.contentId
+        isEpisode = detail.type == "episode"
+        seriesId = detail.seriesId
+        displayTitle = detail.title
+        displaySubtitle = Self.episodeSubtitle(
+            seasonNumber: detail.seasonNumber,
+            episodeNumber: detail.episodeNumber,
+            fallback: detail.seriesTitle
+        )
+        year = detail.year
+        posterThumbhash = detail.posterThumbhash
+        self.versions = versions
+        candidateFileSizes = versions.compactMap(\.fileSize)
+        self.selectedVersionFileId = selectedVersionFileId
+        lastVersionFileId = detail.userData?.lastFileId
+        _showOptions = showOptions
+    }
+
+    /// Compact episode-card control. Episode list items only carry
+    /// `EpisodeFile` metadata, so version options stay on the episode detail
+    /// page and the failed state re-runs the same registration instead of
+    /// offering the sheet.
+    init(episode: EpisodeListItem, context: EpisodeDownloadContext) {
+        style = .compact
+        contentId = episode.contentId
+        isEpisode = true
+        seriesId = context.seriesId
+        displayTitle = episode.title ?? "Episode \(episode.episodeNumber)"
+        displaySubtitle = Self.episodeSubtitle(
+            seasonNumber: episode.seasonNumber,
+            episodeNumber: episode.episodeNumber,
+            fallback: nil
+        )
+        year = nil
+        posterThumbhash = context.posterThumbhash
+        versions = []
+        candidateFileSizes = (episode.files ?? []).compactMap(\.fileSize)
+        selectedVersionFileId = nil
+        lastVersionFileId = nil
+        _showOptions = .constant(false)
+    }
 
     var body: some View {
         content
+            .overlay(alignment: .top) { noticeCaption }
+            .sensoryFeedback(.success, trigger: startFeedbackCount)
+            .sensoryFeedback(.error, trigger: failFeedbackCount)
             .sheet(isPresented: $showOptions) {
                 DownloadOptionsSheet(
-                    title: detail.title,
+                    title: displayTitle,
                     versions: versions,
                     selectedVersionFileId: selectedVersionFileId,
-                    lastVersionFileId: detail.userData?.lastFileId,
+                    lastVersionFileId: lastVersionFileId,
                     onStart: startDownload
                 )
+            }
+            .confirmationDialog(
+                cancelPrompt,
+                isPresented: $confirmingCancel,
+                titleVisibility: .visible
+            ) {
+                Button("Discard Download", role: .destructive, action: cancel)
+                Button("Keep Download", role: .cancel) {}
+            }
+            .confirmationDialog(
+                "\(largeDownloadWarning ?? "") Download anyway?",
+                isPresented: Binding(
+                    get: { largeDownloadWarning != nil },
+                    set: { if !$0 { largeDownloadWarning = nil } }
+                ),
+                titleVisibility: .visible
+            ) {
+                Button("Download Anyway", action: startWithDefaults)
+                if style == .regular {
+                    Button("Choose Options…") { showOptions = true }
+                }
+                Button("Cancel", role: .cancel) {}
             }
     }
 
@@ -32,25 +151,50 @@ struct DownloadActionButton: View {
     private var content: some View {
         switch record?.localStatus {
         case .none:
-            Button { showOptions = true } label: {
+            let button = Button(action: handleDownloadTap) {
                 circleLabel(icon: "arrow.down.to.line", active: false)
             }
             .buttonStyle(.plain)
             .accessibilityLabel("Download")
+            if style == .regular {
+                button.contextMenu {
+                    Button { showOptions = true } label: {
+                        Label("Download Options…", systemImage: "slider.horizontal.3")
+                    }
+                }
+            } else {
+                button
+            }
 
         case .downloading:
             Menu {
-                Button(role: .destructive, action: cancel) {
+                Button(action: pause) {
+                    Label("Pause", systemImage: "pause")
+                }
+                Button(role: .destructive) { confirmingCancel = true } label: {
                     Label("Cancel Download", systemImage: "xmark.circle")
                 }
             } label: {
-                progressLabel(fraction: record?.progressFraction ?? 0)
+                progressLabel(fraction: record?.progressFraction ?? 0, paused: false)
             }
             .accessibilityLabel("Downloading")
 
+        case .paused:
+            Menu {
+                Button(action: resume) {
+                    Label("Resume", systemImage: "play")
+                }
+                Button(role: .destructive) { confirmingCancel = true } label: {
+                    Label("Cancel Download", systemImage: "xmark.circle")
+                }
+            } label: {
+                progressLabel(fraction: record?.progressFraction ?? 0, paused: true)
+            }
+            .accessibilityLabel("Download paused")
+
         case .registering, .preparing, .queued, .fetchingAssets:
             Menu {
-                Button(role: .destructive, action: cancel) {
+                Button(role: .destructive) { confirmingCancel = true } label: {
                     Label("Cancel Download", systemImage: "xmark.circle")
                 }
             } label: {
@@ -80,8 +224,14 @@ struct DownloadActionButton: View {
 
         case .failed:
             Menu {
-                Button { showOptions = true } label: {
-                    Label("Retry With Options", systemImage: "arrow.clockwise")
+                if style == .regular {
+                    Button { showOptions = true } label: {
+                        Label("Retry With Options", systemImage: "arrow.clockwise")
+                    }
+                } else {
+                    Button(action: retry) {
+                        Label("Try Again", systemImage: "arrow.clockwise")
+                    }
                 }
                 Button(role: .destructive, action: delete) {
                     Label("Remove", systemImage: "trash")
@@ -95,33 +245,103 @@ struct DownloadActionButton: View {
 
     // MARK: - Actions
 
+    /// One-tap entry: start immediately with defaults unless the size that
+    /// would land on disk (max of the Auto range, or the exact size of the
+    /// selected version) warrants confirming first.
+    private func handleDownloadTap() {
+        let estimate = versions.isEmpty
+            ? DownloadSizeEstimate.estimate(fileSizes: candidateFileSizes)
+            : DownloadSizeEstimate.estimate(versions: versions, fileId: selectedVersionFileId)
+        let available = DownloadFilePaths.deviceStorage().available
+        if let warning = estimate?.warningMessage(availableBytes: available) {
+            largeDownloadWarning = warning
+            return
+        }
+        startWithDefaults()
+    }
+
+    /// The version picked on the detail screen (Auto when none — matching
+    /// what the options sheet preselects) + the global Downloads quality
+    /// preference, clamped to what the server currently offers.
+    private func startWithDefaults() {
+        startDownload(DownloadRequestOptions(
+            fileId: selectedVersionFileId,
+            quality: DownloadSettings.shared.resolvedFormat(
+                allowedFormats: manager.capability?.qualityPresets ?? []
+            )
+        ))
+    }
+
+    /// One-tap gives no sheet dismissal to mark the moment, so pair a
+    /// success haptic with a short-lived caption above the button. The
+    /// compact style keeps only the haptic — its state flip to the spinner
+    /// is visible feedback, and a caption would clip against neighboring
+    /// cards in the rail.
+    private func announceStart() {
+        startFeedbackCount += 1
+        showNotice("Download started")
+    }
+
+    /// A registration that fails before a record exists (offline, 4xx)
+    /// surfaces nowhere in Downloads, so the failure must be announced here
+    /// or the tap silently evaporates.
+    private func announceStartFailure() {
+        failFeedbackCount += 1
+        showNotice("Couldn't start download")
+    }
+
+    private func showNotice(_ text: String) {
+        guard style == .regular else { return }
+        withAnimation(.easeOut(duration: 0.2)) { startNotice = text }
+        Task {
+            try? await Task.sleep(for: .seconds(2))
+            withAnimation(.easeIn(duration: 0.3)) { startNotice = nil }
+        }
+    }
+
     private func startDownload(_ options: DownloadRequestOptions) {
         Task {
             do {
-                if detail.type == "episode" {
+                if isEpisode {
                     try await manager.downloadEpisode(
-                        seriesId: detail.seriesId ?? detail.contentId,
-                        episodeId: detail.contentId,
-                        displayTitle: detail.title,
-                        displaySubtitle: episodeSubtitle,
-                        posterThumbhash: detail.posterThumbhash,
+                        seriesId: seriesId ?? contentId,
+                        episodeId: contentId,
+                        displayTitle: displayTitle,
+                        displaySubtitle: displaySubtitle,
+                        posterThumbhash: posterThumbhash,
                         fileId: options.fileId,
                         quality: options.quality
                     )
                 } else {
                     try await manager.downloadMovie(
-                        contentId: detail.contentId,
-                        displayTitle: detail.title,
-                        year: detail.year,
-                        posterThumbhash: detail.posterThumbhash,
+                        contentId: contentId,
+                        displayTitle: displayTitle,
+                        year: year,
+                        posterThumbhash: posterThumbhash,
                         fileId: options.fileId,
                         quality: options.quality
                     )
                 }
+                // Only announce once registration reached the server — a
+                // premature "started" over a failed create would be the
+                // last the user ever hears of this download.
+                announceStart()
             } catch {
-                // The record (if any) reflects failure; nothing else to do.
+                announceStartFailure()
             }
         }
+    }
+
+    private func pause() {
+        if let id = record?.id { manager.pauseDownload(id: id) }
+    }
+
+    private func resume() {
+        if let id = record?.id { manager.resumeDownload(id: id) }
+    }
+
+    private func retry() {
+        if let id = record?.id { manager.retryDownload(id: id) }
     }
 
     private func cancel() {
@@ -132,14 +352,61 @@ struct DownloadActionButton: View {
         if let id = record?.id { manager.deleteDownload(id: id) }
     }
 
-    private var episodeSubtitle: String? {
-        let season = detail.seasonNumber.map { "S\($0)" }
-        let episode = detail.episodeNumber.map { "E\($0)" }
+    /// States what a destructive cancel throws away; bytes are omitted when
+    /// nothing has transferred yet.
+    private var cancelPrompt: String {
+        if let bytes = record?.bytesDownloaded, bytes > 0 {
+            return "Discard \(DownloadFormatting.bytes(bytes)) of downloaded data?"
+        }
+        return "Cancel this download?"
+    }
+
+    private static func episodeSubtitle(
+        seasonNumber: Int?,
+        episodeNumber: Int?,
+        fallback: String?
+    ) -> String? {
+        let season = seasonNumber.map { "S\($0)" }
+        let episode = episodeNumber.map { "E\($0)" }
         let tag = [season, episode].compactMap { $0 }.joined(separator: " · ")
-        return tag.isEmpty ? detail.seriesTitle : tag
+        return tag.isEmpty ? fallback : tag
     }
 
     // MARK: - Labels
+
+    @ViewBuilder
+    private var noticeCaption: some View {
+        if let startNotice {
+            Text(startNotice)
+                .font(.continuumCaption)
+                .foregroundColor(.continuumOnSurface)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(.ultraThinMaterial, in: Capsule())
+                .fixedSize()
+                .offset(y: -36)
+                .transition(.opacity.combined(with: .move(edge: .bottom)))
+                .allowsHitTesting(false)
+        }
+    }
+
+    private var diameter: CGFloat {
+        style == .regular ? 44 : Self.compactDiameter
+    }
+
+    private var iconPointSize: CGFloat {
+        style == .regular ? 16 : 12
+    }
+
+    /// The regular style sits on the detail hero's dark scrim, so a white
+    /// wash reads; the compact style sits directly on episode stills and
+    /// needs a darker fill for contrast on bright frames.
+    private func circleFill(active: Bool) -> Color {
+        switch style {
+        case .regular: return Color.white.opacity(active ? 0.18 : 0.10)
+        case .compact: return Color.black.opacity(active ? 0.65 : 0.55)
+        }
+    }
 
     private func circleLabel(
         icon: String,
@@ -149,7 +416,7 @@ struct DownloadActionButton: View {
     ) -> some View {
         ZStack {
             Circle()
-                .fill(Color.white.opacity(active ? 0.18 : 0.10))
+                .fill(circleFill(active: active))
                 .overlay(
                     Circle().stroke(Color.white.opacity(active ? 0.55 : 0.25), lineWidth: 1)
                 )
@@ -159,29 +426,32 @@ struct DownloadActionButton: View {
                     .tint(.white)
             } else {
                 Image(systemName: icon)
-                    .font(.system(size: 16, weight: .semibold))
+                    .font(.system(size: iconPointSize, weight: .semibold))
                     .foregroundColor(tint)
                     .contentTransition(.symbolEffect(.replace.magic(fallback: .replace)))
             }
         }
-        .frame(width: 44, height: 44)
+        .frame(width: diameter, height: diameter)
     }
 
-    private func progressLabel(fraction: Double) -> some View {
+    private func progressLabel(fraction: Double, paused: Bool) -> some View {
         ZStack {
             Circle()
-                .fill(Color.white.opacity(0.10))
+                .fill(circleFill(active: false))
                 .overlay(Circle().stroke(Color.white.opacity(0.25), lineWidth: 1))
             Circle()
                 .trim(from: 0, to: max(0.02, fraction))
-                .stroke(Color.white, style: StrokeStyle(lineWidth: 2.5, lineCap: .round))
+                .stroke(
+                    Color.white.opacity(paused ? 0.55 : 1),
+                    style: StrokeStyle(lineWidth: style == .regular ? 2.5 : 2, lineCap: .round)
+                )
                 .rotationEffect(.degrees(-90))
-                .padding(4)
-            Image(systemName: "stop.fill")
-                .font(.system(size: 10, weight: .bold))
+                .padding(style == .regular ? 4 : 3)
+            Image(systemName: paused ? "play.fill" : "pause.fill")
+                .font(.system(size: style == .regular ? 10 : 8, weight: .bold))
                 .foregroundColor(.white)
         }
-        .frame(width: 44, height: 44)
+        .frame(width: diameter, height: diameter)
     }
 }
 #endif

--- a/iosApp/iosApp/Downloads/DownloadActivityAttributes.swift
+++ b/iosApp/iosApp/Downloads/DownloadActivityAttributes.swift
@@ -1,0 +1,46 @@
+// os(iOS) rather than canImport: the macOS SDK ships ActivityKit but marks
+// its API unavailable, so the import alone doesn't gate compilation.
+#if os(iOS)
+import ActivityKit
+import Foundation
+
+/// Content schema for the downloads Live Activity, shared between the app
+/// (which starts/updates the activity) and the SiloDownloadsActivity widget
+/// extension (which renders it on the lock screen and in the Dynamic
+/// Island). One activity summarizes the whole active queue rather than one
+/// per item — iOS caps concurrent Live Activities per app, and a queue
+/// summary reads better than N competing cards.
+struct DownloadActivityAttributes: ActivityAttributes {
+    struct ContentState: Codable, Hashable {
+        enum Phase: String, Codable, Hashable {
+            /// At least one transfer (or asset fetch) is running.
+            case downloading
+            /// Every active record is user-paused.
+            case paused
+            /// Registered/preparing/queued only — nothing moving yet.
+            case preparing
+            /// Terminal state used for the linger-after-finish content.
+            case completed
+        }
+
+        var phase: Phase
+        /// Headline: the transferring item's title, or a queue summary.
+        var title: String
+        /// Secondary line, e.g. "Severance · S1 · E4".
+        var subtitle: String?
+        /// Item-weighted overall progress across the queue (0…1); completed
+        /// items count as 1 so the bar never moves backwards when a new
+        /// episode joins mid-queue.
+        var fraction: Double
+        /// Aggregate transfer bytes across active records with known sizes.
+        var bytesDownloaded: Int64
+        var bytesExpected: Int64
+        /// "2 of 5" numbers: items finished since the activity started and
+        /// the total it is tracking.
+        var completedCount: Int
+        var totalCount: Int
+        /// Smoothed aggregate rate; nil when nothing is transferring.
+        var bytesPerSecond: Double?
+    }
+}
+#endif

--- a/iosApp/iosApp/Downloads/DownloadBackgroundRefresh.swift
+++ b/iosApp/iosApp/Downloads/DownloadBackgroundRefresh.swift
@@ -61,6 +61,13 @@ enum DownloadBackgroundRefresh {
         // crash mid-sync doesn't drop the schedule.
         schedule()
         let work = Task { @MainActor in
+            // A cold BGTaskScheduler launch lands here before
+            // ContentView.checkInitialState() has pointed TokenStore at the
+            // active registry server, and the sync authenticates through
+            // it. Idempotent on every later call.
+            if let serverId = ServerRegistry.shared.activeServerId, !serverId.isEmpty {
+                await TokenStore.shared.retargetActiveServer(serverId: serverId)
+            }
             // Same capability-gated path as a foreground activation:
             // activate scope → refresh capability → reconcile →
             // monitoring/progress sync (which also kicks the pipeline).

--- a/iosApp/iosApp/Downloads/DownloadBackgroundRefresh.swift
+++ b/iosApp/iosApp/Downloads/DownloadBackgroundRefresh.swift
@@ -1,0 +1,78 @@
+#if os(iOS)
+import BackgroundTasks
+import Foundation
+import OSLog
+
+/// Schedules and services the app-refresh task that keeps series monitoring
+/// alive while the app is backgrounded. Media transfers already ride the
+/// background `URLSession` on their own; this task exists only to run the
+/// subscription/progress sync and kick the pipeline for anything it
+/// registered — without it, "auto-download new episodes" would only happen
+/// when the user opens the app.
+enum DownloadBackgroundRefresh {
+    /// Must stay listed in `BGTaskSchedulerPermittedIdentifiers`
+    /// (iosApp/Info.plist); the scheduler rejects submissions for
+    /// identifiers outside that allowlist.
+    static let taskIdentifier = "com.continuum.play.downloads-refresh"
+
+    /// A floor, not a promise — iOS picks the real cadence from usage
+    /// patterns. Hours-scale matches the monitoring feature: new episodes
+    /// land on a release schedule, not minute-by-minute.
+    private static let earliestInterval: TimeInterval = 4 * 60 * 60
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.continuum.app",
+        category: "Downloads"
+    )
+
+    /// Must run before `didFinishLaunching` returns — the system traps if a
+    /// task it launched the app for has no registered handler.
+    static func register() {
+        BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: taskIdentifier,
+            using: nil
+        ) { task in
+            guard let refresh = task as? BGAppRefreshTask else {
+                task.setTaskCompleted(success: false)
+                return
+            }
+            handle(refresh)
+        }
+    }
+
+    /// Submit (or re-submit) the next refresh. Safe to call on every
+    /// background transition — a pending request with the same identifier is
+    /// replaced, not stacked.
+    static func schedule() {
+        let request = BGAppRefreshTaskRequest(identifier: taskIdentifier)
+        request.earliestBeginDate = Date(timeIntervalSinceNow: earliestInterval)
+        do {
+            try BGTaskScheduler.shared.submit(request)
+        } catch {
+            // Expected on the simulator (BGTaskScheduler is unavailable)
+            // and when the user disabled Background App Refresh; the
+            // foreground sync path still covers both.
+            logger.debug("BG refresh submit failed: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    private static func handle(_ task: BGAppRefreshTask) {
+        // Chain the next wake before doing any work so an expiration or
+        // crash mid-sync doesn't drop the schedule.
+        schedule()
+        let work = Task { @MainActor in
+            // Same capability-gated path as a foreground activation:
+            // activate scope → refresh capability → reconcile →
+            // monitoring/progress sync (which also kicks the pipeline).
+            await DownloadManager.shared.onAppActive()
+            task.setTaskCompleted(success: !Task.isCancelled)
+        }
+        task.expirationHandler = {
+            // Abandon cleanly: the sync's HTTP calls are async URLSession
+            // requests, so cancellation propagates and the task above
+            // finishes fast, reporting `success: false` via the flag.
+            work.cancel()
+        }
+    }
+}
+#endif

--- a/iosApp/iosApp/Downloads/DownloadFilePaths.swift
+++ b/iosApp/iosApp/Downloads/DownloadFilePaths.swift
@@ -1,0 +1,163 @@
+import Foundation
+import OSLog
+
+/// On-disk layout for offline downloads. Everything lives under
+/// Application Support (NOT Caches — the OS purges Caches under storage
+/// pressure and downloaded media must survive that). Paths are scoped by
+/// `(serverId, profileId)` so a profile or server switch is just a
+/// different directory tree with no migration.
+///
+/// ```
+/// <AppSupport>/SiloDownloads/<serverId>/<profileId>/
+///   store.json
+///   <downloadId>/
+///     media.<ext>
+///     manifest.json
+///     poster.jpg | backdrop.jpg | logo.png
+///     sub_<n>.<ext>
+/// ```
+///
+/// `DownloadRecord` stores **relative filenames** (e.g. `media.mp4`), not
+/// absolute URLs, because the iOS app-container path can change between
+/// launches. Absolute URLs are rebuilt here against the current container.
+enum DownloadFilePaths {
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.continuum.app",
+        category: "Downloads"
+    )
+
+    private static let rootFolderName = "SiloDownloads"
+    static let storeFileName = "store.json"
+
+    /// `<AppSupport>/SiloDownloads`, created on first use and excluded from
+    /// iCloud/iTunes backup (downloads are large and not re-uploadable).
+    static func rootDirectory() -> URL {
+        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        let root = base.appendingPathComponent(rootFolderName, isDirectory: true)
+        ensureDirectory(root, excludeFromBackup: true)
+        return root
+    }
+
+    static func scopeDirectory(serverId: String, profileId: String) -> URL {
+        let dir = rootDirectory()
+            .appendingPathComponent(sanitize(serverId), isDirectory: true)
+            .appendingPathComponent(sanitize(profileId), isDirectory: true)
+        ensureDirectory(dir)
+        return dir
+    }
+
+    static func storeFileURL(serverId: String, profileId: String) -> URL {
+        scopeDirectory(serverId: serverId, profileId: profileId)
+            .appendingPathComponent(storeFileName, isDirectory: false)
+    }
+
+    /// Staging area where the background session delegate parks a finished
+    /// download's temp file (which is only valid during the delegate
+    /// callback) before the manager resolves its record and moves it to the
+    /// final per-download directory. Keyed by task identifier.
+    static func stagingFileURL(taskIdentifier: Int) -> URL {
+        let dir = rootDirectory().appendingPathComponent("staging", isDirectory: true)
+        ensureDirectory(dir, excludeFromBackup: true)
+        return dir.appendingPathComponent("task-\(taskIdentifier).bin", isDirectory: false)
+    }
+
+    static func downloadDirectory(serverId: String, profileId: String, downloadId: String) -> URL {
+        let dir = scopeDirectory(serverId: serverId, profileId: profileId)
+            .appendingPathComponent(sanitize(downloadId), isDirectory: true)
+        ensureDirectory(dir)
+        return dir
+    }
+
+    /// Absolute URL for a relative filename stored on a `DownloadRecord`.
+    static func fileURL(
+        serverId: String,
+        profileId: String,
+        downloadId: String,
+        filename: String
+    ) -> URL {
+        downloadDirectory(serverId: serverId, profileId: profileId, downloadId: downloadId)
+            .appendingPathComponent(filename, isDirectory: false)
+    }
+
+    /// Delete every on-disk asset for one download (media, manifest,
+    /// artwork, subtitles). The JSON store record is removed separately.
+    static func removeDownloadDirectory(serverId: String, profileId: String, downloadId: String) {
+        let dir = scopeDirectory(serverId: serverId, profileId: profileId)
+            .appendingPathComponent(sanitize(downloadId), isDirectory: true)
+        try? FileManager.default.removeItem(at: dir)
+    }
+
+    /// Total bytes used by all download assets in a scope.
+    static func bytesUsed(serverId: String, profileId: String) -> Int64 {
+        let dir = scopeDirectory(serverId: serverId, profileId: profileId)
+        guard let enumerator = FileManager.default.enumerator(
+            at: dir,
+            includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey]
+        ) else { return 0 }
+        var total: Int64 = 0
+        for case let url as URL in enumerator {
+            let values = try? url.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
+            if values?.isRegularFile == true, let size = values?.fileSize {
+                total += Int64(size)
+            }
+        }
+        return total
+    }
+
+    /// Total and available bytes on the device volume, for the storage hero
+    /// "X of Y on this iPhone" context. Best-effort; zero when unavailable.
+    struct DeviceStorage: Sendable {
+        let total: Int64
+        let available: Int64
+    }
+
+    static func deviceStorage() -> DeviceStorage {
+#if os(tvOS)
+        DeviceStorage(total: 0, available: 0)
+#else
+        let url = URL(fileURLWithPath: NSHomeDirectory())
+        let values = try? url.resourceValues(forKeys: [
+            .volumeTotalCapacityKey,
+            .volumeAvailableCapacityForImportantUsageKey,
+        ])
+        return DeviceStorage(
+            total: Int64(values?.volumeTotalCapacity ?? 0),
+            available: values?.volumeAvailableCapacityForImportantUsage ?? 0
+        )
+#endif
+    }
+
+    // MARK: - Helpers
+
+    private static func ensureDirectory(_ url: URL, excludeFromBackup: Bool = false) {
+        let fm = FileManager.default
+        if !fm.fileExists(atPath: url.path) {
+            do {
+                try fm.createDirectory(at: url, withIntermediateDirectories: true)
+            } catch {
+                logger.error("Failed to create download dir \(url.path, privacy: .public): \(String(describing: error), privacy: .public)")
+            }
+        }
+        if excludeFromBackup {
+            var mutable = url
+            var values = URLResourceValues()
+            values.isExcludedFromBackup = true
+            try? mutable.setResourceValues(values)
+        }
+    }
+
+    /// Strip path separators from id components used as directory names.
+    /// Server IDs are base64url (already filesystem-safe) and profile IDs
+    /// are UUIDs, but defend against anything unexpected.
+    private static func sanitize(_ component: String) -> String {
+        let allowed = component.unicodeScalars.map { scalar -> Character in
+            let c = Character(scalar)
+            if c.isLetter || c.isNumber || c == "-" || c == "_" || c == "." {
+                return c
+            }
+            return "_"
+        }
+        let result = String(allowed)
+        return result.isEmpty ? "_" : result
+    }
+}

--- a/iosApp/iosApp/Downloads/DownloadFilePaths.swift
+++ b/iosApp/iosApp/Downloads/DownloadFilePaths.swift
@@ -158,6 +158,10 @@ enum DownloadFilePaths {
             return "_"
         }
         let result = String(allowed)
-        return result.isEmpty ? "_" : result
+        // "." and ".." survive the character filter but traverse out of the
+        // scope directory when used as a path component — never let a
+        // dot-only value through.
+        if result.isEmpty || result.allSatisfy({ $0 == "." }) { return "_" }
+        return result
     }
 }

--- a/iosApp/iosApp/Downloads/DownloadGrouping.swift
+++ b/iosApp/iosApp/Downloads/DownloadGrouping.swift
@@ -44,11 +44,16 @@ struct DownloadSeriesGroup: Identifiable, Hashable, Sendable {
 struct DownloadStorageBreakdown: Hashable, Sendable {
     let series: Int64
     let movies: Int64
-    /// Artwork, manifests, subtitles, and in-flight partials — the
-    /// remainder of true on-disk usage beyond completed media.
+    /// Bytes transferred so far by in-flight downloads. Tracked from the
+    /// records' progress rather than disk usage — partial media sits in the
+    /// session's staging area, invisible to the on-disk walk — so mid-flight
+    /// usage shows up here instead of vanishing (or bucketing as "Other").
+    let inProgress: Int64
+    /// Artwork, manifests, subtitles — the remainder of true on-disk usage
+    /// beyond completed media.
     let other: Int64
 
-    var total: Int64 { series + movies + other }
+    var total: Int64 { series + movies + inProgress + other }
 }
 
 /// A single row in the Manager list: either a whole series (collapsed to

--- a/iosApp/iosApp/Downloads/DownloadGrouping.swift
+++ b/iosApp/iosApp/Downloads/DownloadGrouping.swift
@@ -1,0 +1,204 @@
+import Foundation
+
+/// Presentation models for the redesigned Downloads screen. These are
+/// derived synchronously from the flat `[DownloadRecord]` registry by
+/// `DownloadManager` (see its "Grouped surface" section) so SwiftUI bodies
+/// never group/aggregate inline.
+
+/// One season's worth of downloaded leaves within a series.
+struct DownloadSeasonGroup: Identifiable, Hashable, Sendable {
+    /// Season number; `0` (or negative) represents Specials.
+    let seasonNumber: Int
+    /// Completed/revoked episode records, sorted by episode number.
+    let records: [DownloadRecord]
+    let totalBytes: Int64
+    let watchedCount: Int
+
+    var id: Int { seasonNumber }
+    var episodeCount: Int { records.count }
+    var isSpecials: Bool { seasonNumber <= 0 }
+    var allWatched: Bool { !records.isEmpty && watchedCount == records.count }
+}
+
+/// All downloaded episodes for one series, grouped by season.
+struct DownloadSeriesGroup: Identifiable, Hashable, Sendable {
+    let seriesId: String
+    let title: String
+    let posterThumbhash: String?
+    /// Seasons newest-first, Specials last.
+    let seasons: [DownloadSeasonGroup]
+    let totalBytes: Int64
+    let episodeCount: Int
+    let watchedCount: Int
+    let isMonitored: Bool
+    /// Newest registration in the group — drives "recently added" sort.
+    let latestRegisteredAt: Date
+
+    var id: String { seriesId }
+    var seasonCount: Int { seasons.count }
+    var allRecords: [DownloadRecord] { seasons.flatMap(\.records) }
+    var allWatched: Bool { episodeCount > 0 && watchedCount == episodeCount }
+}
+
+/// Storage split for the Downloads storage hero bar.
+struct DownloadStorageBreakdown: Hashable, Sendable {
+    let series: Int64
+    let movies: Int64
+    /// Artwork, manifests, subtitles, and in-flight partials — the
+    /// remainder of true on-disk usage beyond completed media.
+    let other: Int64
+
+    var total: Int64 { series + movies + other }
+}
+
+/// A single row in the Manager list: either a whole series (collapsed to
+/// one expandable card) or a standalone movie.
+enum DownloadListItem: Identifiable, Hashable {
+    case series(DownloadSeriesGroup)
+    case movie(DownloadRecord)
+
+    var id: String {
+        switch self {
+        case .series(let group): return "series:" + group.seriesId
+        case .movie(let record): return "movie:" + record.id
+        }
+    }
+
+    var totalBytes: Int64 {
+        switch self {
+        case .series(let group): return group.totalBytes
+        case .movie(let record): return record.fileSize
+        }
+    }
+
+    var latestRegisteredAt: Date {
+        switch self {
+        case .series(let group): return group.latestRegisteredAt
+        case .movie(let record): return record.registeredAt
+        }
+    }
+
+    var sortTitle: String {
+        switch self {
+        case .series(let group): return group.title
+        case .movie(let record): return record.title ?? record.contentId
+        }
+    }
+
+    /// All download ids this row represents (a series contributes every
+    /// episode id) — used by batch delete and select-mode tallies.
+    var downloadIds: [String] {
+        switch self {
+        case .series(let group): return group.allRecords.map(\.id)
+        case .movie(let record): return [record.id]
+        }
+    }
+}
+
+/// Pure grouping/sorting for the Downloads Manager. Kept free of
+/// `DownloadManager` state (watched/title/monitored are injected as
+/// closures) so the ordering rules are unit-testable in isolation.
+enum DownloadGroupBuilder {
+    /// Group episode records (those with a `seriesId`) into per-series,
+    /// per-season cards. Records without a `seriesId` (movies) are ignored.
+    static func seriesGroups(
+        from records: [DownloadRecord],
+        isWatched: (DownloadRecord) -> Bool,
+        seriesTitle: (String) -> String?,
+        isMonitored: (String) -> Bool
+    ) -> [DownloadSeriesGroup] {
+        let episodes = records.filter { $0.seriesId != nil }
+        return Dictionary(grouping: episodes) { $0.seriesId! }
+            .map { seriesId, recs in
+                makeSeriesGroup(
+                    seriesId: seriesId,
+                    records: recs,
+                    isWatched: isWatched,
+                    seriesTitle: seriesTitle(seriesId),
+                    isMonitored: isMonitored(seriesId)
+                )
+            }
+    }
+
+    static func makeSeriesGroup(
+        seriesId: String,
+        records: [DownloadRecord],
+        isWatched: (DownloadRecord) -> Bool,
+        seriesTitle: String?,
+        isMonitored: Bool
+    ) -> DownloadSeriesGroup {
+        let seasons = Dictionary(grouping: records) { $0.seasonNumber ?? 0 }
+            .map { season, recs -> DownloadSeasonGroup in
+                let sorted = recs.sorted { ($0.episodeNumber ?? 0) < ($1.episodeNumber ?? 0) }
+                return DownloadSeasonGroup(
+                    seasonNumber: season,
+                    records: sorted,
+                    totalBytes: sorted.reduce(0) { $0 + $1.fileSize },
+                    watchedCount: sorted.filter(isWatched).count
+                )
+            }
+            .sorted { lhs, rhs in
+                // Real seasons newest-first; Specials (<= 0) always last.
+                if (lhs.seasonNumber <= 0) != (rhs.seasonNumber <= 0) {
+                    return rhs.seasonNumber <= 0
+                }
+                return lhs.seasonNumber > rhs.seasonNumber
+            }
+
+        let title = records.compactMap(\.seriesTitle).first
+            ?? seriesTitle
+            ?? records.first?.title
+            ?? seriesId
+
+        return DownloadSeriesGroup(
+            seriesId: seriesId,
+            title: title,
+            posterThumbhash: records.compactMap(\.posterThumbhash).first,
+            seasons: seasons,
+            totalBytes: records.reduce(0) { $0 + $1.fileSize },
+            episodeCount: records.count,
+            watchedCount: records.filter(isWatched).count,
+            isMonitored: isMonitored,
+            latestRegisteredAt: records.map(\.registeredAt).max() ?? .distantPast
+        )
+    }
+
+    /// Order the unified list of series groups + movies.
+    static func sorted(_ items: [DownloadListItem], by option: DownloadSortOption) -> [DownloadListItem] {
+        items.sorted { lhs, rhs in
+            switch option {
+            case .largestFirst:
+                return lhs.totalBytes > rhs.totalBytes
+            case .recentlyAdded:
+                return lhs.latestRegisteredAt > rhs.latestRegisteredAt
+            case .alphabetical:
+                return lhs.sortTitle.localizedCaseInsensitiveCompare(rhs.sortTitle) == .orderedAscending
+            }
+        }
+    }
+}
+
+/// How the Downloads Manager list is ordered. Persisted in `DownloadSettings`.
+enum DownloadSortOption: String, CaseIterable, Identifiable, Sendable {
+    case largestFirst
+    case recentlyAdded
+    case alphabetical
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .largestFirst: return "Largest first"
+        case .recentlyAdded: return "Recently added"
+        case .alphabetical: return "Name (A–Z)"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .largestFirst: return "arrow.down.to.line"
+        case .recentlyAdded: return "clock"
+        case .alphabetical: return "textformat"
+        }
+    }
+}

--- a/iosApp/iosApp/Downloads/DownloadLiveActivity.swift
+++ b/iosApp/iosApp/Downloads/DownloadLiveActivity.swift
@@ -1,0 +1,211 @@
+#if os(iOS)
+import ActivityKit
+import Foundation
+
+/// Owns the single downloads Live Activity: starts it when the queue gains
+/// its first active record, updates it as `DownloadManager` publishes
+/// progress, and ends it when the queue drains.
+///
+/// Fed exclusively from `DownloadManager.file`'s `didSet`, so every state
+/// mutation flows through here; identical content states are deduped before
+/// touching ActivityKit, and the manager's 1s progress-publish cadence
+/// already keeps update frequency readable.
+///
+/// Known limitation, by design: transfers run on a background `URLSession`,
+/// whose progress callbacks stop once iOS suspends the app. The content is
+/// stamped with a short `staleDate` so the widget can switch to a
+/// "Continuing in background…" treatment instead of freezing a live-looking
+/// bar; the completion relaunch then ends the activity with a final state.
+@MainActor
+final class DownloadLiveActivityController {
+    static let shared = DownloadLiveActivityController()
+    private init() {}
+
+    private var activity: Activity<DownloadActivityAttributes>?
+    private var adoptedExisting = false
+    /// Every record id seen active while the current activity has been live.
+    /// Intersected with the completed set each sync to produce the
+    /// "2 of 5" numerator — the store itself has no notion of "finished
+    /// during this batch".
+    private var trackedActiveIds: Set<String> = []
+    private var sessionCompletedIds: Set<String> = []
+    private var lastState: DownloadActivityAttributes.ContentState?
+    /// Serializes ActivityKit calls so a burst of syncs can't land updates
+    /// out of order (mirror of `DownloadManager.saveChain`).
+    private var activityChain: Task<Void, Never>?
+
+    /// How long after the last update the widget may treat the content as
+    /// current. Progress publishes every ~1s while the app runs, so blowing
+    /// past this means the app was suspended mid-transfer.
+    private static let staleInterval: TimeInterval = 90
+    /// How long the final "complete" card lingers on the lock screen.
+    private static let completedLinger: TimeInterval = 240
+
+    func sync(
+        activeRecords: [DownloadRecord],
+        completedRecordIds: Set<String>,
+        totalBytesPerSecond: Double
+    ) {
+        adoptExistingActivityIfNeeded()
+        sessionCompletedIds.formUnion(trackedActiveIds.intersection(completedRecordIds))
+        trackedActiveIds.formUnion(activeRecords.map(\.id))
+
+        guard !activeRecords.isEmpty else {
+            finishActivity()
+            return
+        }
+        let state = makeState(activeRecords: activeRecords, totalBytesPerSecond: totalBytesPerSecond)
+        guard state != lastState else { return }
+        if let activity {
+            lastState = state
+            queueUpdate(activity, state: state)
+        } else {
+            startActivity(state)
+        }
+    }
+
+    // MARK: - Lifecycle
+
+    private func startActivity(_ state: DownloadActivityAttributes.ContentState) {
+        // Don't resurrect an activity at launch for a queue that's entirely
+        // user-paused — a days-old paused download shouldn't repopulate the
+        // lock screen every time the app opens. An already-live activity
+        // still updates into the paused state normally.
+        guard state.phase != .paused else { return }
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
+        // Requesting throws when the app isn't foreground — e.g. a
+        // monitored-series download kicked off by a background refresh.
+        // Silent by design: the next foreground sync starts it.
+        activity = try? Activity.request(
+            attributes: DownloadActivityAttributes(),
+            content: ActivityContent(state: state, staleDate: Date().addingTimeInterval(Self.staleInterval))
+        )
+        if activity != nil { lastState = state }
+    }
+
+    private func queueUpdate(
+        _ activity: Activity<DownloadActivityAttributes>,
+        state: DownloadActivityAttributes.ContentState
+    ) {
+        let previous = activityChain
+        activityChain = Task {
+            await previous?.value
+            await activity.update(
+                ActivityContent(state: state, staleDate: Date().addingTimeInterval(Self.staleInterval))
+            )
+        }
+    }
+
+    private func finishActivity() {
+        let completedCount = sessionCompletedIds.count
+        sessionCompletedIds.removeAll()
+        trackedActiveIds.removeAll()
+        lastState = nil
+        guard let activity else { return }
+        self.activity = nil
+        let previous = activityChain
+        activityChain = Task {
+            await previous?.value
+            if completedCount > 0 {
+                let state = DownloadActivityAttributes.ContentState(
+                    phase: .completed,
+                    title: completedCount == 1
+                        ? "Download complete"
+                        : "\(completedCount) downloads complete",
+                    subtitle: nil,
+                    fraction: 1,
+                    bytesDownloaded: 0,
+                    bytesExpected: 0,
+                    completedCount: completedCount,
+                    totalCount: completedCount,
+                    bytesPerSecond: nil
+                )
+                await activity.end(
+                    ActivityContent(state: state, staleDate: nil),
+                    dismissalPolicy: .after(Date().addingTimeInterval(Self.completedLinger))
+                )
+            } else {
+                // The queue drained without finishing anything (cancelled,
+                // failed, signed out) — nothing worth lingering for.
+                await activity.end(nil, dismissalPolicy: .immediate)
+            }
+        }
+    }
+
+    /// A relaunch can find the previous run's activity still on the lock
+    /// screen. Adopt it instead of stacking a duplicate; fold any extras
+    /// (there should only ever be one).
+    private func adoptExistingActivityIfNeeded() {
+        guard !adoptedExisting else { return }
+        adoptedExisting = true
+        let existing = Activity<DownloadActivityAttributes>.activities
+        guard !existing.isEmpty else { return }
+        activity = existing.first
+        for extra in existing.dropFirst() {
+            Task { await extra.end(nil, dismissalPolicy: .immediate) }
+        }
+    }
+
+    // MARK: - State
+
+    private func makeState(
+        activeRecords: [DownloadRecord],
+        totalBytesPerSecond: Double
+    ) -> DownloadActivityAttributes.ContentState {
+        // `activeRecords` arrives newest-first; headline the transfer the
+        // user has been waiting on longest.
+        let headline = activeRecords.reversed().first {
+            $0.localStatus == .downloading || $0.localStatus == .fetchingAssets
+        } ?? activeRecords.last
+
+        let completedCount = sessionCompletedIds.count
+        let totalCount = completedCount + activeRecords.count
+        let fractionSum = activeRecords.reduce(0.0) { $0 + $1.progressFraction }
+        let fraction = totalCount > 0
+            ? min(1, (Double(completedCount) + fractionSum) / Double(totalCount))
+            : 0
+
+        let sized = activeRecords.filter { $0.fileSize > 0 }
+        let bytesDownloaded = sized.reduce(Int64(0)) { $0 + min($1.bytesDownloaded, $1.fileSize) }
+        let bytesExpected = sized.reduce(Int64(0)) { $0 + $1.fileSize }
+
+        let phase: DownloadActivityAttributes.ContentState.Phase
+        if activeRecords.contains(where: {
+            $0.localStatus == .downloading || $0.localStatus == .fetchingAssets
+        }) {
+            phase = .downloading
+        } else if activeRecords.allSatisfy({ $0.localStatus == .paused }) {
+            phase = .paused
+        } else {
+            phase = .preparing
+        }
+
+        let title = headline?.title
+            ?? headline?.seriesTitle
+            ?? (activeRecords.count == 1 ? "Download" : "\(activeRecords.count) downloads")
+        var subtitleParts: [String] = []
+        if let headline {
+            if let series = headline.seriesTitle, series != title {
+                subtitleParts.append(series)
+            }
+            if let sub = headline.subtitle {
+                subtitleParts.append(sub)
+            }
+        }
+
+        return DownloadActivityAttributes.ContentState(
+            phase: phase,
+            title: title,
+            subtitle: subtitleParts.isEmpty ? nil : subtitleParts.joined(separator: " · "),
+            fraction: fraction,
+            bytesDownloaded: bytesDownloaded,
+            bytesExpected: bytesExpected,
+            completedCount: completedCount,
+            totalCount: totalCount,
+            bytesPerSecond: phase == .downloading && totalBytesPerSecond > 0
+                ? totalBytesPerSecond
+                : nil
+        )
+    }
+}
+#endif

--- a/iosApp/iosApp/Downloads/DownloadManager.swift
+++ b/iosApp/iosApp/Downloads/DownloadManager.swift
@@ -39,7 +39,13 @@ final class DownloadManager {
 
     /// In-memory persisted blob. `private(set)` so the `@Observable` macro
     /// tracks reads of its derived accessors below.
-    private(set) var file: DownloadStoreFile = .empty
+    private(set) var file: DownloadStoreFile = .empty {
+        didSet {
+            rebuildDownloadedIndex()
+            let enabled = file.capability?.isUsable == true
+            if enabled != downloadsEnabled { downloadsEnabled = enabled }
+        }
+    }
 
     private(set) var scopeServerId: String = ""
     private(set) var scopeProfileId: String = ""
@@ -48,12 +54,37 @@ final class DownloadManager {
     private var intentionalCancels: Set<Int> = []
     private var pollTask: Task<Void, Never>?
     private var lastProgressPersist = Date.distantPast
+    /// Session events that arrive before the first scope activation loads the
+    /// persisted registry (a background relaunch replays buffered delegate
+    /// events the moment the session is recreated). Handling them against an
+    /// empty registry would discard finished media as unmatched, so they are
+    /// held here and replayed by `releaseHeldSessionEvents()`.
+    private var pendingSessionEvents: [DownloadSessionEvent] = []
+    private var sessionEventsHeld = true
+    /// In-flight back-off timers keyed by record id, tracked so a foreground
+    /// reconcile doesn't re-queue a record that already has a scheduled
+    /// restart (double-starting the transfer) and so pause/delete can abort
+    /// the timer instead of leaving it to fire against a dead record.
+    private var retryTasks: [String: Task<Void, Never>] = [:]
+    /// Records whose pause is still waiting on the resume-data capture
+    /// round-trip. A resume tapped inside that window is deferred to
+    /// `finishPause` (via `pendingResumeIds`) so the captured data isn't
+    /// dropped and the transfer restarted from byte zero.
+    private var pendingPauseIds: Set<String> = []
+    private var pendingResumeIds: Set<String> = []
     /// Serializes disk saves so a rapid burst of `persist()` calls can't land
     /// out of order and overwrite a newer snapshot with an older one.
     private var saveChain: Task<Void, Never>?
     /// Cached scope storage usage; refreshed off the MainActor (a filesystem
     /// walk) so SwiftUI bodies reading `totalBytesUsed` don't block.
     private(set) var storageBytesUsed: Int64 = 0
+    /// Smoothed transfer rate (bytes/sec) per downloading record, derived
+    /// from progress deltas so the UI never needs its own timer competing
+    /// with the `@Observable` update path.
+    private(set) var transferRates: [String: Double] = [:]
+    private var rateSamples: [String: (bytes: Int64, at: Date)] = [:]
+    private static let rateSampleInterval: TimeInterval = 0.5
+    private static let rateSmoothing = 0.3
 
     private init() {
         // Drain background-session events for the lifetime of the app.
@@ -68,7 +99,11 @@ final class DownloadManager {
     // MARK: - Observable surface
 
     var capability: DownloadCapability? { file.capability }
-    var downloadsEnabled: Bool { capability?.isUsable == true }
+    /// Stored mirror of `capability?.isUsable`, maintained by `file`'s
+    /// `didSet`, so hot per-card checks (`isDownloaded`) never register the
+    /// whole `file` blob — reassigned on every transfer progress tick — as
+    /// their observed state.
+    private(set) var downloadsEnabled: Bool = false
     var canDownloadSeason: Bool { downloadsEnabled && capability?.seasonDownload == true }
     var canMonitorSeries: Bool { downloadsEnabled && capability?.seriesMonitoring == true }
 
@@ -92,6 +127,36 @@ final class DownloadManager {
     var totalBytesUsed: Int64 { storageBytesUsed }
 
     // MARK: - Lookups
+
+    /// Leaf content ids (movie `contentId` / episode `episodeId`) whose media
+    /// is on disk. Cached separately from `records` because poster cards check
+    /// membership per card render — and only republished when membership
+    /// actually changes, so in-flight progress ticks (which also mutate `file`)
+    /// don't invalidate every visible card.
+    private(set) var downloadedContentIds: Set<String> = []
+
+    /// Single capability-aware check for the card badges: true only when the
+    /// server still advertises downloads for this profile *and* the item's
+    /// media is on device, so badges vanish alongside every other download
+    /// affordance on servers without the capability. Membership is checked
+    /// first so the (overwhelmingly common) non-downloaded card never touches
+    /// the capability flag at all.
+    func isDownloaded(contentId: String) -> Bool {
+        downloadedContentIds.contains(contentId) && downloadsEnabled
+    }
+
+    private func rebuildDownloadedIndex() {
+        // Revoked downloads keep their on-device file (playable offline),
+        // so they badge the same as completed ones.
+        let ids = Set(
+            file.records.values
+                .filter { $0.localStatus == .completed || $0.localStatus == .revoked }
+                .map { $0.episodeId ?? $0.contentId }
+        )
+        if ids != downloadedContentIds {
+            downloadedContentIds = ids
+        }
+    }
 
     /// The download record for a leaf content id (movie or episode), if any.
     func record(forContentId contentId: String) -> DownloadRecord? {
@@ -126,6 +191,17 @@ final class DownloadManager {
 
     func localProgress(forMediaItemId mediaItemId: String) -> LocalProgressEntry? {
         file.localProgress[mediaItemId]
+    }
+
+    /// On-disk poster image for a record — present once the asset pipeline
+    /// has fetched artwork, which runs before the media transfer starts, so
+    /// in-progress rows can show real art rather than a placeholder.
+    func posterImageURL(for record: DownloadRecord) -> URL? {
+        record.posterFilename.flatMap { absoluteFileURL(for: record, filename: $0) }
+    }
+
+    func transferRate(id: String) -> Double? {
+        transferRates[id]
     }
 
     /// Decode the on-disk offline manifest for a completed download. The file
@@ -179,8 +255,10 @@ final class DownloadManager {
     }
 
     /// Storage split for the hero bar: series vs movies (summed from record
-    /// sizes), plus an "other" remainder (artwork/manifests/subtitles/
-    /// in-flight) derived from the true on-disk total.
+    /// sizes), in-flight transfer bytes (from active records' progress —
+    /// invisible to the on-disk walk while the media sits in the session's
+    /// staging area), plus an "other" remainder (artwork/manifests/
+    /// subtitles) derived from the true on-disk total.
     var storageBreakdown: DownloadStorageBreakdown {
         var series: Int64 = 0
         var movies: Int64 = 0
@@ -188,8 +266,16 @@ final class DownloadManager {
             if record.seriesId == nil { movies += record.fileSize }
             else { series += record.fileSize }
         }
+        let inProgress = records.reduce(Int64(0)) {
+            $0 + ($1.localStatus.isActive ? $1.bytesDownloaded : 0)
+        }
         let other = max(0, storageBytesUsed - series - movies)
-        return DownloadStorageBreakdown(series: series, movies: movies, other: other)
+        return DownloadStorageBreakdown(
+            series: series,
+            movies: movies,
+            inProgress: inProgress,
+            other: other
+        )
     }
 
     /// Total bytes downloaded for one series across all seasons.
@@ -217,7 +303,10 @@ final class DownloadManager {
                 intentionalCancels.insert(taskId)
                 sessionDelegate.cancel(taskId: taskId)
             }
+            retryTasks[id]?.cancel()
+            retryTasks[id] = nil
             file.records.removeValue(forKey: id)
+            clearTransferRate(recordId: id)
             if !scopeServerId.isEmpty {
                 DownloadFilePaths.removeDownloadDirectory(
                     serverId: scopeServerId,
@@ -271,14 +360,17 @@ final class DownloadManager {
         let profileId = await TokenStore.shared.getProfileId() ?? ""
         guard !serverId.isEmpty, !profileId.isEmpty else {
             deactivate()
+            releaseHeldSessionEvents()
             return false
         }
         if serverId == scopeServerId, profileId == scopeProfileId, !file.records.isEmpty || file.capability != nil {
+            releaseHeldSessionEvents()
             return true
         }
         scopeServerId = serverId
         scopeProfileId = profileId
         file = await DownloadStore.shared.load(serverId: serverId, profileId: profileId)
+        releaseHeldSessionEvents()
         refreshStorageUsage()
         await backfillEpisodeMetadataIfNeeded()
         return true
@@ -311,9 +403,15 @@ final class DownloadManager {
     private func deactivate() {
         pollTask?.cancel()
         pollTask = nil
+        for task in retryTasks.values { task.cancel() }
+        retryTasks.removeAll()
+        pendingPauseIds.removeAll()
+        pendingResumeIds.removeAll()
         scopeServerId = ""
         scopeProfileId = ""
         file = .empty
+        rateSamples.removeAll()
+        transferRates.removeAll()
     }
 
     private func cancelActiveTasks() {
@@ -469,7 +567,10 @@ final class DownloadManager {
             intentionalCancels.insert(taskId)
             sessionDelegate.cancel(taskId: taskId)
         }
+        retryTasks[id]?.cancel()
+        retryTasks[id] = nil
         file.records.removeValue(forKey: id)
+        clearTransferRate(recordId: id)
         persist()
         if !scopeServerId.isEmpty {
             DownloadFilePaths.removeDownloadDirectory(
@@ -487,6 +588,83 @@ final class DownloadManager {
         if let record = record(forContentId: contentId) {
             deleteDownload(id: record.id)
         }
+    }
+
+    /// Suspend an in-flight media transfer. The status flips to `.paused`
+    /// synchronously (so the UI responds on the tap) and the resume data is
+    /// captured asynchronously — the task identifier stays on the record
+    /// until then so a transfer that finishes during the race still
+    /// completes normally instead of being discarded.
+    func pauseDownload(id: String) {
+        guard var record = file.records[id], record.localStatus == .downloading else { return }
+        guard let taskId = record.taskIdentifier else {
+            // No live task: the record is waiting out a retry back-off.
+            // Abort the timer and park the record so the pause control isn't
+            // dead during the window; resume re-queues from scratch.
+            retryTasks[id]?.cancel()
+            retryTasks[id] = nil
+            record.localStatus = .paused
+            file.records[id] = record
+            clearTransferRate(recordId: id)
+            persist()
+            processQueue()
+            return
+        }
+        intentionalCancels.insert(taskId)
+        pendingPauseIds.insert(id)
+        record.localStatus = .paused
+        file.records[id] = record
+        clearTransferRate(recordId: id)
+        persist()
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let data = await self.sessionDelegate.pause(taskId: taskId)
+            self.finishPause(recordId: id, resumeData: data)
+        }
+        processQueue()
+    }
+
+    /// Continue a paused transfer. Routed through the queue so resumes honor
+    /// the concurrency cap — `processQueue` starts the record from its
+    /// captured resume data when present, falling back to a full restart
+    /// (same server registration, byte zero) when the data is missing,
+    /// unreadable, or was never produced.
+    func resumeDownload(id: String) {
+        guard var record = file.records[id], record.localStatus == .paused else { return }
+        // The pause's resume-data capture is still in flight — flag the
+        // intent and let `finishPause` re-queue with the data instead of
+        // discarding the partial transfer.
+        if pendingPauseIds.contains(id) {
+            pendingResumeIds.insert(id)
+            return
+        }
+        record.localStatus = .queued
+        file.records[id] = record
+        persist()
+        processQueue()
+    }
+
+    /// Lands after `pause(taskId:)` resolves. Guarded on `.paused` because
+    /// the transfer may have finished (or the record been deleted) during
+    /// the cancel round-trip — clobbering the newer state would orphan it.
+    /// A resume requested mid-round-trip re-queues here, once the captured
+    /// data is on disk, rather than restarting from byte zero.
+    private func finishPause(recordId: String, resumeData: Data?) {
+        pendingPauseIds.remove(recordId)
+        let resumeRequested = pendingResumeIds.remove(recordId) != nil
+        guard var record = file.records[recordId], record.localStatus == .paused else { return }
+        record.taskIdentifier = nil
+        if let resumeData,
+           let url = absoluteFileURLForNewAsset(recordId: recordId, filename: "resume.bin") {
+            try? resumeData.write(to: url, options: .atomic)
+            record.resumeDataFilename = "resume.bin"
+        }
+        if resumeRequested {
+            record.localStatus = .queued
+        }
+        file.records[recordId] = record
+        persist()
+        if resumeRequested { processQueue() }
     }
 
     func retryDownload(id: String) {
@@ -517,9 +695,32 @@ final class DownloadManager {
             // the same record before its async pipeline flips the status.
             guard !exceedsStorageCap(for: record) else { continue }
             slots -= 1
-            setLocalStatus(.fetchingAssets, id: record.id)
-            Task { await self.startMediaPipeline(recordId: record.id) }
+            startQueuedRecord(record)
         }
+    }
+
+    /// Start one queued record, preferring its captured resume data (a
+    /// paused transfer) so completed byte ranges aren't refetched; missing
+    /// or unreadable data falls back to the full pipeline restart.
+    private func startQueuedRecord(_ record: DownloadRecord) {
+        var record = record
+        if let filename = record.resumeDataFilename,
+           let url = absoluteFileURL(for: record, filename: filename) {
+            let resumeData = try? Data(contentsOf: url)
+            try? FileManager.default.removeItem(at: url)
+            record.resumeDataFilename = nil
+            if let resumeData {
+                record.taskIdentifier = sessionDelegate.resume(data: resumeData)
+                record.localStatus = .downloading
+                file.records[record.id] = record
+                persist()
+                return
+            }
+            record.bytesDownloaded = 0
+            file.records[record.id] = record
+        }
+        setLocalStatus(.fetchingAssets, id: record.id)
+        Task { await self.startMediaPipeline(recordId: record.id) }
     }
 
     private func startMediaPipeline(recordId: String) async {
@@ -681,18 +882,41 @@ final class DownloadManager {
         }
         file.records[recordId] = record
         persist()
+        if record.localStatus == .failed {
+            notifyTerminalFailure(record)
+        }
         processQueue()
+    }
+
+    /// Notify only for transfer/pipeline failures the user would otherwise
+    /// discover much later. Reconcile-driven failures (rows revoked or
+    /// removed server-side) stay silent — they can arrive in bulk during a
+    /// sync and the Downloads screen already surfaces them.
+    private func notifyTerminalFailure(_ record: DownloadRecord) {
+        #if os(iOS)
+        DownloadNotifier.downloadFailed(record)
+        #endif
     }
 
     // MARK: - Background session events
 
     private func handleSessionEvent(_ event: DownloadSessionEvent) {
+        // Hold events until the first scope activation has loaded the
+        // persisted registry — on a cold (background) relaunch the recreated
+        // session replays its buffered events immediately, and matching them
+        // against a not-yet-loaded registry would delete finished media as
+        // orphaned and re-download it from scratch.
+        guard !sessionEventsHeld else {
+            pendingSessionEvents.append(event)
+            return
+        }
         switch event {
         case let .progress(taskId, written, total):
             guard var record = recordByTask(taskId) else { return }
             record.bytesDownloaded = written
             if total > 0 { record.fileSize = total }
             file.records[record.id] = record
+            updateTransferRate(recordId: record.id, bytes: written)
             persistProgressThrottled()
 
         case let .finished(taskId, stagedURL, _):
@@ -707,12 +931,24 @@ final class DownloadManager {
         }
     }
 
+    /// Replay events held during launch, in arrival order, now that the
+    /// registry reflects the active scope (or the lack of one — orphan
+    /// cleanup is then correct rather than premature).
+    private func releaseHeldSessionEvents() {
+        guard sessionEventsHeld else { return }
+        sessionEventsHeld = false
+        while !pendingSessionEvents.isEmpty {
+            handleSessionEvent(pendingSessionEvents.removeFirst())
+        }
+    }
+
     private func handleMediaFinished(taskId: Int, stagedURL: URL) {
         intentionalCancels.remove(taskId)
         guard var record = recordByTask(taskId) else {
             try? FileManager.default.removeItem(at: stagedURL)
             return
         }
+        clearTransferRate(recordId: record.id)
         let ext = mediaExtension(for: record)
         let filename = "media.\(ext)"
         guard let destination = absoluteFileURLForNewAsset(recordId: record.id, filename: filename) else {
@@ -743,6 +979,9 @@ final class DownloadManager {
         record.bytesDownloaded = record.fileSize
         file.records[record.id] = record
         persist()
+        #if os(iOS)
+        DownloadNotifier.downloadCompleted(record)
+        #endif
         let id = record.id
         Task { try? await ContinuumAPI.shared.patchDownloadStatus(id: id, status: "completed") }
         processQueue()
@@ -754,6 +993,7 @@ final class DownloadManager {
         if intentionalCancels.remove(taskId) != nil { return }
         guard var record = recordByTask(taskId) else { return }
         record.taskIdentifier = nil
+        clearTransferRate(recordId: record.id)
 
         if let statusCode {
             switch statusCode {
@@ -769,6 +1009,7 @@ final class DownloadManager {
                 record.lastError = statusCode == 404 ? "not_found" : "forbidden"
                 file.records[record.id] = record
                 persist()
+                notifyTerminalFailure(record)
                 processQueue()
                 return
             case 401:
@@ -789,6 +1030,7 @@ final class DownloadManager {
             record.lastError = message
             file.records[record.id] = record
             persist()
+            notifyTerminalFailure(record)
             processQueue()
         }
     }
@@ -796,10 +1038,18 @@ final class DownloadManager {
     private func scheduleRetry(recordId: String, resumeData: Data?, refreshToken: Bool) {
         let attempt = file.records[recordId]?.retryCount ?? 1
         let delaySeconds = min(120, Int(pow(2.0, Double(attempt))) * 5)
-        Task { @MainActor [weak self] in
+        retryTasks[recordId]?.cancel()
+        retryTasks[recordId] = Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: UInt64(delaySeconds) * 1_000_000_000)
-            guard let self, !self.scopeServerId.isEmpty else { return }
-            guard let record = self.file.records[recordId], record.localStatus != .completed else { return }
+            guard !Task.isCancelled, let self, !self.scopeServerId.isEmpty else { return }
+            self.retryTasks[recordId] = nil
+            // Fire only while the record still looks like the failure this
+            // retry was scheduled for — a pause, delete, revoke, or re-queue
+            // that landed during the back-off owns the record now, and
+            // restarting on top of it would run two transfers of one file.
+            guard let record = self.file.records[recordId],
+                  record.taskIdentifier == nil,
+                  record.localStatus == .downloading || record.localStatus == .fetchingAssets else { return }
             if refreshToken {
                 // Force HTTPClient's single-flight 401 refresh so the next
                 // background request carries a fresh token.
@@ -898,11 +1148,31 @@ final class DownloadManager {
     /// task is no longer live.
     private func reconnectActiveTasks() async {
         let active = await sessionDelegate.activeTaskIdentifiers()
-        // `.fetchingAssets` records were mid-pipeline in a detached Task that
-        // did not survive the relaunch; re-queue them too so they aren't
-        // wedged (and don't keep occupying a concurrency slot forever).
-        for (id, record) in file.records
-        where record.localStatus == .downloading || record.localStatus == .fetchingAssets {
+        for (id, record) in file.records {
+            var record = record
+            // Task identifiers are only unique within one URLSession
+            // instance — a recreated session hands the same small integers
+            // to new tasks, so a persisted id with no live task must be
+            // dropped before it can match (and misroute) another record's
+            // transfer. Pause round-trips keep theirs: the cancelled task
+            // may still deliver a final event that must find this record.
+            if let taskId = record.taskIdentifier,
+               !active.contains(taskId),
+               !pendingPauseIds.contains(id) {
+                record.taskIdentifier = nil
+                file.records[id] = record
+            }
+            // Records with a live back-off timer are owned by the retry;
+            // re-queuing them here would double-start the transfer when it
+            // fires.
+            guard retryTasks[id] == nil else { continue }
+            guard record.localStatus == .downloading || record.localStatus == .fetchingAssets else {
+                continue
+            }
+            // `.fetchingAssets` records were mid-pipeline in a detached Task
+            // that did not survive the relaunch; re-queue them too so they
+            // aren't wedged (and don't keep occupying a concurrency slot
+            // forever).
             if record.localStatus == .downloading,
                let taskId = record.taskIdentifier, active.contains(taskId) {
                 continue
@@ -963,16 +1233,40 @@ final class DownloadManager {
     }
 
     /// Subscription sync + offline progress reconciliation, run on
-    /// foreground. Client-driven: no server background worker.
+    /// foreground and from the background refresh task. Client-driven: no
+    /// server background worker.
     func runMonitoringAndProgressSync() async {
         guard downloadsEnabled else { return }
+        var priorRecordIds: Set<String> = []
+        var registered = 0
         if !file.subscriptions.isEmpty {
-            _ = try? await ContinuumAPI.shared.syncSubscriptions()
+            priorRecordIds = Set(file.records.keys)
+            registered = (try? await ContinuumAPI.shared.syncSubscriptions()) ?? 0
         }
         await flushProgressQueue()
         await pullProgressDeltas()
         await reconcileWithServer(triggerPipeline: true)
+        notifyMonitoringBatch(registered: registered, priorRecordIds: priorRecordIds)
         await enforceRetention()
+    }
+
+    /// One notification per sync batch when monitoring registered new
+    /// episodes. The rows land locally via the reconcile that just ran; a
+    /// fresh episode row's `contentId` is the series id (episode
+    /// registrations are keyed by series), which is how the batch resolves
+    /// the show name for the copy before the manifest hydrates `seriesId`.
+    private func notifyMonitoringBatch(registered: Int, priorRecordIds: Set<String>) {
+        #if os(iOS)
+        guard registered > 0 else { return }
+        let newEpisodes = file.records.values.filter {
+            !priorRecordIds.contains($0.id) && $0.episodeId != nil
+        }
+        guard !newEpisodes.isEmpty else { return }
+        let titles = Set(newEpisodes.compactMap {
+            subscription(forSeriesId: $0.seriesId ?? $0.contentId)?.seriesTitle
+        })
+        DownloadNotifier.newEpisodesQueued(count: newEpisodes.count, seriesTitles: titles)
+        #endif
     }
 
     /// Client-enforced `delete_watched`: remove completed downloads whose
@@ -1027,7 +1321,8 @@ final class DownloadManager {
 
     func flushProgressQueue() async {
         guard !file.progressQueue.isEmpty else { return }
-        let items = file.progressQueue.map {
+        let batch = file.progressQueue
+        let items = batch.map {
             SyncProgressItem(
                 mediaItemId: $0.mediaItemId,
                 position: $0.position,
@@ -1036,18 +1331,21 @@ final class DownloadManager {
                 updatedAt: $0.updatedAt
             )
         }
-        let sentIds = Set(items.map { $0.mediaItemId })
         do {
             let results = try await ContinuumAPI.shared.syncProgressBatch(items: items)
-            let okIds = Set(results.filter { $0.isOK }.map { $0.mediaItemId })
-            // Only touch items that were part of this batch — items enqueued
-            // while the POST was in flight keep their full retry budget.
+            let okItemIds = Set(results.filter { $0.isOK }.map { $0.mediaItemId })
+            // Match queue entries by identity, not media item — an entry
+            // appended while the POST was in flight carries a newer position
+            // the server never saw, so it must survive this batch with its
+            // full retry budget.
+            let sentEntryIds = Set(batch.map { $0.id })
+            let okEntryIds = Set(batch.filter { okItemIds.contains($0.mediaItemId) }.map { $0.id })
             file.progressQueue.removeAll {
-                okIds.contains($0.mediaItemId)
-                    || ($0.attempts >= Self.maxRetries && sentIds.contains($0.mediaItemId))
+                okEntryIds.contains($0.id)
+                    || ($0.attempts >= Self.maxRetries && sentEntryIds.contains($0.id))
             }
             for index in file.progressQueue.indices
-            where sentIds.contains(file.progressQueue[index].mediaItemId) {
+            where sentEntryIds.contains(file.progressQueue[index].id) {
                 file.progressQueue[index].attempts += 1
             }
             persist()
@@ -1155,6 +1453,7 @@ final class DownloadManager {
         record.backdropFilename = nil
         record.logoFilename = nil
         record.subtitleFilenames = [:]
+        record.resumeDataFilename = nil
         record.container = nil
         record.stableIdentity = nil
         record.bytesDownloaded = 0
@@ -1325,5 +1624,39 @@ final class DownloadManager {
     private func persistProgressThrottled() {
         guard Date().timeIntervalSince(lastProgressPersist) > 2 else { return }
         persist()
+    }
+
+    // MARK: - Transfer rate
+
+    /// Exponentially-smoothed rate from progress deltas. Samples at least
+    /// `rateSampleInterval` apart so the burst-y delegate callbacks don't
+    /// produce jittery instantaneous rates.
+    private func updateTransferRate(recordId: String, bytes: Int64) {
+        let now = Date()
+        guard let sample = rateSamples[recordId] else {
+            rateSamples[recordId] = (bytes, now)
+            return
+        }
+        let elapsed = now.timeIntervalSince(sample.at)
+        guard elapsed >= Self.rateSampleInterval else { return }
+        // Resume-data restarts can report fewer bytes than the last sample;
+        // reset the window instead of publishing a negative rate.
+        guard bytes >= sample.bytes else {
+            rateSamples[recordId] = (bytes, now)
+            transferRates.removeValue(forKey: recordId)
+            return
+        }
+        let instant = Double(bytes - sample.bytes) / elapsed
+        if let previous = transferRates[recordId] {
+            transferRates[recordId] = previous + Self.rateSmoothing * (instant - previous)
+        } else {
+            transferRates[recordId] = instant
+        }
+        rateSamples[recordId] = (bytes, now)
+    }
+
+    private func clearTransferRate(recordId: String) {
+        rateSamples.removeValue(forKey: recordId)
+        transferRates.removeValue(forKey: recordId)
     }
 }

--- a/iosApp/iosApp/Downloads/DownloadManager.swift
+++ b/iosApp/iosApp/Downloads/DownloadManager.swift
@@ -44,6 +44,7 @@ final class DownloadManager {
             rebuildDownloadedIndex()
             let enabled = file.capability?.isUsable == true
             if enabled != downloadsEnabled { downloadsEnabled = enabled }
+            syncLiveActivity()
         }
     }
 
@@ -886,6 +887,26 @@ final class DownloadManager {
             notifyTerminalFailure(record)
         }
         processQueue()
+    }
+
+    /// Mirror the active queue into the lock-screen Live Activity. Hooked
+    /// into `file`'s `didSet` so every mutation flows through — including
+    /// scope deactivation (empty blob ends the activity). The controller
+    /// dedupes identical content states, so burst mutations (reconcile
+    /// loops, pipeline steps) cost a snapshot build and nothing more.
+    private func syncLiveActivity() {
+        #if os(iOS)
+        let completedIds = Set(
+            file.records.values
+                .filter { $0.localStatus == .completed }
+                .map(\.id)
+        )
+        DownloadLiveActivityController.shared.sync(
+            activeRecords: activeRecords,
+            completedRecordIds: completedIds,
+            totalBytesPerSecond: transferRates.values.reduce(0, +)
+        )
+        #endif
     }
 
     /// Notify only for transfer/pipeline failures the user would otherwise

--- a/iosApp/iosApp/Downloads/DownloadManager.swift
+++ b/iosApp/iosApp/Downloads/DownloadManager.swift
@@ -1,0 +1,1329 @@
+import Foundation
+import OSLog
+
+enum DownloadError: LocalizedError {
+    case unavailable
+    case fileURLUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .unavailable: return "Downloads aren't available for this profile."
+        case .fileURLUnavailable: return "Could not resolve the download URL."
+        }
+    }
+}
+
+/// Coordinates the offline-downloads feature: capability gating, the local
+/// registry, the background transfer pipeline, series-monitoring sync, and
+/// offline progress reconciliation.
+///
+/// Concurrency model (the chosen hybrid): this is a single `@MainActor`
+/// `@Observable` coordinator the UI reads directly, with all disk I/O
+/// delegated to the `DownloadStore` actor and all media transfers to the
+/// `DownloadSessionDelegate`'s background `URLSession`. The in-memory
+/// `file` blob is the source of truth; every mutation persists through the
+/// store actor.
+@Observable
+@MainActor
+final class DownloadManager {
+    static let shared = DownloadManager()
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.continuum.app",
+        category: "Downloads"
+    )
+
+    private static let maxConcurrentTransfers = 3
+    private static let maxRetries = 4
+    private static let capabilityTTL: TimeInterval = 86_400
+
+    /// In-memory persisted blob. `private(set)` so the `@Observable` macro
+    /// tracks reads of its derived accessors below.
+    private(set) var file: DownloadStoreFile = .empty
+
+    private(set) var scopeServerId: String = ""
+    private(set) var scopeProfileId: String = ""
+
+    private let sessionDelegate = DownloadSessionDelegate()
+    private var intentionalCancels: Set<Int> = []
+    private var pollTask: Task<Void, Never>?
+    private var lastProgressPersist = Date.distantPast
+    /// Serializes disk saves so a rapid burst of `persist()` calls can't land
+    /// out of order and overwrite a newer snapshot with an older one.
+    private var saveChain: Task<Void, Never>?
+    /// Cached scope storage usage; refreshed off the MainActor (a filesystem
+    /// walk) so SwiftUI bodies reading `totalBytesUsed` don't block.
+    private(set) var storageBytesUsed: Int64 = 0
+
+    private init() {
+        // Drain background-session events for the lifetime of the app.
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            for await event in self.sessionDelegate.events {
+                self.handleSessionEvent(event)
+            }
+        }
+    }
+
+    // MARK: - Observable surface
+
+    var capability: DownloadCapability? { file.capability }
+    var downloadsEnabled: Bool { capability?.isUsable == true }
+    var canDownloadSeason: Bool { downloadsEnabled && capability?.seasonDownload == true }
+    var canMonitorSeries: Bool { downloadsEnabled && capability?.seriesMonitoring == true }
+
+    var availableFormats: [DownloadFormat] {
+        (capability?.qualityPresets ?? []).compactMap(DownloadFormat.init(rawValue:))
+    }
+
+    var monitoringModes: [SubscriptionMode] {
+        (capability?.monitoringModes ?? []).compactMap(SubscriptionMode.init(rawValue:))
+    }
+
+    /// All records, newest first.
+    var records: [DownloadRecord] {
+        file.records.values.sorted { $0.registeredAt > $1.registeredAt }
+    }
+
+    var activeRecords: [DownloadRecord] { records.filter { $0.localStatus.isActive } }
+    var completedRecords: [DownloadRecord] { records.filter { !$0.localStatus.isActive } }
+    var subscriptions: [DownloadSubscription] { file.subscriptions }
+
+    var totalBytesUsed: Int64 { storageBytesUsed }
+
+    // MARK: - Lookups
+
+    /// The download record for a leaf content id (movie or episode), if any.
+    func record(forContentId contentId: String) -> DownloadRecord? {
+        file.records.values.first { $0.contentId == contentId || $0.episodeId == contentId }
+    }
+
+    func record(id: String) -> DownloadRecord? { file.records[id] }
+
+    func subscription(forSeriesId seriesId: String) -> DownloadSubscription? {
+        file.subscriptions.first { $0.seriesId == seriesId }
+    }
+
+    func absoluteMediaURL(for record: DownloadRecord) -> URL? {
+        guard let filename = record.mediaFilename, !scopeServerId.isEmpty else { return nil }
+        return DownloadFilePaths.fileURL(
+            serverId: scopeServerId,
+            profileId: scopeProfileId,
+            downloadId: record.id,
+            filename: filename
+        )
+    }
+
+    func absoluteFileURL(for record: DownloadRecord, filename: String) -> URL? {
+        guard !scopeServerId.isEmpty else { return nil }
+        return DownloadFilePaths.fileURL(
+            serverId: scopeServerId,
+            profileId: scopeProfileId,
+            downloadId: record.id,
+            filename: filename
+        )
+    }
+
+    func localProgress(forMediaItemId mediaItemId: String) -> LocalProgressEntry? {
+        file.localProgress[mediaItemId]
+    }
+
+    /// Decode the on-disk offline manifest for a completed download. The file
+    /// read + decode happens on the `DownloadStore` actor, off the MainActor.
+    func loadManifest(for record: DownloadRecord) async -> OfflineManifest? {
+        guard let filename = record.manifestFilename,
+              let url = absoluteFileURL(for: record, filename: filename) else {
+            return nil
+        }
+        return await DownloadStore.shared.loadManifest(at: url)
+    }
+
+    // MARK: - Grouped surface (Downloads redesign)
+
+    /// Whether this download's leaf item has been watched to completion —
+    /// drives the reclaim suggestion and the "watched" episode dimming.
+    func isWatched(_ record: DownloadRecord) -> Bool {
+        file.localProgress[record.leafMediaItemId]?.completed == true
+    }
+
+    /// Completed/revoked records that physically occupy storage and can be
+    /// browsed offline. Excludes failed and in-flight records.
+    var onDeviceRecords: [DownloadRecord] {
+        records.filter { $0.localStatus == .completed || $0.localStatus == .revoked }
+    }
+
+    /// Standalone downloaded movies (no parent series).
+    var movieRecords: [DownloadRecord] {
+        onDeviceRecords.filter { $0.seriesId == nil }
+    }
+
+    /// Downloaded episodes grouped by series, then season — the spine of the
+    /// redesigned Downloads list and the offline series-browse screen.
+    var seriesGroups: [DownloadSeriesGroup] {
+        DownloadGroupBuilder.seriesGroups(
+            from: onDeviceRecords,
+            isWatched: { isWatched($0) },
+            seriesTitle: { subscription(forSeriesId: $0)?.seriesTitle },
+            isMonitored: { subscription(forSeriesId: $0) != nil }
+        )
+    }
+
+    /// Records downloaded *and* watched to completion — the set the
+    /// "Free up space" suggestion offers to delete.
+    var reclaimableRecords: [DownloadRecord] {
+        onDeviceRecords.filter { $0.localStatus == .completed && isWatched($0) }
+    }
+
+    var reclaimableBytes: Int64 {
+        reclaimableRecords.reduce(0) { $0 + $1.fileSize }
+    }
+
+    /// Storage split for the hero bar: series vs movies (summed from record
+    /// sizes), plus an "other" remainder (artwork/manifests/subtitles/
+    /// in-flight) derived from the true on-disk total.
+    var storageBreakdown: DownloadStorageBreakdown {
+        var series: Int64 = 0
+        var movies: Int64 = 0
+        for record in onDeviceRecords {
+            if record.seriesId == nil { movies += record.fileSize }
+            else { series += record.fileSize }
+        }
+        let other = max(0, storageBytesUsed - series - movies)
+        return DownloadStorageBreakdown(series: series, movies: movies, other: other)
+    }
+
+    /// Total bytes downloaded for one series across all seasons.
+    func bytesForSeries(_ seriesId: String) -> Int64 {
+        onDeviceRecords
+            .filter { $0.seriesId == seriesId }
+            .reduce(0) { $0 + $1.fileSize }
+    }
+
+    /// The unified, sorted list the Manager renders: one entry per series
+    /// group and one per standalone movie.
+    func downloadListItems(sortedBy option: DownloadSortOption) -> [DownloadListItem] {
+        var items = seriesGroups.map(DownloadListItem.series)
+        items += movieRecords.map(DownloadListItem.movie)
+        return DownloadGroupBuilder.sorted(items, by: option)
+    }
+
+    /// Delete several downloads in one pass: one store write, one storage
+    /// recompute, and the server DELETEs fanned out in a single task.
+    func deleteDownloads(ids: [String]) {
+        var removed = false
+        for id in ids {
+            guard let record = file.records[id] else { continue }
+            if let taskId = record.taskIdentifier {
+                intentionalCancels.insert(taskId)
+                sessionDelegate.cancel(taskId: taskId)
+            }
+            file.records.removeValue(forKey: id)
+            if !scopeServerId.isEmpty {
+                DownloadFilePaths.removeDownloadDirectory(
+                    serverId: scopeServerId,
+                    profileId: scopeProfileId,
+                    downloadId: id
+                )
+            }
+            removed = true
+        }
+        guard removed else { return }
+        persist()
+        let serverIds = ids
+        Task {
+            for id in serverIds { try? await ContinuumAPI.shared.deleteDownloadRow(id: id) }
+        }
+        processQueue()
+        refreshStorageUsage()
+    }
+
+    /// One-time hydration of `seasonNumber`/`episodeNumber`/`seriesTitle` for
+    /// episode downloads created before those fields existed. A cheap no-op
+    /// once every record carries them.
+    private func backfillEpisodeMetadataIfNeeded() async {
+        let needing = file.records.values.filter {
+            $0.seriesId != nil
+                && $0.manifestFilename != nil
+                && ($0.seasonNumber == nil || $0.seriesTitle == nil)
+        }
+        guard !needing.isEmpty else { return }
+        var changed = false
+        for record in needing {
+            guard let manifest = await loadManifest(for: record),
+                  var current = file.records[record.id] else { continue }
+            if current.seasonNumber == nil { current.seasonNumber = manifest.seasonNumber }
+            if current.episodeNumber == nil { current.episodeNumber = manifest.episodeNumber }
+            if current.seriesTitle == nil { current.seriesTitle = manifest.seriesTitle }
+            file.records[record.id] = current
+            changed = true
+        }
+        if changed { persist() }
+    }
+
+    // MARK: - Lifecycle
+
+    /// Re-point the manager at the active `(server, profile)` scope,
+    /// loading that scope's persisted blob. Returns false when there is no
+    /// signed-in scope.
+    @discardableResult
+    func activateScopeIfNeeded() async -> Bool {
+        let serverId = ServerRegistry.shared.activeServerId ?? ""
+        let profileId = await TokenStore.shared.getProfileId() ?? ""
+        guard !serverId.isEmpty, !profileId.isEmpty else {
+            deactivate()
+            return false
+        }
+        if serverId == scopeServerId, profileId == scopeProfileId, !file.records.isEmpty || file.capability != nil {
+            return true
+        }
+        scopeServerId = serverId
+        scopeProfileId = profileId
+        file = await DownloadStore.shared.load(serverId: serverId, profileId: profileId)
+        refreshStorageUsage()
+        await backfillEpisodeMetadataIfNeeded()
+        return true
+    }
+
+    /// Called on app launch / foreground and on the first authenticated
+    /// transition. Refreshes capability, reconciles with the server, and
+    /// runs subscription + progress sync.
+    func onAppActive() async {
+        guard await activateScopeIfNeeded() else { return }
+        await refreshCapabilityIfStale()
+        guard downloadsEnabled else { return }
+        await reconcileWithServer(triggerPipeline: true)
+        await runMonitoringAndProgressSync()
+    }
+
+    /// Profile/server switched — load the new scope and refresh.
+    func onScopeChanged() async {
+        deactivate()
+        await onAppActive()
+    }
+
+    /// Sign-out: stop active transfers and drop in-memory state. On-disk
+    /// files are intentionally preserved (the user may sign back in).
+    func clearForSignOut() {
+        cancelActiveTasks()
+        deactivate()
+    }
+
+    private func deactivate() {
+        pollTask?.cancel()
+        pollTask = nil
+        scopeServerId = ""
+        scopeProfileId = ""
+        file = .empty
+    }
+
+    private func cancelActiveTasks() {
+        for record in file.records.values where record.localStatus == .downloading {
+            if let taskId = record.taskIdentifier {
+                intentionalCancels.insert(taskId)
+                sessionDelegate.cancel(taskId: taskId)
+            }
+        }
+    }
+
+    // MARK: - Background relaunch
+
+    /// Store the system completion handler delivered when iOS relaunches
+    /// the app to finish background events.
+    func setBackgroundCompletionHandler(_ handler: @escaping () -> Void) {
+        sessionDelegate.backgroundCompletionHandler = handler
+    }
+
+    // MARK: - Capability
+
+    func refreshCapability() async {
+        guard !scopeServerId.isEmpty else { return }
+        do {
+            let capability = try await ContinuumAPI.shared.downloadCapability()
+            file.capability = capability
+            file.capabilityFetchedAt = Date()
+            persist()
+        } catch {
+            Self.logger.debug("capability refresh failed: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    func refreshCapabilityIfStale() async {
+        let stale: Bool = {
+            guard let fetchedAt = file.capabilityFetchedAt else { return true }
+            return Date().timeIntervalSince(fetchedAt) > Self.capabilityTTL
+        }()
+        if file.capability == nil || stale {
+            await refreshCapability()
+        }
+    }
+
+    // MARK: - Public download actions
+
+    func downloadMovie(
+        contentId: String,
+        displayTitle: String?,
+        year: Int?,
+        posterThumbhash: String?,
+        fileId: Int? = nil,
+        quality: String? = nil
+    ) async throws {
+        try await requestDownload(
+            contentId: contentId,
+            fileId: fileId,
+            quality: quality,
+            type: "movie",
+            displayTitle: displayTitle,
+            displaySubtitle: year.map(String.init),
+            posterThumbhash: posterThumbhash
+        )
+    }
+
+    func downloadEpisode(
+        seriesId: String,
+        episodeId: String,
+        displayTitle: String?,
+        displaySubtitle: String?,
+        posterThumbhash: String?,
+        fileId: Int? = nil,
+        quality: String? = nil
+    ) async throws {
+        try await requestDownload(
+            contentId: seriesId,
+            episodeId: episodeId,
+            fileId: fileId,
+            quality: quality,
+            type: "episode",
+            seriesId: seriesId,
+            displayTitle: displayTitle,
+            displaySubtitle: displaySubtitle,
+            posterThumbhash: posterThumbhash
+        )
+    }
+
+    func downloadSeason(seriesId: String, seasonNumber: Int) async throws {
+        try await requestDownload(contentId: seriesId, series: true, seasonNumber: seasonNumber, seriesId: seriesId)
+    }
+
+    func downloadSeries(seriesId: String) async throws {
+        try await requestDownload(contentId: seriesId, series: true, seriesId: seriesId)
+    }
+
+    private func requestDownload(
+        contentId: String,
+        episodeId: String? = nil,
+        fileId: Int? = nil,
+        quality requestedQuality: String? = nil,
+        series: Bool = false,
+        seasonNumber: Int? = nil,
+        type: String? = nil,
+        seriesId: String? = nil,
+        displayTitle: String? = nil,
+        displaySubtitle: String? = nil,
+        posterThumbhash: String? = nil
+    ) async throws {
+        guard downloadsEnabled else { throw DownloadError.unavailable }
+
+        // Series/season batches are original-quality only per the server
+        // contract; single items may use any advertised public quality preset.
+        let isBatch = series || seasonNumber != nil
+        let quality = isBatch
+            ? DownloadFormat.original.rawValue
+            : resolvedDownloadQuality(requestedQuality)
+
+        let request = CreateDownloadRequest(
+            contentId: contentId,
+            episodeId: episodeId,
+            fileId: fileId,
+            quality: quality,
+            series: series ? true : nil,
+            seasonNumber: seasonNumber,
+            caps: DownloadCaps.current()
+        )
+        let rows = try await ContinuumAPI.shared.createDownload(request)
+        for row in rows {
+            upsertRow(
+                row,
+                displayTitle: rows.count == 1 ? displayTitle : nil,
+                displaySubtitle: rows.count == 1 ? displaySubtitle : nil,
+                type: type,
+                seriesId: seriesId,
+                posterThumbhash: rows.count == 1 ? posterThumbhash : nil
+            )
+        }
+        persist()
+        processQueue()
+        ensurePolling()
+    }
+
+    private func resolvedDownloadQuality(_ requestedQuality: String?) -> String {
+        let allowed = capability?.qualityPresets ?? []
+        if let requestedQuality, allowed.contains(requestedQuality) {
+            return requestedQuality
+        }
+        return DownloadSettings.shared.resolvedFormat(allowedFormats: allowed)
+    }
+
+    func deleteDownload(id: String) {
+        guard let record = file.records[id] else { return }
+        if let taskId = record.taskIdentifier {
+            intentionalCancels.insert(taskId)
+            sessionDelegate.cancel(taskId: taskId)
+        }
+        file.records.removeValue(forKey: id)
+        persist()
+        if !scopeServerId.isEmpty {
+            DownloadFilePaths.removeDownloadDirectory(
+                serverId: scopeServerId,
+                profileId: scopeProfileId,
+                downloadId: id
+            )
+        }
+        Task { try? await ContinuumAPI.shared.deleteDownloadRow(id: id) }
+        processQueue()
+        refreshStorageUsage()
+    }
+
+    func deleteDownload(forContentId contentId: String) {
+        if let record = record(forContentId: contentId) {
+            deleteDownload(id: record.id)
+        }
+    }
+
+    func retryDownload(id: String) {
+        guard var record = file.records[id], record.localStatus == .failed else { return }
+        record.localStatus = .queued
+        record.retryCount = 0
+        record.lastError = nil
+        file.records[id] = record
+        persist()
+        processQueue()
+    }
+
+    // MARK: - Pipeline
+
+    private func processQueue() {
+        let activeCount = file.records.values.filter {
+            $0.localStatus == .downloading || $0.localStatus == .fetchingAssets
+        }.count
+        var slots = max(0, Self.maxConcurrentTransfers - activeCount)
+        guard slots > 0 else { return }
+
+        let queued = file.records.values
+            .filter { $0.localStatus == .queued }
+            .sorted { $0.registeredAt < $1.registeredAt }
+
+        for record in queued where slots > 0 {
+            // Reserve the slot synchronously so a second pass doesn't pick
+            // the same record before its async pipeline flips the status.
+            guard !exceedsStorageCap(for: record) else { continue }
+            slots -= 1
+            setLocalStatus(.fetchingAssets, id: record.id)
+            Task { await self.startMediaPipeline(recordId: record.id) }
+        }
+    }
+
+    private func startMediaPipeline(recordId: String) async {
+        guard file.records[recordId] != nil else { return }
+        do {
+            let manifest = try await ContinuumAPI.shared.fetchManifest(downloadId: recordId)
+            await persistManifest(manifest, recordId: recordId)
+            applyManifestDisplay(manifest, recordId: recordId)
+            await fetchArtwork(manifest, recordId: recordId)
+            await fetchSubtitles(manifest, recordId: recordId)
+            await startMediaTransfer(recordId: recordId)
+        } catch {
+            handlePipelineError(error, recordId: recordId)
+        }
+    }
+
+    private func startMediaTransfer(recordId: String) async {
+        guard var record = file.records[recordId] else { return }
+        guard let fileURL = await ContinuumAPI.shared.downloadFileURL(downloadId: recordId) else {
+            handlePipelineError(DownloadError.fileURLUnavailable, recordId: recordId)
+            return
+        }
+        let request = await DownloadAuthHeaders.authorizedRequest(
+            url: fileURL,
+            allowsCellular: !DownloadSettings.shared.wifiOnly
+        )
+        let taskId = sessionDelegate.start(request: request)
+        record.taskIdentifier = taskId
+        record.localStatus = .downloading
+        file.records[recordId] = record
+        persist()
+        Task { try? await ContinuumAPI.shared.patchDownloadStatus(id: recordId, status: "downloading") }
+    }
+
+    private func persistManifest(_ manifest: OfflineManifest, recordId: String) async {
+        guard let url = absoluteFileURLForNewAsset(recordId: recordId, filename: "manifest.json") else { return }
+        await DownloadStore.shared.saveManifest(manifest, to: url)
+        if var record = file.records[recordId] {
+            record.manifestFilename = "manifest.json"
+            file.records[recordId] = record
+        }
+    }
+
+    private func applyManifestDisplay(_ manifest: OfflineManifest, recordId: String) {
+        guard var record = file.records[recordId] else { return }
+        record.title = record.title ?? manifest.title
+        record.type = manifest.type
+        record.format = manifest.quality
+        record.effectiveQuality = manifest.effectiveQuality
+        record.deliveryFormat = manifest.deliveryFormat
+        record.targetBitrateKbps = manifest.targetBitrateKbps
+        record.revision = manifest.revision ?? record.revision
+        record.mediaFileId = manifest.mediaFileId
+        record.container = manifest.container
+        record.posterThumbhash = record.posterThumbhash ?? manifest.posterThumbhash
+        record.stableIdentity = manifest.stableIdentity
+        if let seriesId = manifest.seriesId { record.seriesId = seriesId }
+        record.seriesTitle = record.seriesTitle ?? manifest.seriesTitle
+        record.seasonNumber = record.seasonNumber ?? manifest.seasonNumber
+        record.episodeNumber = record.episodeNumber ?? manifest.episodeNumber
+        if record.subtitle == nil {
+            if manifest.type == "episode" {
+                let season = manifest.seasonNumber.map { "S\($0)" }
+                let episode = manifest.episodeNumber.map { "E\($0)" }
+                record.subtitle = [season, episode].compactMap { $0 }.joined(separator: " · ")
+            } else if let year = manifest.year {
+                record.subtitle = String(year)
+            }
+        }
+        if record.fileSize <= 0, let size = manifest.fileSize { record.fileSize = size }
+        file.records[recordId] = record
+        persist()
+    }
+
+    private func fetchArtwork(_ manifest: OfflineManifest, recordId: String) async {
+        let kinds: [(kind: String, path: String?, filename: String)] = [
+            ("poster", manifest.artworkUrls?.poster, "poster.jpg"),
+            ("backdrop", manifest.artworkUrls?.backdrop, "backdrop.jpg"),
+            ("logo", manifest.artworkUrls?.logo, "logo.png"),
+        ]
+        for entry in kinds {
+            // Only fetch artwork the manifest actually advertises. The server
+            // omits artwork_urls.* (omitempty) when a title has no poster/
+            // backdrop/logo, so synthesizing a path here would guarantee a 404.
+            guard let path = entry.path else { continue }
+            guard let data = try? await ContinuumAPI.shared.fetchDownloadAssetData(path: path),
+                  !data.isEmpty,
+                  let url = absoluteFileURLForNewAsset(recordId: recordId, filename: entry.filename) else {
+                continue
+            }
+            try? data.write(to: url, options: .atomic)
+            guard var record = file.records[recordId] else { continue }
+            switch entry.kind {
+            case "poster": record.posterFilename = entry.filename
+            case "backdrop": record.backdropFilename = entry.filename
+            case "logo": record.logoFilename = entry.filename
+            default: break
+            }
+            file.records[recordId] = record
+        }
+        persist()
+    }
+
+    private func fetchSubtitles(_ manifest: OfflineManifest, recordId: String) async {
+        guard let subtitles = manifest.subtitles, !subtitles.isEmpty else { return }
+        for (index, subtitle) in subtitles.enumerated() {
+            let ext = (subtitle.format ?? "srt").lowercased()
+            let filename = "sub_\(index).\(ext)"
+            guard let data = try? await ContinuumAPI.shared.fetchDownloadAssetData(path: subtitle.fetchUrl),
+                  !data.isEmpty,
+                  let url = absoluteFileURLForNewAsset(recordId: recordId, filename: filename) else {
+                continue
+            }
+            try? data.write(to: url, options: .atomic)
+            guard var record = file.records[recordId] else { continue }
+            record.subtitleFilenames[subtitle.fetchUrl] = filename
+            file.records[recordId] = record
+        }
+        persist()
+    }
+
+    private func handlePipelineError(_ error: Error, recordId: String) {
+        guard var record = file.records[recordId] else { return }
+        record.taskIdentifier = nil
+        if case let HTTPError.http(statusCode, _) = error {
+            switch statusCode {
+            case 409:
+                record.localStatus = .revoked
+                record.serverStatus = "revoked"
+            case 404:
+                record.localStatus = .failed
+                record.lastError = "not_found"
+            case 403:
+                record.localStatus = .failed
+                record.lastError = "forbidden"
+            case 429, 500...599:
+                // Cap and back off pipeline retries (manifest/asset fetch),
+                // mirroring the media-transfer retry path; otherwise a
+                // persistent 429 would retry every 5s forever.
+                if record.retryCount < Self.maxRetries {
+                    record.retryCount += 1
+                    file.records[recordId] = record
+                    scheduleRetry(recordId: recordId, resumeData: nil, refreshToken: false)
+                } else {
+                    record.localStatus = .failed
+                    record.lastError = "http_\(statusCode)"
+                    file.records[recordId] = record
+                    persist()
+                    processQueue()
+                }
+                return
+            default:
+                record.localStatus = .failed
+                record.lastError = "http_\(statusCode)"
+            }
+        } else {
+            record.localStatus = .failed
+            record.lastError = error.localizedDescription
+        }
+        file.records[recordId] = record
+        persist()
+        processQueue()
+    }
+
+    // MARK: - Background session events
+
+    private func handleSessionEvent(_ event: DownloadSessionEvent) {
+        switch event {
+        case let .progress(taskId, written, total):
+            guard var record = recordByTask(taskId) else { return }
+            record.bytesDownloaded = written
+            if total > 0 { record.fileSize = total }
+            file.records[record.id] = record
+            persistProgressThrottled()
+
+        case let .finished(taskId, stagedURL, _):
+            handleMediaFinished(taskId: taskId, stagedURL: stagedURL)
+
+        case let .failed(taskId, statusCode, resumeData, message):
+            handleMediaFailure(taskId: taskId, statusCode: statusCode, resumeData: resumeData, message: message)
+
+        case .allEventsDelivered:
+            sessionDelegate.backgroundCompletionHandler?()
+            sessionDelegate.backgroundCompletionHandler = nil
+        }
+    }
+
+    private func handleMediaFinished(taskId: Int, stagedURL: URL) {
+        intentionalCancels.remove(taskId)
+        guard var record = recordByTask(taskId) else {
+            try? FileManager.default.removeItem(at: stagedURL)
+            return
+        }
+        let ext = mediaExtension(for: record)
+        let filename = "media.\(ext)"
+        guard let destination = absoluteFileURLForNewAsset(recordId: record.id, filename: filename) else {
+            try? FileManager.default.removeItem(at: stagedURL)
+            return
+        }
+        try? FileManager.default.removeItem(at: destination)
+        do {
+            try FileManager.default.moveItem(at: stagedURL, to: destination)
+        } catch {
+            Self.logger.error("Failed to move finished media for \(record.id, privacy: .public): \(String(describing: error), privacy: .public)")
+            record.localStatus = .failed
+            record.lastError = "move_failed"
+            record.taskIdentifier = nil
+            file.records[record.id] = record
+            persist()
+            processQueue()
+            return
+        }
+        record.mediaFilename = filename
+        record.localStatus = .completed
+        record.downloadedAt = Date()
+        record.taskIdentifier = nil
+        record.lastError = nil
+        if record.fileSize <= 0 {
+            record.fileSize = fileSizeOnDisk(destination)
+        }
+        record.bytesDownloaded = record.fileSize
+        file.records[record.id] = record
+        persist()
+        let id = record.id
+        Task { try? await ContinuumAPI.shared.patchDownloadStatus(id: id, status: "completed") }
+        processQueue()
+        refreshStorageUsage()
+        Task { await self.enforceRetention() }
+    }
+
+    private func handleMediaFailure(taskId: Int, statusCode: Int?, resumeData: Data?, message: String) {
+        if intentionalCancels.remove(taskId) != nil { return }
+        guard var record = recordByTask(taskId) else { return }
+        record.taskIdentifier = nil
+
+        if let statusCode {
+            switch statusCode {
+            case 409:
+                record.localStatus = .revoked
+                record.serverStatus = "revoked"
+                file.records[record.id] = record
+                persist()
+                processQueue()
+                return
+            case 404, 403:
+                record.localStatus = .failed
+                record.lastError = statusCode == 404 ? "not_found" : "forbidden"
+                file.records[record.id] = record
+                persist()
+                processQueue()
+                return
+            case 401:
+                file.records[record.id] = record
+                scheduleRetry(recordId: record.id, resumeData: nil, refreshToken: true)
+                return
+            default:
+                break
+            }
+        }
+
+        if record.retryCount < Self.maxRetries {
+            record.retryCount += 1
+            file.records[record.id] = record
+            scheduleRetry(recordId: record.id, resumeData: resumeData, refreshToken: false)
+        } else {
+            record.localStatus = .failed
+            record.lastError = message
+            file.records[record.id] = record
+            persist()
+            processQueue()
+        }
+    }
+
+    private func scheduleRetry(recordId: String, resumeData: Data?, refreshToken: Bool) {
+        let attempt = file.records[recordId]?.retryCount ?? 1
+        let delaySeconds = min(120, Int(pow(2.0, Double(attempt))) * 5)
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(delaySeconds) * 1_000_000_000)
+            guard let self, !self.scopeServerId.isEmpty else { return }
+            guard let record = self.file.records[recordId], record.localStatus != .completed else { return }
+            if refreshToken {
+                // Force HTTPClient's single-flight 401 refresh so the next
+                // background request carries a fresh token.
+                _ = try? await ContinuumAPI.shared.listDownloads()
+            }
+            if let resumeData {
+                let taskId = self.sessionDelegate.resume(data: resumeData)
+                guard var rec = self.file.records[recordId] else { return }
+                rec.taskIdentifier = taskId
+                rec.localStatus = .downloading
+                self.file.records[recordId] = rec
+                self.persist()
+            } else {
+                // Restart from the manifest step — a pipeline failure may have
+                // been in the manifest/asset fetch, not the media transfer.
+                self.setLocalStatus(.fetchingAssets, id: recordId)
+                await self.startMediaPipeline(recordId: recordId)
+            }
+        }
+    }
+
+    // MARK: - Polling (preparing → ready)
+
+    private func ensurePolling() {
+        guard pollTask == nil else { return }
+        guard file.records.values.contains(where: { $0.localStatus == .preparing }) else { return }
+        pollTask = Task { @MainActor in
+            defer { self.pollTask = nil }
+            while !Task.isCancelled {
+                guard self.file.records.values.contains(where: { $0.localStatus == .preparing }) else { break }
+                try? await Task.sleep(nanoseconds: 15_000_000_000)
+                if Task.isCancelled { break }
+                await self.reconcileWithServer(triggerPipeline: true)
+            }
+        }
+    }
+
+    // MARK: - Reconcile with server
+
+    func reconcileWithServer(triggerPipeline: Bool) async {
+        guard !scopeServerId.isEmpty, downloadsEnabled else { return }
+        let rows: [ServerDownloadRow]
+        do {
+            rows = try await ContinuumAPI.shared.listDownloads()
+        } catch {
+            return
+        }
+        let byId = Dictionary(rows.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+
+        for (id, original) in file.records {
+            if let row = byId[id] {
+                var record = mergeExistingRecord(original, with: row)
+                switch row.status {
+                case "ready":
+                    if record.localStatus == .preparing || record.localStatus == .registering {
+                        record.localStatus = .queued
+                    }
+                case "revoked":
+                    if record.localStatus == .completed {
+                        record.localStatus = .revoked
+                    } else if record.localStatus.isActive {
+                        record.localStatus = .revoked
+                    }
+                case "failed":
+                    if record.localStatus != .completed {
+                        record.localStatus = .failed
+                        record.lastError = "server_failed"
+                    }
+                default:
+                    break
+                }
+                file.records[id] = record
+            } else if original.localStatus.isActive {
+                var record = original
+                record.localStatus = .failed
+                record.lastError = "removed_on_server"
+                file.records[id] = record
+            }
+        }
+
+        // Pick up rows registered out-of-band (e.g. subscription sync).
+        for row in rows where file.records[row.id] == nil {
+            file.records[row.id] = makeRecord(from: row, type: row.episodeId != nil ? "episode" : nil)
+        }
+        persist()
+
+        await reconnectActiveTasks()
+        if triggerPipeline {
+            processQueue()
+            ensurePolling()
+        }
+    }
+
+    /// After a relaunch the background session may have lost in-flight
+    /// tasks (or finished them while we were dead). Re-queue records whose
+    /// task is no longer live.
+    private func reconnectActiveTasks() async {
+        let active = await sessionDelegate.activeTaskIdentifiers()
+        // `.fetchingAssets` records were mid-pipeline in a detached Task that
+        // did not survive the relaunch; re-queue them too so they aren't
+        // wedged (and don't keep occupying a concurrency slot forever).
+        for (id, record) in file.records
+        where record.localStatus == .downloading || record.localStatus == .fetchingAssets {
+            if record.localStatus == .downloading,
+               let taskId = record.taskIdentifier, active.contains(taskId) {
+                continue
+            }
+            setLocalStatus(.queued, id: id)
+        }
+    }
+
+    // MARK: - Series monitoring
+
+    func createSubscription(
+        seriesId: String,
+        seriesTitle: String?,
+        mode: SubscriptionMode,
+        seasonNumbers: [Int]?,
+        deleteWatched: Bool,
+        maxStorageBytes: Int64
+    ) async throws {
+        let request = CreateSubscriptionRequest(
+            seriesId: seriesId,
+            mode: mode.rawValue,
+            seasonNumbers: mode == .specificSeasons ? seasonNumbers : nil,
+            deleteWatched: deleteWatched,
+            maxStorageBytes: maxStorageBytes
+        )
+        let response = try await ContinuumAPI.shared.createSubscription(request)
+        upsertSubscription(response.subscription, seriesTitle: seriesTitle)
+        persist()
+        await reconcileWithServer(triggerPipeline: true)
+    }
+
+    func updateSubscription(
+        id: String,
+        mode: SubscriptionMode? = nil,
+        seasonNumbers: [Int]? = nil,
+        deleteWatched: Bool? = nil,
+        maxStorageBytes: Int64? = nil,
+        active: Bool? = nil
+    ) async throws {
+        let existingTitle = file.subscriptions.first(where: { $0.id == id })?.seriesTitle
+        let request = UpdateSubscriptionRequest(
+            mode: mode?.rawValue,
+            seasonNumbers: seasonNumbers,
+            deleteWatched: deleteWatched,
+            maxStorageBytes: maxStorageBytes,
+            active: active
+        )
+        let response = try await ContinuumAPI.shared.updateSubscription(id: id, request)
+        upsertSubscription(response.subscription, seriesTitle: existingTitle)
+        persist()
+        await reconcileWithServer(triggerPipeline: true)
+    }
+
+    func deleteSubscription(id: String) async {
+        file.subscriptions.removeAll { $0.id == id }
+        persist()
+        try? await ContinuumAPI.shared.deleteSubscription(id: id)
+    }
+
+    /// Subscription sync + offline progress reconciliation, run on
+    /// foreground. Client-driven: no server background worker.
+    func runMonitoringAndProgressSync() async {
+        guard downloadsEnabled else { return }
+        if !file.subscriptions.isEmpty {
+            _ = try? await ContinuumAPI.shared.syncSubscriptions()
+        }
+        await flushProgressQueue()
+        await pullProgressDeltas()
+        await reconcileWithServer(triggerPipeline: true)
+        await enforceRetention()
+    }
+
+    /// Client-enforced `delete_watched`: remove completed downloads whose
+    /// series is monitored with retention enabled and whose progress is
+    /// completed. The server never deletes on-device files.
+    private func enforceRetention() async {
+        let retentionSeries = Set(
+            file.subscriptions.filter { $0.deleteWatched }.map { $0.seriesId }
+        )
+        guard !retentionSeries.isEmpty else { return }
+        let toDelete = file.records.values.filter { record in
+            // Progress is keyed by the leaf item id (the episode), which for an
+            // episode download is `episodeId`, not the series `contentId`.
+            let leafId = record.episodeId ?? record.contentId
+            return record.localStatus == .completed
+                && record.seriesId.map(retentionSeries.contains) == true
+                && file.localProgress[leafId]?.completed == true
+        }
+        for record in toDelete {
+            deleteDownload(id: record.id)
+        }
+    }
+
+    // MARK: - Offline progress
+
+    /// Record a watch-progress event from offline playback: update the
+    /// local resume point and queue it for the next reconnect flush.
+    func recordOfflineProgress(mediaItemId: String, position: Double, duration: Double, completed: Bool) {
+        guard !mediaItemId.isEmpty, position.isFinite, position >= 0 else { return }
+        let now = Date()
+        var entry = file.localProgress[mediaItemId]
+            ?? LocalProgressEntry(position: 0, duration: duration, completed: false, updatedAt: now)
+        entry.position = position
+        if duration.isFinite, duration > 0 { entry.duration = duration }
+        entry.completed = entry.completed || completed
+        entry.updatedAt = now
+        file.localProgress[mediaItemId] = entry
+
+        // Collapse to the latest event per item so an offline session that
+        // ticks every few seconds doesn't grow an unbounded flush queue.
+        file.progressQueue.removeAll { $0.mediaItemId == mediaItemId }
+        file.progressQueue.append(QueuedProgress(
+            id: UUID(),
+            mediaItemId: mediaItemId,
+            position: position,
+            duration: duration,
+            updatedAt: now,
+            attempts: 0
+        ))
+        persist()
+    }
+
+    func flushProgressQueue() async {
+        guard !file.progressQueue.isEmpty else { return }
+        let items = file.progressQueue.map {
+            SyncProgressItem(
+                mediaItemId: $0.mediaItemId,
+                position: $0.position,
+                duration: $0.duration,
+                forceOverwrite: false,
+                updatedAt: $0.updatedAt
+            )
+        }
+        let sentIds = Set(items.map { $0.mediaItemId })
+        do {
+            let results = try await ContinuumAPI.shared.syncProgressBatch(items: items)
+            let okIds = Set(results.filter { $0.isOK }.map { $0.mediaItemId })
+            // Only touch items that were part of this batch — items enqueued
+            // while the POST was in flight keep their full retry budget.
+            file.progressQueue.removeAll {
+                okIds.contains($0.mediaItemId)
+                    || ($0.attempts >= Self.maxRetries && sentIds.contains($0.mediaItemId))
+            }
+            for index in file.progressQueue.indices
+            where sentIds.contains(file.progressQueue[index].mediaItemId) {
+                file.progressQueue[index].attempts += 1
+            }
+            persist()
+        } catch {
+            // Keep the queue for the next reconnect.
+        }
+    }
+
+    func pullProgressDeltas() async {
+        do {
+            let response = try await ContinuumAPI.shared.pullProgressDeltas(since: file.progressCursor)
+            for item in response.progress {
+                let serverTime = item.updatedAt ?? Date()
+                var entry = file.localProgress[item.mediaItemId]
+                    ?? LocalProgressEntry(
+                        position: item.positionSeconds,
+                        duration: item.durationSeconds,
+                        completed: item.completed,
+                        updatedAt: serverTime
+                    )
+                if serverTime >= entry.updatedAt {
+                    entry.position = item.positionSeconds
+                    if item.durationSeconds > 0 { entry.duration = item.durationSeconds }
+                    entry.completed = entry.completed || item.completed
+                    entry.updatedAt = serverTime
+                    file.localProgress[item.mediaItemId] = entry
+                }
+            }
+            if let cursor = response.nextCursor, !cursor.isEmpty {
+                file.progressCursor = cursor
+            }
+            persist()
+        } catch {
+            // Non-fatal; retry next foreground.
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func upsertRow(
+        _ row: ServerDownloadRow,
+        displayTitle: String?,
+        displaySubtitle: String?,
+        type: String?,
+        seriesId: String?,
+        posterThumbhash: String?
+    ) {
+        if let existing = file.records[row.id] {
+            var merged = mergeExistingRecord(existing, with: row)
+            if existing.localStatus == .failed || existing.localStatus == .revoked {
+                merged.localStatus = mapInitialStatus(row.status)
+                merged.lastError = nil
+                merged.retryCount = 0
+            }
+            file.records[row.id] = merged
+            return
+        }
+        var record = makeRecord(from: row, type: type)
+        record.title = displayTitle
+        record.subtitle = displaySubtitle
+        record.seriesId = seriesId ?? record.seriesId
+        record.posterThumbhash = posterThumbhash
+        file.records[row.id] = record
+    }
+
+    private func mergeExistingRecord(_ existing: DownloadRecord, with row: ServerDownloadRow) -> DownloadRecord {
+        var record = existing
+        if shouldReplaceLocalAssets(record, with: row) {
+            discardLocalAssets(for: record)
+            resetLocalAssets(on: &record, status: row.status)
+        }
+        applyServerRow(row, to: &record)
+        return record
+    }
+
+    private func shouldReplaceLocalAssets(_ record: DownloadRecord, with row: ServerDownloadRow) -> Bool {
+        if let currentRevision = record.revision,
+           let serverRevision = row.revision,
+           serverRevision > currentRevision {
+            return true
+        }
+        if record.revision == nil {
+            return record.mediaFileId != row.mediaFileId || record.format != row.quality
+        }
+        return false
+    }
+
+    private func discardLocalAssets(for record: DownloadRecord) {
+        if let taskId = record.taskIdentifier {
+            intentionalCancels.insert(taskId)
+            sessionDelegate.cancel(taskId: taskId)
+        }
+        guard !scopeServerId.isEmpty else { return }
+        DownloadFilePaths.removeDownloadDirectory(
+            serverId: scopeServerId,
+            profileId: scopeProfileId,
+            downloadId: record.id
+        )
+    }
+
+    private func resetLocalAssets(on record: inout DownloadRecord, status: String) {
+        record.mediaFilename = nil
+        record.manifestFilename = nil
+        record.posterFilename = nil
+        record.backdropFilename = nil
+        record.logoFilename = nil
+        record.subtitleFilenames = [:]
+        record.container = nil
+        record.stableIdentity = nil
+        record.bytesDownloaded = 0
+        record.localStatus = mapInitialStatus(status)
+        record.downloadedAt = nil
+        record.lastError = nil
+        record.retryCount = 0
+        record.taskIdentifier = nil
+    }
+
+    private func applyServerRow(_ row: ServerDownloadRow, to record: inout DownloadRecord) {
+        record.contentId = row.contentId
+        record.mediaFileId = row.mediaFileId
+        record.format = row.quality
+        record.effectiveQuality = row.effectiveQuality
+        record.deliveryFormat = row.deliveryFormat
+        record.targetBitrateKbps = row.targetBitrateKbps
+        record.revision = row.revision ?? record.revision
+        record.serverStatus = row.status
+        if let size = row.fileSize, size > 0, record.fileSize <= 0 {
+            record.fileSize = size
+        }
+        if let completedAt = row.completedAt {
+            record.downloadedAt = completedAt
+        }
+    }
+
+    private func makeRecord(from row: ServerDownloadRow, type: String?) -> DownloadRecord {
+        DownloadRecord(
+            id: row.id,
+            contentId: row.contentId,
+            episodeId: row.episodeId,
+            batchId: row.batchId,
+            mediaFileId: row.mediaFileId,
+            format: row.quality,
+            effectiveQuality: row.effectiveQuality,
+            deliveryFormat: row.deliveryFormat,
+            targetBitrateKbps: row.targetBitrateKbps,
+            revision: row.revision,
+            serverStatus: row.status,
+            localStatus: mapInitialStatus(row.status),
+            fileSize: row.fileSize ?? 0,
+            bytesDownloaded: 0,
+            mediaFilename: nil,
+            manifestFilename: nil,
+            posterFilename: nil,
+            backdropFilename: nil,
+            logoFilename: nil,
+            subtitleFilenames: [:],
+            title: nil,
+            subtitle: nil,
+            type: type,
+            seriesId: nil,
+            posterThumbhash: nil,
+            container: nil,
+            stableIdentity: nil,
+            registeredAt: row.createdAt ?? Date(),
+            downloadedAt: row.completedAt,
+            lastError: nil,
+            retryCount: 0,
+            taskIdentifier: nil
+        )
+    }
+
+    private func mapInitialStatus(_ serverStatus: String) -> LocalDownloadStatus {
+        switch serverStatus {
+        case "ready": return .queued
+        case "preparing": return .preparing
+        case "revoked": return .revoked
+        case "failed": return .failed
+        default: return .registering
+        }
+    }
+
+    private func upsertSubscription(_ server: ServerSubscription, seriesTitle: String?) {
+        let mirror = DownloadSubscription(from: server, seriesTitle: seriesTitle)
+        if let index = file.subscriptions.firstIndex(where: { $0.id == server.id }) {
+            file.subscriptions[index] = mirror
+        } else {
+            file.subscriptions.append(mirror)
+        }
+    }
+
+    private func setLocalStatus(_ status: LocalDownloadStatus, id: String) {
+        guard var record = file.records[id] else { return }
+        record.localStatus = status
+        file.records[id] = record
+        persist()
+    }
+
+    private func recordByTask(_ taskId: Int) -> DownloadRecord? {
+        file.records.values.first { $0.taskIdentifier == taskId }
+    }
+
+    private func mediaExtension(for record: DownloadRecord) -> String {
+        switch (record.container ?? "").lowercased() {
+        case "mkv", "matroska": return "mkv"
+        case "mov": return "mov"
+        case "m4v": return "m4v"
+        case "webm": return "webm"
+        case "avi": return "avi"
+        case "ts": return "ts"
+        case "m2ts": return "m2ts"
+        default: return "mp4"
+        }
+    }
+
+    /// Per-subscription `max_storage_bytes` soft gate: skip starting a
+    /// download that would push its series over the cap. The server only
+    /// soft-gates; the client is authoritative.
+    private func exceedsStorageCap(for record: DownloadRecord) -> Bool {
+        guard let seriesId = record.seriesId,
+              let subscription = subscription(forSeriesId: seriesId),
+              subscription.maxStorageBytes > 0 else {
+            return false
+        }
+        let used = file.records.values
+            .filter { $0.seriesId == seriesId && $0.localStatus == .completed }
+            .reduce(Int64(0)) { $0 + $1.fileSize }
+        return used + max(record.fileSize, 0) > subscription.maxStorageBytes
+    }
+
+    private func absoluteFileURLForNewAsset(recordId: String, filename: String) -> URL? {
+        guard !scopeServerId.isEmpty else { return nil }
+        return DownloadFilePaths.fileURL(
+            serverId: scopeServerId,
+            profileId: scopeProfileId,
+            downloadId: recordId,
+            filename: filename
+        )
+    }
+
+    private func fileSizeOnDisk(_ url: URL) -> Int64 {
+        let values = try? url.resourceValues(forKeys: [.fileSizeKey])
+        return Int64(values?.fileSize ?? 0)
+    }
+
+    private func persist() {
+        guard !scopeServerId.isEmpty, !scopeProfileId.isEmpty else { return }
+        lastProgressPersist = Date()
+        let snapshot = file
+        let serverId = scopeServerId
+        let profileId = scopeProfileId
+        // Chain each save after the previous so writes land in call order.
+        let previous = saveChain
+        saveChain = Task { @MainActor in
+            await previous?.value
+            await DownloadStore.shared.save(snapshot, serverId: serverId, profileId: profileId)
+        }
+    }
+
+    /// Recompute scope storage usage off the MainActor and publish it.
+    private func refreshStorageUsage() {
+        let serverId = scopeServerId
+        let profileId = scopeProfileId
+        guard !serverId.isEmpty, !profileId.isEmpty else {
+            storageBytesUsed = 0
+            return
+        }
+        Task.detached(priority: .utility) {
+            let bytes = DownloadFilePaths.bytesUsed(serverId: serverId, profileId: profileId)
+            await MainActor.run { [weak self] in self?.storageBytesUsed = bytes }
+        }
+    }
+
+    /// Throttle disk writes during the high-frequency progress callbacks;
+    /// the in-memory mutation already drives the UI.
+    private func persistProgressThrottled() {
+        guard Date().timeIntervalSince(lastProgressPersist) > 2 else { return }
+        persist()
+    }
+}

--- a/iosApp/iosApp/Downloads/DownloadManager.swift
+++ b/iosApp/iosApp/Downloads/DownloadManager.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Observation
 import OSLog
 
 enum DownloadError: LocalizedError {
@@ -86,6 +87,11 @@ final class DownloadManager {
     private var rateSamples: [String: (bytes: Int64, at: Date)] = [:]
     private static let rateSampleInterval: TimeInterval = 0.5
     private static let rateSmoothing = 0.3
+    /// Last time each record's byte counter was published into the
+    /// `@Observable` `file` blob. Delegate callbacks arrive many times per
+    /// second; UI counters should tick at a readable cadence instead.
+    private var lastProgressPublish: [String: Date] = [:]
+    private static let progressPublishInterval: TimeInterval = 1.0
 
     private init() {
         // Drain background-session events for the lifetime of the app.
@@ -934,10 +940,18 @@ final class DownloadManager {
         switch event {
         case let .progress(taskId, written, total):
             guard var record = recordByTask(taskId) else { return }
+            updateTransferRate(recordId: record.id, bytes: written)
+            // Publish to the observable blob at a readable cadence — the raw
+            // callbacks fire many times per second and each reassignment
+            // redraws every byte counter "live". Skipped ticks lose nothing:
+            // `written` is cumulative, so the next publish catches up.
+            let now = Date()
+            guard now.timeIntervalSince(lastProgressPublish[record.id] ?? .distantPast)
+                >= Self.progressPublishInterval else { return }
+            lastProgressPublish[record.id] = now
             record.bytesDownloaded = written
             if total > 0 { record.fileSize = total }
             file.records[record.id] = record
-            updateTransferRate(recordId: record.id, bytes: written)
             persistProgressThrottled()
 
         case let .finished(taskId, stagedURL, _):
@@ -947,8 +961,17 @@ final class DownloadManager {
             handleMediaFailure(taskId: taskId, statusCode: statusCode, resumeData: resumeData, message: message)
 
         case .allEventsDelivered:
-            sessionDelegate.backgroundCompletionHandler?()
+            // Flush queued store writes before handing control back — iOS
+            // can suspend the process as soon as the completion handler
+            // runs, and the `.finished`/`.failed` records handled above are
+            // still on the async save chain.
+            guard let handler = sessionDelegate.backgroundCompletionHandler else { return }
             sessionDelegate.backgroundCompletionHandler = nil
+            let pendingSave = saveChain
+            Task { @MainActor in
+                await pendingSave?.value
+                handler()
+            }
         }
     }
 
@@ -1034,8 +1057,21 @@ final class DownloadManager {
                 processQueue()
                 return
             case 401:
-                file.records[record.id] = record
-                scheduleRetry(recordId: record.id, resumeData: nil, refreshToken: true)
+                // Bounded like every other retry path — a persistently
+                // expired credential would otherwise refresh-and-retry
+                // forever with the record stuck in `.downloading`.
+                if record.retryCount < Self.maxRetries {
+                    record.retryCount += 1
+                    file.records[record.id] = record
+                    scheduleRetry(recordId: record.id, resumeData: nil, refreshToken: true)
+                } else {
+                    record.localStatus = .failed
+                    record.lastError = "unauthorized"
+                    file.records[record.id] = record
+                    persist()
+                    notifyTerminalFailure(record)
+                    processQueue()
+                }
                 return
             default:
                 break
@@ -1586,15 +1622,33 @@ final class DownloadManager {
     /// download that would push its series over the cap. The server only
     /// soft-gates; the client is authoritative.
     private func exceedsStorageCap(for record: DownloadRecord) -> Bool {
-        guard let seriesId = record.seriesId,
+        guard let seriesId = capSeriesId(for: record),
               let subscription = subscription(forSeriesId: seriesId),
               subscription.maxStorageBytes > 0 else {
             return false
         }
+        // Count completed bytes plus the expected size of in-flight
+        // transfers — `processQueue` can start several episodes in one
+        // pass, and counting only `.completed` would let each of them see
+        // the same free capacity and overshoot the cap together.
         let used = file.records.values
-            .filter { $0.seriesId == seriesId && $0.localStatus == .completed }
-            .reduce(Int64(0)) { $0 + $1.fileSize }
+            .filter { other in
+                guard other.id != record.id, capSeriesId(for: other) == seriesId else { return false }
+                switch other.localStatus {
+                case .completed, .downloading, .fetchingAssets, .paused: return true
+                default: return false
+                }
+            }
+            .reduce(Int64(0)) { $0 + max($1.fileSize, $1.bytesDownloaded) }
         return used + max(record.fileSize, 0) > subscription.maxStorageBytes
+    }
+
+    /// Series identity for cap accounting. Episode rows registered by
+    /// subscription sync carry the series id in `contentId` until the
+    /// manifest hydrates `seriesId` — without the fallback, freshly synced
+    /// episodes would bypass the cap entirely.
+    private func capSeriesId(for record: DownloadRecord) -> String? {
+        record.seriesId ?? (record.episodeId != nil ? record.contentId : nil)
     }
 
     private func absoluteFileURLForNewAsset(recordId: String, filename: String) -> URL? {
@@ -1679,5 +1733,6 @@ final class DownloadManager {
     private func clearTransferRate(recordId: String) {
         rateSamples.removeValue(forKey: recordId)
         transferRates.removeValue(forKey: recordId)
+        lastProgressPublish.removeValue(forKey: recordId)
     }
 }

--- a/iosApp/iosApp/Downloads/DownloadModels.swift
+++ b/iosApp/iosApp/Downloads/DownloadModels.swift
@@ -1,0 +1,735 @@
+import Foundation
+
+// MARK: - Capability (GET /api/v1/downloads/capability)
+
+/// Server-advertised download feature gate. Fetched at login + profile
+/// switch; the UI is hidden when `enabled`/`downloadAllowed` is false.
+/// Mirrors §3 of the server downloads API guide.
+struct DownloadCapability: Codable, Hashable, Sendable {
+    let enabled: Bool
+    let downloadAllowed: Bool
+    let qualityPresets: [String]
+    let transcodeEnabled: Bool
+    let transcodeUserAllowed: Bool
+    let seasonDownload: Bool
+    let seriesMonitoring: Bool
+    let monitoringModes: [String]
+
+    /// Downloads are usable at all only when the feature is on AND this
+    /// user is allowed to download.
+    var isUsable: Bool { enabled && downloadAllowed }
+
+    /// Compatibility alias for stores written before the server renamed
+    /// public download choices from formats to quality presets.
+    var formats: [String] { qualityPresets }
+
+    private enum CodingKeys: String, CodingKey {
+        case enabled
+        case downloadAllowed
+        case qualityPresets
+        case formats
+        case transcodeEnabled
+        case transcodeUserAllowed
+        case seasonDownload
+        case seriesMonitoring
+        case monitoringModes
+    }
+
+    init(
+        enabled: Bool,
+        downloadAllowed: Bool,
+        qualityPresets: [String],
+        transcodeEnabled: Bool,
+        transcodeUserAllowed: Bool,
+        seasonDownload: Bool,
+        seriesMonitoring: Bool,
+        monitoringModes: [String]
+    ) {
+        self.enabled = enabled
+        self.downloadAllowed = downloadAllowed
+        self.qualityPresets = qualityPresets
+        self.transcodeEnabled = transcodeEnabled
+        self.transcodeUserAllowed = transcodeUserAllowed
+        self.seasonDownload = seasonDownload
+        self.seriesMonitoring = seriesMonitoring
+        self.monitoringModes = monitoringModes
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        enabled = try container.decode(Bool.self, forKey: .enabled)
+        downloadAllowed = try container.decode(Bool.self, forKey: .downloadAllowed)
+        qualityPresets = try container.decodeIfPresent([String].self, forKey: .qualityPresets)
+            ?? container.decodeIfPresent([String].self, forKey: .formats)
+            ?? [DownloadFormat.original.rawValue]
+        transcodeEnabled = try container.decodeIfPresent(Bool.self, forKey: .transcodeEnabled) ?? false
+        transcodeUserAllowed = try container.decodeIfPresent(Bool.self, forKey: .transcodeUserAllowed) ?? false
+        seasonDownload = try container.decodeIfPresent(Bool.self, forKey: .seasonDownload) ?? false
+        seriesMonitoring = try container.decodeIfPresent(Bool.self, forKey: .seriesMonitoring) ?? false
+        monitoringModes = try container.decodeIfPresent([String].self, forKey: .monitoringModes) ?? []
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(enabled, forKey: .enabled)
+        try container.encode(downloadAllowed, forKey: .downloadAllowed)
+        try container.encode(qualityPresets, forKey: .qualityPresets)
+        try container.encode(transcodeEnabled, forKey: .transcodeEnabled)
+        try container.encode(transcodeUserAllowed, forKey: .transcodeUserAllowed)
+        try container.encode(seasonDownload, forKey: .seasonDownload)
+        try container.encode(seriesMonitoring, forKey: .seriesMonitoring)
+        try container.encode(monitoringModes, forKey: .monitoringModes)
+    }
+}
+
+/// Public quality presets offered for a managed download. Only values that
+/// appear in `DownloadCapability.qualityPresets` may be requested.
+enum DownloadFormat: String, Codable, CaseIterable, Sendable {
+    case original
+    case twentyMbps = "20mbps"
+    case tenMbps = "10mbps"
+    case fiveMbps = "5mbps"
+    case twoMbps = "2mbps"
+    case oneMbps = "1mbps"
+
+    var displayName: String {
+        switch self {
+        case .original: return "Original"
+        case .twentyMbps: return "20 Mbps"
+        case .tenMbps: return "10 Mbps"
+        case .fiveMbps: return "5 Mbps"
+        case .twoMbps: return "2 Mbps"
+        case .oneMbps: return "1 Mbps"
+        }
+    }
+}
+
+// MARK: - Download row (POST/GET /api/v1/downloads)
+
+/// A managed device download row as returned by create/list. Field
+/// reference: §5 of the server downloads API guide.
+struct ServerDownloadRow: Decodable, Hashable, Sendable {
+    let id: String
+    let contentId: String
+    let episodeId: String?
+    let batchId: String?
+    let deviceId: String?
+    let mediaFileId: Int
+    let fileSize: Int64?
+    let bytesSent: Int64?
+    let kind: String?
+    let status: String
+    let quality: String
+    let effectiveQuality: String?
+    let deliveryFormat: String?
+    let targetBitrateKbps: Int?
+    let revision: Int?
+    let createdAt: Date?
+    let completedAt: Date?
+
+    /// Compatibility alias for local code that still names the stored
+    /// requested quality `format`.
+    var format: String { quality }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case contentId
+        case episodeId
+        case batchId
+        case deviceId
+        case mediaFileId
+        case fileSize
+        case bytesSent
+        case kind
+        case status
+        case quality
+        case format
+        case effectiveQuality
+        case deliveryFormat
+        case targetBitrateKbps
+        case revision
+        case createdAt
+        case completedAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        contentId = try container.decode(String.self, forKey: .contentId)
+        episodeId = try container.decodeIfPresent(String.self, forKey: .episodeId)
+        batchId = try container.decodeIfPresent(String.self, forKey: .batchId)
+        deviceId = try container.decodeIfPresent(String.self, forKey: .deviceId)
+        mediaFileId = try container.decodeIfPresent(Int.self, forKey: .mediaFileId) ?? 0
+        fileSize = try container.decodeIfPresent(Int64.self, forKey: .fileSize)
+        bytesSent = try container.decodeIfPresent(Int64.self, forKey: .bytesSent)
+        kind = try container.decodeIfPresent(String.self, forKey: .kind)
+        status = try container.decode(String.self, forKey: .status)
+        quality = try container.decodeIfPresent(String.self, forKey: .quality)
+            ?? container.decodeIfPresent(String.self, forKey: .format)
+            ?? DownloadFormat.original.rawValue
+        effectiveQuality = try container.decodeIfPresent(String.self, forKey: .effectiveQuality)
+        deliveryFormat = try container.decodeIfPresent(String.self, forKey: .deliveryFormat)
+        targetBitrateKbps = try container.decodeIfPresent(Int.self, forKey: .targetBitrateKbps)
+        revision = try container.decodeIfPresent(Int.self, forKey: .revision)
+        createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt)
+        completedAt = try container.decodeIfPresent(Date.self, forKey: .completedAt)
+    }
+}
+
+/// Single-item create returns a bare row; series/season create returns a
+/// `{ "downloads": [...] }` batch. We attempt the batch shape first and
+/// fall back to the single row.
+struct ServerDownloadsResponse: Decodable, Sendable {
+    let downloads: [ServerDownloadRow]
+}
+
+/// Body for `POST /api/v1/downloads`.
+struct CreateDownloadRequest: Encodable, Sendable {
+    let contentId: String
+    let episodeId: String?
+    let fileId: Int?
+    let quality: String
+    let series: Bool?
+    let seasonNumber: Int?
+    let caps: DownloadCaps?
+}
+
+/// Device decode capability used to decide whether `original` can be served
+/// directly or should fall back to a compatibility artifact.
+struct DownloadCaps: Encodable, Sendable {
+    let codecsVideo: [String]
+    let codecsAudio: [String]
+    let audioPassthroughCodecs: [String]?
+    let containers: [String]
+    let maxResolution: String?
+    let hdr: Bool
+
+    /// Reasonable decode caps for the current Apple platform. Matches the
+    /// truthful direct-play surface the playback bootstrap reports.
+    static func current() -> DownloadCaps {
+        #if os(macOS)
+        return DownloadCaps(
+            codecsVideo: ["h264", "hevc"],
+            codecsAudio: ["aac", "ac3", "eac3", "alac", "mp3"],
+            audioPassthroughCodecs: ["ac3", "eac3"],
+            containers: ["mp4", "mov", "m4v"],
+            maxResolution: nil,
+            hdr: true
+        )
+        #else
+        return DownloadCaps(
+            codecsVideo: ["h264", "hevc"],
+            codecsAudio: ["aac", "ac3", "eac3", "dts", "truehd", "flac", "mp3", "opus"],
+            audioPassthroughCodecs: ["ac3", "eac3"],
+            containers: ["mkv", "mp4", "mov", "m4v", "webm", "avi", "ts", "m2ts"],
+            maxResolution: nil,
+            hdr: true
+        )
+        #endif
+    }
+}
+
+// MARK: - Offline manifest (GET /api/v1/downloads/{id}/manifest)
+
+/// The offline playback bundle for one download. Stable and
+/// presigned-URL-free — persisted on disk and read offline indefinitely.
+/// Reuses `TimeRange` and `VersionChapter` from the online model layer so
+/// the player's chapters / skip-intro logic works unchanged. Mirrors
+/// §6 of the server downloads API guide.
+struct OfflineManifest: Codable, Hashable, Sendable {
+    let downloadId: String
+    let contentId: String
+    let episodeId: String?
+    let type: String          // "movie" | "episode"
+    let revision: Int?
+    let quality: String
+    let effectiveQuality: String?
+    let deliveryFormat: String?
+    let targetBitrateKbps: Int?
+    let mediaFileId: Int
+    let fileSize: Int64?
+
+    let title: String
+    let year: Int?
+    let overview: String?
+    let runtime: Int?
+    let contentRating: String?
+    let genres: [String]?
+    let seriesId: String?
+    let seriesTitle: String?
+    let seasonNumber: Int?
+    let episodeNumber: Int?
+
+    let posterThumbhash: String?
+    let backdropThumbhash: String?
+    let artworkUrls: ArtworkUrls?
+
+    let container: String?
+    let codecVideo: String?
+    let codecAudio: String?
+    let resolution: String?
+    let hdr: Bool?
+    let durationSeconds: Double?
+    let selectedAudioTrackIndex: Int?
+    let audioTracks: [OfflineAudioTrack]?
+
+    let chapters: [VersionChapter]?
+    let intro: TimeRange?
+    let credits: TimeRange?
+    let recap: TimeRange?
+    let preview: TimeRange?
+
+    let subtitles: [OfflineSubtitle]?
+    let stableIdentity: StableIdentity?
+    let integrity: OfflineIntegrity?
+
+    let manifestVersion: Int?
+    let generatedAt: Date?
+
+    /// Compatibility alias for code paths and saved manifests that used
+    /// the former public `format` name.
+    var format: String { quality }
+
+    private enum CodingKeys: String, CodingKey {
+        case downloadId
+        case contentId
+        case episodeId
+        case type
+        case revision
+        case quality
+        case format
+        case effectiveQuality
+        case deliveryFormat
+        case targetBitrateKbps
+        case mediaFileId
+        case fileSize
+        case title
+        case year
+        case overview
+        case runtime
+        case contentRating
+        case genres
+        case seriesId
+        case seriesTitle
+        case seasonNumber
+        case episodeNumber
+        case posterThumbhash
+        case backdropThumbhash
+        case artworkUrls
+        case container
+        case codecVideo
+        case codecAudio
+        case resolution
+        case hdr
+        case durationSeconds
+        case selectedAudioTrackIndex
+        case audioTracks
+        case chapters
+        case intro
+        case credits
+        case recap
+        case preview
+        case subtitles
+        case stableIdentity
+        case integrity
+        case manifestVersion
+        case generatedAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let keyed = try decoder.container(keyedBy: CodingKeys.self)
+        downloadId = try keyed.decode(String.self, forKey: .downloadId)
+        contentId = try keyed.decode(String.self, forKey: .contentId)
+        episodeId = try keyed.decodeIfPresent(String.self, forKey: .episodeId)
+        type = try keyed.decode(String.self, forKey: .type)
+        revision = try keyed.decodeIfPresent(Int.self, forKey: .revision)
+        quality = try keyed.decodeIfPresent(String.self, forKey: .quality)
+            ?? keyed.decodeIfPresent(String.self, forKey: .format)
+            ?? DownloadFormat.original.rawValue
+        effectiveQuality = try keyed.decodeIfPresent(String.self, forKey: .effectiveQuality)
+        deliveryFormat = try keyed.decodeIfPresent(String.self, forKey: .deliveryFormat)
+        targetBitrateKbps = try keyed.decodeIfPresent(Int.self, forKey: .targetBitrateKbps)
+        mediaFileId = try keyed.decodeIfPresent(Int.self, forKey: .mediaFileId) ?? 0
+        fileSize = try keyed.decodeIfPresent(Int64.self, forKey: .fileSize)
+        title = try keyed.decode(String.self, forKey: .title)
+        year = try keyed.decodeIfPresent(Int.self, forKey: .year)
+        overview = try keyed.decodeIfPresent(String.self, forKey: .overview)
+        runtime = try keyed.decodeIfPresent(Int.self, forKey: .runtime)
+        contentRating = try keyed.decodeIfPresent(String.self, forKey: .contentRating)
+        genres = try keyed.decodeIfPresent([String].self, forKey: .genres)
+        seriesId = try keyed.decodeIfPresent(String.self, forKey: .seriesId)
+        seriesTitle = try keyed.decodeIfPresent(String.self, forKey: .seriesTitle)
+        seasonNumber = try keyed.decodeIfPresent(Int.self, forKey: .seasonNumber)
+        episodeNumber = try keyed.decodeIfPresent(Int.self, forKey: .episodeNumber)
+        posterThumbhash = try keyed.decodeIfPresent(String.self, forKey: .posterThumbhash)
+        backdropThumbhash = try keyed.decodeIfPresent(String.self, forKey: .backdropThumbhash)
+        artworkUrls = try keyed.decodeIfPresent(ArtworkUrls.self, forKey: .artworkUrls)
+        container = try keyed.decodeIfPresent(String.self, forKey: .container)
+        codecVideo = try keyed.decodeIfPresent(String.self, forKey: .codecVideo)
+        codecAudio = try keyed.decodeIfPresent(String.self, forKey: .codecAudio)
+        resolution = try keyed.decodeIfPresent(String.self, forKey: .resolution)
+        hdr = try keyed.decodeIfPresent(Bool.self, forKey: .hdr)
+        durationSeconds = try keyed.decodeIfPresent(Double.self, forKey: .durationSeconds)
+        selectedAudioTrackIndex = try keyed.decodeIfPresent(Int.self, forKey: .selectedAudioTrackIndex)
+        audioTracks = try keyed.decodeIfPresent([OfflineAudioTrack].self, forKey: .audioTracks)
+        chapters = try keyed.decodeIfPresent([VersionChapter].self, forKey: .chapters)
+        intro = try keyed.decodeIfPresent(TimeRange.self, forKey: .intro)
+        credits = try keyed.decodeIfPresent(TimeRange.self, forKey: .credits)
+        recap = try keyed.decodeIfPresent(TimeRange.self, forKey: .recap)
+        preview = try keyed.decodeIfPresent(TimeRange.self, forKey: .preview)
+        subtitles = try keyed.decodeIfPresent([OfflineSubtitle].self, forKey: .subtitles)
+        stableIdentity = try keyed.decodeIfPresent(StableIdentity.self, forKey: .stableIdentity)
+        integrity = try keyed.decodeIfPresent(OfflineIntegrity.self, forKey: .integrity)
+        manifestVersion = try keyed.decodeIfPresent(Int.self, forKey: .manifestVersion)
+        generatedAt = try keyed.decodeIfPresent(Date.self, forKey: .generatedAt)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var keyed = encoder.container(keyedBy: CodingKeys.self)
+        try keyed.encode(downloadId, forKey: .downloadId)
+        try keyed.encode(contentId, forKey: .contentId)
+        try keyed.encodeIfPresent(episodeId, forKey: .episodeId)
+        try keyed.encode(type, forKey: .type)
+        try keyed.encodeIfPresent(revision, forKey: .revision)
+        try keyed.encode(quality, forKey: .quality)
+        try keyed.encodeIfPresent(effectiveQuality, forKey: .effectiveQuality)
+        try keyed.encodeIfPresent(deliveryFormat, forKey: .deliveryFormat)
+        try keyed.encodeIfPresent(targetBitrateKbps, forKey: .targetBitrateKbps)
+        try keyed.encode(mediaFileId, forKey: .mediaFileId)
+        try keyed.encodeIfPresent(fileSize, forKey: .fileSize)
+        try keyed.encode(title, forKey: .title)
+        try keyed.encodeIfPresent(year, forKey: .year)
+        try keyed.encodeIfPresent(overview, forKey: .overview)
+        try keyed.encodeIfPresent(runtime, forKey: .runtime)
+        try keyed.encodeIfPresent(contentRating, forKey: .contentRating)
+        try keyed.encodeIfPresent(genres, forKey: .genres)
+        try keyed.encodeIfPresent(seriesId, forKey: .seriesId)
+        try keyed.encodeIfPresent(seriesTitle, forKey: .seriesTitle)
+        try keyed.encodeIfPresent(seasonNumber, forKey: .seasonNumber)
+        try keyed.encodeIfPresent(episodeNumber, forKey: .episodeNumber)
+        try keyed.encodeIfPresent(posterThumbhash, forKey: .posterThumbhash)
+        try keyed.encodeIfPresent(backdropThumbhash, forKey: .backdropThumbhash)
+        try keyed.encodeIfPresent(artworkUrls, forKey: .artworkUrls)
+        try keyed.encodeIfPresent(container, forKey: .container)
+        try keyed.encodeIfPresent(codecVideo, forKey: .codecVideo)
+        try keyed.encodeIfPresent(codecAudio, forKey: .codecAudio)
+        try keyed.encodeIfPresent(resolution, forKey: .resolution)
+        try keyed.encodeIfPresent(hdr, forKey: .hdr)
+        try keyed.encodeIfPresent(durationSeconds, forKey: .durationSeconds)
+        try keyed.encodeIfPresent(selectedAudioTrackIndex, forKey: .selectedAudioTrackIndex)
+        try keyed.encodeIfPresent(audioTracks, forKey: .audioTracks)
+        try keyed.encodeIfPresent(chapters, forKey: .chapters)
+        try keyed.encodeIfPresent(intro, forKey: .intro)
+        try keyed.encodeIfPresent(credits, forKey: .credits)
+        try keyed.encodeIfPresent(recap, forKey: .recap)
+        try keyed.encodeIfPresent(preview, forKey: .preview)
+        try keyed.encodeIfPresent(subtitles, forKey: .subtitles)
+        try keyed.encodeIfPresent(stableIdentity, forKey: .stableIdentity)
+        try keyed.encodeIfPresent(integrity, forKey: .integrity)
+        try keyed.encodeIfPresent(manifestVersion, forKey: .manifestVersion)
+        try keyed.encodeIfPresent(generatedAt, forKey: .generatedAt)
+    }
+
+    struct ArtworkUrls: Codable, Hashable, Sendable {
+        let poster: String?
+        let backdrop: String?
+        let logo: String?
+    }
+}
+
+struct OfflineAudioTrack: Codable, Hashable, Sendable {
+    let index: Int?
+    let language: String?
+    let codec: String?
+    let channels: Int?
+    let isDefault: Bool?
+
+    private enum CodingKeys: String, CodingKey {
+        case index
+        case language
+        case codec
+        case channels
+        case isDefault = "default"
+    }
+}
+
+/// A subtitle attached to an offline download. `fetchUrl` is taken
+/// verbatim from the manifest and resolved against this server's API
+/// origin (`external:{index}` or `downloaded:{id}`).
+struct OfflineSubtitle: Codable, Hashable, Sendable {
+    let language: String?
+    let format: String?
+    let forced: Bool?
+    let hearingImpaired: Bool?
+    let external: Bool?
+    let fetchUrl: String
+    let fileSize: Int64?
+}
+
+/// Rescan-stable identity mirroring the watch-state identity. Used to
+/// re-resolve a download whose `content_id` changed on the server.
+struct StableIdentity: Codable, Hashable, Sendable {
+    let stableType: String?
+    let providerIds: [String: String]?
+    let season: Int?
+    let episode: Int?
+}
+
+struct OfflineIntegrity: Codable, Hashable, Sendable {
+    let expectedBytes: Int64?
+    let mediaFileHash: String?
+    let metadataEtag: String?
+}
+
+// MARK: - Subscriptions (series monitoring)
+
+/// A series-monitoring subscription as returned by the server.
+struct ServerSubscription: Codable, Hashable, Sendable {
+    let id: String
+    let seriesId: String
+    let mode: String
+    let targetSeason: Int?
+    let seasonNumbers: [Int]?
+    let deleteWatched: Bool
+    let maxStorageBytes: Int64
+    let active: Bool
+    let createdAt: Date?
+    let updatedAt: Date?
+}
+
+/// Subscription modes the client may request. Filtered against
+/// `DownloadCapability.monitoringModes`.
+enum SubscriptionMode: String, Codable, CaseIterable, Sendable {
+    case all
+    case future
+    case latestSeason = "latest_season"
+    case specificSeasons = "specific_seasons"
+
+    var displayName: String {
+        switch self {
+        case .all: return "All Seasons"
+        case .future: return "New Episodes Only"
+        case .latestSeason: return "Latest Season & Newer"
+        case .specificSeasons: return "Specific Seasons"
+        }
+    }
+}
+
+struct CreateSubscriptionRequest: Encodable, Sendable {
+    let seriesId: String
+    let mode: String
+    let seasonNumbers: [Int]?
+    let deleteWatched: Bool
+    let maxStorageBytes: Int64
+}
+
+struct UpdateSubscriptionRequest: Encodable, Sendable {
+    let mode: String?
+    let seasonNumbers: [Int]?
+    let deleteWatched: Bool?
+    let maxStorageBytes: Int64?
+    let active: Bool?
+}
+
+struct CreateSubscriptionResponse: Codable, Sendable {
+    let subscription: ServerSubscription
+    let registered: Int
+}
+
+struct SubscriptionsListResponse: Codable, Sendable {
+    let subscriptions: [ServerSubscription]
+}
+
+struct SubscriptionSyncResponse: Codable, Sendable {
+    let registered: Int
+}
+
+// MARK: - Progress reconciliation
+
+/// `GET /api/v1/progress?since={cursor}` delta response. §5.2.
+struct ProgressPullResponse: Codable, Sendable {
+    let progress: [ProgressPullItem]
+    let nextCursor: String?
+}
+
+struct ProgressPullItem: Codable, Sendable {
+    let mediaItemId: String
+    let positionSeconds: Double
+    let durationSeconds: Double
+    let completed: Bool
+    let updatedAt: Date?
+}
+
+// MARK: - Local persistence types
+
+/// Client-side lifecycle of a managed download, layered on top of the
+/// server's row status. The server owns `ready`/`preparing`/`revoked`/
+/// `failed`; the client owns the local fetch progression below.
+enum LocalDownloadStatus: String, Codable, Sendable {
+    /// `POST /downloads` registered; awaiting the asset pipeline.
+    case registering
+    /// Server is producing a remux/transcode artifact (`preparing`).
+    case preparing
+    /// Server row is `ready`; queued behind the concurrency cap.
+    case queued
+    /// Background `URLSession` task is transferring the media file.
+    case downloading
+    /// Media file is local; fetching manifest/artwork/subtitles.
+    case fetchingAssets
+    /// Everything is on disk and playable offline.
+    case completed
+    /// Unrecoverable failure; see `lastError`.
+    case failed
+    /// Server revoked future serves (409). An already-downloaded file
+    /// stays playable.
+    case revoked
+
+    var isTerminalSuccess: Bool { self == .completed }
+    var isActive: Bool {
+        switch self {
+        case .registering, .preparing, .queued, .downloading, .fetchingAssets:
+            return true
+        case .completed, .failed, .revoked:
+            return false
+        }
+    }
+}
+
+/// The single local source of truth for one managed download. On-disk
+/// paths are stored as **relative filenames** (the app-container path can
+/// change between launches) and rebuilt against the current container via
+/// `DownloadFilePaths`.
+struct DownloadRecord: Codable, Identifiable, Hashable, Sendable {
+    let id: String                       // server download id
+    var contentId: String                // mutable: may be re-resolved via stableIdentity
+    let episodeId: String?
+    let batchId: String?
+    var mediaFileId: Int
+    var format: String
+    var effectiveQuality: String? = nil
+    var deliveryFormat: String? = nil
+    var targetBitrateKbps: Int? = nil
+    var revision: Int? = nil
+    var serverStatus: String
+    var localStatus: LocalDownloadStatus
+    var fileSize: Int64
+    var bytesDownloaded: Int64
+
+    var mediaFilename: String?
+    var manifestFilename: String?
+    var posterFilename: String?
+    var backdropFilename: String?
+    var logoFilename: String?
+    /// Manifest `fetch_url` → relative on-disk filename.
+    var subtitleFilenames: [String: String]
+
+    // Display fields cached so the Downloads list renders before the
+    // manifest is fetched and offline.
+    var title: String?
+    var subtitle: String?                // e.g. "2024" or "S1 · E2"
+    var type: String?                    // "movie" | "episode" | "series"
+    var seriesId: String?
+    /// Cached parent-series title for episode downloads (from the manifest),
+    /// so the grouped Downloads UI can label a series card offline.
+    var seriesTitle: String? = nil
+    /// Structured season/episode numbers, populated from the offline
+    /// manifest. Default `nil` keeps the synthesized memberwise init and
+    /// Codable backward-compatible with stores written before they existed.
+    var seasonNumber: Int? = nil
+    var episodeNumber: Int? = nil
+    var posterThumbhash: String?
+    var container: String?               // media container, drives file ext + engine
+
+    var stableIdentity: StableIdentity?
+    var registeredAt: Date
+    var downloadedAt: Date?
+    var lastError: String?
+    var retryCount: Int
+    /// `URLSessionDownloadTask.taskIdentifier`, for reconnecting on relaunch.
+    var taskIdentifier: Int?
+
+    var isPlayableOffline: Bool {
+        (localStatus == .completed || localStatus == .revoked) && mediaFilename != nil
+    }
+
+    /// The leaf media item id watch-progress is keyed by: the episode id for
+    /// an episode download, otherwise the (movie) content id.
+    var leafMediaItemId: String { episodeId ?? contentId }
+
+    var progressFraction: Double {
+        guard fileSize > 0 else { return 0 }
+        return min(1, max(0, Double(bytesDownloaded) / Double(fileSize)))
+    }
+}
+
+/// A locally-mirrored subscription with the series title cached for
+/// offline display.
+struct DownloadSubscription: Codable, Identifiable, Hashable, Sendable {
+    let id: String
+    let seriesId: String
+    var seriesTitle: String?
+    var mode: String
+    var targetSeason: Int?
+    var seasonNumbers: [Int]?
+    var deleteWatched: Bool
+    var maxStorageBytes: Int64
+    var active: Bool
+
+    init(from server: ServerSubscription, seriesTitle: String?) {
+        self.id = server.id
+        self.seriesId = server.seriesId
+        self.seriesTitle = seriesTitle
+        self.mode = server.mode
+        self.targetSeason = server.targetSeason
+        self.seasonNumbers = server.seasonNumbers
+        self.deleteWatched = server.deleteWatched
+        self.maxStorageBytes = server.maxStorageBytes
+        self.active = server.active
+    }
+}
+
+/// A watch-progress event queued while offline, flushed via
+/// `POST /api/v1/sync/progress` on reconnect. `updatedAt` becomes the
+/// last-write-wins event time (§5.1).
+struct QueuedProgress: Codable, Identifiable, Sendable {
+    let id: UUID
+    let mediaItemId: String
+    let position: Double
+    let duration: Double
+    let updatedAt: Date
+    var attempts: Int
+}
+
+/// Last-known resume point for a downloaded item, updated by offline
+/// playback and by pulled server deltas. Drives offline resume.
+struct LocalProgressEntry: Codable, Sendable {
+    var position: Double
+    var duration: Double
+    var completed: Bool
+    var updatedAt: Date
+}
+
+/// The entire on-disk store blob for one `(server, profile)` scope.
+struct DownloadStoreFile: Codable, Sendable {
+    var version: Int
+    var records: [String: DownloadRecord]
+    var subscriptions: [DownloadSubscription]
+    var capability: DownloadCapability?
+    var capabilityFetchedAt: Date?
+    var progressQueue: [QueuedProgress]
+    var progressCursor: String?
+    var localProgress: [String: LocalProgressEntry]
+
+    static let currentVersion = 1
+
+    static let empty = DownloadStoreFile(
+        version: currentVersion,
+        records: [:],
+        subscriptions: [],
+        capability: nil,
+        capabilityFetchedAt: nil,
+        progressQueue: [],
+        progressCursor: nil,
+        localProgress: [:]
+    )
+}

--- a/iosApp/iosApp/Downloads/DownloadModels.swift
+++ b/iosApp/iosApp/Downloads/DownloadModels.swift
@@ -574,6 +574,12 @@ enum LocalDownloadStatus: String, Codable, Sendable {
     case queued
     /// Background `URLSession` task is transferring the media file.
     case downloading
+    /// User-suspended transfer. The task was cancelled with resume data
+    /// (persisted next to the media, see `DownloadRecord.resumeDataFilename`)
+    /// so the transfer can continue without refetching completed ranges.
+    /// Only an explicit user resume leaves this state — the pipeline and
+    /// server reconciliation must never auto-restart it.
+    case paused
     /// Media file is local; fetching manifest/artwork/subtitles.
     case fetchingAssets
     /// Everything is on disk and playable offline.
@@ -585,9 +591,12 @@ enum LocalDownloadStatus: String, Codable, Sendable {
     case revoked
 
     var isTerminalSuccess: Bool { self == .completed }
+    /// `paused` counts as active so it stays in the in-progress UI, but the
+    /// pipeline only ever starts `.queued` records — pausing both surfaces
+    /// the row and blocks any automatic restart.
     var isActive: Bool {
         switch self {
-        case .registering, .preparing, .queued, .downloading, .fetchingAssets:
+        case .registering, .preparing, .queued, .downloading, .paused, .fetchingAssets:
             return true
         case .completed, .failed, .revoked:
             return false
@@ -622,6 +631,10 @@ struct DownloadRecord: Codable, Identifiable, Hashable, Sendable {
     var logoFilename: String?
     /// Manifest `fetch_url` → relative on-disk filename.
     var subtitleFilenames: [String: String]
+    /// Persisted `cancel(byProducingResumeData:)` blob for a paused
+    /// transfer. Default `nil` keeps Codable backward-compatible with
+    /// stores written before pause existed.
+    var resumeDataFilename: String? = nil
 
     // Display fields cached so the Downloads list renders before the
     // manifest is fetched and offline.

--- a/iosApp/iosApp/Downloads/DownloadNotifications.swift
+++ b/iosApp/iosApp/Downloads/DownloadNotifications.swift
@@ -1,0 +1,84 @@
+#if os(iOS)
+import Foundation
+import UserNotifications
+
+/// Posts local notifications for download lifecycle events: completion,
+/// terminal failure, and monitoring-queued episodes.
+///
+/// Authorization is owned by `ApplePushRegistrationCoordinator` — it
+/// requests permission on the first authenticated profile — so this only
+/// checks the current status and stays silent when the user declined,
+/// never re-prompting.
+@MainActor
+enum DownloadNotifier {
+    /// Tapping any download notification lands on the Downloads screen via
+    /// the same userInfo key the push pipeline uses, so
+    /// `SiloAppDelegate.userNotificationCenter(_:didReceive:)` routes both
+    /// kinds through one code path.
+    private static let downloadsDeepLink = "continuum://downloads"
+
+    static func downloadCompleted(_ record: DownloadRecord) {
+        post(
+            id: "download-completed-\(record.id)",
+            body: "\(displayName(for: record)) is ready to watch offline"
+        )
+    }
+
+    static func downloadFailed(_ record: DownloadRecord) {
+        post(
+            id: "download-failed-\(record.id)",
+            body: "Download failed: \(displayName(for: record))"
+        )
+    }
+
+    /// One notification per monitoring-sync batch. When every queued
+    /// episode belongs to one series the body names the show; a
+    /// multi-series batch falls back to a count-only summary.
+    static func newEpisodesQueued(count: Int, seriesTitles: Set<String>) {
+        guard count > 0 else { return }
+        let noun = count == 1 ? "episode" : "episodes"
+        let verb = count == 1 ? "is" : "are"
+        let body: String
+        if seriesTitles.count == 1, let title = seriesTitles.first {
+            body = "\(count) new \(noun) of \(title) \(verb) downloading"
+        } else {
+            body = "\(count) new \(noun) \(verb) downloading"
+        }
+        post(id: "downloads-monitoring-\(UUID().uuidString)", body: body)
+    }
+
+    /// "Exodus (S2E8)" for episodes, plain title for movies. The series
+    /// title is preferred for episodes because the S/E marker already
+    /// disambiguates which entry finished.
+    private static func displayName(for record: DownloadRecord) -> String {
+        let base = record.seriesTitle ?? record.title ?? "Download"
+        if let season = record.seasonNumber, let episode = record.episodeNumber {
+            return "\(base) (S\(season)E\(episode))"
+        }
+        return base
+    }
+
+    /// No title: banners then lead with the app name, keeping the copy a
+    /// single sentence. Foreground presentation is intentionally not
+    /// suppressed — the app-wide delegate already presents banners for
+    /// every notification while active.
+    private static func post(id: String, body: String) {
+        Task {
+            let center = UNUserNotificationCenter.current()
+            let settings = await center.notificationSettings()
+            switch settings.authorizationStatus {
+            case .authorized, .provisional, .ephemeral:
+                break
+            default:
+                return
+            }
+            let content = UNMutableNotificationContent()
+            content.body = body
+            content.sound = .default
+            content.userInfo = [ApplePushDisplayWire.urlUserInfoKey: downloadsDeepLink]
+            let request = UNNotificationRequest(identifier: id, content: content, trigger: nil)
+            try? await center.add(request)
+        }
+    }
+}
+#endif

--- a/iosApp/iosApp/Downloads/DownloadOptionsSheet.swift
+++ b/iosApp/iosApp/Downloads/DownloadOptionsSheet.swift
@@ -1,0 +1,324 @@
+#if !os(tvOS)
+import SwiftUI
+
+struct DownloadRequestOptions: Hashable {
+    let fileId: Int?
+    let quality: String
+}
+
+struct DownloadOptionsSheet: View {
+    let title: String
+    let versions: [FileVersion]
+    let selectedVersionFileId: Int?
+    let lastVersionFileId: Int?
+    let onStart: (DownloadRequestOptions) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    private var manager: DownloadManager { DownloadManager.shared }
+
+    @State private var fileId: Int?
+    @State private var quality: String
+
+    init(
+        title: String,
+        versions: [FileVersion],
+        selectedVersionFileId: Int?,
+        lastVersionFileId: Int?,
+        onStart: @escaping (DownloadRequestOptions) -> Void
+    ) {
+        self.title = title
+        self.versions = versions
+        self.selectedVersionFileId = selectedVersionFileId
+        self.lastVersionFileId = lastVersionFileId
+        self.onStart = onStart
+
+        _fileId = State(initialValue: selectedVersionFileId)
+        _quality = State(initialValue: DownloadSettings.shared.preferredFormat)
+    }
+
+    private var formats: [DownloadFormat] {
+        let available = manager.availableFormats
+        return available.isEmpty ? [.original] : available
+    }
+
+    private var editions: [PlaybackEditions.Edition] {
+        PlaybackEditions.editions(from: versions)
+    }
+
+    private var effectiveVersion: FileVersion? {
+        DetailVersionSelection.displayVersion(
+            versions: versions,
+            selectedFileId: fileId,
+            lastFileId: lastVersionFileId,
+            preferredQualityId: PlayerSettings.shared.preferredQuality
+        )
+    }
+
+    private var currentEdition: PlaybackEditions.Edition? {
+        DetailPlaybackFormatting.currentEdition(
+            versions: versions,
+            currentVersion: effectiveVersion
+        )
+    }
+
+    private var scopedVersions: [FileVersion] {
+        if editions.count > 1, let currentEdition {
+            return currentEdition.versions
+        }
+        return versions
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    summaryRow
+                } header: {
+                    Text("Download")
+                }
+
+                if editions.count > 1 {
+                    editionSection
+                }
+
+                if !versions.isEmpty {
+                    versionSection
+                }
+
+                qualitySection
+                mediaSummarySection
+            }
+            .navigationTitle("Download Options")
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .continuumScrollContentBackgroundHidden()
+            .background(Color.continuumBackground)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Download") {
+                        onStart(DownloadRequestOptions(fileId: fileId, quality: quality))
+                        dismiss()
+                    }
+                }
+            }
+            .onAppear(perform: clampQuality)
+        }
+        #if os(iOS)
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+        #endif
+    }
+
+    private var summaryRow: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(.continuumOnSurface)
+                .lineLimit(2)
+            Text(summaryDetail)
+                .font(.continuumCaption)
+                .foregroundColor(.continuumSecondaryText)
+                .lineLimit(3)
+        }
+        .padding(.vertical, 2)
+    }
+
+    private var summaryDetail: String {
+        let qualityLabel = DownloadFormat(rawValue: quality)?.displayName ?? quality
+        let versionLabel = fileId == nil
+            ? "Auto version"
+            : (effectiveVersion.map(DetailPlaybackFormatting.versionPrimaryText) ?? "Selected version")
+        return "\(versionLabel) · \(qualityLabel)"
+    }
+
+    private var editionSection: some View {
+        Section("Edition") {
+            ForEach(editions) { edition in
+                optionButton(
+                    title: edition.label,
+                    detail: "\(edition.versions.count) version\(edition.versions.count == 1 ? "" : "s")",
+                    isSelected: currentEdition?.id == edition.id
+                ) {
+                    let best = DetailVersionSelection.displayVersion(
+                        versions: edition.versions,
+                        selectedFileId: nil,
+                        lastFileId: lastVersionFileId,
+                        preferredQualityId: PlayerSettings.shared.preferredQuality
+                    )
+                    fileId = best?.fileId
+                }
+            }
+        }
+    }
+
+    private var versionSection: some View {
+        Section("Version") {
+            optionButton(
+                title: "Auto",
+                detail: "Let the server choose the file",
+                isSelected: fileId == nil
+            ) {
+                fileId = nil
+            }
+            ForEach(scopedVersions) { version in
+                optionButton(
+                    title: DetailPlaybackFormatting.versionPrimaryText(version),
+                    detail: DetailPlaybackFormatting.versionSecondaryText(version),
+                    isSelected: fileId == version.fileId
+                ) {
+                    fileId = version.fileId
+                }
+            }
+        }
+    }
+
+    private var qualitySection: some View {
+        Section {
+            if formats.count > 1 {
+                ForEach(formats, id: \.self) { format in
+                    optionButton(
+                        title: format.displayName,
+                        detail: qualityDetail(for: format),
+                        isSelected: quality == format.rawValue
+                    ) {
+                        quality = format.rawValue
+                    }
+                }
+            } else {
+                optionButton(
+                    title: formats.first?.displayName ?? DownloadFormat.original.displayName,
+                    detail: qualityDetail(for: formats.first ?? .original),
+                    isSelected: true,
+                    isEnabled: false
+                ) {}
+            }
+        } header: {
+            Text("Quality")
+        } footer: {
+            Text("This starts from your global Downloads default. Changing it here applies only to this download.")
+        }
+    }
+
+    private func qualityDetail(for format: DownloadFormat) -> String {
+        switch format {
+        case .original:
+            return "Source quality, with compatibility fallback if needed"
+        case .twentyMbps, .tenMbps, .fiveMbps, .twoMbps, .oneMbps:
+            return "Prepared server-side before transfer"
+        }
+    }
+
+    private func clampQuality() {
+        guard !formats.contains(where: { $0.rawValue == quality }) else { return }
+        quality = DownloadSettings.shared.resolvedFormat(
+            allowedFormats: manager.capability?.qualityPresets ?? []
+        )
+    }
+
+    private var mediaSummarySection: some View {
+        Section {
+            if let effectiveVersion {
+                readOnlyRow(
+                    title: "Audio",
+                    detail: DetailPlaybackFormatting.audioValueLabel(
+                        version: effectiveVersion,
+                        selectedAudioTrackIndex: nil
+                    )
+                )
+                readOnlyRow(
+                    title: "Subtitles",
+                    detail: subtitleSummary(for: effectiveVersion)
+                )
+            } else {
+                readOnlyRow(title: "Audio", detail: "File default")
+                readOnlyRow(title: "Subtitles", detail: "Available tracks")
+            }
+        } header: {
+            Text("Included Media")
+        } footer: {
+            Text("Audio and subtitle selection is resolved by the server for the selected file. Available subtitle files are cached for offline playback.")
+        }
+    }
+
+    private func subtitleSummary(for version: FileVersion) -> String {
+        let tracks = version.subtitleTracks ?? []
+        guard !tracks.isEmpty else { return "None advertised" }
+        let languages = tracks
+            .compactMap { languageDisplayName($0.language) }
+            .uniqued()
+        if languages.isEmpty {
+            return "\(tracks.count) track\(tracks.count == 1 ? "" : "s")"
+        }
+        return languages.joined(separator: ", ")
+    }
+
+    private func languageDisplayName(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else {
+            return nil
+        }
+        if value.count <= 3 {
+            let locale = Locale.current
+            return locale.localizedString(forLanguageCode: value.lowercased()) ?? value.uppercased()
+        }
+        return value
+    }
+
+    private func readOnlyRow(title: String, detail: String) -> some View {
+        HStack {
+            Text(title)
+            Spacer(minLength: 12)
+            Text(detail)
+                .foregroundColor(.continuumSecondaryText)
+                .multilineTextAlignment(.trailing)
+        }
+    }
+
+    private func optionButton(
+        title: String,
+        detail: String?,
+        isSelected: Bool,
+        isEnabled: Bool = true,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(alignment: .top, spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(.continuumOnSurface)
+                        .lineLimit(2)
+                    if let detail, !detail.isEmpty {
+                        Text(detail)
+                            .font(.continuumCaption)
+                            .foregroundColor(.continuumSecondaryText)
+                            .lineLimit(2)
+                    }
+                }
+                Spacer(minLength: 8)
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 14, weight: .bold))
+                        .foregroundColor(.continuumOnSurface)
+                }
+            }
+            .padding(.vertical, 4)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!isEnabled)
+        .opacity(isEnabled ? 1 : 0.56)
+    }
+}
+
+private extension Array where Element: Hashable {
+    func uniqued() -> [Element] {
+        var seen = Set<Element>()
+        return filter { seen.insert($0).inserted }
+    }
+}
+#endif

--- a/iosApp/iosApp/Downloads/DownloadOptionsSheet.swift
+++ b/iosApp/iosApp/Downloads/DownloadOptionsSheet.swift
@@ -132,7 +132,26 @@ struct DownloadOptionsSheet: View {
         let versionLabel = fileId == nil
             ? "Auto version"
             : (effectiveVersion.map(DetailPlaybackFormatting.versionPrimaryText) ?? "Selected version")
-        return "\(versionLabel) · \(qualityLabel)"
+        var parts = [versionLabel, qualityLabel]
+        if let estimate = selectionEstimate {
+            parts.append(estimate.isRange ? "\(estimate.sizeLabel) depending on server choice" : estimate.sizeLabel)
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    /// Size expectation for what the current selection would download:
+    /// candidate range for Auto, exact size for a chosen version.
+    private var selectionEstimate: DownloadSizeEstimate? {
+        DownloadSizeEstimate.estimate(versions: versions, fileId: fileId)
+    }
+
+    /// Over-threshold / insufficient-space caveat for the current selection,
+    /// mirroring the one-tap confirmation so switching versions in the sheet
+    /// keeps the warning honest.
+    private var selectionSizeWarning: String? {
+        selectionEstimate?.warningMessage(
+            availableBytes: DownloadFilePaths.deviceStorage().available
+        )
     }
 
     private var editionSection: some View {
@@ -156,24 +175,81 @@ struct DownloadOptionsSheet: View {
     }
 
     private var versionSection: some View {
-        Section("Version") {
+        Section {
             optionButton(
                 title: "Auto",
-                detail: "Let the server choose the file",
+                detail: autoVersionDetail,
                 isSelected: fileId == nil
             ) {
                 fileId = nil
             }
-            ForEach(scopedVersions) { version in
+            ForEach(versionRows, id: \.version.fileId) { row in
                 optionButton(
-                    title: DetailPlaybackFormatting.versionPrimaryText(version),
-                    detail: DetailPlaybackFormatting.versionSecondaryText(version),
-                    isSelected: fileId == version.fileId
+                    title: row.title,
+                    detail: row.detail,
+                    isSelected: fileId == row.version.fileId
                 ) {
-                    fileId = version.fileId
+                    fileId = row.version.fileId
                 }
             }
+        } header: {
+            Text("Version")
+        } footer: {
+            if let selectionSizeWarning {
+                Text(selectionSizeWarning)
+                    .foregroundColor(.orange)
+            }
         }
+    }
+
+    /// Version rows with a disambiguator appended when two distinct files
+    /// would otherwise render identical primary/secondary text (same
+    /// resolution/codec/size), so every row stays tellable-apart.
+    private var versionRows: [(version: FileVersion, title: String, detail: String?)] {
+        let rows = scopedVersions.map { version in
+            (
+                version: version,
+                title: DetailPlaybackFormatting.versionPrimaryText(version),
+                detail: DetailPlaybackFormatting.versionSecondaryText(version)
+            )
+        }
+        var counts: [String: Int] = [:]
+        for row in rows {
+            counts["\(row.title)|\(row.detail ?? "")", default: 0] += 1
+        }
+        return rows.map { row in
+            guard counts["\(row.title)|\(row.detail ?? "")", default: 0] > 1 else { return row }
+            let detail = [row.detail, disambiguator(for: row.version)]
+                .compactMap { $0 }
+                .joined(separator: " · ")
+            return (row.version, row.title, detail)
+        }
+    }
+
+    /// Edition name when the file has one, else a filename fragment — just
+    /// enough to tell apart two files whose technical summary reads the same.
+    private func disambiguator(for version: FileVersion) -> String {
+        let edition = version.editionDisplayLabel
+        if edition != "Standard" { return edition }
+        if let fragment = version.fileName?
+            .components(separatedBy: "/").last?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !fragment.isEmpty {
+            return fragment
+        }
+        return "File \(version.fileId)"
+    }
+
+    /// Auto spans every version the server might pick, so disclose the full
+    /// candidate range rather than pretending the size is unknown.
+    private var autoVersionDetail: String {
+        guard let estimate = DownloadSizeEstimate.estimate(versions: versions, fileId: nil) else {
+            return "Let the server choose the file"
+        }
+        if estimate.isRange {
+            return "\(estimate.sizeLabel) depending on server choice"
+        }
+        return "\(estimate.sizeLabel) · Let the server choose the file"
     }
 
     private var qualitySection: some View {
@@ -208,7 +284,7 @@ struct DownloadOptionsSheet: View {
         case .original:
             return "Source quality, with compatibility fallback if needed"
         case .twentyMbps, .tenMbps, .fiveMbps, .twoMbps, .oneMbps:
-            return "Prepared server-side before transfer"
+            return "Prepared on the server before download starts"
         }
     }
 
@@ -240,20 +316,26 @@ struct DownloadOptionsSheet: View {
         } header: {
             Text("Included Media")
         } footer: {
-            Text("Audio and subtitle selection is resolved by the server for the selected file. Available subtitle files are cached for offline playback.")
+            Text("Audio and subtitles are chosen automatically for the selected file. Available subtitles are saved for offline playback.")
         }
     }
 
+    /// Capped at three languages — a file with dozens of tracks would
+    /// otherwise render a wall of language names in one row.
+    private static let subtitleLanguageDisplayCap = 3
+
     private func subtitleSummary(for version: FileVersion) -> String {
         let tracks = version.subtitleTracks ?? []
-        guard !tracks.isEmpty else { return "None advertised" }
+        guard !tracks.isEmpty else { return "None" }
         let languages = tracks
             .compactMap { languageDisplayName($0.language) }
             .uniqued()
         if languages.isEmpty {
             return "\(tracks.count) track\(tracks.count == 1 ? "" : "s")"
         }
-        return languages.joined(separator: ", ")
+        let shown = languages.prefix(Self.subtitleLanguageDisplayCap).joined(separator: ", ")
+        let remainder = languages.count - Self.subtitleLanguageDisplayCap
+        return remainder > 0 ? "\(shown) +\(remainder) more" : shown
     }
 
     private func languageDisplayName(_ value: String?) -> String? {

--- a/iosApp/iosApp/Downloads/DownloadSessionDelegate.swift
+++ b/iosApp/iosApp/Downloads/DownloadSessionDelegate.swift
@@ -1,0 +1,192 @@
+import Foundation
+import OSLog
+
+/// Events surfaced by the background download session, consumed by
+/// `DownloadManager` on the MainActor via an `AsyncStream`.
+enum DownloadSessionEvent: Sendable {
+    case progress(taskId: Int, bytesWritten: Int64, totalExpected: Int64)
+    /// Media transfer succeeded (HTTP 2xx). `stagedURL` is a stable file in
+    /// the staging directory — the volatile temp file has already been
+    /// moved there synchronously inside the delegate callback.
+    case finished(taskId: Int, stagedURL: URL, statusCode: Int)
+    /// Transfer ended without a usable file: a network error, a
+    /// cancellation, or a non-2xx server response (e.g. 409 revoked).
+    case failed(taskId: Int, statusCode: Int?, resumeData: Data?, message: String)
+    /// All background events for this launch have been delivered; the app
+    /// may call the system-provided completion handler.
+    case allEventsDelivered
+}
+
+/// Owns the app's single background `URLSession` used to transfer media
+/// files. A background session continues across suspension/termination and
+/// resumes via HTTP Range, so this is an `NSObject` delegate (background
+/// sessions cannot use the async `URLSession` data API).
+final class DownloadSessionDelegate: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
+    static let sessionIdentifier = "com.continuum.play.downloads"
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.continuum.app",
+        category: "Downloads"
+    )
+
+    private let continuation: AsyncStream<DownloadSessionEvent>.Continuation
+    let events: AsyncStream<DownloadSessionEvent>
+
+    /// Set when iOS relaunches the app to deliver background events; called
+    /// once `allEventsDelivered` is processed.
+    var backgroundCompletionHandler: (() -> Void)?
+
+    override init() {
+        let (stream, continuation) = AsyncStream<DownloadSessionEvent>.makeStream()
+        self.events = stream
+        self.continuation = continuation
+        super.init()
+        _ = session   // force lazy creation so the delegate is registered
+    }
+
+    private(set) lazy var session: URLSession = {
+        let config = URLSessionConfiguration.background(withIdentifier: Self.sessionIdentifier)
+        config.sessionSendsLaunchEvents = true
+        config.isDiscretionary = false
+        config.allowsCellularAccess = true
+        config.httpMaximumConnectionsPerHost = 4
+        return URLSession(configuration: config, delegate: self, delegateQueue: nil)
+    }()
+
+    // MARK: - Task control
+
+    /// Start a fresh media download. Returns the task identifier to persist
+    /// on the record for relaunch reconnection.
+    func start(request: URLRequest) -> Int {
+        let task = session.downloadTask(with: request)
+        task.resume()
+        return task.taskIdentifier
+    }
+
+    /// Resume a previously-interrupted download from its `resumeData`.
+    func resume(data: Data) -> Int {
+        let task = session.downloadTask(withResumeData: data)
+        task.resume()
+        return task.taskIdentifier
+    }
+
+    func cancel(taskId: Int) {
+        session.getAllTasks { tasks in
+            tasks.first(where: { $0.taskIdentifier == taskId })?.cancel()
+        }
+    }
+
+    /// Identifiers of tasks still live in the (possibly relaunched) session.
+    func activeTaskIdentifiers() async -> Set<Int> {
+        await withCheckedContinuation { cont in
+            session.getAllTasks { tasks in
+                cont.resume(returning: Set(tasks.map { $0.taskIdentifier }))
+            }
+        }
+    }
+
+    // MARK: - URLSessionDownloadDelegate
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didWriteData bytesWritten: Int64,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        continuation.yield(.progress(
+            taskId: downloadTask.taskIdentifier,
+            bytesWritten: totalBytesWritten,
+            totalExpected: totalBytesExpectedToWrite
+        ))
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didFinishDownloadingTo location: URL
+    ) {
+        let taskId = downloadTask.taskIdentifier
+        let statusCode = (downloadTask.response as? HTTPURLResponse)?.statusCode ?? 0
+
+        // A non-2xx "success" means the body is an error envelope, not media.
+        guard (200..<300).contains(statusCode) else {
+            Self.logger.error("Download task \(taskId) finished with HTTP \(statusCode); treating as failure")
+            continuation.yield(.failed(
+                taskId: taskId,
+                statusCode: statusCode,
+                resumeData: nil,
+                message: "HTTP \(statusCode)"
+            ))
+            return
+        }
+
+        // The temp file is only valid during this callback — move it to a
+        // stable staging location synchronously, then hand off the path.
+        let staged = DownloadFilePaths.stagingFileURL(taskIdentifier: taskId)
+        try? FileManager.default.removeItem(at: staged)
+        do {
+            try FileManager.default.moveItem(at: location, to: staged)
+            continuation.yield(.finished(taskId: taskId, stagedURL: staged, statusCode: statusCode))
+        } catch {
+            Self.logger.error("Failed to stage finished download \(taskId): \(String(describing: error), privacy: .public)")
+            continuation.yield(.failed(
+                taskId: taskId,
+                statusCode: statusCode,
+                resumeData: nil,
+                message: "stage_failed"
+            ))
+        }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: Error?
+    ) {
+        // Success path is handled in didFinishDownloadingTo. Only act on a
+        // real transport error / cancellation here.
+        guard let error else { return }
+        let nsError = error as NSError
+        let resumeData = nsError.userInfo[NSURLSessionDownloadTaskResumeData] as? Data
+        let statusCode = (task.response as? HTTPURLResponse)?.statusCode
+        // A user-initiated cancel still surfaces here; the manager checks
+        // its own intent and ignores cancellations it requested.
+        continuation.yield(.failed(
+            taskId: task.taskIdentifier,
+            statusCode: statusCode,
+            resumeData: resumeData,
+            message: error.localizedDescription
+        ))
+    }
+
+    func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
+        continuation.yield(.allEventsDelivered)
+    }
+}
+
+/// Builds an authenticated `URLRequest` for the background download
+/// session, replicating the header set `HTTPClient.attachAuthHeaders`
+/// applies (the background session can't share that actor's `URLSession`).
+enum DownloadAuthHeaders {
+    static func authorizedRequest(url: URL, allowsCellular: Bool) async -> URLRequest {
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.allowsCellularAccess = allowsCellular
+
+        if let token = await TokenStore.shared.getAccessToken() {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        if let profileId = await TokenStore.shared.getProfileId() {
+            request.setValue(profileId, forHTTPHeaderField: "X-Profile-Id")
+        }
+        if let profileToken = await TokenStore.shared.getProfileToken() {
+            request.setValue(profileToken, forHTTPHeaderField: "X-Profile-Token")
+        }
+        let device = AppleDeviceIdentity.current
+        request.setValue(device.id, forHTTPHeaderField: "X-Silo-Device-Id")
+        request.setValue(device.name, forHTTPHeaderField: "X-Silo-Device-Name")
+        request.setValue(device.platform, forHTTPHeaderField: "X-Silo-Device-Platform")
+        return request
+    }
+}

--- a/iosApp/iosApp/Downloads/DownloadSessionDelegate.swift
+++ b/iosApp/iosApp/Downloads/DownloadSessionDelegate.swift
@@ -76,6 +76,24 @@ final class DownloadSessionDelegate: NSObject, URLSessionDownloadDelegate, @unch
         }
     }
 
+    /// Suspend a transfer by cancelling it with resume data. Returns `nil`
+    /// when the server/transfer doesn't support ranged resume or the task is
+    /// no longer live — callers must treat that as "restart from zero".
+    func pause(taskId: Int) async -> Data? {
+        await withCheckedContinuation { cont in
+            session.getAllTasks { tasks in
+                guard let task = tasks.first(where: { $0.taskIdentifier == taskId })
+                    as? URLSessionDownloadTask else {
+                    cont.resume(returning: nil)
+                    return
+                }
+                task.cancel(byProducingResumeData: { data in
+                    cont.resume(returning: data)
+                })
+            }
+        }
+    }
+
     /// Identifiers of tasks still live in the (possibly relaunched) session.
     func activeTaskIdentifiers() async -> Set<Int> {
         await withCheckedContinuation { cont in

--- a/iosApp/iosApp/Downloads/DownloadSettings.swift
+++ b/iosApp/iosApp/Downloads/DownloadSettings.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+/// Device-level download preferences. Persisted to `UserDefaults` in each
+/// property's `didSet`, mirroring the `PlayerSettings` convention. These
+/// are local decisions (not server-synced): the download quality to
+/// request, whether to restrict to Wi-Fi, and the defaults used when
+/// creating a new series-monitoring subscription.
+@Observable
+final class DownloadSettings {
+    static let shared = DownloadSettings()
+
+    /// Requested download quality. Coerced to `original` if the active
+    /// server doesn't currently offer the stored choice.
+    var preferredFormat: String {
+        didSet { defaults.set(preferredFormat, forKey: Keys.preferredFormat) }
+    }
+
+    /// When true, downloads only transfer over Wi-Fi.
+    var wifiOnly: Bool {
+        didSet { defaults.set(wifiOnly, forKey: Keys.wifiOnly) }
+    }
+
+    /// Default `delete_watched` for new subscriptions.
+    var defaultDeleteWatched: Bool {
+        didSet { defaults.set(defaultDeleteWatched, forKey: Keys.defaultDeleteWatched) }
+    }
+
+    /// Default per-subscription storage cap in GB. `0` = unlimited.
+    var defaultMaxStorageGB: Int {
+        didSet { defaults.set(defaultMaxStorageGB, forKey: Keys.defaultMaxStorageGB) }
+    }
+
+    /// Last-chosen ordering for the Downloads Manager list.
+    var sortOption: DownloadSortOption {
+        didSet { defaults.set(sortOption.rawValue, forKey: Keys.sortOption) }
+    }
+
+    /// When true, suppress the "Free up space" reclaim suggestion (the user
+    /// prefers to keep watched downloads around).
+    var keepWatchedDownloads: Bool {
+        didSet { defaults.set(keepWatchedDownloads, forKey: Keys.keepWatchedDownloads) }
+    }
+
+    /// When true, offline series-browse hides episodes that aren't on-device
+    /// instead of offering them for download.
+    var showOnlyDownloadedInBrowse: Bool {
+        didSet { defaults.set(showOnlyDownloadedInBrowse, forKey: Keys.showOnlyDownloadedInBrowse) }
+    }
+
+    private let defaults: UserDefaults
+
+    private init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        defaults.register(defaults: [
+            Keys.preferredFormat: DownloadFormat.original.rawValue,
+            Keys.wifiOnly: true,
+            Keys.defaultDeleteWatched: false,
+            Keys.defaultMaxStorageGB: 0,
+            Keys.sortOption: DownloadSortOption.largestFirst.rawValue,
+            Keys.keepWatchedDownloads: false,
+            Keys.showOnlyDownloadedInBrowse: false,
+        ])
+        preferredFormat = defaults.string(forKey: Keys.preferredFormat) ?? DownloadFormat.original.rawValue
+        wifiOnly = defaults.bool(forKey: Keys.wifiOnly)
+        defaultDeleteWatched = defaults.bool(forKey: Keys.defaultDeleteWatched)
+        defaultMaxStorageGB = defaults.integer(forKey: Keys.defaultMaxStorageGB)
+        sortOption = defaults.string(forKey: Keys.sortOption)
+            .flatMap(DownloadSortOption.init(rawValue:)) ?? .largestFirst
+        keepWatchedDownloads = defaults.bool(forKey: Keys.keepWatchedDownloads)
+        showOnlyDownloadedInBrowse = defaults.bool(forKey: Keys.showOnlyDownloadedInBrowse)
+    }
+
+    /// The quality to actually request, given what the server offers right
+    /// now. Falls back to `original`, which should always be available.
+    func resolvedFormat(allowedFormats: [String]) -> String {
+        if allowedFormats.contains(preferredFormat) {
+            return preferredFormat
+        }
+        return DownloadFormat.original.rawValue
+    }
+
+    /// Bytes per gigabyte (GiB), shared by the storage-cap conversions.
+    static let bytesPerGB: Int64 = 1_073_741_824
+
+    var defaultMaxStorageBytes: Int64 {
+        guard defaultMaxStorageGB > 0 else { return 0 }
+        return Int64(defaultMaxStorageGB) * Self.bytesPerGB
+    }
+
+    private enum Keys {
+        static let preferredFormat = "downloads.preferredFormat"
+        static let wifiOnly = "downloads.wifiOnly"
+        static let defaultDeleteWatched = "downloads.defaultDeleteWatched"
+        static let defaultMaxStorageGB = "downloads.defaultMaxStorageGB"
+        static let sortOption = "downloads.sortOption"
+        static let keepWatchedDownloads = "downloads.keepWatchedDownloads"
+        static let showOnlyDownloadedInBrowse = "downloads.showOnlyDownloadedInBrowse"
+    }
+}

--- a/iosApp/iosApp/Downloads/DownloadSettings.swift
+++ b/iosApp/iosApp/Downloads/DownloadSettings.swift
@@ -41,12 +41,6 @@ final class DownloadSettings {
         didSet { defaults.set(keepWatchedDownloads, forKey: Keys.keepWatchedDownloads) }
     }
 
-    /// When true, offline series-browse hides episodes that aren't on-device
-    /// instead of offering them for download.
-    var showOnlyDownloadedInBrowse: Bool {
-        didSet { defaults.set(showOnlyDownloadedInBrowse, forKey: Keys.showOnlyDownloadedInBrowse) }
-    }
-
     private let defaults: UserDefaults
 
     private init(defaults: UserDefaults = .standard) {
@@ -58,7 +52,6 @@ final class DownloadSettings {
             Keys.defaultMaxStorageGB: 0,
             Keys.sortOption: DownloadSortOption.largestFirst.rawValue,
             Keys.keepWatchedDownloads: false,
-            Keys.showOnlyDownloadedInBrowse: false,
         ])
         preferredFormat = defaults.string(forKey: Keys.preferredFormat) ?? DownloadFormat.original.rawValue
         wifiOnly = defaults.bool(forKey: Keys.wifiOnly)
@@ -67,7 +60,6 @@ final class DownloadSettings {
         sortOption = defaults.string(forKey: Keys.sortOption)
             .flatMap(DownloadSortOption.init(rawValue:)) ?? .largestFirst
         keepWatchedDownloads = defaults.bool(forKey: Keys.keepWatchedDownloads)
-        showOnlyDownloadedInBrowse = defaults.bool(forKey: Keys.showOnlyDownloadedInBrowse)
     }
 
     /// The quality to actually request, given what the server offers right
@@ -94,6 +86,5 @@ final class DownloadSettings {
         static let defaultMaxStorageGB = "downloads.defaultMaxStorageGB"
         static let sortOption = "downloads.sortOption"
         static let keepWatchedDownloads = "downloads.keepWatchedDownloads"
-        static let showOnlyDownloadedInBrowse = "downloads.showOnlyDownloadedInBrowse"
     }
 }

--- a/iosApp/iosApp/Downloads/DownloadSizeEstimate.swift
+++ b/iosApp/iosApp/Downloads/DownloadSizeEstimate.swift
@@ -1,0 +1,79 @@
+#if !os(tvOS)
+import Foundation
+
+/// Pre-flight size expectation for a download. When the user picks Auto the
+/// server resolves the actual file, so the only honest disclosure is the
+/// min–max range across the item's candidate versions; a chosen version is
+/// exact. Sizes come from the catalog's original-file metadata, so for
+/// transcoded qualities the estimate is an upper bound.
+struct DownloadSizeEstimate {
+    /// Downloads past this point warrant an explicit confirmation before the
+    /// one-tap path proceeds. Decimal bytes so the threshold lines up with
+    /// the `ByteCountFormatter` display ("5 GB", not 5 GiB).
+    static let largeDownloadThresholdBytes: Int64 = 5_000_000_000
+
+    let minBytes: Int64
+    let maxBytes: Int64
+    /// True when the estimate spans multiple candidate files (Auto with
+    /// differing sizes); false means `maxBytes` is the exact file size.
+    let isRange: Bool
+
+    /// `nil` when the catalog reports no usable sizes — there is nothing
+    /// truthful to disclose or guard against.
+    static func estimate(versions: [FileVersion], fileId: Int?) -> DownloadSizeEstimate? {
+        if let fileId {
+            guard let size = versions.first(where: { $0.fileId == fileId })?.fileSize,
+                  size > 0 else { return nil }
+            return DownloadSizeEstimate(minBytes: size, maxBytes: size, isRange: false)
+        }
+        return estimate(fileSizes: versions.compactMap(\.fileSize))
+    }
+
+    /// Auto-quality disclosure from bare candidate sizes — episode cards only
+    /// carry `EpisodeFile` metadata, not full versions, and their one-tap path
+    /// never pins a specific file.
+    static func estimate(fileSizes: [Int64]) -> DownloadSizeEstimate? {
+        let sizes = fileSizes.filter { $0 > 0 }
+        guard let smallest = sizes.min(), let largest = sizes.max() else { return nil }
+        return DownloadSizeEstimate(
+            minBytes: smallest,
+            maxBytes: largest,
+            isRange: smallest != largest
+        )
+    }
+
+    /// "2.1–5.4 GB" for a range, "5.4 GB" when exact.
+    var sizeLabel: String {
+        guard isRange else { return DownloadFormatting.bytes(maxBytes) }
+        return "\(DownloadFormatting.bytes(minBytes))–\(DownloadFormatting.bytes(maxBytes))"
+    }
+
+    var exceedsLargeThreshold: Bool { maxBytes > Self.largeDownloadThresholdBytes }
+
+    /// Available space of 0 means the volume lookup failed, not a full disk,
+    /// so it never triggers the insufficient-space warning.
+    func exceedsAvailableSpace(_ availableBytes: Int64) -> Bool {
+        availableBytes > 0 && maxBytes > availableBytes
+    }
+
+    /// Warning copy shared by the one-tap confirmation dialog and the
+    /// options-sheet footer; `nil` when the size needs no caveat. The guard
+    /// uses `maxBytes` because Auto commits the user to whichever candidate
+    /// the server picks.
+    func warningMessage(availableBytes: Int64) -> String? {
+        let size = DownloadFormatting.bytes(maxBytes)
+        if exceedsAvailableSpace(availableBytes) {
+            let free = DownloadFormatting.bytes(availableBytes)
+            return isRange
+                ? "This download may be up to \(size), but only \(free) is free on this device."
+                : "This download is \(size), but only \(free) is free on this device."
+        }
+        if exceedsLargeThreshold {
+            return isRange
+                ? "This download may be up to \(size)."
+                : "This download is \(size)."
+        }
+        return nil
+    }
+}
+#endif

--- a/iosApp/iosApp/Downloads/DownloadStore.swift
+++ b/iosApp/iosApp/Downloads/DownloadStore.swift
@@ -1,0 +1,69 @@
+import Foundation
+import OSLog
+
+/// Off-main persistence for the offline-downloads blob. Keeps disk I/O and
+/// JSON (de)serialization off the MainActor; `DownloadManager` owns the
+/// in-memory `@Observable` truth and reads/writes through this actor.
+actor DownloadStore {
+    static let shared = DownloadStore()
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.continuum.app",
+        category: "Downloads"
+    )
+
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    init() {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.withoutEscapingSlashes]
+        self.encoder = encoder
+        self.decoder = JSONDecoder()
+    }
+
+    /// Load the persisted blob for a scope, or a fresh empty one. Tolerant
+    /// of a missing/corrupt file (returns empty so the feature self-heals).
+    func load(serverId: String, profileId: String) -> DownloadStoreFile {
+        guard !serverId.isEmpty, !profileId.isEmpty else { return .empty }
+        let url = DownloadFilePaths.storeFileURL(serverId: serverId, profileId: profileId)
+        guard FileManager.default.fileExists(atPath: url.path),
+              let data = try? Data(contentsOf: url) else {
+            return .empty
+        }
+        do {
+            var file = try decoder.decode(DownloadStoreFile.self, from: data)
+            if file.version != DownloadStoreFile.currentVersion {
+                file.version = DownloadStoreFile.currentVersion
+            }
+            return file
+        } catch {
+            Self.logger.error("Download store decode failed; starting empty: \(String(describing: error), privacy: .public)")
+            return .empty
+        }
+    }
+
+    /// Atomically persist the blob for a scope. No-op for an empty scope.
+    func save(_ file: DownloadStoreFile, serverId: String, profileId: String) {
+        guard !serverId.isEmpty, !profileId.isEmpty else { return }
+        let url = DownloadFilePaths.storeFileURL(serverId: serverId, profileId: profileId)
+        do {
+            let data = try encoder.encode(file)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            Self.logger.error("Download store save failed: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    /// Persist an offline manifest beside its media file. Uses the same bare
+    /// coder pair as `loadManifest` so the on-disk round-trip is consistent.
+    func saveManifest(_ manifest: OfflineManifest, to url: URL) {
+        guard let data = try? encoder.encode(manifest) else { return }
+        try? data.write(to: url, options: .atomic)
+    }
+
+    func loadManifest(at url: URL) -> OfflineManifest? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? decoder.decode(OfflineManifest.self, from: data)
+    }
+}

--- a/iosApp/iosApp/Downloads/DownloadsSettingsView.swift
+++ b/iosApp/iosApp/Downloads/DownloadsSettingsView.swift
@@ -1,0 +1,91 @@
+#if !os(tvOS)
+import SwiftUI
+
+/// Download preferences: Wi-Fi-only, requested quality, series-monitoring
+/// retention defaults, and storage usage. Backed by the `DownloadSettings`
+/// singleton (local `UserDefaults`, same pattern as `PlayerSettings`).
+struct DownloadsSettingsView: View {
+    @Bindable private var settings = DownloadSettings.shared
+    private var manager: DownloadManager { DownloadManager.shared }
+    @State private var showDeleteAllConfirm = false
+
+    private var formats: [DownloadFormat] {
+        let available = manager.availableFormats
+        return available.isEmpty ? [.original] : available
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle("Download over Wi-Fi only", isOn: $settings.wifiOnly)
+                if formats.count > 1 {
+                    Picker("Quality", selection: $settings.preferredFormat) {
+                        ForEach(formats, id: \.self) { format in
+                            Text(format.displayName).tag(format.rawValue)
+                        }
+                    }
+                }
+            } header: {
+                Text("Downloads")
+            } footer: {
+                Text("Original prefers source quality and may prepare a compatibility file if this device needs one. Bitrate presets are prepared on the server before download starts.")
+            }
+
+            Section("Series Monitoring Defaults") {
+                Toggle("Delete watched episodes", isOn: $settings.defaultDeleteWatched)
+                Stepper(
+                    settings.defaultMaxStorageGB == 0
+                        ? "Storage limit: Unlimited"
+                        : "Storage limit: \(settings.defaultMaxStorageGB) GB",
+                    value: $settings.defaultMaxStorageGB,
+                    in: 0...1000,
+                    step: 5
+                )
+            }
+
+            Section {
+                Toggle("Keep watched downloads", isOn: $settings.keepWatchedDownloads)
+            } header: {
+                Text("Cleanup")
+            } footer: {
+                Text("When off, the Downloads tab suggests freeing up space by removing items you've finished watching.")
+            }
+
+            Section("Storage") {
+                HStack {
+                    Text("Used")
+                    Spacer()
+                    Text(DownloadFormatting.bytes(manager.totalBytesUsed))
+                        .foregroundColor(.continuumSecondaryText)
+                }
+                if !manager.records.isEmpty {
+                    Button(role: .destructive) {
+                        showDeleteAllConfirm = true
+                    } label: {
+                        Text("Remove All Downloads")
+                    }
+                }
+            }
+        }
+        .navigationTitle("Downloads")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .continuumScrollContentBackgroundHidden()
+        .background(Color.continuumBackground)
+        .continuumToolbarColorSchemeDark()
+        .confirmationDialog(
+            "Remove all downloaded files?",
+            isPresented: $showDeleteAllConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("Remove All", role: .destructive) {
+                for record in manager.records {
+                    manager.deleteDownload(id: record.id)
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        }
+    }
+}
+#endif

--- a/iosApp/iosApp/Downloads/DownloadsSettingsView.swift
+++ b/iosApp/iosApp/Downloads/DownloadsSettingsView.swift
@@ -28,7 +28,12 @@ struct DownloadsSettingsView: View {
             } header: {
                 Text("Downloads")
             } footer: {
-                Text("Original prefers source quality and may prepare a compatibility file if this device needs one. Bitrate presets are prepared on the server before download starts.")
+                // Quality-behavior copy only makes sense alongside the
+                // quality picker, which is hidden when the server offers a
+                // single preset.
+                if formats.count > 1 {
+                    Text("Original prefers source quality and may prepare a compatibility file if this device needs one. Bitrate presets are prepared on the server before download starts.")
+                }
             }
 
             Section("Series Monitoring Defaults") {

--- a/iosApp/iosApp/Downloads/DownloadsSettingsView.swift
+++ b/iosApp/iosApp/Downloads/DownloadsSettingsView.swift
@@ -85,9 +85,7 @@ struct DownloadsSettingsView: View {
             titleVisibility: .visible
         ) {
             Button("Remove All", role: .destructive) {
-                for record in manager.records {
-                    manager.deleteDownload(id: record.id)
-                }
+                manager.deleteDownloads(ids: manager.records.map(\.id))
             }
             Button("Cancel", role: .cancel) {}
         }

--- a/iosApp/iosApp/Downloads/DownloadsView.swift
+++ b/iosApp/iosApp/Downloads/DownloadsView.swift
@@ -24,11 +24,7 @@ struct DownloadsView: View {
                     subtitle: "Downloads aren't enabled for this profile."
                 )
             } else if manager.records.isEmpty && manager.subscriptions.isEmpty {
-                EmptyStateView(
-                    icon: "arrow.down.circle",
-                    title: "No Downloads",
-                    subtitle: "Downloaded movies and episodes appear here for offline viewing."
-                )
+                noDownloadsState
             } else {
                 content
             }
@@ -49,11 +45,50 @@ struct DownloadsView: View {
         manager.downloadListItems(sortedBy: settings.sortOption)
     }
 
+    /// Mirrors `EmptyStateView` but adds a route into content: an empty
+    /// Downloads tab is most often a brand-new user, so hand them the
+    /// browse entry point rather than a dead end.
+    private var noDownloadsState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "arrow.down.circle")
+                .font(.system(size: 44))
+                .foregroundColor(.continuumOnSurface.opacity(0.3))
+            Text("No Downloads")
+                .font(.continuumSubheadline)
+                .foregroundColor(.continuumOnSurface)
+            Text("Downloaded movies and episodes appear here for offline viewing.")
+                .font(.continuumCaption)
+                .foregroundColor(.continuumSecondaryText)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, ContinuumTheme.largePadding)
+            Button {
+                router.switchTab(to: .libraries)
+            } label: {
+                Text("Browse Libraries")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(.continuumOnSurface)
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 10)
+                    .background(
+                        Capsule().fill(Color.continuumChromeSelectedFill)
+                            .overlay(Capsule().stroke(Color.continuumChromeSelectedBorder, lineWidth: 1))
+                    )
+            }
+            .buttonStyle(.plain)
+            .padding(.top, 8)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
     private var content: some View {
         ScrollView {
             LazyVStack(spacing: 10) {
-                DownloadsStorageHeader(used: manager.totalBytesUsed, breakdown: manager.storageBreakdown)
-                    .padding(.top, 6)
+                DownloadsStorageHeader(
+                    used: manager.totalBytesUsed,
+                    breakdown: manager.storageBreakdown,
+                    activeCount: manager.activeRecords.count
+                )
+                .padding(.top, 6)
 
                 if showReclaimBanner {
                     DownloadReclaimBanner(
@@ -65,7 +100,15 @@ struct DownloadsView: View {
                 if !manager.activeRecords.isEmpty {
                     sectionLabel("In Progress", count: manager.activeRecords.count)
                     ForEach(manager.activeRecords) { record in
-                        DownloadActiveRow(record: record) { manager.deleteDownload(id: record.id) }
+                        DownloadActiveRow(
+                            record: record,
+                            bytesPerSecond: manager.transferRate(id: record.id),
+                            onPauseResume: {
+                                if record.localStatus == .paused { manager.resumeDownload(id: record.id) }
+                                else { manager.pauseDownload(id: record.id) }
+                            },
+                            onCancel: { manager.deleteDownload(id: record.id) }
+                        )
                     }
                 }
 
@@ -81,7 +124,9 @@ struct DownloadsView: View {
                     }
                 }
 
-                DownloadSortControl(option: $settings.sortOption, itemCount: listItems.count)
+                if !listItems.isEmpty {
+                    DownloadSortControl(option: $settings.sortOption, itemCount: listItems.count)
+                }
 
                 ForEach(listItems) { item in
                     row(for: item)

--- a/iosApp/iosApp/Downloads/DownloadsView.swift
+++ b/iosApp/iosApp/Downloads/DownloadsView.swift
@@ -1,0 +1,313 @@
+#if !os(tvOS)
+import SwiftUI
+
+/// The Downloads tab — a storage-forward "Manager": a storage hero, a
+/// one-tap "reclaim watched" suggestion, in-progress transfers, and a
+/// size-sortable list where each series collapses to one expandable card.
+/// Reads `DownloadManager.shared` directly and drives offline playback
+/// through the router.
+struct DownloadsView: View {
+    @Environment(AppRouter.self) private var router
+    @Bindable private var settings = DownloadSettings.shared
+    private var manager: DownloadManager { DownloadManager.shared }
+
+    @State private var isSelecting = false
+    @State private var selection: Set<String> = []
+    @State private var showReclaim = false
+
+    var body: some View {
+        Group {
+            if !manager.downloadsEnabled {
+                EmptyStateView(
+                    icon: "arrow.down.circle",
+                    title: "Downloads Unavailable",
+                    subtitle: "Downloads aren't enabled for this profile."
+                )
+            } else if manager.records.isEmpty && manager.subscriptions.isEmpty {
+                EmptyStateView(
+                    icon: "arrow.down.circle",
+                    title: "No Downloads",
+                    subtitle: "Downloaded movies and episodes appear here for offline viewing."
+                )
+            } else {
+                content
+            }
+        }
+        .navigationTitle(isSelecting ? "\(selection.count) Selected" : "Downloads")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.large)
+        #endif
+        .toolbar { toolbarContent }
+        .safeAreaInset(edge: .bottom) { bottomBar }
+        .sheet(isPresented: $showReclaim) { DownloadReclaimSheet() }
+        .continuumToolbarColorSchemeDark()
+    }
+
+    // MARK: - Content
+
+    private var listItems: [DownloadListItem] {
+        manager.downloadListItems(sortedBy: settings.sortOption)
+    }
+
+    private var content: some View {
+        ScrollView {
+            LazyVStack(spacing: 10) {
+                DownloadsStorageHeader(used: manager.totalBytesUsed, breakdown: manager.storageBreakdown)
+                    .padding(.top, 6)
+
+                if showReclaimBanner {
+                    DownloadReclaimBanner(
+                        episodeCount: manager.reclaimableRecords.count,
+                        bytes: manager.reclaimableBytes
+                    ) { showReclaim = true }
+                }
+
+                if !manager.activeRecords.isEmpty {
+                    sectionLabel("In Progress", count: manager.activeRecords.count)
+                    ForEach(manager.activeRecords) { record in
+                        DownloadActiveRow(record: record) { manager.deleteDownload(id: record.id) }
+                    }
+                }
+
+                let failed = manager.records.filter { $0.localStatus == .failed }
+                if !failed.isEmpty {
+                    sectionLabel("Needs Attention", count: failed.count)
+                    ForEach(failed) { record in
+                        DownloadAttentionRow(
+                            record: record,
+                            onRetry: { manager.retryDownload(id: record.id) },
+                            onDelete: { manager.deleteDownload(id: record.id) }
+                        )
+                    }
+                }
+
+                DownloadSortControl(option: $settings.sortOption, itemCount: listItems.count)
+
+                ForEach(listItems) { item in
+                    row(for: item)
+                }
+
+                monitoredOnlySection
+
+                Color.clear.frame(height: 24)
+            }
+            .padding(.bottom, 8)
+            .animation(.easeInOut(duration: 0.2), value: isSelecting)
+        }
+        .background(Color.continuumBackground)
+    }
+
+    @ViewBuilder
+    private func row(for item: DownloadListItem) -> some View {
+        switch item {
+        case .series(let group):
+            DownloadSeriesRow(
+                group: group,
+                selecting: isSelecting,
+                selected: selection.contains(item.id),
+                isWatched: { manager.isWatched($0) },
+                onSelectToggle: { toggle(item.id) },
+                onOpenSeries: isSelecting ? nil : { router.navigate(to: .offlineSeriesBrowse(seriesId: group.seriesId)) },
+                onPlayEpisode: { play($0) },
+                onDeleteEpisode: { manager.deleteDownload(id: $0.id) }
+            )
+            .contextMenu {
+                if !isSelecting {
+                    Button(role: .destructive) {
+                        manager.deleteDownloads(ids: group.allRecords.map(\.id))
+                    } label: {
+                        Label("Delete All Episodes", systemImage: "trash")
+                    }
+                }
+            }
+        case .movie(let record):
+            DownloadMovieRow(
+                record: record,
+                watched: manager.isWatched(record),
+                selecting: isSelecting,
+                selected: selection.contains(item.id),
+                onTap: {
+                    if isSelecting { toggle(item.id) }
+                    else { router.navigate(to: .offlineDownloadDetail(downloadId: record.id)) }
+                }
+            )
+            .contextMenu {
+                if !isSelecting {
+                    Button(role: .destructive) {
+                        manager.deleteDownload(id: record.id)
+                    } label: {
+                        Label("Delete Download", systemImage: "trash")
+                    }
+                }
+            }
+        }
+    }
+
+    /// Monitored series that have no on-device episodes yet, so an active
+    /// subscription is still visible (and stoppable) before its first download.
+    @ViewBuilder
+    private var monitoredOnlySection: some View {
+        let groupedSeriesIds = Set(manager.seriesGroups.map(\.seriesId))
+        let pending = manager.subscriptions.filter { !groupedSeriesIds.contains($0.seriesId) }
+        if !pending.isEmpty {
+            sectionLabel("Monitoring", count: pending.count)
+            ForEach(pending) { subscription in
+                monitoredRow(subscription)
+            }
+        }
+    }
+
+    private func monitoredRow(_ subscription: DownloadSubscription) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: "antenna.radiowaves.left.and.right")
+                .font(.system(size: 17))
+                .foregroundColor(.continuumOnSurface)
+                .frame(width: 40, height: 40)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(subscription.seriesTitle ?? subscription.seriesId)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundColor(.continuumOnSurface)
+                    .lineLimit(1)
+                Text(SubscriptionMode(rawValue: subscription.mode)?.displayName ?? subscription.mode)
+                    .font(.system(size: 12))
+                    .foregroundColor(.continuumSecondaryText)
+            }
+            Spacer(minLength: 8)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color.continuumSurfaceVariant)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .stroke(Color.continuumOutline, lineWidth: 1)
+                )
+        )
+        .padding(.horizontal, 16)
+        .contextMenu {
+            Button(role: .destructive) {
+                Task { await manager.deleteSubscription(id: subscription.id) }
+            } label: {
+                Label("Stop Monitoring", systemImage: "xmark.circle")
+            }
+        }
+    }
+
+    private func sectionLabel(_ text: String, count: Int) -> some View {
+        HStack {
+            Text(text.uppercased())
+                .font(.system(size: 12.5, weight: .semibold))
+                .tracking(0.3)
+                .foregroundColor(.continuumSecondaryText)
+            Spacer()
+            Text("\(count)")
+                .font(.system(size: 12.5))
+                .foregroundColor(.continuumOnSurface.opacity(0.38))
+        }
+        .padding(.horizontal, 22)
+        .padding(.top, 14)
+        .padding(.bottom, 2)
+    }
+
+    // MARK: - Toolbar & select mode
+
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+        if isSelecting {
+            ToolbarItem(placement: .navigation) {
+                Button(allSelected ? "Clear" : "Select All") { toggleSelectAll() }
+            }
+            ToolbarItem(placement: .primaryAction) {
+                Button("Done") { exitSelectMode() }
+            }
+        } else if !listItems.isEmpty {
+            ToolbarItem(placement: .primaryAction) {
+                Button("Select") { isSelecting = true }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var bottomBar: some View {
+        if isSelecting && !selection.isEmpty {
+            Button {
+                manager.deleteDownloads(ids: selectedDownloadIds)
+                exitSelectMode()
+            } label: {
+                HStack(spacing: 9) {
+                    Image(systemName: "trash")
+                    Text("Delete \(selection.count) · Free \(DownloadFormatting.bytes(selectedBytes))")
+                        .fontWeight(.bold)
+                }
+                .font(.system(size: 15))
+                .frame(maxWidth: .infinity)
+                .frame(height: 50)
+                .background(Color.continuumOnSurface)
+                .foregroundColor(.black)
+                .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, 16)
+            .padding(.top, 8)
+            .padding(.bottom, 6)
+            .background(.ultraThinMaterial)
+        }
+    }
+
+    private var showReclaimBanner: Bool {
+        !isSelecting && !settings.keepWatchedDownloads && manager.reclaimableBytes > 0
+    }
+
+    private var allSelected: Bool {
+        !listItems.isEmpty && Set(listItems.map(\.id)).isSubset(of: selection)
+    }
+
+    private var selectedItems: [DownloadListItem] {
+        listItems.filter { selection.contains($0.id) }
+    }
+
+    private var selectedDownloadIds: [String] {
+        selectedItems.flatMap(\.downloadIds)
+    }
+
+    private var selectedBytes: Int64 {
+        selectedItems.reduce(0) { $0 + $1.totalBytes }
+    }
+
+    private func toggle(_ id: String) {
+        if selection.contains(id) { selection.remove(id) } else { selection.insert(id) }
+    }
+
+    private func toggleSelectAll() {
+        if allSelected { selection.removeAll() }
+        else { selection = Set(listItems.map(\.id)) }
+    }
+
+    private func exitSelectMode() {
+        isSelecting = false
+        selection.removeAll()
+    }
+
+    // MARK: - Playback
+
+    private func play(_ record: DownloadRecord) {
+        guard record.isPlayableOffline else { return }
+        let leafId = record.leafMediaItemId
+        router.presentOfflinePlayer(
+            downloadId: record.id,
+            contentId: leafId,
+            resumePosition: manager.localProgress(forMediaItemId: leafId)?.position
+        )
+    }
+}
+
+// MARK: - Formatting
+
+enum DownloadFormatting {
+    static func bytes(_ count: Int64) -> String {
+        guard count > 0 else { return "—" }
+        return ByteCountFormatter.string(fromByteCount: count, countStyle: .file)
+    }
+}
+#endif

--- a/iosApp/iosApp/Downloads/DownloadsView.swift
+++ b/iosApp/iosApp/Downloads/DownloadsView.swift
@@ -14,6 +14,15 @@ struct DownloadsView: View {
     @State private var isSelecting = false
     @State private var selection: Set<String> = []
     @State private var showReclaim = false
+    /// Confirmation gate for the bulk/context-menu deletes — downloads are
+    /// costly to re-fetch, so a stray tap must not remove them outright.
+    @State private var pendingDeletion: PendingDeletion?
+
+    private struct PendingDeletion: Identifiable {
+        let id = UUID()
+        let ids: [String]
+        let endsSelection: Bool
+    }
 
     var body: some View {
         Group {
@@ -36,6 +45,24 @@ struct DownloadsView: View {
         .toolbar { toolbarContent }
         .safeAreaInset(edge: .bottom) { bottomBar }
         .sheet(isPresented: $showReclaim) { DownloadReclaimSheet() }
+        .confirmationDialog(
+            "Delete downloaded files?",
+            isPresented: Binding(
+                get: { pendingDeletion != nil },
+                set: { if !$0 { pendingDeletion = nil } }
+            ),
+            titleVisibility: .visible,
+            presenting: pendingDeletion
+        ) { pending in
+            Button(
+                pending.ids.count == 1 ? "Delete Download" : "Delete \(pending.ids.count) Downloads",
+                role: .destructive
+            ) {
+                manager.deleteDownloads(ids: pending.ids)
+                if pending.endsSelection { exitSelectMode() }
+            }
+            Button("Cancel", role: .cancel) {}
+        }
         .continuumToolbarColorSchemeDark()
     }
 
@@ -159,7 +186,10 @@ struct DownloadsView: View {
             .contextMenu {
                 if !isSelecting {
                     Button(role: .destructive) {
-                        manager.deleteDownloads(ids: group.allRecords.map(\.id))
+                        pendingDeletion = PendingDeletion(
+                            ids: group.allRecords.map(\.id),
+                            endsSelection: false
+                        )
                     } label: {
                         Label("Delete All Episodes", systemImage: "trash")
                     }
@@ -179,7 +209,7 @@ struct DownloadsView: View {
             .contextMenu {
                 if !isSelecting {
                     Button(role: .destructive) {
-                        manager.deleteDownload(id: record.id)
+                        pendingDeletion = PendingDeletion(ids: [record.id], endsSelection: false)
                     } label: {
                         Label("Delete Download", systemImage: "trash")
                     }
@@ -277,8 +307,7 @@ struct DownloadsView: View {
     private var bottomBar: some View {
         if isSelecting && !selection.isEmpty {
             Button {
-                manager.deleteDownloads(ids: selectedDownloadIds)
-                exitSelectMode()
+                pendingDeletion = PendingDeletion(ids: selectedDownloadIds, endsSelection: true)
             } label: {
                 HStack(spacing: 9) {
                     Image(systemName: "trash")

--- a/iosApp/iosApp/Downloads/OfflinePlayback.swift
+++ b/iosApp/iosApp/Downloads/OfflinePlayback.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// Synthesizes the same `PreparedPlayback` the online path produces, but
+/// from a stored offline manifest + local media file, so the player loads
+/// with no server session. The local file plays via the existing engines
+/// (FFmpeg `PlayerCore` for MKV/etc., `AVPlayer` for MP4) and the manifest
+/// drives chapters, intro/credits markers, and subtitles unchanged.
+enum OfflinePlaybackBuilder {
+    static func makePreparedPlayback(
+        leafContentId: String,
+        manifest: OfflineManifest,
+        mediaURL: URL,
+        subtitleURLs: [SubtitleUrl],
+        resumePosition: Double?
+    ) -> PreparedPlayback {
+        let version = FileVersion(
+            fileId: manifest.mediaFileId,
+            fileName: nil,
+            resolution: manifest.resolution,
+            codecVideo: manifest.codecVideo,
+            codecAudio: manifest.codecAudio,
+            hdr: manifest.hdr,
+            container: manifest.container,
+            fileSize: manifest.fileSize,
+            duration: manifest.durationSeconds,
+            bitrate: nil,
+            videoTracks: nil,
+            audioTracks: nil,
+            subtitleTracks: nil,
+            chapters: manifest.chapters,
+            intro: manifest.intro,
+            credits: manifest.credits
+        )
+
+        let watchDetail = WatchDetail(
+            offlineLeafContentId: leafContentId,
+            manifest: manifest,
+            version: version
+        )
+
+        let session = PlaybackSessionResponse(
+            sessionId: "offline-\(manifest.downloadId)",
+            userId: nil,
+            profileId: nil,
+            mediaFileId: manifest.mediaFileId,
+            playMethod: "direct",
+            position: resumePosition ?? 0,
+            isPaused: false,
+            streamUrl: mediaURL.absoluteString,
+            audioTrackIndex: nil,
+            durationSeconds: manifest.durationSeconds,
+            timelineOffsetSeconds: 0,
+            subtitleUrls: subtitleURLs.isEmpty ? nil : subtitleURLs,
+            playbackInfo: nil
+        )
+
+        return PreparedPlayback(
+            watchDetail: watchDetail,
+            selectedVersion: version,
+            session: session
+        )
+    }
+}
+
+extension WatchDetail {
+    /// Build a `WatchDetail` from a stored offline manifest. `WatchDetail`
+    /// has only a decoding initializer, so this sets every stored property
+    /// directly. `userData` is nil — the offline resume point is carried on
+    /// the synthetic session's `position` instead.
+    init(offlineLeafContentId: String, manifest: OfflineManifest, version: FileVersion) {
+        contentId = offlineLeafContentId
+        type = manifest.type
+        title = manifest.title
+        year = manifest.year
+        overview = manifest.overview
+        versions = [version]
+        subtitles = nil
+        intro = manifest.intro
+        credits = manifest.credits
+        userData = nil
+        seriesId = manifest.seriesId
+        seriesTitle = manifest.seriesTitle
+        seasonNumber = manifest.seasonNumber
+        episodeNumber = manifest.episodeNumber
+        effectiveSubtitleLanguage = nil
+        effectiveSubtitleMode = nil
+        effectiveShowForcedSubtitles = nil
+        effectiveSubtitleTrackSignature = nil
+    }
+}

--- a/iosApp/iosApp/Downloads/OfflinePlayback.swift
+++ b/iosApp/iosApp/Downloads/OfflinePlayback.swift
@@ -1,11 +1,149 @@
 import Foundation
 
+/// Failure modes for the local offline prepare. Terminal — there is no
+/// server to fall back to, so these surface through the player's standard
+/// error wall via `errorDescription`.
+enum OfflinePlaybackError: LocalizedError {
+    case downloadNotFound
+    case manifestUnavailable
+    case mediaFileMissing
+
+    var errorDescription: String? {
+        switch self {
+        case .downloadNotFound:
+            return "This download is no longer on this device."
+        case .manifestUnavailable:
+            return "The offline playback data for this download is missing. Delete and re-download it."
+        case .mediaFileMissing:
+            return "The downloaded video file is missing. Delete and re-download it."
+        }
+    }
+}
+
+/// A locally-synthesized playback bundle plus the identity the player needs
+/// to route watch progress into the offline queue instead of a server
+/// session.
+struct OfflinePreparedPlayback {
+    let prepared: PreparedPlayback
+    let downloadId: String
+    /// Leaf media item id progress is keyed by — the episode id for an
+    /// episode download, otherwise the movie content id.
+    let mediaItemId: String
+    /// Cached poster on disk, so the Now Playing widget gets artwork
+    /// without a catalog fetch.
+    let posterFileURL: URL?
+}
+
 /// Synthesizes the same `PreparedPlayback` the online path produces, but
 /// from a stored offline manifest + local media file, so the player loads
 /// with no server session. The local file plays via the existing engines
 /// (FFmpeg `PlayerCore` for MKV/etc., `AVPlayer` for MP4) and the manifest
 /// drives chapters, intro/credits markers, and subtitles unchanged.
 enum OfflinePlaybackBuilder {
+    /// Near-end resume points restart from zero, mirroring the session
+    /// bridge's suppression window so offline resume feels identical to
+    /// the online path.
+    private static let nearEndResumeSuppressionSeconds: Double = 5
+
+    /// Assemble a fully local `OfflinePreparedPlayback` for a completed
+    /// download. Reads only the on-device record/manifest/media — never
+    /// the network — so it works in airplane mode.
+    @MainActor
+    static func loadPreparedPlayback(
+        downloadId: String,
+        startFromBeginning: Bool,
+        resumePositionOverride: Double?
+    ) async throws -> OfflinePreparedPlayback {
+        let manager = DownloadManager.shared
+        guard let record = manager.record(id: downloadId), record.isPlayableOffline else {
+            throw OfflinePlaybackError.downloadNotFound
+        }
+        guard let manifest = await manager.loadManifest(for: record) else {
+            throw OfflinePlaybackError.manifestUnavailable
+        }
+        guard let mediaURL = manager.absoluteMediaURL(for: record),
+              FileManager.default.fileExists(atPath: mediaURL.path) else {
+            throw OfflinePlaybackError.mediaFileMissing
+        }
+
+        let leafId = record.leafMediaItemId
+        let prepared = makePreparedPlayback(
+            leafContentId: leafId,
+            manifest: manifest,
+            mediaURL: mediaURL,
+            subtitleURLs: localSubtitleUrls(record: record, manifest: manifest, manager: manager),
+            resumePosition: resolvedResumePosition(
+                startFromBeginning: startFromBeginning,
+                explicitPosition: resumePositionOverride,
+                storedPosition: manager.localProgress(forMediaItemId: leafId)?.position,
+                duration: manifest.durationSeconds
+            )
+        )
+        let posterFileURL = record.posterFilename.flatMap {
+            manager.absoluteFileURL(for: record, filename: $0)
+        }
+        return OfflinePreparedPlayback(
+            prepared: prepared,
+            downloadId: record.id,
+            mediaItemId: leafId,
+            posterFileURL: posterFileURL
+        )
+    }
+
+    /// Map the manifest's sidecar subtitles to their cached on-disk files.
+    /// Entries whose fetch never completed are skipped rather than surfaced
+    /// as broken tracks.
+    @MainActor
+    private static func localSubtitleUrls(
+        record: DownloadRecord,
+        manifest: OfflineManifest,
+        manager: DownloadManager
+    ) -> [SubtitleUrl] {
+        var urls: [SubtitleUrl] = []
+        for (index, subtitle) in (manifest.subtitles ?? []).enumerated() {
+            guard let filename = record.subtitleFilenames[subtitle.fetchUrl],
+                  let fileURL = manager.absoluteFileURL(for: record, filename: filename),
+                  FileManager.default.fileExists(atPath: fileURL.path) else {
+                continue
+            }
+            urls.append(SubtitleUrl(
+                index: index,
+                language: subtitle.language,
+                codec: subtitle.format,
+                label: nil,
+                // Manifest subtitles are always sidecar files
+                // (`external:{i}` / `downloaded:{id}`), never embedded, so
+                // they must survive the player's embedded-track dedup on
+                // AVPlayer routes.
+                source: "external",
+                forced: subtitle.forced,
+                url: fileURL.absoluteString
+            ))
+        }
+        return urls
+    }
+
+    /// Offline mirror of the session bridge's resume resolution: explicit
+    /// "start over" wins, then the caller's position, then the stored local
+    /// resume point — with near-end positions restarting from zero.
+    private static func resolvedResumePosition(
+        startFromBeginning: Bool,
+        explicitPosition: Double?,
+        storedPosition: Double?,
+        duration: Double?
+    ) -> Double? {
+        if startFromBeginning { return 0 }
+        let candidate = [explicitPosition, storedPosition]
+            .compactMap { value -> Double? in
+                guard let value, value.isFinite, value >= 0 else { return nil }
+                return value
+            }
+            .first
+        guard let candidate else { return nil }
+        guard let duration, duration.isFinite, duration > 0 else { return candidate }
+        return candidate >= max(0, duration - nearEndResumeSuppressionSeconds) ? 0 : candidate
+    }
+
     static func makePreparedPlayback(
         leafContentId: String,
         manifest: OfflineManifest,

--- a/iosApp/iosApp/Downloads/SeriesDownloadControls.swift
+++ b/iosApp/iosApp/Downloads/SeriesDownloadControls.swift
@@ -1,0 +1,294 @@
+#if !os(tvOS)
+import SwiftUI
+
+/// Series-level download + monitoring control for the series/season detail
+/// action row. A circle menu offering whole-season / whole-series download
+/// and a series-monitoring subscription editor. Reads
+/// `DownloadManager.shared` directly so it reflects live state.
+struct SeriesDownloadMenuButton: View {
+    let detail: ItemDetail
+    let seasons: [Season]
+    let selectedSeason: Season?
+
+    private var manager: DownloadManager { DownloadManager.shared }
+    @State private var activeSheet: SeriesDownloadSheet?
+
+    private var seriesId: String { detail.seriesId ?? detail.contentId }
+    private var isMonitored: Bool { manager.subscription(forSeriesId: seriesId) != nil }
+
+    var body: some View {
+        Button {
+            activeSheet = .downloadOptions
+        } label: {
+            Image(systemName: isMonitored ? "arrow.down.circle.fill" : "arrow.down.circle")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(.white)
+                .frame(width: 44, height: 44)
+                .background(
+                    Circle()
+                        .fill(Color.white.opacity(isMonitored ? 0.18 : 0.10))
+                        .overlay(Circle().stroke(Color.white.opacity(isMonitored ? 0.55 : 0.25), lineWidth: 1))
+                )
+        }
+        .accessibilityLabel("Download or monitor series")
+        .sheet(item: $activeSheet) { sheet in
+            switch sheet {
+            case .downloadOptions:
+                SeriesDownloadOptionsSheet(
+                    seriesId: seriesId,
+                    seriesTitle: detail.title,
+                    selectedSeason: selectedSeason,
+                    canDownloadSeason: manager.canDownloadSeason,
+                    canMonitorSeries: manager.canMonitorSeries,
+                    isMonitored: isMonitored,
+                    onMonitor: openMonitorSheet
+                )
+            case .monitor:
+                SeriesMonitorSheet(seriesId: seriesId, seriesTitle: detail.title, seasons: seasons)
+            }
+        }
+    }
+
+    private func openMonitorSheet() {
+        activeSheet = nil
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 300_000_000)
+            activeSheet = .monitor
+        }
+    }
+}
+
+private enum SeriesDownloadSheet: Identifiable {
+    case downloadOptions
+    case monitor
+
+    var id: String {
+        switch self {
+        case .downloadOptions: return "downloadOptions"
+        case .monitor: return "monitor"
+        }
+    }
+}
+
+private struct SeriesDownloadOptionsSheet: View {
+    let seriesId: String
+    let seriesTitle: String
+    let selectedSeason: Season?
+    let canDownloadSeason: Bool
+    let canMonitorSeries: Bool
+    let isMonitored: Bool
+    let onMonitor: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    private var manager: DownloadManager { DownloadManager.shared }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    if canDownloadSeason, let selectedSeason {
+                        optionButton(
+                            title: "Download Season \(selectedSeason.seasonNumber)",
+                            detail: "Original quality · \(selectedSeason.episodeCount) episode\(selectedSeason.episodeCount == 1 ? "" : "s")",
+                            icon: "arrow.down.square.on.square"
+                        ) {
+                            Task { try? await manager.downloadSeason(seriesId: seriesId, seasonNumber: selectedSeason.seasonNumber) }
+                            dismiss()
+                        }
+                    }
+
+                    optionButton(
+                        title: "Download All Episodes",
+                        detail: "Original quality",
+                        icon: "arrow.down.circle"
+                    ) {
+                        Task { try? await manager.downloadSeries(seriesId: seriesId) }
+                        dismiss()
+                    }
+                } header: {
+                    Text("Download")
+                } footer: {
+                    Text("Series and season downloads use Original quality in the current server contract.")
+                }
+
+                if canMonitorSeries {
+                    Section("Monitoring") {
+                        optionButton(
+                            title: isMonitored ? "Edit Monitoring" : "Monitor Series",
+                            detail: isMonitored ? "Change auto-download rules" : "Auto-download future episodes",
+                            icon: "antenna.radiowaves.left.and.right"
+                        ) {
+                            dismiss()
+                            onMonitor()
+                        }
+                        if isMonitored {
+                            Button(role: .destructive) {
+                                if let sub = manager.subscription(forSeriesId: seriesId) {
+                                    Task { await manager.deleteSubscription(id: sub.id) }
+                                }
+                                dismiss()
+                            } label: {
+                                Label("Stop Monitoring", systemImage: "xmark.circle")
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle(seriesTitle)
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .continuumScrollContentBackgroundHidden()
+            .background(Color.continuumBackground)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+        #if os(iOS)
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+        #endif
+    }
+
+    private func optionButton(
+        title: String,
+        detail: String,
+        icon: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 12) {
+                Image(systemName: icon)
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundColor(.continuumOnSurface)
+                    .frame(width: 28)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(.continuumOnSurface)
+                    Text(detail)
+                        .font(.continuumCaption)
+                        .foregroundColor(.continuumSecondaryText)
+                }
+                Spacer(minLength: 8)
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundColor(.continuumSecondaryText)
+            }
+            .padding(.vertical, 4)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+/// Create / edit a series-monitoring subscription. The retention fields
+/// (`delete_watched`, `max_storage_bytes`) are client-enforced; the server
+/// only soft-gates auto-registration.
+struct SeriesMonitorSheet: View {
+    let seriesId: String
+    let seriesTitle: String
+    let seasons: [Season]
+
+    @Environment(\.dismiss) private var dismiss
+    private var manager: DownloadManager { DownloadManager.shared }
+
+    @State private var mode: SubscriptionMode = .all
+    @State private var selectedSeasons: Set<Int> = []
+    @State private var deleteWatched: Bool = DownloadSettings.shared.defaultDeleteWatched
+    @State private var maxStorageGB: Int = DownloadSettings.shared.defaultMaxStorageGB
+    @State private var isSaving = false
+
+    private var existing: DownloadSubscription? { manager.subscription(forSeriesId: seriesId) }
+    private var availableModes: [SubscriptionMode] {
+        manager.monitoringModes.isEmpty ? SubscriptionMode.allCases : manager.monitoringModes
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Keep Downloaded") {
+                    Picker("Episodes", selection: $mode) {
+                        ForEach(availableModes, id: \.self) { Text($0.displayName).tag($0) }
+                    }
+                    if mode == .specificSeasons {
+                        ForEach(seasons) { season in
+                            Toggle("Season \(season.seasonNumber)", isOn: Binding(
+                                get: { selectedSeasons.contains(season.seasonNumber) },
+                                set: { isOn in
+                                    if isOn { selectedSeasons.insert(season.seasonNumber) }
+                                    else { selectedSeasons.remove(season.seasonNumber) }
+                                }
+                            ))
+                        }
+                    }
+                }
+                Section("Storage") {
+                    Toggle("Delete watched episodes", isOn: $deleteWatched)
+                    Stepper(
+                        maxStorageGB == 0 ? "Limit: Unlimited" : "Limit: \(maxStorageGB) GB",
+                        value: $maxStorageGB,
+                        in: 0...1000,
+                        step: 5
+                    )
+                }
+            }
+            .navigationTitle(existing == nil ? "Monitor Series" : "Edit Monitoring")
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save", action: save)
+                        .disabled(isSaving || (mode == .specificSeasons && selectedSeasons.isEmpty))
+                }
+            }
+            .onAppear(perform: prefill)
+        }
+    }
+
+    private func prefill() {
+        guard let existing else { return }
+        mode = SubscriptionMode(rawValue: existing.mode) ?? .all
+        selectedSeasons = Set(existing.seasonNumbers ?? [])
+        deleteWatched = existing.deleteWatched
+        maxStorageGB = Int(existing.maxStorageBytes / DownloadSettings.bytesPerGB)
+    }
+
+    private func save() {
+        isSaving = true
+        let bytes = Int64(maxStorageGB) * DownloadSettings.bytesPerGB
+        let seasonNumbers = mode == .specificSeasons ? Array(selectedSeasons).sorted() : nil
+        Task {
+            do {
+                if let existing {
+                    try await manager.updateSubscription(
+                        id: existing.id,
+                        mode: mode,
+                        seasonNumbers: seasonNumbers,
+                        deleteWatched: deleteWatched,
+                        maxStorageBytes: bytes,
+                        active: true
+                    )
+                } else {
+                    try await manager.createSubscription(
+                        seriesId: seriesId,
+                        seriesTitle: seriesTitle,
+                        mode: mode,
+                        seasonNumbers: seasonNumbers,
+                        deleteWatched: deleteWatched,
+                        maxStorageBytes: bytes
+                    )
+                }
+            } catch {
+                // Surface nothing for now; the sheet just closes.
+            }
+            dismiss()
+        }
+    }
+}
+#endif

--- a/iosApp/iosApp/Downloads/SeriesDownloadControls.swift
+++ b/iosApp/iosApp/Downloads/SeriesDownloadControls.swift
@@ -108,7 +108,7 @@ private struct SeriesDownloadOptionsSheet: View {
                 } header: {
                     Text("Download")
                 } footer: {
-                    Text("Series and season downloads use Original quality in the current server contract.")
+                    Text("Series and season downloads use original quality.")
                 }
 
                 if canMonitorSeries {
@@ -226,12 +226,11 @@ struct SeriesMonitorSheet: View {
                 }
                 Section("Storage") {
                     Toggle("Delete watched episodes", isOn: $deleteWatched)
-                    Stepper(
-                        maxStorageGB == 0 ? "Limit: Unlimited" : "Limit: \(maxStorageGB) GB",
-                        value: $maxStorageGB,
-                        in: 0...1000,
-                        step: 5
-                    )
+                    Picker("Limit", selection: $maxStorageGB) {
+                        ForEach(storageLimitOptionsGB, id: \.self) { gb in
+                            Text(gb == 0 ? "Unlimited" : "\(gb) GB").tag(gb)
+                        }
+                    }
                 }
             }
             .navigationTitle(existing == nil ? "Monitor Series" : "Edit Monitoring")
@@ -249,6 +248,18 @@ struct SeriesMonitorSheet: View {
             }
             .onAppear(perform: prefill)
         }
+    }
+
+    /// Common caps, plus the stored value when it doesn't match one —
+    /// subscriptions written by the old stepper (or another client) must
+    /// stay representable rather than silently snapping to a preset.
+    private var storageLimitOptionsGB: [Int] {
+        var options = [0, 10, 25, 50, 100]
+        if !options.contains(maxStorageGB) {
+            options.append(maxStorageGB)
+            options.sort()
+        }
+        return options
     }
 
     private func prefill() {

--- a/iosApp/iosApp/Downloads/SeriesDownloadControls.swift
+++ b/iosApp/iosApp/Downloads/SeriesDownloadControls.swift
@@ -12,6 +12,7 @@ struct SeriesDownloadMenuButton: View {
 
     private var manager: DownloadManager { DownloadManager.shared }
     @State private var activeSheet: SeriesDownloadSheet?
+    @State private var pendingMonitorSheet = false
 
     private var seriesId: String { detail.seriesId ?? detail.contentId }
     private var isMonitored: Bool { manager.subscription(forSeriesId: seriesId) != nil }
@@ -31,7 +32,16 @@ struct SeriesDownloadMenuButton: View {
                 )
         }
         .accessibilityLabel("Download or monitor series")
-        .sheet(item: $activeSheet) { sheet in
+        // Chaining sheets from `onDismiss` waits out the real dismiss
+        // animation instead of guessing a delay — a fixed sleep silently
+        // fails to present when teardown runs long (slow device,
+        // accessibility animations, low power).
+        .sheet(item: $activeSheet, onDismiss: {
+            if pendingMonitorSheet {
+                pendingMonitorSheet = false
+                activeSheet = .monitor
+            }
+        }) { sheet in
             switch sheet {
             case .downloadOptions:
                 SeriesDownloadOptionsSheet(
@@ -41,19 +51,11 @@ struct SeriesDownloadMenuButton: View {
                     canDownloadSeason: manager.canDownloadSeason,
                     canMonitorSeries: manager.canMonitorSeries,
                     isMonitored: isMonitored,
-                    onMonitor: openMonitorSheet
+                    onMonitor: { pendingMonitorSheet = true }
                 )
             case .monitor:
                 SeriesMonitorSheet(seriesId: seriesId, seriesTitle: detail.title, seasons: seasons)
             }
-        }
-    }
-
-    private func openMonitorSheet() {
-        activeSheet = nil
-        Task { @MainActor in
-            try? await Task.sleep(nanoseconds: 300_000_000)
-            activeSheet = .monitor
         }
     }
 }
@@ -81,6 +83,8 @@ private struct SeriesDownloadOptionsSheet: View {
 
     @Environment(\.dismiss) private var dismiss
     private var manager: DownloadManager { DownloadManager.shared }
+    @State private var errorMessage: String?
+    @State private var isWorking = false
 
     var body: some View {
         NavigationStack {
@@ -92,8 +96,9 @@ private struct SeriesDownloadOptionsSheet: View {
                             detail: "Original quality · \(selectedSeason.episodeCount) episode\(selectedSeason.episodeCount == 1 ? "" : "s")",
                             icon: "arrow.down.square.on.square"
                         ) {
-                            Task { try? await manager.downloadSeason(seriesId: seriesId, seasonNumber: selectedSeason.seasonNumber) }
-                            dismiss()
+                            startDownload {
+                                try await manager.downloadSeason(seriesId: seriesId, seasonNumber: selectedSeason.seasonNumber)
+                            }
                         }
                     }
 
@@ -102,8 +107,9 @@ private struct SeriesDownloadOptionsSheet: View {
                         detail: "Original quality",
                         icon: "arrow.down.circle"
                     ) {
-                        Task { try? await manager.downloadSeries(seriesId: seriesId) }
-                        dismiss()
+                        startDownload {
+                            try await manager.downloadSeries(seriesId: seriesId)
+                        }
                     }
                 } header: {
                     Text("Download")
@@ -150,6 +156,33 @@ private struct SeriesDownloadOptionsSheet: View {
         .presentationDetents([.medium, .large])
         .presentationDragIndicator(.visible)
         #endif
+        .alert(
+            "Download Failed",
+            isPresented: Binding(
+                get: { errorMessage != nil },
+                set: { if !$0 { errorMessage = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(errorMessage ?? "")
+        }
+    }
+
+    /// Run a download request, dismissing only on success — a silent
+    /// `try?` here made an offline/unauthenticated tap look like it worked.
+    private func startDownload(_ work: @escaping () async throws -> Void) {
+        guard !isWorking else { return }
+        isWorking = true
+        Task {
+            do {
+                try await work()
+                dismiss()
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+            isWorking = false
+        }
     }
 
     private func optionButton(
@@ -199,6 +232,7 @@ struct SeriesMonitorSheet: View {
     @State private var deleteWatched: Bool = DownloadSettings.shared.defaultDeleteWatched
     @State private var maxStorageGB: Int = DownloadSettings.shared.defaultMaxStorageGB
     @State private var isSaving = false
+    @State private var saveError: String?
 
     private var existing: DownloadSubscription? { manager.subscription(forSeriesId: seriesId) }
     private var availableModes: [SubscriptionMode] {
@@ -247,6 +281,17 @@ struct SeriesMonitorSheet: View {
                 }
             }
             .onAppear(perform: prefill)
+            .alert(
+                "Couldn't Save Monitoring",
+                isPresented: Binding(
+                    get: { saveError != nil },
+                    set: { if !$0 { saveError = nil } }
+                )
+            ) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(saveError ?? "")
+            }
         }
     }
 
@@ -295,10 +340,13 @@ struct SeriesMonitorSheet: View {
                         maxStorageBytes: bytes
                     )
                 }
+                dismiss()
             } catch {
-                // Surface nothing for now; the sheet just closes.
+                // Keep the sheet up so the edits aren't lost — the user can
+                // retry or cancel once they've seen why the save failed.
+                saveError = error.localizedDescription
             }
-            dismiss()
+            isSaving = false
         }
     }
 }

--- a/iosApp/iosApp/Downloads/Views/DownloadManagerRows.swift
+++ b/iosApp/iosApp/Downloads/Views/DownloadManagerRows.swift
@@ -1,0 +1,409 @@
+#if !os(tvOS)
+import SwiftUI
+
+// MARK: - In-progress row
+
+/// A pinned active-transfer row (downloading / queued / preparing) with a
+/// circular progress ring that doubles as a stop button.
+struct DownloadActiveRow: View {
+    let record: DownloadRecord
+    var onCancel: () -> Void = {}
+
+    var body: some View {
+        HStack(spacing: 12) {
+            DownloadPosterThumb(thumbhash: record.posterThumbhash, width: 40)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(displayTitle)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundColor(.continuumOnSurface)
+                    .lineLimit(1)
+                Text(statusLine)
+                    .font(.system(size: 12.5))
+                    .foregroundColor(.continuumSecondaryText)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 8)
+            progressRing
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color.continuumSurfaceElevated)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .stroke(Color.continuumOutline, lineWidth: 1)
+                )
+        )
+        .padding(.horizontal, 16)
+    }
+
+    private var displayTitle: String {
+        if record.type == "episode", let sub = record.subtitle, !sub.isEmpty {
+            return "\(record.title ?? record.contentId) · \(sub)"
+        }
+        return record.title ?? record.contentId
+    }
+
+    private var statusLine: String {
+        switch record.localStatus {
+        case .downloading:
+            let pct = Int((record.progressFraction * 100).rounded())
+            return "\(pct)% · \(DownloadFormatting.bytes(record.bytesDownloaded)) of \(DownloadFormatting.bytes(record.fileSize))"
+        case .registering, .queued: return "Queued"
+        case .preparing: return "Preparing on server…"
+        case .fetchingAssets: return "Finishing…"
+        case .completed: return DownloadFormatting.bytes(record.fileSize)
+        case .failed: return "Failed"
+        case .revoked: return "No longer available"
+        }
+    }
+
+    @ViewBuilder private var progressRing: some View {
+        if record.localStatus == .downloading {
+            Button(action: onCancel) {
+                ZStack {
+                    Circle().stroke(Color.continuumOnSurface.opacity(0.15), lineWidth: 3)
+                    Circle()
+                        .trim(from: 0, to: max(0.02, record.progressFraction))
+                        .stroke(Color.continuumOnSurface, style: StrokeStyle(lineWidth: 3, lineCap: .round))
+                        .rotationEffect(.degrees(-90))
+                    Image(systemName: "stop.fill")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundColor(.continuumOnSurface)
+                }
+                .frame(width: 36, height: 36)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Cancel download")
+        } else {
+            ProgressView().controlSize(.small).tint(.continuumOnSurface)
+        }
+    }
+}
+
+// MARK: - Failed / attention row
+
+/// A failed download surfaced for retry or removal so it isn't silently lost.
+struct DownloadAttentionRow: View {
+    let record: DownloadRecord
+    var onRetry: () -> Void = {}
+    var onDelete: () -> Void = {}
+
+    var body: some View {
+        HStack(spacing: 12) {
+            DownloadPosterThumb(thumbhash: record.posterThumbhash, width: 40)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(record.title ?? record.contentId)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundColor(.continuumOnSurface)
+                    .lineLimit(1)
+                Text("Download failed")
+                    .font(.system(size: 12.5))
+                    .foregroundColor(.continuumError)
+            }
+            Spacer(minLength: 8)
+            Button(action: onRetry) {
+                Image(systemName: "arrow.clockwise")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundColor(.continuumOnSurface)
+                    .frame(width: 32, height: 32)
+            }
+            .buttonStyle(.plain)
+            Button(action: onDelete) {
+                Image(systemName: "trash")
+                    .font(.system(size: 15))
+                    .foregroundColor(.continuumSecondaryText)
+                    .frame(width: 32, height: 32)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color.continuumSurfaceVariant)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .stroke(Color.continuumOutline, lineWidth: 1)
+                )
+        )
+        .padding(.horizontal, 16)
+    }
+}
+
+// MARK: - Movie row
+
+struct DownloadMovieRow: View {
+    let record: DownloadRecord
+    let watched: Bool
+    var selecting: Bool = false
+    var selected: Bool = false
+    var onTap: () -> Void = {}
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 12) {
+                if selecting { DownloadSelectionCircle(selected: selected) }
+                DownloadPosterThumb(thumbhash: record.posterThumbhash, width: 40)
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 7) {
+                        Text(record.title ?? record.contentId)
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundColor(.continuumOnSurface)
+                            .lineLimit(1)
+                        DownloadKindChip(text: "Movie")
+                    }
+                    if !meta.isEmpty {
+                        Text(meta)
+                            .font(.system(size: 12))
+                            .foregroundColor(.continuumSecondaryText)
+                            .lineLimit(1)
+                    }
+                }
+                Spacer(minLength: 8)
+                Text(DownloadFormatting.bytes(record.fileSize))
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(.continuumOnSurface)
+            }
+            .padding(.horizontal, 18)
+            .padding(.vertical, 10)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var meta: String {
+        var parts: [String] = []
+        if let sub = record.subtitle, !sub.isEmpty { parts.append(sub) }
+        if watched { parts.append("watched") }
+        return parts.joined(separator: " · ")
+    }
+}
+
+// MARK: - Series row (collapses to one card, expands in place)
+
+struct DownloadSeriesRow: View {
+    let group: DownloadSeriesGroup
+    var selecting: Bool = false
+    var selected: Bool = false
+    let isWatched: (DownloadRecord) -> Bool
+    var onSelectToggle: () -> Void = {}
+    /// When non-nil, tapping the header opens the offline browse detail
+    /// (Phase 3). When nil, the header simply toggles inline expansion.
+    var onOpenSeries: (() -> Void)? = nil
+    var onPlayEpisode: (DownloadRecord) -> Void = { _ in }
+    var onDeleteEpisode: (DownloadRecord) -> Void = { _ in }
+
+    @State private var expanded = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            if expanded && !selecting {
+                ForEach(group.seasons) { season in
+                    Divider().overlay(Color.continuumDivider)
+                    seasonHeader(season)
+                    ForEach(season.records) { record in
+                        DownloadEpisodeRow(record: record, watched: isWatched(record)) {
+                            onPlayEpisode(record)
+                        }
+                        .contextMenu {
+                            Button(role: .destructive) { onDeleteEpisode(record) } label: {
+                                Label("Delete Download", systemImage: "trash")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(expanded ? Color.continuumSurfaceElevated : Color.continuumSurfaceVariant)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .stroke(Color.continuumOutline, lineWidth: 1)
+                )
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .padding(.horizontal, 16)
+    }
+
+    private var header: some View {
+        HStack(spacing: 13) {
+            if selecting { DownloadSelectionCircle(selected: selected) }
+            posterStack
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 7) {
+                    Text(group.title)
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(.continuumOnSurface)
+                        .lineLimit(1)
+                    if group.isMonitored { monitorBadge }
+                }
+                Text(subtitleLine)
+                    .font(.system(size: 12.5))
+                    .foregroundColor(.continuumSecondaryText)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 6)
+            Text(DownloadFormatting.bytes(group.totalBytes))
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(.continuumOnSurface)
+            if !selecting {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) { expanded.toggle() }
+                } label: {
+                    Image(systemName: expanded ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(.continuumSecondaryText)
+                        .frame(width: 26, height: 36)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(expanded ? "Collapse episodes" : "Expand episodes")
+            }
+        }
+        .padding(12)
+        .contentShape(Rectangle())
+        .onTapGesture(perform: headerTap)
+    }
+
+    private func headerTap() {
+        if selecting {
+            onSelectToggle()
+        } else if let onOpenSeries {
+            onOpenSeries()
+        } else {
+            withAnimation(.easeInOut(duration: 0.2)) { expanded.toggle() }
+        }
+    }
+
+    private var posterStack: some View {
+        ZStack(alignment: .leading) {
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .fill(Color.continuumSurfaceVariant)
+                .frame(width: 46, height: 62)
+                .offset(x: 9)
+                .opacity(0.45)
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .fill(Color.continuumSurface)
+                .frame(width: 46, height: 64)
+                .offset(x: 4)
+                .opacity(0.7)
+            DownloadPosterThumb(thumbhash: group.posterThumbhash, width: 46)
+        }
+        .frame(width: 59, height: 66, alignment: .leading)
+    }
+
+    private var monitorBadge: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "antenna.radiowaves.left.and.right")
+                .font(.system(size: 9, weight: .semibold))
+            Text("Monitoring")
+                .font(.system(size: 9.5, weight: .semibold))
+        }
+        .foregroundColor(.continuumOnSurface)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(Color.continuumChromeRestingFill)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .stroke(Color.continuumChromeRestingBorder, lineWidth: 1)
+                )
+        )
+    }
+
+    private var subtitleLine: String {
+        let seasons = group.seasonCount
+        let seasonPart = seasons > 1
+            ? "\(seasons) seasons"
+            : (group.seasons.first.map { $0.isSpecials ? "Specials" : "Season \($0.seasonNumber)" } ?? "")
+        var line = "\(group.episodeCount) episode\(group.episodeCount == 1 ? "" : "s")"
+        if !seasonPart.isEmpty { line += " · \(seasonPart)" }
+        if group.allWatched {
+            line += " · all watched"
+        } else if group.watchedCount > 0 {
+            line += " · \(group.watchedCount) watched"
+        }
+        return line
+    }
+
+    private func seasonHeader(_ season: DownloadSeasonGroup) -> some View {
+        HStack {
+            Text(season.isSpecials ? "Specials" : "Season \(season.seasonNumber)")
+                .font(.system(size: 12.5, weight: .semibold))
+                .foregroundColor(.continuumOnSurface)
+            Spacer()
+            Text("\(season.episodeCount) ep\(season.episodeCount == 1 ? "" : "s") · \(DownloadFormatting.bytes(season.totalBytes))")
+                .font(.system(size: 11.5))
+                .foregroundColor(.continuumSecondaryText)
+        }
+        .padding(.horizontal, 14)
+        .padding(.top, 9)
+        .padding(.bottom, 5)
+    }
+}
+
+// MARK: - Episode row (inside an expanded series / reclaim sheet)
+
+struct DownloadEpisodeRow: View {
+    let record: DownloadRecord
+    let watched: Bool
+    var onPlay: () -> Void = {}
+
+    var body: some View {
+        Button(action: onPlay) {
+            HStack(spacing: 11) {
+                ThumbhashImage(thumbhash: record.posterThumbhash)
+                    .frame(width: 54, height: 32)
+                    .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+                    .overlay(
+                        Image(systemName: "play.fill")
+                            .font(.system(size: 11))
+                            .foregroundColor(.white.opacity(0.9))
+                    )
+                    .opacity(watched ? 0.5 : 1)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.system(size: 13.5, weight: .medium))
+                        .foregroundColor(.continuumOnSurface)
+                        .lineLimit(1)
+                        .opacity(watched ? 0.55 : 1)
+                    Text(meta)
+                        .font(.system(size: 11.5))
+                        .foregroundColor(.continuumSecondaryText)
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 6)
+
+                Image(systemName: watched ? "checkmark" : "play.circle")
+                    .font(.system(size: watched ? 13 : 18, weight: watched ? .semibold : .regular))
+                    .foregroundColor(watched ? .continuumOnSurface.opacity(0.5) : .continuumOnSurface)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var title: String {
+        if let episode = record.episodeNumber {
+            return "E\(episode) · \(record.title ?? record.contentId)"
+        }
+        return record.title ?? record.contentId
+    }
+
+    private var meta: String {
+        let size = DownloadFormatting.bytes(record.fileSize)
+        return watched ? "Watched · \(size)" : size
+    }
+}
+#endif

--- a/iosApp/iosApp/Downloads/Views/DownloadManagerRows.swift
+++ b/iosApp/iosApp/Downloads/Views/DownloadManagerRows.swift
@@ -3,15 +3,45 @@ import SwiftUI
 
 // MARK: - In-progress row
 
-/// A pinned active-transfer row (downloading / queued / preparing) with a
-/// circular progress ring that doubles as a stop button.
+/// A pinned active-transfer row (downloading / paused / queued / preparing)
+/// whose circular progress ring toggles pause/resume. Cancelling is
+/// deliberately harder to reach — context menu or swipe, both behind a
+/// confirmation that states how much downloaded data would be discarded.
 struct DownloadActiveRow: View {
     let record: DownloadRecord
+    /// Smoothed transfer rate from the manager; nil until enough progress
+    /// deltas have landed for the estimate to be meaningful.
+    var bytesPerSecond: Double? = nil
+    var onPauseResume: () -> Void = {}
     var onCancel: () -> Void = {}
 
+    @State private var confirmingCancel = false
+
     var body: some View {
+        DownloadSwipeRevealContainer(actionLabel: "Cancel") {
+            confirmingCancel = true
+        } content: {
+            card
+        }
+        .padding(.horizontal, 16)
+        .contextMenu { menuItems }
+        .confirmationDialog(
+            cancelPrompt,
+            isPresented: $confirmingCancel,
+            titleVisibility: .visible
+        ) {
+            Button("Discard Download", role: .destructive, action: onCancel)
+            Button("Keep Download", role: .cancel) {}
+        }
+    }
+
+    private var card: some View {
         HStack(spacing: 12) {
-            DownloadPosterThumb(thumbhash: record.posterThumbhash, width: 40)
+            DownloadPosterThumb(
+                thumbhash: record.posterThumbhash,
+                fileURL: DownloadManager.shared.posterImageURL(for: record),
+                width: 40
+            )
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(displayTitle)
@@ -37,7 +67,30 @@ struct DownloadActiveRow: View {
                         .stroke(Color.continuumOutline, lineWidth: 1)
                 )
         )
-        .padding(.horizontal, 16)
+    }
+
+    @ViewBuilder private var menuItems: some View {
+        if record.localStatus == .downloading {
+            Button(action: onPauseResume) {
+                Label("Pause", systemImage: "pause")
+            }
+        } else if record.localStatus == .paused {
+            Button(action: onPauseResume) {
+                Label("Resume", systemImage: "play")
+            }
+        }
+        Button(role: .destructive) { confirmingCancel = true } label: {
+            Label("Cancel Download", systemImage: "xmark.circle")
+        }
+    }
+
+    /// States what a destructive cancel throws away; bytes are omitted when
+    /// nothing has transferred yet.
+    private var cancelPrompt: String {
+        if record.bytesDownloaded > 0 {
+            return "Discard \(DownloadFormatting.bytes(record.bytesDownloaded)) of downloaded data?"
+        }
+        return "Cancel this download?"
     }
 
     private var displayTitle: String {
@@ -50,8 +103,9 @@ struct DownloadActiveRow: View {
     private var statusLine: String {
         switch record.localStatus {
         case .downloading:
-            let pct = Int((record.progressFraction * 100).rounded())
-            return "\(pct)% · \(DownloadFormatting.bytes(record.bytesDownloaded)) of \(DownloadFormatting.bytes(record.fileSize))"
+            return ([percentText, sizeText] + rateParts).joined(separator: " · ")
+        case .paused:
+            return "Paused · \(percentText) · \(sizeText)"
         case .registering, .queued: return "Queued"
         case .preparing: return "Preparing on server…"
         case .fetchingAssets: return "Finishing…"
@@ -61,26 +115,133 @@ struct DownloadActiveRow: View {
         }
     }
 
+    private var percentText: String {
+        "\(Int((record.progressFraction * 100).rounded()))%"
+    }
+
+    private var sizeText: String {
+        "\(DownloadFormatting.bytes(record.bytesDownloaded)) of \(DownloadFormatting.bytes(record.fileSize))"
+    }
+
+    /// "12 MB/s · 3 min left" once the manager has a smoothed rate; omitted
+    /// while the rate is still settling so the line never shows garbage.
+    private var rateParts: [String] {
+        guard let bytesPerSecond, bytesPerSecond >= 1 else { return [] }
+        var parts = ["\(DownloadFormatting.bytes(Int64(bytesPerSecond)))/s"]
+        let remaining = record.fileSize - record.bytesDownloaded
+        if remaining > 0 {
+            parts.append(Self.remainingText(seconds: Double(remaining) / bytesPerSecond))
+        }
+        return parts
+    }
+
+    private static func remainingText(seconds: Double) -> String {
+        let minutes = Int((seconds / 60).rounded())
+        if minutes < 1 { return "under 1 min left" }
+        if minutes < 60 { return "\(minutes) min left" }
+        return "\(minutes / 60) hr \(minutes % 60) min left"
+    }
+
     @ViewBuilder private var progressRing: some View {
-        if record.localStatus == .downloading {
-            Button(action: onCancel) {
+        switch record.localStatus {
+        case .downloading, .paused:
+            let paused = record.localStatus == .paused
+            Button(action: onPauseResume) {
                 ZStack {
                     Circle().stroke(Color.continuumOnSurface.opacity(0.15), lineWidth: 3)
                     Circle()
                         .trim(from: 0, to: max(0.02, record.progressFraction))
-                        .stroke(Color.continuumOnSurface, style: StrokeStyle(lineWidth: 3, lineCap: .round))
+                        .stroke(
+                            Color.continuumOnSurface.opacity(paused ? 0.55 : 1),
+                            style: StrokeStyle(lineWidth: 3, lineCap: .round)
+                        )
                         .rotationEffect(.degrees(-90))
-                    Image(systemName: "stop.fill")
+                    Image(systemName: paused ? "play.fill" : "pause.fill")
                         .font(.system(size: 10, weight: .bold))
                         .foregroundColor(.continuumOnSurface)
                 }
                 .frame(width: 36, height: 36)
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("Cancel download")
-        } else {
+            .accessibilityLabel(paused ? "Resume download" : "Pause download")
+        default:
             ProgressView().controlSize(.small).tint(.continuumOnSurface)
         }
+    }
+}
+
+// MARK: - Swipe-to-reveal (LazyVStack rows)
+
+/// Trailing swipe affordance for rows hosted in the Manager's `LazyVStack`
+/// (`.swipeActions` only functions inside a `List`). The drag activates
+/// only when clearly horizontal so it doesn't fight the scroll view.
+struct DownloadSwipeRevealContainer<Content: View>: View {
+    let actionLabel: String
+    let action: () -> Void
+    @ViewBuilder let content: () -> Content
+
+    @State private var offset: CGFloat = 0
+    @State private var isOpen = false
+
+    private let revealWidth: CGFloat = 84
+
+    var body: some View {
+        ZStack(alignment: .trailing) {
+            revealButton
+            content()
+                .offset(x: offset)
+                .simultaneousGesture(drag)
+                .onTapGesture {
+                    if isOpen { close() }
+                }
+        }
+        .animation(.easeInOut(duration: 0.2), value: offset)
+    }
+
+    private var revealButton: some View {
+        Button {
+            close()
+            action()
+        } label: {
+            VStack(spacing: 5) {
+                Image(systemName: "xmark.circle")
+                    .font(.system(size: 17, weight: .semibold))
+                Text(actionLabel)
+                    .font(.system(size: 11.5, weight: .semibold))
+            }
+            .foregroundColor(.white)
+            .frame(width: revealWidth - 8)
+            .frame(maxHeight: .infinity)
+            .background(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(Color.continuumError)
+            )
+        }
+        .buttonStyle(.plain)
+        .opacity(offset < -8 ? 1 : 0)
+    }
+
+    private var drag: some Gesture {
+        DragGesture(minimumDistance: 24)
+            .onChanged { value in
+                // Ignore mostly-vertical drags — those belong to the scroll.
+                guard abs(value.translation.width) > abs(value.translation.height) else { return }
+                let base: CGFloat = isOpen ? -revealWidth : 0
+                offset = min(0, max(-revealWidth, base + value.translation.width))
+            }
+            .onEnded { _ in
+                if offset < -revealWidth / 2 {
+                    offset = -revealWidth
+                    isOpen = true
+                } else {
+                    close()
+                }
+            }
+    }
+
+    private func close() {
+        offset = 0
+        isOpen = false
     }
 }
 
@@ -94,7 +255,11 @@ struct DownloadAttentionRow: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            DownloadPosterThumb(thumbhash: record.posterThumbhash, width: 40)
+            DownloadPosterThumb(
+                thumbhash: record.posterThumbhash,
+                fileURL: DownloadManager.shared.posterImageURL(for: record),
+                width: 40
+            )
             VStack(alignment: .leading, spacing: 4) {
                 Text(record.title ?? record.contentId)
                     .font(.system(size: 15, weight: .semibold))
@@ -147,7 +312,11 @@ struct DownloadMovieRow: View {
         Button(action: onTap) {
             HStack(spacing: 12) {
                 if selecting { DownloadSelectionCircle(selected: selected) }
-                DownloadPosterThumb(thumbhash: record.posterThumbhash, width: 40)
+                DownloadPosterThumb(
+                    thumbhash: record.posterThumbhash,
+                    fileURL: DownloadManager.shared.posterImageURL(for: record),
+                    width: 40
+                )
                 VStack(alignment: .leading, spacing: 4) {
                     HStack(spacing: 7) {
                         Text(record.title ?? record.contentId)
@@ -293,9 +462,21 @@ struct DownloadSeriesRow: View {
                 .frame(width: 46, height: 64)
                 .offset(x: 4)
                 .opacity(0.7)
-            DownloadPosterThumb(thumbhash: group.posterThumbhash, width: 46)
+            DownloadPosterThumb(
+                thumbhash: group.posterThumbhash,
+                fileURL: posterFileURL,
+                width: 46
+            )
         }
         .frame(width: 59, height: 66, alignment: .leading)
+    }
+
+    /// First on-disk poster among the group's episodes — every episode of a
+    /// series carries the same series poster in its download bundle.
+    private var posterFileURL: URL? {
+        group.allRecords.lazy
+            .compactMap { DownloadManager.shared.posterImageURL(for: $0) }
+            .first
     }
 
     private var monitorBadge: some View {

--- a/iosApp/iosApp/Downloads/Views/DownloadManagerRows.swift
+++ b/iosApp/iosApp/Downloads/Views/DownloadManagerRows.swift
@@ -219,6 +219,10 @@ struct DownloadSwipeRevealContainer<Content: View>: View {
         }
         .buttonStyle(.plain)
         .opacity(offset < -8 ? 1 : 0)
+        // Opacity alone leaves the closed button in the hierarchy —
+        // reachable by VoiceOver and hit testing under the row content.
+        .allowsHitTesting(isOpen)
+        .accessibilityHidden(!isOpen)
     }
 
     private var drag: some Gesture {

--- a/iosApp/iosApp/Downloads/Views/DownloadReclaimSheet.swift
+++ b/iosApp/iosApp/Downloads/Views/DownloadReclaimSheet.swift
@@ -1,0 +1,171 @@
+#if !os(tvOS)
+import SwiftUI
+
+/// "Free Up Space" review sheet: every downloaded-and-watched item,
+/// pre-selected, so the most common cleanup is a single confirmed tap.
+/// The user can deselect anything they want to keep.
+struct DownloadReclaimSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    private var manager: DownloadManager { DownloadManager.shared }
+
+    /// Record ids the user has chosen to keep (everything starts selected).
+    @State private var kept: Set<String> = []
+
+    private var records: [DownloadRecord] { manager.reclaimableRecords }
+    private var selected: [DownloadRecord] { records.filter { !kept.contains($0.id) } }
+    private var selectedBytes: Int64 { selected.reduce(0) { $0 + $1.fileSize } }
+    private var allSelected: Bool { kept.isEmpty }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if records.isEmpty {
+                    EmptyStateView(
+                        icon: "checkmark.circle",
+                        title: "All Caught Up",
+                        subtitle: "There are no watched downloads to clear right now."
+                    )
+                    .background(Color.continuumBackground)
+                } else {
+                    list
+                }
+            }
+            .navigationTitle("Free Up Space")
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { dismiss() }
+                }
+                if !records.isEmpty {
+                    ToolbarItem(placement: .primaryAction) {
+                        Button(allSelected ? "Deselect All" : "Select All") { toggleAll() }
+                    }
+                }
+            }
+            .safeAreaInset(edge: .bottom) { bottomBar }
+            .continuumToolbarColorSchemeDark()
+        }
+    }
+
+    private var list: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                header
+                ForEach(records) { record in
+                    row(record)
+                    Divider().overlay(Color.continuumDivider).padding(.leading, 56)
+                }
+                Color.clear.frame(height: 24)
+            }
+        }
+        .background(Color.continuumBackground)
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("\(records.count) item\(records.count == 1 ? "" : "s") you've finished watching")
+                .font(.system(size: 13))
+                .foregroundColor(.continuumSecondaryText)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 18)
+        .padding(.top, 8)
+        .padding(.bottom, 10)
+    }
+
+    private func row(_ record: DownloadRecord) -> some View {
+        Button {
+            toggle(record.id)
+        } label: {
+            HStack(spacing: 12) {
+                DownloadSelectionCircle(selected: !kept.contains(record.id))
+                ThumbhashImage(thumbhash: record.posterThumbhash)
+                    .frame(width: 48, height: 28)
+                    .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(label(record))
+                        .font(.system(size: 13.5, weight: .medium))
+                        .foregroundColor(.continuumOnSurface)
+                        .lineLimit(1)
+                    Text("Watched")
+                        .font(.system(size: 11.5))
+                        .foregroundColor(.continuumSecondaryText)
+                }
+                Spacer(minLength: 8)
+                Text(DownloadFormatting.bytes(record.fileSize))
+                    .font(.system(size: 12.5, weight: .semibold))
+                    .foregroundColor(.continuumOnSurface)
+            }
+            .padding(.horizontal, 18)
+            .padding(.vertical, 10)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private var bottomBar: some View {
+        if !records.isEmpty {
+            VStack(spacing: 9) {
+                Button {
+                    manager.deleteDownloads(ids: selected.map(\.id))
+                    dismiss()
+                } label: {
+                    HStack(spacing: 9) {
+                        Image(systemName: "trash")
+                        Text("Delete \(selected.count) · Free \(DownloadFormatting.bytes(selectedBytes))")
+                            .fontWeight(.bold)
+                    }
+                    .font(.system(size: 15))
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 50)
+                    .background(selected.isEmpty ? Color.continuumDisabled : Color.continuumOnSurface)
+                    .foregroundColor(.black)
+                    .clipShape(RoundedRectangle(cornerRadius: 15, style: .continuous))
+                }
+                .buttonStyle(.plain)
+                .disabled(selected.isEmpty)
+
+                Button("Not now") { dismiss() }
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(.continuumOnSurface)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 42)
+                    .background(
+                        RoundedRectangle(cornerRadius: 13, style: .continuous)
+                            .fill(Color.continuumChromeRestingFill)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 13, style: .continuous)
+                                    .stroke(Color.continuumChromeRestingBorder, lineWidth: 1)
+                            )
+                    )
+                    .buttonStyle(.plain)
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 10)
+            .padding(.bottom, 8)
+            .background(.ultraThinMaterial)
+        }
+    }
+
+    private func label(_ record: DownloadRecord) -> String {
+        guard record.seriesId != nil else { return record.title ?? record.contentId }
+        let tag = [record.seasonNumber.map { "S\($0)" }, record.episodeNumber.map { "E\($0)" }]
+            .compactMap { $0 }
+            .joined()
+        let series = record.seriesTitle ?? record.title ?? ""
+        return tag.isEmpty ? (record.title ?? series) : "\(series) · \(tag)"
+    }
+
+    private func toggle(_ id: String) {
+        if kept.contains(id) { kept.remove(id) } else { kept.insert(id) }
+    }
+
+    private func toggleAll() {
+        if allSelected { kept = Set(records.map(\.id)) }
+        else { kept.removeAll() }
+    }
+}
+#endif

--- a/iosApp/iosApp/Downloads/Views/DownloadsManagerComponents.swift
+++ b/iosApp/iosApp/Downloads/Views/DownloadsManagerComponents.swift
@@ -4,10 +4,12 @@ import SwiftUI
 // MARK: - Storage hero
 
 /// The storage hero at the top of the Downloads Manager: a big "used of
-/// device" figure with a typed breakdown bar (series / movies / other).
+/// device" figure with a typed breakdown bar (series / movies / in
+/// progress / other).
 struct DownloadsStorageHeader: View {
     let used: Int64
     let breakdown: DownloadStorageBreakdown
+    var activeCount: Int = 0
 
     @State private var device = DownloadFilePaths.deviceStorage()
 
@@ -21,6 +23,12 @@ struct DownloadsStorageHeader: View {
                     .font(.system(size: 14))
                     .foregroundColor(.continuumSecondaryText)
             )
+
+            if activeCount > 0 {
+                Text(inProgressLine)
+                    .font(.system(size: 12.5))
+                    .foregroundColor(.continuumSecondaryText)
+            }
 
             if breakdown.total > 0 {
                 breakdownBar
@@ -46,6 +54,17 @@ struct DownloadsStorageHeader: View {
             : "  downloaded"
     }
 
+    /// Mid-flight transfers are invisible to `used` (partial media sits in
+    /// the session's staging area), so this line keeps the hero honest
+    /// while something is downloading.
+    private var inProgressLine: String {
+        var line = "\(activeCount) download\(activeCount == 1 ? "" : "s") in progress"
+        if breakdown.inProgress > 0 {
+            line += " · \(DownloadFormatting.bytes(breakdown.inProgress)) so far"
+        }
+        return line
+    }
+
     private var breakdownBar: some View {
         GeometryReader { geo in
             let total = max(CGFloat(breakdown.total), 1)
@@ -53,7 +72,8 @@ struct DownloadsStorageHeader: View {
             HStack(spacing: 2) {
                 segment(width: width * CGFloat(breakdown.series) / total, opacity: 1)
                 segment(width: width * CGFloat(breakdown.movies) / total, opacity: 0.52)
-                segment(width: width * CGFloat(breakdown.other) / total, opacity: 0.22)
+                segment(width: width * CGFloat(breakdown.inProgress) / total, opacity: 0.34)
+                segment(width: width * CGFloat(breakdown.other) / total, opacity: 0.18)
             }
         }
         .frame(height: 10)
@@ -68,7 +88,8 @@ struct DownloadsStorageHeader: View {
         HStack(spacing: 16) {
             legendItem(opacity: 1, bytes: breakdown.series, label: "Series")
             legendItem(opacity: 0.52, bytes: breakdown.movies, label: "Movies")
-            legendItem(opacity: 0.22, bytes: breakdown.other, label: "Other")
+            legendItem(opacity: 0.34, bytes: breakdown.inProgress, label: "In progress")
+            legendItem(opacity: 0.18, bytes: breakdown.other, label: "Other")
         }
     }
 
@@ -217,13 +238,26 @@ struct DownloadSelectionCircle: View {
 /// A 2:3 poster tile sized for a Manager / browse row.
 struct DownloadPosterThumb: View {
     let thumbhash: String?
+    /// Poster image on local disk, fetched by the download pipeline before
+    /// the media transfer starts — drawn over the thumbhash placeholder so
+    /// in-progress rows aren't a blank tile for the whole transfer.
+    var fileURL: URL? = nil
     var width: CGFloat = 40
     var corner: CGFloat = 7
 
     var body: some View {
-        ThumbhashImage(thumbhash: thumbhash)
-            .frame(width: width, height: width * 1.5)
-            .clipShape(RoundedRectangle(cornerRadius: corner, style: .continuous))
+        ZStack {
+            ThumbhashImage(thumbhash: thumbhash)
+            if let fileURL {
+                AsyncImage(url: fileURL) { image in
+                    image.resizable().scaledToFill()
+                } placeholder: {
+                    Color.clear
+                }
+            }
+        }
+        .frame(width: width, height: width * 1.5)
+        .clipShape(RoundedRectangle(cornerRadius: corner, style: .continuous))
     }
 }
 

--- a/iosApp/iosApp/Downloads/Views/DownloadsManagerComponents.swift
+++ b/iosApp/iosApp/Downloads/Views/DownloadsManagerComponents.swift
@@ -1,0 +1,251 @@
+#if !os(tvOS)
+import SwiftUI
+
+// MARK: - Storage hero
+
+/// The storage hero at the top of the Downloads Manager: a big "used of
+/// device" figure with a typed breakdown bar (series / movies / other).
+struct DownloadsStorageHeader: View {
+    let used: Int64
+    let breakdown: DownloadStorageBreakdown
+
+    @State private var device = DownloadFilePaths.deviceStorage()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 13) {
+            (
+                Text(DownloadFormatting.bytes(used))
+                    .font(.system(size: 26, weight: .bold))
+                    .foregroundColor(.continuumOnSurface)
+                + Text(contextSuffix)
+                    .font(.system(size: 14))
+                    .foregroundColor(.continuumSecondaryText)
+            )
+
+            if breakdown.total > 0 {
+                breakdownBar
+                legend
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .fill(Color.continuumSurfaceElevated)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 20, style: .continuous)
+                        .stroke(Color.continuumOutline, lineWidth: 1)
+                )
+        )
+        .padding(.horizontal, 16)
+    }
+
+    private var contextSuffix: String {
+        device.total > 0
+            ? "  of \(DownloadFormatting.bytes(device.total)) on this device"
+            : "  downloaded"
+    }
+
+    private var breakdownBar: some View {
+        GeometryReader { geo in
+            let total = max(CGFloat(breakdown.total), 1)
+            let width = geo.size.width
+            HStack(spacing: 2) {
+                segment(width: width * CGFloat(breakdown.series) / total, opacity: 1)
+                segment(width: width * CGFloat(breakdown.movies) / total, opacity: 0.52)
+                segment(width: width * CGFloat(breakdown.other) / total, opacity: 0.22)
+            }
+        }
+        .frame(height: 10)
+        .clipShape(Capsule())
+    }
+
+    private func segment(width: CGFloat, opacity: Double) -> some View {
+        Color.continuumOnSurface.opacity(opacity).frame(width: max(0, width))
+    }
+
+    @ViewBuilder private var legend: some View {
+        HStack(spacing: 16) {
+            legendItem(opacity: 1, bytes: breakdown.series, label: "Series")
+            legendItem(opacity: 0.52, bytes: breakdown.movies, label: "Movies")
+            legendItem(opacity: 0.22, bytes: breakdown.other, label: "Other")
+        }
+    }
+
+    @ViewBuilder private func legendItem(opacity: Double, bytes: Int64, label: String) -> some View {
+        if bytes > 0 {
+            HStack(spacing: 6) {
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(Color.continuumOnSurface.opacity(opacity))
+                    .frame(width: 9, height: 9)
+                Text(DownloadFormatting.bytes(bytes))
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(.continuumOnSurface)
+                Text(label)
+                    .font(.system(size: 12))
+                    .foregroundColor(.continuumSecondaryText)
+            }
+        }
+    }
+}
+
+// MARK: - Reclaim banner
+
+/// "Free up X — N watched episodes" suggestion. Tapping opens the reclaim
+/// review sheet.
+struct DownloadReclaimBanner: View {
+    let episodeCount: Int
+    let bytes: Int64
+    let onReview: () -> Void
+
+    var body: some View {
+        Button(action: onReview) {
+            HStack(spacing: 12) {
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(Color.continuumChromeSelectedFill)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                            .stroke(Color.continuumChromeSelectedBorder, lineWidth: 1)
+                    )
+                    .frame(width: 34, height: 34)
+                    .overlay(
+                        Image(systemName: "sparkles")
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundColor(.continuumOnSurface)
+                    )
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Free up \(DownloadFormatting.bytes(bytes))")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundColor(.continuumOnSurface)
+                    Text("\(episodeCount) item\(episodeCount == 1 ? "" : "s") you've finished")
+                        .font(.system(size: 12.5))
+                        .foregroundColor(.continuumSecondaryText)
+                }
+
+                Spacer(minLength: 8)
+
+                Text("Review")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(.continuumOnSurface)
+                    .padding(.horizontal, 13)
+                    .padding(.vertical, 7)
+                    .background(
+                        Capsule().fill(Color.continuumChromeSelectedFill)
+                            .overlay(Capsule().stroke(Color.continuumChromeSelectedBorder, lineWidth: 1))
+                    )
+            }
+            .padding(13)
+            .background(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(Color.continuumSurfaceVariant)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .stroke(Color.continuumChromeSelectedBorder, lineWidth: 1)
+                    )
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, 16)
+    }
+}
+
+// MARK: - Sort control
+
+/// "Sort: Largest first ▾   N items" row above the Manager list.
+struct DownloadSortControl: View {
+    @Binding var option: DownloadSortOption
+    let itemCount: Int
+
+    var body: some View {
+        HStack {
+            Menu {
+                Picker("Sort", selection: $option) {
+                    ForEach(DownloadSortOption.allCases) { opt in
+                        Label(opt.displayName, systemImage: opt.systemImage).tag(opt)
+                    }
+                }
+            } label: {
+                HStack(spacing: 5) {
+                    Text(option.displayName)
+                        .font(.system(size: 13.5, weight: .semibold))
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 11, weight: .semibold))
+                }
+                .foregroundColor(.continuumOnSurface)
+            }
+
+            Spacer()
+
+            Text("\(itemCount) item\(itemCount == 1 ? "" : "s")")
+                .font(.system(size: 12.5))
+                .foregroundColor(.continuumOnSurface.opacity(0.38))
+        }
+        .padding(.horizontal, 22)
+        .padding(.top, 8)
+        .padding(.bottom, 2)
+    }
+}
+
+// MARK: - Small reusable bits
+
+/// Selection circle shown on the leading edge of rows in select mode.
+struct DownloadSelectionCircle: View {
+    let selected: Bool
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(selected ? Color.continuumOnSurface : Color.clear)
+                .overlay(
+                    Circle().stroke(
+                        selected ? Color.continuumOnSurface : Color.continuumOnSurface.opacity(0.35),
+                        lineWidth: 1.5
+                    )
+                )
+            if selected {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundColor(.black)
+            }
+        }
+        .frame(width: 22, height: 22)
+    }
+}
+
+/// A 2:3 poster tile sized for a Manager / browse row.
+struct DownloadPosterThumb: View {
+    let thumbhash: String?
+    var width: CGFloat = 40
+    var corner: CGFloat = 7
+
+    var body: some View {
+        ThumbhashImage(thumbhash: thumbhash)
+            .frame(width: width, height: width * 1.5)
+            .clipShape(RoundedRectangle(cornerRadius: corner, style: .continuous))
+    }
+}
+
+/// "MOVIE" / "SERIES" capsule chip used in Manager rows.
+struct DownloadKindChip: View {
+    let text: String
+
+    var body: some View {
+        Text(text.uppercased())
+            .font(.system(size: 9.5, weight: .semibold))
+            .tracking(0.4)
+            .foregroundColor(.continuumSecondaryText)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(Color.continuumChromeRestingFill)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 5, style: .continuous)
+                            .stroke(Color.continuumChromeRestingBorder, lineWidth: 1)
+                    )
+            )
+    }
+}
+#endif

--- a/iosApp/iosApp/Downloads/Views/OfflineBrowse.swift
+++ b/iosApp/iosApp/Downloads/Views/OfflineBrowse.swift
@@ -1,0 +1,571 @@
+#if !os(tvOS)
+import SwiftUI
+
+// MARK: - Series browse
+
+/// Offline series browse: a season/episode list scoped to downloaded
+/// content, reachable from the Downloads Manager. Rendered entirely from
+/// `DownloadManager.seriesGroups` + stored progress — no network.
+struct OfflineSeriesBrowseView: View {
+    let seriesId: String
+
+    @Environment(AppRouter.self) private var router
+    @Environment(\.dismiss) private var dismiss
+    private var manager: DownloadManager { DownloadManager.shared }
+
+    @State private var selectedSeasonNumber: Int?
+
+    private var group: DownloadSeriesGroup? {
+        manager.seriesGroups.first { $0.seriesId == seriesId }
+    }
+
+    var body: some View {
+        Group {
+            if let group {
+                content(group)
+            } else {
+                EmptyStateView(
+                    icon: "tv",
+                    title: "No Downloads",
+                    subtitle: "This series has no downloaded episodes."
+                )
+                .background(Color.continuumBackground)
+            }
+        }
+        .navigationTitle(group?.title ?? "Series")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .toolbar {
+            if let group {
+                ToolbarItem(placement: .primaryAction) {
+                    Menu {
+                        Button(role: .destructive) {
+                            manager.deleteDownloads(ids: group.allRecords.map(\.id))
+                            dismiss()
+                        } label: {
+                            Label("Delete All Episodes", systemImage: "trash")
+                        }
+                    } label: {
+                        Image(systemName: "ellipsis.circle")
+                    }
+                }
+            }
+        }
+        .continuumToolbarColorSchemeDark()
+    }
+
+    private func content(_ group: DownloadSeriesGroup) -> some View {
+        let season = currentSeason(group)
+        return ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                OfflineBrowseHero(
+                    title: group.title,
+                    eyebrow: heroEyebrow(group),
+                    posterThumbhash: group.posterThumbhash,
+                    availability: "Downloaded · \(group.episodeCount) episode\(group.episodeCount == 1 ? "" : "s") · \(DownloadFormatting.bytes(group.totalBytes))",
+                    isMonitored: group.isMonitored,
+                    playTitle: playTitle(season),
+                    onPlay: { if let record = playTarget(season) { play(record) } }
+                )
+
+                if group.seasons.count > 1 {
+                    seasonChips(group)
+                }
+
+                if let season {
+                    seasonHeaderRow(season)
+                    ForEach(season.records) { record in
+                        DownloadEpisodeRow(record: record, watched: manager.isWatched(record)) {
+                            play(record)
+                        }
+                        .contextMenu {
+                            Button(role: .destructive) {
+                                manager.deleteDownload(id: record.id)
+                            } label: {
+                                Label("Delete Download", systemImage: "trash")
+                            }
+                        }
+                    }
+                }
+
+                Color.clear.frame(height: 30)
+            }
+        }
+        .background(Color.continuumBackground)
+    }
+
+    private func seasonChips(_ group: DownloadSeriesGroup) -> some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(group.seasons) { season in
+                    let isSelected = season.seasonNumber == currentSeason(group)?.seasonNumber
+                    Button {
+                        selectedSeasonNumber = season.seasonNumber
+                    } label: {
+                        Text(season.isSpecials ? "Specials" : "Season \(season.seasonNumber)")
+                            .font(.system(size: 13.5, weight: .semibold))
+                            .foregroundColor(isSelected ? .continuumOnSurface : .continuumSecondaryText)
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 8)
+                            .background(
+                                Capsule()
+                                    .fill(isSelected ? Color.continuumChromeSelectedFill : Color.continuumChromeRestingFill)
+                                    .overlay(
+                                        Capsule().stroke(
+                                            isSelected ? Color.continuumChromeSelectedBorder : Color.continuumChromeRestingBorder,
+                                            lineWidth: 1
+                                        )
+                                    )
+                            )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal, 18)
+        }
+        .padding(.top, 14)
+    }
+
+    private func seasonHeaderRow(_ season: DownloadSeasonGroup) -> some View {
+        HStack {
+            Text("Episodes")
+                .font(.system(size: 16, weight: .bold))
+                .foregroundColor(.continuumOnSurface)
+            Spacer()
+            Text("\(season.episodeCount) on this device · \(DownloadFormatting.bytes(season.totalBytes))")
+                .font(.system(size: 11.5))
+                .foregroundColor(.continuumOnSurface.opacity(0.38))
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 18)
+        .padding(.bottom, 6)
+    }
+
+    private func currentSeason(_ group: DownloadSeriesGroup) -> DownloadSeasonGroup? {
+        if let selectedSeasonNumber,
+           let match = group.seasons.first(where: { $0.seasonNumber == selectedSeasonNumber }) {
+            return match
+        }
+        return group.seasons.first
+    }
+
+    private func heroEyebrow(_ group: DownloadSeriesGroup) -> String {
+        let seasons = group.seasonCount
+        return seasons > 1 ? "Series · \(seasons) seasons" : "Series"
+    }
+
+    private func playTarget(_ season: DownloadSeasonGroup?) -> DownloadRecord? {
+        guard let season else { return nil }
+        return season.records.first(where: { !manager.isWatched($0) }) ?? season.records.first
+    }
+
+    private func playTitle(_ season: DownloadSeasonGroup?) -> String {
+        guard let record = playTarget(season) else { return "Play" }
+        if manager.localProgress(forMediaItemId: record.leafMediaItemId)?.position ?? 0 > 30 {
+            return "Resume\(episodeTag(record))"
+        }
+        return "Play\(episodeTag(record))"
+    }
+
+    private func episodeTag(_ record: DownloadRecord) -> String {
+        guard let episode = record.episodeNumber else { return "" }
+        if let season = record.seasonNumber, season > 0 { return " S\(season)·E\(episode)" }
+        return " E\(episode)"
+    }
+
+    private func play(_ record: DownloadRecord) {
+        guard record.isPlayableOffline else { return }
+        let leafId = record.leafMediaItemId
+        router.presentOfflinePlayer(
+            downloadId: record.id,
+            contentId: leafId,
+            resumePosition: manager.localProgress(forMediaItemId: leafId)?.position
+        )
+    }
+}
+
+// MARK: - Leaf detail (movie or episode)
+
+/// Offline leaf detail for one downloaded movie or episode: synopsis,
+/// resume, the audio/subtitle/quality baked into the stored manifest, and
+/// a single-item delete.
+struct OfflineDownloadDetailView: View {
+    let downloadId: String
+
+    @Environment(AppRouter.self) private var router
+    @Environment(\.dismiss) private var dismiss
+    private var manager: DownloadManager { DownloadManager.shared }
+
+    @State private var manifest: OfflineManifest?
+
+    private var record: DownloadRecord? { manager.record(id: downloadId) }
+
+    var body: some View {
+        Group {
+            if let record {
+                content(record)
+            } else {
+                EmptyStateView(icon: "arrow.down.circle", title: "Download Removed", subtitle: nil)
+                    .background(Color.continuumBackground)
+            }
+        }
+        .navigationTitle("")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .task {
+            if manifest == nil, let record { manifest = await manager.loadManifest(for: record) }
+        }
+        .continuumToolbarColorSchemeDark()
+    }
+
+    private func content(_ record: DownloadRecord) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                still(record)
+
+                VStack(alignment: .leading, spacing: 0) {
+                    if record.type == "episode" {
+                        Text(episodeEyebrow(record))
+                            .font(.system(size: 12, weight: .semibold))
+                            .tracking(0.4)
+                            .foregroundColor(.continuumSecondaryText)
+                            .padding(.bottom, 5)
+                    }
+                    Text(record.title ?? record.contentId)
+                        .font(.system(size: 21, weight: .bold))
+                        .foregroundColor(.continuumOnSurface)
+                    Text(metaLine(record))
+                        .font(.system(size: 12))
+                        .foregroundColor(.continuumSecondaryText)
+                        .padding(.top, 4)
+
+                    availabilityChip(record)
+                        .padding(.top, 13)
+
+                    playRow(record)
+                        .padding(.top, 14)
+
+                    if let overview = manifest?.overview, !overview.isEmpty {
+                        Text(overview)
+                            .font(.system(size: 13))
+                            .foregroundColor(.continuumSecondaryText)
+                            .lineSpacing(2)
+                            .padding(.top, 16)
+                    }
+
+                    facts(record)
+                        .padding(.top, 16)
+
+                    deleteButton(record)
+                        .padding(.top, 16)
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 16)
+
+                Color.clear.frame(height: 30)
+            }
+        }
+        .background(Color.continuumBackground)
+    }
+
+    private func still(_ record: DownloadRecord) -> some View {
+        Button { play(record) } label: {
+            ZStack {
+                LinearGradient(
+                    colors: [Color.continuumSurfaceElevated, Color.continuumBackground],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+                Image(systemName: "play.circle.fill")
+                    .font(.system(size: 50))
+                    .foregroundColor(.white.opacity(0.92))
+                if let fraction = resumeFraction(record) {
+                    VStack {
+                        Spacer()
+                        GeometryReader { geo in
+                            ZStack(alignment: .leading) {
+                                Color.continuumOnSurface.opacity(0.22)
+                                Color.continuumOnSurface.frame(width: geo.size.width * fraction)
+                            }
+                        }
+                        .frame(height: 4)
+                    }
+                }
+            }
+            .frame(height: 190)
+            .clipped()
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Play")
+    }
+
+    private func availabilityChip(_ record: DownloadRecord) -> some View {
+        HStack(spacing: 7) {
+            Image(systemName: "checkmark.circle")
+                .font(.system(size: 12, weight: .semibold))
+            Text(availabilityText(record))
+                .font(.system(size: 11.5, weight: .semibold))
+        }
+        .foregroundColor(.continuumOnSurface)
+        .padding(.horizontal, 11)
+        .padding(.vertical, 6)
+        .background(
+            Capsule()
+                .fill(Color.continuumChromeSelectedFill)
+                .overlay(Capsule().stroke(Color.continuumChromeSelectedBorder, lineWidth: 1))
+        )
+    }
+
+    private func playRow(_ record: DownloadRecord) -> some View {
+        HStack(spacing: 11) {
+            Button { play(record) } label: {
+                HStack(spacing: 8) {
+                    Image(systemName: "play.fill")
+                    Text(playLabel(record)).fontWeight(.bold)
+                }
+                .font(.system(size: 14.5))
+                .frame(maxWidth: .infinity)
+                .frame(height: 46)
+                .background(Color.continuumOnSurface)
+                .foregroundColor(.black)
+                .clipShape(RoundedRectangle(cornerRadius: 13, style: .continuous))
+            }
+            .buttonStyle(.plain)
+
+            if resumeFraction(record) != nil {
+                Button { playFromStart(record) } label: {
+                    Image(systemName: "gobackward")
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundColor(.continuumOnSurface)
+                        .frame(width: 46, height: 46)
+                        .background(
+                            RoundedRectangle(cornerRadius: 13, style: .continuous)
+                                .fill(Color.continuumChromeRestingFill)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 13, style: .continuous)
+                                        .stroke(Color.continuumChromeRestingBorder, lineWidth: 1)
+                                )
+                        )
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Restart from beginning")
+            }
+        }
+    }
+
+    private func facts(_ record: DownloadRecord) -> some View {
+        VStack(spacing: 0) {
+            ForEach(factRows(record), id: \.0) { key, value in
+                HStack {
+                    Text(key)
+                        .font(.system(size: 12.5))
+                        .foregroundColor(.continuumSecondaryText)
+                    Spacer()
+                    Text(value)
+                        .font(.system(size: 12.5, weight: .medium))
+                        .foregroundColor(.continuumOnSurface)
+                }
+                .padding(.vertical, 11)
+                Divider().overlay(Color.continuumDivider)
+            }
+        }
+        .overlay(Divider().overlay(Color.continuumDivider), alignment: .top)
+    }
+
+    private func deleteButton(_ record: DownloadRecord) -> some View {
+        Button {
+            manager.deleteDownload(id: record.id)
+            dismiss()
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: "trash")
+                Text("Delete download · Free \(DownloadFormatting.bytes(record.fileSize))")
+                    .fontWeight(.semibold)
+            }
+            .font(.system(size: 13.5))
+            .frame(maxWidth: .infinity)
+            .frame(height: 44)
+            .foregroundColor(.continuumError)
+            .background(
+                RoundedRectangle(cornerRadius: 13, style: .continuous)
+                    .fill(Color.continuumChromeRestingFill)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 13, style: .continuous)
+                            .stroke(Color.continuumChromeRestingBorder, lineWidth: 1)
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Derived text
+
+    private func episodeEyebrow(_ record: DownloadRecord) -> String {
+        let series = (record.seriesTitle ?? manifest?.seriesTitle ?? "").uppercased()
+        let tag = [record.seasonNumber.map { "S\($0)" }, record.episodeNumber.map { "E\($0)" }]
+            .compactMap { $0 }
+            .joined(separator: " · ")
+        return [series, tag].filter { !$0.isEmpty }.joined(separator: " · ")
+    }
+
+    private func metaLine(_ record: DownloadRecord) -> String {
+        var parts: [String] = []
+        if let runtime = manifest?.runtime, runtime > 0 { parts.append("\(runtime) min") }
+        if let year = manifest?.year { parts.append(String(year)) }
+        return parts.joined(separator: " · ")
+    }
+
+    private func availabilityText(_ record: DownloadRecord) -> String {
+        var parts = ["Downloaded", DownloadFormatting.bytes(record.fileSize)]
+        if let resolution = manifest?.resolution, !resolution.isEmpty { parts.append(resolution) }
+        return parts.joined(separator: " · ")
+    }
+
+    private func factRows(_ record: DownloadRecord) -> [(String, String)] {
+        var rows: [(String, String)] = []
+        if let audio = manifest?.codecAudio, !audio.isEmpty {
+            rows.append(("Audio", audio.uppercased()))
+        }
+        if let subtitles = manifest?.subtitles, !subtitles.isEmpty {
+            let langs = subtitles.compactMap { $0.language }.joined(separator: ", ")
+            rows.append(("Subtitles", langs.isEmpty ? "\(subtitles.count) track\(subtitles.count == 1 ? "" : "s")" : langs))
+        }
+        var quality: [String] = []
+        if let resolution = manifest?.resolution, !resolution.isEmpty { quality.append(resolution) }
+        if let codec = manifest?.codecVideo, !codec.isEmpty { quality.append(codec.uppercased()) }
+        if manifest?.hdr == true { quality.append("HDR") }
+        let qualityValue = manifest?.effectiveQuality ?? record.effectiveQuality ?? record.format
+        quality.append(DownloadFormat(rawValue: qualityValue)?.displayName ?? qualityValue.capitalized)
+        if let delivery = manifest?.deliveryFormat ?? record.deliveryFormat,
+           delivery != "original",
+           !delivery.isEmpty {
+            quality.append(deliveryDisplayName(delivery))
+        }
+        if !quality.isEmpty { rows.append(("Quality", quality.joined(separator: " · "))) }
+        if let date = record.downloadedAt {
+            rows.append(("Downloaded", date.formatted(date: .abbreviated, time: .omitted)))
+        }
+        return rows
+    }
+
+    private func deliveryDisplayName(_ raw: String) -> String {
+        switch raw {
+        case "remux": return "Remux"
+        case "transcode": return "Transcode"
+        default: return raw.capitalized
+        }
+    }
+
+    private func playLabel(_ record: DownloadRecord) -> String {
+        guard let progress = manager.localProgress(forMediaItemId: record.leafMediaItemId),
+              progress.position > 30 else { return "Play" }
+        return "Resume \(PlayerTimeFormatter.formatHMS(progress.position))"
+    }
+
+    private func resumeFraction(_ record: DownloadRecord) -> Double? {
+        guard let progress = manager.localProgress(forMediaItemId: record.leafMediaItemId),
+              progress.position > 30, progress.duration > 0 else { return nil }
+        let fraction = progress.position / progress.duration
+        guard fraction < 0.98 else { return nil }
+        return min(max(fraction, 0), 1)
+    }
+
+    private func play(_ record: DownloadRecord) {
+        guard record.isPlayableOffline else { return }
+        let leafId = record.leafMediaItemId
+        router.presentOfflinePlayer(
+            downloadId: record.id,
+            contentId: leafId,
+            resumePosition: manager.localProgress(forMediaItemId: leafId)?.position
+        )
+    }
+
+    private func playFromStart(_ record: DownloadRecord) {
+        guard record.isPlayableOffline else { return }
+        router.presentOfflinePlayer(
+            downloadId: record.id,
+            contentId: record.leafMediaItemId,
+            resumePosition: 0
+        )
+    }
+}
+
+// MARK: - Shared hero
+
+/// A compact cinematic header for the offline browse screens. Backdrop art
+/// degrades to a gradient (artwork thumbhashes aren't decoded yet), keeping
+/// the chrome strictly monochrome.
+private struct OfflineBrowseHero: View {
+    let title: String
+    let eyebrow: String
+    let posterThumbhash: String?
+    let availability: String
+    var isMonitored: Bool = false
+    let playTitle: String
+    let onPlay: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 13) {
+            HStack(alignment: .bottom, spacing: 14) {
+                DownloadPosterThumb(thumbhash: posterThumbhash, width: 72, corner: 10)
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 7) {
+                        Text(eyebrow)
+                            .font(.system(size: 11.5, weight: .semibold))
+                            .foregroundColor(.continuumSecondaryText)
+                        if isMonitored {
+                            Image(systemName: "antenna.radiowaves.left.and.right")
+                                .font(.system(size: 10, weight: .semibold))
+                                .foregroundColor(.continuumOnSurface)
+                        }
+                    }
+                    Text(title)
+                        .font(.system(size: 24, weight: .bold))
+                        .foregroundColor(.continuumOnSurface)
+                        .lineLimit(2)
+                }
+            }
+
+            HStack(spacing: 7) {
+                Image(systemName: "checkmark.circle")
+                    .font(.system(size: 12, weight: .semibold))
+                Text(availability)
+                    .font(.system(size: 11.5, weight: .semibold))
+            }
+            .foregroundColor(.continuumOnSurface)
+            .padding(.horizontal, 11)
+            .padding(.vertical, 6)
+            .background(
+                Capsule()
+                    .fill(Color.continuumChromeSelectedFill)
+                    .overlay(Capsule().stroke(Color.continuumChromeSelectedBorder, lineWidth: 1))
+            )
+
+            Button(action: onPlay) {
+                HStack(spacing: 8) {
+                    Image(systemName: "play.fill")
+                    Text(playTitle).fontWeight(.bold)
+                }
+                .font(.system(size: 15))
+                .frame(maxWidth: .infinity)
+                .frame(height: 48)
+                .background(Color.continuumOnSurface)
+                .foregroundColor(.black)
+                .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(20)
+        .background(
+            LinearGradient(
+                colors: [Color.continuumSurfaceVariant, Color.continuumBackground],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        )
+    }
+}
+#endif

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>com.continuum.play.downloads-refresh</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
@@ -62,6 +66,7 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
+		<string>fetch</string>
 		<string>remote-notification</string>
 	</array>
 	<key>UILaunchScreen</key>

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -54,6 +54,8 @@
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>Silo uses your local network to find, set up, and control Silo on your Apple TV.</string>
 	<key>NSBonjourServices</key>

--- a/iosApp/iosApp/Navigation/AppRouter.swift
+++ b/iosApp/iosApp/Navigation/AppRouter.swift
@@ -57,6 +57,8 @@ class AppRouter {
         let subtitleTrackIndex: Int?
         let startFromBeginning: Bool
         let resumePosition: Double?
+        /// Set for offline playback of a completed download.
+        var offlineDownloadId: String? = nil
         /// Hints supplied by the originating screen (e.g. the detail page,
         /// which has just loaded the catalog item) so the player's now-
         /// playing widget can publish artwork without re-fetching the
@@ -107,6 +109,34 @@ class AppRouter {
             resumePosition: resumePosition,
             posterURL: posterURL,
             backdropURL: backdropURL
+        )
+        #endif
+    }
+
+    /// Present offline playback of a completed download. iOS/iPadOS use a
+    /// full-window cover; macOS pushes the offline player route.
+    func presentOfflinePlayer(
+        downloadId: String,
+        contentId: String,
+        resumePosition: Double? = nil
+    ) {
+        #if os(macOS)
+        navigate(to: .offlinePlayer(
+            downloadId: downloadId,
+            contentId: contentId,
+            resumePosition: resumePosition
+        ))
+        #else
+        presentedPlayer = PlayerPresentation(
+            contentId: contentId,
+            fileId: nil,
+            audioTrackIndex: nil,
+            subtitleTrackIndex: nil,
+            startFromBeginning: false,
+            resumePosition: resumePosition,
+            offlineDownloadId: downloadId,
+            posterURL: nil,
+            backdropURL: nil
         )
         #endif
     }

--- a/iosApp/iosApp/Navigation/AppRouter.swift
+++ b/iosApp/iosApp/Navigation/AppRouter.swift
@@ -130,12 +130,14 @@ class AppRouter {
     func presentOfflinePlayer(
         downloadId: String,
         contentId: String,
+        startFromBeginning: Bool = false,
         resumePosition: Double? = nil
     ) {
         #if os(macOS)
         navigate(to: .offlinePlayer(
             downloadId: downloadId,
             contentId: contentId,
+            startFromBeginning: startFromBeginning,
             resumePosition: resumePosition
         ))
         #else
@@ -144,7 +146,7 @@ class AppRouter {
             fileId: nil,
             audioTrackIndex: nil,
             subtitleTrackIndex: nil,
-            startFromBeginning: false,
+            startFromBeginning: startFromBeginning,
             resumePosition: resumePosition,
             offlineDownloadId: downloadId,
             posterURL: nil,

--- a/iosApp/iosApp/Navigation/AppRouter.swift
+++ b/iosApp/iosApp/Navigation/AppRouter.swift
@@ -69,6 +69,18 @@ class AppRouter {
 
     var presentedPlayer: PlayerPresentation?
 
+    // MARK: - Tab Selection
+
+    /// One-shot tab-switch request, consumed (and cleared) by `MainTabView`,
+    /// which owns the actual selection state. Routed here so leaf screens —
+    /// e.g. the Downloads empty state's "Browse Libraries" — can jump tabs
+    /// without threading a selection binding through the tree.
+    var requestedTab: AppTab?
+
+    func switchTab(to tab: AppTab) {
+        requestedTab = tab
+    }
+
     /// Present the player using the platform-appropriate path. iOS/iPadOS use
     /// a full-window cover; macOS pushes into the main navigation content so
     /// playback replaces the detail pane instead of opening in a sheet.

--- a/iosApp/iosApp/Navigation/Route.swift
+++ b/iosApp/iosApp/Navigation/Route.swift
@@ -37,6 +37,20 @@ enum Route: Hashable {
     case recommendations
     case admin
     case serverList
+    case downloads
+
+    /// Offline playback of a completed download. Distinct from `.player`
+    /// so the player reads the local file + stored manifest instead of
+    /// starting a server session.
+    case offlinePlayer(downloadId: String, contentId: String, resumePosition: Double?)
+
+    /// Offline series browse, reached from the Downloads tab: a season /
+    /// episode list scoped to downloaded content, rendered entirely from
+    /// stored records + manifests (no network).
+    case offlineSeriesBrowse(seriesId: String)
+
+    /// Offline leaf detail for one downloaded movie or episode.
+    case offlineDownloadDetail(downloadId: String)
 
     // tvOS-specific: deep-linked library grid with a pre-applied filter.
     // Pushed from `TVLibraryLandingView` when the user picks a genre,

--- a/iosApp/iosApp/Navigation/Route.swift
+++ b/iosApp/iosApp/Navigation/Route.swift
@@ -42,7 +42,7 @@ enum Route: Hashable {
     /// Offline playback of a completed download. Distinct from `.player`
     /// so the player reads the local file + stored manifest instead of
     /// starting a server session.
-    case offlinePlayer(downloadId: String, contentId: String, resumePosition: Double?)
+    case offlinePlayer(downloadId: String, contentId: String, startFromBeginning: Bool, resumePosition: Double?)
 
     /// Offline series browse, reached from the Downloads tab: a season /
     /// episode list scoped to downloaded content, rendered entirely from

--- a/iosApp/iosApp/Navigation/TabRouter.swift
+++ b/iosApp/iosApp/Navigation/TabRouter.swift
@@ -12,6 +12,7 @@ enum AppTab: String, CaseIterable, Identifiable {
     case libraries = "Libraries"
     case recommendations = "For You"
     case calendar = "Calendar"
+    case downloads = "Downloads"
     case settings = "Settings"
     case switchProfile = "Profile"
     case switchServer = "Server"
@@ -34,6 +35,9 @@ enum AppTab: String, CaseIterable, Identifiable {
         #if os(tvOS)
         return [.home, .libraries, .search, .recommendations, .settings, .switchProfile, .switchServer]
         #else
+        // Downloads is appended dynamically by `MainTabView` only when the
+        // server advertises the capability, so it stays hidden when the
+        // feature is off rather than showing an empty tab.
         return [.home, .libraries, .recommendations, .calendar]
         #endif
     }
@@ -46,6 +50,7 @@ enum AppTab: String, CaseIterable, Identifiable {
         case .search: return "magnifyingglass"
         case .recommendations: return "sparkles"
         case .calendar: return "calendar"
+        case .downloads: return "arrow.down.circle"
         case .settings: return "gearshape"
         case .switchProfile: return "person.crop.circle"
         case .switchServer: return "server.rack"
@@ -60,6 +65,7 @@ enum AppTab: String, CaseIterable, Identifiable {
         case .search: return "magnifyingglass"
         case .recommendations: return "sparkles"
         case .calendar: return "calendar"
+        case .downloads: return "arrow.down.circle.fill"
         case .settings: return "gearshape.fill"
         case .switchProfile: return "person.crop.circle.fill"
         case .switchServer: return "server.rack"

--- a/iosApp/iosApp/Networking/ContinuumAPI.swift
+++ b/iosApp/iosApp/Networking/ContinuumAPI.swift
@@ -17,7 +17,9 @@ import Foundation
 actor ContinuumAPI {
     static let shared = ContinuumAPI()
 
-    private let http: HTTPClient
+    /// Non-private so endpoint methods declared in extensions (e.g. the
+    /// downloads API) can reuse the same injected transport.
+    let http: HTTPClient
     private let tokenStore: TokenStore
 
     init(http: HTTPClient = .shared, tokenStore: TokenStore = .shared) {

--- a/iosApp/iosApp/Networking/HTTPClient.swift
+++ b/iosApp/iosApp/Networking/HTTPClient.swift
@@ -132,6 +132,30 @@ actor HTTPClient {
         _ = try await sendRaw(method: "DELETE", path: path, query: query, body: Optional<String>.none)
     }
 
+    func patch<T: Decodable>(
+        _ path: String,
+        body: (any Encodable)? = nil,
+        query: [String: String] = [:]
+    ) async throws -> T {
+        try await send(method: "PATCH", path: path, query: query, body: body)
+    }
+
+    func patchVoid(
+        _ path: String,
+        body: (any Encodable)? = nil,
+        query: [String: String] = [:]
+    ) async throws {
+        _ = try await sendRaw(method: "PATCH", path: path, query: query, body: body)
+    }
+
+    /// GET an endpoint that returns raw bytes (not JSON) — e.g. the
+    /// download artwork/subtitle proxies. Goes through the same auth +
+    /// 401-refresh path as the decoding `get`, but hands the caller the
+    /// undecoded body.
+    func getData(_ path: String, query: [String: String] = [:]) async throws -> Data {
+        try await sendRaw(method: "GET", path: path, query: query, body: Optional<String>.none)
+    }
+
     /// Cancel all in-flight tasks on the shared session and drop any
     /// pending refresh. Called by the registry *before* retargeting
     /// `TokenStore` on a server switch so a response from the old server
@@ -158,7 +182,15 @@ actor HTTPClient {
     /// decoding, which would otherwise throw on an empty 204 response.
     func exists(_ path: String, query: [String: String] = [:]) async throws -> Bool {
         do {
-            _ = try await sendRaw(method: "GET", path: path, query: query, body: Optional<String>.none)
+            // A 404 here is the documented "not found" signal, not a failure,
+            // so mark it quiet to keep it out of the error log.
+            _ = try await sendRaw(
+                method: "GET",
+                path: path,
+                query: query,
+                body: Optional<String>.none,
+                quietStatuses: [404]
+            )
             return true
         } catch HTTPError.http(let code, _) where code == 404 {
             return false
@@ -222,7 +254,8 @@ actor HTTPClient {
         method: String,
         path: String,
         query: [String: String],
-        body: (any Encodable)?
+        body: (any Encodable)?,
+        quietStatuses: Set<Int> = []
     ) async throws -> Data {
         let serverUrl = await tokenStore.getServerUrl()
         guard !serverUrl.isEmpty else {
@@ -255,12 +288,12 @@ actor HTTPClient {
                 )
                 await attachAuthHeaders(&retry, accessToken: refreshedToken)
                 let (retryData, retryResponse) = try await perform(request: retry)
-                try ensureSuccess(retryData, retryResponse, method: method)
+                try ensureSuccess(retryData, retryResponse, method: method, quietStatuses: quietStatuses)
                 return retryData
             }
         }
 
-        try ensureSuccess(data, response, method: method)
+        try ensureSuccess(data, response, method: method, quietStatuses: quietStatuses)
         return data
     }
 
@@ -356,12 +389,19 @@ actor HTTPClient {
         return (data, http)
     }
 
-    private func ensureSuccess(_ data: Data, _ response: HTTPURLResponse, method: String) throws {
+    private func ensureSuccess(_ data: Data, _ response: HTTPURLResponse, method: String, quietStatuses: Set<Int> = []) throws {
         guard (200..<300).contains(response.statusCode) else {
             let bodyStr = String(data: data, encoding: .utf8)
             let urlStr = response.url?.absoluteString ?? ""
             let preview = (bodyStr ?? "").prefix(512)
-            Self.logger.error("HTTP \(response.statusCode, privacy: .public) \(method, privacy: .public) \(urlStr, privacy: .public) body=\(preview, privacy: .private)")
+            // A status the caller treats as an expected signal (e.g. a 404
+            // existence probe) is demoted to debug so it doesn't read as a
+            // failure in the log; everything else stays at error level.
+            if quietStatuses.contains(response.statusCode) {
+                Self.logger.debug("HTTP \(response.statusCode, privacy: .public) \(method, privacy: .public) \(urlStr, privacy: .public) body=\(preview, privacy: .private)")
+            } else {
+                Self.logger.error("HTTP \(response.statusCode, privacy: .public) \(method, privacy: .public) \(urlStr, privacy: .public) body=\(preview, privacy: .private)")
+            }
             throw HTTPError.http(
                 statusCode: response.statusCode,
                 body: bodyStr

--- a/iosApp/iosApp/Networking/Models.swift
+++ b/iosApp/iosApp/Networking/Models.swift
@@ -1237,6 +1237,24 @@ struct SyncProgressItem: Codable {
     let position: Double
     let duration: Double
     let forceOverwrite: Bool
+    /// Client **event** time for offline-queued items (RFC3339). Present →
+    /// last-write-wins merge on the bounded event time; absent → server
+    /// uses `now()`. See §5.1 of `docs/download-api.md`.
+    let updatedAt: Date?
+
+    init(
+        mediaItemId: String,
+        position: Double,
+        duration: Double,
+        forceOverwrite: Bool,
+        updatedAt: Date? = nil
+    ) {
+        self.mediaItemId = mediaItemId
+        self.position = position
+        self.duration = duration
+        self.forceOverwrite = forceOverwrite
+        self.updatedAt = updatedAt
+    }
 }
 
 // MARK: - Playback Start Request (sent to server)

--- a/iosApp/iosApp/Notifications/SiloAppDelegate+Push.swift
+++ b/iosApp/iosApp/Notifications/SiloAppDelegate+Push.swift
@@ -5,16 +5,43 @@ import UserNotifications
 extension SiloAppDelegate: UNUserNotificationCenterDelegate {
     /// iOS gives background remote-notification wakes roughly 30 seconds to
     /// call the completion handler, while HTTPClient's default URLSession
-    /// request timeout is 60 seconds — so the sync is raced against a
-    /// deadline that leaves the system budget intact.
-    private static let backgroundSyncDeadlineSeconds: TimeInterval = 15
+    /// request timeout is 60 seconds — so the syncs are raced against a
+    /// deadline that leaves the system budget intact. 20s (up from 15s)
+    /// because the wake now also runs the download monitoring sync, whose
+    /// chain of sequential requests ends with the pipeline kick that
+    /// enqueues new episodes — cutting it short loses the enqueue.
+    private static let backgroundSyncDeadlineSeconds: TimeInterval = 20
 
     func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
         UNUserNotificationCenter.current().delegate = self
+        // BGTaskScheduler requires every identifier to be registered before
+        // launch finishes — the system traps when it launches the app for a
+        // task with no handler.
+        DownloadBackgroundRefresh.register()
         return true
+    }
+
+    func application(
+        _ application: UIApplication,
+        handleEventsForBackgroundURLSession identifier: String,
+        completionHandler: @escaping () -> Void
+    ) {
+        guard identifier == DownloadSessionDelegate.sessionIdentifier else {
+            completionHandler()
+            return
+        }
+        Task { @MainActor in
+            // Touching `shared` recreates the background session so its
+            // buffered events replay; the handler fires once the manager
+            // drains `allEventsDelivered`. Scope activation runs right
+            // after so finished media can resolve its on-disk destination
+            // even on a cold background relaunch.
+            DownloadManager.shared.setBackgroundCompletionHandler(completionHandler)
+            await DownloadManager.shared.activateScopeIfNeeded()
+        }
     }
 
     func application(
@@ -50,8 +77,12 @@ extension SiloAppDelegate: UNUserNotificationCenterDelegate {
     ) async -> UNNotificationPresentationOptions {
         // Present immediately: the inbox sync must never delay the banner,
         // and the system only waits a few seconds for this return value.
-        Task { @MainActor in
-            await ApplePushNotificationSyncCoordinator.shared.refreshFromRemoteNotification()
+        // Local download notifications carry no inbox payload, so only a
+        // remote push kicks the sync.
+        if notification.request.trigger is UNPushNotificationTrigger {
+            Task { @MainActor in
+                await ApplePushNotificationSyncCoordinator.shared.refreshFromRemoteNotification()
+            }
         }
         return [.banner, .list, .sound]
     }
@@ -64,20 +95,37 @@ extension SiloAppDelegate: UNUserNotificationCenterDelegate {
         // deep link before any network work so the tap routes instantly.
         let userInfo = response.notification.request.content.userInfo
         await ApplePushDeepLinkCoordinator.shared.postDeepLink(from: userInfo)
-        Task { @MainActor in
-            await ApplePushNotificationSyncCoordinator.shared.refreshFromRemoteNotification()
+        if response.notification.request.trigger is UNPushNotificationTrigger {
+            Task { @MainActor in
+                await ApplePushNotificationSyncCoordinator.shared.refreshFromRemoteNotification()
+            }
         }
     }
 
-    /// Runs the notification sync but returns `false` once the deadline
-    /// passes, cancelling the underlying request. The completion handler for
-    /// a background wake must be called inside the system budget even when
-    /// the server is unreachable.
+    /// Runs the notification-inbox sync and the download monitoring sync,
+    /// but returns `false` once the deadline passes, cancelling the
+    /// underlying requests. The completion handler for a background wake
+    /// must be called inside the system budget even when the server is
+    /// unreachable.
     @MainActor
     private static func syncWithDeadline(_ seconds: TimeInterval) async -> Bool {
         await withTaskGroup(of: Bool.self) { group in
             group.addTask { @MainActor in
-                await ApplePushNotificationSyncCoordinator.shared.refreshFromRemoteNotification()
+                // A cold background launch lands here before
+                // ContentView.checkInitialState() has pointed TokenStore at
+                // the active registry server, and both syncs authenticate
+                // through it. Idempotent on every later call.
+                if let serverId = ServerRegistry.shared.activeServerId, !serverId.isEmpty {
+                    await TokenStore.shared.retargetActiveServer(serverId: serverId)
+                }
+                async let inboxSynced = ApplePushNotificationSyncCoordinator.shared
+                    .refreshFromRemoteNotification()
+                // Same path as DownloadBackgroundRefresh: a new-episode push
+                // for a monitored series registers the episode and enqueues
+                // it into the background URLSession here, so the transfer
+                // runs out-of-process without the user opening the app.
+                await DownloadManager.shared.onAppActive()
+                return await inboxSynced
             }
             group.addTask {
                 try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))

--- a/iosApp/iosApp/Notifications/SiloAppDelegate+Push.swift
+++ b/iosApp/iosApp/Notifications/SiloAppDelegate+Push.swift
@@ -40,6 +40,14 @@ extension SiloAppDelegate: UNUserNotificationCenterDelegate {
             // after so finished media can resolve its on-disk destination
             // even on a cold background relaunch.
             DownloadManager.shared.setBackgroundCompletionHandler(completionHandler)
+            // A cold background relaunch lands here before
+            // ContentView.checkInitialState() has pointed TokenStore at the
+            // active registry server; activating against an unresolved
+            // profile would release the held session events into an empty
+            // scope and discard the staged completions.
+            if let serverId = ServerRegistry.shared.activeServerId, !serverId.isEmpty {
+                await TokenStore.shared.retargetActiveServer(serverId: serverId)
+            }
             await DownloadManager.shared.activateScopeIfNeeded()
         }
     }
@@ -124,7 +132,14 @@ extension SiloAppDelegate: UNUserNotificationCenterDelegate {
                 // for a monitored series registers the episode and enqueues
                 // it into the background URLSession here, so the transfer
                 // runs out-of-process without the user opening the app.
-                await DownloadManager.shared.onAppActive()
+                //
+                // Deadline check between the phases: `withTaskGroup` only
+                // returns once this child unwinds, so when the timer has
+                // already won (cancelAll ran) don't start the download sync
+                // — it would hold the completion handler past the budget.
+                if !Task.isCancelled {
+                    await DownloadManager.shared.onAppActive()
+                }
                 return await inboxSynced
             }
             group.addTask {

--- a/iosApp/iosApp/Screens/Browse/FilterView.swift
+++ b/iosApp/iosApp/Screens/Browse/FilterView.swift
@@ -308,6 +308,10 @@ private struct ConditionalSearchable: ViewModifier {
         if isActive {
 #if os(tvOS)
             content
+#elseif os(macOS)
+            // `.navigationBarDrawer` doesn't exist on macOS; the toolbar
+            // placement is the native equivalent.
+            content.searchable(text: $text, placement: .toolbar)
 #else
             content.searchable(text: $text, placement: .navigationBarDrawer(displayMode: .always))
 #endif

--- a/iosApp/iosApp/Screens/Detail/ItemDetailView.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailView.swift
@@ -29,6 +29,25 @@ private struct CastRequestBox: Identifiable {
 #endif
 
 #if !os(tvOS)
+/// A play tap paused on the downloaded-vs-stream choice. Created only when
+/// the target item has a playable offline copy; carries the original
+/// streaming parameters so "Stream" resumes exactly the tap that was
+/// interrupted.
+private struct OfflinePlayChoice: Identifiable {
+    let downloadId: String
+    /// Leaf id (episode id / movie content id) offline progress is keyed by.
+    let leafContentId: String
+    /// e.g. "Play Downloaded (10 Mbps · 2.1 GB)"
+    let downloadedLabel: String
+    let contentId: String
+    let fileId: Int?
+    let audioTrackIndex: Int?
+    let subtitleTrackIndex: Int?
+    let startFromBeginning: Bool
+    let resumePosition: Double?
+    var id: String { downloadId }
+}
+
 private struct ItemDetailPhoneContent: View {
     let contentId: String
 
@@ -41,6 +60,7 @@ private struct ItemDetailPhoneContent: View {
     @State private var preferredNextUpSubtitleTrackIndex: Int?
     @State private var nextUpWatchDetail: WatchDetail?
     @State private var refreshOnPlayerDismiss = false
+    @State private var offlinePlayChoice: OfflinePlayChoice?
     #if os(iOS)
     @Environment(SiloCastController.self) private var castController
     @State private var castRequestBox: CastRequestBox?
@@ -75,6 +95,37 @@ private struct ItemDetailPhoneContent: View {
             guard oldValue != nil, newValue == nil, refreshOnPlayerDismiss else { return }
             refreshOnPlayerDismiss = false
             Task { await viewModel.loadDetail(contentId: contentId) }
+        }
+        .alert(
+            "Downloaded on This Device",
+            isPresented: Binding(
+                get: { offlinePlayChoice != nil },
+                set: { if !$0 { offlinePlayChoice = nil } }
+            ),
+            presenting: offlinePlayChoice
+        ) { choice in
+            Button(choice.downloadedLabel) {
+                refreshOnPlayerDismiss = true
+                router.presentOfflinePlayer(
+                    downloadId: choice.downloadId,
+                    contentId: choice.leafContentId,
+                    startFromBeginning: choice.startFromBeginning,
+                    resumePosition: choice.resumePosition
+                )
+            }
+            Button("Stream from Server") {
+                presentStreamingPlayer(
+                    contentId: choice.contentId,
+                    fileId: choice.fileId,
+                    audioTrackIndex: choice.audioTrackIndex,
+                    subtitleTrackIndex: choice.subtitleTrackIndex,
+                    startFromBeginning: choice.startFromBeginning,
+                    resumePosition: choice.resumePosition
+                )
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: { _ in
+            Text("Play the copy saved on this device, or stream from the server.")
         }
         #if os(iOS)
         .toolbar {
@@ -597,6 +648,44 @@ private struct ItemDetailPhoneContent: View {
         }
         #endif
 
+        // A playable local copy exists: pause the tap on a source choice so
+        // the user can pick the downloaded file (e.g. a saved 1080p) or the
+        // server stream (e.g. the full 4K). The cast branch above never
+        // offers this — a cast target can't read the local file.
+        if let record = DownloadManager.shared.record(forContentId: contentId),
+           record.isPlayableOffline {
+            offlinePlayChoice = OfflinePlayChoice(
+                downloadId: record.id,
+                leafContentId: record.leafMediaItemId,
+                downloadedLabel: Self.downloadedOptionLabel(for: record),
+                contentId: contentId,
+                fileId: fileId,
+                audioTrackIndex: audioTrackIndex,
+                subtitleTrackIndex: subtitleTrackIndex,
+                startFromBeginning: startFromBeginning,
+                resumePosition: resumePosition
+            )
+            return
+        }
+
+        presentStreamingPlayer(
+            contentId: contentId,
+            fileId: fileId,
+            audioTrackIndex: audioTrackIndex,
+            subtitleTrackIndex: subtitleTrackIndex,
+            startFromBeginning: startFromBeginning,
+            resumePosition: resumePosition
+        )
+    }
+
+    private func presentStreamingPlayer(
+        contentId: String,
+        fileId: Int?,
+        audioTrackIndex: Int?,
+        subtitleTrackIndex: Int?,
+        startFromBeginning: Bool,
+        resumePosition: Double?
+    ) {
         refreshOnPlayerDismiss = true
         // Pass the artwork URLs we already loaded into the detail view so
         // PlayerViewModel.pushNowPlayingArtwork can publish lock-screen art
@@ -614,6 +703,22 @@ private struct ItemDetailPhoneContent: View {
             posterURL: isOwnDetail ? viewModel.detail?.posterUrl : nil,
             backdropURL: isOwnDetail ? viewModel.detail?.backdropUrl : nil
         )
+    }
+
+    /// Dialog label for the local copy, annotated with its stored quality
+    /// and size so the choice against the stream is an informed one.
+    private static func downloadedOptionLabel(for record: DownloadRecord) -> String {
+        var parts: [String] = []
+        let quality = record.effectiveQuality ?? record.format
+        if !quality.isEmpty {
+            parts.append(DownloadFormat(rawValue: quality)?.displayName ?? quality.capitalized)
+        }
+        if record.fileSize > 0 {
+            parts.append(ByteCountFormatter.string(fromByteCount: record.fileSize, countStyle: .file))
+        }
+        return parts.isEmpty
+            ? "Play Downloaded"
+            : "Play Downloaded (\(parts.joined(separator: " · ")))"
     }
 }
 #endif

--- a/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
@@ -138,7 +138,10 @@ class ItemDetailViewModel {
     }
 
     private func enrichPlaybackMetadata(for item: ItemDetail, contentId: String) async -> ItemDetail {
-        guard item.type != "series" else { return item }
+        // Series and season containers have no single watch target — `/watch/{id}`
+        // returns 404 "Watch target not found" for them. Only enrich playable
+        // leaf items, rather than firing a request we know will fail.
+        guard item.type != "series", item.type != "season" else { return item }
 
         do {
             let watchDetail = try await ContinuumAPI.shared.watchDetail(contentId: contentId)

--- a/iosApp/iosApp/Screens/Detail/MovieDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/MovieDetailContent.swift
@@ -37,6 +37,9 @@ struct MovieDetailContent<BelowOverview: View>: View {
     @ViewBuilder let belowOverview: () -> BelowOverview
 
     @State private var showResumeDialog = false
+    /// Presents the DownloadActionButton's options sheet; lives here so the
+    /// overflow menu can open it now that a plain tap downloads directly.
+    @State private var showDownloadOptions = false
 
     var body: some View {
         ScrollView(.vertical, showsIndicators: false) {
@@ -143,11 +146,12 @@ struct MovieDetailContent<BelowOverview: View>: View {
                 DownloadActionButton(
                     detail: detail,
                     versions: availableVersions,
-                    selectedVersionFileId: selectedVersionFileId
+                    selectedVersionFileId: selectedVersionFileId,
+                    showOptions: $showDownloadOptions
                 )
             }
 
-            if hasOverflowNavigation {
+            if hasOverflowMenu {
                 overflowMenu
             }
         }
@@ -162,6 +166,12 @@ struct MovieDetailContent<BelowOverview: View>: View {
 
     private var hasOverflowNavigation: Bool {
         detail.type == "episode" && detail.seriesId != nil
+    }
+
+    /// Downloads also earn the overflow menu: the one-tap download button no
+    /// longer opens the options sheet, so the menu keeps it discoverable.
+    private var hasOverflowMenu: Bool {
+        hasOverflowNavigation || showsDownloadButton
     }
 
     @ViewBuilder
@@ -180,6 +190,13 @@ struct MovieDetailContent<BelowOverview: View>: View {
                     onNavigateToItem(seriesId)
                 } label: {
                     Label("Go to Series", systemImage: "tv")
+                }
+            }
+            if showsDownloadButton {
+                Button {
+                    showDownloadOptions = true
+                } label: {
+                    Label("Download Options…", systemImage: "slider.horizontal.3")
                 }
             }
         }
@@ -236,10 +253,20 @@ struct MovieDetailContent<BelowOverview: View>: View {
                 PhoneEpisodeRail(
                     episodes: seasonEpisodes,
                     onSelect: onEpisodeTap,
-                    currentContentId: detail.contentId
+                    currentContentId: detail.contentId,
+                    downloadContext: episodeDownloadContext
                 )
             }
         }
+    }
+
+    /// Series scope for the per-card download controls; same seriesId
+    /// resolution as `SeriesDownloadMenuButton`.
+    private var episodeDownloadContext: EpisodeDownloadContext {
+        EpisodeDownloadContext(
+            seriesId: detail.seriesId ?? detail.contentId,
+            posterThumbhash: detail.posterThumbhash
+        )
     }
 
     private var episodeRailEyebrow: String {

--- a/iosApp/iosApp/Screens/Detail/MovieDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/MovieDetailContent.swift
@@ -139,10 +139,25 @@ struct MovieDetailContent<BelowOverview: View>: View {
                 action: onToggleWatched
             )
 
+            if showsDownloadButton {
+                DownloadActionButton(
+                    detail: detail,
+                    versions: availableVersions,
+                    selectedVersionFileId: selectedVersionFileId
+                )
+            }
+
             if hasOverflowNavigation {
                 overflowMenu
             }
         }
+    }
+
+    /// Download is offered for movies and individual episodes once the
+    /// server advertises the capability for this profile.
+    private var showsDownloadButton: Bool {
+        DownloadManager.shared.downloadsEnabled
+            && (detail.type == "movie" || detail.type == "episode")
     }
 
     private var hasOverflowNavigation: Bool {

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeRail.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeRail.swift
@@ -9,6 +9,10 @@ struct PhoneEpisodeRail: View {
     let episodes: [EpisodeListItem]
     let onSelect: (String) -> Void
     var currentContentId: String? = nil
+    /// Enables the per-card compact download control; `nil` (rails without a
+    /// series scope) hides it. Capability gating happens per card so this
+    /// stays a plain pass-through.
+    var downloadContext: EpisodeDownloadContext? = nil
 
     private let cardWidth: CGFloat = 240
     private let stillHeight: CGFloat = 135   // 16:9 of 240
@@ -26,6 +30,7 @@ struct PhoneEpisodeRail: View {
                             cardWidth: cardWidth,
                             stillHeight: stillHeight,
                             stillCornerRadius: stillCornerRadius,
+                            downloadContext: downloadContext,
                             onSelect: { onSelect(episode.contentId) }
                         )
                         .id(episode.contentId)
@@ -52,9 +57,32 @@ private struct PhoneEpisodeCard: View {
     let cardWidth: CGFloat
     let stillHeight: CGFloat
     let stillCornerRadius: CGFloat
+    let downloadContext: EpisodeDownloadContext?
     let onSelect: () -> Void
 
+    private let downloadControlInset: CGFloat = 6
+
     var body: some View {
+        cardButton
+            // Sibling overlay rather than a control nested inside the card
+            // button's label, so the menu / confirmation dialogs get their
+            // own hit target instead of competing with the card tap.
+            .overlay(alignment: .topTrailing) { downloadControl }
+    }
+
+    /// Compact one-tap download control pinned to the still's bottom-trailing
+    /// corner (top-trailing hosts the watched check). Reads the same
+    /// capability gate as every other download affordance.
+    @ViewBuilder
+    private var downloadControl: some View {
+        if let downloadContext, DownloadManager.shared.downloadsEnabled {
+            DownloadActionButton(episode: episode, context: downloadContext)
+                .padding(.top, stillHeight - DownloadActionButton.compactDiameter - downloadControlInset)
+                .padding(.trailing, downloadControlInset)
+        }
+    }
+
+    private var cardButton: some View {
         Button(action: onSelect) {
             VStack(alignment: .leading, spacing: 8) {
                 still

--- a/iosApp/iosApp/Screens/Detail/SeasonDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/SeasonDetailContent.swift
@@ -145,6 +145,14 @@ struct SeasonDetailContent<BelowOverview: View>: View {
                 action: onToggleWatched
             )
 
+            if DownloadManager.shared.downloadsEnabled {
+                SeriesDownloadMenuButton(
+                    detail: detail,
+                    seasons: seasons,
+                    selectedSeason: selectedSeason ?? seasons.first(where: { $0.seasonNumber == detail.seasonNumber })
+                )
+            }
+
             if let seriesId = detail.seriesId {
                 PhoneCircleMenuButton(accessibilityLabel: "More options") {
                     Button {

--- a/iosApp/iosApp/Screens/Detail/SeasonDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/SeasonDetailContent.swift
@@ -245,9 +245,22 @@ struct SeasonDetailContent<BelowOverview: View>: View {
                     .foregroundColor(.continuumSecondaryText)
                     .padding(.horizontal, ContinuumTheme.safePadding)
             } else {
-                PhoneEpisodeRail(episodes: episodes, onSelect: onEpisodeTap)
+                PhoneEpisodeRail(
+                    episodes: episodes,
+                    onSelect: onEpisodeTap,
+                    downloadContext: episodeDownloadContext
+                )
             }
         }
+    }
+
+    /// Series scope for the per-card download controls; same seriesId
+    /// resolution as `SeriesDownloadMenuButton`.
+    private var episodeDownloadContext: EpisodeDownloadContext {
+        EpisodeDownloadContext(
+            seriesId: detail.seriesId ?? detail.contentId,
+            posterThumbhash: detail.posterThumbhash
+        )
     }
 
     @ViewBuilder

--- a/iosApp/iosApp/Screens/Detail/SeriesDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/SeriesDetailContent.swift
@@ -139,6 +139,14 @@ struct SeriesDetailContent<BelowOverview: View>: View {
                 accessibilityLabel: isWatched ? "Mark Series Unwatched" : "Mark Series Watched",
                 action: onToggleWatched
             )
+
+            if DownloadManager.shared.downloadsEnabled {
+                SeriesDownloadMenuButton(
+                    detail: detail,
+                    seasons: seasons,
+                    selectedSeason: selectedSeason
+                )
+            }
         }
     }
 

--- a/iosApp/iosApp/Screens/Detail/SeriesDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/SeriesDetailContent.swift
@@ -280,9 +280,19 @@ struct SeriesDetailContent<BelowOverview: View>: View {
         } else {
             PhoneEpisodeRail(
                 episodes: episodes,
-                onSelect: onEpisodeTap
+                onSelect: onEpisodeTap,
+                downloadContext: episodeDownloadContext
             )
         }
+    }
+
+    /// Series scope for the per-card download controls; same seriesId
+    /// resolution as `SeriesDownloadMenuButton`.
+    private var episodeDownloadContext: EpisodeDownloadContext {
+        EpisodeDownloadContext(
+            seriesId: detail.seriesId ?? detail.contentId,
+            posterThumbhash: detail.posterThumbhash
+        )
     }
 
     // MARK: - Cast

--- a/iosApp/iosApp/Screens/Personal/FavoritesView.swift
+++ b/iosApp/iosApp/Screens/Personal/FavoritesView.swift
@@ -63,7 +63,8 @@ struct FavoritesView: View {
                         overlayData: OverlayData.from(item),
                         action: {
                             router.navigate(to: .itemDetail(contentId: item.contentId))
-                        }
+                        },
+                        contentId: item.contentId
                     )
                     .frame(maxWidth: .infinity)
                 }

--- a/iosApp/iosApp/Screens/Personal/WatchlistView.swift
+++ b/iosApp/iosApp/Screens/Personal/WatchlistView.swift
@@ -63,7 +63,8 @@ struct WatchlistView: View {
                         overlayData: OverlayData.from(item),
                         action: {
                             router.navigate(to: .itemDetail(contentId: item.contentId))
-                        }
+                        },
+                        contentId: item.contentId
                     )
                     .frame(maxWidth: .infinity)
                 }

--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -14,6 +14,11 @@ struct PlayerView: View {
     /// session bridge so both direct-play and transcode paths align.
     let startFromBeginning: Bool
     let resumePositionOverride: Double?
+    /// Set when the caller wants offline playback of a completed download.
+    /// Routes the prepare through `OfflinePlaybackBuilder` (stored manifest
+    /// + local media file, no server session) so playback works with no
+    /// network and progress queues for the next `/sync/progress` flush.
+    let offlineDownloadId: String?
     /// Optional poster/backdrop URLs the presenter already has on hand.
     /// When set, the now-playing widget skips its own catalog-item fetch
     /// for artwork. Nil falls back to the prior fetch-on-prepare path.
@@ -34,6 +39,7 @@ struct PlayerView: View {
         preferredSubtitleTrackIndex: Int? = nil,
         startFromBeginning: Bool = false,
         resumePositionOverride: Double? = nil,
+        offlineDownloadId: String? = nil,
         posterURLHint: String? = nil,
         backdropURLHint: String? = nil
     ) {
@@ -43,6 +49,7 @@ struct PlayerView: View {
         self.preferredSubtitleTrackIndex = preferredSubtitleTrackIndex
         self.startFromBeginning = startFromBeginning
         self.resumePositionOverride = resumePositionOverride
+        self.offlineDownloadId = offlineDownloadId
         self.posterURLHint = posterURLHint
         self.backdropURLHint = backdropURLHint
     }
@@ -207,7 +214,8 @@ struct PlayerView: View {
                 preferredAudioTrackIndex: preferredAudioTrackIndex,
                 preferredSubtitleTrackIndex: preferredSubtitleTrackIndex,
                 startFromBeginning: startFromBeginning,
-                resumePositionOverride: resumePositionOverride
+                resumePositionOverride: resumePositionOverride,
+                offlineDownloadId: offlineDownloadId
             )
             #if os(tvOS)
             TVCastReceiver.shared.registerPlayer(viewModel, contentId: contentId)

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -758,6 +758,21 @@ class PlayerViewModel {
     /// offset here so UI/progress reporting remain full-runtime based.
     private var playbackTimelineOffset: Double = 0
 
+    /// Identity of the active offline download when playback was prepared
+    /// locally (no server session). While set, watch progress is routed to
+    /// `DownloadManager.recordOfflineProgress` — which queues it for the
+    /// next `/sync/progress` flush — instead of the session bridge, so
+    /// nothing on this path ever hits a server session/progress endpoint.
+    private struct OfflinePlaybackContext {
+        let downloadId: String
+        let mediaItemId: String
+    }
+    private var offlinePlaybackContext: OfflinePlaybackContext?
+    /// Mirrors the server's default watched threshold (90%) so an offline
+    /// watch latches `completed` — and with it delete-watched retention and
+    /// the reclaim sheet — the same way an online session would.
+    private static let offlineWatchedFraction: Double = 0.9
+
     /// Cached external subtitle URLs returned by the server; added to the
     /// player once the file has loaded.
     private var pendingExternalSubtitles: [SubtitleUrl] = []
@@ -869,6 +884,10 @@ class PlayerViewModel {
         let preferredSubtitleTrackIndex: Int?
         let preferredSidecarSubtitleTrackId: Int64?
         let startFromBeginning: Bool
+        /// Set for local playback of a completed download. Routes the
+        /// prepare through `OfflinePlaybackBuilder` instead of a server
+        /// session, so retry after an error stays on the offline path.
+        var offlineDownloadId: String? = nil
     }
 
     /// Where a `beginFreshLoad` invocation came from. Determines (a) whether
@@ -2500,6 +2519,21 @@ class PlayerViewModel {
             isPlaying: false
         )
 
+        // Natural end of an offline download: latch the local watched state
+        // immediately (not just at close) so retention/reclaim see it even
+        // if the process dies before `cleanup()` runs. DownloadManager is
+        // MainActor-isolated; this callback may not be.
+        if !isPremature, let offline = offlinePlaybackContext {
+            let endPosition = currentTime
+            Task { @MainActor [weak self] in
+                self?.recordOfflineProgress(
+                    context: offline,
+                    position: endPosition,
+                    markCompleted: true
+                )
+            }
+        }
+
         beginNextUpPostroll(videoEnded: true)
     }
 
@@ -2631,7 +2665,8 @@ class PlayerViewModel {
             preferredAudioTrackIndex: resolvedAudioTrackIndexForResume(),
             preferredSubtitleTrackIndex: resolvedSubtitleTrackIndexForResume(),
             preferredSidecarSubtitleTrackId: resolvedSidecarSubtitleTrackIdForResume(),
-            startFromBeginning: false
+            startFromBeginning: false,
+            offlineDownloadId: lastLoadRequest.offlineDownloadId
         )
         let resumePosition = currentTime.isFinite ? max(0, currentTime) : 0
         return SuspendedPlaybackContext(
@@ -2664,6 +2699,7 @@ class PlayerViewModel {
         PosterImageCache.trimDecodedMemory()
         #endif
         lastLoadRequest = request
+        offlinePlaybackContext = nil
         contentIdsNeedingDetailRefresh.insert(request.contentId)
         hasReachedEndOfFile = false
         cancelNextUpFlow()
@@ -2723,18 +2759,37 @@ class PlayerViewModel {
                 await self.settingsRefreshTask?.value
                 guard !Task.isCancelled, !self.isDisposed else { return }
 
-                // Bound the start-session call when the load was triggered
-                // by autoplay or interruption recovery. A user-initiated load
-                // keeps the unbounded behavior — a slow manual pick is
-                // annoying but doesn't wedge the UI; a hung autoplay does
-                // (the user is stuck on a half-cross-faded Next Up screen
-                // with no obvious way out).
-                let prepared = try await self.runStartSession(
-                    request: request,
-                    resumePosition: resumePositionOverride,
-                    allowNearEndResume: allowNearEndResume,
-                    timeout: origin == .userInitiated ? nil : Self.autoplayStartSessionTimeout
-                )
+                let prepared: PreparedPlayback
+                if let offlineDownloadId = request.offlineDownloadId {
+                    // Fully local prepare from the stored record + manifest.
+                    // Must keep working in airplane mode, so nothing on this
+                    // branch (or downstream of it while
+                    // `offlinePlaybackContext` is set) may require the server.
+                    let offline = try await OfflinePlaybackBuilder.loadPreparedPlayback(
+                        downloadId: offlineDownloadId,
+                        startFromBeginning: request.startFromBeginning,
+                        resumePositionOverride: resumePositionOverride
+                    )
+                    self.offlinePlaybackContext = OfflinePlaybackContext(
+                        downloadId: offline.downloadId,
+                        mediaItemId: offline.mediaItemId
+                    )
+                    self.nowPlaying.setArtworkURL(offline.posterFileURL)
+                    prepared = offline.prepared
+                } else {
+                    // Bound the start-session call when the load was triggered
+                    // by autoplay or interruption recovery. A user-initiated load
+                    // keeps the unbounded behavior — a slow manual pick is
+                    // annoying but doesn't wedge the UI; a hung autoplay does
+                    // (the user is stuck on a half-cross-faded Next Up screen
+                    // with no obvious way out).
+                    prepared = try await self.runStartSession(
+                        request: request,
+                        resumePosition: resumePositionOverride,
+                        allowNearEndResume: allowNearEndResume,
+                        timeout: origin == .userInitiated ? nil : Self.autoplayStartSessionTimeout
+                    )
+                }
                 guard !Task.isCancelled, !self.isDisposed else { return }
 
                 let session = prepared.session
@@ -2770,9 +2825,14 @@ class PlayerViewModel {
                 self.knownExternalSubtitles = self.pendingExternalSubtitles
                 self.currentWatchDetail = prepared.watchDetail
                 self.currentSelectedVersion = prepared.selectedVersion
-                self.pushNowPlayingArtwork(contentId: prepared.watchDetail.contentId)
-                self.loadNextUpCandidate(for: prepared.watchDetail)
-                self.loadNextUpOnDeckItems(for: prepared.watchDetail)
+                // Artwork and Next Up are catalog fetches; the offline path
+                // already published its cached poster above and has no
+                // server to resolve a next episode against.
+                if request.offlineDownloadId == nil {
+                    self.pushNowPlayingArtwork(contentId: prepared.watchDetail.contentId)
+                    self.loadNextUpCandidate(for: prepared.watchDetail)
+                    self.loadNextUpOnDeckItems(for: prepared.watchDetail)
+                }
                 self.qualityOptions = ApplePlaybackQuality.playbackOptions(for: prepared.selectedVersion)
                 self.activeQualityId = prepared.activeQualityId
                 self.isQualitySwitching = false
@@ -2785,8 +2845,12 @@ class PlayerViewModel {
                     credits: prepared.selectedVersion.credits ?? prepared.watchDetail.credits
                 )
 
-                await self.realtimeClient.bind(sessionId: session.sessionId)
-                guard !Task.isCancelled, !self.isDisposed else { return }
+                // The realtime channel is a server websocket keyed by a real
+                // session id; the synthetic offline session has neither.
+                if request.offlineDownloadId == nil {
+                    await self.realtimeClient.bind(sessionId: session.sessionId)
+                    guard !Task.isCancelled, !self.isDisposed else { return }
+                }
 
                 guard let streamRequest = await self.makeStreamRequest(session: session) else {
                     self.finalizeTerminalPlaybackError("Invalid stream URL")
@@ -3244,7 +3308,8 @@ class PlayerViewModel {
         preferredAudioTrackIndex: Int? = nil,
         preferredSubtitleTrackIndex: Int? = nil,
         startFromBeginning: Bool,
-        resumePositionOverride: Double? = nil
+        resumePositionOverride: Double? = nil,
+        offlineDownloadId: String? = nil
     ) {
         let request = LoadRequest(
             contentId: contentId,
@@ -3252,7 +3317,8 @@ class PlayerViewModel {
             preferredAudioTrackIndex: preferredAudioTrackIndex,
             preferredSubtitleTrackIndex: preferredSubtitleTrackIndex,
             preferredSidecarSubtitleTrackId: nil,
-            startFromBeginning: startFromBeginning
+            startFromBeginning: startFromBeginning,
+            offlineDownloadId: offlineDownloadId
         )
         beginFreshLoad(
             request: request,
@@ -4608,6 +4674,24 @@ class PlayerViewModel {
         debugStopFakeLiveSubtitles()
         #endif
 
+        // Final offline progress flush before teardown — the counterpart of
+        // the online path's `stopSession` report below. Captured into locals
+        // so the detached task doesn't read torn-down player state.
+        if let offline = offlinePlaybackContext {
+            let finalOfflinePosition = completionProgressPositionForCurrentItem()
+            let endedNaturally = hasReachedEndOfFile || showNextUpScreen
+            // Strong capture on purpose: this is the last write of the
+            // resume point and must not be dropped because the VM was
+            // released between dismiss and the hop to the MainActor.
+            Task { @MainActor in
+                self.recordOfflineProgress(
+                    context: offline,
+                    position: finalOfflinePosition,
+                    markCompleted: endedNaturally
+                )
+            }
+        }
+
         let finalPosition = currentTime
         activePlayer.dispose()
         // Drop the disposed backend so any post-teardown call is an explicit
@@ -4883,7 +4967,7 @@ class PlayerViewModel {
         }
 
         var headers: [String: String] = [:]
-        if let token, !token.isEmpty {
+        if let token, !token.isEmpty, !url.isFileURL {
             headers["Authorization"] = "Bearer \(token)"
         }
 
@@ -4891,8 +4975,10 @@ class PlayerViewModel {
     }
 
     /// Turns a server-supplied URL (absolute or API-relative) into an absolute URL.
+    /// Local `file://` URLs (offline downloads and their cached sidecar
+    /// subtitles) pass through untouched.
     private func resolveServerUrl(_ raw: String, serverUrl: String) -> URL? {
-        if raw.hasPrefix("http://") || raw.hasPrefix("https://") {
+        if raw.hasPrefix("http://") || raw.hasPrefix("https://") || raw.hasPrefix("file://") {
             return URL(string: raw)
         }
 
@@ -5928,6 +6014,10 @@ class PlayerViewModel {
                 try? await Task.sleep(nanoseconds: 10_000_000_000)
                 guard !Task.isCancelled else { return }
                 guard let self else { return }
+                if let offline = self.offlinePlaybackContext {
+                    self.recordOfflineProgress(context: offline)
+                    continue
+                }
                 let result = await self.sessionBridge.reportProgress(
                     position: self.currentTime,
                     isPaused: !self.isPlaying
@@ -5940,6 +6030,30 @@ class PlayerViewModel {
                 }
             }
         }
+    }
+
+    /// Route one watch-progress sample into the offline queue. The explicit
+    /// `position` lets the terminal flushes (EOF, player close) pin the
+    /// end-state instead of relying on the last observed tick; `markCompleted`
+    /// force-latches watched on natural end even when the file's duration
+    /// never resolved.
+    @MainActor
+    private func recordOfflineProgress(
+        context: OfflinePlaybackContext,
+        position: Double? = nil,
+        markCompleted: Bool = false
+    ) {
+        let position = position ?? currentTime
+        guard position.isFinite, position >= 0 else { return }
+        let duration = duration.isFinite && duration > 0 ? duration : 0
+        let watched = markCompleted
+            || (duration > 0 && position / duration > Self.offlineWatchedFraction)
+        DownloadManager.shared.recordOfflineProgress(
+            mediaItemId: context.mediaItemId,
+            position: position,
+            duration: duration,
+            completed: watched
+        )
     }
 
     /// Duration the transport overlay stays on-screen after the last user

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -2721,7 +2721,11 @@ class PlayerViewModel {
         freshLoadGeneration &+= 1
         let currentFreshLoadGeneration = freshLoadGeneration
         let snapshotPosition = progressPosition
-        let shouldFinalizeCurrentSession = finalizeCurrentSession
+        // Offline loads never start a replacement server session, so the
+        // prior one must be finalized here — otherwise the bridge keeps
+        // holding it and a later teardown would report the offline item's
+        // position against the stale session.
+        let shouldFinalizeCurrentSession = finalizeCurrentSession || request.offlineDownloadId != nil
         freshLoadTask = Task { @MainActor [weak self] in
             guard let self, !self.isDisposed else { return }
             defer {
@@ -4677,6 +4681,10 @@ class PlayerViewModel {
         // Final offline progress flush before teardown — the counterpart of
         // the online path's `stopSession` report below. Captured into locals
         // so the detached task doesn't read torn-down player state.
+        // Offline playback has no server session of its own (the fresh-load
+        // path finalized any prior one), so skip the server stop below —
+        // it would report the offline position against a stale session.
+        let stopServerSessionOnTeardown = offlinePlaybackContext == nil
         if let offline = offlinePlaybackContext {
             let finalOfflinePosition = completionProgressPositionForCurrentItem()
             let endedNaturally = hasReachedEndOfFile || showNextUpScreen
@@ -4715,7 +4723,9 @@ class PlayerViewModel {
                 await realtimeClient.removeUnavailabilityObserver(unavailabilityToken)
             }
             await realtimeClient.unbind()
-            await sessionBridge.stopSession(position: finalPosition, isPaused: true)
+            if stopServerSessionOnTeardown {
+                await sessionBridge.stopSession(position: finalPosition, isPaused: true)
+            }
         }
     }
 

--- a/iosApp/iosApp/Screens/Settings/SettingsView.swift
+++ b/iosApp/iosApp/Screens/Settings/SettingsView.swift
@@ -165,6 +165,28 @@ struct SettingsView: View {
                     value: subtitleLanguageName(viewModel.editorSubtitleLanguage)
                 )
             }
+
+            NavigationLink {
+                CardOverlaySettingsView()
+            } label: {
+                SettingsRowLabel(
+                    title: "Card Overlays",
+                    systemImage: "rectangle.stack.badge.plus",
+                    color: .indigo
+                )
+            }
+
+            if DownloadManager.shared.downloadsEnabled {
+                NavigationLink {
+                    DownloadsSettingsView()
+                } label: {
+                    SettingsRowLabel(
+                        title: "Downloads",
+                        systemImage: "arrow.down.circle.fill",
+                        color: .blue
+                    )
+                }
+            }
         }
     }
 

--- a/iosApp/iosApp/Screens/Settings/SettingsView.swift
+++ b/iosApp/iosApp/Screens/Settings/SettingsView.swift
@@ -166,16 +166,6 @@ struct SettingsView: View {
                 )
             }
 
-            NavigationLink {
-                CardOverlaySettingsView()
-            } label: {
-                SettingsRowLabel(
-                    title: "Card Overlays",
-                    systemImage: "rectangle.stack.badge.plus",
-                    color: .indigo
-                )
-            }
-
             if DownloadManager.shared.downloadsEnabled {
                 NavigationLink {
                     DownloadsSettingsView()

--- a/iosApp/iosApp/macOS/PlayerView.swift
+++ b/iosApp/iosApp/macOS/PlayerView.swift
@@ -8,6 +8,11 @@ struct PlayerView: View {
     let preferredSubtitleTrackIndex: Int?
     let startFromBeginning: Bool
     let resumePositionOverride: Double?
+    /// Set when the caller wants offline playback of a completed download.
+    /// Routes the prepare through `OfflinePlaybackBuilder` (stored manifest
+    /// + local media file, no server session) so playback works with no
+    /// network.
+    let offlineDownloadId: String?
 
     @Environment(\.dismiss) private var dismiss
     @Environment(\.scenePhase) private var scenePhase
@@ -21,7 +26,8 @@ struct PlayerView: View {
         preferredAudioTrackIndex: Int? = nil,
         preferredSubtitleTrackIndex: Int? = nil,
         startFromBeginning: Bool = false,
-        resumePositionOverride: Double? = nil
+        resumePositionOverride: Double? = nil,
+        offlineDownloadId: String? = nil
     ) {
         self.contentId = contentId
         self.preferredFileId = preferredFileId
@@ -29,6 +35,7 @@ struct PlayerView: View {
         self.preferredSubtitleTrackIndex = preferredSubtitleTrackIndex
         self.startFromBeginning = startFromBeginning
         self.resumePositionOverride = resumePositionOverride
+        self.offlineDownloadId = offlineDownloadId
     }
 
     var body: some View {
@@ -103,7 +110,8 @@ struct PlayerView: View {
                 preferredAudioTrackIndex: preferredAudioTrackIndex,
                 preferredSubtitleTrackIndex: preferredSubtitleTrackIndex,
                 startFromBeginning: startFromBeginning,
-                resumePositionOverride: resumePositionOverride
+                resumePositionOverride: resumePositionOverride,
+                offlineDownloadId: offlineDownloadId
             )
         }
         .onDisappear {

--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -85,6 +85,8 @@ targets:
         product: NukeUI
       - target: SiloNotificationService
         embed: true
+      - target: SiloDownloadsActivity
+        embed: true
 
   # NOTE: tvOS-specific source files live under iosApp/tvOS/. They are guarded
   # by #if os(tvOS) so they compile out on the iOS target even though the
@@ -235,6 +237,34 @@ targets:
         SUPPORTED_PLATFORMS: "iphoneos iphonesimulator"
     dependencies:
       - sdk: UserNotifications.framework
+
+  # iOS WidgetKit extension hosting the downloads Live Activity: the
+  # lock-screen / Dynamic Island progress card for active downloads. The
+  # host app owns the activity lifecycle (DownloadLiveActivityController)
+  # and pushes content states through ActivityKit; this target only renders
+  # them, so it compiles just the shared attributes schema and needs no
+  # entitlements or shared storage.
+  SiloDownloadsActivity:
+    type: app-extension
+    platform: iOS
+    sources:
+      - path: DownloadsActivity
+      - path: iosApp/Downloads/DownloadActivityAttributes.swift
+    configFiles:
+      Debug: Signing/SiloDownloadsActivity.xcconfig
+      Release: Signing/SiloDownloadsActivity.xcconfig
+    settings:
+      base:
+        PRODUCT_NAME: SiloDownloadsActivity
+        INFOPLIST_FILE: DownloadsActivity/Info.plist
+        MARKETING_VERSION: "0.1.0"
+        CURRENT_PROJECT_VERSION: 1
+        TARGETED_DEVICE_FAMILY: "1,2"
+        SDKROOT: iphoneos
+        SUPPORTED_PLATFORMS: "iphoneos iphonesimulator"
+    dependencies:
+      - sdk: WidgetKit.framework
+      - sdk: SwiftUI.framework
 
   # Unit-test bundle for the iOS Silo app. Hosts the XCTest cases under
   # Tests/ and loads the Silo.app binary so `@testable import Silo` can


### PR DESCRIPTION
## What changed

Adds the iOS offline download feature and its follow-up iteration:

- **Download pipeline** (`iosApp/iosApp/Downloads/`): background `URLSession` transfers, per-scope persistence, series monitoring/subscriptions, offline playback, downloads manager UI, and settings.
- **Background refresh**: a `BGAppRefreshTask` (`DownloadBackgroundRefresh`) runs the subscription/progress sync every few hours so "auto-download new episodes" works without opening the app.
- **Local notifications** (`DownloadNotifications`): announce newly queued episodes and completed downloads.
- **UI**: downloaded badges on media cards, size estimates in the download options sheet, download controls on detail screens.
- **Push-triggered auto-download** (`SiloAppDelegate+Push`): the push relay already sends `content-available: 1` on every APNs push, so iOS wakes the app for ~30s when a new-episode notification arrives. That wake now also runs `DownloadManager.onAppActive()` (in parallel with the notification-inbox sync, under the existing deadline race), which registers monitored episodes and enqueues them into the background `URLSession` — the download starts and completes while the app stays closed. `TokenStore` is retargeted before both syncs so a cold background launch authenticates, and the wake deadline is widened from 15s to 20s because the monitoring chain ends with the pipeline kick that performs the enqueue.

## Why

Lets users keep media available offline, and makes series monitoring hands-off: a monitored show's new episode starts downloading the moment the push arrives, with the 4-hour BG refresh task as the fallback for throttled or missed pushes.

## Reviewer notes

- No server or relay changes needed — `content-available` was already on every push.
- Simulator can't do real APNs wakes; push-triggered download needs an on-device check. Known platform limits: force-quit apps and disabled Background App Refresh suppress background wakes (next-open fallback applies).
- iOS build is green (`Silo` scheme, iPhone 17 Pro simulator, `CODE_SIGNING_ALLOWED=NO`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full Downloads area with grouped browsing (series/season), sorting, multi-select, storage summary, and reclaimable-space review.
  * Added download controls on detail screens, plus a Downloads settings page for format, Wi‑Fi-only, sorting, and cleanup preferences.
  * Introduced offline playback for completed downloads, including offline series/movie/episode detail views with resume support.
  * Added download-completion badges and local notifications for download events.
  * Added a Live Activity to show ongoing download progress.

* **Bug Fixes**
  * Improved deep-link routing to downloads.
  * Refined background refresh and app-active updates to keep download status current.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->