### PR TITLE
fix(player): complete playback on pipeline drain, not clock proximity

### DIFF
--- a/iosApp/Tests/PlaybackEndPolicyTests.swift
+++ b/iosApp/Tests/PlaybackEndPolicyTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import Silo
+
+final class PlaybackEndPolicyTests: XCTestCase {
+
+    private func inputs(
+        eof: Bool = true,
+        observed: Double = 100,
+        duration: Double = 100,
+        audioPackets: Int = 0,
+        videoPackets: Int = 0,
+        decodedFrames: Int = 0,
+        audioChunks: Int = 0
+    ) -> PlaybackEndPolicy.Inputs {
+        .init(
+            reachedInputEOF: eof,
+            observedSeconds: observed,
+            durationSeconds: duration,
+            audioPacketsQueued: audioPackets,
+            videoPacketsQueued: videoPackets,
+            decodedVideoFramesQueued: decodedFrames,
+            audioChunksQueued: audioChunks
+        )
+    }
+
+    func testNoInputEOFNeverCompletes() {
+        XCTAssertFalse(PlaybackEndPolicy.shouldComplete(inputs(eof: false, observed: 100, duration: 100)))
+    }
+
+    func testDrainedPipelineCompletes() {
+        XCTAssertTrue(PlaybackEndPolicy.shouldComplete(inputs(observed: 42, duration: 100)))
+    }
+
+    func testDrainedPipelineCompletesWithUnknownDuration() {
+        XCTAssertTrue(PlaybackEndPolicy.shouldComplete(inputs(observed: 42, duration: 0)))
+        XCTAssertTrue(PlaybackEndPolicy.shouldComplete(inputs(observed: 42, duration: .nan)))
+    }
+
+    func testQueuedTailBlocksCompletionNearTheEnd() {
+        // The truncation case the old clock-only rule got wrong: input EOF,
+        // clock within half a second of duration, but audio still queued.
+        XCTAssertFalse(PlaybackEndPolicy.shouldComplete(
+            inputs(observed: 99.6, duration: 100, audioChunks: 3)
+        ))
+        XCTAssertFalse(PlaybackEndPolicy.shouldComplete(
+            inputs(observed: 99.6, duration: 100, audioPackets: 2)
+        ))
+        XCTAssertFalse(PlaybackEndPolicy.shouldComplete(
+            inputs(observed: 99.6, duration: 100, decodedFrames: 1)
+        ))
+        XCTAssertFalse(PlaybackEndPolicy.shouldComplete(
+            inputs(observed: 99.6, duration: 100, videoPackets: 1)
+        ))
+    }
+
+    func testUnknownDurationWaitsForDrain() {
+        // The old rule completed immediately on unknown duration even with
+        // a full pipeline.
+        XCTAssertFalse(PlaybackEndPolicy.shouldComplete(
+            inputs(observed: 42, duration: 0, videoPackets: 100, audioChunks: 8)
+        ))
+    }
+
+    func testClockPastDurationCompletesDespiteWedgedDrain() {
+        XCTAssertTrue(PlaybackEndPolicy.shouldComplete(
+            inputs(observed: 100.0, duration: 100, decodedFrames: 1)
+        ))
+        XCTAssertTrue(PlaybackEndPolicy.shouldComplete(
+            inputs(observed: 103.2, duration: 100, audioChunks: 1)
+        ))
+    }
+
+    func testClockBeforeDurationWithQueuedDataDoesNotComplete() {
+        XCTAssertFalse(PlaybackEndPolicy.shouldComplete(
+            inputs(observed: 50, duration: 100, videoPackets: 500)
+        ))
+    }
+}

--- a/iosApp/iosApp/Screens/Player/CoreMedia/AudioOutput.swift
+++ b/iosApp/iosApp/Screens/Player/CoreMedia/AudioOutput.swift
@@ -155,6 +155,18 @@ final class AudioEngineAudioOutput {
         return Double(frames) / rate
     }
 
