### PR TITLE
iOS/tvOS in-player subtitle search (provider parity with Android/web)

### DIFF
--- a/iosApp/Tests/SubtitleSearchModelTests.swift
+++ b/iosApp/Tests/SubtitleSearchModelTests.swift
@@ -111,6 +111,15 @@ final class SubtitleSearchModelTests: XCTestCase {
         XCTAssertEqual(response.subtitle.provider, "subdl")
     }
 
+    func testUniqueKeyCombinesProviderAndId() {
+        // Provider-local ids can collide across providers; row identity must
+        // key on the (provider, id) pair.
+        let a = SubtitleSearchResult(id: "123", provider: "opensubtitles")
+        let b = SubtitleSearchResult(id: "123", provider: "subdl")
+        XCTAssertEqual(a.uniqueKey, "opensubtitles:123")
+        XCTAssertNotEqual(a.uniqueKey, b.uniqueKey)
+    }
+
     func testScoreTierThresholds() {
         XCTAssertEqual(SubtitleSearchScoreTier(score: 100), .good)
         XCTAssertEqual(SubtitleSearchScoreTier(score: 70), .good)

--- a/iosApp/Tests/SubtitleSearchModelTests.swift
+++ b/iosApp/Tests/SubtitleSearchModelTests.swift
@@ -1,0 +1,122 @@
+//
+//  SubtitleSearchModelTests.swift
+//  SiloTests
+//
+//  Focused tests for the subtitle provider-search wire contract: the
+//  snake_case decode of search responses (including tolerant defaults), the
+//  download body echoing the chosen result (the server re-fetches by
+//  provider + subtitle_id — a silently-wrong echo would no-op the download),
+//  and the score-tier thresholds shared with Android/web.
+//
+
+import XCTest
+@testable import Silo
+
+final class SubtitleSearchModelTests: XCTestCase {
+    private var decoder: JSONDecoder {
+        let d = JSONDecoder()
+        d.keyDecodingStrategy = .convertFromSnakeCase
+        return d
+    }
+
+    private var encoder: JSONEncoder {
+        let e = JSONEncoder()
+        e.keyEncodingStrategy = .convertToSnakeCase
+        return e
+    }
+
+    func testSearchResponseDecodesSnakeCasePayload() throws {
+        let json = Data("""
+        {
+          "results": [
+            {
+              "id": "os-123",
+              "provider": "opensubtitles",
+              "language": "en",
+              "release_name": "Some.Movie.2024.1080p.WEB",
+              "format": "srt",
+              "score": 87.5,
+              "downloads": 4321,
+              "hearing_impaired": true,
+              "upload_date": "2024-11-02T10:00:00Z"
+            }
+          ],
+          "warnings": ["subdl: rate limited"]
+        }
+        """.utf8)
+
+        let response = try decoder.decode(SubtitleSearchResponse.self, from: json)
+        XCTAssertEqual(response.results.count, 1)
+        let result = try XCTUnwrap(response.results.first)
+        XCTAssertEqual(result.id, "os-123")
+        XCTAssertEqual(result.provider, "opensubtitles")
+        XCTAssertEqual(result.releaseName, "Some.Movie.2024.1080p.WEB")
+        XCTAssertEqual(result.score, 87.5)
+        XCTAssertEqual(result.downloads, 4321)
+        XCTAssertTrue(result.hearingImpaired)
+        XCTAssertEqual(response.warnings, ["subdl: rate limited"])
+    }
+
+    func testSearchResponseToleratesMissingFields() throws {
+        // Only `id` is required on a result; `warnings` may be omitted
+        // entirely (`omitempty` server-side).
+        let json = Data(#"{"results": [{"id": "ss-9"}]}"#.utf8)
+        let response = try decoder.decode(SubtitleSearchResponse.self, from: json)
+        let result = try XCTUnwrap(response.results.first)
+        XCTAssertEqual(result.id, "ss-9")
+        XCTAssertEqual(result.score, 0)
+        XCTAssertEqual(result.downloads, 0)
+        XCTAssertFalse(result.hearingImpaired)
+        XCTAssertEqual(response.warnings, [])
+    }
+
+    func testDownloadBodyEchoesChosenResult() throws {
+        let result = SubtitleSearchResult(
+            id: "os-123",
+            provider: "opensubtitles",
+            language: "en",
+            releaseName: "Some.Movie.2024.1080p.WEB",
+            format: "srt",
+            score: 87.5,
+            downloads: 4321,
+            hearingImpaired: true
+        )
+        let body = SubtitleDownloadBody(from: result, mediaFileId: 42)
+        let encoded = try encoder.encode(body)
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+
+        XCTAssertEqual(object["media_file_id"] as? Int, 42)
+        XCTAssertEqual(object["provider"] as? String, "opensubtitles")
+        // The result's provider-scoped `id` must land on the `subtitle_id`
+        // key — the pair the server uses to re-fetch the bytes.
+        XCTAssertEqual(object["subtitle_id"] as? String, "os-123")
+        XCTAssertEqual(object["language"] as? String, "en")
+        XCTAssertEqual(object["release_name"] as? String, "Some.Movie.2024.1080p.WEB")
+        XCTAssertEqual(object["format"] as? String, "srt")
+        XCTAssertEqual(object["score"] as? Double, 87.5)
+        XCTAssertEqual(object["hearing_impaired"] as? Bool, true)
+    }
+
+    func testDownloadResponseDecodesDownloadedSubtitle() throws {
+        let json = Data("""
+        {"subtitle": {"id": 7, "media_file_id": 42, "provider": "subdl",
+                      "language": "en", "format": "srt",
+                      "release_name": "Some.Movie", "score": 61.2,
+                      "hearing_impaired": false}}
+        """.utf8)
+        let response = try decoder.decode(SubtitleDownloadResponse.self, from: json)
+        XCTAssertEqual(response.subtitle.id, 7)
+        XCTAssertEqual(response.subtitle.provider, "subdl")
+    }
+
+    func testScoreTierThresholds() {
+        XCTAssertEqual(SubtitleSearchScoreTier(score: 100), .good)
+        XCTAssertEqual(SubtitleSearchScoreTier(score: 70), .good)
+        XCTAssertEqual(SubtitleSearchScoreTier(score: 69.9), .fair)
+        XCTAssertEqual(SubtitleSearchScoreTier(score: 40), .fair)
+        XCTAssertEqual(SubtitleSearchScoreTier(score: 39.9), .poor)
+        XCTAssertEqual(SubtitleSearchScoreTier(score: 0), .poor)
+    }
+}

--- a/iosApp/iosApp/Networking/ContinuumAI.swift
+++ b/iosApp/iosApp/Networking/ContinuumAI.swift
@@ -82,4 +82,25 @@ actor ContinuumAI {
         )
         return response.subtitles
     }
+
+    // MARK: - Subtitle provider search
+
+    /// Synchronous fan-out search across the server's configured external
+    /// subtitle providers. Can legitimately take 20–30s (per-provider
+    /// timeouts); the session's default 60s request timeout covers it.
+    /// No providers configured yields an empty result set, not an error.
+    func searchSubtitles(_ body: SubtitleSearchBody) async throws -> SubtitleSearchResponse {
+        try await http.post("/api/v1/subtitles/search", body: body)
+    }
+
+    /// Synchronously download one chosen search result. The server persists
+    /// it before responding; the returned ``DownloadedSubtitle`` then appears
+    /// in ``downloadedSubtitles(mediaFileId:)``.
+    func downloadSubtitle(_ body: SubtitleDownloadBody) async throws -> DownloadedSubtitle {
+        let response: SubtitleDownloadResponse = try await http.post(
+            "/api/v1/subtitles/download",
+            body: body
+        )
+        return response.subtitle
+    }
 }

