### PR TITLE
feat(player): Dolby Atmos passthrough on the DV loopback route

### DIFF
--- a/iosApp/Tests/ISOBoxSurgeryDec3Tests.swift
+++ b/iosApp/Tests/ISOBoxSurgeryDec3Tests.swift
@@ -1,0 +1,171 @@
+import XCTest
+@testable import Silo
+
+/// Pins the dec3 JOC-extension surgery that makes DDP-Atmos signalling
+/// survive the FFmpeg 7.1 muxer (which writes num_dep_sub/chan_loc but not
+/// the ETSI TS 103 420 extension AVFoundation keys on for Atmos).
+final class ISOBoxSurgeryDec3Tests: XCTestCase {
+
+    // MARK: - Synthetic box-tree builder
+
+    private func box(_ type: String, _ payload: Data) -> Data {
+        var out = Data()
+        let size = UInt32(8 + payload.count)
+        out.append(contentsOf: [
+            UInt8((size >> 24) & 0xFF), UInt8((size >> 16) & 0xFF),
+            UInt8((size >> 8) & 0xFF), UInt8(size & 0xFF),
+        ])
+        out.append(type.data(using: .ascii)!)
+        out.append(payload)
+        return out
+    }
+
+    private func hdlr(_ handler: String) -> Data {
+        var payload = Data(count: 8)  // FullBox version/flags + pre_defined
+        payload.append(handler.data(using: .ascii)!)
+        payload.append(0)  // empty name
+        return box("hdlr", payload)
+    }
+
+    private func trak(handler: String, stblChildren: Data) -> Data {
+        let stbl = box("stbl", stblChildren)
+        let minf = box("minf", stbl)
+        let mdia = box("mdia", hdlr(handler) + minf)
+        return box("trak", mdia)
+    }
+
+    /// An `ec-3` AudioSampleEntry: 28 bytes of entry fields, then children.
+    private func ec3Entry(dec3Payload: Data) -> Data {
+        box("ec-3", Data(count: 28) + box("dec3", dec3Payload))
+    }
+
+    private func initSegment(dec3Payload: Data, videoTrakFirst: Bool = true) -> Data {
+        let stsdPayload = Data(count: 8) + ec3Entry(dec3Payload: dec3Payload)  // FullBox + entry_count
+        let audioTrak = trak(handler: "soun", stblChildren: box("stsd", stsdPayload))
+        let videoTrak = trak(handler: "vide", stblChildren: Data())
+        let moov = box("moov", videoTrakFirst ? videoTrak + audioTrak : audioTrak + videoTrak)
+        return box("ftyp", Data(count: 8)) + moov
+    }
+
+    // MARK: - Bit-exact vectors (hand-computed)
+
+    /// FFmpeg 7.1 output (its non-ETSI 5-reserved-bit layout): data_rate=768,
+    /// one independent substream (bsid 16, acmod 3/2, lfeon 1),
+    /// num_dep_sub=1, chan_loc=4. No JOC extension.
+    private let jocLessPayload = Data([0x18, 0x00, 0x20, 0x0F, 0x00, 0x81, 0x00])
+    /// jocLessPayload converted to the ETSI layout (3 reserved bits) with
+    /// the JOC extension (flag=1, complexity=16).
+    private let extendedPayload = Data([0x18, 0x00, 0x20, 0x0F, 0x02, 0x04, 0x01, 0x10])
+    /// The exact dec3 payload FFmpeg 7.1 wrote on-device for a real
+    /// streaming WEB-DL DDP-Atmos stream (num_dep_sub=0 — streaming Atmos
+    /// carries JOC in the independent frame's EMDF).
+    private let devicePayload = Data([0x18, 0x00, 0x20, 0x0F, 0x00, 0x00])
+    /// GROUND TRUTH: what FFmpeg 8.1 emits when remuxing the identical
+    /// device stream (`1800200f000110`). The conversion must match it
+    /// byte-for-byte.
+    private let deviceExtendedPayload = Data([0x18, 0x00, 0x20, 0x0F, 0x00, 0x01, 0x10])
+
+    // MARK: - Tests
+
+    func testAppendsExtensionBitExact() {
+        let input = initSegment(dec3Payload: jocLessPayload)
+        guard let output = ISOBoxSurgery.appendDec3JOCExtension(into: input, complexityIndex: 16) else {
+            return XCTFail("surgery must succeed on the JOC-less tree")
+        }
+        XCTAssertEqual(output.count, input.count + 1)
+
+        guard let moov = ISOBoxSurgery.findTopLevelBox(in: output, type: "moov"),
+              let audioTrak = ISOBoxSurgery.findAudioTrak(in: output, moov: moov),
+              let mdia = ISOBoxSurgery.findChildBox(in: output, parent: audioTrak, childType: "mdia"),
+              let minf = ISOBoxSurgery.findChildBox(in: output, parent: mdia, childType: "minf"),
+              let stbl = ISOBoxSurgery.findChildBox(in: output, parent: minf, childType: "stbl"),
+              let stsd = ISOBoxSurgery.findChildBox(in: output, parent: stbl, childType: "stsd"),
+              let entry = ISOBoxSurgery.findAnyFirstChildBox(in: output, parent: stsd, contentSkip: 8),
+              let dec3 = ISOBoxSurgery.findChildBox(in: output, parent: entry, childType: "dec3", contentSkip: 28)
+        else {
+            return XCTFail("patched tree must still walk")
+        }
+        XCTAssertEqual(dec3.size, 8 + extendedPayload.count)
+        XCTAssertEqual(output.subdata(in: (dec3.start + 8) ..< (dec3.start + dec3.size)), extendedPayload)
+    }
+
+    func testAncestorSizesGrowByDelta() {
+        let input = initSegment(dec3Payload: jocLessPayload)
+        guard let output = ISOBoxSurgery.appendDec3JOCExtension(into: input, complexityIndex: 16) else {
+            return XCTFail("surgery must succeed")
+        }
+        guard let moovIn = ISOBoxSurgery.findTopLevelBox(in: input, type: "moov"),
+              let moovOut = ISOBoxSurgery.findTopLevelBox(in: output, type: "moov") else {
+            return XCTFail("moov must exist in both")
+        }
+        XCTAssertEqual(moovOut.size, moovIn.size + 1)
+        // The video trak (first child) must be byte-identical.
+        guard let videoIn = ISOBoxSurgery.findVideoTrak(in: input, moov: moovIn),
+              let videoOut = ISOBoxSurgery.findVideoTrak(in: output, moov: moovOut) else {
+            return XCTFail("video trak must exist in both")
+        }
+        XCTAssertEqual(
+            input.subdata(in: videoIn.start ..< videoIn.start + videoIn.size),
+            output.subdata(in: videoOut.start ..< videoOut.start + videoOut.size)
+        )
+    }
+
+    func testAlreadyExtendedReturnsNil() {
+        for payload in [extendedPayload, deviceExtendedPayload] {
+            let input = initSegment(dec3Payload: payload)
+            XCTAssertNil(
+                ISOBoxSurgery.appendDec3JOCExtension(into: input, complexityIndex: 16),
+                "an ETSI-layout dec3 with a valid extension (FFmpeg ≥ 8) must be left untouched"
+            )
+        }
+    }
+
+    func testAppendThenReappendIsIdempotent() {
+        let input = initSegment(dec3Payload: jocLessPayload)
+        guard let once = ISOBoxSurgery.appendDec3JOCExtension(into: input, complexityIndex: 16) else {
+            return XCTFail("first pass must succeed")
+        }
+        XCTAssertNil(ISOBoxSurgery.appendDec3JOCExtension(into: once, complexityIndex: 16))
+    }
+
+    func testDevicePayloadConvertsToFFmpeg8GroundTruth() {
+        // The exact on-device case: the 7.1-written payload must convert to
+        // the byte-identical output FFmpeg 8.1 produces for the same stream.
+        // (Two prior failures pinned here: requiring a dependent substream,
+        // and extending 7.1's 5-reserved-bit layout instead of rewriting to
+        // ETSI's 3 — the flag landed two bits past where Apple reads it.)
+        let input = initSegment(dec3Payload: devicePayload)
+        guard let output = ISOBoxSurgery.appendDec3JOCExtension(into: input, complexityIndex: 16) else {
+            return XCTFail("surgery must convert the ndep=0 streaming-Atmos shape")
+        }
+        guard let moov = ISOBoxSurgery.findTopLevelBox(in: output, type: "moov"),
+              let audioTrak = ISOBoxSurgery.findAudioTrak(in: output, moov: moov),
+              let mdia = ISOBoxSurgery.findChildBox(in: output, parent: audioTrak, childType: "mdia"),
+              let minf = ISOBoxSurgery.findChildBox(in: output, parent: mdia, childType: "minf"),
+              let stbl = ISOBoxSurgery.findChildBox(in: output, parent: minf, childType: "stbl"),
+              let stsd = ISOBoxSurgery.findChildBox(in: output, parent: stbl, childType: "stsd"),
+              let entry = ISOBoxSurgery.findAnyFirstChildBox(in: output, parent: stsd, contentSkip: 8),
+              let dec3 = ISOBoxSurgery.findChildBox(in: output, parent: entry, childType: "dec3", contentSkip: 28)
+        else {
+            return XCTFail("patched tree must still walk")
+        }
+        XCTAssertEqual(output.subdata(in: (dec3.start + 8) ..< (dec3.start + dec3.size)), deviceExtendedPayload)
+        // And idempotence on the ndep=0 shape.
+        XCTAssertNil(ISOBoxSurgery.appendDec3JOCExtension(into: output, complexityIndex: 16))
+    }
+
+    func testMissingDec3ReturnsNil() {
+        let stsdPayload = Data(count: 8) + box("ec-3", Data(count: 28))  // no dec3 child
+        let audioTrak = trak(handler: "soun", stblChildren: box("stsd", stsdPayload))
+        let input = box("moov", audioTrak)
+        XCTAssertNil(ISOBoxSurgery.appendDec3JOCExtension(into: input, complexityIndex: 16))
+    }
+
+    func testAudioTrakFoundBehindVideoTrak() {
+        // MKV sources often list video first; the walker must skip it.
+        let input = initSegment(dec3Payload: jocLessPayload, videoTrakFirst: true)
+        XCTAssertNotNil(ISOBoxSurgery.appendDec3JOCExtension(into: input, complexityIndex: 16))
+        let flipped = initSegment(dec3Payload: jocLessPayload, videoTrakFirst: false)
+        XCTAssertNotNil(ISOBoxSurgery.appendDec3JOCExtension(into: flipped, complexityIndex: 16))
+    }
+}

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
@@ -910,11 +910,55 @@ final class AVPlayerBackend {
         let url = URL(string: "http://127.0.0.1:\(server.port)/\(playlistName)")!
         cmpLog("[CMP-AVP] local playlist ready \(url.absoluteString)")
         logTVDisplayManagerState(context: "before_prepare_\(playlistName)")
-        applyTVDisplayCriteriaForLoopbackIfNeeded(context: "before_prepare_\(playlistName)")
+        let appliedCriteria = applyTVDisplayCriteriaForLoopbackIfNeeded(context: "before_prepare_\(playlistName)")
         // The local loopback server is an in-app HTTP surface. Remote auth
         // headers are only for libavformat's source fetch and should not be
         // propagated into AVPlayer's localhost HLS requests.
+        if appliedCriteria {
+            // tvOS 26.5 validates a variant's VIDEO-RANGE against the
+            // panel's CURRENT mode, synchronously, before fetching the init
+            // segment. Creating the item while the panel is mid-switch
+            // fails it with -11868 (observed underlying -17223) and drops
+            // the session to the PlayerCore fallback. Wait for the switch
+            // to settle first — two stages, because the handshake itself
+            // starts asynchronously after preferredDisplayCriteria is set.
+            Task { @MainActor [weak self] in
+                await Self.waitForDisplayModeSwitchToSettle()
+                guard let self, !self.isDisposed, self.currentItem == nil,
+                      self.activeLoopbackSessionID == sessionID else { return }
+                self.logTVDisplayManagerState(context: "after_switch_wait_\(playlistName)")
+                self.prepareAssetPlayback(url: url, headers: [:])
+            }
+            return
+        }
         prepareAssetPlayback(url: url, headers: [:])
+    }
+
+    /// Two-stage wait for the tvOS display-mode switch to settle after
+    /// `preferredDisplayCriteria` is written: up to 1 s for
+    /// `isDisplayModeSwitchInProgress` to become true (the handshake begins
+    /// asynchronously; it may also never begin if the panel is already in
+    /// the target mode), then up to 5 s for it to clear.
+    @MainActor
+    private static func waitForDisplayModeSwitchToSettle() async {
+        #if os(tvOS)
+        guard let dm = TVDisplayCriteria.activeTVWindow()?.avDisplayManager else { return }
+        let stage1Start = Date()
+        var began = false
+        while Date().timeIntervalSince(stage1Start) < 1.0 {
+            if dm.isDisplayModeSwitchInProgress { began = true; break }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        let stage2Start = Date()
+        while dm.isDisplayModeSwitchInProgress,
+              Date().timeIntervalSince(stage2Start) < 5.0 {
+            try? await Task.sleep(nanoseconds: 100_000_000)
+        }
+        print(String(format: "[CMP-AVP] display switch settle began=%d stillInProgress=%d waited=%.2fs",
+                     began ? 1 : 0,
+                     dm.isDisplayModeSwitchInProgress ? 1 : 0,
+                     Date().timeIntervalSince(stage1Start)))
+        #endif
     }
 
     private func prepareAssetPlayback(url: URL, headers: [String: String]) {
@@ -2357,9 +2401,13 @@ final class AVPlayerBackend {
         #endif
     }
 
-    private func applyTVDisplayCriteriaForLoopbackIfNeeded(context: String) {
+    /// Returns true when Dolby Vision display criteria were written (the
+    /// caller must then wait for the panel switch to settle before creating
+    /// the AVPlayerItem — see `waitForDisplayModeSwitchToSettle`).
+    @discardableResult
+    private func applyTVDisplayCriteriaForLoopbackIfNeeded(context: String) -> Bool {
         #if os(tvOS)
-        guard case .localDVLoopback(let spec) = currentSourceStrategy else { return }
+        guard case .localDVLoopback(let spec) = currentSourceStrategy else { return false }
         switch spec.videoMode {
         case .passthroughProfile5, .convertProfile7To81, .passthroughProfile8:
             let preservedForReload = isPreservingTVDisplayCriteriaForReload
@@ -2378,11 +2426,11 @@ final class AVPlayerBackend {
             }()
             guard let displayManager = window?.avDisplayManager else {
                 print("[CMP-AVP] tv display apply context=\(context) manager=nil")
-                return
+                return false
             }
             guard displayManager.isDisplayCriteriaMatchingEnabled else {
                 print("[CMP-AVP] tv display apply context=\(context) matching=0 skipped=matching_disabled")
-                return
+                return false
             }
 
             let refreshRate = spec.sourceVideoFrameRate ?? 24.0
@@ -2392,10 +2440,13 @@ final class AVPlayerBackend {
             )
             displayManager.preferredDisplayCriteria = criteria
             print(String(format: "[CMP-AVP] tv display apply context=%@ fps=%.3f dr=%d matching=1 preservedReload=%d", context, Double(refreshRate), Int(SpikeDynamicRange.dolbyVision.rawValue), preservedForReload ? 1 : 0))
+            return true
         case .passthroughHEVC, .passthroughH264:
             isPreservingTVDisplayCriteriaForReload = false
-            return
+            return false
         }
+        #else
+        return false
         #endif
     }
 

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/DVSegmentWriter.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/DVSegmentWriter.swift
@@ -400,6 +400,11 @@ final class DVSegmentWriter {
         }
     }
     private var throughputTiming = ThroughputTiming()
+    /// True when the selected copy-mode audio stream is E-AC-3 with a JOC
+    /// (Atmos) extension — `codecpar.profile == 30`
+    /// (`AV_PROFILE_EAC3_DDP_ATMOS`, libavcodec defs.h). Drives the dec3
+    /// JOC surgery in `writeInitSegment`.
+    private var selectedAudioIsAtmosJOC = false
     /// Threshold tuned to tolerate the brief reorder bursts the fmp4 muxer
     /// occasionally emits during keyframe boundary realignment without
     /// missing a genuinely broken stream.
@@ -1075,8 +1080,16 @@ final class DVSegmentWriter {
                 ensureAudioFrameSize(codecpar: outStream.pointee.codecpar)
                 outputAudioCodecID = codecpar.pointee.codec_id
                 outputAudioCodecToken = codecToken(for: codecpar.pointee.codec_id)
+                // AV_PROFILE_EAC3_DDP_ATMOS (= 30): the demuxer sets it when
+                // the E-AC-3 dependent substream carries a JOC (Atmos)
+                // extension. The vendored FFmpeg 7.1 muxer writes no dec3 JOC
+                // extension of its own, so writeInitSegment patches one in —
+                // without it AVFoundation classifies the track as plain
+                // E-AC-3 and Atmos passthrough never engages.
+                selectedAudioIsAtmosJOC = codecpar.pointee.codec_id == AV_CODEC_ID_EAC3
+                    && codecpar.pointee.profile == 30
                 let codecName = outputAudioCodecToken ?? String(cString: avcodec_get_name(codecpar.pointee.codec_id))
-                print("[CMP-AVP] selected audio copy sourceStream=\(i) codec=\(codecName) channels=\(codecpar.pointee.ch_layout.nb_channels)")
+                print("[CMP-AVP] selected audio copy sourceStream=\(i) codec=\(codecName) channels=\(codecpar.pointee.ch_layout.nb_channels) atmosJOC=\(selectedAudioIsAtmosJOC ? 1 : 0)")
             } else {
                 try openAudioTranscodePipeline(
                     inputStream: inStream,
@@ -2806,6 +2819,22 @@ final class DVSegmentWriter {
                 print("[CMP-AVP] dvvC injected (init.mp4 grew by 32 bytes) \(doviLog)")
             } else {
                 print("[CMP-AVP] dvvC injection failed — hvcC not found in init tree")
+            }
+        }
+        if selectedAudioIsAtmosJOC {
+            // complexity_index_type_a = 16 is the standard object count for
+            // streaming DDP-Atmos; FFmpeg 7.1's parser does not expose the
+            // stream's true value, and the field is a decoder complexity
+            // hint. A vendored FFmpeg ≥ 8 bump writes the parsed value
+            // natively (the surgery then no-ops via its already-extended
+            // guard).
+            if let patched = ISOBoxSurgery.appendDec3JOCExtension(into: bytes, complexityIndex: 16) {
+                bytes = patched
+                print("[CMP-AVP] dec3 JOC extension appended (Atmos signalling, complexity=16)")
+            } else {
+                // print too: OSLog is invisible to devicectl console capture.
+                print("[CMP-AVP] dec3 JOC extension append FAILED — Atmos will present as plain E-AC-3 5.1")
+                Self.logger.error("dec3 JOC extension append failed — Atmos will present as plain E-AC-3 5.1")
             }
         }
         do {

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/DVSegmentWriter.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/DVSegmentWriter.swift
@@ -409,6 +409,14 @@ final class DVSegmentWriter {
     /// occasionally emits during keyframe boundary realignment without
     /// missing a genuinely broken stream.
     private static let maxConsecutiveMuxWriteFailures = 5
+    /// Output video dimensions, captured at stream setup for the master
+    /// playlist's RESOLUTION/FRAME-RATE attributes. FRAME-RATE is
+    /// load-bearing: AVFoundation's variant filter silently drops a
+    /// VIDEO-RANGE=PQ variant that carries no FRAME-RATE (verified against
+    /// macOS AVAsset.variants with the on-device artifacts), which surfaced
+    /// as NSURLError -1002 and a silent PlayerCore fallback.
+    private var masterVideoWidth: Int32 = 0
+    private var masterVideoHeight: Int32 = 0
 
     private struct DoviRecord {
         let versionMajor: UInt8
@@ -1035,6 +1043,8 @@ final class DVSegmentWriter {
                 if avcodec_parameters_copy(outStream.pointee.codecpar, codecpar) < 0 {
                     throw DVWriterError.allocOutput
                 }
+                masterVideoWidth = codecpar.pointee.width
+                masterVideoHeight = codecpar.pointee.height
                 outStream.pointee.time_base = inStream.pointee.time_base
                 outStream.pointee.codecpar.pointee.codec_tag = 0
                 let dovi = outputDoviConfig(from: readDoviConfig(codecpar: codecpar))
@@ -1501,11 +1511,17 @@ final class DVSegmentWriter {
                 .joined()
         }
 
-        var codec = "\(sampleEntry).\(profileSpacePrefix)\(profileIDC).\(compatibilityString).\(tierFlag ? "H" : "L")\(levelIDC)"
-        if let constraintString, !constraintString.isEmpty {
-            codec += ".\(constraintString)"
-        }
-        return codec
+        // Always declare Main tier ('L') and omit the constraint suffix,
+        // whatever the stream's actual tier flag says. AVPlayer's
+        // master-level codec filter silently drops variants whose CODECS it
+        // won't claim — a faithful "hvc1.2.4.H150.B0" (High tier, device
+        // stream) was rejected with NSURLErrorDomain -1002 before the
+        // variant playlist was ever fetched, while the lenient Main-tier
+        // declaration is accepted everywhere. The declaration only feeds
+        // variant selection; the bitstream is untouched.
+        _ = tierFlag
+        _ = constraintString
+        return "\(sampleEntry).\(profileSpacePrefix)\(profileIDC).\(compatibilityString).L\(levelIDC)"
     }
 
     private func reversedBits32(_ value: UInt32) -> UInt32 {
@@ -3285,14 +3301,16 @@ final class DVSegmentWriter {
         let mediaRate = elapsed > 0
             ? String(format: "%.2fx", totalMediaDuration / elapsed)
             : "unknown"
-        // Start AVPlayer from the media playlist. The multivariant manifest is
-        // still emitted for artifact inspection and DV/HDR validation metadata,
-        // but iOS rejected the current local master surface before fetching the
-        // child playlist. The media playlist path is the proven playback path.
+        // EXPERIMENT (local/device-testing only): start AVPlayer from the
+        // master playlist. Apple grants premium format claims (Dolby Atmos
+        // MAT output for EAC3-JOC) at master-variant level; media-direct
+        // start dodged a historical master rejection at the cost of any
+        // master-level grants. Master playback confirmed working on-device
+        // 2026-07-03; Atmos grant validation in progress.
         print(
-            "[CMP-AVP] startup runway ready startPlaylist=playlist.m3u8 generated=\(String(format: "%.1f", totalMediaDuration))s threshold=\(String(format: "%.1f", minimumPlayableWindow))s segments=\(segmentEntries.count) targetDuration=\(String(format: "%.1f", playlistTargetDuration))s elapsed=\(String(format: "%.2f", elapsed))s mediaRate=\(mediaRate) reason=\(startupReason) note=media_playlist_start_hint"
+            "[CMP-AVP] startup runway ready startPlaylist=master.m3u8 generated=\(String(format: "%.1f", totalMediaDuration))s threshold=\(String(format: "%.1f", minimumPlayableWindow))s segments=\(segmentEntries.count) targetDuration=\(String(format: "%.1f", playlistTargetDuration))s elapsed=\(String(format: "%.2f", elapsed))s mediaRate=\(mediaRate) reason=\(startupReason) note=master_playlist_experiment"
         )
-        onFirstSegmentReady?("playlist.m3u8")
+        onFirstSegmentReady?("master.m3u8")
     }
 
     // MARK: - Playlist
@@ -3407,6 +3425,17 @@ final class DVSegmentWriter {
         if let supplemental = supplementalCodecString() {
             inf += ",SUPPLEMENTAL-CODECS=\"\(supplemental)\""
         }
+        if masterVideoWidth > 0, masterVideoHeight > 0 {
+            inf += ",RESOLUTION=\(masterVideoWidth)x\(masterVideoHeight)"
+        }
+        // FRAME-RATE is load-bearing for VIDEO-RANGE=PQ variants: AVFoundation
+        // filters out a PQ variant that carries no FRAME-RATE before the media
+        // playlist is fetched. Always emit it, defaulting to the 23.976 film
+        // cadence (the same default the display-criteria path uses) when the
+        // server provides no parsable frame rate — otherwise DV/PQ files with
+        // missing fps metadata would be dropped by the variant filter.
+        let masterFrameRate = (sessionSpec.sourceVideoFrameRate).flatMap { $0 > 0 ? $0 : nil } ?? 23.976
+        inf += ",FRAME-RATE=\(String(format: "%.3f", masterFrameRate))"
         inf += ",VIDEO-RANGE=\(manifestMetadata.videoRange)"
         if !loggedMasterManifest {
             loggedMasterManifest = true

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/ISOBoxSurgery.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/ISOBoxSurgery.swift
@@ -365,6 +365,207 @@ enum ISOBoxSurgery {
         return parts.joined(separator: ",")
     }
 
+    // MARK: - dec3 JOC extension (Atmos signalling)
+
+    /// Walk all `trak` children of `moov` and return the first one whose
+    /// `mdia > hdlr` handler_type is `soun`.
+    static func findAudioTrak(in data: Data, moov: Box) -> Box? {
+        var cursor = moov.start + 8
+        let end = moov.start + moov.size
+        while cursor + 8 <= end {
+            let size = Int(readU32BE(data, at: cursor))
+            if size < 8 || cursor + size > end { return nil }
+            let t = readFourCC(data, at: cursor + 4)
+            if t == "trak" {
+                let trak = Box(start: cursor, size: size)
+                if isAudioTrak(in: data, trak: trak) {
+                    return trak
+                }
+            }
+            cursor += size
+        }
+        return nil
+    }
+
+    static func isAudioTrak(in data: Data, trak: Box) -> Bool {
+        guard let mdia = findChildBox(in: data, parent: trak, childType: "mdia") else { return false }
+        guard let hdlr = findChildBox(in: data, parent: mdia, childType: "hdlr") else { return false }
+        let typeOffset = hdlr.start + 16  // 8 box header + 4 FullBox + 4 pre_defined
+        guard typeOffset + 4 <= hdlr.start + hdlr.size else { return false }
+        return readFourCC(data, at: typeOffset) == "soun"
+    }
+
+    /// Rewrite the audio sample entry's `dec3` box into the ETSI layout with
+    /// the E-AC-3 JOC extension (ETSI TS 103 420:
+    /// `flag_ec3_extension_type_a` + `complexity_index_type_a`) and adjust
+    /// every ancestor size. Two FFmpeg 7.1 muxer defects are corrected at
+    /// once:
+    ///
+    ///  1. It never writes the JOC extension — the field AVFoundation keys
+    ///     on to classify a track as Dolby Atmos.
+    ///  2. Its substream entry writes FIVE reserved bits between `lfeon`
+    ///     and `num_dep_sub` where ETSI TS 102 366 F.6 specifies THREE, so
+    ///     everything after `lfeon` is bit-shifted versus what Apple
+    ///     parses. (Simply appending the extension to the 7.1 payload put
+    ///     the flag two bits past where Apple reads it — flag parsed as 0,
+    ///     no Atmos. Device-verified.)
+    ///
+    /// The whole payload is therefore re-emitted bit-by-bit in the ETSI
+    /// layout. Ground truth: FFmpeg 8.1 remuxing the identical device
+    /// stream emits `1800200f000110`, pinned in ISOBoxSurgeryDec3Tests.
+    ///
+    /// Returns nil (caller ships the unmodified data) when the tree shape is
+    /// missing, the sample entry isn't `ec-3`, or a valid ETSI-layout
+    /// extension is already present (a future FFmpeg bump writes it
+    /// natively). Whether the stream is actually JOC is the caller's call
+    /// (`codecpar.profile == 30`) — the dec3 substream fields cannot tell:
+    /// streaming DDP-Atmos carries JOC in the independent frame's EMDF with
+    /// num_dep_sub = 0.
+    static func appendDec3JOCExtension(into data: Data, complexityIndex: UInt8) -> Data? {
+        guard let moov = findTopLevelBox(in: data, type: "moov") else { return nil }
+        guard let trak = findAudioTrak(in: data, moov: moov) else { return nil }
+        guard let mdia = findChildBox(in: data, parent: trak, childType: "mdia") else { return nil }
+        guard let minf = findChildBox(in: data, parent: mdia, childType: "minf") else { return nil }
+        guard let stbl = findChildBox(in: data, parent: minf, childType: "stbl") else { return nil }
+        guard let stsd = findChildBox(in: data, parent: stbl, childType: "stsd") else { return nil }
+        guard let entry = findAnyFirstChildBox(in: data, parent: stsd, contentSkip: 8) else { return nil }
+        guard readFourCC(data, at: entry.start + 4) == "ec-3" else { return nil }
+        // AudioSampleEntry: 8 SampleEntry bytes (6 reserved + 2
+        // data_reference_index) + 20 AudioSampleEntry bytes (8 reserved +
+        // 2 channelcount + 2 samplesize + 2 pre_defined + 2 reserved +
+        // 4 samplerate) = 28 bytes before child boxes.
+        guard let dec3 = findChildBox(in: data, parent: entry, childType: "dec3", contentSkip: 28) else { return nil }
+
+        let payloadStart = dec3.start + 8
+        let payloadCount = dec3.size - 8
+        guard payloadCount >= 2 else { return nil }
+
+        // Already in the ETSI layout with a valid extension (an FFmpeg ≥ 8
+        // muxer writes both natively): leave untouched.
+        if dec3PayloadHasETSIExtension(data: data, payloadStart: payloadStart, payloadCount: payloadCount) {
+            return nil
+        }
+
+        // Parse FFmpeg 7.1's layout (5 reserved bits before num_dep_sub),
+        // re-emit the ETSI layout (3 reserved bits) plus the JOC extension.
+        // NOTE: no dependent-substream requirement — streaming DDP-Atmos
+        // (the streaming 5.1-bed variant) carries JOC inside the
+        // independent frame's EMDF metadata; num_dep_sub is 0 there.
+        var reader = Dec3BitReader(data: data, byteOffset: payloadStart, byteCount: payloadCount)
+        var writer = Dec3BitWriter()
+        guard let dataRate = reader.read(13), let numIndSub = reader.read(3) else { return nil }
+        writer.write(dataRate, bits: 13)
+        writer.write(numIndSub, bits: 3)
+
+        for _ in 0...Int(numIndSub) {
+            guard let fscod = reader.read(2), let bsid = reader.read(5),
+                  let reserved1 = reader.read(1), let asvc = reader.read(1),
+                  let bsmod = reader.read(3), let acmod = reader.read(3),
+                  let lfeon = reader.read(1), reader.read(5) != nil,
+                  let numDepSub = reader.read(4) else { return nil }
+            writer.write(fscod, bits: 2)
+            writer.write(bsid, bits: 5)
+            writer.write(reserved1, bits: 1)
+            writer.write(asvc, bits: 1)
+            writer.write(bsmod, bits: 3)
+            writer.write(acmod, bits: 3)
+            writer.write(lfeon, bits: 1)
+            writer.write(0, bits: 3)  // ETSI reserved (7.1 wrongly wrote 5 bits)
+            writer.write(numDepSub, bits: 4)
+            if numDepSub > 0 {
+                guard let chanLoc = reader.read(9) else { return nil }
+                writer.write(chanLoc, bits: 9)
+            } else {
+                guard let reserved = reader.read(1) else { return nil }
+                writer.write(reserved, bits: 1)
+            }
+        }
+
+        writer.write(0, bits: 7)                       // reserved
+        writer.write(1, bits: 1)                       // flag_ec3_extension_type_a
+        writer.write(UInt32(complexityIndex), bits: 8) // complexity_index_type_a
+        let newPayload = writer.flushed()
+
+        var out = data
+        out.replaceSubrange(payloadStart ..< payloadStart + payloadCount, with: newPayload)
+        let delta = newPayload.count - payloadCount
+        addToBoxSize(in: &out, boxOffset: dec3.start, delta: delta)
+        for box in [moov, trak, mdia, minf, stbl, stsd, entry] {
+            addToBoxSize(in: &out, boxOffset: box.start, delta: delta)
+        }
+        return out
+    }
+
+    /// True when the payload parses under the ETSI TS 102 366 layout
+    /// (3 reserved bits before num_dep_sub) with a valid JOC extension
+    /// (zero reserved bits, flag set) immediately after the substream loop.
+    private static func dec3PayloadHasETSIExtension(
+        data: Data, payloadStart: Int, payloadCount: Int
+    ) -> Bool {
+        var reader = Dec3BitReader(data: data, byteOffset: payloadStart, byteCount: payloadCount)
+        guard reader.read(13) != nil, let numIndSub = reader.read(3) else { return false }
+        for _ in 0...Int(numIndSub) {
+            guard reader.read(2) != nil, reader.read(5) != nil,
+                  reader.read(1) != nil, reader.read(1) != nil,
+                  reader.read(3) != nil, reader.read(3) != nil,
+                  reader.read(1) != nil, reader.read(3) != nil,
+                  let numDepSub = reader.read(4) else { return false }
+            if numDepSub > 0 {
+                guard reader.read(9) != nil else { return false }
+            } else {
+                guard reader.read(1) != nil else { return false }
+            }
+        }
+        guard reader.remainingBits >= 16,
+              let reserved7 = reader.read(7), reserved7 == 0,
+              let flag = reader.read(1), flag == 1 else { return false }
+        return true
+    }
+
+    /// Minimal MSB-first bit reader over a byte range of `data`.
+    struct Dec3BitReader {
+        private let data: Data
+        private var bit: Int
+        private let endBit: Int
+
+        init(data: Data, byteOffset: Int, byteCount: Int) {
+            self.data = data
+            self.bit = byteOffset * 8
+            self.endBit = (byteOffset + byteCount) * 8
+        }
+
+        var remainingBits: Int { endBit - bit }
+
+        mutating func read(_ count: Int) -> UInt32? {
+            guard count > 0, count <= 32, count <= remainingBits else { return nil }
+            var value: UInt32 = 0
+            for _ in 0..<count {
+                let byte = data[bit >> 3]
+                let shift = 7 - (bit & 7)
+                value = (value << 1) | UInt32((byte >> shift) & 1)
+                bit += 1
+            }
+            return value
+        }
+    }
+
+    /// Minimal MSB-first bit writer; `flushed()` zero-pads to a byte boundary.
+    struct Dec3BitWriter {
+        private var bytes: [UInt8] = []
+        private var bitCount = 0
+
+        mutating func write(_ value: UInt32, bits: Int) {
+            for i in stride(from: bits - 1, through: 0, by: -1) {
+                if bitCount & 7 == 0 { bytes.append(0) }
+                let bitValue = UInt8((value >> UInt32(i)) & 1)
+                bytes[bytes.count - 1] |= bitValue << (7 - UInt8(bitCount & 7))
+                bitCount += 1
+            }
+        }
+
+        func flushed() -> Data { Data(bytes) }
+    }
+
     // MARK: - Byte helpers
 
     static func readU32BE(_ data: Data, at offset: Int) -> UInt32 {


### PR DESCRIPTION
## Summary
Makes DDP-Atmos (E-AC-3 + JOC) actually reach the AVR/soundbar as Dolby Atmos on the local Dolby Vision loopback route. Previously these tracks stream-copied bit-exact but AVFoundation classified them as plain E-AC-3 5.1, so Atmos never engaged. **Device-verified end to end: an AVR reports "Dolby Atmos" for a streaming WEB-DL DDP-Atmos episode.**

Five stacked defects had to be fixed; each was necessary, none sufficient alone:

1. **dec3 JOC signalling** — the vendored FFmpeg 7.1 mp4 muxer writes `dec3` without the ETSI TS 103 420 JOC extension (`flag_ec3_extension_type_a` + `complexity_index_type_a`), the field AVFoundation keys on for Atmos. It also emits a non-ETSI 5-reserved-bit substream layout where the spec has 3. `ISOBoxSurgery` now rewrites `dec3` into the ETSI layout with the extension, gated on `codecpar.profile == AV_PROFILE_EAC3_DDP_ATMOS`. Ground truth: byte-identical to what FFmpeg 8.1 emits for the same stream (pinned in tests).
2. **Start from the master playlist** — Apple grants premium-format claims (Atmos MAT output) at master-variant level; media-direct start never gets them.
3. **`FRAME-RATE` on the PQ variant** — AVFoundation silently drops a `VIDEO-RANGE=PQ` variant with no `FRAME-RATE` (`-1002` before the variant playlist is even fetched; isolated via `AVAsset.variants`).
4. **Main-tier `CODECS`** — a faithful High-tier `hvc1.2.4.H150.B0` is also variant-filtered; declaring `L150` is accepted (declaration only feeds selection; bitstream untouched).
5. **Wait for the panel mode switch** — tvOS 26.5 validates a variant's `VIDEO-RANGE` against the panel's *current* mode; creating the item mid-switch fails `-11868`. Two-stage settle wait before item creation.

## Verification
Builds clean on `SiloTV`; `ISOBoxSurgeryDec3Tests` (7) pin the dec3 rewrite bit-for-bit. On-device: DV Profile 8 + E-AC-3 JOC through the loopback → AVR shows Dolby Atmos; DV picture unaffected.

> Touches the DV loopback files #52 renames to `LoopbackSegment*` — I'll rebase onto that structure whenever #52 lands.

_Authored with Claude Code._
