### PR TITLE
Subtitle appearance redesign + mid-playback toggle latency + override restore

### DIFF
--- a/iosApp/Tests/SubtitleStylingOverrideTests.swift
+++ b/iosApp/Tests/SubtitleStylingOverrideTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+
+@testable import Silo
+
+final class SubtitleStylingOverrideTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Splits the `Style: Default,...` line of a synthetic header into its
+    /// comma-separated fields. Field indices follow the Format line:
+    /// 0 name, 1 Fontname, 2 Fontsize, 3 Primary, 4 Secondary, 5 Outline,
+    /// 6 Back, 7-10 attrs, 11-12 scale, 13-14 spacing/angle, 15 BorderStyle,
+    /// 16 Outline size, 17 Shadow, 18 Alignment, 19-21 margins, 22 Encoding.
+    private func styleFields(params: SubtitleStylingOverride.Parameters) -> [String] {
+        let header = SubtitleStylingOverride.syntheticHeader(params: params, slot: .primary)
+        guard let line = header.split(separator: "\n").first(where: { $0.hasPrefix("Style: Default,") }) else {
+            XCTFail("no Default style line in header")
+            return []
+        }
+        return line.split(separator: ",", omittingEmptySubsequences: false).map(String.init)
+    }
+
+    // MARK: - Box background opacity
+
+    func testBoxHeaderUsesBorderStyle4WithOpacityInBackColour() {
+        var params = SubtitleStylingOverride.Parameters.default
+        params.backgroundStyle = .box
+        params.backgroundOpacityPercent = 20
+        params.backgroundColorHex = "#000000"
+
+        let fields = styleFields(params: params)
+        // 20% opacity → inverted ASS alpha = (100-20)*255/100 = 204 = 0xCC.
+        XCTAssertEqual(fields[6], "&HCC000000") // BackColour carries the alpha
+        XCTAssertEqual(fields[15], "4") // BorderStyle 4: box fill = BackColour
+        XCTAssertGreaterThan(Double(fields[17]) ?? 0, 0) // Shadow field = box padding
+    }
+
+    func testFullyOpaqueBoxHeaderStillUsesBorderStyle4() {
+        var params = SubtitleStylingOverride.Parameters.default
+        params.backgroundStyle = .box
+        params.backgroundOpacityPercent = 100
+
+        let fields = styleFields(params: params)
+        XCTAssertEqual(fields[6], "&H00000000")
+        XCTAssertEqual(fields[15], "4")
+    }
+
+    func testZeroOpacityBoxHeaderFallsBackToPlainText() {
+        var params = SubtitleStylingOverride.Parameters.default
+        params.backgroundStyle = .box
+        params.backgroundOpacityPercent = 0
+
+        let fields = styleFields(params: params)
+        XCTAssertEqual(fields[15], "1") // no box
+        XCTAssertEqual(fields[17], "0.0") // no padding/shadow
+    }
+
+    // MARK: - Drop shadow visibility
+
+    func testShadowHeaderHasVisibleShadowColor() {
+        var params = SubtitleStylingOverride.Parameters.default
+        params.backgroundStyle = .shadow
+
+        let fields = styleFields(params: params)
+        XCTAssertEqual(fields[15], "1") // outline+shadow border style
+        XCTAssertEqual(fields[17], "1.5") // shadow depth
+        // Shadow color must not be fully transparent (alpha 0xFF); expect
+        // 50% black.
+        XCTAssertEqual(fields[6], "&H80000000")
+    }
+
+    // MARK: - Font size presets (rebased so large == old xxlarge)
+
+    func testFontSizePresetsRebasedAroundLarge() {
+        #if os(iOS)
+        XCTAssertEqual(SubtitleFontSizePreset.small.pointSize, 43)
+        XCTAssertEqual(SubtitleFontSizePreset.medium.pointSize, 48)
+        XCTAssertEqual(SubtitleFontSizePreset.large.pointSize, 54)
+        XCTAssertEqual(SubtitleFontSizePreset.xlarge.pointSize, 65)
+        XCTAssertEqual(SubtitleFontSizePreset.xxlarge.pointSize, 77)
+        #endif
+    }
+
+    func testReferenceFontSizeTracksDefaultPreset() {
+        XCTAssertEqual(
+            SubtitleStylingOverride.Parameters.referenceFontSize,
+            SubtitleAppearance.default.fontSize.pointSize
+        )
+    }
+}

--- a/iosApp/Tests/SubtitleStylingOverrideTests.swift
+++ b/iosApp/Tests/SubtitleStylingOverrideTests.swift
@@ -69,6 +69,28 @@ final class SubtitleStylingOverrideTests: XCTestCase {
         XCTAssertEqual(fields[6], "&H80000000")
     }
 
