### PR TITLE
fix(player): harden DV loopback reliability (silent truncation, fail-loud, 503)

### DIFF
--- a/iosApp/Tests/DVSegmentStoreResourceTests.swift
+++ b/iosApp/Tests/DVSegmentStoreResourceTests.swift
@@ -24,4 +24,35 @@ final class DVSegmentStoreResourceTests: XCTestCase {
 
         XCTAssertEqual(store.stats().tempSpillBudgetBytes, 1024 * 1024)
     }
+
+    func testUnproducedSegmentIsPendingNotMissing() {
+        let store = DVSegmentStore(
+            generation: 102,
+            memoryBudgetBytes: 1024 * 1024,
+            spillPolicy: .disabled(reason: "test")
+        )
+        _ = store.putSegment(name: "seg_000000.m4s", data: Data(repeating: 1, count: 16), duration: 4)
+
+        switch store.resource(path: "seg_000001.m4s", waitForNearFuture: false) {
+        case .pending:
+            break
+        default:
+            XCTFail("an un-produced, non-evicted segment must report .pending")
+        }
+    }
+
+    func testNonSegmentJunkPathIsMissing() {
+        let store = DVSegmentStore(
+            generation: 103,
+            memoryBudgetBytes: 1024 * 1024,
+            spillPolicy: .disabled(reason: "test")
+        )
+
+        switch store.resource(path: "nope.txt", waitForNearFuture: false) {
+        case .missing:
+            break
+        default:
+            XCTFail("a non-segment junk path must stay .missing (404)")
+        }
+    }
 }

--- a/iosApp/Tests/MuxWriteFailurePolicyTests.swift
+++ b/iosApp/Tests/MuxWriteFailurePolicyTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+@testable import Silo
+
+final class MuxWriteFailurePolicyTests: XCTestCase {
+
+    func testConsecutiveBurstAborts() {
+        var policy = MuxWriteFailurePolicy()
+        for _ in 0..<4 {
+            XCTAssertFalse(policy.recordFailure())
+        }
+        XCTAssertTrue(policy.recordFailure(), "5th consecutive failure must abort")
+    }
+
+    func testSuccessResetsConsecutiveCount() {
+        var policy = MuxWriteFailurePolicy()
+        for _ in 0..<4 { _ = policy.recordFailure() }
+        policy.recordSuccess()
+        XCTAssertEqual(policy.consecutiveFailures, 0)
+        XCTAssertFalse(policy.recordFailure(), "burst counter restarts after a success")
+    }
+
+    func testFlappingPatternAborts() {
+        // The fail-4/succeed-1 pattern that a consecutive-only counter
+        // never catches: each cycle stays below the burst threshold but
+        // the failures keep accumulating.
+        var policy = MuxWriteFailurePolicy()
+        var aborted = false
+        cycles: for _ in 0..<10 {
+            for _ in 0..<4 {
+                if policy.recordFailure() { aborted = true; break cycles }
+            }
+            policy.recordSuccess()
+        }
+        XCTAssertTrue(aborted, "persistent flapping must abort")
+        XCTAssertEqual(policy.outstandingFailures, policy.maxOutstanding)
+    }
+
+    func testSparseFailuresAreForgivenByCleanRuns() {
+        var policy = MuxWriteFailurePolicy()
+        for _ in 0..<20 {
+            XCTAssertFalse(policy.recordFailure(), "sparse one-off failures must not abort")
+            for _ in 0..<policy.successesToForgiveOne {
+                policy.recordSuccess()
+            }
+            XCTAssertEqual(policy.outstandingFailures, 0, "a sustained clean run retires the failure")
+        }
+    }
+
+    func testShortCleanRunDoesNotForgive() {
+        var policy = MuxWriteFailurePolicy()
+        _ = policy.recordFailure()
+        for _ in 0..<(policy.successesToForgiveOne - 1) {
+            policy.recordSuccess()
+        }
+        XCTAssertEqual(policy.outstandingFailures, 1, "forgiveness requires the full clean run")
+    }
+
+    func testFailureResetsForgivenessProgress() {
+        var policy = MuxWriteFailurePolicy()
+        _ = policy.recordFailure()
+        for _ in 0..<(policy.successesToForgiveOne - 1) {
+            policy.recordSuccess()
+        }
+        _ = policy.recordFailure()
+        for _ in 0..<(policy.successesToForgiveOne - 1) {
+            policy.recordSuccess()
+        }
+        XCTAssertEqual(policy.outstandingFailures, 2, "a new failure restarts the clean-run requirement")
+    }
+}