--- a/iosApp/iosApp/Networking/SubtitleSearchModels.swift
+++ b/iosApp/iosApp/Networking/SubtitleSearchModels.swift
@@ -1,0 +1,141 @@
+//
+//  SubtitleSearchModels.swift
+//  Continuum (iOS + tvOS)
+//
+//  Wire types for silo-server's external subtitle-provider search
+//  (OpenSubtitles / SubDL / Subsource). Both calls are synchronous —
+//  no job, no polling, no websocket (contrast the AI flow in AIModels):
+//    POST /api/v1/subtitles/search    → ranked results + provider warnings
+//    POST /api/v1/subtitles/download  → the persisted ``DownloadedSubtitle``
+//
+//  Like AIModels, these ride ``HTTPClient/shared`` whose coders are
+//  `.convertFromSnakeCase` / `.convertToSnakeCase`, so properties stay
+//  camelCase with no `CodingKeys`.
+//
+
+import Foundation
+
+/// Body for `POST /api/v1/subtitles/search`. The server derives
+/// title/year/episode/hash from the media file itself; the client only
+/// scopes by language.
+struct SubtitleSearchBody: Encodable {
+    let mediaFileId: Int
+    let languages: [String]
+}
+
+/// One ranked hit from a provider search. `id` is provider-scoped and,
+/// together with `provider`, is the load-bearing pair echoed back on
+/// download. Decoders are tolerant: only `id` is required.
+struct SubtitleSearchResult: Codable, Identifiable, Equatable {
+    let id: String
+    let provider: String
+    let language: String
+    let releaseName: String
+    let format: String
+    /// Server-computed relevance, 0–100; results arrive sorted descending.
+    let score: Double
+    let downloads: Int
+    let hearingImpaired: Bool
+    let uploadDate: String?
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(String.self, forKey: .id)
+        provider = try c.decodeIfPresent(String.self, forKey: .provider) ?? ""
+        language = try c.decodeIfPresent(String.self, forKey: .language) ?? ""
+        releaseName = try c.decodeIfPresent(String.self, forKey: .releaseName) ?? ""
+        format = try c.decodeIfPresent(String.self, forKey: .format) ?? ""
+        score = try c.decodeIfPresent(Double.self, forKey: .score) ?? 0
+        downloads = try c.decodeIfPresent(Int.self, forKey: .downloads) ?? 0
+        hearingImpaired = try c.decodeIfPresent(Bool.self, forKey: .hearingImpaired) ?? false
+        uploadDate = try c.decodeIfPresent(String.self, forKey: .uploadDate)
+    }
+
+    /// Memberwise init for tests / previews.
+    init(
+        id: String,
+        provider: String = "",
+        language: String = "",
+        releaseName: String = "",
+        format: String = "",
+        score: Double = 0,
+        downloads: Int = 0,
+        hearingImpaired: Bool = false,
+        uploadDate: String? = nil
+    ) {
+        self.id = id
+        self.provider = provider
+        self.language = language
+        self.releaseName = releaseName
+        self.format = format
+        self.score = score
+        self.downloads = downloads
+        self.hearingImpaired = hearingImpaired
+        self.uploadDate = uploadDate
+    }
+}
+
+/// `POST /api/v1/subtitles/search` response. `warnings` carries per-provider
+/// soft failures ("opensubtitles: …") — partial success, not fatal; results
+/// from the other providers may still be present.
+struct SubtitleSearchResponse: Codable {
+    let results: [SubtitleSearchResult]
+    let warnings: [String]
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        results = try c.decodeIfPresent([SubtitleSearchResult].self, forKey: .results) ?? []
+        warnings = try c.decodeIfPresent([String].self, forKey: .warnings) ?? []
+    }
+
+    init(results: [SubtitleSearchResult], warnings: [String] = []) {
+        self.results = results
+        self.warnings = warnings
+    }
+}
+
+/// Body for `POST /api/v1/subtitles/download` — echoes the chosen result
+/// (the server re-fetches the bytes from `provider` by `subtitleId` and
+/// persists them; the rest is stored metadata).
+struct SubtitleDownloadBody: Encodable {
+    let mediaFileId: Int
+    let provider: String
+    let subtitleId: String
+    let language: String
+    let releaseName: String
+    let format: String
+    let score: Double
+    let hearingImpaired: Bool
+
+    init(from result: SubtitleSearchResult, mediaFileId: Int) {
+        self.mediaFileId = mediaFileId
+        self.provider = result.provider
+        self.subtitleId = result.id
+        self.language = result.language
+        self.releaseName = result.releaseName
+        self.format = result.format
+        self.score = result.score
+        self.hearingImpaired = result.hearingImpaired
+    }
+}
+
+/// Envelope for the download endpoint: `{"subtitle": DownloadedSubtitle}`.
+/// The subtitle is persisted before the response returns; it carries the DB
+/// `id` but no combined index / stream URL (see ``DownloadedSubtitle``).
+struct SubtitleDownloadResponse: Codable {
+    let subtitle: DownloadedSubtitle
+}
+
+/// Quality bucket for a search result's 0–100 score. Thresholds mirror the
+/// web player and Android: ≥70 good, ≥40 fair, else poor.
+enum SubtitleSearchScoreTier {
+    case good
+    case fair
+    case poor
+
+    init(score: Double) {
+        if score >= 70 { self = .good }
+        else if score >= 40 { self = .fair }
+        else { self = .poor }
+    }
+}