+    // MARK: - Struct color packing (libass internal RRGGBBAA)
+
+    func testStructColorPackingIsInternalRGBA() {
+        // Black box at 75% opacity: alpha byte (100-75)*255/100 = 63 = 0x3F
+        // must land in the LOW byte, not the red channel — packing it high
+        // rendered the default box as opaque dark red.
+        XCTAssertEqual(
+            SubtitleStylingOverride.assColor(hexRGBUInt: "#000000", alphaByte: 0x3F),
+            0x0000003F
+        )
+        // Opaque white text.
+        XCTAssertEqual(
+            SubtitleStylingOverride.assColor(hexRGBUInt: "#FFFFFF", alphaByte: 0x00),
+            0xFFFFFF00
+        )
+        // Channel order: pure red opaque → R in the high byte.
+        XCTAssertEqual(
+            SubtitleStylingOverride.assColor(hexRGBUInt: "#FF0000", alphaByte: 0x00),
+            0xFF000000
+        )
+    }
+
     // MARK: - Font size presets (rebased so large == old xxlarge)
 
     func testFontSizePresetsRebasedAroundLarge() {

--- a/iosApp/Tests/VideoDisplayRectTests.swift
+++ b/iosApp/Tests/VideoDisplayRectTests.swift
@@ -1,0 +1,53 @@
+import AVFoundation
+import XCTest
+
+@testable import Silo
+
+final class VideoDisplayRectTests: XCTestCase {
+    func testAspectFitLetterboxesWideVideoInPortraitBounds() {
+        // 2.4:1 movie on an iPhone portrait canvas: full width, centered.
+        let rect = VideoDisplayRect.compute(
+            videoSize: CGSize(width: 1920, height: 800),
+            bounds: CGRect(x: 0, y: 0, width: 390, height: 844),
+            gravity: .resizeAspect
+        )
+        XCTAssertEqual(rect.minX, 0, accuracy: 0.5)
+        XCTAssertEqual(rect.width, 390, accuracy: 0.5)
+        XCTAssertEqual(rect.height, 390 * 800 / 1920, accuracy: 0.5)
+        XCTAssertEqual(rect.midY, 422, accuracy: 0.5)
+    }
+
+    func testAspectFitPillarboxesTallVideoInLandscapeBounds() {
+        let rect = VideoDisplayRect.compute(
+            videoSize: CGSize(width: 1080, height: 1920),
+            bounds: CGRect(x: 0, y: 0, width: 844, height: 390),
+            gravity: .resizeAspect
+        )
+        XCTAssertEqual(rect.height, 390, accuracy: 0.5)
+        XCTAssertEqual(rect.width, 390 * 1080 / 1920, accuracy: 0.5)
+        XCTAssertEqual(rect.midX, 422, accuracy: 0.5)
+    }
+
+    func testUnknownVideoSizeFallsBackToBounds() {
+        let bounds = CGRect(x: 0, y: 0, width: 844, height: 390)
+        let rect = VideoDisplayRect.compute(
+            videoSize: .zero,
+            bounds: bounds,
+            gravity: .resizeAspect
+        )
+        XCTAssertEqual(rect, bounds)
+    }
+
+    func testFillAndStretchGravityReturnBounds() {
+        let bounds = CGRect(x: 0, y: 0, width: 844, height: 390)
+        let videoSize = CGSize(width: 1920, height: 800)
+        XCTAssertEqual(
+            VideoDisplayRect.compute(videoSize: videoSize, bounds: bounds, gravity: .resizeAspectFill),
+            bounds
+        )
+        XCTAssertEqual(
+            VideoDisplayRect.compute(videoSize: videoSize, bounds: bounds, gravity: .resize),
+            bounds
+        )
+    }
+}

--- a/iosApp/iosApp/Networking/Models.swift
+++ b/iosApp/iosApp/Networking/Models.swift
@@ -389,6 +389,13 @@ struct ItemDetail: Codable {
     let subtitles: [SubtitleInfoBasic]?
     let intro: TimeRange?
     let credits: TimeRange?
+    /// Server-resolved subtitle policy, folded in from the watch detail
+    /// during playback enrichment (absent on the raw catalog payload).
+    /// The signature is only present when an explicit per-series /
+    /// per-movie subtitle override is stored, so it doubles as the
+    /// "user picked a track" marker for selector seeding.
+    let effectiveSubtitleMode: String?
+    let effectiveSubtitleTrackSignature: SubtitleTrackSignature?
     let overlaySummary: OverlaySummary?
     let audiobook: AudiobookDetail?
     /// Set by the server (omitted when empty) when a description exists

--- a/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
+++ b/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
@@ -194,6 +194,66 @@ enum DetailPlaybackFormatting {
         return tokens.joined(separator: " · ")
     }
 
+    /// Resolve the server-remembered subtitle override for display /
+    /// launch seeding. Audio gets this for free via the per-version
+    /// `effectiveAudioTrackIndex`; subtitles have no index field on the
+    /// wire, so the stored signature is re-matched against this
+    /// version's track list. Returns the ffmpeg stream index to
+    /// pre-select, `-1` for "Off", or nil when nothing points at a
+    /// track in this file ("Auto" — the player's resolver decides).
+    static func serverPreferredSubtitleIndex(
+        version: FileVersion?,
+        signature: SubtitleTrackSignature?,
+        mode: String?
+    ) -> Int? {
+        if let signature,
+           let tracks = version?.subtitleTracks,
+           let match = bestSignatureMatch(signature, in: tracks) {
+            return match.index
+        }
+        if SubtitleMode(rawValue: mode ?? "") == .off {
+            return -1
+        }
+        return nil
+    }
+
+    /// Mirrors `SubtitleAutoResolver.bestSignatureMatch` scoring, applied
+    /// to the detail payload's `SubtitleTrack` metadata, so the selector
+    /// shows the same track the player would restore on its own.
+    private static func bestSignatureMatch(
+        _ sig: SubtitleTrackSignature,
+        in tracks: [SubtitleTrack]
+    ) -> SubtitleTrack? {
+        var best: (SubtitleTrack, Int)?
+        for track in tracks where track.index != nil {
+            var score = 0
+            if let sigLang = sig.language, !sigLang.isEmpty,
+               let lang = track.language,
+               SubtitleAutoResolver.languagesMatch(lang, sigLang) {
+                score += 5
+            }
+            if sig.forced == (track.forced ?? false) {
+                score += 1
+            }
+            if sig.hearingImpaired == (track.hearingImpaired ?? false) {
+                score += 1
+            }
+            if let sigCodec = sig.codec, let codec = track.codec,
+               sigCodec.caseInsensitiveCompare(codec) == .orderedSame {
+                score += 1
+            }
+            if let sigLabel = sig.label, !sigLabel.isEmpty,
+               let title = track.title ?? track.embeddedTitle,
+               title.localizedCaseInsensitiveContains(sigLabel) {
+                score += 2
+            }
+            if score > (best?.1 ?? 0) {
+                best = (track, score)
+            }
+        }
+        return best?.0
+    }
+
     static func subtitleOptions(
         version: FileVersion?,
         selectedSubtitleTrackIndex: Int?,

--- a/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
+++ b/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
@@ -227,10 +227,12 @@ enum DetailPlaybackFormatting {
         var best: (SubtitleTrack, Int)?
         for track in tracks where track.index != nil {
             var score = 0
+            var strongSignal = false
             if let sigLang = sig.language, !sigLang.isEmpty,
                let lang = track.language,
                SubtitleAutoResolver.languagesMatch(lang, sigLang) {
                 score += 5
+                strongSignal = true
             }
             if sig.forced == (track.forced ?? false) {
                 score += 1
@@ -246,8 +248,12 @@ enum DetailPlaybackFormatting {
                let title = track.title ?? track.embeddedTitle,
                title.localizedCaseInsensitiveContains(sigLabel) {
                 score += 2
+                strongSignal = true
             }
-            if score > (best?.1 ?? 0) {
+            // Forced/HI/codec equality alone is meaningless (`false ==
+            // false` holds for nearly every track); require a language or
+            // label hit so a weak "match" can't override Auto.
+            if strongSignal, score > (best?.1 ?? 0) {
                 best = (track, score)
             }
         }

--- a/iosApp/iosApp/Screens/Detail/ItemDetailView.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailView.swift
@@ -104,11 +104,19 @@ private struct ItemDetailPhoneContent: View {
             nextUpWatchDetail = nil
             refreshOnPlayerDismiss = false
             await viewModel.loadDetail(contentId: contentId)
+            seedSubtitleOverrideIfNeeded()
         }
         .onChange(of: router.presentedPlayer?.id) { oldValue, newValue in
             guard oldValue != nil, newValue == nil, refreshOnPlayerDismiss else { return }
             refreshOnPlayerDismiss = false
-            Task { await viewModel.loadDetail(contentId: contentId) }
+            Task {
+                await viewModel.loadDetail(contentId: contentId)
+                // A track picked inside the player persisted server-side;
+                // drop the pre-play selector state so the reloaded pref
+                // re-seeds and the selector reflects the latest pick.
+                preferredSubtitleTrackIndex = nil
+                seedSubtitleOverrideIfNeeded()
+            }
         }
         .alert(
             "Downloaded on This Device",
@@ -671,6 +679,20 @@ private struct ItemDetailPhoneContent: View {
     // by their own content id. "Auto" (nil) clears the override so the
     // library/profile cascade applies again.
 
+    /// Reflect a server-remembered subtitle override in the selector on
+    /// entry. `preferredSubtitleTrackIndex` is per-visit state, so
+    /// without this the selector always reopens on "Auto" even though
+    /// the pick was persisted; audio doesn't need an equivalent because
+    /// `resolvedAudioOrdinal` falls back to `effectiveAudioTrackIndex`.
+    private func seedSubtitleOverrideIfNeeded() {
+        guard preferredSubtitleTrackIndex == nil, let detail = viewModel.detail else { return }
+        preferredSubtitleTrackIndex = DetailPlaybackFormatting.serverPreferredSubtitleIndex(
+            version: effectiveVersion(for: detail, versionFileId: preferredVersionFileId),
+            signature: detail.effectiveSubtitleTrackSignature,
+            mode: detail.effectiveSubtitleMode
+        )
+    }
+
     private func prefKey(for detail: ItemDetail) -> String? {
         TrackSelectionPersistence.prefKey(seriesId: detail.seriesId, contentId: detail.contentId)
     }
@@ -752,6 +774,11 @@ private struct ItemDetailPhoneContent: View {
             let watchDetail = try await ContinuumAPI.shared.watchDetail(contentId: nextUp.contentId)
             guard !Task.isCancelled else { return }
             nextUpWatchDetail = watchDetail
+            preferredNextUpSubtitleTrackIndex = DetailPlaybackFormatting.serverPreferredSubtitleIndex(
+                version: effectiveVersion(for: watchDetail, versionFileId: nil),
+                signature: watchDetail.effectiveSubtitleTrackSignature,
+                mode: watchDetail.effectiveSubtitleMode
+            )
         } catch {
             guard !Task.isCancelled else { return }
             nextUpWatchDetail = nil

--- a/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
@@ -194,6 +194,8 @@ class ItemDetailViewModel {
                 subtitles: watchDetail.subtitles,
                 intro: watchDetail.intro,
                 credits: watchDetail.credits,
+                effectiveSubtitleMode: watchDetail.effectiveSubtitleMode,
+                effectiveSubtitleTrackSignature: watchDetail.effectiveSubtitleTrackSignature,
                 overlaySummary: item.overlaySummary,
                 audiobook: item.audiobook,
                 pendingTranslationLanguage: item.pendingTranslationLanguage

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
@@ -2199,6 +2199,7 @@ final class AVPlayerBackend {
         let syncOffsetMs = Int64(session.currentParams.syncOffsetMs)
         let assNowMs = nowMs - syncOffsetMs
         let bounds = overlay.bounds
+        let videoInsets = overlay.videoInsets
         #if os(macOS)
         let scale = overlay.window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 2
         #else
@@ -2209,7 +2210,8 @@ final class AVPlayerBackend {
             let out = renderer.renderOnSessionQueue(
                 atMilliseconds: assNowMs,
                 frameSize: bounds.size,
-                scale: scale
+                scale: scale,
+                videoInsets: videoInsets
             )
             guard out.isDirty else { return }
             let image = out.image

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerSurface.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerSurface.swift
@@ -83,8 +83,15 @@ final class AVPlayerLayerView: UIView {
         super.layoutSubviews()
         playerLayer.frame = bounds
         let videoRect = playerLayer.videoRect
-        let overlayFrame = videoRect.isEmpty ? bounds : videoRect
-        subtitleOverlay.frame = overlayFrame
+        #if os(tvOS)
+        // Full-frame overlay with libass margins marking the video area:
+        // fonts keep scaling with the video rect, and the "Bottom" position
+        // preset can render below the picture into the letterbox bar.
+        subtitleOverlay.frame = bounds
+        subtitleOverlay.videoInsets = SubtitleVideoInsets(videoRect: videoRect, bounds: bounds)
+        #else
+        subtitleOverlay.frame = videoRect.isEmpty ? bounds : videoRect
+        #endif
     }
 
     private func setupSubtitleOverlay() {
@@ -97,6 +104,9 @@ final class AVPlayerLayerView: UIView {
         readyForDisplayObservation = playerLayer.observe(\.isReadyForDisplay, options: [.new, .initial]) { [weak self] layer, _ in
             guard layer.isReadyForDisplay else { return }
             DispatchQueue.main.async {
+                // `videoRect` becomes meaningful once the layer is ready;
+                // re-run layout so the subtitle overlay picks it up.
+                self?.setNeedsLayout()
                 self?.backend?.videoSurfaceBecameReadyForDisplay()
             }
         }

--- a/iosApp/iosApp/Screens/Player/CoreMedia/PlayerCore.swift
+++ b/iosApp/iosApp/Screens/Player/CoreMedia/PlayerCore.swift
@@ -1893,10 +1893,13 @@ final class PlayerCore: NSObject {
         } else {
             size = .zero
         }
-        guard size != videoPresentationSize else { return }
-        videoPresentationSize = size
+        // Compare-and-assign on main: `PlayerSurfaceHostView.attach` reads
+        // the property from the UI thread, so keep it main-confined rather
+        // than writing from the demux/control path.
         DispatchQueue.main.async { [weak self] in
-            self?.onVideoPresentationSizeChange?(size)
+            guard let self, size != self.videoPresentationSize else { return }
+            self.videoPresentationSize = size
+            self.onVideoPresentationSizeChange?(size)
         }
     }
 

--- a/iosApp/iosApp/Screens/Player/CoreMedia/PlayerCore.swift
+++ b/iosApp/iosApp/Screens/Player/CoreMedia/PlayerCore.swift
@@ -5260,10 +5260,16 @@ final class PlayerCore: NSObject {
         // immediately. The in-band pipeline still serves selections made
         // during `openAndDemux`, where the demux head is at the playhead.
         if let extractor = ensureRuntimeSubtitleExtractor() {
+            // Same race as `performAudioTrackSwitch`: a selection applied
+            // while `openAndDemux` is still priming reads a ~0 playback
+            // clock. `pendingSkipBelowPTS` holds the requested anchor
+            // (load startTime or seek target) — without it, a resumed
+            // playback's initial subtitle selection feeds cues from the
+            // start of the file instead of the resume point.
             extractor.select(
                 trackId: SubtitleTrackIdSpace.makeAVPlayerEmbeddedTrackId(streamIndex: candidate),
                 slot: slot,
-                startSeconds: currentPlaybackTimeSeconds()
+                startSeconds: max(0, currentPlaybackTimeSeconds(), pendingSkipBelowPTS)
             )
             return
         }
@@ -5291,7 +5297,11 @@ final class PlayerCore: NSObject {
         guard let session = subtitleSession, let url = lastLoadURL else { return nil }
         let extractor = AVPlayerEmbeddedSubtitleExtractor(subtitleSession: session)
         extractor.currentMediaTimeProvider = { [weak self] in
-            self?.currentPlaybackTimeSeconds() ?? 0
+            guard let self else { return 0 }
+            // Pre-anchor the clock reads ~0; use the pending anchor so the
+            // read-ahead throttle doesn't stall a resume-point feed against
+            // a not-yet-started timeline.
+            return max(0, self.currentPlaybackTimeSeconds(), self.pendingSkipBelowPTS)
         }
         extractor.configure(
             source: AVPlayerSubtitleExtractionSource(

--- a/iosApp/iosApp/Screens/Player/CoreMedia/PlayerCore.swift
+++ b/iosApp/iosApp/Screens/Player/CoreMedia/PlayerCore.swift
@@ -772,6 +772,16 @@ final class PlayerCore: NSObject {
 
     private let embeddedSubtitlePipeline = EmbeddedSubtitlePipeline()
 
+    /// Dedicated subtitle-only FFmpeg context for runtime embedded-track
+    /// switches (shared implementation with the AVPlayer route). The main
+    /// demuxer runs tens of seconds ahead of the playhead and discards
+    /// packets of unselected subtitle streams, so enabling a track through
+    /// the in-band pipeline mid-playback would show no cues until the
+    /// playhead crosses the toggle-time demux head. This context re-opens
+    /// the source, seeks to the playhead, and feeds libass immediately.
+    /// Created lazily on the first runtime switch; reset per load.
+    private var runtimeSubtitleExtractor: AVPlayerEmbeddedSubtitleExtractor?
+
     /// libass-backed subtitle session. Created eagerly in `init()` so the
     /// overlay view can receive a non-nil renderer reference before the
     /// first `load()` is issued — otherwise `layoutSubviews` never pushes
@@ -1407,6 +1417,10 @@ final class PlayerCore: NSObject {
         // but keep the renderer/library alive — the overlay view already
         // holds a weak reference to it and we don't want to break that.
         subtitleSession?.teardown()
+        // The runtime extractor is bound to the previous load's URL;
+        // rebuild lazily against the new source on the next switch.
+        runtimeSubtitleExtractor?.teardown()
+        runtimeSubtitleExtractor = nil
         applyCurrentSubtitleStyling()
 
         // Re-open. This zeroes the cancel flag inside `resetCancellation`.
@@ -1803,6 +1817,11 @@ final class PlayerCore: NSObject {
             self.lastReportedSeconds = -1
             self.onTimeChange?(target)
         }
+
+        // Extractor-fed subtitle slots re-seek their own context to the
+        // new target (re-select is a fresh open + seek). Runs only on the
+        // final seek of a scrub burst — superseded seeks returned above.
+        runtimeSubtitleExtractor?.seek(to: target)
 
         // Restart demux + feeds from the seek point. Re-check disposal —
         // dispose() may have landed while we were blocked in
@@ -2358,7 +2377,7 @@ final class PlayerCore: NSObject {
                     isExternal: false,
                     // Phase 3: subtitle rendering is live. The selected stream
                     // is whichever decoder we've opened.
-                    isSelected: streamIndex == embeddedSubtitlePipeline.streamIndex(for: .primary),
+                    isSelected: streamIndex == selectedEmbeddedSubtitleStreamIndex(slot: .primary),
                     ffIndex: Int(streamIndex),
                     srcId: nil
                 ))
@@ -2919,8 +2938,17 @@ final class PlayerCore: NSObject {
         return Self.containsAtmosHint(track.title) || Self.containsAtmosHint(track.codec)
     }
 
+    /// Embedded subtitle stream selected in `slot`, regardless of which
+    /// mechanism feeds it: the in-band pipeline (selections made during
+    /// open) or the runtime extractor (mid-playback switches). -1 = none.
+    private func selectedEmbeddedSubtitleStreamIndex(slot: SubtitleSlot) -> Int32 {
+        let pipelineIndex = embeddedSubtitlePipeline.streamIndex(for: slot)
+        if pipelineIndex >= 0 { return pipelineIndex }
+        return runtimeSubtitleExtractor?.selectedStreamIndex(for: slot) ?? -1
+    }
+
     private func currentSubtitleStats() -> String? {
-        let subtitleStreamIndex = embeddedSubtitlePipeline.streamIndex(for: .primary)
+        let subtitleStreamIndex = selectedEmbeddedSubtitleStreamIndex(slot: .primary)
         guard subtitleStreamIndex >= 0 else { return "Off" }
         if let track = currentTracks.first(where: { $0.kind == .sub && $0.trackId == Int64(subtitleStreamIndex) }) {
             return track.title ?? track.lang ?? track.codec ?? "On"
@@ -5192,6 +5220,7 @@ final class PlayerCore: NSObject {
         // selection).
         if let newId, SubtitleTrackIdSpace.isAILive(newId) {
             embeddedSubtitlePipeline.tearDownEmbeddedSlot(slot: slot)
+            runtimeSubtitleExtractor?.stopFeeding(slot: slot)
             return
         }
 
@@ -5201,12 +5230,14 @@ final class PlayerCore: NSObject {
         // this slot.
         if let newId, SubtitleTrackIdSpace.isSidecar(newId) {
             embeddedSubtitlePipeline.tearDownEmbeddedSlot(slot: slot)
+            runtimeSubtitleExtractor?.stopFeeding(slot: slot)
             let idx = SubtitleTrackIdSpace.sidecarIndex(from: newId)
             subtitleSession?.openSidecar(urlIndex: idx, slot: slot)
             return
         }
 
         embeddedSubtitlePipeline.tearDownEmbeddedSlot(slot: slot)
+        runtimeSubtitleExtractor?.stopFeeding(slot: slot)
 
         guard let formatCtx, let newId else {
             // No new track — user disabled subtitles in this slot.
@@ -5219,6 +5250,26 @@ final class PlayerCore: NSObject {
             subtitleSession?.closeSlot(slot)
             return
         }
+
+        // Runtime enable goes through the dedicated extractor, not the
+        // in-band pipeline: the main demuxer has already read (and, with
+        // the stream unselected, discarded) the subtitle packets for the
+        // whole buffered region ahead of the playhead, so an in-band feed
+        // would render nothing until that buffer plays through. The
+        // extractor seeks its own context to the playhead and feeds cues
+        // immediately. The in-band pipeline still serves selections made
+        // during `openAndDemux`, where the demux head is at the playhead.
+        if let extractor = ensureRuntimeSubtitleExtractor() {
+            extractor.select(
+                trackId: SubtitleTrackIdSpace.makeAVPlayerEmbeddedTrackId(streamIndex: candidate),
+                slot: slot,
+                startSeconds: currentPlaybackTimeSeconds()
+            )
+            return
+        }
+
+        // No source URL to re-open (should not happen after a successful
+        // load) — fall back to the in-band feed.
         if !setupSubtitleDecoder(streamIndex: candidate, slot: slot) {
             Self.logger.warning(
                 "setSubtitleTrack: decoder setup failed for id=\(candidate) slot=\(slot.rawValue)"
@@ -5231,6 +5282,28 @@ final class PlayerCore: NSObject {
             session: subtitleSession,
             isCancelled: { [weak self] in self?.isCancelled ?? true }
         )
+    }
+
+    /// Lazily creates the runtime subtitle extractor for the current
+    /// load. Runs on `controlQueue`.
+    private func ensureRuntimeSubtitleExtractor() -> AVPlayerEmbeddedSubtitleExtractor? {
+        if let runtimeSubtitleExtractor { return runtimeSubtitleExtractor }
+        guard let session = subtitleSession, let url = lastLoadURL else { return nil }
+        let extractor = AVPlayerEmbeddedSubtitleExtractor(subtitleSession: session)
+        extractor.currentMediaTimeProvider = { [weak self] in
+            self?.currentPlaybackTimeSeconds() ?? 0
+        }
+        extractor.configure(
+            source: AVPlayerSubtitleExtractionSource(
+                mediaURL: url,
+                requestHeaders: lastLoadHeaders,
+                routeLabel: "coremedia-runtime",
+                seekable: true
+            ),
+            probe: false
+        )
+        runtimeSubtitleExtractor = extractor
+        return extractor
     }
 
     // MARK: - Font attachments
@@ -5405,6 +5478,8 @@ final class PlayerCore: NSObject {
         audioOutputConfig = nil
 
         embeddedSubtitlePipeline.teardown()
+        runtimeSubtitleExtractor?.teardown()
+        runtimeSubtitleExtractor = nil
 
         videoStreamIndex = -1
         audioStreamIndex = -1

--- a/iosApp/iosApp/Screens/Player/CoreMedia/PlayerCore.swift
+++ b/iosApp/iosApp/Screens/Player/CoreMedia/PlayerCore.swift
@@ -5379,7 +5379,17 @@ final class PlayerCore: NSObject {
 
         guard let overlay = subtitleOverlay else { return }
         let renderer = session.underlyingRenderer
-        guard renderer.hasAnyActiveTrack else { return }
+        guard renderer.hasAnyActiveTrack else {
+            // Disabling a track drops it without a final render pass —
+            // bailing here would leave the last composited cue on the
+            // layer indefinitely. Clearing every tick while inactive also
+            // covers an in-flight session-queue render re-pushing a stale
+            // image right after the drop. Mirrors the AVPlayer route.
+            DispatchQueue.main.async {
+                overlay.clear()
+            }
+            return
+        }
 
         let syncOffsetMs = Int64(session.currentParams.syncOffsetMs)
         let assNowMs = nowMs - syncOffsetMs

--- a/iosApp/iosApp/Screens/Player/CoreMedia/PlayerCore.swift
+++ b/iosApp/iosApp/Screens/Player/CoreMedia/PlayerCore.swift
@@ -5394,6 +5394,7 @@ final class PlayerCore: NSObject {
         let syncOffsetMs = Int64(session.currentParams.syncOffsetMs)
         let assNowMs = nowMs - syncOffsetMs
         let bounds = overlay.bounds
+        let videoInsets = overlay.videoInsets
         #if os(macOS)
         let scale = overlay.window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 2
         #else
@@ -5418,7 +5419,8 @@ final class PlayerCore: NSObject {
             let out = renderer.renderOnSessionQueue(
                 atMilliseconds: assNowMs,
                 frameSize: bounds.size,
-                scale: scale
+                scale: scale,
+                videoInsets: videoInsets
             )
             if liveDiag {
                 Self.logger.info(

--- a/iosApp/iosApp/Screens/Player/CoreMedia/PlayerCore.swift
+++ b/iosApp/iosApp/Screens/Player/CoreMedia/PlayerCore.swift
@@ -104,6 +104,14 @@ final class PlayerCore: NSObject {
     /// view when re-attaching (e.g. on window/screen change) so EDR can be
     /// re-evaluated without replaying the whole stream. Always 0 on tvOS.
     private(set) var lastSigPeak: Double = 0
+    /// Pixel-aspect-corrected presentation size of the active video stream,
+    /// derived from `videoFormatDescription`. `.zero` until the format is
+    /// known. The hosting view sizes the subtitle overlay to the displayed
+    /// video rect with it, so libass font scale tracks the video frame
+    /// rather than the full view.
+    private(set) var videoPresentationSize: CGSize = .zero
+    /// Fires on main whenever `videoPresentationSize` changes.
+    var onVideoPresentationSizeChange: ((CGSize) -> Void)?
 
     // MARK: - Master clock
 
@@ -1851,6 +1859,28 @@ final class PlayerCore: NSObject {
     /// per load (after dynamicRange is known) and whenever `setHDREnabled`
     /// changes the preference. No-op on tvOS — HDR is handled via
     /// AVDisplayManager there, not EDR.
+    /// Recomputes `videoPresentationSize` from the current
+    /// `videoFormatDescription` and notifies the hosting view on main when
+    /// it changes. Called wherever `videoFormatDescription` is assigned or
+    /// cleared.
+    private func publishVideoPresentationSize() {
+        let size: CGSize
+        if let fd = videoFormatDescription {
+            size = CMVideoFormatDescriptionGetPresentationDimensions(
+                fd,
+                usePixelAspectRatio: true,
+                useCleanAperture: true
+            )
+        } else {
+            size = .zero
+        }
+        guard size != videoPresentationSize else { return }
+        videoPresentationSize = size
+        DispatchQueue.main.async { [weak self] in
+            self?.onVideoPresentationSizeChange?(size)
+        }
+    }
+
     private func publishSigPeakIfNeeded() {
         #if os(iOS)
         // 1.1 is a sentinel "HDR content present" value; the actual peak
@@ -3638,6 +3668,7 @@ final class PlayerCore: NSObject {
             return false
         }
         videoFormatDescription = fd
+        publishVideoPresentationSize()
         return true
     }
 
@@ -3807,6 +3838,7 @@ final class PlayerCore: NSObject {
         )
         if simplified.session != nil {
             videoFormatDescription = simplifiedFormatDescription
+            publishVideoPresentationSize()
         }
         return simplified
         #else
@@ -5365,6 +5397,7 @@ final class PlayerCore: NSObject {
 
         videoDecodeMode = .videoToolbox
         videoFormatDescription = nil
+        publishVideoPresentationSize()
         videoDecodeOutputDimensions = nil
         useUntimedCompressedVideoSamples = false
         isRebuildingDecoder = false

--- a/iosApp/iosApp/Screens/Player/CoreMedia/PlayerSurface.swift
+++ b/iosApp/iosApp/Screens/Player/CoreMedia/PlayerSurface.swift
@@ -53,10 +53,16 @@ final class PlayerSurfaceHostView: UIView {
 
     private weak var attachedPlayer: PlayerCore?
 
-    /// libass-backed subtitle overlay. Covers the full frame — libass
-    /// handles positioning via its own margin model + line-position
-    /// percentage, so there's no need to pin this to a specific edge.
+    /// libass-backed subtitle overlay. Sized to the displayed video rect in
+    /// `layoutSubviews()` (not the full view) so libass — which scales the
+    /// ASS 1080-line coordinate space to the overlay's pixel height — keeps
+    /// the font size proportional to the video across orientations, and so
+    /// subtitles render inside the video frame in portrait.
     private let subtitleOverlay = SubtitleOverlayView()
+
+    /// Latest presentation size from the attached player; `.zero` until the
+    /// video format is known (overlay falls back to full bounds).
+    private var videoPresentationSize: CGSize = .zero
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -71,14 +77,8 @@ final class PlayerSurfaceHostView: UIView {
     }
 
     private func setupSubtitleOverlay() {
-        subtitleOverlay.translatesAutoresizingMaskIntoConstraints = false
+        subtitleOverlay.autoresizingMask = []
         addSubview(subtitleOverlay)
-        NSLayoutConstraint.activate([
-            subtitleOverlay.leadingAnchor.constraint(equalTo: leadingAnchor),
-            subtitleOverlay.trailingAnchor.constraint(equalTo: trailingAnchor),
-            subtitleOverlay.topAnchor.constraint(equalTo: topAnchor),
-            subtitleOverlay.bottomAnchor.constraint(equalTo: bottomAnchor),
-        ])
     }
 
     func attach(player: PlayerCore) {
@@ -91,6 +91,14 @@ final class PlayerSurfaceHostView: UIView {
         // doesn't extend the session's lifetime beyond playback.
         subtitleOverlay.renderer = player.subtitleRendererForOverlay
         player.subtitleOverlay = subtitleOverlay
+
+        // Track the video's presentation size so layoutSubviews() can pin
+        // the subtitle overlay to the displayed video rect.
+        videoPresentationSize = player.videoPresentationSize
+        player.onVideoPresentationSizeChange = { [weak self] size in
+            self?.videoPresentationSize = size
+            self?.setNeedsLayout()
+        }
 
         // iOS EDR: sig-peak > 0 means the stream is HDR and the user has
         // HDR enabled. Combine with the screen's available EDR headroom
@@ -105,11 +113,17 @@ final class PlayerSurfaceHostView: UIView {
         guard displayLayer.videoGravity != gravity else { return }
         displayLayer.videoGravity = gravity
         attachedPlayer?.setVideoGravity(gravity)
+        setNeedsLayout()
     }
 
     override func layoutSubviews() {
         super.layoutSubviews()
         displayLayer.frame = bounds
+        subtitleOverlay.frame = VideoDisplayRect.compute(
+            videoSize: videoPresentationSize,
+            bounds: bounds,
+            gravity: displayLayer.videoGravity
+        )
     }
 
     override func didMoveToWindow() {

--- a/iosApp/iosApp/Screens/Player/CoreMedia/PlayerSurface.swift
+++ b/iosApp/iosApp/Screens/Player/CoreMedia/PlayerSurface.swift
@@ -119,11 +119,20 @@ final class PlayerSurfaceHostView: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
         displayLayer.frame = bounds
-        subtitleOverlay.frame = VideoDisplayRect.compute(
+        let videoRect = VideoDisplayRect.compute(
             videoSize: videoPresentationSize,
             bounds: bounds,
             gravity: displayLayer.videoGravity
         )
+        #if os(tvOS)
+        // Full-frame overlay with libass margins marking the video area:
+        // fonts keep scaling with the video rect, and the "Bottom" position
+        // preset can render below the picture into the letterbox bar.
+        subtitleOverlay.frame = bounds
+        subtitleOverlay.videoInsets = SubtitleVideoInsets(videoRect: videoRect, bounds: bounds)
+        #else
+        subtitleOverlay.frame = videoRect
+        #endif
     }
 
     override func didMoveToWindow() {

--- a/iosApp/iosApp/Screens/Player/PlaybackPrefsResolver.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackPrefsResolver.swift
@@ -110,7 +110,10 @@ struct SubtitleAutoResolver {
     // MARK: - Matching helpers
 
     /// Score-based signature match. Higher score = better. Returns the
-    /// top scorer if anything above zero matched, else nil.
+    /// top scorer, or nil when no track matched a strong signal
+    /// (language or label) — forced/HI/codec equality alone is
+    /// meaningless since `false == false` holds for nearly every track,
+    /// and a weak "match" would hijack the Auto path.
     private static func bestSignatureMatch(
         _ sig: SubtitleTrackSignature,
         in tracks: [PlayerTrack]
@@ -118,9 +121,11 @@ struct SubtitleAutoResolver {
         var best: (PlayerTrack, Int)?
         for track in tracks {
             var score = 0
+            var strongSignal = false
             if let sigLang = sig.language, !sigLang.isEmpty,
                let trackLang = track.lang, languagesMatch(trackLang, sigLang) {
                 score += 5
+                strongSignal = true
             }
             if sig.forced == track.isForced {
                 score += 1
@@ -136,8 +141,9 @@ struct SubtitleAutoResolver {
                let title = track.title,
                title.localizedCaseInsensitiveContains(sigLabel) {
                 score += 2
+                strongSignal = true
             }
-            if score > (best?.1 ?? 0) {
+            if strongSignal, score > (best?.1 ?? 0) {
                 best = (track, score)
             }
         }

--- a/iosApp/iosApp/Screens/Player/Subtitles/AVPlayerEmbeddedSubtitleExtractor.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/AVPlayerEmbeddedSubtitleExtractor.swift
@@ -83,7 +83,10 @@ final class AVPlayerEmbeddedSubtitleExtractor {
         self.subtitleSession = subtitleSession
     }
 
-    func configure(source newSource: AVPlayerSubtitleExtractionSource?) {
+    /// - Parameter probe: when false, skips the async track-enumeration
+    ///   pass. The CoreMedia route already knows the container's tracks
+    ///   from its own format context and only needs `select`/`seek`.
+    func configure(source newSource: AVPlayerSubtitleExtractionSource?, probe: Bool = true) {
         stateLock.lock()
         source = newSource
         extractedTracks = []
@@ -99,7 +102,7 @@ final class AVPlayerEmbeddedSubtitleExtractor {
             self?.onTracksChanged?([])
         }
 
-        guard let sourceSnapshot else { return }
+        guard probe, let sourceSnapshot else { return }
 
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             self?.probe(source: sourceSnapshot, generation: generation)
@@ -157,11 +160,25 @@ final class AVPlayerEmbeddedSubtitleExtractor {
     }
 
     func clear(slot: SubtitleSlot) {
+        stopFeeding(slot: slot)
+        subtitleSession.closeSlot(slot)
+    }
+
+    /// Stop feeding `slot` without closing its libass track. For callers
+    /// handing the slot to another source (sidecar, live AI) that will
+    /// replace or close the session slot themselves.
+    func stopFeeding(slot: SubtitleSlot) {
         stateLock.lock()
         activeSelections.removeValue(forKey: slot)
         slotGenerations[slot, default: 0] &+= 1
         stateLock.unlock()
-        subtitleSession.closeSlot(slot)
+    }
+
+    /// Stream index currently being fed into `slot`, or nil when idle.
+    func selectedStreamIndex(for slot: SubtitleSlot) -> Int32? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return activeSelections[slot]?.streamIndex
     }
 
     func seek(to mediaSeconds: Double) {

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleAppearance.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleAppearance.swift
@@ -22,30 +22,35 @@ enum SubtitleFontSizePreset: String, Codable, CaseIterable, Identifiable {
         }
     }
 
+    /// Point sizes are interpreted inside the fixed 1080-line ASS playfield
+    /// and scale with the displayed video rect, so they read the same in any
+    /// orientation. The ladder is rebased ~1.4x from the original values
+    /// (large = old xxlarge) after the overlay switched from full-screen to
+    /// video-rect sizing, which shrank the effective render size.
     var pointSize: Double {
         #if os(iOS)
         switch self {
-        case .small: return 30
-        case .medium: return 34
-        case .large: return 38
-        case .xlarge: return 46
-        case .xxlarge: return 54
+        case .small: return 43
+        case .medium: return 48
+        case .large: return 54
+        case .xlarge: return 65
+        case .xxlarge: return 77
         }
         #elseif os(tvOS)
         switch self {
-        case .small: return 28
-        case .medium: return 34
-        case .large: return 40
-        case .xlarge: return 48
-        case .xxlarge: return 56
+        case .small: return 39
+        case .medium: return 48
+        case .large: return 56
+        case .xlarge: return 67
+        case .xxlarge: return 78
         }
         #else
         switch self {
-        case .small: return 44
-        case .medium: return 56
-        case .large: return 68
-        case .xlarge: return 82
-        case .xxlarge: return 96
+        case .small: return 62
+        case .medium: return 79
+        case .large: return 96
+        case .xlarge: return 116
+        case .xxlarge: return 136
         }
         #endif
     }

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleAppearance.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleAppearance.swift
@@ -195,7 +195,7 @@ struct SubtitleAppearance: Codable, Equatable {
         fontFamily: .sansSerif,
         fontColor: "#ffffff",
         backgroundColor: "#000000",
-        backgroundStyle: .shadow,
+        backgroundStyle: .box,
         backgroundOpacity: 75,
         textOutline: false,
         textOutlineColor: "#000000",

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleAppearance.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleAppearance.swift
@@ -37,12 +37,14 @@ enum SubtitleFontSizePreset: String, Codable, CaseIterable, Identifiable {
         case .xxlarge: return 77
         }
         #elseif os(tvOS)
+        // Ladder rebased ~1.3x from the original tvOS values (large = old
+        // ~xlarge+) after the defaults read small on a living-room screen.
         switch self {
-        case .small: return 39
-        case .medium: return 48
-        case .large: return 56
-        case .xlarge: return 67
-        case .xxlarge: return 78
+        case .small: return 51
+        case .medium: return 63
+        case .large: return 74
+        case .xlarge: return 88
+        case .xxlarge: return 103
         }
         #else
         switch self {

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleOverlayView.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleOverlayView.swift
@@ -35,6 +35,17 @@ final class SubtitleOverlayView: UIView {
     /// renderer of frame-size changes directly.
     weak var renderer: SubtitleRenderer?
 
+    /// Distance from this overlay's edges to the displayed video rect.
+    /// Zero when the host sizes the overlay to the video rect (iOS);
+    /// set by the tvOS hosts, which size the overlay to the full frame so
+    /// libass can place the "Bottom" preset in the letterbox bar.
+    var videoInsets: SubtitleVideoInsets = .zero {
+        didSet {
+            guard videoInsets != oldValue else { return }
+            pushFrameGeometry()
+        }
+    }
+
     /// Layer that holds the composited subtitle image. Separate from
     /// `self.layer` so we can swap its `contents` without disturbing
     /// any other decoration the view might grow in the future.
@@ -69,11 +80,7 @@ final class SubtitleOverlayView: UIView {
         withoutImplicitLayerAnimation {
             contentsLayer.frame = bounds
         }
-        let scale = window?.screen.scale ?? traitCollection.displayScale
-        withoutImplicitLayerAnimation {
-            contentsLayer.contentsScale = scale
-        }
-        renderer?.updateFrameSize(bounds.size, scale: scale)
+        pushFrameGeometry()
     }
 
     override func didMoveToWindow() {
@@ -82,12 +89,16 @@ final class SubtitleOverlayView: UIView {
         // airplay). Re-push frame size so libass re-paints at the right
         // pixel density.
         if window != nil {
-            let scale = window?.screen.scale ?? traitCollection.displayScale
-            withoutImplicitLayerAnimation {
-                contentsLayer.contentsScale = scale
-            }
-            renderer?.updateFrameSize(bounds.size, scale: scale)
+            pushFrameGeometry()
         }
+    }
+
+    private func pushFrameGeometry() {
+        let scale = window?.screen.scale ?? traitCollection.displayScale
+        withoutImplicitLayerAnimation {
+            contentsLayer.contentsScale = scale
+        }
+        renderer?.updateFrameSize(bounds.size, scale: scale, videoInsets: videoInsets)
     }
 
     /// Assign the newest composited image. Call on main thread.
@@ -113,6 +124,16 @@ final class SubtitleOverlayView: NSView {
     /// session) because layout notifies the renderer of frame-size changes
     /// directly.
     weak var renderer: SubtitleRenderer?
+
+    /// Distance from this overlay's edges to the displayed video rect.
+    /// Always zero on macOS (the hosts size the overlay to the video rect);
+    /// present so shared pump code can read it uniformly.
+    var videoInsets: SubtitleVideoInsets = .zero {
+        didSet {
+            guard videoInsets != oldValue else { return }
+            updateLayout()
+        }
+    }
 
     /// Layer that holds the composited subtitle image. Separate from
     /// `self.layer` so we can swap its `contents` without disturbing the
@@ -155,7 +176,7 @@ final class SubtitleOverlayView: NSView {
         withoutImplicitLayerAnimation {
             contentsLayer.contentsScale = scale
         }
-        renderer?.updateFrameSize(bounds.size, scale: scale)
+        renderer?.updateFrameSize(bounds.size, scale: scale, videoInsets: videoInsets)
     }
 
     /// Assign the newest composited image. Call on main thread.

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleRenderer.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleRenderer.swift
@@ -107,6 +107,13 @@ final class SubtitleRenderer {
     // so we don't churn libass's internal caches.
     private var lastWidth: Int32 = 0
     private var lastHeight: Int32 = 0
+    /// libass margins in pixels: distance from the overlay frame's edges to
+    /// the displayed video rect. Non-zero only when the host sizes the
+    /// overlay beyond the video (tvOS full-frame overlay).
+    private var lastMarginTop: Int32 = 0
+    private var lastMarginBottom: Int32 = 0
+    private var lastMarginLeft: Int32 = 0
+    private var lastMarginRight: Int32 = 0
     private var frameSizeDirty = false
 
     // Most recent user styling params per slot. Re-applied after any
@@ -235,7 +242,8 @@ final class SubtitleRenderer {
             SubtitleStylingOverride.apply(
                 renderer: self.renderer(for: slot),
                 params: self.currentParams,
-                isNativeASS: isNativeASS
+                isNativeASS: isNativeASS,
+                slot: slot
             )
         }
     }
@@ -284,7 +292,8 @@ final class SubtitleRenderer {
             SubtitleStylingOverride.apply(
                 renderer: self.renderer(for: slot),
                 params: self.currentParams,
-                isNativeASS: isNativeASS
+                isNativeASS: isNativeASS,
+                slot: slot
             )
         }
     }
@@ -391,24 +400,20 @@ final class SubtitleRenderer {
 
     // MARK: - Frame size
 
-    /// Update the libass frame/storage size. Called by the overlay view's
-    /// `layoutSubviews`. Safe from main thread — hops internally.
-    func updateFrameSize(_ size: CGSize, scale: CGFloat) {
+    /// Update the libass frame/storage size and video-area margins. Called
+    /// by the overlay view's `layoutSubviews`. Safe from main thread — hops
+    /// internally.
+    func updateFrameSize(
+        _ size: CGSize,
+        scale: CGFloat,
+        videoInsets: SubtitleVideoInsets = .zero
+    ) {
         let w = Int32(max(1, size.width * scale))
         let h = Int32(max(1, size.height * scale))
+        let margins = Self.pixelMargins(for: videoInsets, scale: scale)
         sessionQueue.async { [weak self] in
             guard let self else { return }
-            if w == self.lastWidth && h == self.lastHeight { return }
-            self.forEachRenderer {
-                ass_set_frame_size($0, w, h)
-                ass_set_storage_size($0, w, h)
-                ass_set_pixel_aspect($0, 1.0)
-            }
-            self.lastWidth = w
-            self.lastHeight = h
-            self.frameSizeDirty = true
-            // Canvas will be reallocated on the next dirty render.
-            self.canvas = nil
+            self.applyFrameGeometryOnSessionQueue(width: w, height: h, margins: margins)
         }
     }
 
@@ -428,12 +433,14 @@ final class SubtitleRenderer {
             SubtitleStylingOverride.apply(
                 renderer: self.primaryRenderer,
                 params: params,
-                isNativeASS: primaryHandle?.isNativeASS ?? false
+                isNativeASS: primaryHandle?.isNativeASS ?? false,
+                slot: .primary
             )
             SubtitleStylingOverride.apply(
                 renderer: self.secondaryRenderer,
                 params: params,
-                isNativeASS: secondaryHandle?.isNativeASS ?? false
+                isNativeASS: secondaryHandle?.isNativeASS ?? false,
+                slot: .secondary
             )
             self.frameSizeDirty = true  // force repaint on next tick
         }
@@ -447,12 +454,13 @@ final class SubtitleRenderer {
     func renderOnSessionQueue(
         atMilliseconds now: Int64,
         frameSize: CGSize,
-        scale: CGFloat
+        scale: CGFloat,
+        videoInsets: SubtitleVideoInsets = .zero
     ) -> SubtitleRenderOutput {
         guard primaryRenderer != nil || secondaryRenderer != nil else {
             return SubtitleRenderOutput(image: nil, isDirty: false)
         }
-        ensureFrameSizeOnSessionQueue(frameSize, scale: scale)
+        ensureFrameSizeOnSessionQueue(frameSize, scale: scale, videoInsets: videoInsets)
 
         handleLock.lock()
         let primaryHandle = primary
@@ -496,20 +504,56 @@ final class SubtitleRenderer {
 
     private func ensureFrameSizeOnSessionQueue(
         _ size: CGSize,
-        scale: CGFloat
+        scale: CGFloat,
+        videoInsets: SubtitleVideoInsets = .zero
     ) {
         let safeScale = scale.isFinite && scale > 0 ? scale : 1
         let w = Int32(max(1, size.width * safeScale))
         let h = Int32(max(1, size.height * safeScale))
-        if w == lastWidth && h == lastHeight { return }
+        let margins = Self.pixelMargins(for: videoInsets, scale: safeScale)
+        applyFrameGeometryOnSessionQueue(width: w, height: h, margins: margins)
+    }
+
+    private static func pixelMargins(
+        for insets: SubtitleVideoInsets,
+        scale: CGFloat
+    ) -> (top: Int32, bottom: Int32, left: Int32, right: Int32) {
+        let safeScale = scale.isFinite && scale > 0 ? scale : 1
+        func px(_ points: CGFloat) -> Int32 {
+            Int32(max(0, (points * safeScale).rounded()))
+        }
+        return (px(insets.top), px(insets.bottom), px(insets.left), px(insets.right))
+    }
+
+    private func applyFrameGeometryOnSessionQueue(
+        width w: Int32,
+        height h: Int32,
+        margins: (top: Int32, bottom: Int32, left: Int32, right: Int32)
+    ) {
+        let sizeChanged = w != lastWidth || h != lastHeight
+        let marginsChanged = margins.top != lastMarginTop
+            || margins.bottom != lastMarginBottom
+            || margins.left != lastMarginLeft
+            || margins.right != lastMarginRight
+        guard sizeChanged || marginsChanged else { return }
         forEachRenderer {
             ass_set_frame_size($0, w, h)
             ass_set_storage_size($0, w, h)
+            // Margins mark the video area inside the frame; libass keys
+            // font scaling to that area, and `use_margins` placement (set
+            // per-slot in SubtitleStylingOverride.apply) may render regular
+            // cues into the margin bars.
+            ass_set_margins($0, margins.top, margins.bottom, margins.left, margins.right)
             ass_set_pixel_aspect($0, 1.0)
         }
         lastWidth = w
         lastHeight = h
+        lastMarginTop = margins.top
+        lastMarginBottom = margins.bottom
+        lastMarginLeft = margins.left
+        lastMarginRight = margins.right
         frameSizeDirty = true
+        // Canvas will be reallocated on the next dirty render.
         canvas = nil
     }
 

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleRenderer.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleRenderer.swift
@@ -640,15 +640,14 @@ private final class CompositorCanvas {
                 continue
             }
 
-            // libass documents render output as RRGGBBTT, where TT is
-            // inverted transparency. The Apple xcframework we are using
-            // can expose the ASS-native AABBGGRR packing through Swift.
-            // Prefer documented order, but fall back when it would make
-            // an otherwise opaque ASS-style color fully transparent.
-            let color = img.color
-            let documented = unpackDocumentedRenderColor(color)
-            let assNative = unpackASSNativeColor(color)
-            let rgba = documented.alpha == 0 && assNative.alpha > 0 ? assNative : documented
+            // libass render output color is RRGGBBTT, where TT is inverted
+            // transparency. (An earlier fallback here re-read the color as
+            // AABBGGRR when the documented read looked fully transparent —
+            // that was masking incorrectly packed override-style colors
+            // from SubtitleStylingOverride, and it resurrected genuinely
+            // faded-out glyphs as opaque. Both are fixed; trust the
+            // documented order.)
+            let rgba = unpackDocumentedRenderColor(img.color)
             if rgba.alpha == 0 {
                 current = img.next
                 continue
@@ -725,13 +724,4 @@ private final class CompositorCanvas {
         )
     }
 
-    private func unpackASSNativeColor(_ color: UInt32) -> (r: UInt8, g: UInt8, b: UInt8, alpha: UInt8) {
-        let transparency = UInt8((color >> 24) & 0xFF)
-        return (
-            UInt8(color & 0xFF),
-            UInt8((color >> 8) & 0xFF),
-            UInt8((color >> 16) & 0xFF),
-            UInt8(255 - UInt16(transparency))
-        )
-    }
 }

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleStylingOverride.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleStylingOverride.swift
@@ -48,9 +48,6 @@ enum SubtitleStylingOverride {
         var syncOffsetMs: Int
 
         var effectiveBorderSize: Double {
-            if backgroundStyle == .box && backgroundOpacityPercent > 0 {
-                return max(1.5, min(4, fontSize * 0.07))
-            }
             if borderSize > 0 {
                 return max(2, min(4, fontSize * 0.08))
             }
@@ -59,6 +56,47 @@ enum SubtitleStylingOverride {
 
         var effectiveOutlineColorHex: String {
             backgroundStyle == .outline ? backgroundColorHex : borderColorHex
+        }
+
+        /// True when the user wants a background box drawn behind the text.
+        var boxEnabled: Bool {
+            backgroundStyle == .box && backgroundOpacityPercent > 0
+        }
+
+        /// Padding of the background box around the text, in the 1080-line
+        /// playfield. Passed through the ASS `Shadow` field: libass's
+        /// BorderStyle 4 uses the shadow size as box padding (and skips the
+        /// drop shadow itself).
+        var boxPadding: Double {
+            boxEnabled ? max(3, min(12, fontSize * 0.15)) : 0
+        }
+
+        /// ASS border style: 4 draws a per-event background rectangle
+        /// filled with `BackColour` (honoring its alpha), unlike 3 whose
+        /// box is per glyph run and filled with the *outline* colour at
+        /// full opacity — which is why 3 can't do translucent boxes.
+        var assBorderStyle: Int {
+            boxEnabled ? 4 : 1
+        }
+
+        /// Value for the ASS `Shadow` field: drop-shadow depth for the
+        /// shadow style, box padding for the box style (see `boxPadding`).
+        var assShadow: Double {
+            backgroundStyle == .shadow ? 1.5 : boxPadding
+        }
+
+        /// Inverted ASS alpha byte for `BackColour` (0x00 opaque … 0xFF
+        /// transparent). Box: user opacity. Shadow: 50% black so the drop
+        /// shadow is actually visible. Otherwise fully transparent.
+        var backgroundAlphaByte: UInt8 {
+            switch backgroundStyle {
+            case .box:
+                return UInt8(max(0, min(255, (100 - backgroundOpacityPercent) * 255 / 100)))
+            case .shadow:
+                return 0x80
+            case .outline, .none:
+                return 0xFF
+            }
         }
 
         static let referenceFontSize: Double = SubtitleAppearance.default.fontSize.pointSize
@@ -112,15 +150,15 @@ enum SubtitleStylingOverride {
     ) -> String {
         let primary = assColor(hexRGB: params.textColorHex, alphaByte: 0x00)
         let outline = assColor(hexRGB: params.effectiveOutlineColorHex, alphaByte: 0x00)
-        let effectiveOpacity = params.backgroundStyle == .box ? params.backgroundOpacityPercent : 0
-        let bgAlpha = UInt8(max(0, min(255, (100 - effectiveOpacity) * 255 / 100)))
-        let back = assColor(hexRGB: params.backgroundColorHex, alphaByte: bgAlpha)
+        let back = assColor(hexRGB: params.backgroundColorHex, alphaByte: params.backgroundAlphaByte)
         let alignment = (slot == .secondary) ? 8 : primaryHeaderAlignment(for: params)
 
-        // BorderStyle 1 = outline + shadow; BorderStyle 3 = opaque box.
-        // Use box iff the user enabled a non-transparent background.
-        let borderStyle = effectiveOpacity > 0 ? 3 : 1
-        let shadow = params.backgroundStyle == .shadow ? 1.5 : 0
+        // BorderStyle 1 = outline + shadow; BorderStyle 4 = per-event
+        // background box filled with BackColour (so its alpha carries the
+        // user's opacity). The Shadow field doubles as box padding under
+        // BorderStyle 4 — see `Parameters.assShadow`.
+        let borderStyle = params.assBorderStyle
+        let shadow = params.assShadow
         let borderSize = params.effectiveBorderSize
 
         // Playfield resolution. 1920x1080 is the cross-industry default —
@@ -228,9 +266,10 @@ enum SubtitleStylingOverride {
         style.PrimaryColour = assColor(hexRGBUInt: params.textColorHex, alphaByte: 0x00)
         style.SecondaryColour = 0x00FFFFFF
         style.OutlineColour = assColor(hexRGBUInt: params.effectiveOutlineColorHex, alphaByte: 0x00)
-        let effectiveOpacity = params.backgroundStyle == .box ? params.backgroundOpacityPercent : 0
-        let bgAlpha = UInt8(max(0, min(255, (100 - effectiveOpacity) * 255 / 100)))
-        style.BackColour = assColor(hexRGBUInt: params.backgroundColorHex, alphaByte: bgAlpha)
+        style.BackColour = assColor(
+            hexRGBUInt: params.backgroundColorHex,
+            alphaByte: params.backgroundAlphaByte
+        )
         // ScaleX/Y are doubles where 1.0 = 100%. The integer 100 here
         // would scale text to 100x authored size (10,000%).
         style.ScaleX = 1.0
@@ -242,8 +281,8 @@ enum SubtitleStylingOverride {
         // authored FontSize=16 grid. Default 0.5 outline + 1.5 shadow
         // matches the web player's "shadow" default (no heavy outline).
         style.Outline = params.effectiveBorderSize
-        style.Shadow = params.backgroundStyle == .shadow ? 1.5 : 0
-        style.BorderStyle = effectiveOpacity > 0 ? 3 : 1
+        style.Shadow = params.assShadow
+        style.BorderStyle = Int32(params.assBorderStyle)
         style.Alignment = Int32(primaryStyleAlignment(for: params))
         style.MarginL = 60
         style.MarginR = 60

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleStylingOverride.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleStylingOverride.swift
@@ -68,7 +68,13 @@ enum SubtitleStylingOverride {
         /// BorderStyle 4 uses the shadow size as box padding (and skips the
         /// drop shadow itself).
         var boxPadding: Double {
-            boxEnabled ? max(3, min(12, fontSize * 0.15)) : 0
+            guard boxEnabled else { return 0 }
+            #if os(iOS) || os(tvOS)
+            // Tighter box: roughly half the original padding.
+            return max(2, min(7, fontSize * 0.08))
+            #else
+            return max(3, min(12, fontSize * 0.15))
+            #endif
         }
 
         /// ASS border style: 4 draws a per-event background rectangle
@@ -222,16 +228,28 @@ enum SubtitleStylingOverride {
     ///   skip color/font/border overrides so the creative work renders
     ///   as the author intended. Sync offset still applies in the overlay
     ///   pump, outside libass style overrides.
+    /// - Parameter slot: which subtitle slot this renderer draws. Only the
+    ///   primary slot participates in `use_margins` placement below.
     static func apply(
         renderer: OpaquePointer?,
         params: Parameters,
-        isNativeASS: Bool
+        isNativeASS: Bool,
+        slot: SubtitleSlot
     ) {
         guard let renderer else { return }
 
         // libass line_position collapses multi-line cues onto the override
         // position. Use margins/alignment from the style override instead.
         ass_set_line_position(renderer, 0)
+
+        // `use_margins` lets regular (non-\pos) events render across the
+        // full overlay frame instead of only the video area, so the
+        // "Bottom" preset can sit in the letterbox bar below the picture
+        // when the overlay extends past the video rect (tvOS). Margins are
+        // zero when the overlay is video-rect sized, making this a no-op
+        // elsewhere. Native ASS keeps authored layout inside the video.
+        let useMargins = !isNativeASS && slot == .primary && params.verticalPosition >= 100
+        ass_set_use_margins(renderer, useMargins ? 1 : 0)
 
         if isNativeASS {
             ass_set_font_scale(renderer, 1.0)
@@ -316,7 +334,23 @@ enum SubtitleStylingOverride {
         }
 
         // Bottom-aligned ASS margins are distance from the bottom edge:
-        // smaller values render lower. Anchor the bottom-aligned presets:
+        // smaller values render lower.
+        #if os(tvOS)
+        // tvOS: "Lower Third" hugs the video's bottom edge (Bottom's old
+        // anchor), while "Bottom" is measured against the full TV frame —
+        // `use_margins` in `apply(...)` drops it into the letterbox bar
+        // below the picture when one exists — with a slightly larger
+        // margin so it doesn't sit flush against the frame edge.
+        switch p {
+        case 0...70:
+            return 30
+        case 71...100:
+            return 60
+        default:
+            return interpolateMargin(position: p, from: 100, to: 150, marginFrom: 60, marginTo: 10)
+        }
+        #else
+        // Anchor the bottom-aligned presets:
         //   lower-third (70) -> 220px
         //   bottom (100)     -> 30px
         //   extreme (150)    -> 10px
@@ -326,6 +360,7 @@ enum SubtitleStylingOverride {
         default:
             return interpolateMargin(position: p, from: 100, to: 150, marginFrom: 30, marginTo: 10)
         }
+        #endif
     }
 
     private static func primaryHeaderAlignment(for params: Parameters) -> Int {

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleStylingOverride.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleStylingOverride.swift
@@ -264,7 +264,7 @@ enum SubtitleStylingOverride {
         style.FontName = fontCString
         style.FontSize = params.fontSize
         style.PrimaryColour = assColor(hexRGBUInt: params.textColorHex, alphaByte: 0x00)
-        style.SecondaryColour = 0x00FFFFFF
+        style.SecondaryColour = 0xFFFFFF00 // opaque white, internal RRGGBBAA
         style.OutlineColour = assColor(hexRGBUInt: params.effectiveOutlineColorHex, alphaByte: 0x00)
         style.BackColour = assColor(
             hexRGBUInt: params.backgroundColorHex,
@@ -359,13 +359,15 @@ enum SubtitleStylingOverride {
         return String(format: "&H%02X%02X%02X%02X", alphaByte, b, g, r)
     }
 
-    /// ASS color format (numeric form, used in struct fields):
-    /// `(alpha<<24) | (blue<<16) | (green<<8) | red` per libass convention.
-    /// Note: libass stores this as UInt32 little-endian but the struct
-    /// field type in C is `uint32_t`.
-    private static func assColor(hexRGBUInt: String, alphaByte: UInt8) -> UInt32 {
+    /// libass internal color format (numeric form, used in `ASS_Style`
+    /// struct fields): `0xRRGGBBAA` with inverted alpha in the low byte
+    /// (00 = opaque, FF = transparent). This is what libass's own parser
+    /// produces (`parse_color_tag` byte-swaps the file-format `&HAABBGGRR`
+    /// value) and what `ass_set_selective_style_override` copies verbatim —
+    /// it is NOT the ASS file format. Internal for tests.
+    static func assColor(hexRGBUInt: String, alphaByte: UInt8) -> UInt32 {
         let (r, g, b) = rgbBytes(fromHex: hexRGBUInt)
-        return (UInt32(alphaByte) << 24) | (UInt32(b) << 16) | (UInt32(g) << 8) | UInt32(r)
+        return (UInt32(r) << 24) | (UInt32(g) << 16) | (UInt32(b) << 8) | UInt32(alphaByte)
     }
 
     /// Parse `#RRGGBB` (or `RRGGBB`) into raw bytes. Falls back to

--- a/iosApp/iosApp/Screens/Player/Subtitles/VideoDisplayRect.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/VideoDisplayRect.swift
@@ -12,6 +12,29 @@
 import AVFoundation
 import CoreGraphics
 
+/// Distances (in points) from a full-frame subtitle overlay's edges to the
+/// displayed video rect inside it. Passed to libass via `ass_set_margins`
+/// so font scaling stays keyed to the video area while `use_margins`
+/// placement can render regular cues into the letterbox bars.
+struct SubtitleVideoInsets: Equatable {
+    var top: CGFloat = 0
+    var bottom: CGFloat = 0
+    var left: CGFloat = 0
+    var right: CGFloat = 0
+
+    static let zero = SubtitleVideoInsets()
+
+    init() {}
+
+    init(videoRect: CGRect, bounds: CGRect) {
+        guard !bounds.isEmpty, !videoRect.isEmpty else { return }
+        top = max(0, videoRect.minY - bounds.minY)
+        bottom = max(0, bounds.maxY - videoRect.maxY)
+        left = max(0, videoRect.minX - bounds.minX)
+        right = max(0, bounds.maxX - videoRect.maxX)
+    }
+}
+
 enum VideoDisplayRect {
     /// - Parameters:
     ///   - videoSize: pixel-aspect-corrected presentation size of the video;

--- a/iosApp/iosApp/Screens/Player/Subtitles/VideoDisplayRect.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/VideoDisplayRect.swift
@@ -1,0 +1,38 @@
+//
+//  VideoDisplayRect.swift
+//  Silo (iOS + tvOS + macOS)
+//
+//  Computes the rect the video occupies inside a host view's bounds for a
+//  given gravity — the AVSampleBufferDisplayLayer equivalent of
+//  `AVPlayerLayer.videoRect`. The CoreMedia player surfaces use it to size
+//  the libass subtitle overlay to the displayed video, so subtitle font
+//  scale tracks the video frame rather than the full view (which would make
+//  text tiny in landscape and huge in portrait).
+
+import AVFoundation
+import CoreGraphics
+
+enum VideoDisplayRect {
+    /// - Parameters:
+    ///   - videoSize: pixel-aspect-corrected presentation size of the video;
+    ///     pass `.zero` when unknown to fall back to `bounds`.
+    ///   - bounds: the host view's bounds.
+    ///   - gravity: the display layer's video gravity.
+    static func compute(
+        videoSize: CGSize,
+        bounds: CGRect,
+        gravity: AVLayerVideoGravity
+    ) -> CGRect {
+        guard videoSize.width > 0, videoSize.height > 0, !bounds.isEmpty else {
+            return bounds
+        }
+        switch gravity {
+        case .resizeAspect:
+            return AVMakeRect(aspectRatio: videoSize, insideRect: bounds)
+        default:
+            // .resizeAspectFill and .resize cover the whole view; the
+            // visible video region is the full bounds.
+            return bounds
+        }
+    }
+}

--- a/iosApp/iosApp/macOS/PlayerSurface.swift
+++ b/iosApp/iosApp/macOS/PlayerSurface.swift
@@ -22,6 +22,10 @@ final class PlayerSurfaceHostView: NSView {
     private weak var attachedPlayer: PlayerCore?
     private let subtitleOverlay = SubtitleOverlayView()
 
+    /// Latest presentation size from the attached player; `.zero` until the
+    /// video format is known (overlay falls back to full bounds).
+    private var videoPresentationSize: CGSize = .zero
+
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         wantsLayer = true
@@ -45,12 +49,25 @@ final class PlayerSurfaceHostView: NSView {
         player.attach(to: displayLayer)
         subtitleOverlay.renderer = player.subtitleRendererForOverlay
         player.subtitleOverlay = subtitleOverlay
+
+        // Track the video's presentation size so layout() can pin the
+        // subtitle overlay to the displayed video rect — keeps libass font
+        // scale proportional to the video as the window is resized.
+        videoPresentationSize = player.videoPresentationSize
+        player.onVideoPresentationSizeChange = { [weak self] size in
+            self?.videoPresentationSize = size
+            self?.needsLayout = true
+        }
     }
 
     override func layout() {
         super.layout()
         displayLayer.frame = bounds
-        subtitleOverlay.frame = bounds
+        subtitleOverlay.frame = VideoDisplayRect.compute(
+            videoSize: videoPresentationSize,
+            bounds: bounds,
+            gravity: displayLayer.videoGravity
+        )
     }
 
     override func viewDidChangeBackingProperties() {

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
@@ -70,6 +70,7 @@ struct TVItemDetailView: View {
             isLoadingNextUpPlaybackDetail = false
             didLoadNextUpPlaybackDetail = false
             await viewModel.loadDetail(contentId: contentId)
+            seedSubtitleOverrideIfNeeded()
         }
     }
 
@@ -509,6 +510,20 @@ struct TVItemDetailView: View {
     // by their own content id. "Auto" (nil) clears the override so the
     // library/profile cascade applies again.
 
+    /// Reflect a server-remembered subtitle override in the selector on
+    /// entry. `preferredSubtitleTrackIndex` is per-visit state, so
+    /// without this the selector always reopens on "Auto" even though
+    /// the pick was persisted; audio doesn't need an equivalent because
+    /// `resolvedAudioOrdinal` falls back to `effectiveAudioTrackIndex`.
+    private func seedSubtitleOverrideIfNeeded() {
+        guard preferredSubtitleTrackIndex == nil, let detail = viewModel.detail else { return }
+        preferredSubtitleTrackIndex = DetailPlaybackFormatting.serverPreferredSubtitleIndex(
+            version: effectiveVersion(for: detail, versionFileId: preferredVersionFileId),
+            signature: detail.effectiveSubtitleTrackSignature,
+            mode: detail.effectiveSubtitleMode
+        )
+    }
+
     private func prefKey(for detail: ItemDetail?) -> String? {
         TrackSelectionPersistence.prefKey(seriesId: detail?.seriesId, contentId: detail?.contentId)
     }
@@ -592,6 +607,11 @@ struct TVItemDetailView: View {
             let enriched = await enrichPlaybackMetadata(for: item, contentId: nextUp.contentId)
             guard !Task.isCancelled else { return }
             nextUpPlaybackDetail = enriched
+            preferredNextUpSubtitleTrackIndex = DetailPlaybackFormatting.serverPreferredSubtitleIndex(
+                version: effectiveVersion(for: enriched, versionFileId: nil),
+                signature: enriched.effectiveSubtitleTrackSignature,
+                mode: enriched.effectiveSubtitleMode
+            )
             didLoadNextUpPlaybackDetail = true
         } catch {
             guard !Task.isCancelled else { return }
@@ -640,6 +660,11 @@ struct TVItemDetailView: View {
             let enriched = await enrichPlaybackMetadata(for: item, contentId: nextUp.contentId)
             guard !Task.isCancelled else { return }
             nextUpPlaybackDetail = enriched
+            preferredNextUpSubtitleTrackIndex = DetailPlaybackFormatting.serverPreferredSubtitleIndex(
+                version: effectiveVersion(for: enriched, versionFileId: nil),
+                signature: enriched.effectiveSubtitleTrackSignature,
+                mode: enriched.effectiveSubtitleMode
+            )
             didLoadNextUpPlaybackDetail = true
         } catch {
             guard !Task.isCancelled else { return }
@@ -702,6 +727,8 @@ struct TVItemDetailView: View {
                 subtitles: watchDetail.subtitles,
                 intro: watchDetail.intro,
                 credits: watchDetail.credits,
+                effectiveSubtitleMode: watchDetail.effectiveSubtitleMode,
+                effectiveSubtitleTrackSignature: watchDetail.effectiveSubtitleTrackSignature,
                 overlaySummary: item.overlaySummary,
                 audiobook: item.audiobook,
                 pendingTranslationLanguage: item.pendingTranslationLanguage

--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -9,6 +9,11 @@ options:
   generateEmptyDirectories: true
 
 settings:
+  configs:
+    Debug:
+      # Required for `@testable import Silo` in SiloTests; Xcode's Debug
+      # template sets this but XcodeGen does not.
+      ENABLE_TESTABILITY: "YES"
   base:
     SWIFT_VERSION: "5"
     ENABLE_USER_SCRIPT_SANDBOXING: false
@@ -287,6 +292,11 @@ targets:
       base:
         PRODUCT_NAME: SiloTests
         GENERATE_INFOPLIST_FILE: "YES"
+        # Without an explicit SDKROOT the generated test config resolves
+        # BUILT_PRODUCTS_DIR without a platform suffix, so TEST_HOST points
+        # at .../Debug/Silo.app and xcodebuild can't find the test host.
+        SDKROOT: iphoneos
+        SUPPORTED_PLATFORMS: "iphoneos iphonesimulator"
         BUNDLE_LOADER: "$(TEST_HOST)"
         TEST_HOST: "$(BUILT_PRODUCTS_DIR)/Silo.app/Silo"
         SWIFT_OBJC_BRIDGING_HEADER: iosApp/Screens/Player/CoreMedia/SiloPlayerBridging.h


### PR DESCRIPTION
Closes #53.

Holistic subtitle appearance redesign for the Apple clients plus a batch of playback-toggle and preference-restore fixes surfaced during on-device testing.

## Appearance
- Size the CoreMedia subtitle overlay to the displayed video rect (iOS/tvOS + macOS) so cues stay inside the frame in portrait / pillarboxed content; expose the video presentation size from `PlayerCore` and add a `VideoDisplayRect` aspect-fit helper.
- Default background style to a filled **box** (Plex parity) instead of drop shadow.
- Rebase the font-size preset ladder ~1.4× so `large` matches the old `xxlarge`, consistent across platforms.
- Honor box opacity via libass `BorderStyle 4`; pack override-style colors in libass internal `RRGGBBAA` order (fixes the default box rendering as opaque dark red).

## Mid-playback toggle
- Route runtime embedded-subtitle selections through the seeked `AVPlayerEmbeddedSubtitleExtractor` so enabling a track mid-playback is near-instant instead of waiting for the buffered region to drain.
- Anchor resume-time enable to `pendingSkipBelowPTS` so a selection applied before the playback clock is primed feeds from the right position (fixes "no subtitles until I scrub").
- Clear the overlay layer on disable so a displayed cue doesn't linger indefinitely.

## Preference restore
- Carry the watch detail's effective subtitle mode + track signature on `ItemDetail`, re-match against the displayed version's tracks (same scoring as the player's `SubtitleAutoResolver`), and seed the detail-screen selector + playback launch index after each load, on next-up episodes, and on the post-player refresh. The remembered subtitle track now shows on re-entry instead of reverting to "Auto".

## Testing
- iOS (`Silo`) and tvOS (`SiloTV`) build clean; `SiloTests` full suite green (339 tests) at the time of the toggle work.
- macOS changes syntax-checked only — the pre-existing `SiloMac` Nuke swiftmodule build breakage is unrelated and deferred.

## Related
- Server extraction-latency counterpart: silo-server#296
- Server track-pref gaps (exact subtitle index, movie audio at start, movie version prefs): silo-server#297
- Android learnings: silo-android#31, silo-android#32


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subtitle preferences are now remembered and restored on detail screens and “Next Up” playback, improving consistency after dismiss/reload and across seasons/series.
  * Subtitle overlays align more precisely to the actual displayed video area, using tracked video presentation size and computed video insets.

* **Bug Fixes**
  * Improved subtitle rendering and styling (background boxes, shadows, border styles) and corrected color/alpha handling.
  * Prevented stale subtitle cues when disabling tracks; enhanced embedded subtitle switching behavior.

* **Tests**
  * Added coverage for subtitle styling headers, video display rect calculations, and expected font-size behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->