### PR TITLE
For You: always show Watchlist/Favorites shortcuts

### DIFF
--- a/iosApp/iosApp/Control/iOS/NowPlayingShelf.swift
+++ b/iosApp/iosApp/Control/iOS/NowPlayingShelf.swift
@@ -20,10 +20,12 @@ struct NowPlayingShelf: View {
     }
 
     /// Mirrors `SiloControlMiniBar.isVisible`: a live session (excluding a
-    /// still-unconfirmed auto-resume probe) or an in-flight reconnect.
+    /// still-unconfirmed auto-resume probe) or an in-flight reconnect. The bar
+    /// stays mounted while the full remote sheet is up — detaching the
+    /// tabViewBottomAccessory there made it re-insert (with a system slide-in)
+    /// every time the sheet was swiped away.
     static func controlBarVisible(_ control: SiloControlClient) -> Bool {
-        guard !control.isShowingRemoteControl else { return false }
-        return (control.hasActiveSession && !control.isAutoResuming) || control.isReconnecting
+        (control.hasActiveSession && !control.isAutoResuming) || control.isReconnecting
     }
     #else
     static func hasActiveAccessory(audio: AudioPlaybackStore) -> Bool {
@@ -36,7 +38,6 @@ struct NowPlayingShelf: View {
         if Self.controlBarVisible(siloControl) {
             SiloControlMiniBar(controller: siloControl, style: style)
                 .animation(.snappy, value: siloControl.hasActiveSession)
-                .animation(.snappy, value: siloControl.isShowingRemoteControl)
                 .animation(.snappy, value: siloControl.isReconnecting)
         } else if audioStore.player.hasActiveSession {
             AudioMiniPlayerView(style: style)

--- a/iosApp/iosApp/Control/iOS/SiloControlMiniBar.swift
+++ b/iosApp/iosApp/Control/iOS/SiloControlMiniBar.swift
@@ -16,10 +16,10 @@ struct SiloControlMiniBar: View {
     /// Whether the bar has anything to show: a live session (that isn't a
     /// still-unconfirmed auto-resume probe) or an in-flight reconnect. Keeping
     /// the bar up through a reconnect (with a spinner) beats having it vanish
-    /// and pop back.
+    /// and pop back. Stays visible under the full remote sheet so dismissing
+    /// the sheet doesn't re-insert the accessory with a second animation.
     private var isVisible: Bool {
-        guard !controller.isShowingRemoteControl else { return false }
-        return (controller.hasActiveSession && !controller.isAutoResuming) || controller.isReconnecting
+        (controller.hasActiveSession && !controller.isAutoResuming) || controller.isReconnecting
     }
 
     private var targetName: String {

--- a/iosApp/iosApp/Screens/Recommendations/RecommendationsView.swift
+++ b/iosApp/iosApp/Screens/Recommendations/RecommendationsView.swift
@@ -82,29 +82,49 @@ struct RecommendationsView: View {
         #endif
     }
 
+    /// The Watchlist/Favorites shortcut row renders in every state — the
+    /// user's saved lists are reachable from here even when there are no
+    /// recommendations (or they failed to load).
     @ViewBuilder
     private var pageContent: some View {
         if !viewModel.sections.isEmpty {
             content
-        } else if let error = viewModel.error {
-            ErrorView(state: error, onRetry: { Task { await viewModel.loadRecommendations() } })
-        } else if viewModel.isLoading {
-            loadingState
         } else {
-            emptyState
+            VStack(spacing: 0) {
+                shortcutsRow
+                    .padding(.horizontal, contentHorizontalPadding)
+                    #if os(tvOS)
+                    .padding(.top, TVTopMenuLayout.contentTopInset)
+                    #endif
+
+                Group {
+                    if let error = viewModel.error {
+                        ErrorView(state: error, onRetry: { Task { await viewModel.loadRecommendations() } })
+                    } else if viewModel.isLoading {
+                        Color.clear
+                    } else {
+                        emptyState
+                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
         }
+    }
+
+    private var shortcutsRow: some View {
+        SavedShortcutsRow(
+            focusRequest: focusRequest,
+            isTopMenuFocused: isTopMenuFocused,
+            onSelect: { router.navigate(to: $0.route) },
+            onMoveUp: onTopMenuFocusRequest
+        )
     }
 
     private var content: some View {
         ScrollView(.vertical, showsIndicators: false) {
             LazyVStack(spacing: sectionSpacing) {
-                SavedShortcutsRow(
-                    focusRequest: focusRequest,
-                    isTopMenuFocused: isTopMenuFocused,
-                    onSelect: { router.navigate(to: $0.route) },
-                    onMoveUp: onTopMenuFocusRequest
-                )
-                .padding(.horizontal, contentHorizontalPadding)
+                shortcutsRow
+                    .padding(.horizontal, contentHorizontalPadding)
 
                 ForEach(Array(viewModel.sections.enumerated()), id: \.element.id) { index, section in
                     SectionRow(
@@ -120,21 +140,6 @@ struct RecommendationsView: View {
             #endif
             .padding(.bottom, ContinuumTheme.largePadding)
         }
-    }
-
-    /// On tvOS the loading state must contain at least one focusable
-    /// element. Without it, focus stays parked on the sidebar tab item
-    /// and `TVMainTabView`'s `.onExitCommand` (which routes Menu/Back to
-    /// Home) never fires — leaving the user with no way out of the tab.
-    @ViewBuilder
-    private var loadingState: some View {
-        #if os(tvOS)
-        Color.clear
-            .padding(.top, TVTopMenuLayout.contentTopInset)
-            .focusable()
-        #else
-        Color.clear
-        #endif
     }
 
     @ViewBuilder
@@ -164,9 +169,6 @@ struct RecommendationsView: View {
             #endif
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        #if os(tvOS)
-        .padding(.top, TVTopMenuLayout.contentTopInset)
-        #endif
     }
 
     /// Load the currently-selected profile so we can render its avatar in


### PR DESCRIPTION
## What changed

On the For You (Recommendations) page, the Watchlist/Favorites saved-shortcuts row was rendered only inside the populated-content branch, gated on `viewModel.sections` being non-empty. The loading, error, and "No recommendations yet" states dropped the buttons entirely, leaving no way to reach those lists from the page.

`RecommendationsView.pageContent` now pins the shortcuts row at the top in every state, with the loading/error/empty content rendered below it.

## Notes for review

- The tvOS-only `loadingState` helper (an invisible `.focusable()` placeholder that existed solely so the loading state had a focus target for Menu/Back routing) is removed — the always-present shortcut row now serves that purpose.
- The tvOS top-menu focus hand-down (`focusRequest`) flows through the same `SavedShortcutsRow` in both branches, so d-pad landing on Watchlist works whether or not recommendations loaded.
- The empty state's tvOS top inset moved to the shared wrapper so it isn't applied twice.
- Verified: iOS, tvOS, and macOS schemes all build clean. Worth a quick d-pad pass on the empty state (shortcut row + Refresh button) in the tvOS sim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Saved shortcuts now stay visible on the Recommendations screen, even when recommendations are loading, empty, or fail to load.

* **Bug Fixes**
  * The now-playing control bar now stays visible during remote-control and reconnect states instead of briefly disappearing.
  * Improved animation behavior so the control mini bar no longer reappears with an extra animation when dismissing the remote control sheet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->