--- a/iosApp/iosApp/Networking/SubtitleSearchModels.swift
+++ b/iosApp/iosApp/Networking/SubtitleSearchModels.swift
@@ -26,7 +26,10 @@ struct SubtitleSearchBody: Encodable {
 /// One ranked hit from a provider search. `id` is provider-scoped and,
 /// together with `provider`, is the load-bearing pair echoed back on
 /// download. Decoders are tolerant: only `id` is required.
-struct SubtitleSearchResult: Codable, Identifiable, Equatable {
+///
+/// Deliberately NOT `Identifiable`: `id` alone can collide across providers,
+/// so UI identity (ForEach, focus, download tracking) keys on ``uniqueKey``.
+struct SubtitleSearchResult: Codable, Equatable {
     let id: String
     let provider: String
     let language: String
@@ -73,6 +76,10 @@ struct SubtitleSearchResult: Codable, Identifiable, Equatable {
         self.hearingImpaired = hearingImpaired
         self.uploadDate = uploadDate
     }
+
+    /// Composite row identity — the `(provider, id)` pair the download API
+    /// also requires. Mirrors Android's `"{provider}:{id}"` download key.
+    var uniqueKey: String { "\(provider):\(id)" }
 }
 
 /// `POST /api/v1/subtitles/search` response. `warnings` carries per-provider

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -4224,6 +4224,82 @@ class PlayerViewModel {
         subtitleAI.transcribe(audioIndex: audioIndex, translateTo: translateTo)
     }
 
+    // MARK: - Subtitle provider search (synchronous, no job machinery)
+
+    /// Whether in-player subtitle search is available: an active playback
+    /// session (the synthesized stream URL is session-scoped), a known media
+    /// file, and a backend that can host downloaded sidecars. False for
+    /// offline/local playback. Gates the "Search Subtitles…" entry row.
+    @MainActor
+    var subtitleSearchAvailable: Bool {
+        activePlaybackSessionId != nil
+            && currentSelectedVersion?.fileId != nil
+            && backendCapabilities.supportsExternalPrimarySubtitles
+    }
+
+    /// Run a provider search for the current media file. Synchronous on the
+    /// server (fan-out with 20–30s per-provider timeouts) — the caller shows
+    /// a long-running spinner. Throws `HTTPError` verbatim for the UI.
+    @MainActor
+    func searchSubtitles(languages: [String]) async throws -> SubtitleSearchResponse {
+        guard let fileId = currentSelectedVersion?.fileId else {
+            throw HTTPError.invalidURL("subtitle search requires an active media file")
+        }
+        return try await ContinuumAI.shared.searchSubtitles(
+            SubtitleSearchBody(mediaFileId: fileId, languages: languages)
+        )
+    }
+
+    /// Download a chosen search result and hand it to the picker (register +
+    /// auto-select) with **no session restart** — the same sidecar path the AI
+    /// completion uses. Returns `true` on success.
+    ///
+    /// Mirrors `SubtitleAIController.completePersistedHandoff` minus the
+    /// job/latch/websocket machinery: the download response carries the DB
+    /// `id` but no combined index or stream URL, so we re-list to find the
+    /// track's *position* and synthesize both (see ``DownloadedSubtitle``).
+    ///
+    /// Idempotency vs the server's `subtitle_ready` broadcast that follows any
+    /// download: that path is register-only (never steals selection) and
+    /// `registerCompletedAISubtitle` de-dupes on combined index, so the echo
+    /// is a harmless no-op — no ownership latch is needed here.
+    @MainActor
+    func downloadSearchedSubtitle(_ result: SubtitleSearchResult) async -> Bool {
+        guard let fileId = currentSelectedVersion?.fileId else { return false }
+        do {
+            let subtitle = try await ContinuumAI.shared.downloadSubtitle(
+                SubtitleDownloadBody(from: result, mediaFileId: fileId)
+            )
+            let downloaded = try await ContinuumAI.shared.downloadedSubtitles(mediaFileId: fileId)
+            guard let position = downloaded.firstIndex(where: { $0.id == subtitle.id }) else {
+                Self.logger.warning(
+                    "[SUB-SEARCH] downloaded subtitle id=\(subtitle.id, privacy: .public) not in listing of \(downloaded.count, privacy: .public)"
+                )
+                return false
+            }
+            guard let context = makeSubtitleHandoffContext(),
+                  let descriptor = downloaded[position].synthesizedDescriptor(
+                      sessionId: context.sessionId,
+                      baseTrackCount: context.baseTrackCount,
+                      position: position,
+                      resolveURL: context.resolveURL
+                  )
+            else {
+                Self.logger.warning(
+                    "[SUB-SEARCH] no handoff context / unresolvable URL for subtitle id=\(subtitle.id, privacy: .public)"
+                )
+                return false
+            }
+            registerCompletedAISubtitle(descriptor, autoSelect: true)
+            return true
+        } catch {
+            Self.logger.warning(
+                "[SUB-SEARCH] download failed: \(error.localizedDescription, privacy: .public)"
+            )
+            return false
+        }
+    }
+
     /// Build the context ``SubtitleAIController`` needs to synthesize a
     /// completed subtitle's player descriptor. Returns `nil` when no active
     /// session exists or the current backend can't host downloaded sidecars —

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -4271,6 +4271,18 @@ class PlayerViewModel {
                 SubtitleDownloadBody(from: result, mediaFileId: fileId)
             )
             let downloaded = try await ContinuumAI.shared.downloadedSubtitles(mediaFileId: fileId)
+            // Revalidate after the awaits: if playback moved to a different
+            // file while the download was in flight, `makeSubtitleHandoffContext`
+            // would now describe the NEW session, and registering the OLD
+            // file's listing position against it would select a wrong or
+            // invalid track. The download itself is persisted server-side
+            // either way; the next session of that file picks it up.
+            guard currentSelectedVersion?.fileId == fileId else {
+                Self.logger.info(
+                    "[SUB-SEARCH] media file changed during download of subtitle id=\(subtitle.id, privacy: .public); skipping live handoff"
+                )
+                return false
+            }
             guard let position = downloaded.firstIndex(where: { $0.id == subtitle.id }) else {
                 Self.logger.warning(
                     "[SUB-SEARCH] downloaded subtitle id=\(subtitle.id, privacy: .public) not in listing of \(downloaded.count, privacy: .public)"

--- a/iosApp/iosApp/Screens/Player/Sheets/SubtitleSearchMenu.swift
+++ b/iosApp/iosApp/Screens/Player/Sheets/SubtitleSearchMenu.swift
@@ -60,9 +60,9 @@ struct SubtitleSearchMenu: View {
 
     #if os(tvOS)
     /// Panel-level focus for language rows and result rows (keys never
-    /// collide: language codes vs provider-scoped result ids). Centralized so
-    /// the list can scroll-follow and recover a dropped focus — mirrors
-    /// ``SubtitleTranslateMenu``.
+    /// collide: language codes vs composite `provider:id` result keys).
+    /// Centralized so the list can scroll-follow and recover a dropped
+    /// focus — mirrors ``SubtitleTranslateMenu``.
     @FocusState private var focusedRowID: String?
     #endif
 
@@ -166,7 +166,7 @@ struct SubtitleSearchMenu: View {
 
     private func download(_ result: SubtitleSearchResult) {
         guard downloadingId == nil else { return }
-        downloadingId = result.id
+        downloadingId = result.uniqueKey
         Task {
             let ok = await viewModel.downloadSearchedSubtitle(result)
             if ok {
@@ -241,7 +241,9 @@ struct SubtitleSearchMenu: View {
         case .picking:
             focusedRowID = selectedLanguage ?? displayLanguages.first?.code
         case .results:
-            focusedRowID = results.first?.id
+            // Empty result set: land focus on the fallback row so the remote
+            // isn't left with nothing focused.
+            focusedRowID = results.first?.uniqueKey ?? "back-to-languages"
         case .searching, .failed:
             break
         }
@@ -421,7 +423,7 @@ struct SubtitleSearchMenu: View {
             .id("back-to-languages")
         } else {
             sectionHeader(searchedLanguage.map { displayName($0) } ?? "Results")
-            ForEach(results) { result in
+            ForEach(results, id: \.uniqueKey) { result in
                 tvResultRow(result)
             }
         }
@@ -429,9 +431,9 @@ struct SubtitleSearchMenu: View {
 
     @ViewBuilder
     private func tvResultRow(_ result: SubtitleSearchResult) -> some View {
-        let isDownloadingThis = downloadingId == result.id
+        let isDownloadingThis = downloadingId == result.uniqueKey
         TVSearchRow(
-            rowID: result.id,
+            rowID: result.uniqueKey,
             isDisabled: downloadingId != nil && !isDownloadingThis,
             focusedID: $focusedRowID,
             action: { download(result) }
@@ -455,7 +457,7 @@ struct SubtitleSearchMenu: View {
                 providerTag(result.provider, fontSize: 15)
             }
         }
-        .id(result.id)
+        .id(result.uniqueKey)
     }
 
     @ViewBuilder
@@ -629,7 +631,7 @@ struct SubtitleSearchMenu: View {
                 }
             } else {
                 Section(searchedLanguage.map { displayName($0) } ?? "Results") {
-                    ForEach(results) { result in
+                    ForEach(results, id: \.uniqueKey) { result in
                         resultRow(result)
                     }
                 }
@@ -640,7 +642,7 @@ struct SubtitleSearchMenu: View {
 
     @ViewBuilder
     private func resultRow(_ result: SubtitleSearchResult) -> some View {
-        let isDownloadingThis = downloadingId == result.id
+        let isDownloadingThis = downloadingId == result.uniqueKey
         Button {
             download(result)
         } label: {

--- a/iosApp/iosApp/Screens/Player/Sheets/SubtitleSearchMenu.swift
+++ b/iosApp/iosApp/Screens/Player/Sheets/SubtitleSearchMenu.swift
@@ -1,0 +1,736 @@
+//
+//  SubtitleSearchMenu.swift
+//  Continuum (iOS + tvOS)
+//
+//  In-player external subtitle search (OpenSubtitles / SubDL / Subsource via
+//  silo-server). Android/web parity: pick a language (the profile's preferred
+//  subtitle language floats to the top and is pre-selected), Search — no
+//  free-text query, the server keys the search on the media file — then tap a
+//  result to download it. The downloaded track registers on the live backend
+//  and auto-selects with no session restart (the same sidecar handoff the AI
+//  flow uses; see `PlayerViewModel.downloadSearchedSubtitle`).
+//
+//  Presented from ``TrackSelectionSheet`` next to the "AI Subtitles…" entry
+//  and gated on ``PlayerViewModel/subtitleSearchAvailable`` (needs an active
+//  server session — hidden for offline/local playback).
+//
+//  Two-platform split mirrors ``SubtitleTranslateMenu``: iOS renders a
+//  sectioned `List` in a sheet; tvOS renders a centered floating panel with a
+//  single panel-level `@FocusState` (scroll-follow + nil-recovery), backdrop
+//  tap + `onExitCommand` dismissal.
+//
+
+import SwiftUI
+
+struct SubtitleSearchMenu: View {
+    let viewModel: PlayerViewModel
+    let onDismiss: () -> Void
+
+    /// Called when a download succeeded and the track is registered +
+    /// selected: dismisses the WHOLE subtitle UI (this menu plus the enclosing
+    /// panel/sheet) down to the player, like the AI menu's `onJobStarted`.
+    /// Defaults to `onDismiss` for call sites that don't distinguish the two.
+    var onDownloaded: () -> Void = {}
+
+    /// The profile's preferred subtitle language, used to pre-select and
+    /// float its row. Observed so a late hydration refreshes the default.
+    @ObservedObject private var profilePrefs = ProfilePrefsStore.shared
+
+    private enum Phase: Equatable {
+        /// Language list shown, no search yet (or user backed out of results).
+        case picking
+        /// `POST /subtitles/search` in flight — can take ~30s.
+        case searching
+        /// Results (possibly empty) for `searchedLanguage`.
+        case results
+        /// Search or download failed; message shown verbatim.
+        case failed(String)
+    }
+
+    @State private var phase: Phase = .picking
+    /// Selected language code; seeded from the preferred subtitle language.
+    @State private var selectedLanguage: String?
+    /// The language the current `results` belong to (for the empty-state copy).
+    @State private var searchedLanguage: String?
+    @State private var results: [SubtitleSearchResult] = []
+    @State private var warnings: [String] = []
+    /// The result currently downloading; non-nil disables every row.
+    @State private var downloadingId: String?
+    @State private var searchTask: Task<Void, Never>?
+
+    #if os(tvOS)
+    /// Panel-level focus for language rows and result rows (keys never
+    /// collide: language codes vs provider-scoped result ids). Centralized so
+    /// the list can scroll-follow and recover a dropped focus — mirrors
+    /// ``SubtitleTranslateMenu``.
+    @FocusState private var focusedRowID: String?
+    #endif
+
+    /// One selectable search language. Mirrors the AI menu's shape.
+    private struct LanguageChoice: Identifiable {
+        let code: String
+        let label: String
+        let hint: String?
+        var id: String { code }
+    }
+
+    var body: some View {
+        #if os(tvOS)
+        tvOSPanel
+        #else
+        phoneList
+        #endif
+    }
+
+    // MARK: - Shared copy
+
+    private var title: String { "Search Subtitles" }
+
+    private var explainer: String {
+        "Pick a language and Silo searches its subtitle providers for this video."
+    }
+
+    // MARK: - Languages
+
+    /// Display name for a language code, preferring the curated label.
+    private func displayName(_ code: String) -> String {
+        if let opt = PlaybackLanguageOption.all.first(where: {
+            $0.code.caseInsensitiveCompare(code) == .orderedSame
+        }) {
+            return opt.label
+        }
+        return Locale(identifier: "en").localizedString(forLanguageCode: code)?.capitalized
+            ?? code.uppercased()
+    }
+
+    /// Languages offered, deduped, preferred language floated to the top.
+    private var orderedLanguages: [LanguageChoice] {
+        var result: [LanguageChoice] = []
+        var seen = Set<String>()
+        func add(_ code: String, hint: String?) {
+            let trimmed = code.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return }
+            let key = trimmed.lowercased()
+            guard !seen.contains(key) else { return }
+            seen.insert(key)
+            result.append(.init(code: trimmed, label: displayName(trimmed), hint: hint))
+        }
+        if let preferred = profilePrefs.preferredSubtitleLanguage {
+            add(preferred, hint: "Preferred")
+        }
+        for option in PlaybackLanguageOption.all {
+            add(option.code, hint: nil)
+        }
+        return result
+    }
+
+    private var suggestedLanguages: [LanguageChoice] { orderedLanguages.filter { $0.hint != nil } }
+
+    private var otherLanguages: [LanguageChoice] {
+        orderedLanguages
+            .filter { $0.hint == nil }
+            .sorted { $0.label.localizedCaseInsensitiveCompare($1.label) == .orderedAscending }
+    }
+
+    /// Seed the selection from the preferred language once hydrated.
+    private func seedSelectedLanguage() {
+        guard selectedLanguage == nil else { return }
+        selectedLanguage = profilePrefs.preferredSubtitleLanguage ?? orderedLanguages.first?.code
+    }
+
+    // MARK: - Actions
+
+    /// Selecting a language IS the search trigger (one-tap, like the AI
+    /// menu routes on language pick) — no separate Search button.
+    private func search(language: String) {
+        guard downloadingId == nil, phase != .searching else { return }
+        selectedLanguage = language
+        searchedLanguage = language
+        phase = .searching
+        searchTask?.cancel()
+        searchTask = Task {
+            do {
+                let response = try await viewModel.searchSubtitles(languages: [language])
+                guard !Task.isCancelled else { return }
+                results = response.results
+                warnings = response.warnings
+                phase = .results
+            } catch {
+                guard !Task.isCancelled else { return }
+                // Verbatim server error — "no providers configured" arrives
+                // here as plain error text (no capability probe exists).
+                phase = .failed(error.localizedDescription)
+            }
+        }
+    }
+
+    private func download(_ result: SubtitleSearchResult) {
+        guard downloadingId == nil else { return }
+        downloadingId = result.id
+        Task {
+            let ok = await viewModel.downloadSearchedSubtitle(result)
+            if ok {
+                // Track registered + auto-selected on the live player;
+                // collapse the whole subtitle UI down to the video.
+                onDownloaded()
+            } else {
+                downloadingId = nil
+                phase = .failed("Couldn't add that subtitle. Try another result.")
+            }
+        }
+    }
+
+    /// Back out of results/failure to the language list (keeps the menu up).
+    private func backToLanguages() {
+        searchTask?.cancel()
+        results = []
+        warnings = []
+        phase = .picking
+    }
+
+    // MARK: - Result presentation
+
+    private func scoreColor(_ score: Double) -> Color {
+        switch SubtitleSearchScoreTier(score: score) {
+        case .good: return .continuumSuccess
+        case .fair: return .continuumWarning
+        case .poor: return .continuumError
+        }
+    }
+
+    /// Short provider tag for the row badge (parity with Android/web).
+    private func providerBadge(_ provider: String) -> String {
+        switch provider.lowercased() {
+        case "opensubtitles": return "OS"
+        case "subdl": return "SDL"
+        case "subsource": return "SS"
+        default: return provider.uppercased()
+        }
+    }
+
+    /// Second row of a result: language • downloads • HI.
+    private func resultDetail(_ result: SubtitleSearchResult) -> String {
+        var parts: [String] = []
+        // Canonical-key check filters junk codes; display goes through the
+        // same `displayName` as the picker so the strings stay consistent.
+        if SubtitleDisplayOrder.canonicalLanguageKey(result.language) != nil {
+            parts.append(displayName(result.language))
+        }
+        if result.downloads > 0 {
+            parts.append("\(result.downloads) downloads")
+        }
+        if result.hearingImpaired {
+            parts.append("HI")
+        }
+        return parts.joined(separator: " • ")
+    }
+
+    private var emptyResultsText: String {
+        let language = searchedLanguage.map(displayName) ?? "that language"
+        return "No subtitles found for \(language)."
+    }
+
+    // MARK: - tvOS
+
+    #if os(tvOS)
+    /// Rows in display order for focus recovery.
+    private var displayLanguages: [LanguageChoice] { suggestedLanguages + otherLanguages }
+
+    private func focusFirstRow() {
+        switch phase {
+        case .picking:
+            focusedRowID = selectedLanguage ?? displayLanguages.first?.code
+        case .results:
+            focusedRowID = results.first?.id
+        case .searching, .failed:
+            break
+        }
+    }
+
+    private func scrollToFocusedRow(_ proxy: ScrollViewProxy, animated: Bool = true) {
+        guard let target = focusedRowID else { return }
+        if animated {
+            withAnimation(.easeOut(duration: ContinuumTheme.fastDuration)) {
+                proxy.scrollTo(target, anchor: .center)
+            }
+        } else {
+            proxy.scrollTo(target, anchor: .center)
+        }
+    }
+
+    private var tvOSPanel: some View {
+        ZStack {
+            Color.black.opacity(0.55)
+                .ignoresSafeArea()
+                .contentShape(Rectangle())
+                .onTapGesture { onDismiss() }
+
+            VStack(alignment: .leading, spacing: 14) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(title.uppercased())
+                        .font(.system(size: 18, weight: .semibold))
+                        .tracking(1.5)
+                        .foregroundStyle(.white.opacity(0.7))
+                    if phase == .picking {
+                        Text(explainer)
+                            .font(.system(size: 16))
+                            .foregroundStyle(.white.opacity(0.45))
+                            .lineLimit(2)
+                    }
+                }
+                .padding(.horizontal, 12)
+
+                switch phase {
+                case .searching:
+                    searchingPanel
+                case .failed(let message):
+                    failurePanel(message)
+                case .picking, .results:
+                    ScrollViewReader { proxy in
+                        ScrollView(showsIndicators: false) {
+                            LazyVStack(alignment: .leading, spacing: 2) {
+                                if phase == .picking {
+                                    tvLanguageRows
+                                } else {
+                                    tvResultRows
+                                }
+                            }
+                            .padding(.vertical, 2)
+                        }
+                        .focusSection()
+                        .onAppear {
+                            focusFirstRow()
+                            scrollToFocusedRow(proxy, animated: false)
+                        }
+                        .onChange(of: focusedRowID) { _, value in
+                            // Focus fell off the list — pull it back rather
+                            // than letting it vanish; else keep it visible.
+                            if value == nil { focusFirstRow() }
+                            else { scrollToFocusedRow(proxy) }
+                        }
+                        .onChange(of: phase) { _, _ in focusFirstRow() }
+                    }
+                }
+            }
+            .padding(28)
+            .frame(maxWidth: 1100, maxHeight: 720)
+            .background(
+                RoundedRectangle(cornerRadius: 24, style: .continuous)
+                    .fill(.ultraThinMaterial)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 24, style: .continuous)
+                            .fill(Color.black.opacity(0.35))
+                    )
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 24, style: .continuous)
+                    .stroke(Color.white.opacity(0.12), lineWidth: 1)
+            )
+        }
+        .onExitCommand {
+            // First back-press from results returns to the language list;
+            // from the language list it dismisses the menu. Back is inert
+            // while a download is in flight (mirrors iOS's disabled
+            // "Language" button) so the resolving download can't later yank
+            // the user off the language list or force-dismiss the menu.
+            switch phase {
+            case .results, .failed, .searching:
+                if downloadingId == nil { backToLanguages() }
+            case .picking:
+                onDismiss()
+            }
+        }
+        .task { await profilePrefs.hydrateIfNeeded() }
+        .onAppear { seedSelectedLanguage() }
+        .onChange(of: profilePrefs.preferredSubtitleLanguage) { _, _ in seedSelectedLanguage() }
+    }
+
+    @ViewBuilder
+    private var tvLanguageRows: some View {
+        if !suggestedLanguages.isEmpty {
+            sectionHeader("Suggested")
+            ForEach(suggestedLanguages) { tvLanguageRow($0) }
+        }
+        sectionHeader(suggestedLanguages.isEmpty ? "Language" : "All Languages")
+        ForEach(otherLanguages) { tvLanguageRow($0) }
+    }
+
+    @ViewBuilder
+    private func tvLanguageRow(_ choice: LanguageChoice) -> some View {
+        TVSearchRow(
+            rowID: choice.code,
+            focusedID: $focusedRowID,
+            action: { search(language: choice.code) }
+        ) {
+            Image(systemName: choice.hint == "Preferred" ? "star.fill" : "globe")
+                .font(.system(size: 22, weight: .regular))
+                .foregroundStyle(.white.opacity(0.8))
+                .frame(width: 34)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(choice.label)
+                    .font(.system(size: 24, weight: .medium))
+                    .foregroundStyle(.white)
+                    .lineLimit(1)
+                if let hint = choice.hint {
+                    Text(hint)
+                        .font(.system(size: 18))
+                        .foregroundStyle(.white.opacity(0.55))
+                        .lineLimit(1)
+                }
+            }
+            Spacer(minLength: 8)
+        }
+        .id(choice.code)
+    }
+
+    /// Per-provider soft failures, shown above the results in amber.
+    @ViewBuilder
+    private var warningRows: some View {
+        ForEach(warnings, id: \.self) { warning in
+            Label(warning, systemImage: "exclamationmark.triangle")
+                .font(.system(size: 16))
+                .foregroundStyle(Color.continuumWarning)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 4)
+        }
+    }
+
+    @ViewBuilder
+    private var tvResultRows: some View {
+        warningRows
+        if results.isEmpty {
+            Text(emptyResultsText)
+                .font(.system(size: 20))
+                .foregroundStyle(.white.opacity(0.55))
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+            TVSearchRow(
+                rowID: "back-to-languages",
+                focusedID: $focusedRowID,
+                action: { backToLanguages() }
+            ) {
+                Image(systemName: "chevron.backward")
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.8))
+                    .frame(width: 34)
+                Text("Choose another language")
+                    .font(.system(size: 22, weight: .medium))
+                    .foregroundStyle(.white)
+                Spacer(minLength: 8)
+            }
+            .id("back-to-languages")
+        } else {
+            sectionHeader(searchedLanguage.map { displayName($0) } ?? "Results")
+            ForEach(results) { result in
+                tvResultRow(result)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func tvResultRow(_ result: SubtitleSearchResult) -> some View {
+        let isDownloadingThis = downloadingId == result.id
+        TVSearchRow(
+            rowID: result.id,
+            isDisabled: downloadingId != nil && !isDownloadingThis,
+            focusedID: $focusedRowID,
+            action: { download(result) }
+        ) {
+            scoreBadge(result.score, fontSize: 18)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(result.releaseName.isEmpty ? "Untitled release" : result.releaseName)
+                    .font(.system(size: 22, weight: .medium))
+                    .foregroundStyle(.white)
+                    .lineLimit(1)
+                Text(resultDetail(result))
+                    .font(.system(size: 17))
+                    .foregroundStyle(.white.opacity(0.55))
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 8)
+            if isDownloadingThis {
+                ProgressView()
+                    .scaleEffect(0.7)
+            } else {
+                providerTag(result.provider, fontSize: 15)
+            }
+        }
+        .id(result.id)
+    }
+
+    @ViewBuilder
+    private var searchingPanel: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 14) {
+                ProgressView()
+                Text("Searching providers…")
+                    .font(.system(size: 22, weight: .medium))
+                    .foregroundStyle(.white)
+            }
+            Text("This can take up to half a minute.")
+                .font(.system(size: 17))
+                .foregroundStyle(.white.opacity(0.5))
+            Button("Cancel") { backToLanguages() }
+                .buttonStyle(.bordered)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private func failurePanel(_ message: String) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Label(message, systemImage: "exclamationmark.triangle")
+                .font(.system(size: 20))
+                .foregroundStyle(.white.opacity(0.7))
+            HStack(spacing: 12) {
+                if let language = searchedLanguage {
+                    Button("Try Again") { search(language: language) }
+                        .buttonStyle(.bordered)
+                }
+                Button("Back") { backToLanguages() }
+                    .buttonStyle(.bordered)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private func sectionHeader(_ text: String) -> some View {
+        Text(text.uppercased())
+            .font(.system(size: 14, weight: .semibold))
+            .tracking(1.2)
+            .foregroundStyle(.white.opacity(0.45))
+            .padding(.horizontal, 12)
+            .padding(.top, 10)
+    }
+    #endif
+
+    // MARK: - iOS
+
+    #if !os(tvOS)
+    private var phoneList: some View {
+        NavigationStack {
+            Group {
+                switch phase {
+                case .searching:
+                    VStack(spacing: 12) {
+                        ProgressView()
+                        Text("Searching providers…")
+                            .font(.headline)
+                        Text("This can take up to half a minute.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                        Button("Cancel") { backToLanguages() }
+                            .buttonStyle(.bordered)
+                            .padding(.top, 4)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                case .failed(let message):
+                    VStack(alignment: .leading, spacing: 16) {
+                        Label(message, systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.secondary)
+                        HStack(spacing: 12) {
+                            if let language = searchedLanguage {
+                                Button("Try Again") { search(language: language) }
+                                    .buttonStyle(.bordered)
+                            }
+                            Button("Back") { backToLanguages() }
+                                .buttonStyle(.bordered)
+                        }
+                    }
+                    .padding()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                case .picking:
+                    languagePickingList
+                case .results:
+                    resultsList
+                }
+            }
+            .navigationTitle(phase == .results ? "Results" : title)
+            .continuumNavigationTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { onDismiss() }
+                }
+                if phase == .results {
+                    ToolbarItem(placement: .primaryAction) {
+                        Button("Language") { backToLanguages() }
+                            .disabled(downloadingId != nil)
+                    }
+                }
+            }
+            .task { await profilePrefs.hydrateIfNeeded() }
+            .onAppear { seedSelectedLanguage() }
+            .onChange(of: profilePrefs.preferredSubtitleLanguage) { _, _ in seedSelectedLanguage() }
+        }
+    }
+
+    private var languagePickingList: some View {
+        List {
+            if !suggestedLanguages.isEmpty {
+                Section("Suggested") {
+                    ForEach(suggestedLanguages) { languageRow($0) }
+                }
+            }
+            Section {
+                ForEach(otherLanguages) { languageRow($0) }
+            } header: {
+                Text(suggestedLanguages.isEmpty ? "Language" : "All Languages")
+            } footer: {
+                Text(explainer)
+            }
+        }
+        .continuumGroupedListStyle()
+    }
+
+    @ViewBuilder
+    private func languageRow(_ choice: LanguageChoice) -> some View {
+        Button {
+            search(language: choice.code)
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: choice.hint == "Preferred" ? "star.fill" : "globe")
+                    .foregroundStyle(.tint)
+                    .frame(width: 24)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(choice.label)
+                        .foregroundStyle(.primary)
+                    if let hint = choice.hint {
+                        Text(hint)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Spacer()
+            }
+        }
+    }
+
+    private var resultsList: some View {
+        List {
+            if !warnings.isEmpty {
+                Section {
+                    ForEach(warnings, id: \.self) { warning in
+                        Label(warning, systemImage: "exclamationmark.triangle")
+                            .font(.footnote)
+                            .foregroundStyle(Color.continuumWarning)
+                    }
+                }
+            }
+            if results.isEmpty {
+                Section {
+                    Text(emptyResultsText)
+                        .foregroundStyle(.secondary)
+                    Button("Choose another language") { backToLanguages() }
+                }
+            } else {
+                Section(searchedLanguage.map { displayName($0) } ?? "Results") {
+                    ForEach(results) { result in
+                        resultRow(result)
+                    }
+                }
+            }
+        }
+        .continuumGroupedListStyle()
+    }
+
+    @ViewBuilder
+    private func resultRow(_ result: SubtitleSearchResult) -> some View {
+        let isDownloadingThis = downloadingId == result.id
+        Button {
+            download(result)
+        } label: {
+            HStack(spacing: 12) {
+                scoreBadge(result.score, fontSize: 13)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(result.releaseName.isEmpty ? "Untitled release" : result.releaseName)
+                        .foregroundStyle(.primary)
+                        .lineLimit(2)
+                    Text(resultDetail(result))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                Spacer()
+                if isDownloadingThis {
+                    ProgressView()
+                } else {
+                    providerTag(result.provider, fontSize: 11)
+                }
+            }
+        }
+        .disabled(downloadingId != nil && !isDownloadingThis)
+    }
+    #endif
+
+    // MARK: - Shared badges
+
+    /// Rounded score chip, tier-colored (≥70 green / ≥40 amber / else red).
+    @ViewBuilder
+    private func scoreBadge(_ score: Double, fontSize: CGFloat) -> some View {
+        Text("\(Int(score.rounded()))")
+            .font(.system(size: fontSize, weight: .bold, design: .rounded))
+            .foregroundStyle(.white)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(scoreColor(score).opacity(0.85))
+            )
+    }
+
+    /// Small capsule with the provider abbreviation.
+    @ViewBuilder
+    private func providerTag(_ provider: String, fontSize: CGFloat) -> some View {
+        if !provider.isEmpty {
+            Text(providerBadge(provider))
+                .font(.system(size: fontSize, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 7)
+                .padding(.vertical, 3)
+                .background(Capsule().strokeBorder(.secondary.opacity(0.45), lineWidth: 1))
+        }
+    }
+}
+
+// MARK: - tvOS focus row
+
+#if os(tvOS)
+/// Generic panel row for the search menu: bare `.focusable` + tap (no system
+/// halo), row-fill focus highlight, focus driven by the panel-level
+/// `@FocusState.Binding` keyed on `rowID` — the `TVLanguageRow` /
+/// `TrackSelectionSheet.TrackRow` idiom generalized over arbitrary content.
+private struct TVSearchRow<Content: View>: View {
+    let rowID: String
+    var isDisabled: Bool = false
+    @FocusState.Binding var focusedID: String?
+    let action: () -> Void
+    @ViewBuilder let content: () -> Content
+
+    private var isFocused: Bool { focusedID == rowID }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 16) {
+            content()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(isFocused ? Color.white.opacity(0.16) : Color.clear)
+        )
+        .contentShape(Rectangle())
+        .focusable(!isDisabled)
+        .focused($focusedID, equals: rowID)
+        .onTapGesture(perform: action)
+        .disabled(isDisabled)
+        .opacity(isDisabled ? 0.35 : 1.0)
+        .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: isFocused)
+        .accessibilityAddTraits(.isButton)
+    }
+}
+#endif

--- a/iosApp/iosApp/Screens/Player/Sheets/TrackSelectionSheet.swift
+++ b/iosApp/iosApp/Screens/Player/Sheets/TrackSelectionSheet.swift
@@ -13,11 +13,20 @@ struct TrackSelectionSheet: View {
     /// Drives presentation of the AI translate/transcribe menu.
     @State private var showAITranslateMenu = false
 
+    /// Drives presentation of the provider subtitle-search menu.
+    @State private var showSubtitleSearchMenu = false
+
     /// Whether any AI subtitle action is available (translate or transcribe),
     /// per the server's capability probes **and** the current track list.
     /// Gates the "Translate with AI…" row so it never opens an empty menu.
     private var aiSubtitlesAvailable: Bool {
         SubtitleTranslateMenu.hasActionableSource(viewModel)
+    }
+
+    /// Whether provider subtitle search is available (active server session +
+    /// sidecar-capable backend). Hidden for offline/local playback.
+    private var subtitleSearchAvailable: Bool {
+        viewModel.subtitleSearchAvailable
     }
 
     var body: some View {
@@ -60,8 +69,23 @@ struct TrackSelectionSheet: View {
                     }
                 }
 
-                if aiSubtitlesAvailable {
-                    AITranslateEntryRow { showAITranslateMenu = true }
+                if aiSubtitlesAvailable || subtitleSearchAvailable {
+                    HStack(spacing: 16) {
+                        if aiSubtitlesAvailable {
+                            MenuEntryRow(
+                                title: "AI Subtitles…",
+                                systemImage: "sparkles",
+                                accessibilityLabel: "AI Subtitles"
+                            ) { showAITranslateMenu = true }
+                        }
+                        if subtitleSearchAvailable {
+                            MenuEntryRow(
+                                title: "Search Subtitles…",
+                                systemImage: "magnifyingglass",
+                                accessibilityLabel: "Search Subtitles"
+                            ) { showSubtitleSearchMenu = true }
+                        }
+                    }
                 }
             }
             .padding(28)
@@ -78,11 +102,11 @@ struct TrackSelectionSheet: View {
                 RoundedRectangle(cornerRadius: 24, style: .continuous)
                     .stroke(Color.white.opacity(0.12), lineWidth: 1)
             )
-            // While the AI translate menu is up, exclude the base panel from
+            // While an overlay menu is up, exclude the base panel from
             // focus and dim it so the d-pad can't escape behind the overlay.
             // Mirrors the `TVPlayerInfoHUD` appearance-dialog precedent.
-            .disabled(showAITranslateMenu)
-            .opacity(showAITranslateMenu ? 0.28 : 1)
+            .disabled(showAITranslateMenu || showSubtitleSearchMenu)
+            .opacity((showAITranslateMenu || showSubtitleSearchMenu) ? 0.28 : 1)
 
             if showAITranslateMenu {
                 SubtitleTranslateMenu(
@@ -96,23 +120,38 @@ struct TrackSelectionSheet: View {
                     }
                 )
                 .transition(.opacity)
+            } else if showSubtitleSearchMenu {
+                SubtitleSearchMenu(
+                    viewModel: viewModel,
+                    // Back-out returns to the track panel; a successful
+                    // download (track already selected) closes both.
+                    onDismiss: { showSubtitleSearchMenu = false },
+                    onDownloaded: {
+                        showSubtitleSearchMenu = false
+                        onDismiss()
+                    }
+                )
+                .transition(.opacity)
             }
         }
         .onExitCommand { onDismiss() }
     }
 
-    /// tvOS entry row that opens the AI translate/transcribe menu. Mirrors the
-    /// bare-`focusable` + row-fill focus idiom of `TrackRow`.
-    private struct AITranslateEntryRow: View {
+    /// tvOS entry row that opens a subtitle tools menu (AI translate / provider
+    /// search). Mirrors the bare-`focusable` + row-fill focus idiom of `TrackRow`.
+    private struct MenuEntryRow: View {
+        let title: String
+        let systemImage: String
+        let accessibilityLabel: String
         let action: () -> Void
         @FocusState private var isFocused: Bool
 
         var body: some View {
             HStack(spacing: 12) {
-                Image(systemName: "sparkles")
+                Image(systemName: systemImage)
                     .font(.system(size: 22, weight: .semibold))
                     .foregroundStyle(.white)
-                Text("AI Subtitles…")
+                Text(title)
                     .font(.system(size: 22, weight: .medium))
                     .foregroundStyle(.white)
             }
@@ -128,7 +167,7 @@ struct TrackSelectionSheet: View {
             .onTapGesture(perform: action)
             .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: isFocused)
             .accessibilityAddTraits(.isButton)
-            .accessibilityLabel("AI Subtitles")
+            .accessibilityLabel(accessibilityLabel)
         }
     }
 
@@ -221,12 +260,21 @@ struct TrackSelectionSheet: View {
                     Section("Secondary Subtitles") { subtitleRows(isSecondary: true) }
                 }
             }
-            if aiSubtitlesAvailable {
+            if aiSubtitlesAvailable || subtitleSearchAvailable {
                 Section {
-                    Button {
-                        showAITranslateMenu = true
-                    } label: {
-                        Label("AI Subtitles…", systemImage: "sparkles")
+                    if aiSubtitlesAvailable {
+                        Button {
+                            showAITranslateMenu = true
+                        } label: {
+                            Label("AI Subtitles…", systemImage: "sparkles")
+                        }
+                    }
+                    if subtitleSearchAvailable {
+                        Button {
+                            showSubtitleSearchMenu = true
+                        } label: {
+                            Label("Search Subtitles…", systemImage: "magnifyingglass")
+                        }
                     }
                 }
             }
@@ -248,6 +296,19 @@ struct TrackSelectionSheet: View {
                 }
             )
             .presentationDetents([.medium, .large])
+        }
+        .sheet(isPresented: $showSubtitleSearchMenu) {
+            SubtitleSearchMenu(
+                viewModel: viewModel,
+                onDismiss: { showSubtitleSearchMenu = false },
+                // Download succeeded (track already selected): close both this
+                // menu and the track sheet so the player is visible.
+                onDownloaded: {
+                    showSubtitleSearchMenu = false
+                    onDismiss()
+                }
+            )
+            .presentationDetents([.large])
         }
     }
     #endif

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPlayerInfoHUD.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPlayerInfoHUD.swift
@@ -55,7 +55,8 @@ struct TVPlayerInfoHUD: View {
         var tabs: [Tab] = [.info, .stats, .video]
         if !viewModel.audioTracks.isEmpty { tabs.append(.audio) }
         if !viewModel.subtitleTracks.isEmpty
-            || SubtitleTranslateMenu.hasActionableSource(viewModel) {
+            || SubtitleTranslateMenu.hasActionableSource(viewModel)
+            || viewModel.subtitleSearchAvailable {
             tabs.append(.subtitles)
         }
         if !viewModel.chapters.isEmpty { tabs.append(.chapters) }
@@ -1436,14 +1437,16 @@ private struct SubtitlesPane: View {
 
     @State private var showAppearanceDialog = false
     @State private var showAITranslateMenu = false
+    @State private var showSubtitleSearchMenu = false
     @State private var activePicker: HUDPickerPresentation?
     @State private var pickerReturnField: Option?
     @FocusState private var focusedOption: Option?
 
     /// Identity for the options-column rows, used only to restore focus when
-    /// a picker dialog, the appearance dialog, or the AI menu closes.
+    /// a picker dialog, the appearance dialog, or the AI/search menu closes.
     private enum Option: Hashable {
         case translate
+        case search
         case delay
         case size
         case position
@@ -1452,6 +1455,7 @@ private struct SubtitlesPane: View {
 
     private var overlayActive: Bool {
         showAppearanceDialog || activePicker != nil || showAITranslateMenu
+            || showSubtitleSearchMenu
     }
 
     var body: some View {
@@ -1501,15 +1505,37 @@ private struct SubtitlesPane: View {
                 )
                 .transition(.opacity)
             }
+
+            // Provider subtitle search — same modal-overlay idiom as the AI
+            // menu above.
+            if showSubtitleSearchMenu {
+                SubtitleSearchMenu(
+                    viewModel: viewModel,
+                    onDismiss: closeSubtitleSearchMenu,
+                    // Download succeeded (track registered + selected): close
+                    // the menu AND the HUD so the player is visible.
+                    onDownloaded: {
+                        closeSubtitleSearchMenu()
+                        onCloseHUD()
+                    }
+                )
+                .transition(.opacity)
+            }
         }
         .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: showAppearanceDialog)
         .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: activePicker?.id)
         .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: showAITranslateMenu)
+        .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: showSubtitleSearchMenu)
     }
 
     private func closeAITranslateMenu() {
         showAITranslateMenu = false
         focusedOption = .translate
+    }
+
+    private func closeSubtitleSearchMenu() {
+        showSubtitleSearchMenu = false
+        focusedOption = .search
     }
 
     /// Whether the server's AI capabilities + the current track list offer any
