### PR TITLE
fix(ui): Dolby Vision label, Atmos in audio format, sharp 4K images

### DIFF
--- a/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
+++ b/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
@@ -23,9 +23,20 @@ enum DetailPlaybackFormatting {
         guard let version else { return "Auto" }
         let tokens = [
             nonEmpty(version.resolution)?.uppercased(),
-            version.hdr == true ? "HDR" : nil,
+            videoRangeLabel(version),
         ].compactMap { $0 }
         return tokens.isEmpty ? "Auto" : tokens.joined(separator: " · ")
+    }
+
+    /// "Dolby Vision" when any video track carries a DV configuration,
+    /// else "HDR" for plain HDR content, else nil. Matches the hero views'
+    /// chip logic so the version selector and the hero never disagree.
+    static func videoRangeLabel(_ version: FileVersion) -> String? {
+        let videoTracks = version.videoTracks ?? []
+        if videoTracks.contains(where: { ($0.dolbyVision ?? "").isEmpty == false }) {
+            return "Dolby Vision"
+        }
+        return version.hdr == true ? "HDR" : nil
     }
 
     static func versionDetailLabel(_ version: FileVersion) -> String {
@@ -41,7 +52,7 @@ enum DetailPlaybackFormatting {
         let tokens = [
             nonEmpty(version.resolution),
             nonEmpty(normalizedVideoCodec(version.codecVideo)),
-            version.hdr == true ? "HDR" : nil,
+            videoRangeLabel(version),
             nonEmpty(normalizedAudioCodec(version.codecAudio)),
         ].compactMap { $0 }
         if !tokens.isEmpty {
@@ -400,22 +411,42 @@ enum DetailPlaybackFormatting {
         return formatter.string(fromByteCount: bytes)
     }
 
-    private static func compactAudioLayout(_ track: AudioTrack) -> String? {
-        if let layout = nonEmpty(track.channelLayout) {
-            let lowered = layout.lowercased()
-            if lowered.contains("atmos") { return "Atmos" }
-            if lowered.contains("7.1") { return "7.1" }
-            if lowered.contains("5.1") { return "5.1" }
-            if lowered.contains("stereo") { return "Stereo" }
-            return layout
+    static func compactAudioLayout(_ track: AudioTrack) -> String? {
+        let bed: String? = {
+            if let layout = nonEmpty(track.channelLayout) {
+                let lowered = layout.lowercased()
+                if lowered.contains("7.1") { return "7.1" }
+                if lowered.contains("5.1") { return "5.1" }
+                if lowered.contains("stereo") { return "Stereo" }
+                // Unrecognized layout notation falls through to the
+                // channel-count mapping instead of echoing the server
+                // string verbatim.
+            }
+            switch track.channels {
+            case 1: return "Mono"
+            case 2: return "Stereo"
+            case 6: return "5.1"
+            case 7: return "6.1"
+            case 8: return "7.1"
+            case let channels?: return "\(channels)ch"
+            case nil: return nonEmpty(track.channelLayout)
+            }
+        }()
+        if audioTrackIsAtmos(track) {
+            return [bed, "Atmos"].compactMap { $0 }.joined(separator: " ")
         }
-        switch track.channels {
-        case 1: return "Mono"
-        case 2: return "Stereo"
-        case 6: return "5.1"
-        case 8: return "7.1"
-        case let channels?: return "\(channels)ch"
-        case nil: return nil
+        return bed
+    }
+
+    /// The server model carries no codec-profile field, so Atmos detection
+    /// mirrors the route planner's heuristic: layout or stream title
+    /// mentioning Atmos/JOC. The durable fix is server-side — ffprobe
+    /// reports the EAC3 JOC profile as "Dolby Digital Plus + Dolby Atmos"
+    /// — after which this becomes a real field check.
+    static func audioTrackIsAtmos(_ track: AudioTrack) -> Bool {
+        [track.channelLayout, track.title, track.embeddedTitle].contains { value in
+            guard let lowered = value?.lowercased() else { return false }
+            return lowered.contains("atmos") || lowered.contains("joc")
         }
     }
 

--- a/iosApp/iosApp/tvOS/Caching/CachedAsyncImage.swift
+++ b/iosApp/iosApp/tvOS/Caching/CachedAsyncImage.swift
@@ -54,9 +54,19 @@ struct CachedAsyncImage: View {
         guard let url = URL(string: url) else { return nil }
         // Scale by the native display scale so we ask the decoder for the
         // exact pixel dimensions we render at.
+        // tvOS reports displayScale 1.0 (logical 1920×1080 canvas) while an
+        // Apple TV 4K composites the UI at 3840×2160 — decoding at point
+        // size hands the panel a 2× upscale, visibly soft on photographic
+        // content (episode stills especially). Decode at 4K pixel density;
+        // `upscale: false` below keeps smaller sources unpadded.
+        #if os(tvOS)
+        let renderScale: CGFloat = 2.0
+        #else
+        let renderScale = displayScale
+        #endif
         let pixelSize = CGSize(
-            width: size.width * displayScale,
-            height: size.height * displayScale
+            width: size.width * renderScale,
+            height: size.height * renderScale
         )
         return ImageRequest(
             url: url,


### PR DESCRIPTION
## Problem
Three detail-page presentation issues on 4K TV clients:
1. Version labels read "2160p HDR" for Dolby Vision media — the selector/primary text keyed only on the `hdr` flag while the hero views already checked `videoTracks[].dolbyVision`.
2. Audio format rows never surfaced Atmos ("EAC3 5.1" for DDP-Atmos tracks).
3. All tvOS images decoded at point size — `displayScale` is 1.0 on the logical 1920×1080 canvas while an Apple TV 4K composites at 3840×2160, so every poster and episode still shipped 2×-upscaled and soft.

## Change
1. Shared `videoRangeLabel()` returns "Dolby Vision" / "HDR" consistently across the selector, primary text, and hero.
2. Audio format renders "EAC3 5.1 Atmos" — detection mirrors the route planner's heuristic (layout/stream-title contains Atmos/JOC), since the server model carries no codec-profile field yet. Unrecognized raw layout notation now falls through to the channel-count mapping instead of echoing the server string.
3. `CachedAsyncImage` decodes at 4K pixel density on tvOS (`upscale` stays disabled for small sources).

## Notes
The Atmos badge is a title/layout heuristic today; a server-side EAC3-JOC profile field (ffprobe reports it) would make it a real field check — tracked separately.

## Verification
Builds clean on `SiloTV`; verified on-device (Apple TV 4K → AVR/panel): DV label correct, Atmos badge shown, episode stills visibly sharper.

_Authored with Claude Code._
