### PR TITLE
fix(tvos): snap probed frame rates to standard HDMI refresh rates

### DIFF
--- a/iosApp/Tests/DisplayRefreshRateSnapTests.swift
+++ b/iosApp/Tests/DisplayRefreshRateSnapTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import Silo
+
+final class DisplayRefreshRateSnapTests: XCTestCase {
+
+    func testExactStandardRatesSnapToThemselves() {
+        for rate in [25.0, 29.97, 30.0, 48.0, 50.0, 59.94, 60.0] {
+            XCTAssertEqual(DisplayRefreshRateSnap.snap(rate), rate)
+        }
+    }
+
+    func testFilmCadenceWindowPrefers23976() {
+        // Exact 24.0 included: panels accepting 24 universally accept
+        // 23.976, and "24" probes are nearly always 24000/1001.
+        XCTAssertEqual(DisplayRefreshRateSnap.snap(23.976), 23.976)
+        XCTAssertEqual(DisplayRefreshRateSnap.snap(24.0), 23.976)
+        XCTAssertEqual(DisplayRefreshRateSnap.snap(23.98), 23.976)
+        XCTAssertEqual(DisplayRefreshRateSnap.snap(23.5), 23.976)
+        XCTAssertEqual(DisplayRefreshRateSnap.snap(24.05), 23.976)
+    }
+
+    func testNearMissesSnapWithinTolerance() {
+        XCTAssertEqual(DisplayRefreshRateSnap.snap(24.42), 24.0)
+        XCTAssertEqual(DisplayRefreshRateSnap.snap(29.5), 29.97)
+        XCTAssertEqual(DisplayRefreshRateSnap.snap(59.5), 59.94)
+        XCTAssertEqual(DisplayRefreshRateSnap.snap(50.3), 50.0)
+    }
+
+    func testOffGridRatesReturnNil() {
+        XCTAssertNil(DisplayRefreshRateSnap.snap(15.0))
+        XCTAssertNil(DisplayRefreshRateSnap.snap(22.9))
+        XCTAssertNil(DisplayRefreshRateSnap.snap(40.0))
+        XCTAssertNil(DisplayRefreshRateSnap.snap(120.0))
+    }
+
+    func testDegenerateInputsReturnNil() {
+        XCTAssertNil(DisplayRefreshRateSnap.snap(0))
+        XCTAssertNil(DisplayRefreshRateSnap.snap(-24))
+        XCTAssertNil(DisplayRefreshRateSnap.snap(.nan))
+        XCTAssertNil(DisplayRefreshRateSnap.snap(.infinity))
+    }
+
+    func testSnapOrFilmDefaultFallsBackTo23976() {
+        XCTAssertEqual(DisplayRefreshRateSnap.snapOrFilmDefault(0), 23.976, accuracy: 0.001)
+        XCTAssertEqual(DisplayRefreshRateSnap.snapOrFilmDefault(40.0), 23.976, accuracy: 0.001)
+        XCTAssertEqual(DisplayRefreshRateSnap.snapOrFilmDefault(59.94), 59.94, accuracy: 0.001)
+    }
+}

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
@@ -2385,7 +2385,9 @@ final class AVPlayerBackend {
                 return
             }
 