@@ -1625,6 +1651,16 @@ private struct SubtitlesPane: View {
                     showAITranslateMenu = true
                 }
                 .focused($focusedOption, equals: .translate)
+            }
+            if viewModel.subtitleSearchAvailable {
+                HUDSettingRow(
+                    label: "Search Subtitles…",
+                    value: "",
+                    systemImage: "magnifyingglass"
+                ) {
+                    showSubtitleSearchMenu = true
+                }
+                .focused($focusedOption, equals: .search)
             }
             if viewModel.backendCapabilities.supportsSubtitleDelay {
                 HUDSettingRow(label: "Delay", value: delayText) {


### PR DESCRIPTION
## Summary

Search external subtitle providers (OpenSubtitles / SubDL / Subsource) from inside the player and download a result mid-playback — parity with the Android and web clients.

- `POST /subtitles/search` + `/subtitles/download` wire types and `ContinuumAI` methods (synchronous two-call API, no job machinery; per-provider soft failures surface as warnings).
- `SubtitleSearchMenu`: one-tap language pick (preferred language floats to top, no free-text field), score/provider/HI-badged results; iOS sheet + tvOS focus panel following the `SubtitleTranslateMenu` idioms.
- Downloaded tracks reuse the AI-subtitle sidecar handoff (re-list → position → synthesized combined-index stream URL → register + auto-select) with no session restart; the `subtitle_ready` websocket echo is a no-op via the existing combined-index de-dupe.
- Entry points in `TrackSelectionSheet` (iOS) and the `TVPlayerInfoHUD` Subtitles pane (tvOS), gated on an active server session (hidden for offline/local playback); tvOS Back is inert while a download is in flight.

## Testing

- iOS + tvOS builds green; focused tests for the wire contract (snake_case decode, download body echo, score tiers) pass.
- Remaining: live-server validation and a tvOS d-pad pass on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added in-player subtitle provider search and download on iOS and tvOS.
  * Added “Search Subtitles…” alongside existing subtitle tools in the track selection UI and tvOS subtitles HUD.
  * Search UI shows relevance tiers, provider info, warnings, and prioritizes the preferred language.
* **Bug Fixes**
  * Improved resilience when decoding search results and handling optional fields.
  * Downloaded subtitles are added and selected without restarting playback.
* **Tests**
  * Added coverage for subtitle search/download request/response decoding and scoring boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->