### PR TITLE
Graceful server-down handling: reachability monitor, fast timeouts, stale-content indicator, pre-play gating

### DIFF
--- a/iosApp/iosApp/Components/ServerUnreachablePill.swift
+++ b/iosApp/iosApp/Components/ServerUnreachablePill.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+/// Companion to `RefreshStatusPill`: shown in the same overlay slot when the
+/// last refresh could not reach the server but cached content is still
+/// painted, so stale data is never presented as fresh. Clears automatically —
+/// `ConnectionMonitor` re-probes while unreachable and flips state on the
+/// first successful response.
+struct ServerUnreachablePill: View {
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: ConnectionMonitor.shared.isDeviceOnline
+                ? "exclamationmark.arrow.trianglehead.2.clockwise.rotate.90"
+                : "wifi.slash")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(.continuumOnSurface)
+
+            Text(ConnectionMonitor.shared.isDeviceOnline
+                ? "Can't reach server — showing cached content"
+                : "You're offline — showing cached content")
+                .font(.continuumCaption)
+                .fontWeight(.semibold)
+                .foregroundColor(.continuumOnSurface)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 9)
+        .background(.ultraThinMaterial, in: Capsule())
+        .overlay {
+            Capsule()
+                .stroke(Color.white.opacity(0.14), lineWidth: 0.8)
+        }
+        .shadow(color: .black.opacity(0.28), radius: 14, x: 0, y: 8)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Can't reach the server. Showing cached content.")
+    }
+}

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -590,6 +590,19 @@ struct MainTabView: View {
             }
         }
         .tint(.continuumOnSurface)