+    /// Chunks not yet fully rendered: the queued backlog plus the chunk the
+    /// render block is currently draining. 0 means the audio pipeline has
+    /// played out everything it was given (at most one render slice,
+    /// ~10 ms, may still be in flight in the hardware). Used by the
+    /// end-of-playback drain check.
+    var queuedChunkCount: Int {
+        stateLock.lock()
+        let count = queuedChunks.count + (currentChunk != nil ? 1 : 0)
+        stateLock.unlock()
+        return count
+    }
+
     var statusCode: Int {
         stateLock.lock()
         let failed = lastErrorDescription != nil

--- a/iosApp/iosApp/Screens/Player/CoreMedia/PlaybackEndPolicy.swift
+++ b/iosApp/iosApp/Screens/Player/CoreMedia/PlaybackEndPolicy.swift
@@ -1,0 +1,59 @@
+//
+//  PlaybackEndPolicy.swift
+//  Continuum (iOS + tvOS)
+//
+//  Pure decision for "playback has actually finished" after the demuxer
+//  reports end of input. The previous rule was clock-based only —
+//  complete when the clock came within 0.5 s of the container duration —
+//  which truncated the final half-second of audio while it was still
+//  queued, fired early on containers whose duration overstates nothing
+//  but whose tail is long, and completed immediately on unknown-duration
+//  sources even with a full pipeline still draining.
+//
+//  The primary signal is now the pipeline itself: input EOF plus every
+//  stage drained (packet queues, decoded-frame queue, audio chunks). The
+//  clock-past-duration check remains only as a fallback for a drain
+//  signal that wedges (e.g. a stuck tail frame), so completion can never
+//  regress behind the old behavior's worst case.
+//
+//  No I/O, no locking — testable in isolation. PlayerCore feeds it from
+//  the throttled time observer, the input-EOF notification, and the
+//  100 ms buffering monitor (the last render produces no further time
+//  callbacks, so a timer must drive the final check).
+//
+
+import Foundation
+
+enum PlaybackEndPolicy {
+
+    struct Inputs {
+        /// The demux loop delivered its EOF sentinel for this generation.
+        let reachedInputEOF: Bool
+        /// Current playback clock, seconds.
+        let observedSeconds: Double
+        /// Container-reported duration; `<= 0` or non-finite = unknown.
+        let durationSeconds: Double
+        let audioPacketsQueued: Int
+        let videoPacketsQueued: Int
+        let decodedVideoFramesQueued: Int
+        let audioChunksQueued: Int
+    }
+
+    static func shouldComplete(_ inputs: Inputs) -> Bool {
+        guard inputs.reachedInputEOF else { return false }
+
+        let drained = inputs.audioPacketsQueued == 0
+            && inputs.videoPacketsQueued == 0
+            && inputs.decodedVideoFramesQueued == 0
+            && inputs.audioChunksQueued == 0
+        if drained { return true }
+
+        // Fallback: the pipeline still holds data but the clock has played
+        // through the advertised duration — trust the clock over a drain
+        // signal that may be wedged on a stuck tail sample.
+        guard inputs.observedSeconds.isFinite,
+              inputs.durationSeconds.isFinite,
+              inputs.durationSeconds > 0 else { return false }
+        return inputs.observedSeconds >= inputs.durationSeconds
+    }
+}

--- a/iosApp/iosApp/Screens/Player/CoreMedia/PlayerCore.swift
+++ b/iosApp/iosApp/Screens/Player/CoreMedia/PlayerCore.swift
@@ -1202,7 +1202,7 @@ final class PlayerCore: NSObject {
                 self.lastOnTimeChange = now
                 self.lastReportedSeconds = reported
                 self.onTimeChange?(reported)
-                self.completePlaybackIfInputEOFAndClockReachedEnd(observedSeconds: reported)
+                self.completePlaybackIfFinished(observedSeconds: reported)
             }
         }
     }
