### PR TITLE
feat(diagnostics): surface libav logs in the unified log

### DIFF
--- a/iosApp/iosApp/Screens/Player/CoreMedia/FFmpegLogFilter.h
+++ b/iosApp/iosApp/Screens/Player/CoreMedia/FFmpegLogFilter.h
@@ -3,13 +3,16 @@
 //  Continuum
 //
 //  Installs an `av_log_set_callback` that drops a small allowlist of known-
-//  cosmetic warnings before they reach stderr. The default FFmpeg callback
-//  emits warnings for every probe-time codec parameter we *deliberately*
+//  cosmetic warnings, collapses consecutive duplicate lines, and forwards
+//  the rest to two sinks: stderr (tvOS `devicectl --console`, Xcode) and,
+//  for warnings and errors, the unified log (subsystem = bundle id,
+//  category "ffmpeg") so libav* diagnostics survive into Console.app and
+//  sysdiagnose on shipped builds. The default FFmpeg callback emits
+//  warnings for every probe-time codec parameter we *deliberately*
 //  skipped (subtitle streams marked AVDISCARD_ALL pre-`find_stream_info`)
 //  and for every TrueHD bitstream gripe during pre-prime, both of which
 //  recover automatically. Suppressing them keeps the player log readable
-//  without losing genuine errors — anything not in the allowlist still
-//  reaches the original sink.
+//  without losing genuine errors.
 //
 
 #ifndef FFmpegLogFilter_h

--- a/iosApp/iosApp/Screens/Player/CoreMedia/FFmpegLogFilter.m
+++ b/iosApp/iosApp/Screens/Player/CoreMedia/FFmpegLogFilter.m
@@ -25,31 +25,66 @@
 //      bitstream parser realigns. They are cosmetic — playback recovers
 //      with the next decoded frame.
 //
-//  Anything else is forwarded to stderr unchanged so genuine errors
-//  remain visible.
+//  Everything that survives the allowlist goes to two sinks:
+//
+//    - stderr, unchanged — tvOS `devicectl --console` and Xcode capture it.
+//    - the unified log (subsystem = bundle id, category "ffmpeg") for
+//      warnings and errors, so libav* diagnostics survive into Console.app
+//      and sysdiagnose on shipped builds, where stderr is not collected.
+//
+//  Consecutive duplicate lines are collapsed into a single "repeated N
+//  times" notice. FFmpeg's own AV_LOG_SKIP_REPEATED flag is a documented
+//  no-op once a custom callback is installed, and a decode-error storm
+//  otherwise floods both sinks. The `print_prefix` state persists across
+//  calls (libav* emits multi-part lines without a trailing newline), which
+//  is also why the whole callback serialises on one lock — `av_log` fires
+//  from every FFmpeg thread.
 //
 
 #import "FFmpegLogFilter.h"
 
+#import <Foundation/Foundation.h>
+#import <os/lock.h>
+#import <os/log.h>
 #import <stdarg.h>
 #import <stdio.h>
 #import <string.h>
 
 #import <Libavutil/log.h>
 
+static os_unfair_lock continuum_log_lock = OS_UNFAIR_LOCK_INIT;
+static os_log_t continuum_ffmpeg_log;
+static int continuum_print_prefix = 1;
+static char continuum_last_line[2048];
+static unsigned continuum_repeat_count = 0;
+
+/// Forward one formatted line to both sinks. Caller holds the lock.
+static void continuum_emit(const char *line, int level) {
+    if (continuum_ffmpeg_log != NULL && level <= AV_LOG_WARNING) {
+        os_log_type_t type = (level <= AV_LOG_ERROR)
+            ? OS_LOG_TYPE_ERROR
+            : OS_LOG_TYPE_DEFAULT;
+        os_log_with_type(continuum_ffmpeg_log, type, "%{public}s", line);
+    }
+    fputs(line, stderr);
+}
+
 static void continuum_av_log_callback(void *avcl, int level, const char *fmt, va_list vl) {
     if (level > av_log_get_level()) {
         return;
     }
 
+    os_unfair_lock_lock(&continuum_log_lock);
+
     char line[2048];
-    int print_prefix = 1;
-    int written = av_log_format_line2(avcl, level, fmt, vl, line, sizeof(line), &print_prefix);
+    int written = av_log_format_line2(avcl, level, fmt, vl, line, sizeof(line), &continuum_print_prefix);
     if (written <= 0) {
+        os_unfair_lock_unlock(&continuum_log_lock);
         return;
     }
 
     if (strstr(line, "Could not find codec parameters") != NULL) {
+        os_unfair_lock_unlock(&continuum_log_lock);
         return;
     }
 
@@ -60,13 +95,34 @@ static void continuum_av_log_callback(void *avcl, int level, const char *fmt, va
             strstr(line, "Invalid blocksize") != NULL ||
             strstr(line, "Lossless check failed") != NULL ||
             strstr(line, "No samples to output") != NULL) {
+            os_unfair_lock_unlock(&continuum_log_lock);
             return;
         }
     }
 
-    fputs(line, stderr);
+    if (strcmp(line, continuum_last_line) == 0) {
+        continuum_repeat_count += 1;
+        os_unfair_lock_unlock(&continuum_log_lock);
+        return;
+    }
+    if (continuum_repeat_count > 0) {
+        char notice[64];
+        snprintf(notice, sizeof(notice),
+                 "    Last message repeated %u times\n", continuum_repeat_count);
+        continuum_emit(notice, level);
+        continuum_repeat_count = 0;
+    }
+    strlcpy(continuum_last_line, line, sizeof(continuum_last_line));
+    continuum_emit(line, level);
+
+    os_unfair_lock_unlock(&continuum_log_lock);
 }
 
 void ContinuumInstallFFmpegLogFilter(void) {
+    const char *subsystem = NSBundle.mainBundle.bundleIdentifier.UTF8String;
+    continuum_ffmpeg_log = os_log_create(
+        subsystem != NULL ? subsystem : "org.siloserver.silo",
+        "ffmpeg"
+    );
     av_log_set_callback(continuum_av_log_callback);
 }


### PR DESCRIPTION
## Problem
Surviving FFmpeg log lines only went to stderr, which isn't collected on shipped builds — every libav* warning and error was invisible in Console.app and sysdiagnose, exactly where playback bugs get triaged.

## Change
The `av_log` filter now mirrors warnings and errors into `os_log` (subsystem = bundle id, category `ffmpeg`) alongside the unchanged stderr sink. Two robustness fixes ride along: consecutive duplicate lines collapse into a "repeated N times" notice (`AV_LOG_SKIP_REPEATED` is a documented no-op once a custom callback is installed), and the `av_log_format_line2` `print_prefix` state now persists across calls under a lock (libav emits multi-part lines without trailing newlines from many threads).

## Verification
Builds clean on `SiloTV` (ObjC callback change; compile-verified).

_Authored with Claude Code._