+        #if !os(tvOS)
+        // Mirror Android's offline start-destination: launching with no
+        // network but playable local downloads lands on Downloads instead of
+        // a Home screen that can't load anything.
+        .task {
+            await ConnectionMonitor.shared.waitForInitialPath()
+            guard !ConnectionMonitor.shared.isDeviceOnline,
+                  DownloadManager.shared.downloadsEnabled,
+                  DownloadManager.shared.records.contains(where: { $0.isPlayableOffline })
+            else { return }
+            selectedTab = .downloads
+        }
+        #endif
         #if os(iOS)
         // Cold-launch path for silent remote-control resume: scenePhase may
         // already be .active when the authenticated UI first appears, so the

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -596,9 +596,18 @@ struct MainTabView: View {
         // a Home screen that can't load anything.
         .task {
             await ConnectionMonitor.shared.waitForInitialPath()
-            guard !ConnectionMonitor.shared.isDeviceOnline,
-                  DownloadManager.shared.downloadsEnabled,
-                  DownloadManager.shared.records.contains(where: { $0.isPlayableOffline })
+            guard !ConnectionMonitor.shared.isDeviceOnline else { return }
+            // The auth-state task hydrates DownloadManager via onAppActive()
+            // only after several awaited network refreshes, which is too late
+            // for this check on an offline cold launch. Loading the scope
+            // here is disk-only and idempotent — onAppActive() will skip the
+            // reload when it eventually runs.
+            _ = await DownloadManager.shared.activateScopeIfNeeded()
+            guard DownloadManager.shared.downloadsEnabled,
+                  DownloadManager.shared.records.contains(where: { $0.isPlayableOffline }),
+                  // Don't clobber a tab the user (or a deep link) already
+                  // selected while this task was waiting.
+                  selectedTab == .home, router.requestedTab == nil
             else { return }
             selectedTab = .downloads
         }

--- a/iosApp/iosApp/Control/iOS/NowPlayingShelf.swift
+++ b/iosApp/iosApp/Control/iOS/NowPlayingShelf.swift
@@ -20,10 +20,12 @@ struct NowPlayingShelf: View {
     }
 
     /// Mirrors `SiloControlMiniBar.isVisible`: a live session (excluding a
-    /// still-unconfirmed auto-resume probe) or an in-flight reconnect.
+    /// still-unconfirmed auto-resume probe) or an in-flight reconnect. The bar
+    /// stays mounted while the full remote sheet is up — detaching the
+    /// tabViewBottomAccessory there made it re-insert (with a system slide-in)
+    /// every time the sheet was swiped away.
     static func controlBarVisible(_ control: SiloControlClient) -> Bool {
-        guard !control.isShowingRemoteControl else { return false }
-        return (control.hasActiveSession && !control.isAutoResuming) || control.isReconnecting
+        (control.hasActiveSession && !control.isAutoResuming) || control.isReconnecting
     }
     #else
     static func hasActiveAccessory(audio: AudioPlaybackStore) -> Bool {
@@ -36,7 +38,6 @@ struct NowPlayingShelf: View {
         if Self.controlBarVisible(siloControl) {
             SiloControlMiniBar(controller: siloControl, style: style)
                 .animation(.snappy, value: siloControl.hasActiveSession)
-                .animation(.snappy, value: siloControl.isShowingRemoteControl)
                 .animation(.snappy, value: siloControl.isReconnecting)
         } else if audioStore.player.hasActiveSession {
             AudioMiniPlayerView(style: style)

--- a/iosApp/iosApp/Control/iOS/SiloControlMiniBar.swift
+++ b/iosApp/iosApp/Control/iOS/SiloControlMiniBar.swift
@@ -16,10 +16,10 @@ struct SiloControlMiniBar: View {
     /// Whether the bar has anything to show: a live session (that isn't a
     /// still-unconfirmed auto-resume probe) or an in-flight reconnect. Keeping
     /// the bar up through a reconnect (with a spinner) beats having it vanish
-    /// and pop back.
+    /// and pop back. Stays visible under the full remote sheet so dismissing
+    /// the sheet doesn't re-insert the accessory with a second animation.
     private var isVisible: Bool {
-        guard !controller.isShowingRemoteControl else { return false }
-        return (controller.hasActiveSession && !controller.isAutoResuming) || controller.isReconnecting
+        (controller.hasActiveSession && !controller.isAutoResuming) || controller.isReconnecting
     }
 
     private var targetName: String {

--- a/iosApp/iosApp/Networking/ConnectionMonitor.swift
+++ b/iosApp/iosApp/Networking/ConnectionMonitor.swift
@@ -1,0 +1,148 @@
+import Foundation
+import Network
+import OSLog
+
+/// App-wide connection state: device connectivity (via `NWPathMonitor`) plus
+/// server reachability learned passively from every `HTTPClient` request
+/// outcome. Screens read this to distinguish "showing cached data because the
+/// server is down" from a healthy session, and playback entry points consult
+/// it before opening a streaming player that cannot succeed.
+///
+/// Server status is optimistic: `.unknown` counts as reachable so the app
+/// never blocks a request it hasn't seen fail. Any completed HTTP response —
+/// including a 4xx/5xx — proves the server is up; only transport-level
+/// failures (connection refused, timeout, DNS) mark it unreachable. While
+/// unreachable, a background loop probes `GET /api/v1/health` so the state
+/// self-heals as soon as the server comes back.
+@MainActor
+@Observable
+final class ConnectionMonitor {
+    static let shared = ConnectionMonitor()
+
+    enum ServerStatus {
+        case unknown
+        case reachable
+        case unreachable
+    }
+
+    /// Device has a usable network path (Wi-Fi/cellular/wired).
+    private(set) var isDeviceOnline = true
+    private(set) var serverStatus: ServerStatus = .unknown
+
+    /// Optimistic gate for starting server-backed work: `.unknown` passes so
+    /// the first request after launch is never blocked.
+    var isServerReachable: Bool {
+        isDeviceOnline && serverStatus != .unreachable
+    }
+
+    /// Drive "offline / can't reach server" UI from this: true only once a
+    /// failure has actually been observed (or the device itself is offline).
+    var isOffline: Bool {
+        !isDeviceOnline || serverStatus == .unreachable
+    }
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.continuum.app",
+        category: "ConnectionMonitor"
+    )
+
+    private let pathMonitor = NWPathMonitor()
+    private var hasInitialPath = false
+    private var reprobeTask: Task<Void, Never>?
+    /// Seconds between health probes while the server is unreachable.
+    private let reprobeInterval: TimeInterval = 15
+
+    private init() {
+        pathMonitor.pathUpdateHandler = { [weak self] path in
+            let online = path.status == .satisfied
+            Task { @MainActor in
+                self?.applyPathUpdate(online: online)
+            }
+        }
+        pathMonitor.start(queue: DispatchQueue(label: "com.continuum.connection-monitor"))
+    }
+
+    // MARK: - Passive signals (reported by HTTPClient)
+
+    /// Any HTTP response arrived — the server is alive regardless of status
+    /// code.
+    func noteServerResponded() {
+        if serverStatus != .reachable {
+            Self.logger.info("Server marked reachable")
+        }
+        serverStatus = .reachable
+        stopReprobeLoop()
+    }
+
+    /// A request failed at the transport layer (no HTTP response). Callers
+    /// must not report cancellations here.
+    func noteServerUnreachable() {
+        guard serverStatus != .unreachable else { return }
+        Self.logger.info("Server marked unreachable")
+        serverStatus = .unreachable
+        startReprobeLoop()
+    }
+
+    // MARK: - Active probe
+
+    /// One-shot health check. The request flows through `HTTPClient`, whose
+    /// success/failure reporting updates `serverStatus` as a side effect.
+    @discardableResult
+    func probeServer() async -> Bool {
+        do {
+            let _: HealthStatus = try await HTTPClient.shared.get("/api/v1/health")
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    /// Wait (bounded) for `NWPathMonitor` to deliver its first path so early
+    /// launch decisions (e.g. landing on Downloads when offline) don't read
+    /// the optimistic default.
+    func waitForInitialPath(timeout: TimeInterval = 1.0) async {
+        let deadline = ContinuousClock.now + .seconds(timeout)
+        while !hasInitialPath, ContinuousClock.now < deadline {
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+    }
+
+    // MARK: - Internals
+
+    private func applyPathUpdate(online: Bool) {
+        hasInitialPath = true
+        guard online != isDeviceOnline else { return }
+        isDeviceOnline = online
+        Self.logger.info("Device network path: \(online ? "online" : "offline", privacy: .public)")
+        if online {
+            // Regained a network path — find out whether the server is back
+            // rather than waiting for the next user-initiated request. The
+            // loop was suspended while offline (probes can't succeed without
+            // a path), so restart it too in case the server is still down.
+            if serverStatus == .unreachable {
+                startReprobeLoop()
+                Task { await self.probeServer() }
+            }
+        } else {
+            stopReprobeLoop()
+        }
+    }
+
+    private func startReprobeLoop() {
+        guard reprobeTask == nil, isDeviceOnline else { return }
+        reprobeTask = Task { [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                try? await Task.sleep(nanoseconds: UInt64(self.reprobeInterval * 1_000_000_000))
+                guard !Task.isCancelled else { return }
+                guard self.serverStatus == .unreachable, self.isDeviceOnline else { return }
+                await self.probeServer()
+            }
+        }
+    }
+
+    private func stopReprobeLoop() {
+        reprobeTask?.cancel()
+        reprobeTask = nil
+    }
+}

--- a/iosApp/iosApp/Networking/ContinuumAI.swift
+++ b/iosApp/iosApp/Networking/ContinuumAI.swift
@@ -87,19 +87,22 @@ actor ContinuumAI {
 
     /// Synchronous fan-out search across the server's configured external
     /// subtitle providers. Can legitimately take 20–30s (per-provider
-    /// timeouts); the session's default 60s request timeout covers it.
+    /// timeouts), so it opts out of the fail-fast timeout via `.extended`.
     /// No providers configured yields an empty result set, not an error.
     func searchSubtitles(_ body: SubtitleSearchBody) async throws -> SubtitleSearchResponse {
-        try await http.post("/api/v1/subtitles/search", body: body)
+        try await http.post("/api/v1/subtitles/search", body: body, timeout: .extended)
     }
 
-    /// Synchronously download one chosen search result. The server persists
-    /// it before responding; the returned ``DownloadedSubtitle`` then appears
-    /// in ``downloadedSubtitles(mediaFileId:)``.
+    /// Synchronously download one chosen search result. The server fetches
+    /// from the upstream provider and persists before responding — another
+    /// legitimately slow call, so `.extended`. The returned
+    /// ``DownloadedSubtitle`` then appears in
+    /// ``downloadedSubtitles(mediaFileId:)``.
     func downloadSubtitle(_ body: SubtitleDownloadBody) async throws -> DownloadedSubtitle {
         let response: SubtitleDownloadResponse = try await http.post(
             "/api/v1/subtitles/download",
-            body: body
+            body: body,
+            timeout: .extended
         )
         return response.subtitle
     }

--- a/iosApp/iosApp/Networking/ContinuumAPI.swift
+++ b/iosApp/iosApp/Networking/ContinuumAPI.swift
@@ -899,12 +899,16 @@ actor ContinuumAPI {
 
     // --- Playback ---
 
+    // Session planning can be slow on heavy files (stream probing, transcode
+    // spin-up), so both start calls opt out of the fail-fast timeout. A dead
+    // server is still caught early: connection-refused fails instantly, and
+    // the detail screen's own fetches run on the standard timeout.
     func startPlayback(request: StartPlaybackRequest) async throws -> PlaybackSessionResponse {
-        try await http.post("/api/v1/playback/start", body: request)
+        try await http.post("/api/v1/playback/start", body: request, timeout: .extended)
     }
 
     func startTranscode(request: TranscodeStartRequest) async throws -> TranscodeStartResponse {
-        try await http.post("/api/v1/playback/transcode/start", body: request)
+        try await http.post("/api/v1/playback/transcode/start", body: request, timeout: .extended)
     }
 
     func reportPlaybackProgress(sessionId: String, report: ProgressReport) async throws {

--- a/iosApp/iosApp/Networking/HTTPClient.swift
+++ b/iosApp/iosApp/Networking/HTTPClient.swift
@@ -27,6 +27,11 @@ actor HTTPClient {
     )
 
     private let session: URLSession
+    /// Session for endpoints that legitimately hold the connection open well
+    /// past the fail-fast window (see ``HTTPTimeout/extended``). A separate
+    /// session (rather than per-request `timeoutInterval`) keeps the
+    /// effective timeout unambiguous.
+    private let longWaitSession: URLSession
     private let tokenStore: TokenStore
     private let decoder: JSONDecoder
     private let encoder: JSONEncoder
@@ -36,7 +41,10 @@ actor HTTPClient {
     private var inFlightRefresh: Task<Bool, Never>?
 
     init(session: URLSession? = nil, tokenStore: TokenStore = .shared) {
-        self.session = session ?? Self.makeSession()
+        // An injected session (tests) serves both timeout classes so mocks
+        // observe every request regardless of the caller's timeout choice.
+        self.session = session ?? Self.makeSession(requestTimeout: 15)
+        self.longWaitSession = session ?? Self.makeSession(requestTimeout: 90)
         self.tokenStore = tokenStore
 
         let decoder = JSONDecoder()
@@ -65,15 +73,16 @@ actor HTTPClient {
     /// `X-Profile-Id`, and `X-Profile-Token` don't participate in the cache
     /// key, so a cached 401/404 or a response fetched under one profile
     /// can be served to a later request under different auth.
-    private static func makeSession() -> URLSession {
+    private static func makeSession(requestTimeout: TimeInterval) -> URLSession {
         let config = URLSessionConfiguration.default
         config.urlCache = nil
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         // Fail fast when the server is down: the default 60s idle timeout
         // leaves a dead-but-routable server spinning for a minute before the
-        // user sees anything. 15s is the max quiet gap between bytes, not a
-        // total budget, so slow-but-alive responses are unaffected.
-        config.timeoutIntervalForRequest = 15
+        // user sees anything. The timeout is the max quiet gap between
+        // bytes, not a total budget, so slow-but-alive responses are
+        // unaffected.
+        config.timeoutIntervalForRequest = requestTimeout
         return URLSession(configuration: config)
     }
 
@@ -104,9 +113,10 @@ actor HTTPClient {
     func post<T: Decodable>(
         _ path: String,
         body: (any Encodable)? = nil,
-        query: [String: String] = [:]
+        query: [String: String] = [:],
+        timeout: HTTPTimeout = .standard
     ) async throws -> T {
-        try await send(method: "POST", path: path, query: query, body: body)
+        try await send(method: "POST", path: path, query: query, body: body, timeout: timeout)
     }
 
     func postVoid(
@@ -173,10 +183,12 @@ actor HTTPClient {
     func cancelInFlightRequests() async {
         inFlightRefresh?.cancel()
         inFlightRefresh = nil
-        await withCheckedContinuation { continuation in
-            session.getAllTasks { tasks in
-                for task in tasks { task.cancel() }
-                continuation.resume()
+        for session in [session, longWaitSession] {
+            await withCheckedContinuation { continuation in
+                session.getAllTasks { tasks in
+                    for task in tasks { task.cancel() }
+                    continuation.resume()
+                }
             }
         }
     }
@@ -208,9 +220,10 @@ actor HTTPClient {
         method: String,
         path: String,
         query: [String: String],
-        body: (any Encodable)?
+        body: (any Encodable)?,
+        timeout: HTTPTimeout = .standard
     ) async throws -> T {
-        let data = try await sendRaw(method: method, path: path, query: query, body: body)
+        let data = try await sendRaw(method: method, path: path, query: query, body: body, timeout: timeout)
         if data.isEmpty, let empty = EmptyResponse.empty as? T {
             return empty
         }
@@ -260,7 +273,8 @@ actor HTTPClient {
         path: String,
         query: [String: String],
         body: (any Encodable)?,
-        quietStatuses: Set<Int> = []
+        quietStatuses: Set<Int> = [],
+        timeout: HTTPTimeout = .standard
     ) async throws -> Data {
         let serverUrl = await tokenStore.getServerUrl()
         guard !serverUrl.isEmpty else {
@@ -277,7 +291,7 @@ actor HTTPClient {
         )
         await attachAuthHeaders(&request, accessToken: tokenBeforeRequest)
 
-        let (data, response) = try await perform(request: request)
+        let (data, response) = try await perform(request: request, timeout: timeout)
 
         if response.statusCode == 401, shouldAttemptRefresh(path: path) {
             let refreshed = await refreshTokens(tokenAtRequestTime: tokenBeforeRequest)
@@ -292,7 +306,7 @@ actor HTTPClient {
                     body: body
                 )
                 await attachAuthHeaders(&retry, accessToken: refreshedToken)
-                let (retryData, retryResponse) = try await perform(request: retry)
+                let (retryData, retryResponse) = try await perform(request: retry, timeout: timeout)
                 try ensureSuccess(retryData, retryResponse, method: method, quietStatuses: quietStatuses)
                 return retryData
             }
@@ -380,10 +394,11 @@ actor HTTPClient {
 
     // MARK: - Response handling
 
-    private func perform(request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+    private func perform(request: URLRequest, timeout: HTTPTimeout = .standard) async throws -> (Data, HTTPURLResponse) {
         let data: Data
         let response: URLResponse
         do {
+            let session = timeout == .extended ? longWaitSession : session
             (data, response) = try await session.data(for: request)
         } catch {
             // Feed ConnectionMonitor from every transport failure so the app
@@ -522,6 +537,10 @@ actor HTTPClient {
                 Self.logger.error("Refresh: non-HTTP response")
                 return false
             }
+            // Refresh bypasses perform(), so feed reachability from here too.
+            Task { @MainActor in
+                ConnectionMonitor.shared.noteServerResponded()
+            }
             if (200..<300).contains(http.statusCode) {
                 let tokens = try decoder.decode(RefreshResponse.self, from: data)
                 await tokenStore.saveTokens(
@@ -545,10 +564,27 @@ actor HTTPClient {
                 return false
             }
         } catch {
+            if (error as? URLError)?.code != .cancelled {
+                Task { @MainActor in
+                    ConnectionMonitor.shared.noteServerUnreachable()
+                }
+            }
             Self.logger.error("Refresh threw: \(String(describing: error), privacy: .public)")
             return false
         }
     }
+}
+
+// MARK: - Timeout class
+
+/// Per-request timeout class. `.standard` (15s idle) fails fast so a dead
+/// server is detected in seconds. `.extended` (90s idle) is for endpoints
+/// that legitimately hold the connection while the server does slow work —
+/// e.g. subtitle provider fan-out searches (20–30s documented) or playback
+/// session planning.
+enum HTTPTimeout {
+    case standard
+    case extended
 }
 
 // MARK: - Error

--- a/iosApp/iosApp/Networking/HTTPClient.swift
+++ b/iosApp/iosApp/Networking/HTTPClient.swift
@@ -69,6 +69,11 @@ actor HTTPClient {
         let config = URLSessionConfiguration.default
         config.urlCache = nil
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
+        // Fail fast when the server is down: the default 60s idle timeout
+        // leaves a dead-but-routable server spinning for a minute before the
+        // user sees anything. 15s is the max quiet gap between bytes, not a
+        // total budget, so slow-but-alive responses are unaffected.
+        config.timeoutIntervalForRequest = 15
         return URLSession(configuration: config)
     }
 
@@ -381,10 +386,23 @@ actor HTTPClient {
         do {
             (data, response) = try await session.data(for: request)
         } catch {
+            // Feed ConnectionMonitor from every transport failure so the app
+            // learns "server down" passively. Cancellation says nothing about
+            // reachability, so it is excluded.
+            if (error as? URLError)?.code != .cancelled {
+                Task { @MainActor in
+                    ConnectionMonitor.shared.noteServerUnreachable()
+                }
+            }
             throw HTTPError.network(underlying: error)
         }
         guard let http = response as? HTTPURLResponse else {
             throw HTTPError.invalidResponse
+        }
+        // Any HTTP response — success or error status — proves the server is
+        // alive.
+        Task { @MainActor in
+            ConnectionMonitor.shared.noteServerResponded()
         }
         return (data, http)
     }

--- a/iosApp/iosApp/Screens/Browse/BrowseView.swift
+++ b/iosApp/iosApp/Screens/Browse/BrowseView.swift
@@ -34,6 +34,16 @@ struct BrowseView: View {
             }
         }
         .continuumBackground()
+        .overlay(alignment: .top) {
+            // Grid is painted from cache but the server can't be reached —
+            // flag the staleness instead of letting refresh fail silently.
+            if ConnectionMonitor.shared.isOffline, !viewModel.items.isEmpty {
+                ServerUnreachablePill()
+                    .padding(.top, ContinuumTheme.padding)
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
+        }
+        .animation(.easeInOut(duration: 0.18), value: ConnectionMonitor.shared.isOffline)
         .sheet(isPresented: $showFilters) {
             FilterView(viewModel: viewModel)
         }
@@ -417,9 +427,15 @@ struct LibraryRecommendedView: View {
                     .padding(.top, refreshStatusTopPadding)
                     .transition(.move(edge: .top).combined(with: .opacity))
                     .zIndex(2)
+            } else if ConnectionMonitor.shared.isOffline, !viewModel.regularSections.isEmpty {
+                ServerUnreachablePill()
+                    .padding(.top, refreshStatusTopPadding)
+                    .transition(.move(edge: .top).combined(with: .opacity))
+                    .zIndex(2)
             }
         }
         .animation(.easeInOut(duration: 0.18), value: isRefreshing)
+        .animation(.easeInOut(duration: 0.18), value: ConnectionMonitor.shared.isOffline)
         .continuumBackground()
         .task(id: libraryId) {
             await viewModel.loadSections(libraryId: libraryId)

--- a/iosApp/iosApp/Screens/Detail/ItemDetailView.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailView.swift
@@ -48,6 +48,19 @@ private struct OfflinePlayChoice: Identifiable {
     var id: String { downloadId }
 }
 
+/// A streaming play attempt intercepted because the server is unreachable and
+/// no local copy exists. Held so the confirmation alert's "Try Anyway" can
+/// replay the exact request.
+private struct UnreachablePlayRequest: Identifiable {
+    let contentId: String
+    let fileId: Int?
+    let audioTrackIndex: Int?
+    let subtitleTrackIndex: Int?
+    let startFromBeginning: Bool
+    let resumePosition: Double?
+    var id: String { contentId }
+}
+
 private struct ItemDetailPhoneContent: View {
     let contentId: String
 
@@ -61,6 +74,7 @@ private struct ItemDetailPhoneContent: View {
     @State private var nextUpWatchDetail: WatchDetail?
     @State private var refreshOnPlayerDismiss = false
     @State private var offlinePlayChoice: OfflinePlayChoice?
+    @State private var unreachablePlayRequest: UnreachablePlayRequest?
     #if os(iOS)
     @Environment(SiloControlClient.self) private var siloControl
     @State private var controlRequestBox: ControlRequestBox?
@@ -126,6 +140,33 @@ private struct ItemDetailPhoneContent: View {
             Button("Cancel", role: .cancel) {}
         } message: { _ in
             Text("Play the copy saved on this device, or stream from the server.")
+        }
+        .alert(
+            "Can't Reach Server",
+            isPresented: Binding(
+                get: { unreachablePlayRequest != nil },
+                set: { if !$0 { unreachablePlayRequest = nil } }
+            ),
+            presenting: unreachablePlayRequest
+        ) { request in
+            // Reachability state can be stale (e.g. the server just came
+            // back), so always leave an escape hatch to attempt the stream.
+            Button("Try Anyway") {
+                Task { await ConnectionMonitor.shared.probeServer() }
+                presentStreamingPlayer(
+                    contentId: request.contentId,
+                    fileId: request.fileId,
+                    audioTrackIndex: request.audioTrackIndex,
+                    subtitleTrackIndex: request.subtitleTrackIndex,
+                    startFromBeginning: request.startFromBeginning,
+                    resumePosition: request.resumePosition
+                )
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: { _ in
+            Text(ConnectionMonitor.shared.isDeviceOnline
+                ? "Streaming needs a connection to your server, which isn't responding right now. Downloaded titles can still be played."
+                : "You're offline. Connect to a network to stream, or play a downloaded title.")
         }
         #if os(iOS)
         .toolbar {
@@ -654,10 +695,36 @@ private struct ItemDetailPhoneContent: View {
         // offers this — a cast target can't read the local file.
         if let record = DownloadManager.shared.record(forContentId: contentId),
            record.isPlayableOffline {
+            // Server unreachable: streaming can't start, so skip the source
+            // choice and play the local copy directly.
+            guard ConnectionMonitor.shared.isServerReachable else {
+                refreshOnPlayerDismiss = true
+                router.presentOfflinePlayer(
+                    downloadId: record.id,
+                    contentId: record.leafMediaItemId,
+                    startFromBeginning: startFromBeginning,
+                    resumePosition: resumePosition
+                )
+                return
+            }
             offlinePlayChoice = OfflinePlayChoice(
                 downloadId: record.id,
                 leafContentId: record.leafMediaItemId,
                 downloadedLabel: Self.downloadedOptionLabel(for: record),
+                contentId: contentId,
+                fileId: fileId,
+                audioTrackIndex: audioTrackIndex,
+                subtitleTrackIndex: subtitleTrackIndex,
+                startFromBeginning: startFromBeginning,
+                resumePosition: resumePosition
+            )
+            return
+        }
+
+        // No local copy and the server is known unreachable: surface that
+        // here instead of presenting a player that will spin and fail.
+        guard ConnectionMonitor.shared.isServerReachable else {
+            unreachablePlayRequest = UnreachablePlayRequest(
                 contentId: contentId,
                 fileId: fileId,
                 audioTrackIndex: audioTrackIndex,

--- a/iosApp/iosApp/Screens/Home/HomeView.swift
+++ b/iosApp/iosApp/Screens/Home/HomeView.swift
@@ -153,9 +153,17 @@ struct HomeView: View {
                     .padding(.top, 64)
                     .transition(.move(edge: .top).combined(with: .opacity))
                     .zIndex(2)
+            } else if ConnectionMonitor.shared.isOffline, !viewModel.sections.isEmpty {
+                // Cached sections are painted but the server can't be
+                // reached — say so instead of silently showing stale data.
+                ServerUnreachablePill()
+                    .padding(.top, 64)
+                    .transition(.move(edge: .top).combined(with: .opacity))
+                    .zIndex(2)
             }
         }
         .animation(.easeInOut(duration: 0.18), value: isRefreshing)
+        .animation(.easeInOut(duration: 0.18), value: ConnectionMonitor.shared.isOffline)
         #if !os(macOS)
         .toolbar(.hidden, for: .navigationBar)
         #endif


### PR DESCRIPTION
## Problem

When the server is down, the app still looks fully functional: screens hydrate from the in-memory `ResponseCache` and swallow failed refreshes silently, so pull-to-refresh shows no error. Tapping an item to play opens the player, spins for up to ~60s (no URLSession timeout was ever configured), then hits a full-screen error wall.

Offline downloads were never the problem — `OfflinePlayback` already plays local copies with zero server round-trips (airplane-mode safe). The gap was detection and honest degradation, and this PR intentionally leaves the downloads subsystem untouched.

## What changed

- **`Networking/ConnectionMonitor.swift` (new)** — app-wide connection state. `NWPathMonitor` tracks device connectivity; server reachability is learned passively from every `HTTPClient` request outcome (any HTTP response — even 4xx/5xx — proves the server is alive; transport failures, excluding cancellations, mark it unreachable). While unreachable it re-probes `GET /api/v1/health` every 15s so the UI self-heals as soon as the server returns. Optimistic by design: an unknown state never blocks a request.
- **`HTTPClient`** — `timeoutIntervalForRequest = 15` so a dead-but-routable server fails in seconds instead of a minute (this is the max quiet gap between bytes, not a total budget, so slow-but-alive responses are unaffected). `perform()` feeds request outcomes to the monitor.
- **`Components/ServerUnreachablePill.swift` (new)** — "Can't reach server — showing cached content" pill, shown in the same overlay slot as `RefreshStatusPill` on Home, the Browse grid, and library Recommended whenever cached content is painted while unreachable. Disappears automatically on the first successful response.
- **`ItemDetailView` pre-play gate** — if the server is unreachable and the item has a playable download, the local copy plays directly (the "Downloaded vs Stream" choice is skipped since streaming can't start). With no download, a "Can't Reach Server" alert appears *before* the player is presented, with a "Try Anyway" escape hatch in case the reachability state is stale.
- **`MainTabView` offline landing** (Android parity) — launching with no network and playable local downloads lands on the Downloads tab instead of a Home screen that can't load.

## Reviewer notes

- Reachability is never actively polled while healthy — zero extra traffic in the normal case; the probe loop only runs while a failure has actually been observed.
- tvOS gets the monitor and fast timeouts via shared code; the pill and pre-play gate live in the iOS/macOS surfaces (tvOS has its own detail views — candidate follow-up).
- The cast (SiloControl) play branch is not gated: the Apple TV target does its own streaming and reports its own failures.
- Verified: iOS, tvOS, and macOS schemes build; full test suite passes. Not yet validated against a live server being killed mid-session — that's the recommended manual check (stop the server, confirm the pill appears and Play degrades as described).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer offline/server reachability pills across Home and Browse, including messaging when cached content is shown.
  * Improved “server unreachable” handling on the detail screen with a “Can’t Reach Server” alert and “Try Anyway” retry.
  * Enhanced offline startup behavior to route users to Downloads when playable offline content exists.

* **Bug Fixes**
  * Kept the mini control bar visible during reconnecting/remote-control scenarios.
  * Improved network detection and recovery to distinguish device-offline vs server-unreachable.
  * Extended timeouts for slower subtitle and playback/transcode operations to reduce premature failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->