### PR TITLE
test: host the shared unit suite on tvOS (SiloTVTests)

### DIFF
--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -119,6 +119,9 @@ targets:
     settings:
       base:
         PRODUCT_NAME: SiloTV
+        # Swift module name stays `Silo` so the shared unit tests
+        # (`@testable import Silo`) can host on either the iOS or tvOS app.
+        PRODUCT_MODULE_NAME: Silo
         INFOPLIST_FILE: iosApp/tvOS-Info.plist
         MARKETING_VERSION: "0.1.0"
         CURRENT_PROJECT_VERSION: 1
@@ -301,6 +304,38 @@ targets:
         TEST_HOST: "$(BUILT_PRODUCTS_DIR)/Silo.app/Silo"
         SWIFT_OBJC_BRIDGING_HEADER: iosApp/Screens/Player/CoreMedia/SiloPlayerBridging.h
 
+  # tvOS twin of SiloTests: hosts the same Tests/ sources on SiloTV.app so
+  # the suite is executable on a tvOS simulator (this repo's primary
+  # platform; there is no CI test workflow and dev machines may lack the
+  # iOS platform). Requires SiloTV's PRODUCT_MODULE_NAME to stay `Silo`.
+  SiloTVTests:
+    type: bundle.unit-test
+    platform: tvOS
+    sources:
+      - path: Tests
+        excludes:
+          # iOS-only companion-pairing coordinator; tvOS builds the
+          # receiver side only.
+          - PairingCoordinatorTests.swift
+          # iOS-only remote-control clock (Control/iOS) and APNs
+          # registration wires (compiled out on tvOS).
+          - SiloControlTests.swift
+          - ApplePushRegistrationTests.swift
+    dependencies:
+      - target: SiloTV
+      # Same rationale as SiloTests: module maps only, symbols come from
+      # the test host via BUNDLE_LOADER.
+      - package: FFmpeg
+        product: FFmpeg
+        link: false
+    settings:
+      base:
+        PRODUCT_NAME: SiloTVTests
+        GENERATE_INFOPLIST_FILE: "YES"
+        BUNDLE_LOADER: "$(TEST_HOST)"
+        TEST_HOST: "$(BUILT_PRODUCTS_DIR)/SiloTV.app/SiloTV"
+        SWIFT_OBJC_BRIDGING_HEADER: iosApp/Screens/Player/CoreMedia/SiloPlayerBridging.h
+
 schemes:
   Silo:
     build:
@@ -338,10 +373,13 @@ schemes:
     build:
       targets:
         SiloTV: all
+        SiloTVTests: [test]
     run:
       config: Debug
     test:
       config: Debug
+      targets:
+        - SiloTVTests
     archive:
       config: Release
     analyze:


### PR DESCRIPTION
## Problem
The shared `Tests/` suite was only hosted on the iOS app (`SiloTests`), so it couldn't run on machines without the iOS platform installed — and tvOS is this repo's primary platform.

## Change
Adds a `SiloTVTests` unit-test bundle that hosts the same `Tests/` sources on `SiloTV.app`, wired into the `SiloTV` scheme's test action. `SiloTV`'s Swift module name is pinned to `Silo` (product name and bundle id unchanged) so the existing `@testable import Silo` files compile against either host. Three iOS-only test files are excluded on tvOS (companion pairing, remote-control clock, APNs registration wires — all compiled out of the tvOS app).

Complementary to the recent iOS `SiloTests` runnability fix on main; this adds the tvOS host, doesn't change the iOS one.

## Verification
312 tests, 0 failures on the Apple TV 4K (3rd gen) simulator (`xcodebuild test`, scheme `SiloTV`).

_Authored with Claude Code (assistant-generated, human-reviewed)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tvOS test coverage for the app, bringing it in line with iOS testing.
  * Updated the tvOS build setup so tests run against the tvOS app as expected, helping catch issues earlier and improve overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
