### PR TITLE
Media request system for iOS, tvOS, and macOS

### DIFF
--- a/docs/requests/mockups.html
+++ b/docs/requests/mockups.html
@@ -1,0 +1,791 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Silo Requests — iOS &amp; tvOS UX Concepts</title>
+<style>
+  :root {
+    --bg: #000000;
+    --surface: #0A0A0A;
+    --elevated: #15171C;
+    --text: #EDEDED;
+    --text2: rgba(237,237,237,.6);
+    --text3: rgba(237,237,237,.38);
+    --hairline: rgba(255,255,255,.12);
+    --chip-bg: rgba(255,255,255,.07);
+    --amber: #FFC107;
+    --emerald: #34D399;
+    --sky: #38BDF8;
+    --rose: #FB7185;
+    --page-bg: #060607;
+    --r-sm: 8px; --r-md: 12px; --r-lg: 18px;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    background: var(--page-bg);
+    color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif;
+    -webkit-font-smoothing: antialiased;
+    padding: 56px 40px 120px;
+  }
+  .wrap { max-width: 1180px; margin: 0 auto; }
+
+  /* ---------- page chrome ---------- */
+  .eyebrow {
+    font-size: 12px; font-weight: 700; letter-spacing: .3em; text-transform: uppercase;
+    color: var(--text3); display: flex; align-items: center; gap: 10px;
+  }
+  .eyebrow::before { content: ""; width: 26px; height: 3px; border-radius: 2px; background: rgba(255,255,255,.85); }
+  h1 { font-size: 44px; font-weight: 800; letter-spacing: -.02em; margin: 14px 0 10px; }
+  .lede { font-size: 17px; line-height: 1.6; color: var(--text2); max-width: 720px; }
+  h2 { font-size: 26px; font-weight: 800; letter-spacing: -.01em; margin: 90px 0 6px; }
+  h2 .num { color: var(--text3); font-variant-numeric: tabular-nums; margin-right: 10px; }
+  .sub { font-size: 15px; line-height: 1.6; color: var(--text2); max-width: 760px; margin-bottom: 34px; }
+  .sub strong { color: var(--text); font-weight: 600; }
+
+  .insight {
+    border: 1px solid var(--hairline); border-radius: var(--r-lg);
+    background: var(--surface); padding: 26px 30px; margin: 36px 0 0;
+    display: grid; grid-template-columns: repeat(3, 1fr); gap: 28px;
+  }
+  .insight h3 { font-size: 13px; font-weight: 700; letter-spacing: .18em; text-transform: uppercase; color: var(--text3); margin-bottom: 10px; }
+  .insight p { font-size: 14px; line-height: 1.55; color: var(--text2); }
+  .insight p b { color: var(--text); font-weight: 600; }
+
+  .gallery { display: flex; flex-wrap: wrap; gap: 44px; align-items: flex-start; }
+  .frame-block { display: flex; flex-direction: column; gap: 14px; }
+  .caption { max-width: 400px; font-size: 13.5px; line-height: 1.55; color: var(--text2); }
+  .caption b { color: var(--text); font-weight: 600; }
+  .caption .tag {
+    display: inline-block; font-size: 10.5px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase;
+    color: var(--text3); border: 1px solid var(--hairline); border-radius: 99px; padding: 3px 9px; margin-bottom: 8px;
+  }
+
+  /* ---------- phone frame ---------- */
+  .phone {
+    width: 393px; border-radius: 46px; background: #101012;
+    padding: 10px; box-shadow: 0 30px 80px rgba(0,0,0,.6), inset 0 0 0 1px rgba(255,255,255,.09);
+    flex-shrink: 0;
+  }
+  .phone .screen {
+    border-radius: 38px; background: var(--bg); overflow: hidden; position: relative;
+    min-height: 740px; display: flex; flex-direction: column;
+  }
+  .statusbar {
+    height: 48px; display: flex; align-items: center; justify-content: space-between;
+    padding: 0 30px; font-size: 14px; font-weight: 600; flex-shrink: 0;
+  }
+  .statusbar .pill { width: 108px; height: 30px; border-radius: 99px; background: #0c0c0e; margin: 0 auto; position: absolute; left: 50%; transform: translateX(-50%); top: 10px; }
+  .statusbar .right { display: flex; gap: 6px; align-items: center; font-size: 12px; letter-spacing: .04em; color: var(--text2); }
+
+  .p-body { padding: 6px 18px 0; flex: 1; display: flex; flex-direction: column; gap: 18px; overflow: hidden; }
+  .p-titlerow { display: flex; align-items: center; justify-content: space-between; }
+  .p-title { font-size: 30px; font-weight: 800; letter-spacing: -.02em; }
+  .p-title-actions { display: flex; gap: 14px; align-items: center; }
+  .icon-btn {
+    width: 36px; height: 36px; border-radius: 50%; background: var(--chip-bg);
+    display: flex; align-items: center; justify-content: center; font-size: 15px; color: var(--text);
+  }
+  .avatar { width: 34px; height: 34px; border-radius: 50%; background: linear-gradient(135deg,#5b6ee1,#8b5cf6); display:flex; align-items:center; justify-content:center; font-size:14px; font-weight:700; }
+
+  .searchfield {
+    height: 42px; border-radius: 13px; background: var(--chip-bg);
+    display: flex; align-items: center; gap: 9px; padding: 0 14px;
+    font-size: 15.5px; color: var(--text);
+  }
+  .searchfield .mag { color: var(--text3); font-size: 15px; }
+  .searchfield.placeholder { color: var(--text3); }
+  .searchfield .cursor { width: 2px; height: 20px; background: var(--sky); border-radius: 1px; }
+
+  .chiprow { display: flex; gap: 8px; }
+  .chip {
+    font-size: 13px; font-weight: 600; padding: 7px 15px; border-radius: 99px;
+    background: var(--chip-bg); color: var(--text2); border: 1px solid rgba(255,255,255,.09);
+  }
+  .chip.on { background: #fff; color: #000; border-color: #fff; }
+
+  .sec-h { display: flex; align-items: baseline; justify-content: space-between; }
+  .sec-h .t { font-size: 18px; font-weight: 700; letter-spacing: -.01em; }
+  .sec-h .t .cnt { font-size: 12px; color: var(--text3); font-weight: 500; margin-left: 7px; letter-spacing: .06em; }
+  .sec-h .more { font-size: 13px; color: var(--text2); font-weight: 600; }
+  .sec-note { font-size: 12px; color: var(--text3); margin-top: -12px; }
+
+  .posterrow { display: flex; gap: 12px; }
+  .pcard { display: flex; flex-direction: column; gap: 7px; width: 108px; flex-shrink: 0; }
+  .pcard.wide { width: 112px; }
+  .poster {
+    width: 100%; aspect-ratio: 2/3; border-radius: var(--r-md); position: relative; overflow: hidden;
+    display: flex; align-items: flex-end; padding: 9px;
+    box-shadow: inset 0 0 0 1px rgba(255,255,255,.08);
+  }
+  .poster .ptitle { font-size: 11px; font-weight: 700; line-height: 1.25; text-shadow: 0 1px 8px rgba(0,0,0,.8); }
+  .pcard .meta { font-size: 11px; color: var(--text3); font-weight: 500; padding: 0 2px; }
+
+  /* poster art */
+  .art1 { background: linear-gradient(160deg,#3d2c17 0%,#191008 60%,#0a0705 100%); }
+  .art2 { background: linear-gradient(160deg,#12303c 0%,#0a1a24 55%,#05090d 100%); }
+  .art3 { background: linear-gradient(160deg,#3a1a2e 0%,#1c0d19 55%,#0b060d 100%); }
+  .art4 { background: linear-gradient(160deg,#1c3a24 0%,#0e1f14 55%,#060d08 100%); }
+  .art5 { background: linear-gradient(160deg,#33262e 0%,#141017 60%,#08060a 100%); }
+  .art6 { background: linear-gradient(160deg,#20344f 0%,#101b2c 55%,#070b12 100%); }
+  .art7 { background: linear-gradient(160deg,#43301a 0%,#241a0e 55%,#0e0a06 100%); }
+  .art8 { background: linear-gradient(160deg,#233a3a 0%,#122020 55%,#080e0e 100%); }
+
+  /* status ribbons + chips */
+  .ribbon {
+    position: absolute; top: 8px; right: 8px; font-size: 9px; font-weight: 700;
+    letter-spacing: .08em; text-transform: uppercase; padding: 4px 8px; border-radius: 99px;
+    background: rgba(0,0,0,.62); backdrop-filter: blur(6px);
+    display: flex; align-items: center; gap: 5px; color: var(--text);
+    box-shadow: inset 0 0 0 1px rgba(255,255,255,.14);
+  }
+  .dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+  .dot.amber { background: var(--amber); box-shadow: 0 0 7px rgba(255,193,7,.7); }
+  .dot.sky { background: var(--sky); box-shadow: 0 0 7px rgba(56,189,248,.7); }
+  .dot.emerald { background: var(--emerald); box-shadow: 0 0 7px rgba(52,211,153,.7); }
+  .dot.rose { background: var(--rose); box-shadow: 0 0 7px rgba(251,113,133,.7); }
+  .dot.dim { background: rgba(255,255,255,.4); }
+
+  .req-pill {
+    position: absolute; bottom: 8px; left: 8px; right: 8px;
+    background: rgba(255,255,255,.95); color: #000; border-radius: 99px;
+    font-size: 10.5px; font-weight: 700; padding: 6px 0; text-align: center; letter-spacing: .02em;
+  }
+  .req-pill.ghost { background: rgba(0,0,0,.55); color: var(--text2); box-shadow: inset 0 0 0 1px rgba(255,255,255,.16); backdrop-filter: blur(6px); }
+
+  .statuschip {
+    display: inline-flex; align-items: center; gap: 7px;
+    font-size: 12px; font-weight: 600; padding: 6px 12px; border-radius: 99px;
+    background: var(--chip-bg); box-shadow: inset 0 0 0 1px rgba(255,255,255,.1);
+  }
+
+  /* request list rows (My Requests) */
+  .reqrow {
+    display: flex; gap: 13px; align-items: center;
+    background: var(--surface); border-radius: var(--r-lg); padding: 11px;
+    box-shadow: inset 0 0 0 1px rgba(255,255,255,.07);
+  }
+  .reqrow .thumb { width: 46px; aspect-ratio: 2/3; border-radius: 8px; flex-shrink: 0; box-shadow: inset 0 0 0 1px rgba(255,255,255,.1); }
+  .reqrow .info { flex: 1; min-width: 0; }
+  .reqrow .rt { font-size: 14.5px; font-weight: 650; }
+  .reqrow .rm { font-size: 11.5px; color: var(--text3); margin-top: 3px; }
+  .reqrow .trail { text-align: right; flex-shrink: 0; }
+  .progressline { height: 3px; border-radius: 2px; background: rgba(255,255,255,.1); margin-top: 7px; overflow: hidden; }
+  .progressline i { display: block; height: 100%; border-radius: 2px; background: var(--sky); }
+
+  .swipe-cancel {
+    position: relative; overflow: hidden; border-radius: var(--r-lg);
+  }
+  .swipe-cancel .under {
+    position: absolute; inset: 0; background: #3d1218; display: flex; align-items: center; justify-content: flex-end;
+    padding-right: 20px; font-size: 12px; font-weight: 700; color: #ffb4be; letter-spacing: .05em;
+  }
+  .swipe-cancel .reqrow { position: relative; transform: translateX(-84px); }
+
+  /* iOS tab bar */
+  .tabbar {
+    margin-top: auto; flex-shrink: 0; display: flex; justify-content: space-around; align-items: center;
+    padding: 12px 10px 26px; border-top: 1px solid rgba(255,255,255,.06);
+    background: rgba(10,10,12,.9); backdrop-filter: blur(20px);
+  }
+  .tab { display: flex; flex-direction: column; align-items: center; gap: 4px; font-size: 10px; color: var(--text3); font-weight: 600; }
+  .tab .g { font-size: 20px; }
+  .tab.on { color: var(--text); }
+
+  /* iOS detail screen */
+  .hero { position: relative; height: 218px; flex-shrink: 0; margin: -6px -18px 0; }
+  .hero .bg { position: absolute; inset: 0; }
+  .hero .fade { position: absolute; inset: 0; background: linear-gradient(180deg, rgba(0,0,0,.15) 0%, rgba(0,0,0,.5) 60%, #000 100%); }
+  .hero .backbtn { position: absolute; top: 14px; left: 18px; }
+  .detailhead { display: flex; gap: 15px; margin-top: -66px; position: relative; z-index: 2; align-items: flex-end; }
+  .detailhead .poster { width: 108px; flex-shrink: 0; box-shadow: 0 12px 32px rgba(0,0,0,.6), inset 0 0 0 1px rgba(255,255,255,.1); }
+  .detailhead .dt { font-size: 23px; font-weight: 800; letter-spacing: -.02em; line-height: 1.08; }
+  .detailhead .dm { font-size: 12.5px; color: var(--text2); margin-top: 7px; line-height: 1.5; }
+  .badges { display: flex; gap: 6px; margin-top: 8px; flex-wrap: wrap; }
+  .badge { font-size: 9.5px; font-weight: 700; letter-spacing: .08em; padding: 3px 7px; border-radius: 5px; background: var(--chip-bg); color: var(--text2); box-shadow: inset 0 0 0 1px rgba(255,255,255,.1); }
+  .cta {
+    height: 50px; border-radius: 15px; background: #fff; color: #000;
+    display: flex; align-items: center; justify-content: center; gap: 8px;
+    font-size: 16px; font-weight: 750;
+  }
+  .cta .plus { font-size: 19px; font-weight: 800; margin-top: -2px; }
+  .cta-note { text-align: center; font-size: 11.5px; color: var(--text3); margin-top: -8px; }
+  .overview { font-size: 13.5px; line-height: 1.6; color: var(--text2); }
+
+  /* variant strip */
+  .variants {
+    display: flex; flex-wrap: wrap; gap: 10px; margin-top: 16px;
+    padding: 18px; border: 1px dashed rgba(255,255,255,.14); border-radius: var(--r-lg); background: var(--surface);
+    max-width: 400px;
+  }
+  .variants .vlab { width: 100%; font-size: 10.5px; font-weight: 700; letter-spacing: .16em; text-transform: uppercase; color: var(--text3); margin-bottom: 2px; }
+
+  /* menu mock */
+  .menupop {
+    width: 250px; background: rgba(28,29,34,.98); border-radius: 16px; padding: 7px;
+    box-shadow: 0 24px 60px rgba(0,0,0,.7), inset 0 0 0 1px rgba(255,255,255,.09);
+    position: absolute; top: 96px; right: 16px; z-index: 30;
+  }
+  .menupop .mi { display: flex; align-items: center; justify-content: space-between; padding: 11px 13px; font-size: 15px; font-weight: 500; border-radius: 10px; }
+  .menupop .mi .g { color: var(--text2); font-size: 15px; }
+  .menupop .mi.hl { background: rgba(255,255,255,.1); }
+  .menupop .div { height: 1px; background: rgba(255,255,255,.08); margin: 6px 4px; }
+  .menupop .mi.danger { color: #ff6b6b; }
+  .dimmed { opacity: .34; filter: saturate(.7); }
+
+  /* ---------- TV frame ---------- */
+  .tv {
+    width: 100%; max-width: 1080px; aspect-ratio: 16/9; border-radius: 18px; background: var(--bg);
+    overflow: hidden; position: relative; flex-shrink: 0;
+    box-shadow: 0 30px 90px rgba(0,0,0,.65), inset 0 0 0 1px rgba(255,255,255,.09);
+    container-type: inline-size;
+  }
+  .tv-inner { position: absolute; inset: 0; padding: 3.2% 4.6% 0; display: flex; flex-direction: column; }
+  .tv-topbar { display: flex; align-items: center; gap: 2.4%; flex-shrink: 0; }
+  .tv-wordmark { font-size: 15px; font-weight: 800; letter-spacing: .34em; }
+  .tv-tabs { display: flex; gap: 6px; margin: 0 auto; }
+  .tv-tab { font-size: 12.5px; font-weight: 600; color: rgba(237,237,237,.62); padding: 7px 15px; border-radius: 99px; }
+  .tv-tab.sel { background: rgba(255,255,255,.14); color: #fff; box-shadow: inset 0 0 0 1px rgba(255,255,255,.1); }
+  .tv-tab.foc { background: #fff; color: #000; }
+  .tv-right { display: flex; gap: 12px; align-items: center; }
+  .tv-iconbtn { width: 30px; height: 30px; border-radius: 50%; background: var(--chip-bg); display:flex; align-items:center; justify-content:center; font-size: 13px; }
+  .tv-avatar { width: 30px; height: 30px; border-radius: 50%; background: linear-gradient(135deg,#5b6ee1,#8b5cf6); display:flex; align-items:center; justify-content:center; font-size: 12px; font-weight: 700; }
+
+  .tv-row-title { font-size: 16px; font-weight: 700; display: flex; align-items: baseline; gap: 9px; }
+  .tv-row-title .cnt { font-size: 10.5px; color: var(--text3); font-weight: 500; letter-spacing: .06em; }
+  .tv-cards { display: flex; gap: 13px; margin-top: 10px; }
+  .tv-pcard { width: 108px; flex-shrink: 0; }
+  .tv-pcard .poster { border-radius: 10px; }
+  .tv-pcard .meta { font-size: 10px; color: var(--text3); margin-top: 6px; padding: 0 2px; font-weight: 500; }
+  .tv-pcard.focused .poster { transform: scale(1.06); box-shadow: 0 0 0 2px #fff, 0 16px 40px rgba(0,0,0,.7); }
+  .tv-pcard.focused .meta { color: var(--text2); }
+
+  .tv-marquee { padding: 2.4% 0 1.8%; max-width: 58%; }
+  .tv-marquee .eyebrow { font-size: 9.5px; letter-spacing: .3em; }
+  .tv-marquee .mtitle { font-size: 34px; font-weight: 800; letter-spacing: -.015em; line-height: 1.02; margin: 8px 0 7px; }
+  .tv-marquee .mmeta { font-size: 11px; color: var(--text2); font-weight: 500; display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+  .tv-marquee .msyn { font-size: 11.5px; line-height: 1.5; color: var(--text2); margin-top: 9px; max-width: 92%; }
+
+  .tv-backdrop { position: absolute; inset: 0; z-index: 0; }
+  .tv-backdrop .fade { position: absolute; inset: 0; background: linear-gradient(180deg, rgba(0,0,0,.34) 0%, rgba(0,0,0,.72) 46%, #000 88%), linear-gradient(90deg, rgba(0,0,0,.6) 0%, rgba(0,0,0,.15) 60%); }
+  .tv-inner.overbg { position: relative; z-index: 1; }
+
+  .tv-pill {
+    display: inline-flex; align-items: center; gap: 8px;
+    font-size: 12px; font-weight: 700; padding: 10px 22px; border-radius: 99px;
+    background: var(--chip-bg); color: var(--text); box-shadow: inset 0 0 0 1px rgba(255,255,255,.12);
+  }
+  .tv-pill.primary-foc { background: #fff; color: #000; box-shadow: 0 10px 30px rgba(0,0,0,.5); }
+  .tv-actionrow { display: flex; gap: 11px; margin-top: 16px; align-items: center; }
+  .tv-hint { font-size: 10px; color: var(--text3); letter-spacing: .05em; }
+
+  .tv-searchfield {
+    height: 40px; border-radius: 11px; background: var(--chip-bg); box-shadow: inset 0 0 0 1px rgba(255,255,255,.1);
+    display: flex; align-items: center; gap: 10px; padding: 0 15px; font-size: 14px; max-width: 46%;
+  }
+
+  /* status table */
+  table.status { border-collapse: collapse; width: 100%; margin-top: 26px; }
+  table.status th {
+    text-align: left; font-size: 11px; font-weight: 700; letter-spacing: .16em; text-transform: uppercase;
+    color: var(--text3); padding: 0 18px 12px 0; border-bottom: 1px solid var(--hairline);
+  }
+  table.status td { padding: 13px 18px 13px 0; border-bottom: 1px solid rgba(255,255,255,.06); font-size: 13.5px; color: var(--text2); vertical-align: middle; }
+  table.status td:first-child { color: var(--text); font-weight: 600; white-space: nowrap; }
+
+  .foot { margin-top: 100px; font-size: 12px; color: var(--text3); border-top: 1px solid var(--hairline); padding-top: 22px; }
+  @media (max-width: 900px) { .insight { grid-template-columns: 1fr; } }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="eyebrow">Silo · Apple Clients · Concept</div>
+  <h1>Requests on iPhone &amp; Apple&nbsp;TV</h1>
+  <p class="lede">
+    Bringing the server's media-request system to iOS and tvOS. The web app already ships a full
+    Discover / Yours hub; Android shipped phone + TV clients. These mockups adapt the same
+    one-tap contract to each Apple surface, following how people actually use requests.
+  </p>
+
+  <div class="insight">
+    <div>
+      <h3>Job 1 · Capture the impulse</h3>
+      <p>“Someone just mentioned a movie.” This happens <b>on the phone</b>, and the user's first instinct
+      is to search the library. The request affordance must live <b>inside search</b> — the moment the library
+      comes up empty is the moment the request happens, with the query already typed.</p>
+    </div>
+    <div>
+      <h3>Job 2 · Fill the gap on the couch</h3>
+      <p>“Nothing to watch → I looked for it → it's not here.” On the TV the same rule applies, but typing is
+      expensive — so the <b>existing Search screen</b> does double duty. A separate hub that makes you re-type
+      the title would be the failure mode.</p>
+    </div>
+    <div>
+      <h3>Job 3 · Track the pipeline</h3>
+      <p>“Where's my movie?” — checked like a package tracker, mostly <b>on the phone</b>, occasionally on TV.
+      Needs a findable home (hub + My Requests), glanceable status language, and a straight jump into the
+      library the moment a request lands.</p>
+    </div>
+  </div>
+
+  <!-- ================================================================ -->
+  <h2><span class="num">01</span>iPhone — request from search</h2>
+  <p class="sub">
+    The primary entry point. Library results render first, exactly as today. When the library can't fully answer
+    the query, an <strong>“Available to request”</strong> section appears below with TMDB matches — the same inline
+    weave the web app uses in <code>⌘K</code> search. Every card carries server-computed state, so a user can never
+    double-request: requestable cards get the white pill, everything else shows why not.
+  </p>
+
+  <div class="gallery">
+    <div class="frame-block">
+      <div class="phone"><div class="screen">
+        <div class="statusbar"><span>9:41</span><span class="pill"></span><span class="right">􀙇 􀋂 􀛨</span></div>
+        <div class="p-body">
+          <div class="searchfield"><span class="mag">􀊫</span>dune<span class="cursor"></span></div>
+          <div class="chiprow"><span class="chip on">All</span><span class="chip">Movies</span><span class="chip">Series</span></div>
+
+          <div class="sec-h"><span class="t">In your library <span class="cnt">2</span></span></div>
+          <div class="posterrow">
+            <div class="pcard"><div class="poster art1"><span class="ptitle">Dune</span></div><div class="meta">2021 · Movie</div></div>
+            <div class="pcard"><div class="poster art7"><span class="ptitle">Dune: Part Two</span></div><div class="meta">2024 · Movie</div></div>
+          </div>
+
+          <div class="sec-h"><span class="t">✦ Available to request</span></div>
+          <p class="sec-note">Not in the library yet · matched on TMDB</p>
+          <div class="posterrow">
+            <div class="pcard">
+              <div class="poster art2">
+                <span class="ptitle">Dune: Part Three</span>
+                <div class="req-pill">＋ Request</div>
+              </div><div class="meta">2026 · Movie</div>
+            </div>
+            <div class="pcard">
+              <div class="poster art3">
+                <div class="ribbon"><span class="dot amber"></span>Pending</div>
+                <span class="ptitle">Dune: Prophecy</span>
+              </div><div class="meta">2024 · Series</div>
+            </div>
+            <div class="pcard">
+              <div class="poster art5">
+                <span class="ptitle">Jodorowsky's Dune</span>
+                <div class="req-pill">＋ Request</div>
+              </div><div class="meta">2013 · Movie</div>
+            </div>
+          </div>
+
+          <div class="tabbar">
+            <div class="tab on"><span class="g">􀎞</span>Home</div>
+            <div class="tab"><span class="g">􀐩</span>Libraries</div>
+            <div class="tab"><span class="g">􀋂</span>For You</div>
+            <div class="tab"><span class="g">􀉉</span>Calendar</div>
+          </div>
+        </div>
+      </div></div>
+      <p class="caption"><span class="tag">iOS · Search</span>
+      <b>Zero extra navigation.</b> The query is already typed; the request section only appears when the
+      library answer is thin (or on the explicit “not finding it?” affordance). Tapping the poster opens the
+      request detail page; tapping <b>＋ Request</b> submits in place — the pill morphs into a Pending ribbon.</p>
+    </div>
+  </div>
+
+  <!-- ================================================================ -->
+  <h2><span class="num">02</span>iPhone — the Requests hub</h2>
+  <p class="sub">
+    The deliberate destination for browsing and tracking. Search-first (it's the number-one action),
+    your active requests one row down so status is glanceable without another hop, then TMDB discovery
+    rows for the “what should I wish for” mood. Trimmed from the web version: no studio/network/genre
+    brand-browse in v1.
+  </p>
+
+  <div class="gallery">
+    <div class="frame-block">
+      <div class="phone"><div class="screen">
+        <div class="statusbar"><span>9:41</span><span class="pill"></span><span class="right">􀙇 􀋂 􀛨</span></div>
+        <div class="p-body">
+          <div class="p-titlerow">
+            <span class="p-title">Requests</span>
+            <div class="p-title-actions"><span class="statuschip"><span class="dot amber"></span>3 active</span></div>
+          </div>
+          <div class="searchfield placeholder"><span class="mag">􀊫</span>Search movies &amp; series to request</div>
+
+          <div class="sec-h"><span class="t">Your requests</span><span class="more">See all ›</span></div>
+          <div class="posterrow">
+            <div class="pcard"><div class="poster art3"><div class="ribbon"><span class="dot amber"></span>Pending</div><span class="ptitle">Dune: Prophecy</span></div></div>
+            <div class="pcard"><div class="poster art6"><div class="ribbon"><span class="dot sky"></span>Downloading</div><span class="ptitle">The Odyssey</span></div></div>
+            <div class="pcard"><div class="poster art4"><div class="ribbon"><span class="dot emerald"></span>In library</div><span class="ptitle">Sinners</span></div></div>
+            <div class="pcard"><div class="poster art8"><div class="ribbon"><span class="dot rose"></span>Declined</div><span class="ptitle">Project Hail M…</span></div></div>
+          </div>
+
+          <div class="sec-h"><span class="t">Trending now</span></div>
+          <div class="posterrow">
+            <div class="pcard"><div class="poster art2"><span class="ptitle">Dune: Part Three</span><div class="req-pill">＋ Request</div></div></div>
+            <div class="pcard"><div class="poster art5"><div class="ribbon">In library</div><span class="ptitle">Weapons</span></div></div>
+            <div class="pcard"><div class="poster art7"><span class="ptitle">Hamnet</span><div class="req-pill">＋ Request</div></div></div>
+            <div class="pcard"><div class="poster art1"><span class="ptitle">Bugonia</span><div class="req-pill">＋ Request</div></div></div>
+          </div>
+
+          <div class="sec-h"><span class="t">Crowd favorites</span></div>
+          <div class="posterrow">
+            <div class="pcard"><div class="poster art6"><span class="ptitle">Frankenstein</span><div class="req-pill">＋ Request</div></div></div>
+            <div class="pcard"><div class="poster art8"><span class="ptitle">Marty Supreme</span><div class="req-pill">＋ Request</div></div></div>
+            <div class="pcard"><div class="poster art4"><div class="ribbon"><span class="dot amber"></span>Pending</div><span class="ptitle">Wake Up Dead…</span></div></div>
+          </div>
+
+          <div class="tabbar">
+            <div class="tab"><span class="g">􀎞</span>Home</div>
+            <div class="tab"><span class="g">􀐩</span>Libraries</div>
+            <div class="tab"><span class="g">􀋂</span>For You</div>
+            <div class="tab"><span class="g">􀉉</span>Calendar</div>
+          </div>
+        </div>
+      </div></div>
+      <p class="caption"><span class="tag">iOS · Requests hub</span>
+      <b>Status is above the fold.</b> The “Your requests” strip means the most common
+      revisit (“any movement?”) is answered in one glance; “See all” pushes the full My Requests queue.
+      Discovery rows reuse the trending/crowd-favorites endpoints the web hub already calls.</p>
+    </div>
+
+    <div class="frame-block">
+      <div class="phone"><div class="screen">
+        <div class="statusbar"><span>9:41</span><span class="pill"></span><span class="right">􀙇 􀋂 􀛨</span></div>
+        <div class="p-body" style="position:relative">
+          <div class="p-titlerow dimmed">
+            <span class="p-title">Home</span>
+            <div class="p-title-actions"><div class="icon-btn">􀊫</div><div class="avatar">N</div></div>
+          </div>
+          <div class="menupop">
+            <div class="mi"><span>Favorites</span><span class="g">􀊵</span></div>
+            <div class="mi"><span>Watchlist</span><span class="g">􀉚</span></div>
+            <div class="mi hl"><span>Requests</span><span class="g">✦</span></div>
+            <div class="div"></div>
+            <div class="mi"><span>Settings</span><span class="g">􀣋</span></div>
+            <div class="mi"><span>Switch Profile</span><span class="g">􀉬</span></div>
+            <div class="mi"><span>Switch Server</span><span class="g">􀪫</span></div>
+            <div class="div"></div>
+            <div class="mi danger"><span>Sign Out</span><span class="g">􀱍</span></div>
+          </div>
+          <div class="dimmed">
+            <div class="posterrow" style="margin-top:56px">
+              <div class="pcard wide"><div class="poster art1"></div></div>
+              <div class="pcard wide"><div class="poster art2"></div></div>
+              <div class="pcard wide"><div class="poster art4"></div></div>
+            </div>
+            <div class="posterrow" style="margin-top:16px">
+              <div class="pcard wide"><div class="poster art6"></div></div>
+              <div class="pcard wide"><div class="poster art5"></div></div>
+              <div class="pcard wide"><div class="poster art7"></div></div>
+            </div>
+          </div>
+          <div class="tabbar" style="position:absolute;left:0;right:0;bottom:0">
+            <div class="tab on"><span class="g">􀎞</span>Home</div>
+            <div class="tab"><span class="g">􀐩</span>Libraries</div>
+            <div class="tab"><span class="g">􀋂</span>For You</div>
+            <div class="tab"><span class="g">􀉉</span>Calendar</div>
+          </div>
+        </div>
+      </div></div>
+      <p class="caption"><span class="tag">iOS · Entry point</span>
+      <b>Profile menu, not a fifth tab</b> — the same call Android made. The tab bar stays a pure
+      consumption surface (Home / Libraries / For You / Calendar, + Downloads when enabled); Requests joins
+      the personal-shelf cluster in the avatar menu. The whole feature is hidden unless the server reports
+      <code>requests_enabled</code>. <i>Alternative if discoverability worries you: a conditional tab à la
+      Downloads — flagged as an open question below.</i></p>
+    </div>
+  </div>
+
+  <!-- ================================================================ -->
+  <h2><span class="num">03</span>iPhone — request detail &amp; My Requests</h2>
+  <p class="sub">
+    A request detail page that reads like a real title page, not a form — backdrop, poster, meta, synopsis —
+    with exactly <strong>one</strong> primary action computed from server state. No confirmation dialog:
+    the button itself is the confirmation, and it morphs into the status pill on success (matching web + Android).
+  </p>
+
+  <div class="gallery">
+    <div class="frame-block">
+      <div class="phone"><div class="screen">
+        <div class="statusbar" style="position:relative;z-index:3"><span>9:41</span><span class="pill"></span><span class="right">􀙇 􀋂 􀛨</span></div>
+        <div class="p-body">
+          <div class="hero">
+            <div class="bg art2"></div>
+            <div class="fade"></div>
+            <div class="backbtn icon-btn">‹</div>
+          </div>
+          <div class="detailhead">
+            <div class="poster art2"><span class="ptitle" style="font-size:12px">Dune: Part Three</span></div>
+            <div>
+              <div class="dt">Dune: Part Three</div>
+              <div class="dm">2026 · Movie · Sci-Fi, Adventure<br>Denis Villeneuve</div>
+              <div class="badges"><span class="badge">TMDB 8.1</span><span class="badge">PG-13</span><span class="badge">NOT IN LIBRARY</span></div>
+            </div>
+          </div>
+          <div class="cta"><span class="plus">＋</span> Request Movie</div>
+          <p class="cta-note">Requests are reviewed by your server admin</p>
+          <p class="overview">The final chapter of Villeneuve's trilogy. Paul Atreides reigns as Emperor
+          while the consequences of his ascension ripple across the Imperium…</p>
+          <div class="sec-h"><span class="t">More like this</span></div>
+          <div class="posterrow">
+            <div class="pcard"><div class="poster art1"><div class="ribbon">In library</div></div></div>
+            <div class="pcard"><div class="poster art6"><div class="req-pill">＋ Request</div></div></div>
+            <div class="pcard"><div class="poster art8"><div class="req-pill">＋ Request</div></div></div>
+          </div>
+        </div>
+      </div></div>
+      <div class="variants">
+        <span class="vlab">Primary-action states (server-computed)</span>
+        <span class="statuschip" style="background:#fff;color:#000">＋ Request Movie</span>
+        <span class="statuschip"><span class="dot amber"></span>Pending approval</span>
+        <span class="statuschip"><span class="dot sky"></span>Downloading</span>
+        <span class="statuschip"><span class="dot emerald"></span>In your library → Open</span>
+        <span class="statuschip"><span class="dot rose"></span>Declined — “4K space”</span>
+        <span class="statuschip"><span class="dot dim"></span>Request limit reached</span>
+      </div>
+      <p class="caption"><span class="tag">iOS · Request detail</span>
+      <b>One button, many states.</b> Requestable → white CTA. Already yours → status pill (with the admin's
+      decline reason when there is one). Already in the library → “Open” jumps straight to the real item via
+      <code>library_content_id</code>. Recommendations keep the loop going — each card is requestable inline.</p>
+    </div>
+
+    <div class="frame-block">
+      <div class="phone"><div class="screen">
+        <div class="statusbar"><span>9:41</span><span class="pill"></span><span class="right">􀙇 􀋂 􀛨</span></div>
+        <div class="p-body">
+          <div class="p-titlerow">
+            <div style="display:flex;align-items:center;gap:10px"><div class="icon-btn">‹</div><span class="p-title" style="font-size:24px">My Requests</span></div>
+            <span class="statuschip" style="font-size:11px">This month: 3 of 10</span>
+          </div>
+
+          <div class="sec-h"><span class="t">In motion <span class="cnt">2</span></span></div>
+          <div class="swipe-cancel">
+            <div class="under">CANCEL</div>
+            <div class="reqrow">
+              <div class="thumb art3"></div>
+              <div class="info"><div class="rt">Dune: Prophecy</div><div class="rm">Series · requested Jun 28</div></div>
+              <div class="trail"><span class="statuschip"><span class="dot amber"></span>Pending</span></div>
+            </div>
+          </div>
+          <div class="reqrow">
+            <div class="thumb art6"></div>
+            <div class="info"><div class="rt">The Odyssey</div><div class="rm">Movie · 1080p done · 4K downloading</div>
+              <div class="progressline"><i style="width:62%"></i></div></div>
+            <div class="trail"><span class="statuschip"><span class="dot sky"></span>Downloading</span></div>
+          </div>
+
+          <div class="sec-h" style="margin-top:6px"><span class="t">Landed in your library <span class="cnt">1</span></span></div>
+          <div class="reqrow">
+            <div class="thumb art4"></div>
+            <div class="info"><div class="rt">Sinners</div><div class="rm">Movie · completed Jun 30</div></div>
+            <div class="trail"><span class="statuschip" style="background:#fff;color:#000">▶ Open</span></div>
+          </div>
+
+          <div class="sec-h" style="margin-top:6px"><span class="t">Needs attention <span class="cnt">1</span></span></div>
+          <div class="reqrow">
+            <div class="thumb art8"></div>
+            <div class="info"><div class="rt">Project Hail Mary</div><div class="rm">Movie · “Waiting for a better release” — admin</div></div>
+            <div class="trail"><span class="statuschip"><span class="dot rose"></span>Declined</span></div>
+          </div>
+
+          <div class="tabbar">
+            <div class="tab"><span class="g">􀎞</span>Home</div>
+            <div class="tab"><span class="g">􀐩</span>Libraries</div>
+            <div class="tab"><span class="g">􀋂</span>For You</div>
+            <div class="tab"><span class="g">􀉉</span>Calendar</div>
+          </div>
+        </div>
+      </div></div>
+      <p class="caption"><span class="tag">iOS · My Requests</span>
+      <b>The package tracker.</b> Same three buckets as the web's “Yours” tab (In motion / Landed / Needs
+      attention). Swipe-to-cancel on pending requests (the server allows owner-cancel until submission).
+      Quota shown quietly in the corner — users learn the limit before hitting the 429, not after.
+      Completed rows deep-link into the real library item.</p>
+    </div>
+  </div>
+
+  <!-- ================================================================ -->
+  <h2><span class="num">04</span>Apple TV — request from Search</h2>
+  <p class="sub">
+    The single most important tvOS decision: <strong>don't build a second keyboard.</strong> The existing
+    Search screen grows one row. Library results stay primary; below them, an “Available to request” row
+    appears for what the library can't answer. The query the user already suffered through the grid keyboard
+    for is reused for free.
+  </p>
+
+  <div class="gallery">
+    <div class="frame-block" style="width:100%">
+      <div class="tv"><div class="tv-inner">
+        <div class="tv-topbar">
+          <span class="tv-wordmark">SILO</span>
+          <div class="tv-tabs">
+            <span class="tv-tab">Home</span><span class="tv-tab">Movies</span><span class="tv-tab">Series</span>
+            <span class="tv-tab">For You</span><span class="tv-tab">Calendar</span>
+          </div>
+          <div class="tv-right"><div class="tv-iconbtn" style="background:#fff;color:#000">􀊫</div><div class="tv-avatar">N</div></div>
+        </div>
+
+        <div style="margin-top:3.4%">
+          <div class="tv-searchfield"><span style="color:var(--text3)">􀊫</span>dune</div>
+        </div>
+
+        <div style="margin-top:2.8%">
+          <div class="tv-row-title">In your library <span class="cnt">2 RESULTS</span></div>
+          <div class="tv-cards">
+            <div class="tv-pcard"><div class="poster art1"><span class="ptitle">Dune</span></div><div class="meta">2021</div></div>
+            <div class="tv-pcard"><div class="poster art7"><span class="ptitle">Dune: Part Two</span></div><div class="meta">2024</div></div>
+          </div>
+        </div>
+
+        <div style="margin-top:2.6%">
+          <div class="tv-row-title">✦ Available to request <span class="cnt">NOT IN YOUR LIBRARY · TMDB</span></div>
+          <div class="tv-cards">
+            <div class="tv-pcard focused"><div class="poster art2"><span class="ptitle">Dune: Part Three</span></div><div class="meta">2026 · Movie · Press to request</div></div>
+            <div class="tv-pcard"><div class="poster art3"><div class="ribbon"><span class="dot amber"></span>Pending</div><span class="ptitle">Dune: Prophecy</span></div><div class="meta">2024 · Series</div></div>
+            <div class="tv-pcard"><div class="poster art5"><span class="ptitle">Jodorowsky's Dune</span></div><div class="meta">2013 · Movie</div></div>
+          </div>
+        </div>
+      </div></div>
+      <p class="caption" style="max-width:760px"><span class="tag">tvOS · Search</span>
+      <b>One extra row, zero extra typing.</b> Pressing a request card pushes the full-screen request detail
+      (below) — press-to-detail keeps the flow identical to library cards, so there's nothing new to learn, and
+      the detail page doubles as the confirmation step, which keeps the d-pad flow to
+      <i>select → press → press</i>. Status ribbons keep the monochrome Skyline grammar plus a single colored dot.</p>
+    </div>
+  </div>
+
+  <!-- ================================================================ -->
+  <h2><span class="num">05</span>Apple TV — request detail</h2>
+  <p class="sub">
+    A pushed full-screen route wearing the same chrome as the squared-Skyline item detail: full-bleed backdrop,
+    left content block, pill actions. One primary action, computed from state — pressing <strong>Request</strong>
+    submits and the pill morphs into the status chip in place. No modal.
+  </p>
+
+  <div class="gallery">
+    <div class="frame-block" style="width:100%">
+      <div class="tv">
+        <div class="tv-backdrop art2"><div class="fade"></div></div>
+        <div class="tv-inner overbg">
+          <div class="tv-marquee" style="margin-top:8%">
+            <div class="eyebrow">REQUEST · MOVIE · NOT IN YOUR LIBRARY</div>
+            <div class="mtitle">Dune: Part Three</div>
+            <div class="mmeta"><span>2026</span><span>·</span><span>Sci-Fi, Adventure</span><span>·</span><span>Denis Villeneuve</span><span>·</span><span class="badge">TMDB 8.1</span><span class="badge">PG-13</span></div>
+            <p class="msyn">The final chapter of Villeneuve's trilogy. Paul Atreides reigns as Emperor while the
+            consequences of his ascension ripple across the Imperium. Sequel to Dune: Part Two (in your library).</p>
+            <div class="tv-actionrow">
+              <span class="tv-pill primary-foc">＋ Request Movie</span>
+              <span class="tv-pill">More Like This</span>
+              <span class="tv-hint">Reviewed by your server admin</span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="variants" style="max-width:760px">
+        <span class="vlab">The same action pill across the lifecycle</span>
+        <span class="statuschip" style="background:#fff;color:#000">＋ Request Movie</span>
+        <span class="statuschip"><span class="dot amber"></span>Requested · Pending</span>
+        <span class="statuschip"><span class="dot sky"></span>Downloading</span>
+        <span class="statuschip" style="background:#fff;color:#000"><span class="dot emerald"></span>In your library · Play</span>
+        <span class="statuschip"><span class="dot rose"></span>Declined</span>
+      </div>
+      <p class="caption" style="max-width:760px"><span class="tag">tvOS · Request detail</span>
+      <b>Completed requests come full circle:</b> once the title lands in the catalog, this route redirects to the
+      real item detail (via <code>library_content_id</code>) — the request page is only ever shown for things you
+      can't play yet.</p>
+    </div>
+  </div>
+
+  <!-- ================================================================ -->
+  <h2><span class="num">06</span>Apple TV — hub &amp; entry point</h2>
+  <p class="sub">
+    Requests joins the profile dropdown next to Watchlist / Favorites / History — the established home for
+    personal shelves — and pushes a full-screen hub: your requests first (glanceable ribbons), then TMDB
+    discovery rows for lean-back wishlisting. Search up top routes to the shared search screen.
+  </p>
+
+  <div class="gallery">
+    <div class="frame-block" style="width:100%">
+      <div class="tv"><div class="tv-inner">
+        <div class="tv-topbar" style="opacity:.5">
+          <span class="tv-wordmark">SILO</span>
+          <div class="tv-tabs">
+            <span class="tv-tab">Home</span><span class="tv-tab">Movies</span><span class="tv-tab">Series</span>
+            <span class="tv-tab">For You</span><span class="tv-tab">Calendar</span>
+          </div>
+          <div class="tv-right"><div class="tv-iconbtn">􀊫</div><div class="tv-avatar">N</div></div>
+        </div>
+
+        <div style="display:flex;justify-content:space-between;align-items:flex-end;margin-top:2.6%">
+          <div>
+            <div class="eyebrow" style="font-size:9.5px">YOUR WISHLIST</div>
+            <div style="font-size:26px;font-weight:800;margin-top:6px">Requests</div>
+          </div>
+          <div style="display:flex;gap:10px">
+            <span class="tv-pill">􀊫 Search</span>
+            <span class="tv-pill"><span class="dot amber"></span>3 active · 3 of 10 this month</span>
+          </div>
+        </div>
+
+        <div style="margin-top:2.2%">
+          <div class="tv-row-title">Your requests</div>
+          <div class="tv-cards">
+            <div class="tv-pcard focused"><div class="poster art6"><div class="ribbon"><span class="dot sky"></span>Downloading</div><span class="ptitle">The Odyssey</span></div><div class="meta">1080p done · 4K 62%</div></div>
+            <div class="tv-pcard"><div class="poster art3"><div class="ribbon"><span class="dot amber"></span>Pending</div><span class="ptitle">Dune: Prophecy</span></div><div class="meta">Requested Jun 28</div></div>
+            <div class="tv-pcard"><div class="poster art4"><div class="ribbon"><span class="dot emerald"></span>In library</div><span class="ptitle">Sinners</span></div><div class="meta">Press to play</div></div>
+            <div class="tv-pcard"><div class="poster art8"><div class="ribbon"><span class="dot rose"></span>Declined</div><span class="ptitle">Project Hail Mary</span></div><div class="meta">See reason</div></div>
+          </div>
+        </div>
+
+        <div style="margin-top:2.4%">
+          <div class="tv-row-title">Trending now <span class="cnt">TMDB</span></div>
+          <div class="tv-cards">
+            <div class="tv-pcard"><div class="poster art2"><span class="ptitle">Dune: Part Three</span></div><div class="meta">2026</div></div>
+            <div class="tv-pcard"><div class="poster art5"><div class="ribbon">In library</div><span class="ptitle">Weapons</span></div><div class="meta">2025</div></div>
+            <div class="tv-pcard"><div class="poster art7"><span class="ptitle">Hamnet</span></div><div class="meta">2025</div></div>
+            <div class="tv-pcard"><div class="poster art1"><span class="ptitle">Bugonia</span></div><div class="meta">2025</div></div>
+          </div>
+        </div>
+      </div></div>
+      <p class="caption" style="max-width:760px"><span class="tag">tvOS · Requests hub</span>
+      <b>Entry:</b> profile dropdown row (mirrors Watchlist/Favorites/History), shown only when the server reports
+      <code>requests_enabled</code>. The hub is a pushed route, so the Skyline top bar dims behind it like other
+      full-screen destinations. Native focus graph throughout — plain buttons and rows, no custom focus machinery.</p>
+    </div>
+  </div>
+
+  <!-- ================================================================ -->
+  <h2><span class="num">07</span>One status language, both feet</h2>
+  <p class="sub">
+    The server's lifecycle (<code>status</code> × <code>outcome</code>) collapses into five user-facing states.
+    Skyline is monochrome by charter — so chips stay monochrome and the <strong>only</strong> color is a 6-pt dot
+    (precedent: the amber rating badge is Skyline's one sanctioned chromatic token). iOS uses the identical
+    mapping so the two platforms read as one system.
+  </p>
+
+  <table class="status">
+    <tr><th>User-facing state</th><th>Server state</th><th>Dot</th><th>Behavior</th></tr>
+    <tr><td><span class="statuschip"><span class="dot amber"></span>Pending</span></td>
+        <td>status=pending · outcome=active</td><td>Amber (pulsing)</td>
+        <td>Cancelable by the requester. “Waiting for approval.”</td></tr>
+    <tr><td><span class="statuschip"><span class="dot sky"></span>On the way</span></td>
+        <td>approved / queued / downloading</td><td>Sky</td>
+        <td>Per-target detail (1080p ✓ · 4K 62%) on My Requests rows; single chip elsewhere.</td></tr>
+    <tr><td><span class="statuschip"><span class="dot emerald"></span>In your library</span></td>
+        <td>completed + library_content_id</td><td>Emerald</td>
+        <td>The chip becomes a door: press/tap opens the real item. Request UI retires itself.</td></tr>
+    <tr><td><span class="statuschip"><span class="dot rose"></span>Needs attention</span></td>
+        <td>outcome=declined / failed</td><td>Rose</td>
+        <td>Shows the admin's decline reason verbatim; failed requests can simply be re-requested (server auto-clears them).</td></tr>
+    <tr><td><span class="statuschip"><span class="dot dim"></span>Unavailable</span></td>
+        <td>requestable=false (limit / disabled / blocked)</td><td>Neutral</td>
+        <td>Quiet reason label; the Request affordance simply never renders. Nothing to press, nothing to fail.</td></tr>
+  </table>
+
+  <div class="foot">
+    Silo · Requests UX concepts for iOS &amp; tvOS · 2026-07-02 · Server contract: <code>/api/v1/requests/*</code> (TMDB movie/series, one-tap, server-computed requestability) ·
+    Parity references: web <code>Requests.tsx</code>, Android mobile/TV requests hubs
+  </div>
+</div>
+</body>
+</html>

--- a/iosApp/Tests/MyRequestsBucketTests.swift
+++ b/iosApp/Tests/MyRequestsBucketTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+@testable import Silo
+
+final class MyRequestsBucketTests: XCTestCase {
+    private func record(
+        id: String,
+        status: RequestStatus,
+        outcome: RequestOutcome = .active,
+        createdAt: Date = Date(timeIntervalSince1970: 0)
+    ) -> MediaRequest {
+        MediaRequest(
+            id: id,
+            mediaType: .movie,
+            tmdbId: 1,
+            title: "Title \(id)",
+            year: 2026,
+            overview: nil,
+            posterPath: nil,
+            backdropPath: nil,
+            status: status,
+            outcome: outcome,
+            targets: nil,
+            libraryContentId: nil,
+            lastError: nil,
+            createdAt: createdAt,
+            updatedAt: createdAt,
+            completedAt: nil
+        )
+    }
+
+    func testBucketAssignment() {
+        let buckets = MyRequestsBucket.bucket([
+            record(id: "a", status: .pending),
+            record(id: "b", status: .downloading),
+            record(id: "c", status: .completed),
+            record(id: "d", status: .pending, outcome: .declined),
+            record(id: "e", status: .queued, outcome: .failed),
+        ])
+
+        XCTAssertEqual(buckets.map(\.bucket), [.inMotion, .landed, .needsAttention])
+        XCTAssertEqual(buckets[0].requests.map(\.id).sorted(), ["a", "b"])
+        XCTAssertEqual(buckets[1].requests.map(\.id), ["c"])
+        XCTAssertEqual(buckets[2].requests.map(\.id).sorted(), ["d", "e"])
+    }
+
+    func testCancelledRequestsDropOffEntirely() {
+        let buckets = MyRequestsBucket.bucket([
+            record(id: "a", status: .pending, outcome: .cancelled)
+        ])
+        XCTAssertTrue(buckets.isEmpty)
+    }
+
+    func testEmptyBucketsAreOmitted() {
+        let buckets = MyRequestsBucket.bucket([
+            record(id: "a", status: .completed)
+        ])
+        XCTAssertEqual(buckets.map(\.bucket), [.landed])
+    }
+
+    func testNewestFirstWithinBucket() {
+        let buckets = MyRequestsBucket.bucket([
+            record(id: "old", status: .pending, createdAt: Date(timeIntervalSince1970: 100)),
+            record(id: "new", status: .pending, createdAt: Date(timeIntervalSince1970: 200)),
+        ])
+        XCTAssertEqual(buckets[0].requests.map(\.id), ["new", "old"])
+    }
+}

--- a/iosApp/Tests/RequestDisplayStateTests.swift
+++ b/iosApp/Tests/RequestDisplayStateTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+@testable import Silo
+
+/// The status mapper is the single source of truth for every request chip,
+/// ribbon, bucket, and primary-action state across iOS/tvOS — branch-heavy
+/// pure logic that would regress silently, so it gets exhaustive coverage.
+final class RequestDisplayStateTests: XCTestCase {
+    // MARK: - Record derivation (status × outcome)
+
+    func testActiveOutcomeMapsStatusAxis() {
+        XCTAssertEqual(RequestDisplayState(status: .pending, outcome: .active), .pending)
+        XCTAssertEqual(RequestDisplayState(status: .approved, outcome: .active), .onTheWay)
+        XCTAssertEqual(RequestDisplayState(status: .queued, outcome: .active), .onTheWay)
+        XCTAssertEqual(RequestDisplayState(status: .downloading, outcome: .active), .onTheWay)
+        XCTAssertEqual(RequestDisplayState(status: .completed, outcome: .active), .inLibrary)
+    }
+
+    func testTerminalOutcomesBeatStatus() {
+        // A declined request keeps its last wire status but is terminal.
+        XCTAssertEqual(
+            RequestDisplayState(status: .downloading, outcome: .declined, reason: "no space"),
+            .needsAttention(reason: "no space")
+        )
+        XCTAssertEqual(
+            RequestDisplayState(status: .completed, outcome: .failed),
+            .needsAttention(reason: nil)
+        )
+        XCTAssertEqual(
+            RequestDisplayState(status: .pending, outcome: .cancelled),
+            .unavailable(reason: nil)
+        )
+    }
+
+    func testFailedStatusWithActiveOutcomeNeedsAttention() {
+        // `failed` is target-only on the wire, but tolerate it on a record.
+        XCTAssertEqual(
+            RequestDisplayState(status: .failed, outcome: .active, reason: "grab failed"),
+            .needsAttention(reason: "grab failed")
+        )
+    }
+
+    func testUnknownWireValuesStayInFlight() {
+        // A newer server's added pipeline stage must not read as an error.
+        XCTAssertEqual(RequestDisplayState(status: .unknown, outcome: .active), .onTheWay)
+        XCTAssertEqual(RequestDisplayState(status: .pending, outcome: .unknown), .pending)
+    }
+
+    // MARK: - Card derivation (availability + RequestState)
+
+    private func state(
+        status: RequestStatus? = nil,
+        requestable: Bool,
+        reason: String? = nil
+    ) -> RequestState {
+        RequestState(status: status, requestable: requestable, reason: reason, requestId: nil)
+    }
+
+    func testAvailableAlwaysWins() {
+        // In-library beats any request state — the card is a door, not a chip.
+        let result = RequestDisplayState(
+            availability: .available,
+            request: state(status: .pending, requestable: false)
+        )
+        XCTAssertEqual(result, .inLibrary)
+    }
+
+    func testActiveRequestOnMissingTitle() {
+        XCTAssertEqual(
+            RequestDisplayState(availability: .missing, request: state(status: .pending, requestable: false)),
+            .pending
+        )
+        XCTAssertEqual(
+            RequestDisplayState(availability: .missing, request: state(status: .downloading, requestable: false)),
+            .onTheWay
+        )
+    }
+
+    func testRequestableMissingTitleHasNoChip() {
+        // No state to show — that's the "Request" affordance, not a chip.
+        XCTAssertNil(
+            RequestDisplayState(availability: .missing, request: state(requestable: true))
+        )
+    }
+
+    func testBlockedMissingTitleIsUnavailableWithReason() {
+        XCTAssertEqual(
+            RequestDisplayState(
+                availability: .missing,
+                request: state(requestable: false, reason: "quota_exceeded")
+            ),
+            .unavailable(reason: "quota_exceeded")
+        )
+    }
+
+    // MARK: - Presentation invariants
+
+    func testTintMapping() {
+        XCTAssertEqual(RequestDisplayState.pending.tint, .amber)
+        XCTAssertEqual(RequestDisplayState.onTheWay.tint, .sky)
+        XCTAssertEqual(RequestDisplayState.inLibrary.tint, .emerald)
+        XCTAssertEqual(RequestDisplayState.needsAttention(reason: nil).tint, .rose)
+        XCTAssertEqual(RequestDisplayState.unavailable(reason: nil).tint, .neutral)
+    }
+
+    func testOnlyPendingIsCancelable() {
+        XCTAssertTrue(RequestDisplayState.pending.isCancelable)
+        XCTAssertFalse(RequestDisplayState.onTheWay.isCancelable)
+        XCTAssertFalse(RequestDisplayState.inLibrary.isCancelable)
+        XCTAssertFalse(RequestDisplayState.needsAttention(reason: nil).isCancelable)
+        XCTAssertFalse(RequestDisplayState.unavailable(reason: nil).isCancelable)
+    }
+}

--- a/iosApp/Tests/RequestErrorCopyTests.swift
+++ b/iosApp/Tests/RequestErrorCopyTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import Silo
+
+final class RequestErrorCopyTests: XCTestCase {
+    func testKnownTokens() {
+        XCTAssertEqual(RequestErrorCopy.message(forToken: "already_requested"), "Already requested")
+        XCTAssertEqual(RequestErrorCopy.message(forToken: "already_available"), "Already in your library")
+        XCTAssertEqual(RequestErrorCopy.message(forToken: "quota_exceeded"), "Request limit reached")
+        XCTAssertEqual(RequestErrorCopy.message(forToken: "requests_disabled"), "Requests are turned off")
+        XCTAssertEqual(RequestErrorCopy.message(forToken: "requesting_blocked"), "You can't request media right now")
+        XCTAssertEqual(RequestErrorCopy.message(forToken: "validation_failed"), "That request couldn't be submitted")
+    }
+
+    func testUnknownTokenHumanizes() {
+        // A newly-added server reason must never render as a raw token or
+        // a blank chip.
+        XCTAssertEqual(RequestErrorCopy.message(forToken: "waiting_for_release"), "Waiting For Release")
+        XCTAssertEqual(RequestErrorCopy.message(forToken: "some-dash-reason"), "Some Dash Reason")
+    }
+
+    func testBlankTokenIsNil() {
+        XCTAssertNil(RequestErrorCopy.message(forToken: nil))
+        XCTAssertNil(RequestErrorCopy.message(forToken: ""))
+    }
+
+    func testHTTPErrorPrefersServerToken() {
+        let body = #"{"error":"quota_exceeded","message":"limit hit"}"#
+        let error = HTTPError.http(statusCode: 429, body: body)
+        XCTAssertEqual(RequestErrorCopy.message(for: error), "Request limit reached")
+    }
+
+    func testNonHTTPErrorFallsBackToErrorState() {
+        struct Boom: Error {}
+        XCTAssertFalse(RequestErrorCopy.message(for: Boom()).isEmpty)
+    }
+}

--- a/iosApp/Tests/RequestImageURLTests.swift
+++ b/iosApp/Tests/RequestImageURLTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import Silo
+
+final class RequestImageURLTests: XCTestCase {
+    func testBuildsTMDBURL() {
+        XCTAssertEqual(
+            RequestImageURL.build("/abc123.jpg", size: .poster),
+            "https://image.tmdb.org/t/p/w342/abc123.jpg"
+        )
+        XCTAssertEqual(
+            RequestImageURL.build("/abc123.jpg", size: .backdrop),
+            "https://image.tmdb.org/t/p/w1280/abc123.jpg"
+        )
+    }
+
+    func testAbsoluteURLPassesThrough() {
+        XCTAssertEqual(
+            RequestImageURL.build("https://example.com/x.jpg", size: .poster),
+            "https://example.com/x.jpg"
+        )
+    }
+
+    func testBlankAndMalformedPathsAreNil() {
+        XCTAssertNil(RequestImageURL.build(nil, size: .poster))
+        XCTAssertNil(RequestImageURL.build("", size: .poster))
+        XCTAssertNil(RequestImageURL.build("abc123.jpg", size: .poster))
+    }
+
+    // MARK: - Carousel merge (small enough to share this file)
+
+    private func result(_ id: Int, type: RequestMediaType = .movie) -> RequestMediaResult {
+        RequestMediaResult(
+            mediaType: type,
+            tmdbId: id,
+            title: "Title \(id)",
+            year: 2026,
+            overview: nil,
+            posterPath: nil,
+            backdropPath: nil,
+            releaseDate: nil,
+            voteAverage: nil,
+            availability: .missing,
+            libraryContentId: nil,
+            request: RequestState(status: nil, requestable: true, reason: nil, requestId: nil)
+        )
+    }
+
+    private func section(_ key: String, _ results: [RequestMediaResult]) -> RequestDiscoverySection {
+        RequestDiscoverySection(
+            key: key,
+            title: key,
+            page: 1,
+            totalPages: 1,
+            totalResults: results.count,
+            results: results
+        )
+    }
+
+    func testInterleaveRoundRobinsUnevenLists() {
+        let merged = RequestCarouselMerge.interleave([
+            [result(1), result(2), result(3)],
+            [result(10, type: .series)],
+        ])
+        XCTAssertEqual(merged.map(\.tmdbId), [1, 10, 2, 3])
+    }
+
+    func testInterleaveDropsDuplicateIds() {
+        let merged = RequestCarouselMerge.interleave([
+            [result(1), result(2)],
+            [result(1), result(3)],
+        ])
+        XCTAssertEqual(merged.map(\.tmdbId), [1, 2, 3])
+    }
+
+    func testCarouselsMergeTrendingAndPopular() {
+        let carousels = RequestCarouselMerge.carousels(from: [
+            section("trending_movies", [result(1)]),
+            section("trending_series", [result(2, type: .series)]),
+            section("popular_movies", [result(3)]),
+            section("upcoming_movies", [result(4)]), // not surfaced in v1
+        ])
+        XCTAssertEqual(carousels.map(\.id), ["trending", "popular"])
+        XCTAssertEqual(carousels[0].results.map(\.tmdbId), [1, 2])
+        XCTAssertEqual(carousels[1].results.map(\.tmdbId), [3])
+    }
+
+    func testEmptySectionsProduceNoCarousels() {
+        XCTAssertTrue(RequestCarouselMerge.carousels(from: []).isEmpty)
+    }
+}

--- a/iosApp/iosApp/Components/TabTopBarActions.swift
+++ b/iosApp/iosApp/Components/TabTopBarActions.swift
@@ -10,6 +10,9 @@ struct TabTopBarActions: View {
     let profile: UserProfile?
     let onSearch: () -> Void
     let onOpenSettings: () -> Void
+    /// Opens the media-requests hub. The menu row only renders when the
+    /// server reports `requests_enabled`, so the closure is inert otherwise.
+    let onOpenRequests: () -> Void
     let onSwitchProfile: () -> Void
     let onSwitchServer: () -> Void
     let onSignOut: () -> Void
@@ -23,6 +26,7 @@ struct TabTopBarActions: View {
             ProfileAvatarMenu(
                 profile: profile,
                 onOpenSettings: onOpenSettings,
+                onOpenRequests: onOpenRequests,
                 onSwitchProfile: onSwitchProfile,
                 onSwitchServer: onSwitchServer,
                 onSignOut: onSignOut
@@ -59,12 +63,29 @@ private struct TopBarIconButton: View {
 private struct ProfileAvatarMenu: View {
     let profile: UserProfile?
     let onOpenSettings: () -> Void
+    let onOpenRequests: () -> Void
     let onSwitchProfile: () -> Void
     let onSwitchServer: () -> Void
     let onSignOut: () -> Void
 
+    /// Capability-gated: the Requests row exists only when the server has
+    /// the feature enabled (older servers 404 the probe and read as off).
+    private var requestsEnabled: Bool {
+        RequestsFeatureStore.shared.isEnabled
+    }
+
     var body: some View {
         Menu {
+            if requestsEnabled {
+                Button {
+                    onOpenRequests()
+                } label: {
+                    Label("Requests", systemImage: "sparkles")
+                }
+
+                Divider()
+            }
+
             Button {
                 onOpenSettings()
             } label: {

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -85,6 +85,7 @@ struct ContentView: View {
                 // features stay hidden until a profile switch. Idempotent and
                 // failure-tolerant, so double-calling with `selectProfile` is safe.
                 await AICapabilities.shared.refresh()
+                await RequestsFeatureStore.shared.refresh()
                 #if os(iOS)
                 await ApplePushRegistrationCoordinator.shared.prepareForAuthenticatedProfile()
                 #endif
@@ -127,6 +128,7 @@ struct ContentView: View {
             // natural retry on foreground. `refresh()` is idempotent, so the
             // happy path costs nothing.
             Task { await AICapabilities.shared.refresh() }
+            Task { await RequestsFeatureStore.shared.refresh() }
             #if os(iOS)
             Task {
                 await ApplePushRegistrationCoordinator.shared.prepareForAuthenticatedProfile()
@@ -839,6 +841,12 @@ struct MainTabView: View {
             CollectionDetailView(collectionId: id)
         case .browse(let libraryId):
             BrowseView(libraryId: libraryId)
+        case .requestsHub:
+            RequestsHubView()
+        case .requestDetail(let mediaType, let tmdbId):
+            RequestDetailView(mediaType: mediaType, tmdbId: tmdbId)
+        case .myRequests:
+            MyRequestsView()
         case .admin:
             AdminDashboardView()
         case .search:

--- a/iosApp/iosApp/Navigation/Route.swift
+++ b/iosApp/iosApp/Navigation/Route.swift
@@ -39,6 +39,18 @@ enum Route: Hashable {
     case serverList
     case downloads
 
+    /// Media-requests hub: discover carousels + search-to-request. Entry
+    /// points (profile menu / tvOS profile dropdown) only render when
+    /// `RequestsFeatureStore.shared.isEnabled`.
+    case requestsHub
+
+    /// TMDB title detail with the single server-state-computed request
+    /// action. Titles already in the library route to `.itemDetail` instead.
+    case requestDetail(mediaType: RequestMediaType, tmdbId: Int)
+
+    /// The signed-in user's own request queue, bucketed by state.
+    case myRequests
+
     /// Offline playback of a completed download. Distinct from `.player`
     /// so the player reads the local file + stored manifest instead of
     /// starting a server session.

--- a/iosApp/iosApp/Networking/ContinuumAPI+Requests.swift
+++ b/iosApp/iosApp/Networking/ContinuumAPI+Requests.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+// MARK: - Media requests
+
+/// User-facing endpoints of the server's media-request system
+/// (`/api/v1/requests/*`, TMDB movies + series). Admin moderation stays on
+/// the web — the clients only search, create, track, and cancel.
+extension ContinuumAPI {
+    /// Feature probe — a 404 on older servers means "disabled".
+    func requestsStatus() async throws -> RequestsFeatureStatus {
+        try await http.get("/api/v1/requests/status")
+    }
+
+    /// TMDB search annotated with availability + per-user request state.
+    func requestsSearch(
+        query: String,
+        mediaType: RequestMediaType = .all,
+        page: Int = 1
+    ) async throws -> RequestMediaPage {
+        try await http.get("/api/v1/requests/search", query: [
+            "q": query,
+            "media_type": mediaType.rawValue,
+            "page": String(page),
+        ])
+    }
+
+    /// Curated TMDB carousels (trending/popular/upcoming/on-air).
+    func requestsDiscover() async throws -> [RequestDiscoverySection] {
+        let response: RequestDiscoverResponse = try await http.get("/api/v1/requests/discover")
+        return response.sections
+    }
+
+    func requestsDetail(mediaType: RequestMediaType, tmdbId: Int) async throws -> RequestMediaDetail {
+        try await http.get("/api/v1/requests/detail/\(mediaType.rawValue)/\(tmdbId)")
+    }
+
+    func createRequest(_ input: CreateRequestInput) async throws -> MediaRequest {
+        try await http.post("/api/v1/requests/", body: input)
+    }
+
+    func myRequests(limit: Int = 200, offset: Int = 0) async throws -> [MediaRequest] {
+        let response: MediaRequestsResponse = try await http.get("/api/v1/requests/mine", query: [
+            "limit": String(limit),
+            "offset": String(offset),
+        ])
+        return response.requests
+    }
+
+    /// Owner-cancel; the server only allows this while the request hasn't
+    /// been submitted to an integration yet.
+    func cancelRequest(id: String, reason: String? = nil) async throws -> MediaRequest {
+        try await http.post("/api/v1/requests/\(id)/cancel", body: CancelRequestBody(reason: reason))
+    }
+}

--- a/iosApp/iosApp/Networking/RequestsFeatureStore.swift
+++ b/iosApp/iosApp/Networking/RequestsFeatureStore.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Cached holder for the server's `requests_enabled` feature flag, gating
+/// every media-request entry point (profile-menu row, tvOS dropdown row,
+/// the "Available to request" search section).
+///
+/// Follows the `AICapabilities` precedent: a `@MainActor` `@Observable`
+/// singleton, probed once per session and reset on profile/server switch.
+/// The probe is failure-tolerant — a 404 (older server without the requests
+/// API) or any transient error reads as "disabled", so entry points simply
+/// never render and no error surfaces.
+///
+/// Reset + refresh hooks live in `AuthService`/`ServerRegistry`/`ContentView`
+/// next to the existing `AICapabilities` calls.
+@MainActor
+@Observable
+final class RequestsFeatureStore {
+    static let shared = RequestsFeatureStore()
+
+    /// False until the first successful probe reports the feature on.
+    /// Hiding entry points during the brief startup probe is the correct
+    /// default, so no separate loading state exists.
+    private(set) var isEnabled = false
+
+    /// Bumped on every `reset()` so a probe that finishes after a sign-out
+    /// or profile switch discards its result instead of repopulating the
+    /// next account's flag.
+    private var generation = 0
+
+    private let api: ContinuumAPI
+
+    init(api: ContinuumAPI = .shared) {
+        self.api = api
+    }
+
+    func refresh() async {
+        let gen = generation
+        let status = try? await api.requestsStatus()
+        guard gen == generation else { return }
+        if let status {
+            isEnabled = status.requestsEnabled
+        }
+        // On error, keep the previous value: a transient failure shouldn't
+        // yank an already-visible entry point, and foreground/auth-state
+        // transitions retry naturally.
+    }
+
+    func reset() {
+        generation &+= 1
+        isEnabled = false
+    }
+}

--- a/iosApp/iosApp/Networking/RequestsModels.swift
+++ b/iosApp/iosApp/Networking/RequestsModels.swift
@@ -1,0 +1,224 @@
+import Foundation
+
+// MARK: - Wire enums
+
+/// Media type for the requests domain (TMDB-shaped: movies + series only).
+/// `.all` exists solely as a search-filter query value; the server never
+/// returns it on a result. Unrecognized values decode as `.unknown` so a
+/// future server addition can't fail the whole payload.
+enum RequestMediaType: String, Codable, Hashable, CaseIterable, Identifiable {
+    case movie
+    case series
+    case all
+    case unknown
+
+    var id: Self { self }
+
+    init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = RequestMediaType(rawValue: raw) ?? .unknown
+    }
+
+    var displayName: String {
+        switch self {
+        case .movie: "Movie"
+        case .series: "Series"
+        case .all: "All"
+        case .unknown: "Title"
+        }
+    }
+}
+
+/// Lifecycle status of a request (or of one fulfillment target). `failed`
+/// only appears on targets; requests express failure via `outcome`.
+enum RequestStatus: String, Codable, Hashable {
+    case pending
+    case approved
+    case queued
+    case downloading
+    case completed
+    case failed
+    case unknown
+
+    init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = RequestStatus(rawValue: raw) ?? .unknown
+    }
+}
+
+/// Terminal-vs-active axis, orthogonal to `RequestStatus`: a declined or
+/// cancelled request keeps its last status but flips its outcome.
+enum RequestOutcome: String, Codable, Hashable {
+    case active
+    case declined
+    case cancelled
+    case failed
+    case unknown
+
+    init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = RequestOutcome(rawValue: raw) ?? .unknown
+    }
+}
+
+enum RequestAvailability: String, Codable, Hashable {
+    case missing
+    case available
+    case unknown
+
+    init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = RequestAvailability(rawValue: raw) ?? .unknown
+    }
+}
+
+// MARK: - Feature status
+
+/// `GET /requests/status` — drives every entry point's visibility.
+struct RequestsFeatureStatus: Codable {
+    let requestsEnabled: Bool
+}
+
+// MARK: - Search / discover results
+
+/// The compact per-item request state embedded on every search/discover/
+/// detail result, computed server-side for the signed-in user — the client
+/// never has to reason about duplicates or quotas itself.
+struct RequestState: Codable, Hashable {
+    let status: RequestStatus?
+    let requestable: Bool
+    /// Raw server token (`already_requested`, `quota_exceeded`, …) when not
+    /// requestable. Translated to copy via `RequestErrorCopy` — never
+    /// rendered verbatim.
+    let reason: String?
+    let requestId: String?
+}
+
+/// One TMDB search/discover result annotated with this server's
+/// availability + request state.
+struct RequestMediaResult: Codable, Identifiable, Hashable {
+    let mediaType: RequestMediaType
+    let tmdbId: Int
+    let title: String
+    let year: Int?
+    let overview: String?
+    let posterPath: String?
+    let backdropPath: String?
+    let releaseDate: String?
+    let voteAverage: Double?
+    let availability: RequestAvailability
+    let libraryContentId: String?
+    let request: RequestState
+
+    var id: String { "\(mediaType.rawValue):\(tmdbId)" }
+}
+
+struct RequestMediaPage: Codable {
+    let page: Int
+    let totalPages: Int
+    let totalResults: Int
+    let results: [RequestMediaResult]
+}
+
+/// One curated TMDB carousel from `GET /requests/discover`. Keys are
+/// server-fixed (`trending_movies`, `popular_series`, …).
+struct RequestDiscoverySection: Codable, Identifiable {
+    let key: String
+    let title: String
+    let page: Int
+    let totalPages: Int
+    let totalResults: Int
+    let results: [RequestMediaResult]
+
+    var id: String { key }
+}
+
+struct RequestDiscoverResponse: Codable {
+    let sections: [RequestDiscoverySection]
+}
+
+// MARK: - Detail
+
+/// Full TMDB detail for a requestable title, annotated like `RequestMediaResult`.
+/// The wire payload also carries a `cast` array — not modeled until a
+/// requests surface renders it.
+struct RequestMediaDetail: Codable {
+    let mediaType: RequestMediaType
+    let tmdbId: Int
+    let imdbId: String?
+    let tvdbId: Int?
+    let title: String
+    let tagline: String?
+    let overview: String?
+    let posterPath: String?
+    let backdropPath: String?
+    let releaseDate: String?
+    let year: Int?
+    let runtime: Int?
+    let genres: [String]?
+    let voteAverage: Double?
+    let voteCount: Int?
+    let contentRating: String?
+    let numberOfSeasons: Int?
+    let numberOfEpisodes: Int?
+    let networks: [String]?
+    let director: String?
+    let creators: [String]?
+    let recommendations: [RequestMediaResult]?
+    let availability: RequestAvailability
+    let libraryContentId: String?
+    let request: RequestState
+}
+
+// MARK: - Request records
+
+/// One fulfillment of a request against a single integration at a single
+/// quality; a request fans out to one target per resolved quality.
+struct RequestTarget: Codable, Hashable {
+    let quality: String?
+    let status: RequestStatus
+    let lastError: String?
+}
+
+/// Full request record from `/requests/mine`, `/requests/{id}`, and the
+/// create/cancel responses.
+struct MediaRequest: Codable, Identifiable, Hashable {
+    let id: String
+    let mediaType: RequestMediaType
+    let tmdbId: Int
+    let title: String
+    let year: Int?
+    let overview: String?
+    let posterPath: String?
+    let backdropPath: String?
+    let status: RequestStatus
+    let outcome: RequestOutcome
+    let targets: [RequestTarget]?
+    let libraryContentId: String?
+    let lastError: String?
+    let createdAt: Date
+    let updatedAt: Date
+    let completedAt: Date?
+}
+
+struct MediaRequestsResponse: Codable {
+    let requests: [MediaRequest]
+}
+
+// MARK: - Mutations
+
+struct CreateRequestInput: Encodable {
+    let mediaType: RequestMediaType
+    let tmdbId: Int
+    let tvdbId: Int?
+    let imdbId: String?
+    let title: String
+    let year: Int?
+    let overview: String?
+    let posterPath: String?
+    let backdropPath: String?
+}
+
+struct CancelRequestBody: Encodable {
+    let reason: String?
+}

--- a/iosApp/iosApp/Networking/ServerRegistry.swift
+++ b/iosApp/iosApp/Networking/ServerRegistry.swift
@@ -199,7 +199,11 @@ final class ServerRegistry {
         // drop the previous server's AI capability/quota probes after the URL,
         // profile, active id, and token slot have all been retargeted so any
         // foreground refresh observes one consistent server context.
-        await MainActor.run { AICapabilities.shared.reset() }
+        await MainActor.run {
+            AICapabilities.shared.reset()
+            RequestsFeatureStore.shared.reset()
+            RequestsEventBus.shared.reset()
+        }
     }
 
     /// Sign out from `serverId` without removing the entry. Clears tokens
@@ -239,7 +243,11 @@ final class ServerRegistry {
                 defaults.removeObject(forKey: "profileId")
                 await TokenStore.shared.switchActiveServer(serverId: "")
             }
-            await MainActor.run { AICapabilities.shared.reset() }
+            await MainActor.run {
+                AICapabilities.shared.reset()
+                RequestsFeatureStore.shared.reset()
+                RequestsEventBus.shared.reset()
+            }
         }
         persist()
     }

--- a/iosApp/iosApp/Networking/ServerRegistry.swift
+++ b/iosApp/iosApp/Networking/ServerRegistry.swift
@@ -203,6 +203,12 @@ final class ServerRegistry {
             AICapabilities.shared.reset()
             RequestsFeatureStore.shared.reset()
             RequestsEventBus.shared.reset()
+            // Re-probe against the just-activated server: a switch between
+            // signed-in servers can keep authState at .authenticated, so
+            // without this the Requests entry points would stay hidden
+            // until the next foreground. Fire-and-forget — the probe
+            // degrades to disabled on any failure.
+            Task { await RequestsFeatureStore.shared.refresh() }
         }
     }
 
@@ -247,6 +253,10 @@ final class ServerRegistry {
                 AICapabilities.shared.reset()
                 RequestsFeatureStore.shared.reset()
                 RequestsEventBus.shared.reset()
+                // Same rationale as `switchTo`: the fallback server may
+                // already be signed in, with no auth-state change to
+                // trigger the usual probe.
+                Task { await RequestsFeatureStore.shared.refresh() }
             }
         }
         persist()

--- a/iosApp/iosApp/Screens/Auth/AuthService.swift
+++ b/iosApp/iosApp/Screens/Auth/AuthService.swift
@@ -177,6 +177,7 @@ final class AuthService: @unchecked Sendable {
         // so nothing blocks on this.
         Task { @MainActor in
             await AICapabilities.shared.refresh()
+            await RequestsFeatureStore.shared.refresh()
         }
     }
 
@@ -203,6 +204,8 @@ final class AuthService: @unchecked Sendable {
         // Server-wide AI capability + per-user ASR quota are reset on every
         // profile switch; `selectProfile` re-fetches after the switch lands.
         AICapabilities.shared.reset()
+        RequestsFeatureStore.shared.reset()
+        RequestsEventBus.shared.reset()
         #if os(tvOS)
         ItemDetailCache.shared.clearAll()
         #endif
@@ -271,6 +274,8 @@ final class AuthService: @unchecked Sendable {
         OverlayPrefsStore.shared.clear()
         ProfilePrefsStore.shared.clear()
         AICapabilities.shared.reset()
+        RequestsFeatureStore.shared.reset()
+        RequestsEventBus.shared.reset()
         #if os(tvOS)
         ItemDetailCache.shared.clearAll()
         #endif

--- a/iosApp/iosApp/Screens/Browse/LibrariesTabView.swift
+++ b/iosApp/iosApp/Screens/Browse/LibrariesTabView.swift
@@ -101,6 +101,7 @@ struct LibrariesTabView: View {
                 onLibraryTap: { showPicker = true },
                 onSearch: { router.navigate(to: .search) },
                 onOpenSettings: { router.navigate(to: .settings) },
+                onOpenRequests: { router.navigate(to: .requestsHub) },
                 onSwitchProfile: {
                     AuthService.shared.profileId = nil
                     router.showProfileSelection()
@@ -188,6 +189,7 @@ private struct LibrariesTopBar: View {
     let onLibraryTap: () -> Void
     let onSearch: () -> Void
     let onOpenSettings: () -> Void
+    let onOpenRequests: () -> Void
     let onSwitchProfile: () -> Void
     let onSwitchServer: () -> Void
     let onSignOut: () -> Void
@@ -208,6 +210,7 @@ private struct LibrariesTopBar: View {
                 profile: profile,
                 onSearch: onSearch,
                 onOpenSettings: onOpenSettings,
+                onOpenRequests: onOpenRequests,
                 onSwitchProfile: onSwitchProfile,
                 onSwitchServer: onSwitchServer,
                 onSignOut: onSignOut

--- a/iosApp/iosApp/Screens/Calendar/CalendarView.swift
+++ b/iosApp/iosApp/Screens/Calendar/CalendarView.swift
@@ -122,6 +122,7 @@ struct CalendarView: View {
                     profile: currentProfile,
                     onSearch: { router.navigate(to: .search) },
                     onOpenSettings: { router.navigate(to: .settings) },
+                    onOpenRequests: { router.navigate(to: .requestsHub) },
                     onSwitchProfile: {
                         AuthService.shared.profileId = nil
                         router.showProfileSelection()

--- a/iosApp/iosApp/Screens/Home/HomeView.swift
+++ b/iosApp/iosApp/Screens/Home/HomeView.swift
@@ -127,6 +127,7 @@ struct HomeView: View {
                         profile: currentProfile,
                         onSearch: { router.navigate(to: .search) },
                         onOpenSettings: { router.navigate(to: .settings) },
+                        onOpenRequests: { router.navigate(to: .requestsHub) },
                         onSwitchProfile: {
                             AuthService.shared.profileId = nil
                             router.showProfileSelection()

--- a/iosApp/iosApp/Screens/Recommendations/RecommendationsView.swift
+++ b/iosApp/iosApp/Screens/Recommendations/RecommendationsView.swift
@@ -60,6 +60,7 @@ struct RecommendationsView: View {
                     profile: currentProfile,
                     onSearch: { router.navigate(to: .search) },
                     onOpenSettings: { router.navigate(to: .settings) },
+                    onOpenRequests: { router.navigate(to: .requestsHub) },
                     onSwitchProfile: {
                         AuthService.shared.profileId = nil
                         router.showProfileSelection()

--- a/iosApp/iosApp/Screens/Requests/Components/RequestCardRail.swift
+++ b/iosApp/iosApp/Screens/Requests/Components/RequestCardRail.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+/// Shared layout metrics for the requests surfaces, so the hub, detail,
+/// search section, and My Requests all agree on card geometry.
+enum RequestsUI {
+    #if os(tvOS)
+    /// Slightly denser than `ContinuumTheme.posterCardWidth` so rails fit
+    /// more titles at 10 feet, matching the search grid's card size.
+    static let cardWidth: CGFloat = 220
+    static let railSpacing: CGFloat = 32
+    static let headerSpacing: CGFloat = 20
+    #else
+    static let cardWidth: CGFloat = ContinuumTheme.posterCardWidth
+    static let railSpacing: CGFloat = 12
+    static let headerSpacing: CGFloat = 10
+    #endif
+}
+
+/// Horizontal poster rail shared by every requests surface. Focus scoping
+/// stays with the caller — some rails share a `.focusSection()` with their
+/// header controls (e.g. the hub's "See all" button), so the rail itself
+/// doesn't own one.
+struct RequestCardRail<Item: Identifiable, Card: View>: View {
+    let items: [Item]
+    @ViewBuilder let card: (Item) -> Card
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            LazyHStack(alignment: .top, spacing: RequestsUI.railSpacing) {
+                ForEach(items) { item in
+                    card(item)
+                }
+            }
+        }
+    }
+}

--- a/iosApp/iosApp/Screens/Requests/Components/RequestMediaCard.swift
+++ b/iosApp/iosApp/Screens/Requests/Components/RequestMediaCard.swift
@@ -38,6 +38,13 @@ struct RequestMediaCard: View {
         self.onTap = onTap
     }
 
+    private var accessibilityTitle: String {
+        var label = title
+        if let year, year > 0 { label += ", \(year)" }
+        if let state { label += ", \(state.label)" }
+        return label
+    }
+
     private var width: CGFloat { RequestsUI.cardWidth }
 
     private var height: CGFloat {
@@ -51,6 +58,10 @@ struct RequestMediaCard: View {
                 posterImage
             }
             .buttonStyle(.card)
+            // The caption lives outside the button (so the .card style
+            // lifts only the poster) — without an explicit label VoiceOver
+            // would announce an image-only "Button".
+            .accessibilityLabel(accessibilityTitle)
 
             caption
         }

--- a/iosApp/iosApp/Screens/Requests/Components/RequestMediaCard.swift
+++ b/iosApp/iosApp/Screens/Requests/Components/RequestMediaCard.swift
@@ -1,0 +1,160 @@
+import SwiftUI
+
+/// Poster card for the requests UI: TMDB artwork, an optional status
+/// ribbon, title + year below. A sibling of `MediaCard` rather than a reuse
+/// of it — request results have no `contentId`, no watched state, no
+/// overlays, and their tap routes by availability, so forcing them through
+/// `MediaCard` would bolt unrelated branches onto a heavily-used component.
+///
+/// Two sources render through the same card: TMDB search/discover results
+/// (`RequestMediaResult`) and the user's own request records
+/// (`MediaRequest`). Tap routing is owned by the caller via `onTap`; use
+/// `AppRouter.openRequestResult(_:)` / `openRequestRecord(_:)` for the
+/// standard in-library-vs-request-detail behavior.
+struct RequestMediaCard: View {
+    let title: String
+    let year: Int?
+    let posterPath: String?
+    let state: RequestDisplayState?
+    let onTap: () -> Void
+
+    init(result: RequestMediaResult, onTap: @escaping () -> Void) {
+        self.title = result.title
+        self.year = result.year
+        self.posterPath = result.posterPath
+        self.state = RequestDisplayState(availability: result.availability, request: result.request)
+        self.onTap = onTap
+    }
+
+    init(record: MediaRequest, onTap: @escaping () -> Void) {
+        self.title = record.title
+        self.year = record.year
+        self.posterPath = record.posterPath
+        self.state = RequestDisplayState(
+            status: record.status,
+            outcome: record.outcome,
+            reason: record.lastError
+        )
+        self.onTap = onTap
+    }
+
+    private var width: CGFloat { RequestsUI.cardWidth }
+
+    private var height: CGFloat {
+        width * (ContinuumTheme.posterCardHeight / ContinuumTheme.posterCardWidth)
+    }
+
+    var body: some View {
+        #if os(tvOS)
+        VStack(alignment: .leading, spacing: 22) {
+            Button(action: onTap) {
+                posterImage
+            }
+            .buttonStyle(.card)
+
+            caption
+        }
+        .frame(width: width)
+        #else
+        Button(action: onTap) {
+            VStack(alignment: .leading, spacing: 4) {
+                posterImage
+                caption
+            }
+        }
+        .buttonStyle(.plain)
+        .frame(width: width)
+        #endif
+    }
+
+    private var posterImage: some View {
+        ZStack(alignment: .topTrailing) {
+            if let url = RequestImageURL.build(posterPath, size: .poster) {
+                AsyncImageView(
+                    url: url,
+                    targetSize: CGSize(width: width, height: height),
+                    contentMode: .fill
+                )
+                .frame(width: width, height: height)
+                .clipped()
+            } else {
+                posterPlaceholder
+            }
+
+            if let state {
+                RequestPosterRibbon(state: state)
+                    .padding(ribbonInset)
+            }
+        }
+        .frame(width: width, height: height)
+        .clipShape(RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius))
+    }
+
+    private var posterPlaceholder: some View {
+        ZStack {
+            Rectangle().fill(Color.continuumSurfaceElevated)
+            Text(title)
+                .font(.continuumCaption)
+                .fontWeight(.semibold)
+                .foregroundColor(.continuumSecondaryText)
+                .multilineTextAlignment(.center)
+                .padding(12)
+        }
+        .frame(width: width, height: height)
+    }
+
+    private var caption: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.continuumSubheadline)
+                .foregroundColor(.continuumOnSurface)
+                #if os(tvOS)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                #else
+                .lineLimit(2, reservesSpace: true)
+                #endif
+
+            if let year, year > 0 {
+                Text(String(year))
+                    .font(.continuumCaption)
+                    .foregroundColor(.continuumSecondaryText)
+            }
+        }
+        .frame(width: width, alignment: .leading)
+    }
+
+    private var ribbonInset: CGFloat {
+        #if os(tvOS)
+        14
+        #else
+        6
+        #endif
+    }
+}
+
+// MARK: - Standard tap routing
+
+extension AppRouter {
+    /// The one routing rule for request cards: titles already in the
+    /// library open the real item detail; everything else opens the
+    /// request detail (including already-requested/blocked cards, so the
+    /// user can always see state and reason).
+    func openRequestResult(_ result: RequestMediaResult) {
+        if result.availability == .available, let contentId = result.libraryContentId {
+            navigate(to: .itemDetail(contentId: contentId))
+        } else {
+            navigate(to: .requestDetail(mediaType: result.mediaType, tmdbId: result.tmdbId))
+        }
+    }
+
+    /// Same rule for the user's own request records: completed requests
+    /// open the real item, everything else opens the request detail.
+    func openRequestRecord(_ record: MediaRequest) {
+        if let contentId = record.libraryContentId, !contentId.isEmpty {
+            navigate(to: .itemDetail(contentId: contentId))
+        } else {
+            navigate(to: .requestDetail(mediaType: record.mediaType, tmdbId: record.tmdbId))
+        }
+    }
+}

--- a/iosApp/iosApp/Screens/Requests/Components/RequestStatusChip.swift
+++ b/iosApp/iosApp/Screens/Requests/Components/RequestStatusChip.swift
@@ -1,0 +1,161 @@
+import SwiftUI
+
+extension RequestStatusTint {
+    /// The one place the pure tint enum becomes a `Color`. Chips stay
+    /// monochrome; the dot is the only chromatic element (Skyline grammar —
+    /// the rating amber is the precedent for a single accent token).
+    var color: Color {
+        switch self {
+        case .amber: .requestAmber
+        case .sky: .requestSky
+        case .emerald: .requestEmerald
+        case .rose: .requestRose
+        case .neutral: .continuumSecondaryText
+        }
+    }
+}
+
+/// Monochrome capsule chip with a small colored status dot — the standalone
+/// status presentation used on detail pages and My Requests rows.
+struct RequestStatusChip: View {
+    let state: RequestDisplayState
+    /// Optional detail text after the label (e.g. a decline reason).
+    var detail: String? = nil
+
+    var body: some View {
+        HStack(spacing: dotSpacing) {
+            Circle()
+                .fill(state.tint.color)
+                .frame(width: dotSize, height: dotSize)
+            Text(text)
+                .font(font)
+                .fontWeight(.semibold)
+                .foregroundColor(.continuumOnSurface)
+                .lineLimit(1)
+        }
+        .padding(.horizontal, hPadding)
+        .padding(.vertical, vPadding)
+        .background(
+            Capsule().fill(Color.continuumChromeRestingFill)
+        )
+        .overlay(
+            Capsule().stroke(Color.continuumChromeRestingBorder, lineWidth: 1)
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(text)
+    }
+
+    private var text: String {
+        if let detail, !detail.isEmpty {
+            return "\(state.label) · \(detail)"
+        }
+        return state.label
+    }
+
+    private var font: Font {
+        #if os(tvOS)
+        .system(size: 24)
+        #else
+        .continuumCaption
+        #endif
+    }
+
+    private var dotSize: CGFloat {
+        #if os(tvOS)
+        11
+        #else
+        7
+        #endif
+    }
+
+    private var dotSpacing: CGFloat {
+        #if os(tvOS)
+        10
+        #else
+        6
+        #endif
+    }
+
+    private var hPadding: CGFloat {
+        #if os(tvOS)
+        22
+        #else
+        10
+        #endif
+    }
+
+    private var vPadding: CGFloat {
+        #if os(tvOS)
+        10
+        #else
+        5
+        #endif
+    }
+}
+
+/// Corner ribbon variant of the same state for poster cards — dark glass
+/// capsule pinned top-trailing over the artwork.
+struct RequestPosterRibbon: View {
+    let state: RequestDisplayState
+
+    var body: some View {
+        HStack(spacing: dotSpacing) {
+            Circle()
+                .fill(state.tint.color)
+                .frame(width: dotSize, height: dotSize)
+            Text(state.label)
+                .font(.system(size: fontSize, weight: .bold))
+                .foregroundColor(.white)
+                .lineLimit(1)
+        }
+        .padding(.horizontal, hPadding)
+        .padding(.vertical, vPadding)
+        .background(
+            Capsule().fill(Color.black.opacity(0.62))
+        )
+        .overlay(
+            Capsule().stroke(Color.white.opacity(0.14), lineWidth: 1)
+        )
+        .accessibilityHidden(true)
+    }
+
+    private var fontSize: CGFloat {
+        #if os(tvOS)
+        20
+        #else
+        10
+        #endif
+    }
+
+    private var dotSize: CGFloat {
+        #if os(tvOS)
+        10
+        #else
+        6
+        #endif
+    }
+
+    private var dotSpacing: CGFloat {
+        #if os(tvOS)
+        8
+        #else
+        5
+        #endif
+    }
+
+    private var hPadding: CGFloat {
+        #if os(tvOS)
+        16
+        #else
+        8
+        #endif
+    }
+
+    private var vPadding: CGFloat {
+        #if os(tvOS)
+        8
+        #else
+        4
+        #endif
+    }
+}

--- a/iosApp/iosApp/Screens/Requests/Core/MyRequestsBucket.swift
+++ b/iosApp/iosApp/Screens/Requests/Core/MyRequestsBucket.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// The three My Requests sections, derived purely from
+/// `RequestDisplayState` so bucketing and chip color can never disagree.
+/// Cancelled requests (`.unavailable`) drop off the list entirely —
+/// cancelling is a terminal user action, not a state worth surfacing.
+enum MyRequestsBucket: CaseIterable {
+    case inMotion
+    case landed
+    case needsAttention
+
+    var title: String {
+        switch self {
+        case .inMotion: "In motion"
+        case .landed: "Landed in your library"
+        case .needsAttention: "Needs attention"
+        }
+    }
+
+    init?(_ state: RequestDisplayState) {
+        switch state {
+        case .pending, .onTheWay: self = .inMotion
+        case .inLibrary: self = .landed
+        case .needsAttention: self = .needsAttention
+        case .unavailable: return nil
+        }
+    }
+
+    /// Groups requests into the ordered buckets, newest-first within each,
+    /// omitting empty buckets.
+    static func bucket(_ requests: [MediaRequest]) -> [(bucket: MyRequestsBucket, requests: [MediaRequest])] {
+        var grouped: [MyRequestsBucket: [MediaRequest]] = [:]
+        for request in requests {
+            let state = RequestDisplayState(
+                status: request.status,
+                outcome: request.outcome,
+                reason: request.lastError
+            )
+            guard let bucket = MyRequestsBucket(state) else { continue }
+            grouped[bucket, default: []].append(request)
+        }
+        return MyRequestsBucket.allCases.compactMap { bucket in
+            guard let items = grouped[bucket], !items.isEmpty else { return nil }
+            return (bucket, items.sorted { $0.createdAt > $1.createdAt })
+        }
+    }
+}

--- a/iosApp/iosApp/Screens/Requests/Core/RequestCarouselMerge.swift
+++ b/iosApp/iosApp/Screens/Requests/Core/RequestCarouselMerge.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// One product carousel on the Requests hub, merged from the server's
+/// per-media-type discover sections.
+struct RequestCarousel: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let results: [RequestMediaResult]
+}
+
+enum RequestCarouselMerge {
+    /// The server returns fixed per-type sections; the hub shows exactly two
+    /// product carousels. "Crowd favorites" is client copy for the popular
+    /// sections.
+    static let trendingKeys: Set<String> = ["trending_movies", "trending_series"]
+    static let popularKeys: Set<String> = ["popular_movies", "popular_series"]
+
+    static func carousels(from sections: [RequestDiscoverySection]) -> [RequestCarousel] {
+        [
+            merge(sections, keys: trendingKeys, id: "trending", title: "Trending now"),
+            merge(sections, keys: popularKeys, id: "popular", title: "Crowd favorites"),
+        ].compactMap { $0 }
+    }
+
+    private static func merge(
+        _ sections: [RequestDiscoverySection],
+        keys: Set<String>,
+        id: String,
+        title: String
+    ) -> RequestCarousel? {
+        let matched = sections.filter { keys.contains($0.key) }
+        let results = interleave(matched.map(\.results))
+        guard !results.isEmpty else { return nil }
+        return RequestCarousel(id: id, title: title, results: results)
+    }
+
+    /// Round-robin interleave so neither media type dominates a merged row;
+    /// tolerates uneven list lengths and drops duplicate ids (the same title
+    /// can chart in more than one source section).
+    static func interleave(_ lists: [[RequestMediaResult]]) -> [RequestMediaResult] {
+        var merged: [RequestMediaResult] = []
+        var seen = Set<String>()
+        let longest = lists.map(\.count).max() ?? 0
+        for index in 0..<longest {
+            for list in lists where index < list.count {
+                let item = list[index]
+                guard seen.insert(item.id).inserted else { continue }
+                merged.append(item)
+            }
+        }
+        return merged
+    }
+}

--- a/iosApp/iosApp/Screens/Requests/Core/RequestDisplayState.swift
+++ b/iosApp/iosApp/Screens/Requests/Core/RequestDisplayState.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+/// The five user-facing request states. Chips render monochrome with a
+/// small dot in the state's tint; the same mapping drives poster ribbons,
+/// the detail page's primary action, and My Requests bucketing, so the two
+/// platforms (and every surface on each) can never disagree about what a
+/// given server state looks like.
+///
+/// Deliberately `Foundation`-only — the tint becomes a `Color` in the view
+/// layer (`RequestStatusChip`), keeping this mapper trivially testable.
+enum RequestDisplayState: Equatable {
+    /// Submitted, awaiting approval. Amber. Cancelable by the requester.
+    case pending
+    /// Approved / queued / downloading — somewhere in the pipeline. Sky.
+    case onTheWay
+    /// Completed, or the title was already in the library. Emerald.
+    case inLibrary
+    /// Declined or failed — shows the reason. Rose.
+    case needsAttention(reason: String?)
+    /// Not requestable and no request exists (limit reached, requests off,
+    /// blocked user, …). Neutral — the request affordance simply doesn't
+    /// render. Also covers cancelled requests.
+    case unavailable(reason: String?)
+
+    var label: String {
+        switch self {
+        case .pending: "Pending"
+        case .onTheWay: "On the way"
+        case .inLibrary: "In library"
+        case .needsAttention: "Needs attention"
+        case .unavailable: "Unavailable"
+        }
+    }
+
+    var tint: RequestStatusTint {
+        switch self {
+        case .pending: .amber
+        case .onTheWay: .sky
+        case .inLibrary: .emerald
+        case .needsAttention: .rose
+        case .unavailable: .neutral
+        }
+    }
+
+    /// Whether this state represents an in-flight request the owner may
+    /// still cancel (the server only allows cancel pre-submission, but
+    /// offering it on any pending request and surfacing the server's
+    /// answer is simpler than mirroring that rule client-side).
+    var isCancelable: Bool {
+        self == .pending
+    }
+}
+
+enum RequestStatusTint {
+    case amber, sky, emerald, rose, neutral
+}
+
+// MARK: - Derivation
+
+extension RequestDisplayState {
+    /// From a full request record (`/requests/mine`, detail-after-submit).
+    /// `outcome` wins over `status` for terminal states: a declined request
+    /// keeps its last status on the wire but is no longer in motion.
+    init(status: RequestStatus, outcome: RequestOutcome, reason: String? = nil) {
+        switch outcome {
+        case .declined, .failed:
+            self = .needsAttention(reason: reason)
+            return
+        case .cancelled:
+            self = .unavailable(reason: reason)
+            return
+        case .active, .unknown:
+            break
+        }
+        switch status {
+        case .pending:
+            self = .pending
+        case .approved, .queued, .downloading, .unknown:
+            // Unknown statuses are treated as in-flight rather than broken —
+            // a newer server's added pipeline stage shouldn't read as an
+            // error on older clients.
+            self = .onTheWay
+        case .completed:
+            self = .inLibrary
+        case .failed:
+            self = .needsAttention(reason: reason)
+        }
+    }
+
+    /// From a search/discover/detail card's compact annotations. Returns
+    /// nil when the card has no state to show (missing, requestable, never
+    /// requested) — that's the "Request" affordance state, not a chip.
+    init?(availability: RequestAvailability, request: RequestState) {
+        if availability == .available {
+            self = .inLibrary
+            return
+        }
+        if let status = request.status {
+            self.init(status: status, outcome: .active, reason: request.reason)
+            return
+        }
+        if request.requestable {
+            return nil
+        }
+        self = .unavailable(reason: request.reason)
+    }
+}

--- a/iosApp/iosApp/Screens/Requests/Core/RequestErrorCopy.swift
+++ b/iosApp/iosApp/Screens/Requests/Core/RequestErrorCopy.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Server reason/error token → user-facing copy. Covers both the soft
+/// `RequestState.reason` on a non-requestable card and the structured
+/// `{error, message}` envelope thrown by create/cancel as `HTTPError`.
+/// Unknown tokens humanize (`some_new_reason` → "Some New Reason") so a
+/// newly-added server reason never regresses to a blank chip.
+enum RequestErrorCopy {
+    static func message(forToken token: String?) -> String? {
+        guard let token, !token.isEmpty else { return nil }
+        switch token {
+        case "already_requested": return "Already requested"
+        case "already_available": return "Already in your library"
+        case "quota_exceeded", "limit_reached": return "Request limit reached"
+        case "requests_disabled": return "Requests are turned off"
+        case "requesting_blocked", "blocked": return "You can't request media right now"
+        case "validation_failed": return "That request couldn't be submitted"
+        case "invalid_state": return "This request can no longer be changed"
+        case "not_found": return "This title is no longer available"
+        default: return humanize(token)
+        }
+    }
+
+    /// Copy for a failed create/cancel, preferring the structured server
+    /// token and falling back to `ErrorState`'s generic humanization.
+    static func message(for error: Error) -> String {
+        if let httpError = error as? HTTPError,
+           let token = httpError.serverErrorCode,
+           let copy = message(forToken: token) {
+            return copy
+        }
+        return ErrorState(error).message
+    }
+
+    private static func humanize(_ token: String) -> String {
+        token
+            .split(whereSeparator: { $0 == "_" || $0 == "-" })
+            .map { $0.prefix(1).uppercased() + $0.dropFirst() }
+            .joined(separator: " ")
+    }
+}

--- a/iosApp/iosApp/Screens/Requests/Core/RequestImageURL.swift
+++ b/iosApp/iosApp/Screens/Requests/Core/RequestImageURL.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// TMDB image sizes used by the requests UI. The server hands back raw TMDB
+/// paths (`/abc123.jpg`); clients build CDN URLs directly, matching the web
+/// app (`tmdbImageURL` in `mediaRequests.ts`) and Android — there is no
+/// server-side proxy for these.
+enum RequestImageSize: String {
+    case poster = "w342"
+    case backdrop = "w1280"
+}
+
+enum RequestImageURL {
+    private static let base = "https://image.tmdb.org/t/p/"
+
+    /// Builds a TMDB image URL from a raw path. Passes through values that
+    /// are already absolute URLs (defensive, mirrors Android's
+    /// `requestImageUrl`); returns nil for blank or malformed paths.
+    static func build(_ path: String?, size: RequestImageSize) -> String? {
+        guard let path, !path.isEmpty else { return nil }
+        if path.hasPrefix("http://") || path.hasPrefix("https://") {
+            return path
+        }
+        guard path.hasPrefix("/") else { return nil }
+        return base + size.rawValue + path
+    }
+}

--- a/iosApp/iosApp/Screens/Requests/Core/RequestStateSync.swift
+++ b/iosApp/iosApp/Screens/Requests/Core/RequestStateSync.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// In-place patching of search/discover results after a create or cancel,
+/// so every visible card flips its ribbon immediately without a refetch
+/// (the `RequestsEventBus` consumers all funnel through this).
+extension RequestState {
+    /// The compact card state implied by a full request record. Active
+    /// requests block re-requesting; cancelled ones re-open the affordance
+    /// (the server's duplicate guard only covers `outcome == active`).
+    init(from record: MediaRequest) {
+        switch record.outcome {
+        case .active, .unknown:
+            self.init(
+                status: record.status,
+                requestable: false,
+                reason: nil,
+                requestId: record.id
+            )
+        case .cancelled:
+            self.init(status: nil, requestable: true, reason: nil, requestId: nil)
+        case .declined, .failed:
+            // Server allows re-requesting after decline/failure (failed rows
+            // auto-clear on re-request), but keep the state visible so the
+            // card explains itself; detail refetches authoritative state.
+            self.init(
+                status: record.status,
+                requestable: true,
+                reason: nil,
+                requestId: record.id
+            )
+        }
+    }
+}
+
+extension RequestMediaResult {
+    /// Copy of this result with the request state implied by `record`,
+    /// when the record refers to the same title. Availability is
+    /// deliberately untouched — a mutation never changes what's in the
+    /// library.
+    func applying(_ record: MediaRequest) -> RequestMediaResult {
+        guard record.mediaType == mediaType, record.tmdbId == tmdbId else { return self }
+        return RequestMediaResult(
+            mediaType: mediaType,
+            tmdbId: tmdbId,
+            title: title,
+            year: year,
+            overview: overview,
+            posterPath: posterPath,
+            backdropPath: backdropPath,
+            releaseDate: releaseDate,
+            voteAverage: voteAverage,
+            availability: availability,
+            libraryContentId: libraryContentId,
+            request: RequestState(from: record)
+        )
+    }
+}
+
+extension Array where Element == RequestMediaResult {
+    /// Patch every element that matches the mutated request.
+    mutating func applyRequestUpdate(_ record: MediaRequest) {
+        for index in indices {
+            self[index] = self[index].applying(record)
+        }
+    }
+}

--- a/iosApp/iosApp/Screens/Requests/Detail/RequestDetailView.swift
+++ b/iosApp/iosApp/Screens/Requests/Detail/RequestDetailView.swift
@@ -1,0 +1,425 @@
+import SwiftUI
+
+/// Full-screen detail for a requestable TMDB title: backdrop, poster/meta,
+/// ONE server-state-computed primary action, overview, and a "More like
+/// this" rail. No confirmation dialog — the button is the confirmation and
+/// morphs into the status in place.
+///
+/// tvOS focus safety: the primary action is a single `Button` whose label
+/// and enabled state vary by `RequestPrimaryAction`. It is never swapped
+/// for a different view identity mid-morph, so focus stays put across
+/// request → submitting → pending.
+struct RequestDetailView: View {
+    @State private var viewModel: RequestDetailViewModel
+    @Environment(AppRouter.self) private var router
+
+    init(mediaType: RequestMediaType, tmdbId: Int) {
+        _viewModel = State(initialValue: RequestDetailViewModel(mediaType: mediaType, tmdbId: tmdbId))
+    }
+
+    var body: some View {
+        Group {
+            if let detail = viewModel.detail {
+                loadedContent(detail)
+            } else if let error = viewModel.error {
+                ErrorView(state: error, onRetry: { Task { await viewModel.load() } })
+                    .continuumBackground()
+            } else {
+                LoadingView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .continuumBackground()
+            }
+        }
+        .task(id: viewModel.tmdbId) {
+            await viewModel.load()
+        }
+        .onChange(of: RequestsEventBus.shared.lastUpdate) { _, update in
+            if let update {
+                viewModel.applyRequestUpdate(update)
+            }
+        }
+        #if !os(tvOS)
+        .navigationTitle(viewModel.detail?.title ?? "")
+        .continuumNavigationTitleDisplayMode(.inline)
+        .continuumToolbarColorSchemeDark()
+        .continuumNavigationBarSurfaceBackground()
+        #endif
+    }
+
+    // MARK: - Layout
+
+    private func loadedContent(_ detail: RequestMediaDetail) -> some View {
+        ScrollView {
+            #if os(tvOS)
+            tvContent(detail)
+            #else
+            phoneContent(detail)
+            #endif
+        }
+        .continuumBackground()
+        #if os(tvOS)
+        .background(alignment: .top) {
+            tvBackdrop(detail)
+        }
+        #endif
+    }
+
+    // MARK: - iOS / macOS
+
+    #if !os(tvOS)
+    private func phoneContent(_ detail: RequestMediaDetail) -> some View {
+        VStack(alignment: .leading, spacing: ContinuumTheme.padding) {
+            phoneHero(detail)
+
+            VStack(alignment: .leading, spacing: ContinuumTheme.padding) {
+                primaryActionButton(detail)
+
+                if let message = viewModel.actionErrorMessage {
+                    actionErrorBanner(message)
+                }
+
+                if let overview = detail.overview, !overview.isEmpty {
+                    Text(overview)
+                        .font(.continuumBody)
+                        .foregroundColor(.continuumSecondaryText)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                recommendationsRail
+            }
+            .padding(.horizontal, ContinuumTheme.padding)
+            .padding(.bottom, ContinuumTheme.largePadding)
+        }
+    }
+
+    private func phoneHero(_ detail: RequestMediaDetail) -> some View {
+        ZStack(alignment: .bottomLeading) {
+            if let backdrop = RequestImageURL.build(detail.backdropPath, size: .backdrop) {
+                AsyncImageView(url: backdrop, contentMode: .fill)
+                    .frame(height: 210)
+                    .frame(maxWidth: .infinity)
+                    .clipped()
+                    .overlay(
+                        LinearGradient(
+                            colors: [.clear, Color.continuumBackground.opacity(0.65), .continuumBackground],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+            } else {
+                Rectangle()
+                    .fill(Color.continuumSurfaceElevated)
+                    .frame(height: 120)
+            }
+
+            HStack(alignment: .bottom, spacing: ContinuumTheme.padding) {
+                if let poster = RequestImageURL.build(detail.posterPath, size: .poster) {
+                    AsyncImageView(url: poster, contentMode: .fill)
+                        .frame(width: 96, height: 144)
+                        .clipShape(RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius))
+                        .shadow(color: .black.opacity(0.5), radius: 12, y: 6)
+                }
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(detail.title)
+                        .font(.continuumTitle)
+                        .foregroundColor(.continuumOnSurface)
+                        .lineLimit(2)
+
+                    Text(metaLine(detail))
+                        .font(.continuumCaption)
+                        .foregroundColor(.continuumSecondaryText)
+                        .lineLimit(2)
+                }
+                .padding(.bottom, 4)
+            }
+            .padding(.horizontal, ContinuumTheme.padding)
+            .offset(y: 48)
+        }
+        .padding(.bottom, 48)
+    }
+    #endif
+
+    // MARK: - tvOS
+
+    #if os(tvOS)
+    private func tvBackdrop(_ detail: RequestMediaDetail) -> some View {
+        Group {
+            if let backdrop = RequestImageURL.build(detail.backdropPath, size: .backdrop) {
+                AsyncImageView(url: backdrop, contentMode: .fill)
+            } else {
+                Color.continuumSurface
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .overlay(
+            LinearGradient(
+                colors: [
+                    Color.black.opacity(0.35),
+                    Color.black.opacity(0.72),
+                    Color.continuumBackground,
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        )
+        .ignoresSafeArea()
+    }
+
+    private func tvContent(_ detail: RequestMediaDetail) -> some View {
+        VStack(alignment: .leading, spacing: 40) {
+            Spacer(minLength: 240)
+
+            VStack(alignment: .leading, spacing: 18) {
+                Text(eyebrow(detail))
+                    .font(.system(size: 24, weight: .bold, design: .monospaced))
+                    .tracking(3)
+                    .foregroundColor(.continuumSecondaryText)
+
+                Text(detail.title)
+                    .font(.system(size: 68, weight: .heavy))
+                    .foregroundColor(.continuumOnSurface)
+                    .lineLimit(2)
+
+                Text(metaLine(detail))
+                    .font(.continuumCaption)
+                    .foregroundColor(.continuumSecondaryText)
+                    .lineLimit(1)
+
+                if let overview = detail.overview, !overview.isEmpty {
+                    Text(overview)
+                        .font(.continuumBody)
+                        .foregroundColor(.continuumSecondaryText)
+                        .lineLimit(3)
+                        .frame(maxWidth: 980, alignment: .leading)
+                }
+            }
+
+            HStack(spacing: 24) {
+                primaryActionButton(detail)
+
+                if let message = viewModel.actionErrorMessage {
+                    Text(message)
+                        .font(.continuumCaption)
+                        .foregroundColor(.continuumSecondaryText)
+                } else if case .request = viewModel.primaryAction {
+                    Text("Reviewed by your server admin")
+                        .font(.continuumSmall)
+                        .foregroundColor(.continuumSecondaryText.opacity(0.7))
+                }
+            }
+            .focusSection()
+
+            recommendationsRail
+                .padding(.bottom, 60)
+        }
+        .padding(.horizontal, 80)
+    }
+
+    private func eyebrow(_ detail: RequestMediaDetail) -> String {
+        var parts = ["REQUEST", detail.mediaType.displayName.uppercased()]
+        if detail.availability != .available {
+            parts.append("NOT IN YOUR LIBRARY")
+        }
+        return parts.joined(separator: " · ")
+    }
+    #endif
+
+    // MARK: - Primary action (single Button, morphs in place)
+
+    @ViewBuilder
+    private func primaryActionButton(_ detail: RequestMediaDetail) -> some View {
+        let action = viewModel.primaryAction
+
+        Button {
+            switch action {
+            case .request:
+                Task { await viewModel.submitRequest() }
+            case .openInLibrary(let contentId):
+                router.navigate(to: .itemDetail(contentId: contentId))
+            case .loading, .submitting, .status:
+                break
+            }
+        } label: {
+            HStack(spacing: buttonContentSpacing) {
+                buttonIcon(for: action)
+                Text(buttonTitle(for: action))
+                    .fontWeight(.bold)
+                    .lineLimit(1)
+            }
+            .font(buttonFont)
+            .foregroundColor(buttonForeground(for: action))
+            .padding(.horizontal, buttonHPadding)
+            .padding(.vertical, buttonVPadding)
+            .frame(maxWidth: buttonMaxWidth)
+            .background(
+                Capsule().fill(action.isInteractive ? Color.continuumOnSurface : Color.continuumChromeRestingFill)
+            )
+            .overlay(
+                Capsule().stroke(
+                    action.isInteractive ? Color.clear : Color.continuumChromeRestingBorder,
+                    lineWidth: 1
+                )
+            )
+        }
+        #if os(tvOS)
+        .buttonStyle(.plain)
+        #else
+        .buttonStyle(.borderless)
+        #endif
+        .disabled(!action.isInteractive)
+        .accessibilityLabel(buttonTitle(for: action))
+        .animation(.easeOut(duration: 0.15), value: action.isInteractive)
+    }
+
+    @ViewBuilder
+    private func buttonIcon(for action: RequestPrimaryAction) -> some View {
+        switch action {
+        case .request:
+            Image(systemName: "plus")
+        case .submitting:
+            ProgressView()
+                .controlSize(.small)
+                .tint(.continuumSecondaryText)
+        case .openInLibrary:
+            Image(systemName: "play.fill")
+        case .status(let state):
+            Circle()
+                .fill(state.tint.color)
+                .frame(width: statusDotSize, height: statusDotSize)
+        case .loading:
+            EmptyView()
+        }
+    }
+
+    private func buttonTitle(for action: RequestPrimaryAction) -> String {
+        switch action {
+        case .loading: ""
+        case .request: viewModel.mediaType == .series ? "Request Series" : "Request Movie"
+        case .submitting: "Requesting…"
+        case .openInLibrary: "In Your Library · Open"
+        case .status(let state): statusTitle(state)
+        }
+    }
+
+    private func statusTitle(_ state: RequestDisplayState) -> String {
+        switch state {
+        case .pending: "Requested · Pending"
+        case .onTheWay: "On the way"
+        case .inLibrary: "In your library"
+        case .needsAttention(let reason):
+            RequestErrorCopy.message(forToken: reason).map { "Declined · \($0)" } ?? "Needs attention"
+        case .unavailable(let reason):
+            RequestErrorCopy.message(forToken: reason) ?? "Unavailable"
+        }
+    }
+
+    private func buttonForeground(for action: RequestPrimaryAction) -> Color {
+        action.isInteractive ? .continuumBackground : .continuumOnSurface
+    }
+
+    private func actionErrorBanner(_ message: String) -> some View {
+        Text(message)
+            .font(.continuumCaption)
+            .foregroundColor(.continuumSecondaryText)
+            .frame(maxWidth: .infinity, alignment: .center)
+    }
+
+    // MARK: - Recommendations
+
+    @ViewBuilder
+    private var recommendationsRail: some View {
+        let recommendations = viewModel.recommendations
+        if !recommendations.isEmpty {
+            VStack(alignment: .leading, spacing: RequestsUI.headerSpacing) {
+                Text("More like this")
+                    .font(.continuumHeadline)
+                    .foregroundColor(.continuumOnSurface)
+
+                RequestCardRail(items: recommendations) { result in
+                    RequestMediaCard(result: result, onTap: { router.openRequestResult(result) })
+                }
+            }
+            #if os(tvOS)
+            .focusSection()
+            #endif
+        }
+    }
+
+    // MARK: - Meta helpers
+
+    private func metaLine(_ detail: RequestMediaDetail) -> String {
+        var parts: [String] = []
+        if let year = detail.year, year > 0 { parts.append(String(year)) }
+        if let genres = detail.genres, !genres.isEmpty {
+            parts.append(genres.prefix(3).joined(separator: ", "))
+        }
+        if detail.mediaType == .series {
+            if let seasons = detail.numberOfSeasons, seasons > 0 {
+                parts.append("\(seasons) season\(seasons == 1 ? "" : "s")")
+            }
+        } else if let runtime = detail.runtime, runtime > 0 {
+            parts.append("\(runtime) min")
+        }
+        if let director = detail.director, !director.isEmpty {
+            parts.append(director)
+        } else if let creators = detail.creators, !creators.isEmpty {
+            parts.append(creators.prefix(2).joined(separator: ", "))
+        }
+        if let rating = detail.voteAverage, rating > 0 {
+            parts.append(String(format: "TMDB %.1f", rating))
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    // MARK: - Metrics
+
+    private var buttonFont: Font {
+        #if os(tvOS)
+        .system(size: 30, weight: .semibold)
+        #else
+        .continuumHeadline
+        #endif
+    }
+
+    private var buttonContentSpacing: CGFloat {
+        #if os(tvOS)
+        16
+        #else
+        8
+        #endif
+    }
+
+    private var buttonHPadding: CGFloat {
+        #if os(tvOS)
+        44
+        #else
+        20
+        #endif
+    }
+
+    private var buttonVPadding: CGFloat {
+        #if os(tvOS)
+        22
+        #else
+        13
+        #endif
+    }
+
+    private var buttonMaxWidth: CGFloat? {
+        #if os(tvOS)
+        nil
+        #else
+        .infinity
+        #endif
+    }
+
+    private var statusDotSize: CGFloat {
+        #if os(tvOS)
+        14
+        #else
+        8
+        #endif
+    }
+
+}

--- a/iosApp/iosApp/Screens/Requests/Detail/RequestDetailView.swift
+++ b/iosApp/iosApp/Screens/Requests/Detail/RequestDetailView.swift
@@ -267,9 +267,22 @@ struct RequestDetailView: View {
         #else
         .buttonStyle(.borderless)
         #endif
-        .disabled(!action.isInteractive)
+        .disabled(isButtonDisabled(for: action))
         .accessibilityLabel(buttonTitle(for: action))
         .animation(.easeOut(duration: 0.15), value: action.isInteractive)
+    }
+
+    /// tvOS keeps the CTA enabled even in non-interactive states — a
+    /// disabled Button drops out of the focus graph, which would yank focus
+    /// mid-morph after a submit (the exact drop the single-Button design
+    /// exists to prevent). The action closure already ignores presses in
+    /// non-interactive states, so the button is inert but focusable.
+    private func isButtonDisabled(for action: RequestPrimaryAction) -> Bool {
+        #if os(tvOS)
+        false
+        #else
+        !action.isInteractive
+        #endif
     }
 
     @ViewBuilder

--- a/iosApp/iosApp/Screens/Requests/Detail/RequestDetailViewModel.swift
+++ b/iosApp/iosApp/Screens/Requests/Detail/RequestDetailViewModel.swift
@@ -39,6 +39,9 @@ final class RequestDetailViewModel {
     private(set) var actionErrorMessage: String?
 
     private let api: ContinuumAPI
+    /// In-flight bus-triggered reload; cancelled and replaced on the next
+    /// event so a slow earlier response can't overwrite a newer one.
+    private var reloadTask: Task<Void, Never>?
 
     init(mediaType: RequestMediaType, tmdbId: Int, api: ContinuumAPI = .shared) {
         self.mediaType = mediaType
@@ -113,6 +116,7 @@ final class RequestDetailViewModel {
               record.mediaType == detail.mediaType,
               record.tmdbId == detail.tmdbId,
               !isSubmitting else { return }
-        Task { await load() }
+        reloadTask?.cancel()
+        reloadTask = Task { await load() }
     }
 }

--- a/iosApp/iosApp/Screens/Requests/Detail/RequestDetailViewModel.swift
+++ b/iosApp/iosApp/Screens/Requests/Detail/RequestDetailViewModel.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+/// The single primary action on a request detail page, computed fresh from
+/// server state on every access so the button can never disagree with the
+/// server after a refresh. The view renders exactly ONE button whose
+/// label/action vary by case — never two swapped `Button` identities,
+/// which would drop tvOS focus mid-morph.
+enum RequestPrimaryAction: Equatable {
+    case loading
+    /// The one-tap request CTA.
+    case request
+    /// Submit in flight — same button, relabeled and disabled.
+    case submitting
+    /// A request exists (or the title is blocked); non-interactive.
+    case status(RequestDisplayState)
+    /// Already in the library — the button becomes a door to the item.
+    case openInLibrary(contentId: String)
+
+    var isInteractive: Bool {
+        switch self {
+        case .request, .openInLibrary: true
+        case .loading, .submitting, .status: false
+        }
+    }
+}
+
+@Observable
+@MainActor
+final class RequestDetailViewModel {
+    let mediaType: RequestMediaType
+    let tmdbId: Int
+
+    private(set) var detail: RequestMediaDetail?
+    var isLoading = false
+    var error: ErrorState?
+    private(set) var isSubmitting = false
+    /// Inline banner near the CTA for a failed create (already requested,
+    /// quota, …) — informational, never a blocking alert.
+    private(set) var actionErrorMessage: String?
+
+    private let api: ContinuumAPI
+
+    init(mediaType: RequestMediaType, tmdbId: Int, api: ContinuumAPI = .shared) {
+        self.mediaType = mediaType
+        self.tmdbId = tmdbId
+        self.api = api
+    }
+
+    var primaryAction: RequestPrimaryAction {
+        guard let detail else { return .loading }
+        if detail.availability == .available, let contentId = detail.libraryContentId {
+            return .openInLibrary(contentId: contentId)
+        }
+        if isSubmitting { return .submitting }
+        if let state = RequestDisplayState(availability: detail.availability, request: detail.request) {
+            if case .inLibrary = state, let contentId = detail.libraryContentId {
+                return .openInLibrary(contentId: contentId)
+            }
+            return .status(state)
+        }
+        return .request
+    }
+
+    /// Recommendations, minus rows the card can't route (unknown types).
+    var recommendations: [RequestMediaResult] {
+        (detail?.recommendations ?? []).filter { $0.mediaType != .unknown }
+    }
+
+    func load() async {
+        isLoading = detail == nil
+        error = nil
+        do {
+            detail = try await api.requestsDetail(mediaType: mediaType, tmdbId: tmdbId)
+        } catch {
+            if detail == nil {
+                self.error = ErrorState(error)
+            }
+        }
+        isLoading = false
+    }
+
+    /// One tap, no confirmation dialog — the button is the confirmation.
+    func submitRequest() async {
+        guard let detail, !isSubmitting, primaryAction == .request else { return }
+        isSubmitting = true
+        actionErrorMessage = nil
+        do {
+            let record = try await api.createRequest(CreateRequestInput(
+                mediaType: detail.mediaType,
+                tmdbId: detail.tmdbId,
+                tvdbId: detail.tvdbId,
+                imdbId: detail.imdbId,
+                title: detail.title,
+                year: detail.year,
+                overview: detail.overview,
+                posterPath: detail.posterPath,
+                backdropPath: detail.backdropPath
+            ))
+            RequestsEventBus.shared.publish(record)
+            // Re-fetch so `request` reflects authoritative server state
+            // (id, status, quota effects) rather than a local guess.
+            await load()
+        } catch {
+            actionErrorMessage = RequestErrorCopy.message(for: error)
+        }
+        isSubmitting = false
+    }
+
+    /// Bus consumer: another surface mutated this title (e.g. cancel from
+    /// My Requests while this page sits in the nav stack).
+    func applyRequestUpdate(_ record: MediaRequest) {
+        guard let detail,
+              record.mediaType == detail.mediaType,
+              record.tmdbId == detail.tmdbId,
+              !isSubmitting else { return }
+        Task { await load() }
+    }
+}

--- a/iosApp/iosApp/Screens/Requests/Hub/RequestsHubView.swift
+++ b/iosApp/iosApp/Screens/Requests/Hub/RequestsHubView.swift
@@ -1,0 +1,182 @@
+import SwiftUI
+
+/// The Requests hub: search TMDB to request (primary interaction), the
+/// user's own requests one glance down, then the discover carousels for
+/// lean-back wishlisting. Reached from the profile avatar menu (iOS) or the
+/// profile dropdown (tvOS); both entry points are hidden unless the server
+/// reports `requests_enabled`.
+struct RequestsHubView: View {
+    @State private var viewModel = RequestsHubViewModel()
+    @Environment(AppRouter.self) private var router
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: ContinuumTheme.largePadding) {
+                content
+            }
+            .padding(.horizontal, ContinuumTheme.padding)
+            .padding(.top, ContinuumTheme.smallPadding)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .continuumBackground()
+        #if os(tvOS)
+        .safeAreaPadding(.horizontal, 40)
+        #endif
+        .navigationTitle("Requests")
+        .continuumNavigationTitleDisplayMode(.inline)
+        .continuumToolbarColorSchemeDark()
+        .continuumNavigationBarSurfaceBackground()
+        .continuumSearchable(text: $viewModel.query, prompt: "Search movies & series to request")
+        .task {
+            await viewModel.load()
+        }
+        #if !os(tvOS)
+        .refreshable {
+            await viewModel.load()
+        }
+        #endif
+        .onChange(of: viewModel.query) { _, _ in
+            viewModel.onQueryChanged()
+        }
+        .onChange(of: RequestsEventBus.shared.lastUpdate) { _, update in
+            if let update {
+                viewModel.applyRequestUpdate(update)
+            }
+        }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var content: some View {
+        if !viewModel.isShowingDiscover {
+            searchResults
+        } else if let error = viewModel.error {
+            ErrorView(state: error, onRetry: { Task { await viewModel.load() } })
+        } else if viewModel.isLoading {
+            LoadingView()
+                .frame(maxWidth: .infinity)
+                .padding(.top, 80)
+        } else if viewModel.myRequests.isEmpty && viewModel.carousels.isEmpty {
+            VStack {
+                Spacer(minLength: 80)
+                EmptyStateView(
+                    icon: "sparkles",
+                    title: "Nothing here yet",
+                    subtitle: "Search for a movie or series to request it"
+                )
+            }
+            .frame(maxWidth: .infinity)
+        } else {
+            if !viewModel.myRequests.isEmpty {
+                yourRequestsStrip
+            }
+            ForEach(viewModel.carousels) { carousel in
+                carouselRow(carousel)
+            }
+        }
+    }
+
+    // MARK: - Search results
+
+    @ViewBuilder
+    private var searchResults: some View {
+        if viewModel.isSearching && viewModel.searchResults.isEmpty {
+            LoadingView()
+                .frame(maxWidth: .infinity)
+                .padding(.top, 80)
+        } else if viewModel.hasSearched && viewModel.searchResults.isEmpty {
+            VStack {
+                Spacer(minLength: 80)
+                EmptyStateView(
+                    icon: "magnifyingglass",
+                    title: "No matches",
+                    subtitle: "Nothing on TMDB matched that search"
+                )
+            }
+            .frame(maxWidth: .infinity)
+        } else {
+            LazyVGrid(
+                columns: [GridItem(.adaptive(minimum: RequestsUI.cardWidth), spacing: RequestsUI.railSpacing, alignment: .top)],
+                alignment: .leading,
+                spacing: RequestsUI.railSpacing
+            ) {
+                ForEach(viewModel.searchResults) { result in
+                    RequestMediaCard(result: result, onTap: { router.openRequestResult(result) })
+                }
+            }
+            #if os(tvOS)
+            .focusSection()
+            #endif
+        }
+    }
+
+    // MARK: - Your requests strip
+
+    private var yourRequestsStrip: some View {
+        VStack(alignment: .leading, spacing: RequestsUI.headerSpacing) {
+            HStack(alignment: .firstTextBaseline) {
+                Text("Your requests")
+                    .font(.continuumHeadline)
+                    .foregroundColor(.continuumOnSurface)
+
+                Spacer(minLength: 0)
+
+                Button {
+                    router.navigate(to: .myRequests)
+                } label: {
+                    seeAllLabel
+                }
+                #if os(tvOS)
+                .buttonStyle(.plain)
+                #else
+                .buttonStyle(.borderless)
+                #endif
+            }
+
+            RequestCardRail(items: viewModel.myRequests) { record in
+                RequestMediaCard(record: record, onTap: { router.openRequestRecord(record) })
+            }
+        }
+        #if os(tvOS)
+        .focusSection()
+        #endif
+    }
+
+    private var seeAllLabel: some View {
+        HStack(spacing: 4) {
+            Text("See all")
+            Image(systemName: "chevron.right")
+                .font(.system(size: seeAllChevronSize, weight: .semibold))
+        }
+        .font(.continuumCaption)
+        .foregroundColor(.continuumSecondaryText)
+    }
+
+    // MARK: - Discover carousels
+
+    private func carouselRow(_ carousel: RequestCarousel) -> some View {
+        VStack(alignment: .leading, spacing: RequestsUI.headerSpacing) {
+            Text(carousel.title)
+                .font(.continuumHeadline)
+                .foregroundColor(.continuumOnSurface)
+
+            RequestCardRail(items: carousel.results) { result in
+                RequestMediaCard(result: result, onTap: { router.openRequestResult(result) })
+            }
+        }
+        #if os(tvOS)
+        .focusSection()
+        #endif
+    }
+
+    // MARK: - Metrics
+
+    private var seeAllChevronSize: CGFloat {
+        #if os(tvOS)
+        18
+        #else
+        10
+        #endif
+    }
+}

--- a/iosApp/iosApp/Screens/Requests/Hub/RequestsHubViewModel.swift
+++ b/iosApp/iosApp/Screens/Requests/Hub/RequestsHubViewModel.swift
@@ -70,13 +70,22 @@ final class RequestsHubViewModel {
 
     private func performSearch(_ trimmed: String) async {
         isSearching = true
+        // Cancellation paths must still clear the spinner: a replacement
+        // search re-raises `isSearching` after its own 300ms debounce, so a
+        // cancelled task's `false` can never stomp a successor's `true`.
         do {
             let page = try await api.requestsSearch(query: trimmed)
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled else {
+                isSearching = false
+                return
+            }
             searchResults = page.results.filter { $0.mediaType != .unknown }
             hasSearched = true
         } catch {
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled else {
+                isSearching = false
+                return
+            }
             searchResults = []
             hasSearched = true
         }

--- a/iosApp/iosApp/Screens/Requests/Hub/RequestsHubViewModel.swift
+++ b/iosApp/iosApp/Screens/Requests/Hub/RequestsHubViewModel.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// State for the Requests hub: TMDB search (the primary interaction), the
+/// user's own requests strip, and the two discover carousels. Fetches fresh
+/// on every visit — request state changes server-side asynchronously, so
+/// the stale-while-revalidate `ResponseCache` pattern would actively
+/// mislead here (a stale "Pending" ribbon is worse than a spinner).
+@Observable
+@MainActor
+final class RequestsHubViewModel {
+    // Discover + own-requests strip
+    private(set) var carousels: [RequestCarousel] = []
+    private(set) var myRequests: [MediaRequest] = []
+    var isLoading = false
+    var error: ErrorState?
+
+    // Search
+    var query = ""
+    private(set) var searchResults: [RequestMediaResult] = []
+    private(set) var isSearching = false
+    private(set) var hasSearched = false
+
+    private var searchTask: Task<Void, Never>?
+    private let api: ContinuumAPI
+
+    init(api: ContinuumAPI = .shared) {
+        self.api = api
+    }
+
+    /// True while the hub should show discover content (no active query).
+    var isShowingDiscover: Bool {
+        query.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    func load() async {
+        isLoading = carousels.isEmpty && myRequests.isEmpty
+        error = nil
+        async let discover = api.requestsDiscover()
+        async let mine = api.myRequests()
+        do {
+            let (sections, requests) = try await (discover, mine)
+            carousels = RequestCarouselMerge.carousels(from: sections)
+            myRequests = MyRequestsBucket.bucket(requests).flatMap(\.requests)
+        } catch {
+            // Keep any prior content on a transient failure; only surface
+            // the error when there's nothing to show instead.
+            if carousels.isEmpty, myRequests.isEmpty {
+                self.error = ErrorState(error)
+            }
+        }
+        isLoading = false
+    }
+
+    /// Debounced TMDB search, mirroring `SearchViewModel`'s 300ms feel.
+    func onQueryChanged() {
+        searchTask?.cancel()
+        let trimmed = query.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else {
+            searchResults = []
+            isSearching = false
+            hasSearched = false
+            return
+        }
+        searchTask = Task {
+            try? await Task.sleep(nanoseconds: 300_000_000)
+            guard !Task.isCancelled else { return }
+            await performSearch(trimmed)
+        }
+    }
+
+    private func performSearch(_ trimmed: String) async {
+        isSearching = true
+        do {
+            let page = try await api.requestsSearch(query: trimmed)
+            guard !Task.isCancelled else { return }
+            searchResults = page.results.filter { $0.mediaType != .unknown }
+            hasSearched = true
+        } catch {
+            guard !Task.isCancelled else { return }
+            searchResults = []
+            hasSearched = true
+        }
+        isSearching = false
+    }
+
+    /// Bus consumer: patch every visible surface in place after a mutation
+    /// anywhere in the app (detail submit, My Requests cancel, …).
+    func applyRequestUpdate(_ record: MediaRequest) {
+        searchResults.applyRequestUpdate(record)
+        carousels = carousels.map { carousel in
+            var results = carousel.results
+            results.applyRequestUpdate(record)
+            return RequestCarousel(id: carousel.id, title: carousel.title, results: results)
+        }
+        if let index = myRequests.firstIndex(where: { $0.id == record.id }) {
+            if record.outcome == .cancelled {
+                myRequests.remove(at: index)
+            } else {
+                myRequests[index] = record
+            }
+        } else if record.outcome == .active {
+            myRequests.insert(record, at: 0)
+        }
+    }
+}

--- a/iosApp/iosApp/Screens/Requests/MyRequests/MyRequestsView.swift
+++ b/iosApp/iosApp/Screens/Requests/MyRequests/MyRequestsView.swift
@@ -1,0 +1,240 @@
+import SwiftUI
+
+/// The signed-in user's request queue, bucketed like the web's "Yours" tab:
+/// In motion / Landed in your library / Needs attention. Pending requests
+/// can be cancelled (swipe on iOS, long-press context menu on tvOS);
+/// completed rows deep-link into the real library item.
+struct MyRequestsView: View {
+    @State private var viewModel = MyRequestsViewModel()
+    @Environment(AppRouter.self) private var router
+
+    var body: some View {
+        Group {
+            if let error = viewModel.error, viewModel.buckets.isEmpty {
+                ErrorView(state: error, onRetry: { Task { await viewModel.load() } })
+            } else if viewModel.isLoading && viewModel.buckets.isEmpty {
+                LoadingView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if viewModel.isEmpty {
+                EmptyStateView(
+                    icon: "sparkles",
+                    title: "No requests yet",
+                    subtitle: "Movies and series you request will show up here"
+                )
+            } else {
+                bucketList
+            }
+        }
+        .continuumBackground()
+        .navigationTitle("My Requests")
+        .continuumNavigationTitleDisplayMode(.inline)
+        .continuumToolbarColorSchemeDark()
+        .continuumNavigationBarSurfaceBackground()
+        .task {
+            await viewModel.load()
+        }
+        .onChange(of: RequestsEventBus.shared.lastUpdate) { _, update in
+            if let update {
+                viewModel.applyRequestUpdate(update)
+            }
+        }
+        #if !os(tvOS)
+        .refreshable {
+            await viewModel.load()
+        }
+        #endif
+    }
+
+    // MARK: - Buckets
+
+    private var bucketList: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: sectionSpacing) {
+                if let message = viewModel.actionErrorMessage {
+                    Text(message)
+                        .font(.continuumCaption)
+                        .foregroundColor(.continuumSecondaryText)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                }
+
+                ForEach(viewModel.buckets, id: \.bucket) { entry in
+                    bucketSection(entry.bucket, requests: entry.requests)
+                }
+            }
+            .padding(.horizontal, ContinuumTheme.padding)
+            .padding(.top, ContinuumTheme.smallPadding)
+            .padding(.bottom, ContinuumTheme.largePadding)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        #if os(tvOS)
+        .safeAreaPadding(.horizontal, 40)
+        #endif
+    }
+
+    @ViewBuilder
+    private func bucketSection(_ bucket: MyRequestsBucket, requests: [MediaRequest]) -> some View {
+        VStack(alignment: .leading, spacing: rowSpacing) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(bucket.title)
+                    .font(.continuumHeadline)
+                    .foregroundColor(.continuumOnSurface)
+                Text(String(requests.count))
+                    .font(.continuumCaption)
+                    .foregroundColor(.continuumSecondaryText)
+            }
+
+            #if os(tvOS)
+            RequestCardRail(items: requests) { record in
+                RequestMediaCard(record: record, onTap: { router.openRequestRecord(record) })
+                    .contextMenu {
+                        if isCancelable(record) {
+                            Button(role: .destructive) {
+                                Task { await viewModel.cancel(record) }
+                            } label: {
+                                Label("Cancel Request", systemImage: "xmark.circle")
+                            }
+                        }
+                    }
+            }
+            .focusSection()
+            #else
+            VStack(spacing: rowSpacing) {
+                ForEach(requests) { record in
+                    requestRow(record)
+                }
+            }
+            #endif
+        }
+    }
+
+    // MARK: - iOS/macOS rows
+
+    #if !os(tvOS)
+    private func requestRow(_ record: MediaRequest) -> some View {
+        Button {
+            router.openRequestRecord(record)
+        } label: {
+            HStack(spacing: 12) {
+                rowThumb(record)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(record.title)
+                        .font(.continuumSubheadline)
+                        .foregroundColor(.continuumOnSurface)
+                        .lineLimit(1)
+
+                    Text(rowMeta(record))
+                        .font(.continuumCaption)
+                        .foregroundColor(.continuumSecondaryText)
+                        .lineLimit(2)
+                }
+
+                Spacer(minLength: 8)
+
+                RequestStatusChip(state: rowState(record))
+            }
+            .padding(10)
+            .background(
+                RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius)
+                    .fill(Color.continuumSurface)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius)
+                    .stroke(Color.continuumOutline.opacity(0.6), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(viewModel.cancellingId == record.id)
+        .opacity(viewModel.cancellingId == record.id ? 0.5 : 1)
+        .contextMenu {
+            if isCancelable(record) {
+                Button(role: .destructive) {
+                    Task { await viewModel.cancel(record) }
+                } label: {
+                    Label("Cancel Request", systemImage: "xmark.circle")
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func rowThumb(_ record: MediaRequest) -> some View {
+        if let url = RequestImageURL.build(record.posterPath, size: .poster) {
+            AsyncImageView(
+                url: url,
+                targetSize: CGSize(width: 46, height: 69),
+                contentMode: .fill
+            )
+            .frame(width: 46, height: 69)
+            .clipped()
+            .clipShape(RoundedRectangle(cornerRadius: ContinuumTheme.smallCornerRadius))
+        } else {
+            RoundedRectangle(cornerRadius: ContinuumTheme.smallCornerRadius)
+                .fill(Color.continuumSurfaceElevated)
+                .frame(width: 46, height: 69)
+        }
+    }
+    #endif
+
+    // MARK: - Row derivation
+
+    private func rowState(_ record: MediaRequest) -> RequestDisplayState {
+        RequestDisplayState(status: record.status, outcome: record.outcome, reason: record.lastError)
+    }
+
+    private func isCancelable(_ record: MediaRequest) -> Bool {
+        rowState(record).isCancelable
+    }
+
+    private func rowMeta(_ record: MediaRequest) -> String {
+        var parts = [record.mediaType.displayName]
+        if let summary = targetSummary(record) {
+            parts.append(summary)
+        } else {
+            parts.append("requested \(record.createdAt.formatted(.dateTime.month(.abbreviated).day()))")
+        }
+        if case .needsAttention(let reason) = rowState(record),
+           let copy = RequestErrorCopy.message(forToken: reason) {
+            parts.append(copy)
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    /// "1080p done · 4K downloading" for multi-target requests in flight.
+    private func targetSummary(_ record: MediaRequest) -> String? {
+        guard let targets = record.targets, targets.count > 1 else { return nil }
+        let summaries = targets.compactMap { target -> String? in
+            guard let quality = target.quality, !quality.isEmpty else { return nil }
+            let word: String
+            switch target.status {
+            case .completed: word = "done"
+            case .downloading: word = "downloading"
+            case .queued, .approved: word = "queued"
+            case .pending: word = "pending"
+            case .failed: word = "failed"
+            case .unknown: return nil
+            }
+            return "\(quality) \(word)"
+        }
+        guard !summaries.isEmpty else { return nil }
+        return summaries.joined(separator: " · ")
+    }
+
+    // MARK: - Metrics
+
+    private var sectionSpacing: CGFloat {
+        #if os(tvOS)
+        48
+        #else
+        24
+        #endif
+    }
+
+    private var rowSpacing: CGFloat {
+        #if os(tvOS)
+        20
+        #else
+        10
+        #endif
+    }
+}

--- a/iosApp/iosApp/Screens/Requests/MyRequests/MyRequestsViewModel.swift
+++ b/iosApp/iosApp/Screens/Requests/MyRequests/MyRequestsViewModel.swift
@@ -12,6 +12,9 @@ final class MyRequestsViewModel {
     private(set) var actionErrorMessage: String?
 
     private var hasLoaded = false
+    /// In-flight bus-triggered reload; cancelled and replaced on the next
+    /// event so a slow earlier response can't overwrite a newer one.
+    private var reloadTask: Task<Void, Never>?
     private let api: ContinuumAPI
 
     init(api: ContinuumAPI = .shared) {
@@ -56,6 +59,7 @@ final class MyRequestsViewModel {
     /// correct response.
     func applyRequestUpdate(_ record: MediaRequest) {
         guard cancellingId == nil else { return }
-        Task { await load() }
+        reloadTask?.cancel()
+        reloadTask = Task { await load() }
     }
 }

--- a/iosApp/iosApp/Screens/Requests/MyRequests/MyRequestsViewModel.swift
+++ b/iosApp/iosApp/Screens/Requests/MyRequests/MyRequestsViewModel.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+@Observable
+@MainActor
+final class MyRequestsViewModel {
+    private(set) var buckets: [(bucket: MyRequestsBucket, requests: [MediaRequest])] = []
+    var isLoading = false
+    var error: ErrorState?
+    /// Id of the request currently being cancelled (disables its row).
+    private(set) var cancellingId: String?
+    /// Inline message for a failed cancel; cleared on the next action.
+    private(set) var actionErrorMessage: String?
+
+    private var hasLoaded = false
+    private let api: ContinuumAPI
+
+    init(api: ContinuumAPI = .shared) {
+        self.api = api
+    }
+
+    var isEmpty: Bool {
+        hasLoaded && buckets.isEmpty
+    }
+
+    func load() async {
+        isLoading = buckets.isEmpty
+        error = nil
+        do {
+            let requests = try await api.myRequests()
+            buckets = MyRequestsBucket.bucket(requests)
+            hasLoaded = true
+        } catch {
+            if buckets.isEmpty {
+                self.error = ErrorState(error)
+            }
+        }
+        isLoading = false
+    }
+
+    func cancel(_ request: MediaRequest) async {
+        guard cancellingId == nil else { return }
+        cancellingId = request.id
+        actionErrorMessage = nil
+        do {
+            let updated = try await api.cancelRequest(id: request.id)
+            RequestsEventBus.shared.publish(updated)
+            await load()
+        } catch {
+            actionErrorMessage = RequestErrorCopy.message(for: error)
+        }
+        cancellingId = nil
+    }
+
+    /// Bus consumer: a mutation elsewhere (detail submit) while this screen
+    /// is mounted — the list is short, so a full refetch is the simplest
+    /// correct response.
+    func applyRequestUpdate(_ record: MediaRequest) {
+        guard cancellingId == nil else { return }
+        Task { await load() }
+    }
+}

--- a/iosApp/iosApp/Screens/Requests/RequestsEventBus.swift
+++ b/iosApp/iosApp/Screens/Requests/RequestsEventBus.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Broadcast of the most recent request mutation (create/cancel result) so
+/// every mounted requests surface can patch its own items in place instead
+/// of refetching. A broadcast value, not a queue — a screen that mounts
+/// after the event fired does its normal fetch and already sees current
+/// state.
+@MainActor
+@Observable
+final class RequestsEventBus {
+    static let shared = RequestsEventBus()
+
+    private(set) var lastUpdate: MediaRequest?
+
+    func publish(_ request: MediaRequest) {
+        lastUpdate = request
+    }
+
+    /// Sign-out / profile switch: don't leak one account's last mutation
+    /// into the next session's `.onChange` observers.
+    func reset() {
+        lastUpdate = nil
+    }
+}

--- a/iosApp/iosApp/Screens/Requests/Search/RequestSearchSectionView.swift
+++ b/iosApp/iosApp/Screens/Requests/Search/RequestSearchSectionView.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+/// The "Available to request" section embedded in the library `SearchView`
+/// below local results: TMDB matches the library can't answer, one tap from
+/// the query the user already typed. Renders nothing when the feature is
+/// disabled or there's nothing requestable to show, so the search screen is
+/// untouched on servers without requests.
+struct RequestSearchSectionView: View {
+    let viewModel: RequestSearchSectionViewModel
+    @Environment(AppRouter.self) private var router
+
+    var body: some View {
+        if !viewModel.results.isEmpty {
+            VStack(alignment: .leading, spacing: RequestsUI.headerSpacing) {
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "sparkles")
+                            .font(.continuumCaption)
+                        Text("Available to request")
+                            .font(.continuumHeadline)
+                    }
+                    .foregroundColor(.continuumOnSurface)
+
+                    Text("Not in the library yet · tap to request")
+                        .font(.continuumSmall)
+                        .foregroundColor(.continuumSecondaryText)
+                }
+
+                RequestCardRail(items: viewModel.results) { result in
+                    RequestMediaCard(result: result, onTap: { router.openRequestResult(result) })
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            #if os(tvOS)
+            .focusSection()
+            #endif
+            .onChange(of: RequestsEventBus.shared.lastUpdate) { _, update in
+                if let update {
+                    viewModel.applyRequestUpdate(update)
+                }
+            }
+        }
+    }
+
+}

--- a/iosApp/iosApp/Screens/Requests/Search/RequestSearchSectionViewModel.swift
+++ b/iosApp/iosApp/Screens/Requests/Search/RequestSearchSectionViewModel.swift
@@ -40,9 +40,15 @@ final class RequestSearchSectionViewModel {
 
     private func performSearch(_ trimmed: String) async {
         isLoading = true
+        // Cancellation paths must still clear the spinner: a replacement
+        // search re-raises `isLoading` after its own 300ms debounce, so a
+        // cancelled task's `false` can never stomp a successor's `true`.
         do {
             let page = try await api.requestsSearch(query: trimmed)
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled else {
+                isLoading = false
+                return
+            }
             // Only titles the library can't already answer — in-library
             // matches are what the catalog grid above is for.
             results = page.results
@@ -50,7 +56,10 @@ final class RequestSearchSectionViewModel {
                 .prefix(maxResults)
                 .map { $0 }
         } catch {
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled else {
+                isLoading = false
+                return
+            }
             // Silent: this is a supplementary strip, not the primary search.
             results = []
         }

--- a/iosApp/iosApp/Screens/Requests/Search/RequestSearchSectionViewModel.swift
+++ b/iosApp/iosApp/Screens/Requests/Search/RequestSearchSectionViewModel.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Backs the "Available to request" section embedded in the library
+/// `SearchView`. Driven by the same query string the catalog search owns
+/// (one text field, one debounce feel, two independent result sets and
+/// failure domains — a requests-API error just hides this supplementary
+/// section without touching the primary search).
+@Observable
+@MainActor
+final class RequestSearchSectionViewModel {
+    private(set) var results: [RequestMediaResult] = []
+    private(set) var isLoading = false
+
+    private var searchTask: Task<Void, Never>?
+    private let api: ContinuumAPI
+
+    /// Cap the inline strip — it supplements library results, it doesn't
+    /// replace the hub's full search.
+    private let maxResults = 12
+
+    init(api: ContinuumAPI = .shared) {
+        self.api = api
+    }
+
+    func onQueryChanged(_ query: String) {
+        searchTask?.cancel()
+        let trimmed = query.trimmingCharacters(in: .whitespaces)
+        guard RequestsFeatureStore.shared.isEnabled, trimmed.count > 1 else {
+            results = []
+            isLoading = false
+            return
+        }
+        searchTask = Task {
+            // Same 300ms debounce as `SearchViewModel` for a single feel.
+            try? await Task.sleep(nanoseconds: 300_000_000)
+            guard !Task.isCancelled else { return }
+            await performSearch(trimmed)
+        }
+    }
+
+    private func performSearch(_ trimmed: String) async {
+        isLoading = true
+        do {
+            let page = try await api.requestsSearch(query: trimmed)
+            guard !Task.isCancelled else { return }
+            // Only titles the library can't already answer — in-library
+            // matches are what the catalog grid above is for.
+            results = page.results
+                .filter { $0.availability != .available && $0.mediaType != .unknown }
+                .prefix(maxResults)
+                .map { $0 }
+        } catch {
+            guard !Task.isCancelled else { return }
+            // Silent: this is a supplementary strip, not the primary search.
+            results = []
+        }
+        isLoading = false
+    }
+
+    /// Bus consumer: flip ribbons in place after a create elsewhere.
+    func applyRequestUpdate(_ record: MediaRequest) {
+        results.applyRequestUpdate(record)
+    }
+}

--- a/iosApp/iosApp/Screens/Search/SearchView.swift
+++ b/iosApp/iosApp/Screens/Search/SearchView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// Full-screen search with debounced query and grid results — Plezy style.
 struct SearchView: View {
     @State private var viewModel = SearchViewModel()
+    @State private var requestsViewModel = RequestSearchSectionViewModel()
     @State private var navPrefs = AppNavPreferences.shared
     @Environment(AppRouter.self) private var router
     #if os(iOS)
@@ -34,6 +35,11 @@ struct SearchView: View {
                 }
 
                 content
+
+                // TMDB titles the library can't answer — the request
+                // system's organic entry point. Renders nothing when the
+                // server has requests disabled.
+                RequestSearchSectionView(viewModel: requestsViewModel)
             }
             .padding(.horizontal, ContinuumTheme.padding)
             #if os(tvOS)
@@ -62,6 +68,7 @@ struct SearchView: View {
         #endif
         .onChange(of: viewModel.query) { _, _ in
             viewModel.onQueryChanged()
+            requestsViewModel.onQueryChanged(viewModel.query)
         }
         .onChange(of: viewModel.selectedMediaType) { _, _ in
             Task { await viewModel.applyMediaType() }

--- a/iosApp/iosApp/Theme/Colors.swift
+++ b/iosApp/iosApp/Theme/Colors.swift
@@ -59,6 +59,22 @@ extension Color {
     /// Page scrim behind anchored dropdowns — `scrim.dropdown`, black @ 55%
     static let continuumDropdownScrim = Color.black.opacity(0.55)
 
+    // MARK: - Request status dots
+
+    /// The requests UI keeps chips monochrome; these tint only the small
+    /// status dot (and match the web app's ribbon palette so both clients
+    /// speak one status language). Pending — amber.
+    static let requestAmber = Color(hex: "#F59E0B")
+
+    /// Approved / queued / downloading — sky.
+    static let requestSky = Color(hex: "#38BDF8")
+
+    /// Completed / in library — emerald.
+    static let requestEmerald = Color(hex: "#34D399")
+
+    /// Declined / failed — rose.
+    static let requestRose = Color(hex: "#FB7185")
+
     // MARK: - Semantic Aliases
 
     /// Outline/border color — white at 12%

--- a/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
@@ -442,6 +442,7 @@ struct TVMainTabView: View {
             onWatchlist: { closePanel(then: { router.navigate(to: .watchlist) }) },
             onFavorites: { closePanel(then: { router.navigate(to: .favorites) }) },
             onHistory: { closePanel(then: { router.navigate(to: .history) }) },
+            onRequests: { closePanel(then: { router.navigate(to: .requestsHub) }) },
             onSettings: { closePanel(then: { router.navigate(to: .settings) }) },
             onSwitchServer: { closePanel(then: { showServerPicker = true }) },
             onSignOut: { closePanel(then: { router.signOutAndReset() }) }
@@ -895,6 +896,12 @@ struct TVMainTabView: View {
             CollectionDetailView(collectionId: id)
         case .browse(let libraryId):
             BrowseView(libraryId: libraryId)
+        case .requestsHub:
+            RequestsHubView()
+        case .requestDetail(let mediaType, let tmdbId):
+            RequestDetailView(mediaType: mediaType, tmdbId: tmdbId)
+        case .myRequests:
+            MyRequestsView()
         case .admin:
             AdminDashboardView()
         case .search:

--- a/iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift
@@ -938,6 +938,7 @@ private enum TVProfileAction: Hashable {
     case watchlist
     case favorites
     case history
+    case requests
     case settings
     case switchServer
     case signOut
@@ -964,12 +965,19 @@ struct TVProfileDropdown: View {
     let onWatchlist: () -> Void
     let onFavorites: () -> Void
     let onHistory: () -> Void
+    let onRequests: () -> Void
     let onSettings: () -> Void
     let onSwitchServer: () -> Void
     let onSignOut: () -> Void
 
     @FocusState private var focusedAction: TVProfileAction?
     @State private var lastAppliedEntryToken = 0
+
+    /// Capability-gated: the Requests row only exists (and only takes a
+    /// focus slot) when the server reports `requests_enabled`.
+    private var showRequests: Bool {
+        RequestsFeatureStore.shared.isEnabled
+    }
 
     var body: some View {
         panel
@@ -1001,6 +1009,9 @@ struct TVProfileDropdown: View {
             actionButton("Watchlist", systemImage: "bookmark.fill", id: .watchlist, action: onWatchlist)
             actionButton("Favorites", systemImage: "heart.fill", id: .favorites, action: onFavorites)
             actionButton("History", systemImage: "clock.fill", id: .history, action: onHistory)
+            if showRequests {
+                actionButton("Requests", systemImage: "sparkles", id: .requests, action: onRequests)
+            }
 
             divider
 


### PR DESCRIPTION
## Summary

Brings the server's media-request system (already live on web and Android) to the Apple clients — user-facing only; moderation stays in the web admin. The entire feature is gated on `GET /api/v1/requests/status`, so servers without the feature (or with it disabled, or pre-requests servers that 404 the probe) show no request UI at all.

### UX

- **Request from search** — the library `SearchView` grows an "Available to request" TMDB section below local results: request the title you just failed to find, with the query already typed (one extra row on tvOS, no second keyboard).
- **Requests hub** (`Route.requestsHub`) — TMDB search, the user's own requests strip with status ribbons, and Trending / Crowd favorites discover carousels. Entry: profile avatar menu (iOS), profile dropdown (tvOS).
- **Request detail** — slim title page with ONE server-state-computed primary action that morphs in place (Request → Requesting… → Pending); no confirmation dialog. Kept as a single `Button` identity so tvOS focus never drops mid-morph. Completed titles route to the real item detail.
- **My Requests** — In motion / Landed in your library / Needs attention buckets (web "Yours" parity), per-quality target summaries ("1080p done · 4K downloading"), cancel for pending requests.
- **Status language** — monochrome chips/ribbons with a single colored dot (amber pending / sky on-the-way / emerald in-library / rose needs-attention), identical mapping on both platforms.

### Architecture

- Typed endpoints as a `ContinuumAPI` extension; wire models rely on the existing snake_case decoding with unknown-tolerant enums (a new server status can never fail a whole payload).
- Tested pure core (`Screens/Requests/Core/`) for status mapping, bucketing, error-token copy, TMDB image URLs, and carousel merging — mirrors Android's `RequestPresentation` so both clients encode identical rules.
- `RequestsFeatureStore` clones the `AICapabilities` capability-gate pattern (generation-guarded; reset on sign-out / profile / server switch).
- `RequestsEventBus` patches every visible card/ribbon in place after a create/cancel.
- UX concepts in `docs/requests/mockups.html`.

## Testing

- `Silo` (iOS), `SiloTV` (tvOS), and `SiloMac` all build green.
- 26 focused XCTests on the pure core (status mapping, bucketing, error copy, image URLs, carousel merge) all pass.
- Wire shapes verified field-for-field against `silo-server` (`internal/requests/types.go`, handlers, router), including date formats and the `POST /requests/` trailing-slash route.
- Remaining before merge: smoke test against a live server with requests enabled; tvOS d-pad pass on device (dropdown row entry + detail button morph).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a server-gated Requests experience, including hub, request detail, and “My Requests.”
  * Added request search, discovery carousels, request status chips, and request-aware routing for iOS and tvOS.
  * Added request creation, cancellation, and UI updates across hub/search/detail/my-requests.
* **Documentation**
  * Added a full UX/design specification for Silo Requests (iOS + tvOS) including status language.
* **Tests**
  * Added unit tests for request bucketing, UI display state, error messaging, image URL building/carousel merging, and request status behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->