--- a/iosApp/Tests/SourceReadOutcomeTests.swift
+++ b/iosApp/Tests/SourceReadOutcomeTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import Silo
+
+final class SourceReadOutcomeTests: XCTestCase {
+
+    func testEOFFinalizes() {
+        XCTAssertEqual(SourceReadOutcome.classify(SourceReadOutcome.avErrorEOF), .endOfInput)
+        // Pin the raw bit pattern: FFERRTAG('E','O','F',' ') — a wrong
+        // constant here reintroduces silent truncation.
+        XCTAssertEqual(SourceReadOutcome.avErrorEOF, -0x20464F45)
+    }
+
+    func testEAGAINRetries() {
+        XCTAssertEqual(SourceReadOutcome.classify(-Int32(EAGAIN)), .retry)
+    }
+
+    func testInterruptAbortIsCancelled() {
+        XCTAssertEqual(SourceReadOutcome.classify(SourceReadOutcome.avErrorExit), .cancelled)
+        XCTAssertEqual(SourceReadOutcome.avErrorExit, -0x54495845)
+    }
+
+    func testNetworkAndGenericErrorsFail() {
+        // The silent-truncation bug: every one of these used to finalize
+        // the playlist as a complete VOD.
+        XCTAssertEqual(SourceReadOutcome.classify(-Int32(EIO)), .failure)
+        XCTAssertEqual(SourceReadOutcome.classify(-Int32(ETIMEDOUT)), .failure)
+        XCTAssertEqual(SourceReadOutcome.classify(-Int32(ECONNRESET)), .failure)
+        XCTAssertEqual(SourceReadOutcome.classify(-Int32(EPIPE)), .failure)
+        // AVERROR_INVALIDDATA
+        XCTAssertEqual(SourceReadOutcome.classify(Int32(-1094995529)), .failure)
+        // AVERROR_HTTP_SERVER_ERROR (5xx)
+        XCTAssertEqual(SourceReadOutcome.classify(-Int32(bitPattern: 0x35303554)), .failure)
+        XCTAssertEqual(SourceReadOutcome.classify(-1), .failure)
+    }
+}

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/DVSegmentServer.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/DVSegmentServer.swift
@@ -15,8 +15,10 @@
 //  parsing on GET. AVPlayer's HLS engine usually fetches segments whole, but
 //  HEAD and Range are the right defaults for any client that probes the
 //  loopback (and removes a class of "AVPlayer hung trying to range-fetch
-//  init.mp4" bug reports). 404 on miss, 416 on un-satisfiable range,
-//  405 on other methods.
+//  init.mp4" bug reports). 503 + Retry-After on a not-yet-produced
+//  segment (AVPlayer treats a VOD 404 as terminal), 410 on an evicted
+//  one, 404 on a genuine miss, 416 on an un-satisfiable range, 405 on
+//  other methods.
 //
 //  ATS (App Transport Security) requires `NSAllowsLocalNetworking=true` in
 //  Info.plist. Without it, AVPlayer fails loading the playlist with
