### PR TITLE
fix(subtitles): keep tvOS styled text size constant across content aspect ratios

### DIFF
--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleRenderer.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleRenderer.swift
@@ -121,6 +121,12 @@ final class SubtitleRenderer {
     // but native-ASS tracks need a different treatment).
     private var currentParams: SubtitleStylingOverride.Parameters = .default
 
+    /// libass keys font scaling to the video area (frame minus letterbox
+    /// margins), which makes Silo-styled text shrink on wide-aspect content.
+    /// This multiplier re-keys the scale to the full frame height so text
+    /// size stays constant on screen. 1.0 whenever margins are zero.
+    private var fontScaleCompensation: Double = 1.0
+
     // Output canvas. Allocated lazily at the requested pixel size and
     // reused across frames. A single mutable buffer feeds a single
     // `CGContext`; the `CGImage` handed to the overlay is a copy so
@@ -243,7 +249,8 @@ final class SubtitleRenderer {
                 renderer: self.renderer(for: slot),
                 params: self.currentParams,
                 isNativeASS: isNativeASS,
-                slot: slot
+                slot: slot,
+                fontScaleCompensation: self.fontScaleCompensation
             )
         }
     }
@@ -293,7 +300,8 @@ final class SubtitleRenderer {
                 renderer: self.renderer(for: slot),
                 params: self.currentParams,
                 isNativeASS: isNativeASS,
-                slot: slot
+                slot: slot,
+                fontScaleCompensation: self.fontScaleCompensation
             )
         }
     }
@@ -426,24 +434,33 @@ final class SubtitleRenderer {
         sessionQueue.async { [weak self] in
             guard let self else { return }
             self.currentParams = params
-            self.handleLock.lock()
-            let primaryHandle = self.primary
-            let secondaryHandle = self.secondary
-            self.handleLock.unlock()
-            SubtitleStylingOverride.apply(
-                renderer: self.primaryRenderer,
-                params: params,
-                isNativeASS: primaryHandle?.isNativeASS ?? false,
-                slot: .primary
-            )
-            SubtitleStylingOverride.apply(
-                renderer: self.secondaryRenderer,
-                params: params,
-                isNativeASS: secondaryHandle?.isNativeASS ?? false,
-                slot: .secondary
-            )
+            self.reapplyStylingOnSessionQueue()
             self.frameSizeDirty = true  // force repaint on next tick
         }
+    }
+
+    /// Re-apply the current styling params (with the current font-scale
+    /// compensation) to both slot renderers. Callable only from
+    /// `sessionQueue`.
+    private func reapplyStylingOnSessionQueue() {
+        handleLock.lock()
+        let primaryHandle = primary
+        let secondaryHandle = secondary
+        handleLock.unlock()
+        SubtitleStylingOverride.apply(
+            renderer: primaryRenderer,
+            params: currentParams,
+            isNativeASS: primaryHandle?.isNativeASS ?? false,
+            slot: .primary,
+            fontScaleCompensation: fontScaleCompensation
+        )
+        SubtitleStylingOverride.apply(
+            renderer: secondaryRenderer,
+            params: currentParams,
+            isNativeASS: secondaryHandle?.isNativeASS ?? false,
+            slot: .secondary,
+            fontScaleCompensation: fontScaleCompensation
+        )
     }
 
     // MARK: - Render + composite
@@ -555,6 +572,19 @@ final class SubtitleRenderer {
         frameSizeDirty = true
         // Canvas will be reallocated on the next dirty render.
         canvas = nil
+
+        // libass keys font scale to the video area (frame height minus
+        // vertical margins), so letterboxed content would render smaller
+        // text than full-frame content. Compensate so Silo-styled text is
+        // keyed to the full frame height instead; a no-op (1.0) when
+        // margins are zero. Reapply overrides only when the factor moves so
+        // steady-state layout passes stay cheap.
+        let videoAreaHeight = h - margins.top - margins.bottom
+        let compensation = videoAreaHeight > 0 ? Double(h) / Double(videoAreaHeight) : 1.0
+        if abs(compensation - fontScaleCompensation) > 0.001 {
+            fontScaleCompensation = compensation
+            reapplyStylingOnSessionQueue()
+        }
     }
 
     private func configureRenderer(_ renderer: OpaquePointer) {

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleStylingOverride.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleStylingOverride.swift
@@ -230,11 +230,18 @@ enum SubtitleStylingOverride {
     ///   pump, outside libass style overrides.
     /// - Parameter slot: which subtitle slot this renderer draws. Only the
     ///   primary slot participates in `use_margins` placement below.
+    /// - Parameter fontScaleCompensation: multiplier that re-keys libass's
+    ///   font scaling from the video area (frame minus letterbox margins)
+    ///   back to the full frame, so Silo-styled text renders at the same
+    ///   physical size regardless of the content's aspect ratio. 1.0 when
+    ///   the overlay is video-rect sized (no margins). Native ASS is never
+    ///   compensated — authored typesetting must keep tracking the picture.
     static func apply(
         renderer: OpaquePointer?,
         params: Parameters,
         isNativeASS: Bool,
-        slot: SubtitleSlot
+        slot: SubtitleSlot,
+        fontScaleCompensation: Double = 1.0
     ) {
         guard let renderer else { return }
 
@@ -261,7 +268,10 @@ enum SubtitleStylingOverride {
         // source. Use renderer font scale for live size changes, but do not
         // use FONT_SIZE_FIELDS below: that path also overrides ScaleX/Y and
         // scales FontSize against each source track's PlayRes.
-        let scale = params.fontSize / Parameters.referenceFontSize
+        let compensation = fontScaleCompensation.isFinite && fontScaleCompensation > 0
+            ? fontScaleCompensation
+            : 1.0
+        let scale = (params.fontSize / Parameters.referenceFontSize) * compensation
         ass_set_font_scale(renderer, scale.isFinite && scale > 0 ? scale : 1.0)
 
         // Swift's `ASS_Style()` already zero-initialises the struct.


### PR DESCRIPTION
## Summary
libass keys font scaling to the video area (frame minus letterbox margins). On tvOS the subtitle overlay is full-frame with margins marking the picture, so letterboxed (wide-aspect) content rendered ~25% smaller subtitles than full-frame content. This read as "1080p vs 4K HDR" size differences in practice, since mastering (black bars cropped vs baked into the frame) correlates with those libraries.

`SubtitleRenderer` now compensates the renderer font scale by `frameHeight / videoAreaHeight`, re-keying Silo-styled text to the full frame height regardless of the content's aspect ratio. Details:

- Compensation is computed whenever frame geometry changes and applied only when the factor actually moves, so steady-state layout passes stay cheap.
- Native ASS tracks stay **uncompensated** — authored typesetting must keep tracking the picture.
- The factor is `1.0` whenever margins are zero, so iOS/macOS (video-rect-sized overlays) are unaffected.

## Test plan
- [ ] tvOS: a letterboxed (2.39:1) file and a 16:9 file show the same subtitle size
- [ ] tvOS: native ASS content still renders at authored size relative to the picture
- [ ] iOS/macOS: no size change

## Notes
Split out from #55 (tvOS size-ladder rebase) so the two changes land independently. Best reviewed/merged alongside it.