@@ -1210,24 +1210,36 @@ final class PlayerCore: NSObject {
     private func noteInputEndOfFile(generation: UInt64) {
         guard !isDisposed else { return }
         guard endOfFileCoordinator.markInputEndOfFile(generation: generation) else { return }
-        completePlaybackIfInputEOFAndClockReachedEnd(
+        completePlaybackIfFinished(
             observedSeconds: currentPlaybackTimeSeconds()
         )
     }
 
-    private func completePlaybackIfInputEOFAndClockReachedEnd(observedSeconds: Double) {
+    /// Fires `onEndOfFile` once the pipeline has genuinely finished: input
+    /// EOF plus every stage drained, with clock-past-duration as the
+    /// fallback for a wedged drain signal (`PlaybackEndPolicy`). Driven by
+    /// the throttled time observer, the input-EOF notification, and the
+    /// 100 ms buffering monitor — the final audio render produces no
+    /// further time callbacks, so the timer must run the last check.
+    private func completePlaybackIfFinished(observedSeconds: Double) {
         guard !isDisposed else { return }
-        guard endOfFileCoordinator.hasReachedInputEndOfFile() else { return }
-        guard observedSeconds.isFinite else { return }
-        guard durationSeconds.isFinite, durationSeconds > 0 else {
-            if endOfFileCoordinator.claimEndOfFile() {
-                onEndOfFile?()
-            }
-            return
-        }
-
-        let remaining = durationSeconds - observedSeconds
-        guard remaining <= 0.5 else { return }
+        // A session with no active audio track (audioStreamIndex < 0) still
+        // gets an audio EOF sentinel enqueued by the demux loop, but
+        // startAudioFeed never consumes it — so the audio queue never reports
+        // empty. Treat an inactive audio queue as already drained, else the
+        // drain predicate stays false forever and, with unknown duration (no
+        // clock fallback), onEndOfFile never fires.
+        let hasAudio = audioStreamIndex >= 0
+        let inputs = PlaybackEndPolicy.Inputs(
+            reachedInputEOF: endOfFileCoordinator.hasReachedInputEndOfFile(),
+            observedSeconds: observedSeconds,
+            durationSeconds: durationSeconds,
+            audioPacketsQueued: hasAudio ? audioPacketQueue.count : 0,
+            videoPacketsQueued: videoPacketQueue.count,
+            decodedVideoFramesQueued: videoFrameScheduler.count,
+            audioChunksQueued: hasAudio ? audioOutput.queuedChunkCount : 0
+        )
+        guard PlaybackEndPolicy.shouldComplete(inputs) else { return }
         if endOfFileCoordinator.claimEndOfFile() {
             onEndOfFile?()
         }
@@ -3017,6 +3029,13 @@ final class PlayerCore: NSObject {
     /// toward the leave threshold via `onBufferingProgress`.
     private func sampleBufferingState() {
         guard !isDisposed else { return }
+
+        // Post-EOF drain check. The final audio render produces no further
+        // time callbacks, so without this tick the drain-based completion
+        // in `completePlaybackIfFinished` would never run its last check.
+        if endOfFileCoordinator.hasReachedInputEndOfFile() {
+            completePlaybackIfFinished(observedSeconds: currentPlaybackTimeSeconds())
+        }
 
         // Seek-stall watchdog. A worker iteration wedged inside FFmpeg I/O
         // (observed: TLS read that ignores both the interrupt callback and


### PR DESCRIPTION
## Problem
End-of-playback fired when the clock came within 0.5 s of the container duration (or immediately on unknown-duration sources) — truncating the final ~0.5 s of audio that was still queued, and firing early/late whenever the container duration was wrong.

## Change
`PlaybackEndPolicy` makes the pipeline itself the primary signal: input EOF **plus every stage drained** (packet queues, decoded-frame queue, and the audio output's chunk backlog via a new `queuedChunkCount`). Clock-past-duration remains only as a fallback for a wedged drain signal, so completion can never regress behind the old rule's worst case. The 100 ms buffering monitor now drives the post-EOF check, since the final audio render produces no further time callbacks.

## Verification
Builds clean on `SiloTV`; covered by `PlaybackEndPolicyTests` (drained-completes, queued-tail-blocks, unknown-duration-waits-for-drain, clock-past-duration fallback).

_Authored with Claude Code._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Playback now finishes only when end-of-input has been reached and playback queues have fully drained, improving end-of-playback handling.
  * Added support for detecting completion during the final drain phase, even if time updates stop arriving.

* **Bug Fixes**
  * Improved handling of stalled playback near the end of media.
  * Prevented completion from being blocked when there is no active audio track.
  * Added coverage for end-of-playback edge cases, including unknown duration and queued audio/video data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->