-            let refreshRate = spec.sourceVideoFrameRate ?? 24.0
+            let refreshRate = DisplayRefreshRateSnap.snapOrFilmDefault(
+                spec.sourceVideoFrameRate ?? 23.976
+            )
             let criteria = AVDisplayCriteria(
                 refreshRate: refreshRate,
                 videoDynamicRange: SpikeDynamicRange.dolbyVision.rawValue

--- a/iosApp/iosApp/Screens/Player/CoreMedia/PlayerCore.swift
+++ b/iosApp/iosApp/Screens/Player/CoreMedia/PlayerCore.swift
@@ -1859,7 +1859,7 @@ final class PlayerCore: NSObject {
         // the next `load()` will pick up the stashed preference.
         guard formatCtx != nil else { return }
         #if os(tvOS)
-        let rate = refreshRate
+        let rate = DisplayRefreshRateSnap.snapOrFilmDefault(refreshRate)
         let range = enabled ? dynamicRange : .sdr
         DispatchQueue.main.async {
             TVDisplayCriteria.apply(refreshRate: rate, dynamicRange: range)
@@ -3321,7 +3321,7 @@ final class PlayerCore: NSObject {
         // tvOS negotiates HDMI mode via AVDisplayManager; iOS toggles EDR on
         // the display layer via a sig-peak event.
         #if os(tvOS)
-        let fps = refreshRate
+        let fps = DisplayRefreshRateSnap.snapOrFilmDefault(refreshRate)
         let range = hdrEnabled ? dynamicRange : .sdr
         let needsDvGate = requiresDolbyVisionDisplay && hdrEnabled
         DispatchQueue.main.async { [weak self] in

--- a/iosApp/iosApp/Screens/Player/DisplayRefreshRateSnap.swift
+++ b/iosApp/iosApp/Screens/Player/DisplayRefreshRateSnap.swift
@@ -1,0 +1,54 @@
+//
+//  DisplayRefreshRateSnap.swift
+//  Continuum (iOS + tvOS)
+//
+//  Quantizes a probed stream frame rate to the standard HDMI refresh
+//  rates before it reaches `AVDisplayCriteria`. Container-probed rates
+//  are frequently off-grid (a Matroska `avg_frame_rate` of 23.98, a VFR
+//  average of 24.42), and an off-grid criteria rate can miss the
+//  panel's mode table entirely instead of engaging the intended mode.
+//
+//  Pure and platform-independent so the table and the film-cadence rule
+//  are unit-testable; both TVDisplayCriteria (PlayerCore route) and
+//  AVPlayerBackend (loopback route) call through here.
+//
+
+import Foundation
+
+enum DisplayRefreshRateSnap {
+
+    /// The HDMI refresh rates tvOS display-criteria matching can target.
+    static let standardRates: [Double] = [
+        23.976, 24.0, 25.0, 29.97, 30.0, 48.0, 50.0, 59.94, 60.0,
+    ]
+
+    /// Half-window around a standard rate that still counts as a match.
+    static let tolerance = 0.5
+
+    /// Nearest standard rate within ±`tolerance`, or nil when the source
+    /// rate is too far off-grid to make a confident mode claim.
+    ///
+    /// The 23.5...24.05 window always snaps to 23.976, including an exact
+    /// 24.0: panels that accept 24 universally accept 23.976 (not vice
+    /// versa), and content probed as "24" is nearly always 24000/1001.
+    /// True-24 material on a 23.976 mode repeats one frame about every
+    /// 41 s, which beats requesting a mode the panel may not have.
+    static func snap(_ fps: Double) -> Double? {
+        guard fps.isFinite, fps > 0 else { return nil }
+        if fps >= 23.5, fps <= 24.05 {
+            return 23.976
+        }
+        guard let nearest = standardRates.min(by: {
+            abs($0 - fps) < abs($1 - fps)
+        }) else { return nil }
+        return abs(nearest - fps) <= tolerance ? nearest : nil
+    }
+
+    /// Convenience for the `AVDisplayCriteria` call sites, which must
+    /// always pass some rate (the criteria also carries the dynamic-range
+    /// claim, so "leave the panel alone" is not an option there). Unknown
+    /// or off-grid rates fall back to 23.976, the dominant film cadence.
+    static func snapOrFilmDefault(_ fps: Float) -> Float {
+        Float(snap(Double(fps)) ?? 23.976)
+    }
+}


### PR DESCRIPTION
## Problem
Both display-criteria call sites passed the raw probed stream rate to `AVDisplayCriteria` — `PlayerCore` forwards `avg_frame_rate` as-is and the loopback backend used `sourceVideoFrameRate ?? 24.0`. Container-probed rates are frequently off-grid (a Matroska 23.98, a VFR average of 24.42), and an off-grid criteria rate can miss the panel's mode table instead of engaging the intended mode.

## Change
`DisplayRefreshRateSnap` quantizes to the standard HDMI table (23.976, 24, 25, 29.97, 30, 48, 50, 59.94, 60) within ±0.5 fps. The 23.5–24.05 window always prefers 23.976 — panels accepting 24 universally accept 23.976 (not vice-versa), and "24" probes are nearly always 24000/1001. Unknown/off-grid rates fall back to 23.976 at the criteria call sites (which must always pass some rate, since the criteria also carries the dynamic-range claim).

## Verification
Builds clean on `SiloTV`; covered by `DisplayRefreshRateSnapTests` (6 tests).

> Note: lightly touches the `AVPlayerBackend` criteria call site, which overlaps #52's loopback rework — expect a trivial rebase if #52 lands first.

_Authored with Claude Code._
