### PR TITLE
Persist audio/subtitle track selections across player exits (web parity)

### DIFF
--- a/iosApp/Tests/TrackSelectionPersistenceTests.swift
+++ b/iosApp/Tests/TrackSelectionPersistenceTests.swift
@@ -1,0 +1,207 @@
+import XCTest
+import Foundation
+@testable import Silo
+
+/// The pref-request builders feed the server's per-series audio /
+/// subtitle preference endpoints; a wrong index space or a signature
+/// field mismatch silently breaks track stickiness, so the wire shapes
+/// are pinned here.
+final class TrackSelectionPersistenceTests: XCTestCase {
+
+    // MARK: - Pref key
+
+    func testPrefKeyPrefersSeriesIdOverContentId() {
+        XCTAssertEqual(
+            TrackSelectionPersistence.prefKey(seriesId: "series-9", contentId: "ep-1"),
+            "series-9"
+        )
+        XCTAssertEqual(
+            TrackSelectionPersistence.prefKey(seriesId: nil, contentId: "movie-7"),
+            "movie-7"
+        )
+        XCTAssertEqual(
+            TrackSelectionPersistence.prefKey(seriesId: "", contentId: "movie-7"),
+            "movie-7"
+        )
+        XCTAssertNil(TrackSelectionPersistence.prefKey(seriesId: nil, contentId: nil))
+        XCTAssertNil(TrackSelectionPersistence.prefKey(seriesId: "", contentId: ""))
+    }
+
+    // MARK: - Audio requests
+
+    func testAudioRequestBuildsSignatureFromServerMetadata() {
+        let version = decodedVersion("""
+        {
+          "file_id": 1,
+          "audio_tracks": [
+            { "language": "en", "codec": "aac", "channels": 2, "layout": "stereo", "default": true },
+            {
+              "language": "ja",
+              "title": "Japanese 5.1",
+              "embedded_title": "JPN Surround",
+              "codec": "eac3",
+              "channels": 6,
+              "layout": "5.1",
+              "default": false
+            }
+          ]
+        }
+        """)
+
+        let request = TrackSelectionPersistence.audioRequest(version: version, ordinal: 1)
+
+        XCTAssertEqual(request?.audioTrackIndex, 1)
+        XCTAssertEqual(request?.audioLanguage, "ja")
+        XCTAssertEqual(request?.trackSignature?.language, "ja")
+        XCTAssertEqual(request?.trackSignature?.title, "Japanese 5.1")
+        XCTAssertEqual(request?.trackSignature?.embeddedTitle, "JPN Surround")
+        XCTAssertEqual(request?.trackSignature?.codec, "eac3")
+        XCTAssertEqual(request?.trackSignature?.layout, "5.1")
+        XCTAssertEqual(request?.trackSignature?.channels, 6)
+        XCTAssertEqual(request?.trackSignature?.isDefault, false)
+    }
+
+    func testAudioRequestRejectsOutOfRangeOrdinal() {
+        let version = decodedVersion("""
+        { "file_id": 1, "audio_tracks": [ { "language": "en", "codec": "aac" } ] }
+        """)
+
+        XCTAssertNil(TrackSelectionPersistence.audioRequest(version: version, ordinal: 1))
+        XCTAssertNil(TrackSelectionPersistence.audioRequest(version: version, ordinal: -1))
+    }
+
+    func testAudioRequestFromPlayerTrackFallsBackToTrackFields() {
+        let track = playerTrack(
+            kind: .audio,
+            title: "Commentary",
+            lang: "en",
+            codec: "ac3",
+            layout: "stereo",
+            channels: 2
+        )
+
+        let request = TrackSelectionPersistence.audioRequest(track: track, ordinal: nil)
+
+        XCTAssertEqual(request.audioTrackIndex, -1, "Unknown ordinal must persist as 'no index' so the server matches by signature/language")
+        XCTAssertEqual(request.audioLanguage, "en")
+        XCTAssertEqual(request.trackSignature?.codec, "ac3")
+        XCTAssertEqual(request.trackSignature?.channels, 2)
+    }
+
+    // MARK: - Subtitle requests
+
+    func testSubtitleRequestForEmbeddedTrack() {
+        let version = decodedVersion("""
+        {
+          "file_id": 1,
+          "subtitle_tracks": [
+            { "index": 2, "language": "en", "codec": "subrip", "title": "English", "forced": false, "hearing_impaired": true }
+          ]
+        }
+        """)
+
+        let request = TrackSelectionPersistence.subtitleRequest(version: version, ffIndex: 2, showForced: true)
+
+        XCTAssertEqual(request?.subtitleTrackIndex, 2)
+        XCTAssertEqual(request?.subtitleLanguage, "en")
+        XCTAssertEqual(request?.subtitleMode, SubtitleMode.always.rawValue)
+        XCTAssertEqual(request?.externalSubtitlePath, "")
+        XCTAssertEqual(request?.trackSignature?.source, "embedded")
+        XCTAssertEqual(request?.trackSignature?.label, "English")
+        XCTAssertEqual(request?.trackSignature?.hearingImpaired, true)
+        XCTAssertEqual(request?.showForcedSubtitles, true)
+    }
+
+    func testSubtitleRequestForExternalTrackCarriesPath() {
+        let version = decodedVersion("""
+        {
+          "file_id": 1,
+          "subtitle_tracks": [
+            { "index": 5, "language": "es", "codec": "subrip", "external": true, "file_name": "Movie.es.srt" }
+          ]
+        }
+        """)
+
+        let request = TrackSelectionPersistence.subtitleRequest(version: version, ffIndex: 5, showForced: nil)
+
+        XCTAssertEqual(request?.trackSignature?.source, "external")
+        XCTAssertEqual(request?.externalSubtitlePath, "Movie.es.srt")
+    }
+
+    func testSubtitleRequestNegativeIndexMeansOff() {
+        let version = decodedVersion("""
+        { "file_id": 1, "subtitle_tracks": [ { "index": 0, "language": "en", "codec": "subrip" } ] }
+        """)
+
+        let request = TrackSelectionPersistence.subtitleRequest(version: version, ffIndex: -1, showForced: false)
+
+        XCTAssertEqual(request?.subtitleTrackIndex, -1)
+        XCTAssertEqual(request?.subtitleLanguage, "")
+        XCTAssertEqual(request?.subtitleMode, SubtitleMode.off.rawValue)
+        XCTAssertNil(request?.trackSignature ?? nil)
+    }
+
+    func testSubtitleRequestUnknownIndexReturnsNil() {
+        let version = decodedVersion("""
+        { "file_id": 1, "subtitle_tracks": [ { "index": 0, "language": "en", "codec": "subrip" } ] }
+        """)
+
+        XCTAssertNil(TrackSelectionPersistence.subtitleRequest(version: version, ffIndex: 3, showForced: nil))
+    }
+
+    func testSubtitleRequestFromPlayerTrackUsesFfIndexAndFlags() {
+        let track = playerTrack(
+            kind: .sub,
+            title: "Signs & Songs",
+            lang: "en",
+            codec: "ass",
+            isForced: true,
+            ffIndex: 4
+        )
+
+        let request = TrackSelectionPersistence.subtitleRequest(track: track, showForced: nil)
+
+        XCTAssertEqual(request.subtitleTrackIndex, 4)
+        XCTAssertEqual(request.subtitleMode, SubtitleMode.always.rawValue)
+        XCTAssertEqual(request.trackSignature?.forced, true)
+        XCTAssertEqual(request.trackSignature?.label, "Signs & Songs")
+    }
+
+    // MARK: - Helpers
+
+    private func decodedVersion(_ json: String) -> FileVersion {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try! decoder.decode(FileVersion.self, from: Data(json.utf8))
+    }
+
+    private func playerTrack(
+        kind: PlayerTrack.Kind,
+        title: String?,
+        lang: String?,
+        codec: String?,
+        layout: String? = nil,
+        channels: Int? = nil,
+        isForced: Bool = false,
+        ffIndex: Int? = nil
+    ) -> PlayerTrack {
+        PlayerTrack(
+            trackId: 1,
+            kind: kind,
+            title: title,
+            lang: lang,
+            codec: codec,
+            audioChannelsLayout: layout,
+            audioChannelCount: channels,
+            bitrate: nil,
+            isDefault: false,
+            isForced: isForced,
+            isHearingImpaired: false,
+            isVisualImpaired: false,
+            isExternal: false,
+            isSelected: false,
+            ffIndex: ffIndex,
+            srcId: nil
+        )
+    }
+}

