### PR TITLE
fix(subtitles): shift tvOS size ladder down one notch

### DIFF
--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleAppearance.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleAppearance.swift
@@ -37,14 +37,16 @@ enum SubtitleFontSizePreset: String, Codable, CaseIterable, Identifiable {
         case .xxlarge: return 77
         }
         #elseif os(tvOS)
-        // Ladder rebased ~1.3x from the original tvOS values (large = old
-        // ~xlarge+) after the defaults read small on a living-room screen.
+        // Ladder shifted down one notch from the prior tvOS values (large =
+        // old medium) after the defaults read one size too big in the living
+        // room. Each preset now takes the prior rung's value; small is a new
+        // ~1.2x step below medium.
         switch self {
-        case .small: return 51
-        case .medium: return 63
-        case .large: return 74
-        case .xlarge: return 88
-        case .xxlarge: return 103
+        case .small: return 43
+        case .medium: return 51
+        case .large: return 63
+        case .xlarge: return 74
+        case .xxlarge: return 88
         }
         #else
         switch self {


### PR DESCRIPTION
## Summary
tvOS default subtitles read one size too big in the living room. This shifts the tvOS size ladder down one notch so `.large` (the default) takes the old medium value, with every other preset moving down correspondingly.

| Preset | Old | New |
|--------|-----|-----|
| small | 51 | 43 (new step) |
| medium | 63 | 51 |
| **large** (default) | 74 | **63** ← old medium |
| xlarge | 88 | 74 |
| xxlarge | 103 | 88 |

Only the tvOS block in `SubtitleAppearance.swift` changed; iOS and macOS ladders are untouched.

## Test plan
- [ ] Verify tvOS subtitle default (Large) renders at the intended size in the player
- [ ] Confirm each size preset steps sensibly on a living-room screen

## Note
The aspect-ratio scale fix that was briefly bundled here is now split into #56. This branch still carries that commit until it's rebased out — see #56.