@@ -319,6 +321,13 @@ final class DVSegmentServer {
         store: DVSegmentStore
     ) {
         switch store.resource(path: path) {
+        case .pending:
+            // Not yet produced but plausibly upcoming. AVPlayer treats a
+            // 404 on a VOD asset as terminal loadFailed; 503 + Retry-After
+            // is retried, so a segment that lands a moment after its
+            // playlist entry doesn't kill the session.
+            logRequest(method: method, path: path, status: 503, bytes: 0, range: rangeHeader, started: started)
+            respondError(503, "Service Unavailable", extraHeaders: ["Retry-After: 1"], on: connection)
         case .missing:
             logRequest(method: method, path: path, status: 404, bytes: 0, range: rangeHeader, started: started)
             respondError(404, "Not Found", on: connection)
@@ -595,11 +604,14 @@ final class DVSegmentServer {
         return .satisfiable(lower: lowerBound, upper: upperBound)
     }
 
-    private func respondError(_ code: Int, _ phrase: String, on connection: NWConnection) {
+    private func respondError(_ code: Int, _ phrase: String, extraHeaders: [String] = [], on connection: NWConnection) {
         let body = "\(code) \(phrase)\n"
         var header = "HTTP/1.1 \(code) \(phrase)\r\n"
         header += "Content-Type: text/plain; charset=utf-8\r\n"
         header += "Content-Length: \(body.utf8.count)\r\n"
+        for extra in extraHeaders {
+            header += "\(extra)\r\n"
+        }
         header += "Connection: close\r\n\r\n"
         var data = Data(header.utf8)
         data.append(body.data(using: .utf8) ?? Data())

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/DVSegmentStore.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/DVSegmentStore.swift
@@ -43,6 +43,11 @@ final class DVSegmentStore {
     }
 
     enum ResourceResult {
+        /// A `seg_*` resource that has not been produced yet and has not
+        /// been evicted — it will plausibly exist shortly. The server
+        /// answers 503 + Retry-After so AVPlayer retries; a 404 on a VOD
+        /// asset is treated as terminal `loadFailed`.
+        case pending
         case found(Resource)
         case missing
         case gone
@@ -266,8 +271,12 @@ final class DVSegmentStore {
            spillingSegments[normalized] == nil,
            spilledSegments[normalized] == nil,
            !evictedResources.contains(normalized) {
+            // Short grace so a segment that is mid-write when requested is
+            // served without a retry round trip. Kept short because this
+            // wait holds up the server's serial connection queue; anything
+            // slower falls through to `.pending` and the client retries.
             waitCount += 1
-            _ = lock.wait(until: Date().addingTimeInterval(1.0))
+            _ = lock.wait(until: Date().addingTimeInterval(0.25))
         }
         let location = resourceLocationLocked(path: normalized)
         lock.unlock()
@@ -279,7 +288,9 @@ final class DVSegmentStore {
         case .disk(let url, let byteCount, let mimeType):
             result = .found(.disk(url: url, byteCount: byteCount, mimeType: mimeType))
         case .missing:
-            result = .missing
+            // An un-produced (not evicted) segment name is upcoming, not
+            // absent — distinguish it so the server can answer retriable.
+            result = normalized.hasPrefix("seg_") ? .pending : .missing
         case .gone:
             result = .gone
         }
@@ -289,7 +300,7 @@ final class DVSegmentStore {
         switch result {
         case .found(let resource):
             bytesServed += Int64(resource.byteCount)
-        case .missing, .gone:
+        case .pending, .missing, .gone:
             break
         }
         lastRequestLatencyMs = (CFAbsoluteTimeGetCurrent() - started) * 1000

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/DVSegmentWriter.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/DVSegmentWriter.swift
@@ -360,12 +360,13 @@ final class DVSegmentWriter {
     /// so they cannot throw directly. The mux loop checks this after every
     /// `av_interleaved_write_frame`/`av_write_trailer` and rethrows.
     private var fatalIOError: DVWriterError?
-    /// Consecutive `av_interleaved_write_frame` failures. Reset on success.
-    /// When this hits `maxConsecutiveMuxWriteFailures`, the mux loop aborts via
-    /// `DVWriterError.muxWriteFailures` so callers see a real error instead of
-    /// a silent no-op. Some negative codes are treated as fatal on first hit
-    /// regardless of count — see `evaluateMuxWriteResult`.
-    private var consecutiveMuxWriteFailures = 0
+    /// Accounting for `av_interleaved_write_frame` failures. Aborts via
+    /// `DVWriterError.muxWriteFailures` on a consecutive burst or on
+    /// persistent flapping — see `MuxWriteFailurePolicy` for the two
+    /// conditions and their tuning. Some negative codes are treated as
+    /// fatal on first hit regardless of count — see
+    /// `evaluateMuxWriteResult`.
+    private var muxWriteFailurePolicy = MuxWriteFailurePolicy()
     private struct ThroughputTiming {
         var readMs: Double = 0
         var videoMs: Double = 0
@@ -400,10 +401,6 @@ final class DVSegmentWriter {
         }
     }
     private var throughputTiming = ThroughputTiming()
-    /// Threshold tuned to tolerate the brief reorder bursts the fmp4 muxer
-    /// occasionally emits during keyframe boundary realignment without
-    /// missing a genuinely broken stream.
-    private static let maxConsecutiveMuxWriteFailures = 5
 
     private struct DoviRecord {
         let versionMajor: UInt8
@@ -661,21 +658,20 @@ final class DVSegmentWriter {
     private func evaluateMuxWriteResult(_ rc: Int32, packet: UnsafeMutablePointer<AVPacket>? = nil) throws {
         try throwIfFatalIOError()
         if rc < 0 {
-            consecutiveMuxWriteFailures += 1
+            let shouldAbort = muxWriteFailurePolicy.recordFailure()
             let detail = Self.ffmpegError(rc)
             Self.logger.error(
-                "av_interleaved_write_frame failed: rc=\(rc) (\(detail, privacy: .public)) consecutive=\(self.consecutiveMuxWriteFailures)"
+                "av_interleaved_write_frame failed: rc=\(rc) (\(detail, privacy: .public)) consecutive=\(self.muxWriteFailurePolicy.consecutiveFailures) outstanding=\(self.muxWriteFailurePolicy.outstandingFailures)"
             )
-            if rc == avErrorInvalidData
-                || consecutiveMuxWriteFailures >= Self.maxConsecutiveMuxWriteFailures {
+            if rc == avErrorInvalidData || shouldAbort {
                 throw DVWriterError.muxWriteFailures(
                     lastRC: rc,
-                    consecutive: consecutiveMuxWriteFailures
+                    consecutive: muxWriteFailurePolicy.consecutiveFailures
                 )
             }
             return
         }
-        consecutiveMuxWriteFailures = 0
+        muxWriteFailurePolicy.recordSuccess()
         if let packet {
             recordMuxedPacketTimestamps(packet)
         }
@@ -2805,7 +2801,28 @@ final class DVSegmentWriter {
                 let doviLog = doviRecord?.logLine ?? "unknown"
                 print("[CMP-AVP] dvvC injected (init.mp4 grew by 32 bytes) \(doviLog)")
             } else {
-                print("[CMP-AVP] dvvC injection failed — hvcC not found in init tree")
+                switch videoMode {
+                case .passthroughProfile5:
+                    // `dvh1` without a dvvC carries no DV signalling:
+                    // AVPlayer decodes the IPT-PQ-c2 stream as plain YCbCr
+                    // and renders a green/purple cast. Unwatchable — abort
+                    // the session so the route fallback runs instead of
+                    // shipping the broken init segment.
+                    Self.logger.error("dvvC injection failed on Profile 5 (hvcC not found in init tree) — aborting session")
+                    fatalIOError = .dvSignalingFailed(
+                        "dvvC injection failed on Profile 5 — hvcC not found in init tree"
+                    )
+                case .convertProfile7To81, .passthroughProfile8:
+                    // The hvc1 base layer is HDR10-compatible and renders
+                    // correctly without the dvvC; the stream just plays as
+                    // plain HDR10 instead of engaging Dolby Vision. Degrade
+                    // loudly rather than fail.
+                    Self.logger.error("dvvC injection failed (hvcC not found in init tree) — DV signalling lost, playing the HDR10 base")
+                case .passthroughHEVC, .passthroughH264:
+                    // These modes make no DV claim; doviConfig should not
+                    // have been set. Log and continue.
+                    Self.logger.error("dvvC injection failed on a non-DV mode (hvcC not found in init tree) — ignoring")
+                }
             }
         }
         do {
@@ -3512,12 +3529,17 @@ enum DVWriterError: Error {
     case unsupportedSelectedAudioCodec(String)
     case audioTranscodeSetup(String)
     case profile81ConversionFailed(String)
-    /// `av_interleaved_write_frame` returned a negative code on three or more
-    /// consecutive packets. The mux is no longer producing valid output; abort
-    /// rather than continue writing a half-broken HLS presentation.
+    /// `av_interleaved_write_frame` failed persistently — either a
+    /// consecutive burst or sustained flapping (see `MuxWriteFailurePolicy`).
+    /// The mux is no longer producing valid output; abort rather than
+    /// continue writing a half-broken HLS presentation.
     case muxWriteFailures(lastRC: Int32, consecutive: Int)
     /// On-disk write of an init segment, media segment, or playlist failed.
     /// These are catastrophic for HLS playback and are propagated rather than
     /// silently logged.
     case fileWriteFailed(String, Error)
+    /// The init segment could not carry the Dolby Vision signalling the
+    /// session's video mode requires (dvvC box surgery failed). Fatal for
+    /// Profile 5, where the un-signalled IPT-PQ stream renders green/purple.
+    case dvSignalingFailed(String)
 }

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/DVSegmentWriter.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/DVSegmentWriter.swift
@@ -520,7 +520,7 @@ final class DVSegmentWriter {
             defer { av_packet_free(&packet) }
 
             let avNoPTS = Int64.min  // AV_NOPTS_VALUE
-            while !isCancelled {
+            readLoop: while !isCancelled {
                 let rc: Int32
                 if DVSegmentWriter.traceThroughput {
                     let started = CFAbsoluteTimeGetCurrent()
@@ -534,10 +534,25 @@ final class DVSegmentWriter {
                     break
                 }
                 if rc < 0 {
-                    // AVERROR_EOF or any other negative code — treat as
-                    // end-of-input. Fine-grained error handling isn't
-                    // worth the noise for a v1 spike.
-                    break
+                    // Only genuine EOF may finalize. The old
+                    // any-negative-is-EOF rule wrote the trailer and
+                    // finalized the playlist as a complete VOD after a
+                    // mid-movie read failure, so the film "ended" early
+                    // with no error (silent truncation). Transient drops
+                    // are absorbed by the http reconnect options set in
+                    // openInput(); whatever reaches here is real.
+                    switch SourceReadOutcome.classify(rc) {
+                    case .endOfInput, .cancelled:
+                        break readLoop
+                    case .retry:
+                        continue readLoop
+                    case .failure:
+                        let detail = Self.ffmpegError(rc)
+                        Self.logger.error(
+                            "av_read_frame failed mid-stream: rc=\(rc) (\(detail, privacy: .public)) — failing session instead of truncating"
+                        )
+                        throw DVWriterError.sourceReadFailed(rc: rc, detail: detail)
+                    }
                 }
                 emitSourceDownloadStatsIfNeeded()
                 guard let pkt = packet else { break }
@@ -749,6 +764,18 @@ final class DVSegmentWriter {
         // Reasonable network timeout — 10 s — so a broken source doesn't
         // hang the mux loop forever.
         av_dict_set(&options, "rw_timeout", "10000000", 0)
+        // Transparent mid-read reconnects for network drops: libavformat
+        // re-issues a ranged GET at the current offset and the mux
+        // continues seamlessly, so a CDN blip or Wi-Fi handoff never
+        // surfaces mid-movie. Failures that outlive the reconnect window
+        // (origin gone, auth expiry) reach the read loop, which fails the
+        // session instead of finalizing the playlist as a complete VOD.
+        if !sourceURL.isFileURL {
+            av_dict_set(&options, "reconnect", "1", 0)
+            av_dict_set(&options, "reconnect_streamed", "1", 0)
+            av_dict_set(&options, "reconnect_on_network_error", "1", 0)
+            av_dict_set(&options, "reconnect_delay_max", "8", 0)
+        }
         // Cap probe cost. We only mux video + the selected audio stream
         // (subtitles, fonts, attachments, extra audio are dropped at mux
         // time — see filtering below and at packet copy in the main loop).
@@ -3542,4 +3569,42 @@ enum DVWriterError: Error {
     /// session's video mode requires (dvvC box surgery failed). Fatal for
     /// Profile 5, where the un-signalled IPT-PQ stream renders green/purple.
     case dvSignalingFailed(String)
+    /// `av_read_frame` failed mid-stream with something other than EOF
+    /// after the http-level reconnects were exhausted. The session fails
+    /// so the recovery ladder runs — finalizing would truncate the movie
+    /// silently.
+    case sourceReadFailed(rc: Int32, detail: String)
+}
+
+/// How the mux read loop reacts to a negative `av_read_frame` return.
+/// Pure and pinned by SourceReadOutcomeTests: the EOF-vs-failure
+/// distinction is the difference between a finished movie and a silently
+/// truncated one.
+enum SourceReadOutcome: Equatable {
+    /// Genuine end of input — drain, write the trailer, finalize as VOD.
+    case endOfInput
+    /// Transient (EAGAIN) — read again.
+    case retry
+    /// The interrupt callback aborted the read (`stop()` mid-read); the
+    /// loop's cancellation path owns teardown.
+    case cancelled
+    /// A real read failure — fail the session, never finalize.
+    case failure
+
+    static let avErrorEOF = -Int32(bitPattern: 0x20464F45)   // FFERRTAG('E','O','F',' ')
+    static let avErrorExit = -Int32(bitPattern: 0x54495845)  // FFERRTAG('E','X','I','T')
+    static let avErrorAgain = -Int32(EAGAIN)
+
+    static func classify(_ rc: Int32) -> SourceReadOutcome {
+        switch rc {
+        case avErrorEOF:
+            return .endOfInput
+        case avErrorAgain:
+            return .retry
+        case avErrorExit:
+            return .cancelled
+        default:
+            return .failure
+        }
+    }
 }

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/MuxWriteFailurePolicy.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/MuxWriteFailurePolicy.swift
@@ -1,0 +1,67 @@
+//
+//  MuxWriteFailurePolicy.swift
+//  Continuum
+//
+//  Pure accounting for `av_interleaved_write_frame` failures in
+//  DVSegmentWriter. Two abort conditions:
+//
+//    1. A consecutive burst (`maxConsecutive`) — the mux stopped
+//       producing valid output outright.
+//    2. Persistent flapping (`maxOutstanding`) — failures that keep
+//       arriving with only short clean runs between them. A plain
+//       consecutive counter reset on every success let a
+//       fail-4/succeed-1 pattern drop packets forever while the output
+//       silently corrupted; here each failure stays "outstanding" until
+//       a sustained clean run (`successesToForgiveOne` writes, roughly
+//       one second of A/V packets) retires it.
+//
+//  Sparse one-off failures (the fmp4 muxer's brief reorder bursts during
+//  keyframe boundary realignment) are forgiven by the clean run that
+//  follows them and never abort. No I/O, no locking — testable in
+//  isolation; DVSegmentWriter owns one instance per session.
+//
+
+struct MuxWriteFailurePolicy {
+    private(set) var consecutiveFailures = 0
+    private(set) var outstandingFailures = 0
+    private var successesSinceLastForgiveness = 0
+
+    /// Consecutive-burst abort threshold. Tuned to tolerate the brief
+    /// reorder bursts the fmp4 muxer occasionally emits during keyframe
+    /// boundary realignment without missing a genuinely broken stream.
+    let maxConsecutive: Int
+    /// Flapping abort threshold: total not-yet-forgiven failures.
+    let maxOutstanding: Int
+    /// Clean writes required to retire one outstanding failure.
+    let successesToForgiveOne: Int
+
+    init(
+        maxConsecutive: Int = 5,
+        maxOutstanding: Int = 12,
+        successesToForgiveOne: Int = 48
+    ) {
+        self.maxConsecutive = maxConsecutive
+        self.maxOutstanding = maxOutstanding
+        self.successesToForgiveOne = successesToForgiveOne
+    }
+
+    /// Record a failed write. Returns true when the mux should abort.
+    mutating func recordFailure() -> Bool {
+        consecutiveFailures += 1
+        outstandingFailures += 1
+        successesSinceLastForgiveness = 0
+        return consecutiveFailures >= maxConsecutive
+            || outstandingFailures >= maxOutstanding
+    }
+
+    /// Record a successful write.
+    mutating func recordSuccess() {
+        consecutiveFailures = 0
+        guard outstandingFailures > 0 else { return }
+        successesSinceLastForgiveness += 1
+        if successesSinceLastForgiveness >= successesToForgiveOne {
+            outstandingFailures -= 1
+            successesSinceLastForgiveness = 0
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Three reliability fixes on the local Dolby Vision loopback writer/server.

### 1. Stop treating mid-stream read failures as end of input (the worst one)
Any negative `av_read_frame` return ended the mux loop as if the movie had finished — trailer written, playlist finalized as complete VOD, `onFinished(nil)`. With the input's 10 s `rw_timeout`, a mid-movie network drop meant the film just ended with no error, no recovery. Now: libavformat http reconnect options absorb transient drops (ranged GET at the current offset), and a pure `SourceReadOutcome` classifier fails the session (`sourceReadFailed` → recovery ladder) on anything that isn't genuine EOF/EAGAIN/interrupt.

### 2. Never ship un-signalled Dolby Vision; harden mux-failure accounting
`dvvC` injection failure was log-only, so the unpatched init shipped — unwatchable green/purple on Profile 5. Now aborts P5 (route fallback); P7→8.1 / P8 degrade loudly to their HDR10 base. Separately, the consecutive mux-write-failure counter reset on every success, so a fail-4/succeed-1 flap corrupted output forever — replaced with `MuxWriteFailurePolicy` (consecutive-burst **and** sustained-flapping thresholds).

### 3. Answer 503 + Retry-After for not-yet-produced segments
AVPlayer treats a VOD 404 as terminal `loadFailed`, so a segment requested just before its bytes land killed the session. The store now distinguishes an un-produced (not evicted) `seg_*` (`.pending`) from a genuine miss, and the server answers 503 + `Retry-After: 1`.

## Verification
Builds clean on `SiloTV`; covered by `SourceReadOutcomeTests`, `MuxWriteFailurePolicyTests`, and the extended `DVSegmentStoreResourceTests` (13 tests). The truncation fix is device-relevant on the loopback route.

> Touches the DV loopback files #52 renames to `LoopbackSegment*`; I'll rebase onto that structure whenever #52 lands. Note #52 carries the same `av_read_frame`-any-negative-is-EOF bug into `LoopbackSegmentWriter`, so fix #1 still applies there.

_Authored with Claude Code._