--- a/iosApp/iosApp/Control/iOS/NowPlayingShelf.swift
+++ b/iosApp/iosApp/Control/iOS/NowPlayingShelf.swift
@@ -20,10 +20,12 @@ struct NowPlayingShelf: View {
     }
 
     /// Mirrors `SiloControlMiniBar.isVisible`: a live session (excluding a
-    /// still-unconfirmed auto-resume probe) or an in-flight reconnect.
+    /// still-unconfirmed auto-resume probe) or an in-flight reconnect. The bar
+    /// stays mounted while the full remote sheet is up — detaching the
+    /// tabViewBottomAccessory there made it re-insert (with a system slide-in)
+    /// every time the sheet was swiped away.
     static func controlBarVisible(_ control: SiloControlClient) -> Bool {
-        guard !control.isShowingRemoteControl else { return false }
-        return (control.hasActiveSession && !control.isAutoResuming) || control.isReconnecting
+        (control.hasActiveSession && !control.isAutoResuming) || control.isReconnecting
     }
     #else
     static func hasActiveAccessory(audio: AudioPlaybackStore) -> Bool {
@@ -36,7 +38,6 @@ struct NowPlayingShelf: View {
         if Self.controlBarVisible(siloControl) {
             SiloControlMiniBar(controller: siloControl, style: style)
                 .animation(.snappy, value: siloControl.hasActiveSession)
-                .animation(.snappy, value: siloControl.isShowingRemoteControl)
                 .animation(.snappy, value: siloControl.isReconnecting)
         } else if audioStore.player.hasActiveSession {
             AudioMiniPlayerView(style: style)

--- a/iosApp/iosApp/Control/iOS/SiloControlMiniBar.swift
+++ b/iosApp/iosApp/Control/iOS/SiloControlMiniBar.swift
@@ -16,10 +16,10 @@ struct SiloControlMiniBar: View {
     /// Whether the bar has anything to show: a live session (that isn't a
     /// still-unconfirmed auto-resume probe) or an in-flight reconnect. Keeping
     /// the bar up through a reconnect (with a spinner) beats having it vanish
-    /// and pop back.
+    /// and pop back. Stays visible under the full remote sheet so dismissing
+    /// the sheet doesn't re-insert the accessory with a second animation.
     private var isVisible: Bool {
-        guard !controller.isShowingRemoteControl else { return false }
-        return (controller.hasActiveSession && !controller.isAutoResuming) || controller.isReconnecting
+        (controller.hasActiveSession && !controller.isAutoResuming) || controller.isReconnecting
     }
 
     private var targetName: String {

--- a/iosApp/iosApp/Networking/Models.swift
+++ b/iosApp/iosApp/Networking/Models.swift
@@ -774,6 +774,10 @@ struct AudioTrack: Codable, Identifiable, Hashable {
     let sampleRate: Int?
     let language: String?
     let title: String?
+    /// Raw stream title as probed, distinct from the cleaned `title`.
+    /// The server's audio-pref signature match compares both fields
+    /// separately, so persisted track choices must echo each back.
+    let embeddedTitle: String?
     /// Server field is the reserved word `default`.
     let isDefault: Bool?
     var id: Int { index ?? 0 }
@@ -787,6 +791,7 @@ struct AudioTrack: Codable, Identifiable, Hashable {
         case sampleRate
         case language
         case title
+        case embeddedTitle
         case isDefault = "default"
     }
 }
@@ -799,7 +804,11 @@ struct SubtitleTrack: Codable, Identifiable, Hashable {
     let codec: String?
     let language: String?
     let title: String?
+    /// Raw stream title as probed, distinct from the cleaned `title`.
+    let embeddedTitle: String?
     let forced: Bool?
+    /// SDH flag — carried into persisted subtitle-pref signatures.
+    let hearingImpaired: Bool?
     /// Server field is the reserved word `default`.
     let isDefault: Bool?
     let external: Bool?
@@ -811,7 +820,9 @@ struct SubtitleTrack: Codable, Identifiable, Hashable {
         case codec
         case language
         case title
+        case embeddedTitle
         case forced
+        case hearingImpaired
         case isDefault = "default"
         case external
         // The API decoder runs `.convertFromSnakeCase`, which rewrites the wire

--- a/iosApp/iosApp/Networking/TrackSelectionPersistence.swift
+++ b/iosApp/iosApp/Networking/TrackSelectionPersistence.swift
@@ -1,0 +1,212 @@
+//
+//  TrackSelectionPersistence.swift
+//  Continuum (iOS + tvOS)
+//
+//  Persists the user's explicit audio / subtitle track choices to the
+//  server's per-series preference endpoints so they survive exiting
+//  the player and revisiting the item — matching the web app. The web
+//  player PUTs `/subtitle-prefs/{key}` on every subtitle change and
+//  relies on its audio-change PATCH to persist audio server-side;
+//  Apple's track switches are engine-local (no wire call), so both
+//  kinds are written here explicitly.
+//
+//  Key semantics mirror the web's `seriesContext?.seriesId ?? contentId`:
+//  episodes persist under their series id (one choice applies to the
+//  whole series), movies under their own content id — which is exactly
+//  the key the server's detail resolver reads movie prefs back from.
+//
+//  Writes are best-effort fire-and-forget: a failed PUT costs the user
+//  a remembered preference, never playback. Reads never happen here —
+//  the server folds saved prefs into `WatchDetail.effective_*` /
+//  `FileVersion.effectiveAudioTrackIndex`, which the detail page and
+//  player already consume.
+//
+
+import Foundation
+import os
+
+enum TrackSelectionPersistence {
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.continuum.app",
+        category: "TrackPrefs"
+    )
+
+    /// Server pref key: the series id for episodes, the item's own
+    /// content id otherwise. Nil when neither is known (e.g. offline
+    /// playback with no server-backed identity).
+    static func prefKey(seriesId: String?, contentId: String?) -> String? {
+        if let seriesId, !seriesId.isEmpty { return seriesId }
+        if let contentId, !contentId.isEmpty { return contentId }
+        return nil
+    }
+
+    // MARK: - Request builders (pure)
+
+    /// Audio pick against server file metadata. `ordinal` indexes
+    /// `version.audioTracks` — the same space the server's
+    /// `audio_track_index` uses. Building the signature from the
+    /// server's own probed fields guarantees an exact match when the
+    /// preference is re-resolved.
+    static func audioRequest(version: FileVersion, ordinal: Int) -> AudioPrefRequest? {
+        guard let tracks = version.audioTracks, tracks.indices.contains(ordinal) else {
+            return nil
+        }
+        let track = tracks[ordinal]
+        return AudioPrefRequest(
+            audioTrackIndex: ordinal,
+            audioLanguage: track.language ?? "",
+            trackSignature: AudioTrackSignature(
+                language: track.language,
+                title: track.title,
+                embeddedTitle: track.embeddedTitle,
+                codec: track.codec,
+                layout: track.channelLayout,
+                channels: track.channels,
+                isDefault: track.isDefault ?? false
+            )
+        )
+    }
+
+    /// Audio pick from a live player track, for selections the watch
+    /// detail can't describe (recovered tracks, ordinal unknown). The
+    /// server matches signature first and treats a negative index as
+    /// "no index" — language and signature still apply.
+    static func audioRequest(track: PlayerTrack, ordinal: Int?) -> AudioPrefRequest {
+        AudioPrefRequest(
+            audioTrackIndex: ordinal ?? -1,
+            audioLanguage: track.normalizedLanguageCode ?? "",
+            trackSignature: AudioTrackSignature(
+                language: track.normalizedLanguageCode,
+                title: track.normalizedTitle,
+                embeddedTitle: track.normalizedTitle,
+                codec: track.codec,
+                layout: track.audioChannelsLayout,
+                channels: track.audioChannelCount,
+                isDefault: track.isDefault
+            )
+        )
+    }
+
+    /// Subtitle pick against server file metadata. `ffIndex` matches
+    /// `version.subtitleTracks[].index`; a negative value is the detail
+    /// page's explicit "Off".
+    static func subtitleRequest(
+        version: FileVersion,
+        ffIndex: Int,
+        showForced: Bool?
+    ) -> SubtitlePrefRequest? {
+        if ffIndex < 0 {
+            return subtitleOffRequest(showForced: showForced)
+        }
+        guard let track = version.subtitleTracks?.first(where: { $0.index == ffIndex }) else {
+            return nil
+        }
+        let isExternal = track.external ?? false
+        return SubtitlePrefRequest(
+            subtitleLanguage: track.language ?? "",
+            subtitleTrackIndex: ffIndex,
+            externalSubtitlePath: isExternal ? (track.externalPath ?? "") : "",
+            subtitleMode: SubtitleMode.always.rawValue,
+            trackSignature: SubtitleTrackSignature(
+                source: isExternal ? "external" : "embedded",
+                language: track.language,
+                codec: track.codec,
+                label: track.title ?? track.embeddedTitle,
+                forced: track.forced ?? false,
+                hearingImpaired: track.hearingImpaired ?? false
+            ),
+            showForcedSubtitles: showForced
+        )
+    }
+
+    /// Subtitle pick from a live player track (sidecar / downloaded /
+    /// embedded rows the watch detail can't describe).
+    static func subtitleRequest(track: PlayerTrack, showForced: Bool?) -> SubtitlePrefRequest {
+        SubtitlePrefRequest(
+            subtitleLanguage: track.normalizedLanguageCode ?? "",
+            subtitleTrackIndex: track.ffIndex ?? -1,
+            externalSubtitlePath: "",
+            subtitleMode: SubtitleMode.always.rawValue,
+            trackSignature: SubtitleTrackSignature(
+                source: track.isExternal ? "external" : "embedded",
+                language: track.normalizedLanguageCode,
+                codec: track.codec,
+                label: track.normalizedTitle,
+                forced: track.isForced,
+                hearingImpaired: track.isHearingImpaired
+            ),
+            showForcedSubtitles: showForced
+        )
+    }
+
+    /// Explicit "subtitles off" — same payload the web writes for a
+    /// null selection: empty language, index -1, mode "off".
+    static func subtitleOffRequest(showForced: Bool?) -> SubtitlePrefRequest {
+        SubtitlePrefRequest(
+            subtitleLanguage: "",
+            subtitleTrackIndex: -1,
+            externalSubtitlePath: "",
+            subtitleMode: SubtitleMode.off.rawValue,
+            trackSignature: nil,
+            showForcedSubtitles: showForced
+        )
+    }
+
+    // MARK: - Fire-and-forget writers
+
+    static func saveAudio(prefKey: String, request: AudioPrefRequest) {
+        Task {
+            do {
+                try await ContinuumAPI.shared.setAudioPref(seriesId: prefKey, body: request)
+            } catch {
+                logger.warning(
+                    "audio pref save failed key=\(prefKey, privacy: .public): \(String(describing: error), privacy: .public)"
+                )
+            }
+        }
+    }
+
+    static func saveSubtitle(prefKey: String, request: SubtitlePrefRequest) {
+        Task {
+            do {
+                try await ContinuumAPI.shared.setSubtitlePref(seriesId: prefKey, body: request)
+            } catch {
+                logger.warning(
+                    "subtitle pref save failed key=\(prefKey, privacy: .public): \(String(describing: error), privacy: .public)"
+                )
+            }
+        }
+    }
+
+    /// The detail selectors' "Auto" choice — remove the sticky override
+    /// so the library/profile cascade applies again. A 404 just means
+    /// no override existed.
+    static func clearAudio(prefKey: String) {
+        Task {
+            do {
+                try await ContinuumAPI.shared.deleteAudioPref(seriesId: prefKey)
+            } catch HTTPError.http(let code, _) where code == 404 {
+                // Nothing to clear.
+            } catch {
+                logger.warning(
+                    "audio pref clear failed key=\(prefKey, privacy: .public): \(String(describing: error), privacy: .public)"
+                )
+            }
+        }
+    }
+
+    static func clearSubtitle(prefKey: String) {
+        Task {
+            do {
+                try await ContinuumAPI.shared.deleteSubtitlePref(seriesId: prefKey)
+            } catch HTTPError.http(let code, _) where code == 404 {
+                // Nothing to clear.
+            } catch {
+                logger.warning(
+                    "subtitle pref clear failed key=\(prefKey, privacy: .public): \(String(describing: error), privacy: .public)"
+                )
+            }
+        }
+    }
+}

--- a/iosApp/iosApp/Screens/Detail/ItemDetailView.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailView.swift
@@ -274,12 +274,25 @@ private struct ItemDetailPhoneContent: View {
                         versionFileId: preferredNextUpFileId,
                         candidate: index
                     )
+                    persistAudioSelection(
+                        prefKey: prefKey(for: nextUpWatchDetail),
+                        version: effectiveVersion(for: nextUpWatchDetail, versionFileId: preferredNextUpFileId),
+                        requested: index,
+                        sanitized: preferredNextUpAudioTrackIndex
+                    )
                 },
                 onSelectNextUpSubtitleTrack: { index in
                     preferredNextUpSubtitleTrackIndex = sanitizedSubtitleTrackIndex(
                         for: nextUpWatchDetail,
                         versionFileId: preferredNextUpFileId,
                         candidate: index
+                    )
+                    persistSubtitleSelection(
+                        prefKey: prefKey(for: nextUpWatchDetail),
+                        version: effectiveVersion(for: nextUpWatchDetail, versionFileId: preferredNextUpFileId),
+                        requested: index,
+                        sanitized: preferredNextUpSubtitleTrackIndex,
+                        showForced: nextUpWatchDetail?.effectiveShowForcedSubtitles
                     )
                 },
                 onToggleFavorite: { Task { await viewModel.toggleFavorite() } },
@@ -361,12 +374,25 @@ private struct ItemDetailPhoneContent: View {
                         versionFileId: preferredNextUpFileId,
                         candidate: index
                     )
+                    persistAudioSelection(
+                        prefKey: prefKey(for: nextUpWatchDetail),
+                        version: effectiveVersion(for: nextUpWatchDetail, versionFileId: preferredNextUpFileId),
+                        requested: index,
+                        sanitized: preferredNextUpAudioTrackIndex
+                    )
                 },
                 onSelectNextUpSubtitleTrack: { index in
                     preferredNextUpSubtitleTrackIndex = sanitizedSubtitleTrackIndex(
                         for: nextUpWatchDetail,
                         versionFileId: preferredNextUpFileId,
                         candidate: index
+                    )
+                    persistSubtitleSelection(
+                        prefKey: prefKey(for: nextUpWatchDetail),
+                        version: effectiveVersion(for: nextUpWatchDetail, versionFileId: preferredNextUpFileId),
+                        requested: index,
+                        sanitized: preferredNextUpSubtitleTrackIndex,
+                        showForced: nextUpWatchDetail?.effectiveShowForcedSubtitles
                     )
                 },
                 onToggleFavorite: { Task { await viewModel.toggleFavorite() } },
@@ -439,12 +465,25 @@ private struct ItemDetailPhoneContent: View {
                         versionFileId: preferredVersionFileId,
                         candidate: index
                     )
+                    persistAudioSelection(
+                        prefKey: prefKey(for: detail),
+                        version: effectiveVersion(for: detail, versionFileId: preferredVersionFileId),
+                        requested: index,
+                        sanitized: preferredAudioTrackIndex
+                    )
                 },
                 onSelectSubtitleTrack: { index in
                     preferredSubtitleTrackIndex = sanitizedSubtitleTrackIndex(
                         for: detail,
                         versionFileId: preferredVersionFileId,
                         candidate: index
+                    )
+                    persistSubtitleSelection(
+                        prefKey: prefKey(for: detail),
+                        version: effectiveVersion(for: detail, versionFileId: preferredVersionFileId),
+                        requested: index,
+                        sanitized: preferredSubtitleTrackIndex,
+                        showForced: nil
                     )
                 },
                 onSelectSeason: { season in
@@ -582,6 +621,61 @@ private struct ItemDetailPhoneContent: View {
         }
         let available = version.subtitleTracks?.compactMap(\.index) ?? []
         return available.contains(candidate) ? candidate : nil
+    }
+
+    // MARK: - Track-choice persistence
+    //
+    // Selector picks are remembered server-side (web-app parity):
+    // episodes key by series id so one choice covers the series, movies
+    // by their own content id. "Auto" (nil) clears the override so the
+    // library/profile cascade applies again.
+
+    private func prefKey(for detail: ItemDetail) -> String? {
+        TrackSelectionPersistence.prefKey(seriesId: detail.seriesId, contentId: detail.contentId)
+    }
+
+    private func prefKey(for detail: WatchDetail?) -> String? {
+        TrackSelectionPersistence.prefKey(seriesId: detail?.seriesId, contentId: detail?.contentId)
+    }
+
+    private func persistAudioSelection(
+        prefKey: String?,
+        version: FileVersion?,
+        requested: Int?,
+        sanitized: Int?
+    ) {
+        guard let prefKey else { return }
+        guard let requested else {
+            TrackSelectionPersistence.clearAudio(prefKey: prefKey)
+            return
+        }
+        guard requested == sanitized,
+              let version,
+              let request = TrackSelectionPersistence.audioRequest(version: version, ordinal: requested)
+        else { return }
+        TrackSelectionPersistence.saveAudio(prefKey: prefKey, request: request)
+    }
+
+    private func persistSubtitleSelection(
+        prefKey: String?,
+        version: FileVersion?,
+        requested: Int?,
+        sanitized: Int?,
+        showForced: Bool?
+    ) {
+        guard let prefKey else { return }
+        guard let requested else {
+            TrackSelectionPersistence.clearSubtitle(prefKey: prefKey)
+            return
+        }
+        guard requested == sanitized, let version,
+              let request = TrackSelectionPersistence.subtitleRequest(
+                  version: version,
+                  ffIndex: requested,
+                  showForced: showForced
+              )
+        else { return }
+        TrackSelectionPersistence.saveSubtitle(prefKey: prefKey, request: request)
     }
 
     private func nextUpEpisode(for detail: ItemDetail) -> EpisodeListItem? {

--- a/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
@@ -279,12 +279,17 @@ actor PlaybackSessionBridge {
                 hasManualSelection: preferredFileId != nil
             )
         let profileId = await TokenStore.shared.getProfileId()
+        // Without an explicit pick, send the server's own detail-resolved
+        // effective audio index. /playback/start only consults saved audio
+        // prefs for episodes (its series-id lookup is empty for movies), so
+        // a movie's remembered track would otherwise be dropped here even
+        // though the watch detail above already resolved it.
         let request = StartPlaybackRequest(
             fileId: selectedVersion.fileId,
             profileId: profileId,
             playMethod: playbackPlan.playMethod,
             startPosition: effectiveStartPosition,
-            audioTrackIndex: preferredAudioTrackIndex,
+            audioTrackIndex: preferredAudioTrackIndex ?? selectedVersion.effectiveAudioTrackIndex,
             preserveDirectAudioSelection: playbackPlan.playMethod == PlaybackDeliveryStrategy.direct.name,
             codecsVideo: playbackPlan.capabilities.codecsVideo,
             codecsAudio: playbackPlan.capabilities.codecsAudio,

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -4225,6 +4225,7 @@ class PlayerViewModel {
         pendingAudioFfIndex = nil
         selectedAudioId = track.trackId
         applyAudioTrackSelection(track.trackId)
+        persistAudioSelection(track)
         scheduleHideControls()
     }
 
@@ -4240,6 +4241,7 @@ class PlayerViewModel {
             "[CMP-SUB] select primary trackId=\(track.trackId, privacy: .public) title=\(track.title ?? "nil", privacy: .public) external=\(track.isExternal, privacy: .public) codec=\(track.codec ?? "nil", privacy: .public)"
         )
         applySubtitleTrackSelection(track.trackId)
+        persistSubtitleSelection(track)
         scheduleHideControls()
     }
 
@@ -4253,7 +4255,66 @@ class PlayerViewModel {
         selectedSubtitleId = nil
         Self.logger.info("[CMP-SUB] disable primary subtitles")
         applySubtitleTrackSelection(nil)
+        persistSubtitleSelection(nil)
         scheduleHideControls()
+    }
+
+    /// Server pref key for remembering explicit track picks: series id
+    /// for episodes (one choice covers the series), the item's own
+    /// content id for movies. Nil during offline playback — there is no
+    /// server to remember anything for.
+    private var trackPrefPersistKey: String? {
+        guard offlinePlaybackContext == nil, let detail = currentWatchDetail else { return nil }
+        return TrackSelectionPersistence.prefKey(
+            seriesId: detail.seriesId,
+            contentId: detail.contentId
+        )
+    }
+
+    /// Best-effort write of an explicit audio pick so it sticks across
+    /// player exits (web-app parity; the server only auto-persists
+    /// audio on its own change endpoint, which Apple's engine-local
+    /// switching never calls). Prefers the server's probed metadata for
+    /// the signature so re-resolution gets an exact match.
+    private func persistAudioSelection(_ track: PlayerTrack) {
+        guard let key = trackPrefPersistKey else { return }
+        let ordinal = audioSelectionIndex(for: track)
+        let request: AudioPrefRequest
+        if let ordinal,
+           let version = currentSelectedVersion,
+           let fromDetail = TrackSelectionPersistence.audioRequest(version: version, ordinal: ordinal) {
+            request = fromDetail
+        } else {
+            request = TrackSelectionPersistence.audioRequest(track: track, ordinal: ordinal)
+        }
+        TrackSelectionPersistence.saveAudio(prefKey: key, request: request)
+    }
+
+    /// Best-effort write of an explicit subtitle pick (or explicit
+    /// "Off" when `track` is nil). Live AI translation tracks are
+    /// session-scoped and never persisted.
+    private func persistSubtitleSelection(_ track: PlayerTrack?) {
+        guard let key = trackPrefPersistKey else { return }
+        if let track, SubtitleTrackIdSpace.isAILive(track.trackId) { return }
+        let showForced = currentWatchDetail?.effectiveShowForcedSubtitles
+        let request: SubtitlePrefRequest
+        if let track {
+            if !track.isExternal,
+               let ffIndex = track.ffIndex,
+               let version = currentSelectedVersion,
+               let fromDetail = TrackSelectionPersistence.subtitleRequest(
+                   version: version,
+                   ffIndex: ffIndex,
+                   showForced: showForced
+               ) {
+                request = fromDetail
+            } else {
+                request = TrackSelectionPersistence.subtitleRequest(track: track, showForced: showForced)
+            }
+        } else {
+            request = TrackSelectionPersistence.subtitleOffRequest(showForced: showForced)
+        }
+        TrackSelectionPersistence.saveSubtitle(prefKey: key, request: request)
     }
 
     func selectSecondarySubtitle(_ track: PlayerTrack) {

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
@@ -151,12 +151,25 @@ struct TVItemDetailView: View {
                         versionFileId: preferredNextUpFileId,
                         candidate: index
                     )
+                    persistAudioSelection(
+                        prefKey: prefKey(for: nextUpPlaybackDetail),
+                        version: effectiveVersion(for: nextUpPlaybackDetail, versionFileId: preferredNextUpFileId),
+                        requested: index,
+                        sanitized: preferredNextUpAudioTrackIndex
+                    )
                 },
                 onSelectNextUpSubtitleTrack: { index in
                     preferredNextUpSubtitleTrackIndex = sanitizedSubtitleTrackIndex(
                         for: nextUpPlaybackDetail,
                         versionFileId: preferredNextUpFileId,
                         candidate: index
+                    )
+                    persistSubtitleSelection(
+                        prefKey: prefKey(for: nextUpPlaybackDetail),
+                        version: effectiveVersion(for: nextUpPlaybackDetail, versionFileId: preferredNextUpFileId),
+                        requested: index,
+                        sanitized: preferredNextUpSubtitleTrackIndex,
+                        showForced: nil
                     )
                 },
                 onToggleFavorite: { Task { await viewModel.toggleFavorite() } },
@@ -244,12 +257,25 @@ struct TVItemDetailView: View {
                         versionFileId: preferredNextUpFileId,
                         candidate: index
                     )
+                    persistAudioSelection(
+                        prefKey: prefKey(for: nextUpPlaybackDetail),
+                        version: effectiveVersion(for: nextUpPlaybackDetail, versionFileId: preferredNextUpFileId),
+                        requested: index,
+                        sanitized: preferredNextUpAudioTrackIndex
+                    )
                 },
                 onSelectNextUpSubtitleTrack: { index in
                     preferredNextUpSubtitleTrackIndex = sanitizedSubtitleTrackIndex(
                         for: nextUpPlaybackDetail,
                         versionFileId: preferredNextUpFileId,
                         candidate: index
+                    )
+                    persistSubtitleSelection(
+                        prefKey: prefKey(for: nextUpPlaybackDetail),
+                        version: effectiveVersion(for: nextUpPlaybackDetail, versionFileId: preferredNextUpFileId),
+                        requested: index,
+                        sanitized: preferredNextUpSubtitleTrackIndex,
+                        showForced: nil
                     )
                 },
                 onToggleFavorite: { Task { await viewModel.toggleFavorite() } },
@@ -326,12 +352,25 @@ struct TVItemDetailView: View {
                         versionFileId: preferredVersionFileId,
                         candidate: index
                     )
+                    persistAudioSelection(
+                        prefKey: prefKey(for: detail),
+                        version: effectiveVersion(for: detail, versionFileId: preferredVersionFileId),
+                        requested: index,
+                        sanitized: preferredAudioTrackIndex
+                    )
                 },
                 onSelectSubtitleTrack: { index in
                     preferredSubtitleTrackIndex = sanitizedSubtitleTrackIndex(
                         for: detail,
                         versionFileId: preferredVersionFileId,
                         candidate: index
+                    )
+                    persistSubtitleSelection(
+                        prefKey: prefKey(for: detail),
+                        version: effectiveVersion(for: detail, versionFileId: preferredVersionFileId),
+                        requested: index,
+                        sanitized: preferredSubtitleTrackIndex,
+                        showForced: nil
                     )
                 },
                 onSelectSeason: { season in
@@ -461,6 +500,57 @@ struct TVItemDetailView: View {
     ) -> Int? {
         guard let detail else { return nil }
         return sanitizedSubtitleTrackIndex(for: detail, versionFileId: versionFileId, candidate: candidate)
+    }
+
+    // MARK: - Track-choice persistence
+    //
+    // Selector picks are remembered server-side (web-app parity):
+    // episodes key by series id so one choice covers the series, movies
+    // by their own content id. "Auto" (nil) clears the override so the
+    // library/profile cascade applies again.
+
+    private func prefKey(for detail: ItemDetail?) -> String? {
+        TrackSelectionPersistence.prefKey(seriesId: detail?.seriesId, contentId: detail?.contentId)
+    }
+
+    private func persistAudioSelection(
+        prefKey: String?,
+        version: FileVersion?,
+        requested: Int?,
+        sanitized: Int?
+    ) {
+        guard let prefKey else { return }
+        guard let requested else {
+            TrackSelectionPersistence.clearAudio(prefKey: prefKey)
+            return
+        }
+        guard requested == sanitized,
+              let version,
+              let request = TrackSelectionPersistence.audioRequest(version: version, ordinal: requested)
+        else { return }
+        TrackSelectionPersistence.saveAudio(prefKey: prefKey, request: request)
+    }
+
+    private func persistSubtitleSelection(
+        prefKey: String?,
+        version: FileVersion?,
+        requested: Int?,
+        sanitized: Int?,
+        showForced: Bool?
+    ) {
+        guard let prefKey else { return }
+        guard let requested else {
+            TrackSelectionPersistence.clearSubtitle(prefKey: prefKey)
+            return
+        }
+        guard requested == sanitized, let version,
+              let request = TrackSelectionPersistence.subtitleRequest(
+                  version: version,
+                  ffIndex: requested,
+                  showForced: showForced
+              )
+        else { return }
+        TrackSelectionPersistence.saveSubtitle(prefKey: prefKey, request: request)
     }
 
     private func seasonNextUpEpisode(for detail: ItemDetail) -> EpisodeListItem? {


### PR DESCRIPTION
## What

Audio and subtitle selections — made on the item detail page or mid-playback — now persist to the server's per-series preference endpoints on iOS, tvOS, and macOS, so they survive exiting the player and revisiting or restarting the video. This matches the web app.

- **New `TrackSelectionPersistence`** (shared): pref-key resolution (episodes key by series id so one pick covers the show; movies by their own content id — the key the server's detail resolver reads movie prefs from), pure request builders, and best-effort fire-and-forget `PUT`/`DELETE` writers.
- **In-player changes stick**: `selectAudio` / `selectSubtitle` / `disableSubtitles` persist the pick on all three platforms. Offline playback and ephemeral live-AI subtitle tracks are excluded. Signatures are built from the server's own probed metadata (`currentSelectedVersion`) when possible so re-resolution gets an exact match.
- **Detail-page selector changes stick** (iOS `ItemDetailView` + tvOS `TVItemDetailView`), including the next-up selectors on season/series pages. Semantics mirror the web: pick → mode `always`, Off → mode `off` + index −1, "Auto" → `DELETE` the override so the library/profile cascade applies again.
- **Model fix**: `AudioTrack`/`SubtitleTrack` now decode `embedded_title` / `hearing_impaired`. The server's signature matcher compares `title` and `embedded_title` separately, so omitting them silently broke exact cross-episode track matching.
- **Start-time fix**: `PlaybackSessionBridge` sends `preferredAudioTrackIndex ?? selectedVersion.effectiveAudioTrackIndex`. `/playback/start` only consults saved audio prefs for episodes (its series-id lookup is empty for movies), so a movie's remembered audio track was otherwise dropped at session start even though the watch detail had already resolved it.

## Why

The read path already existed end-to-end — the server cascades per-series → per-library → profile prefs into `effective_*` fields that the detail selectors and `SubtitleAutoResolver` consume — but the Apple clients never wrote anything, so every explicit pick was lost on exit. Version choice needed no work: last-played version hints on `watch_progress` (written server-side at stop) plus series-level traits already round-trip and are honored by `DetailVersionSelection` and `selectVersion`.

## Reviewer notes

- Writes are deliberately best-effort (matching the web's silent-failure pattern): a failed PUT costs a remembered preference, never playback.
- Wire shapes were verified against `silo-server` (`audio_prefs.go`, `subtitle_prefs.go`, `playback.SelectAudioTrack`, `catalog/detail.go`); the subtitle mode derivation matches the web's `derivePersistedSubtitleMode`.
- Not yet validated against a live server. Smoke test: pick a track (detail page or in-player), exit, re-open → selector row and next playback should reflect it; for episodes, the pick should carry to other episodes of the same series.

## Testing

- `Silo` (iOS), `SiloTV`, `SiloMac` all build clean.
- 313 tests pass, including 9 new `TrackSelectionPersistenceTests` pinning the request builders (index spaces, signature fields, off/auto semantics, external-subtitle path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Track selections for audio and subtitles now persist across playback sessions on supported devices.
  * Selection memory now works for both episode and movie detail flows, including “Off” subtitle choices and forced-subtitle handling.
  * Playback now better restores the last chosen audio track when starting a session.

* **Bug Fixes**
  * Improved visibility of the now-playing mini bar and control bar during remote-control and reconnect states.
  * Better handling of track metadata so selected audio/subtitle options stay accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->