### PR TITLE
SiloPlayer: streaming origin fetch — fix buffering on high-latency connections

### DIFF
--- a/iosApp/Tests/PlaybackOriginStreamPolicyTests.swift
+++ b/iosApp/Tests/PlaybackOriginStreamPolicyTests.swift
@@ -1,0 +1,227 @@
+import XCTest
+
+@testable import Silo
+
+final class PlaybackOriginStreamPolicyTests: XCTestCase {
+    private func snapshot(
+        id: UUID = UUID(),
+        start: Int64 = 0,
+        cursor: Int64,
+        order: UInt64
+    ) -> PlaybackOriginStreamPolicy.StreamSnapshot {
+        PlaybackOriginStreamPolicy.StreamSnapshot(
+            id: id,
+            startOffset: start,
+            writeCursor: cursor,
+            lastDemandOrder: order
+        )
+    }
+
+    func testDemandJustAheadOfCursorRidesThrough() {
+        let id = UUID()
+        let streams = [snapshot(id: id, cursor: 10_000_000, order: 1)]
+
+        XCTAssertEqual(
+            PlaybackOriginStreamPolicy.action(demandOffset: 10_000_000, streams: streams),
+            .rideThrough(id)
+        )
+        XCTAssertEqual(
+            PlaybackOriginStreamPolicy.action(
+                demandOffset: 10_000_000 + PlaybackOriginStreamPolicy.rideThroughBytes,
+                streams: streams
+            ),
+            .rideThrough(id)
+        )
+    }
+
+    func testDemandBehindCursorNeverRidesThrough() {
+        // Bytes behind a cursor will never arrive on that stream; a miss
+        // there means the cache evicted them and a connection must move.
+        let streams = [snapshot(cursor: 50_000_000, order: 1)]
+
+        XCTAssertEqual(
+            PlaybackOriginStreamPolicy.action(demandOffset: 10_000_000, streams: streams),
+            .spawn
+        )
+    }
+
+    func testFarDemandSpawnsSecondStreamThenRetargetsLeastRecent() {
+        let a = UUID()
+        let b = UUID()
+        let one = [snapshot(id: a, cursor: 1_000_000, order: 1)]
+        XCTAssertEqual(
+            PlaybackOriginStreamPolicy.action(demandOffset: 900_000_000, streams: one),
+            .spawn
+        )
+
+        let two = [
+            snapshot(id: a, cursor: 1_000_000, order: 1),
+            snapshot(id: b, start: 900_000_000, cursor: 901_000_000, order: 2),
+        ]
+        XCTAssertEqual(
+            PlaybackOriginStreamPolicy.action(demandOffset: 500_000_000, streams: two),
+            .retarget(a)
+        )
+    }
+
+    func testNoStreamsSpawns() {
+        XCTAssertEqual(PlaybackOriginStreamPolicy.action(demandOffset: 0, streams: []), .spawn)
+    }
+
+    func testCoveringStreamPrefersNearestRegionStart() {
+        let head = UUID()
+        let tail = UUID()
+        let streams = [
+            snapshot(id: head, start: 0, cursor: 30_000_000, order: 1),
+            snapshot(id: tail, start: 900_000_000, cursor: 910_000_000, order: 2),
+        ]
+
+        XCTAssertEqual(
+            PlaybackOriginStreamPolicy.coveringStream(offset: 10_000_000, streams: streams),
+            head
+        )
+        XCTAssertEqual(
+            PlaybackOriginStreamPolicy.coveringStream(offset: 905_000_000, streams: streams),
+            tail
+        )
+        XCTAssertNil(
+            PlaybackOriginStreamPolicy.coveringStream(offset: 500_000_000, streams: streams)
+        )
+    }
+
+    func testPrimaryStreamPausesOnlyOnGlobalBudget() {
+        XCTAssertFalse(
+            PlaybackOriginStreamPolicy.shouldPause(
+                writeCursor: 500_000_000,
+                demandMark: 0,
+                isMostRecentlyDemanded: true,
+                globalBudgetAvailable: true
+            )
+        )
+        XCTAssertTrue(
+            PlaybackOriginStreamPolicy.shouldPause(
+                writeCursor: 500_000_000,
+                demandMark: 499_000_000,
+                isMostRecentlyDemanded: true,
+                globalBudgetAvailable: false
+            )
+        )
+    }
+
+    func testSecondaryStreamPausesAtForwardCap() {
+        XCTAssertFalse(
+            PlaybackOriginStreamPolicy.shouldPause(
+                writeCursor: 10_000_000,
+                demandMark: 0,
+                isMostRecentlyDemanded: false,
+                globalBudgetAvailable: true
+            )
+        )
+        XCTAssertTrue(
+            PlaybackOriginStreamPolicy.shouldPause(
+                writeCursor: PlaybackOriginStreamPolicy.secondaryForwardCapBytes,
+                demandMark: 0,
+                isMostRecentlyDemanded: false,
+                globalBudgetAvailable: true
+            )
+        )
+    }
+}
+
+final class PlaybackOriginReconnectPolicyTests: XCTestCase {
+    func testBackoffDoublesAndCaps() {
+        XCTAssertEqual(PlaybackOriginReconnectPolicy.backoffSeconds(streak: 0), 0.5)
+        XCTAssertEqual(PlaybackOriginReconnectPolicy.backoffSeconds(streak: 1), 1.0)
+        XCTAssertEqual(PlaybackOriginReconnectPolicy.backoffSeconds(streak: 2), 2.0)
+        XCTAssertEqual(PlaybackOriginReconnectPolicy.backoffSeconds(streak: 10), 8.0)
+    }
+
+    func testProductiveConnectionsExtendNetworkRetries() {
+        // A link that has delivered real bytes gets 8 attempts before the
+        // player is torn down; one that never produced anything gets 4.
+        XCTAssertEqual(
+            PlaybackOriginReconnectPolicy.decide(cause: .network, unproductiveStreak: 7, everProductive: true),
+            .retry(afterSeconds: 8.0)
+        )
+        XCTAssertEqual(
+            PlaybackOriginReconnectPolicy.decide(cause: .network, unproductiveStreak: 8, everProductive: true),
+            .giveUp
+        )
+        XCTAssertEqual(
+            PlaybackOriginReconnectPolicy.decide(cause: .network, unproductiveStreak: 4, everProductive: false),
+            .giveUp
+        )
+    }
+
+    func testHttpOutageRetriesBeforeGivingUp() {
+        XCTAssertEqual(
+            PlaybackOriginReconnectPolicy.decide(cause: .httpOutage(503), unproductiveStreak: 0, everProductive: false),
+            .retry(afterSeconds: 0.5)
+        )
+        XCTAssertEqual(
+            PlaybackOriginReconnectPolicy.decide(cause: .httpOutage(503), unproductiveStreak: 4, everProductive: true),
+            .giveUp
+        )
+    }
+
+    func testFatalCausesGetSingleRetry() {
+        XCTAssertEqual(
+            PlaybackOriginReconnectPolicy.decide(cause: .httpFatal(500), unproductiveStreak: 0, everProductive: true),
+            .retry(afterSeconds: 0.5)
+        )
+        XCTAssertEqual(
+            PlaybackOriginReconnectPolicy.decide(cause: .httpFatal(500), unproductiveStreak: 1, everProductive: true),
+            .giveUp
+        )
+        XCTAssertEqual(
+            PlaybackOriginReconnectPolicy.decide(cause: .rangeIgnored, unproductiveStreak: 1, everProductive: true),
+            .giveUp
+        )
+    }
+
+    func testContentRangeParsing() {
+        XCTAssertEqual(PlaybackOriginStream.totalLength(fromContentRange: "bytes 100-499/12345"), 12_345)
+        XCTAssertNil(PlaybackOriginStream.totalLength(fromContentRange: "bytes 100-499/*"))
+        XCTAssertNil(PlaybackOriginStream.totalLength(fromContentRange: nil))
+        XCTAssertEqual(PlaybackOriginStream.rangeStart(fromContentRange: "bytes 100-499/12345"), 100)
+        XCTAssertNil(PlaybackOriginStream.rangeStart(fromContentRange: "garbage"))
+    }
+}
+
+final class PlaybackSourceCacheStreamingAppendTests: XCTestCase {
+    func testAdjacentStoresGrowOneSpanAndReadAcrossBoundary() {
+        let cache = PlaybackSourceCache(maxBytes: 8 * 1024 * 1024)
+        cache.store(start: 0, data: Data(repeating: 1, count: 1024), totalLength: nil)
+        cache.store(start: 1024, data: Data(repeating: 2, count: 1024), totalLength: nil)
+
+        let across = cache.read(start: 512, maxLength: 1024)
+        XCTAssertEqual(across?.count, 1024)
+        XCTAssertEqual(across?.first, 1)
+        XCTAssertEqual(across?.last, 2)
+    }
+
+    func testNonAdjacentStoresStaySeparate() {
+        let cache = PlaybackSourceCache(maxBytes: 8 * 1024 * 1024)
+        cache.store(start: 0, data: Data(repeating: 1, count: 1024), totalLength: nil)
+        cache.store(start: 4096, data: Data(repeating: 2, count: 1024), totalLength: nil)
+
+        XCTAssertNil(cache.read(start: 2048, maxLength: 16))
+        XCTAssertTrue(cache.contains(offset: 0))
+        XCTAssertTrue(cache.contains(offset: 4096))
+        XCTAssertFalse(cache.contains(offset: 2048))
+        // A read at the first span still stops at its end.
+        XCTAssertEqual(cache.read(start: 1000, maxLength: 4096)?.count, 24)
+    }
+
+    func testOverlappingStoreStillMerges() {
+        let cache = PlaybackSourceCache(maxBytes: 8 * 1024 * 1024)
+        cache.store(start: 0, data: Data(repeating: 1, count: 1024), totalLength: nil)
+        cache.store(start: 512, data: Data(repeating: 2, count: 1024), totalLength: nil)
+
+        let merged = cache.read(start: 0, maxLength: 1536)
+        XCTAssertEqual(merged?.count, 1536)
+        XCTAssertEqual(merged?[0], 1)
+        XCTAssertEqual(merged?[600], 2)
+        XCTAssertEqual(merged?[1535], 2)
+    }
+}

--- a/iosApp/Tests/PlaybackOriginStreamPolicyTests.swift
+++ b/iosApp/Tests/PlaybackOriginStreamPolicyTests.swift
@@ -7,13 +7,15 @@ final class PlaybackOriginStreamPolicyTests: XCTestCase {
         id: UUID = UUID(),
         start: Int64 = 0,
         cursor: Int64,
-        order: UInt64
+        order: UInt64,
+        age: TimeInterval = .infinity
     ) -> PlaybackOriginStreamPolicy.StreamSnapshot {
         PlaybackOriginStreamPolicy.StreamSnapshot(
             id: id,
             startOffset: start,
             writeCursor: cursor,
-            lastDemandOrder: order
+            lastDemandOrder: order,
+            secondsSinceTargeted: age
         )
     }
 
@@ -68,6 +70,50 @@ final class PlaybackOriginStreamPolicyTests: XCTestCase {
         XCTAssertEqual(PlaybackOriginStreamPolicy.action(demandOffset: 0, streams: []), .spawn)
     }
 
+    func testDemandWaitsWhenEveryStreamIsStillConnecting() {
+        // Neither stream has delivered since its last (re)target and neither
+        // has aged out: retargeting one would kill a connection before its
+        // first byte — with three demand regions and two slots that cycle
+        // livelocks. The demand must wait instead.
+        let fresh = [
+            snapshot(start: 0, cursor: 0, order: 1, age: 0),
+            snapshot(start: 900_000_000, cursor: 900_000_000, order: 2, age: 0),
+        ]
+        XCTAssertEqual(
+            PlaybackOriginStreamPolicy.action(demandOffset: 500_000_000, streams: fresh),
+            .wait
+        )
+    }
+
+    func testDeliveredStreamIsTheRetargetVictimOverAFresherOne() {
+        // Only the stream that has delivered since its target is eligible,
+        // even though the still-connecting one is less recently demanded.
+        let connecting = UUID()
+        let delivered = UUID()
+        let streams = [
+            snapshot(id: connecting, start: 0, cursor: 0, order: 1, age: 0),
+            snapshot(id: delivered, start: 900_000_000, cursor: 901_000_000, order: 2, age: 0),
+        ]
+        XCTAssertEqual(
+            PlaybackOriginStreamPolicy.action(demandOffset: 500_000_000, streams: streams),
+            .retarget(delivered)
+        )
+    }
+
+    func testGracePeriodMakesAWedgedStreamRetargetable() {
+        // A connection that opens but never produces must not block
+        // retargets forever; after the grace period it becomes a victim.
+        let wedged = UUID()
+        let streams = [
+            snapshot(id: wedged, start: 0, cursor: 0, order: 1, age: PlaybackOriginStreamPolicy.retargetGraceSeconds),
+            snapshot(start: 900_000_000, cursor: 900_000_000, order: 2, age: 0),
+        ]
+        XCTAssertEqual(
+            PlaybackOriginStreamPolicy.action(demandOffset: 500_000_000, streams: streams),
+            .retarget(wedged)
+        )
+    }
+
     func testCoveringStreamPrefersNearestRegionStart() {
         let head = UUID()
         let tail = UUID()
@@ -103,6 +149,28 @@ final class PlaybackOriginStreamPolicyTests: XCTestCase {
                 writeCursor: 500_000_000,
                 demandMark: 499_000_000,
                 isMostRecentlyDemanded: true,
+                globalBudgetAvailable: false
+            )
+        )
+    }
+
+    func testBlockedDemandAtCursorOverridesBudgetPark() {
+        // A demand at or ahead of the cursor is blocked on bytes only this
+        // connection will deliver; a full readahead budget must not park it
+        // (the budget frees through reads, and the read is what's blocked).
+        XCTAssertFalse(
+            PlaybackOriginStreamPolicy.shouldPause(
+                writeCursor: 500_000_000,
+                demandMark: 500_000_000,
+                isMostRecentlyDemanded: true,
+                globalBudgetAvailable: false
+            )
+        )
+        XCTAssertFalse(
+            PlaybackOriginStreamPolicy.shouldPause(
+                writeCursor: 500_000_000,
+                demandMark: 502_000_000,
+                isMostRecentlyDemanded: false,
                 globalBudgetAvailable: false
             )
         )

--- a/iosApp/Tests/PlaybackSourcePrefetchPolicyTests.swift
+++ b/iosApp/Tests/PlaybackSourcePrefetchPolicyTests.swift
@@ -17,30 +17,4 @@ final class PlaybackSourcePrefetchPolicyTests: XCTestCase {
         XCTAssertEqual(PlaybackSourcePrefetchPolicy.initialOffset(sourceStartTimeSeconds: 12, sourceBitrateBps: nil), 0)
         XCTAssertEqual(PlaybackSourcePrefetchPolicy.initialOffset(sourceStartTimeSeconds: .nan, sourceBitrateBps: 92_633_000), 0)
     }
-
-    func testRetargetsOnlyFarAwayPrefetches() {
-        let chunkBytes = 8 * 1024 * 1024
-
-        XCTAssertFalse(
-            PlaybackSourcePrefetchPolicy.shouldRetargetPrefetch(
-                activeStart: 0,
-                requestedStart: Int64(chunkBytes),
-                chunkBytes: chunkBytes
-            )
-        )
-        XCTAssertFalse(
-            PlaybackSourcePrefetchPolicy.shouldRetargetPrefetch(
-                activeStart: 0,
-                requestedStart: Int64(chunkBytes * 2),
-                chunkBytes: chunkBytes
-            )
-        )
-        XCTAssertTrue(
-            PlaybackSourcePrefetchPolicy.shouldRetargetPrefetch(
-                activeStart: 0,
-                requestedStart: Int64(chunkBytes * 2 + 1),
-                chunkBytes: chunkBytes
-            )
-        )
-    }
 }

--- a/iosApp/Tests/PlaybackSourceResponseEndTests.swift
+++ b/iosApp/Tests/PlaybackSourceResponseEndTests.swift
@@ -85,6 +85,21 @@ final class PlaybackSourceResponseEndTests: XCTestCase {
         XCTAssertEqual(cause, .complete)
     }
 
+    func testRangePromisingPastRealEOFIsComplete() {
+        // An exact range issued while the total was still unknown can
+        // promise bytes past the real EOF; reaching the true end must
+        // classify as complete once the total is known.
+        let cause = PlaybackSourceResponseEnd.classify(
+            cursor: 1000,
+            responseEnd: 1999,
+            totalLength: 1000,
+            wasCancelled: false,
+            sawEmptyFetch: true,
+            sawFetchError: false
+        )
+        XCTAssertEqual(cause, .complete)
+    }
+
     func testExpectedEndFallsBackToTotalLength() {
         let cause = PlaybackSourceResponseEnd.classify(
             cursor: 100,

--- a/iosApp/iosApp/Screens/Player/PlaybackSourceOriginStream.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSourceOriginStream.swift
@@ -1,0 +1,700 @@
+import Foundation
+import OSLog
+
+/// Routing decisions for byte demands across the (at most two) live origin
+/// streams. Pure so ride-through/spawn/retarget behavior is testable.
+///
+/// Why streams instead of ranged chunks: a strictly sequential range-chunk
+/// fetcher pays one RTT of dead air plus a fresh TCP slow-start per chunk, so
+/// effective throughput collapses on high-latency links even when raw
+/// bandwidth is plentiful (gigabit fiber at 150 ms RTT delivered ~14 Mbps).
+/// A long-lived open-ended range GET pays slow-start once and then rides the
+/// congestion window at line rate, which is what ordinary direct-play clients
+/// do. Two stream slots exist so the matroska open pattern (head probe ↔ cues
+/// at tail) and demuxer recycling never churn the warm playback connection.
+enum PlaybackOriginStreamPolicy {
+    struct StreamSnapshot: Equatable {
+        let id: UUID
+        let startOffset: Int64
+        let writeCursor: Int64
+        let lastDemandOrder: UInt64
+    }
+
+    enum Action: Equatable {
+        /// Demand is at or just ahead of this stream's cursor; wait for it.
+        case rideThrough(UUID)
+        case spawn
+        case retarget(UUID)
+    }
+
+    /// A miss this close ahead of a live cursor waits for the stream instead
+    /// of opening a new connection.
+    static let rideThroughBytes: Int64 = 8 * 1024 * 1024
+    static let maxStreams = 2
+    /// A stream that is not the most recently demanded stops filling once it
+    /// is this far past the last offset anything asked it for.
+    static let secondaryForwardCapBytes: Int64 = 16 * 1024 * 1024
+
+    static func action(demandOffset: Int64, streams: [StreamSnapshot]) -> Action {
+        if let covered = streams.first(where: {
+            demandOffset >= $0.writeCursor && demandOffset - $0.writeCursor <= rideThroughBytes
+        }) {
+            return .rideThrough(covered.id)
+        }
+        if streams.count < maxStreams {
+            return .spawn
+        }
+        guard let victim = streams.min(by: { $0.lastDemandOrder < $1.lastDemandOrder }) else {
+            return .spawn
+        }
+        return .retarget(victim.id)
+    }
+
+    /// The stream whose fetch region contains `offset`, for demand hints
+    /// from cached reads. Prefers the nearest region start so a tail stream
+    /// never absorbs demand that belongs to the playback stream.
+    static func coveringStream(offset: Int64, streams: [StreamSnapshot]) -> UUID? {
+        streams
+            .filter { offset >= $0.startOffset && offset <= $0.writeCursor + rideThroughBytes }
+            .max(by: { $0.startOffset < $1.startOffset })?
+            .id
+    }
+
+    static func shouldPause(
+        writeCursor: Int64,
+        demandMark: Int64,
+        isMostRecentlyDemanded: Bool,
+        globalBudgetAvailable: Bool
+    ) -> Bool {
+        if !globalBudgetAvailable { return true }
+        if isMostRecentlyDemanded { return false }
+        return writeCursor - demandMark >= secondaryForwardCapBytes
+    }
+}
+
+/// Retry/give-up decisions for a dropped origin connection. Transient WAN
+/// errors (radio blips, one RST, a server restart) must reconnect quietly at
+/// the write cursor instead of tearing playback down — with a full forward
+/// cache the user never notices. Progress-aware: only connections that
+/// delivered fewer than `productiveBytesFloor` bytes count toward the streak,
+/// so a link that keeps limping forward never gives up.
+enum PlaybackOriginReconnectPolicy {
+    static let productiveBytesFloor: Int64 = 512 * 1024
+    /// No bytes for this long on an unparked connection means the transfer is
+    /// wedged (half-open socket, hung origin) and it should be reconnected.
+    static let stallSeconds: TimeInterval = 20
+
+    enum EndCause: Equatable {
+        case network
+        case stalled
+        case httpOutage(Int)
+        case httpFatal(Int)
+        case prematureEOF
+        case rangeIgnored
+    }
+
+    enum Decision: Equatable {
+        case retry(afterSeconds: Double)
+        case giveUp
+    }
+
+    static func decide(cause: EndCause, unproductiveStreak: Int, everProductive: Bool) -> Decision {
+        let cap: Int
+        switch cause {
+        case .network, .stalled:
+            cap = everProductive ? 8 : 4
+        case .httpOutage:
+            cap = 4
+        case .httpFatal, .rangeIgnored:
+            cap = 1
+        case .prematureEOF:
+            cap = 3
+        }
+        guard unproductiveStreak < cap else { return .giveUp }
+        return .retry(afterSeconds: backoffSeconds(streak: unproductiveStreak))
+    }
+
+    static func backoffSeconds(streak: Int) -> Double {
+        min(8.0, 0.5 * pow(2.0, Double(max(0, streak))))
+    }
+}
+
+/// One long-lived streaming origin connection: an open-ended
+/// `Range: bytes=<cursor>-` GET whose body is stored into the span cache
+/// incrementally as each URLSession delivery arrives. Throttling is
+/// suspend-based: when the owner reports the readahead budget is full the
+/// data task is suspended, TCP flow control parks the connection server-side,
+/// and resume is instant — the connection is never closed and re-requested.
+final class PlaybackOriginStream {
+    struct Callbacks {
+        /// Invoked on the session delegate queue after bytes are stored.
+        let didStore: (PlaybackOriginStream, ClosedRange<Int64>) -> Void
+        /// First response headers for a connection (total length if known).
+        let didReceiveResponse: (PlaybackOriginStream, Int64?) -> Void
+        let didDetectSessionMissing: (PlaybackOriginStream) -> Void
+        let didFinish: (PlaybackOriginStream) -> Void
+        let didGiveUp: (PlaybackOriginStream, PlaybackOriginReconnectPolicy.EndCause, Int?) -> Void
+        /// Budget/park decision; called with the stream's current cursor and
+        /// demand mark, outside the stream's internal lock.
+        let mayContinueFilling: (PlaybackOriginStream, Int64, Int64) -> Bool
+        let store: (Int64, Data, Int64?) -> Void
+    }
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.continuum.app",
+        category: "PlaybackOriginStream"
+    )
+
+    let id = UUID()
+    private let originURL: URL
+    private let originHeaders: [String: String]
+    private let callbacks: Callbacks
+
+    private let lock = NSLock()
+    private var generation: UInt64 = 0
+    private var startOffset: Int64
+    private var writeCursor: Int64
+    private var demandMark: Int64
+    private var demandOrder: UInt64
+    private var parked = false
+    private var cancelled = false
+    private var finished = false
+    private var session: URLSession?
+    private var task: URLSessionDataTask?
+    private var reconnectTask: Task<Void, Never>?
+    private var watchdogTask: Task<Void, Never>?
+    private var lastDataAt = Date()
+    private var bytesSinceConnect: Int64 = 0
+    private var everProductive = false
+    private var unproductiveStreak = 0
+    private var knownTotalLength: Int64?
+    private var responseValidatedForGeneration: UInt64?
+    private var errorBody = Data()
+    private var errorStatusCode: Int?
+
+    init(
+        originURL: URL,
+        originHeaders: [String: String],
+        startOffset: Int64,
+        demandOrder: UInt64,
+        callbacks: Callbacks
+    ) {
+        self.originURL = originURL
+        self.originHeaders = originHeaders
+        self.startOffset = startOffset
+        self.writeCursor = startOffset
+        self.demandMark = startOffset
+        self.demandOrder = demandOrder
+        self.callbacks = callbacks
+    }
+
+    deinit {
+        // Backstop: a stream dropped without cancel() would otherwise leave
+        // its URLSession (which retains itself until invalidated) pulling
+        // the file into a deallocated delegate forever.
+        cancel()
+    }
+
+    func snapshot() -> PlaybackOriginStreamPolicy.StreamSnapshot {
+        lock.lock()
+        defer { lock.unlock() }
+        return PlaybackOriginStreamPolicy.StreamSnapshot(
+            id: id,
+            startOffset: startOffset,
+            writeCursor: writeCursor,
+            lastDemandOrder: demandOrder
+        )
+    }
+
+    var currentDemandOrder: UInt64 {
+        lock.lock()
+        defer { lock.unlock() }
+        return demandOrder
+    }
+
+    var isFinished: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return finished
+    }
+
+    func start() {
+        openConnection()
+        startWatchdog()
+    }
+
+    func cancel() {
+        lock.lock()
+        cancelled = true
+        generation &+= 1
+        let session = self.session
+        self.session = nil
+        self.task = nil
+        let reconnect = reconnectTask
+        reconnectTask = nil
+        let watchdog = watchdogTask
+        watchdogTask = nil
+        lock.unlock()
+        session?.invalidateAndCancel()
+        reconnect?.cancel()
+        watchdog?.cancel()
+    }
+
+    /// Repoint this stream at a new offset (seek/demand moved outside every
+    /// stream's coverage). Reconnects immediately; reconnect bookkeeping
+    /// resets because this is a new region, not a failing one. Returns
+    /// false if the stream already finished or gave up — a terminal stream
+    /// must never be revived, because its removal from the owner's pool is
+    /// already in flight and a revived connection would leak.
+    @discardableResult
+    func retarget(to offset: Int64, order: UInt64) -> Bool {
+        lock.lock()
+        guard !cancelled, !finished else {
+            lock.unlock()
+            return false
+        }
+        generation &+= 1
+        let oldSession = session
+        session = nil
+        task = nil
+        let reconnect = reconnectTask
+        reconnectTask = nil
+        startOffset = offset
+        writeCursor = offset
+        demandMark = offset
+        demandOrder = order
+        parked = false
+        bytesSinceConnect = 0
+        unproductiveStreak = 0
+        lock.unlock()
+        oldSession?.invalidateAndCancel()
+        reconnect?.cancel()
+        openConnection()
+        startWatchdog()
+        return true
+    }
+
+    /// Record a demand landing in this stream's region and unpark if the
+    /// budget allows.
+    func noteDemand(offset: Int64, order: UInt64) {
+        lock.lock()
+        demandMark = max(demandMark, max(startOffset, offset))
+        demandOrder = max(demandOrder, order)
+        lock.unlock()
+        resumeFillingIfNeeded()
+    }
+
+    func resumeFillingIfNeeded() {
+        lock.lock()
+        let shouldConsider = parked && !cancelled && !finished
+        let cursor = writeCursor
+        let mark = demandMark
+        lock.unlock()
+        guard shouldConsider else { return }
+        guard callbacks.mayContinueFilling(self, cursor, mark) else { return }
+        lock.lock()
+        if parked, !cancelled {
+            parked = false
+            task?.resume()
+        }
+        lock.unlock()
+    }
+
+    // MARK: - Connection lifecycle
+
+    private func openConnection() {
+        lock.lock()
+        guard !cancelled, !finished else {
+            lock.unlock()
+            return
+        }
+        generation &+= 1
+        let gen = generation
+        let cursor = writeCursor
+        let oldSession = session
+        parked = false
+        bytesSinceConnect = 0
+        lastDataAt = Date()
+        responseValidatedForGeneration = nil
+        errorBody.removeAll(keepingCapacity: false)
+        errorStatusCode = nil
+
+        let config = URLSessionConfiguration.ephemeral
+        config.requestCachePolicy = .reloadIgnoringLocalCacheData
+        config.urlCache = nil
+        config.httpMaximumConnectionsPerHost = 2
+        // The long-lived request is paused via task suspension for
+        // arbitrarily long stretches; the idle-based request timeout must
+        // never fire underneath it. Wedged transfers are detected by the
+        // stall watchdog instead.
+        config.timeoutIntervalForRequest = 3600
+        let delegateQueue = OperationQueue()
+        delegateQueue.maxConcurrentOperationCount = 1
+        delegateQueue.qualityOfService = .userInitiated
+        let delegate = ConnectionDelegate(stream: self, generation: gen)
+        let newSession = URLSession(configuration: config, delegate: delegate, delegateQueue: delegateQueue)
+
+        var request = URLRequest(url: originURL)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 3600
+        for (key, value) in originHeaders {
+            request.setValue(value, forHTTPHeaderField: key)
+        }
+        request.setValue("bytes=\(cursor)-", forHTTPHeaderField: "Range")
+        let newTask = newSession.dataTask(with: request)
+        session = newSession
+        task = newTask
+        lock.unlock()
+
+        oldSession?.invalidateAndCancel()
+        Self.logger.info("[CMP-SOURCE-CACHE] origin stream connect offset=\(cursor, privacy: .public) gen=\(gen, privacy: .public)")
+        newTask.resume()
+    }
+
+    private func startWatchdog() {
+        lock.lock()
+        guard watchdogTask == nil, !cancelled else {
+            lock.unlock()
+            return
+        }
+        watchdogTask = Task.detached(priority: .utility) { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 5_000_000_000)
+                guard let self else { return }
+                self.reconnectIfStalled()
+            }
+        }
+        lock.unlock()
+    }
+
+    private func reconnectIfStalled() {
+        lock.lock()
+        let stalled = !cancelled && !finished && !parked && session != nil
+            && Date().timeIntervalSince(lastDataAt) > PlaybackOriginReconnectPolicy.stallSeconds
+        lock.unlock()
+        guard stalled else { return }
+        Self.logger.warning("[CMP-SOURCE-CACHE] origin stream stalled; reconnecting cursor=\(self.snapshot().writeCursor, privacy: .public)")
+        connectionEnded(generation: currentGeneration(), cause: .stalled, statusCode: nil)
+    }
+
+    private func currentGeneration() -> UInt64 {
+        lock.lock()
+        defer { lock.unlock() }
+        return generation
+    }
+
+    // MARK: - Delegate plumbing (called on the session delegate queue)
+
+    fileprivate func handleResponse(_ response: URLResponse, generation gen: UInt64) -> Bool {
+        guard let http = response as? HTTPURLResponse else {
+            connectionEnded(generation: gen, cause: .network, statusCode: nil)
+            return false
+        }
+        lock.lock()
+        guard gen == generation, !cancelled else {
+            lock.unlock()
+            return false
+        }
+        let cursor = writeCursor
+        lock.unlock()
+
+        switch http.statusCode {
+        case 206:
+            let total = Self.totalLength(fromContentRange: http.value(forHTTPHeaderField: "Content-Range"))
+            if let rangeStart = Self.rangeStart(fromContentRange: http.value(forHTTPHeaderField: "Content-Range")),
+               rangeStart != cursor {
+                Self.logger.warning("[CMP-SOURCE-CACHE] origin stream range mismatch expected=\(cursor, privacy: .public) got=\(rangeStart, privacy: .public)")
+                connectionEnded(generation: gen, cause: .rangeIgnored, statusCode: http.statusCode)
+                return false
+            }
+            noteResponse(total: total, generation: gen)
+            return true
+        case 200 where cursor == 0:
+            let total = http.expectedContentLength > 0 ? http.expectedContentLength : nil
+            noteResponse(total: total, generation: gen)
+            return true
+        case 200:
+            // The origin ignored the Range header; accepting the body would
+            // silently corrupt the cache with head bytes at a nonzero offset.
+            connectionEnded(generation: gen, cause: .rangeIgnored, statusCode: 200)
+            return false
+        case 416:
+            // Requested past the end. If the origin tells us the real total,
+            // learn it and finish cleanly so waiters re-drive to EOF.
+            if let total = Self.totalLength(fromContentRange: http.value(forHTTPHeaderField: "Content-Range")) {
+                noteResponse(total: total, generation: gen)
+                finishStream(expectedGeneration: gen)
+                return false
+            }
+            connectionEnded(generation: gen, cause: .httpFatal(416), statusCode: 416)
+            return false
+        default:
+            // Keep the (small) error body so session-missing 404s can be
+            // classified at completion.
+            lock.lock()
+            errorStatusCode = http.statusCode
+            lock.unlock()
+            return true
+        }
+    }
+
+    private func noteResponse(total: Int64?, generation gen: UInt64) {
+        lock.lock()
+        guard gen == generation else {
+            lock.unlock()
+            return
+        }
+        responseValidatedForGeneration = gen
+        if let total { knownTotalLength = total }
+        lock.unlock()
+        callbacks.didReceiveResponse(self, total)
+    }
+
+    fileprivate func handleData(_ data: Data, generation gen: UInt64) {
+        lock.lock()
+        guard gen == generation, !cancelled else {
+            lock.unlock()
+            return
+        }
+        if errorStatusCode != nil {
+            if errorBody.count < 4096 {
+                errorBody.append(data.prefix(4096 - errorBody.count))
+            }
+            lock.unlock()
+            return
+        }
+        guard responseValidatedForGeneration == gen else {
+            lock.unlock()
+            return
+        }
+        let start = writeCursor
+        writeCursor += Int64(data.count)
+        let cursor = writeCursor
+        let mark = demandMark
+        lastDataAt = Date()
+        bytesSinceConnect += Int64(data.count)
+        if bytesSinceConnect >= PlaybackOriginReconnectPolicy.productiveBytesFloor {
+            everProductive = true
+            unproductiveStreak = 0
+        }
+        let total = knownTotalLength
+        lock.unlock()
+
+        callbacks.store(start, data, total)
+        callbacks.didStore(self, start...(cursor - 1))
+
+        if let total, cursor >= total {
+            finishStream(expectedGeneration: gen)
+            return
+        }
+        if !callbacks.mayContinueFilling(self, cursor, mark) {
+            lock.lock()
+            let didPark = !parked && !cancelled && gen == generation
+            if didPark {
+                // Suspend while still holding the lock so `parked` and the
+                // task state can never be observed inconsistent: a resume
+                // racing this park would otherwise fire against a
+                // still-running task (no-op) and be lost.
+                parked = true
+                task?.suspend()
+            }
+            lock.unlock()
+            if didPark {
+                // A demand may have raised the mark between the decision
+                // above and the park; its unpark attempt saw parked ==
+                // false and did nothing. Re-run the decision with fresh
+                // marks so that demand is honored.
+                resumeFillingIfNeeded()
+            }
+        }
+    }
+
+    fileprivate func handleCompletion(error: Error?, generation gen: UInt64) {
+        lock.lock()
+        guard gen == generation, !cancelled, !finished else {
+            lock.unlock()
+            return
+        }
+        let status = errorStatusCode
+        let body = String(data: errorBody, encoding: .utf8)
+        let cursor = writeCursor
+        let total = knownTotalLength
+        lock.unlock()
+
+        if let status {
+            if Self.isPlaybackSessionMissing(statusCode: status, body: body) {
+                callbacks.didDetectSessionMissing(self)
+                giveUp(cause: .httpFatal(status), statusCode: status, expectedGeneration: gen)
+                return
+            }
+            let cause: PlaybackOriginReconnectPolicy.EndCause =
+                [502, 503, 504].contains(status) ? .httpOutage(status) : .httpFatal(status)
+            connectionEnded(generation: gen, cause: cause, statusCode: status)
+            return
+        }
+        if let error {
+            if (error as NSError).domain == NSURLErrorDomain,
+               (error as NSError).code == NSURLErrorCancelled {
+                return
+            }
+            connectionEnded(generation: gen, cause: .network, statusCode: nil)
+            return
+        }
+        // Clean close. Either we reached the promised end or the origin
+        // stopped early.
+        if let total, cursor >= total {
+            finishStream(expectedGeneration: gen)
+            return
+        }
+        connectionEnded(generation: gen, cause: .prematureEOF, statusCode: nil)
+    }
+
+    private func finishStream(expectedGeneration: UInt64) {
+        lock.lock()
+        guard generation == expectedGeneration, !finished, !cancelled else {
+            lock.unlock()
+            return
+        }
+        finished = true
+        generation &+= 1
+        let session = self.session
+        self.session = nil
+        self.task = nil
+        let watchdog = watchdogTask
+        watchdogTask = nil
+        lock.unlock()
+        session?.invalidateAndCancel()
+        watchdog?.cancel()
+        callbacks.didFinish(self)
+    }
+
+    private func connectionEnded(
+        generation gen: UInt64,
+        cause: PlaybackOriginReconnectPolicy.EndCause,
+        statusCode: Int?
+    ) {
+        lock.lock()
+        guard gen == generation, !cancelled, !finished else {
+            lock.unlock()
+            return
+        }
+        generation &+= 1
+        let newGeneration = generation
+        let oldSession = session
+        session = nil
+        task = nil
+        parked = false
+        if bytesSinceConnect < PlaybackOriginReconnectPolicy.productiveBytesFloor {
+            unproductiveStreak += 1
+        } else {
+            unproductiveStreak = 0
+        }
+        let streak = unproductiveStreak
+        let productive = everProductive
+        lock.unlock()
+        oldSession?.invalidateAndCancel()
+
+        // The streak was already advanced for this failure; decide() gets the
+        // pre-failure count so caps mean "attempts before giving up".
+        switch PlaybackOriginReconnectPolicy.decide(
+            cause: cause,
+            unproductiveStreak: streak - 1,
+            everProductive: productive
+        ) {
+        case .giveUp:
+            giveUp(cause: cause, statusCode: statusCode, expectedGeneration: newGeneration)
+        case .retry(let delay):
+            Self.logger.info("[CMP-SOURCE-CACHE] origin stream reconnect in \(delay, privacy: .public)s cause=\(String(describing: cause), privacy: .public) streak=\(streak, privacy: .public)")
+            lock.lock()
+            reconnectTask?.cancel()
+            reconnectTask = Task.detached(priority: .userInitiated) { [weak self] in
+                try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                guard !Task.isCancelled else { return }
+                self?.openConnection()
+            }
+            lock.unlock()
+        }
+    }
+
+    private func giveUp(
+        cause: PlaybackOriginReconnectPolicy.EndCause,
+        statusCode: Int?,
+        expectedGeneration: UInt64
+    ) {
+        lock.lock()
+        guard generation == expectedGeneration, !cancelled, !finished else {
+            lock.unlock()
+            return
+        }
+        finished = true
+        generation &+= 1
+        let session = self.session
+        self.session = nil
+        self.task = nil
+        let watchdog = watchdogTask
+        watchdogTask = nil
+        lock.unlock()
+        session?.invalidateAndCancel()
+        watchdog?.cancel()
+        Self.logger.warning("[CMP-SOURCE-CACHE] origin stream gave up cause=\(String(describing: cause), privacy: .public)")
+        callbacks.didGiveUp(self, cause, statusCode)
+    }
+
+    // MARK: - Parsing helpers
+
+    static func totalLength(fromContentRange header: String?) -> Int64? {
+        guard let header, let slash = header.lastIndex(of: "/") else { return nil }
+        let suffix = header[header.index(after: slash)...]
+        guard suffix != "*", let total = Int64(suffix) else { return nil }
+        return total
+    }
+
+    static func rangeStart(fromContentRange header: String?) -> Int64? {
+        guard let header else { return nil }
+        // "bytes 123-456/789"
+        guard let spaceIdx = header.firstIndex(of: " ") else { return nil }
+        let afterUnit = header[header.index(after: spaceIdx)...]
+        guard let dash = afterUnit.firstIndex(of: "-") else { return nil }
+        return Int64(afterUnit[..<dash])
+    }
+
+    static func isPlaybackSessionMissing(statusCode: Int, body: String?) -> Bool {
+        guard statusCode == 404 else { return false }
+        let text = body ?? ""
+        return text.contains("playback_session_not_found")
+            || text.contains("Playback session not found")
+    }
+
+    // MARK: - URLSession delegate bridge
+
+    private final class ConnectionDelegate: NSObject, URLSessionDataDelegate {
+        private weak var stream: PlaybackOriginStream?
+        private let generation: UInt64
+
+        init(stream: PlaybackOriginStream, generation: UInt64) {
+            self.stream = stream
+            self.generation = generation
+        }
+
+        func urlSession(
+            _ session: URLSession,
+            dataTask: URLSessionDataTask,
+            didReceive response: URLResponse,
+            completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+        ) {
+            guard let stream, stream.handleResponse(response, generation: generation) else {
+                completionHandler(.cancel)
+                return
+            }
+            completionHandler(.allow)
+        }
+
+        func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+            stream?.handleData(data, generation: generation)
+        }
+
+        func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+            stream?.handleCompletion(error: error, generation: generation)
+        }
+    }
+}

--- a/iosApp/iosApp/Screens/Player/PlaybackSourceOriginStream.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSourceOriginStream.swift
@@ -18,6 +18,24 @@ enum PlaybackOriginStreamPolicy {
         let startOffset: Int64
         let writeCursor: Int64
         let lastDemandOrder: UInt64
+        /// Seconds since the stream was last pointed at its current region.
+        /// Together with `writeCursor > startOffset` this decides whether the
+        /// stream may be torn down for a new region.
+        let secondsSinceTargeted: TimeInterval
+
+        init(
+            id: UUID,
+            startOffset: Int64,
+            writeCursor: Int64,
+            lastDemandOrder: UInt64,
+            secondsSinceTargeted: TimeInterval = .infinity
+        ) {
+            self.id = id
+            self.startOffset = startOffset
+            self.writeCursor = writeCursor
+            self.lastDemandOrder = lastDemandOrder
+            self.secondsSinceTargeted = secondsSinceTargeted
+        }
     }
 
     enum Action: Equatable {
@@ -25,6 +43,11 @@ enum PlaybackOriginStreamPolicy {
         case rideThrough(UUID)
         case spawn
         case retarget(UUID)
+        /// Every slot is still connecting (nothing delivered since its last
+        /// (re)target and the grace period has not elapsed). The demand's
+        /// waiter stays registered; it is re-driven when a stream delivers
+        /// its first bytes or leaves the pool.
+        case wait
     }
 
     /// A miss this close ahead of a live cursor waits for the stream instead
@@ -34,18 +57,41 @@ enum PlaybackOriginStreamPolicy {
     /// A stream that is not the most recently demanded stops filling once it
     /// is this far past the last offset anything asked it for.
     static let secondaryForwardCapBytes: Int64 = 16 * 1024 * 1024
+    /// A stream that has not delivered since its last (re)target may still be
+    /// torn down for a new region after this long — the escape hatch for a
+    /// connection that opens but never produces (the stall watchdog and
+    /// reconnect ladder are slower).
+    static let retargetGraceSeconds: TimeInterval = 10
+
+    /// The stream a demand at `offset` can wait on (at or just ahead of a
+    /// live cursor), if any.
+    static func rideThroughTarget(offset: Int64, streams: [StreamSnapshot]) -> UUID? {
+        streams.first(where: {
+            offset >= $0.writeCursor && offset - $0.writeCursor <= rideThroughBytes
+        })?.id
+    }
+
+    /// Whether a stream may be torn down and pointed at a new region: it has
+    /// delivered bytes since its last (re)target, or it has had a full grace
+    /// period to try. Retargeting a still-connecting stream is what livelocks
+    /// with more demand regions than slots — each re-driven waiter kills the
+    /// connection the previous one just opened before its first byte lands.
+    static func isRetargetable(_ stream: StreamSnapshot) -> Bool {
+        stream.writeCursor > stream.startOffset
+            || stream.secondsSinceTargeted >= retargetGraceSeconds
+    }
 
     static func action(demandOffset: Int64, streams: [StreamSnapshot]) -> Action {
-        if let covered = streams.first(where: {
-            demandOffset >= $0.writeCursor && demandOffset - $0.writeCursor <= rideThroughBytes
-        }) {
-            return .rideThrough(covered.id)
+        if let covered = rideThroughTarget(offset: demandOffset, streams: streams) {
+            return .rideThrough(covered)
         }
         if streams.count < maxStreams {
             return .spawn
         }
-        guard let victim = streams.min(by: { $0.lastDemandOrder < $1.lastDemandOrder }) else {
-            return .spawn
+        guard let victim = streams
+            .filter(isRetargetable)
+            .min(by: { $0.lastDemandOrder < $1.lastDemandOrder }) else {
+            return .wait
         }
         return .retarget(victim.id)
     }
@@ -66,6 +112,11 @@ enum PlaybackOriginStreamPolicy {
         isMostRecentlyDemanded: Bool,
         globalBudgetAvailable: Bool
     ) -> Bool {
+        // A demand at or ahead of the cursor is blocked on bytes only this
+        // connection will deliver. Budget pressure must never park it: the
+        // budget frees through reads, and the read is exactly what is
+        // blocked — parking here wedges playback permanently.
+        if demandMark >= writeCursor { return false }
         if !globalBudgetAvailable { return true }
         if isMostRecentlyDemanded { return false }
         return writeCursor - demandMark >= secondaryForwardCapBytes
@@ -137,8 +188,21 @@ final class PlaybackOriginStream {
         /// Budget/park decision; called with the stream's current cursor and
         /// demand mark, outside the stream's internal lock.
         let mayContinueFilling: (PlaybackOriginStream, Int64, Int64) -> Bool
+        /// First byte at or after the given offset that the cache does not
+        /// already hold (nil when everything to the known EOF is cached);
+        /// used to jump the connection over long already-cached runs instead
+        /// of re-downloading them.
+        let nextMissingByte: (Int64) -> Int64?
         let store: (Int64, Data, Int64?) -> Void
     }
+
+    /// While filling, every this many delivered bytes the stream checks
+    /// whether an already-cached run starts at its cursor.
+    static let cachedRunCheckStrideBytes: Int64 = 1 * 1024 * 1024
+    /// A cached run at least this long is worth a reconnect to jump over
+    /// instead of re-downloading through it (a back-scrubbed forward cache
+    /// can hold hundreds of megabytes the stream would otherwise re-pull).
+    static let cachedRunSkipBytes: Int64 = 8 * 1024 * 1024
 
     private static let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "com.continuum.app",
@@ -156,11 +220,14 @@ final class PlaybackOriginStream {
     private var writeCursor: Int64
     private var demandMark: Int64
     private var demandOrder: UInt64
+    private var targetedAt = Date()
+    private var skipCheckCursor: Int64
     private var parked = false
     private var cancelled = false
     private var finished = false
     private var session: URLSession?
     private var task: URLSessionDataTask?
+    private var currentTaskID: Int?
     private var reconnectTask: Task<Void, Never>?
     private var watchdogTask: Task<Void, Never>?
     private var lastDataAt = Date()
@@ -185,6 +252,7 @@ final class PlaybackOriginStream {
         self.writeCursor = startOffset
         self.demandMark = startOffset
         self.demandOrder = demandOrder
+        self.skipCheckCursor = startOffset + Self.cachedRunCheckStrideBytes
         self.callbacks = callbacks
     }
 
@@ -202,7 +270,8 @@ final class PlaybackOriginStream {
             id: id,
             startOffset: startOffset,
             writeCursor: writeCursor,
-            lastDemandOrder: demandOrder
+            lastDemandOrder: demandOrder,
+            secondsSinceTargeted: Date().timeIntervalSince(targetedAt)
         )
     }
 
@@ -230,6 +299,7 @@ final class PlaybackOriginStream {
         let session = self.session
         self.session = nil
         self.task = nil
+        currentTaskID = nil
         let reconnect = reconnectTask
         reconnectTask = nil
         let watchdog = watchdogTask
@@ -254,23 +324,24 @@ final class PlaybackOriginStream {
             return false
         }
         generation &+= 1
-        let oldSession = session
-        session = nil
+        let oldTask = task
         task = nil
+        currentTaskID = nil
         let reconnect = reconnectTask
         reconnectTask = nil
         startOffset = offset
         writeCursor = offset
         demandMark = offset
         demandOrder = order
+        targetedAt = Date()
+        skipCheckCursor = offset + Self.cachedRunCheckStrideBytes
         parked = false
         bytesSinceConnect = 0
         unproductiveStreak = 0
         lock.unlock()
-        oldSession?.invalidateAndCancel()
+        oldTask?.cancel()
         reconnect?.cancel()
         openConnection()
-        startWatchdog()
         return true
     }
 
@@ -311,7 +382,7 @@ final class PlaybackOriginStream {
         generation &+= 1
         let gen = generation
         let cursor = writeCursor
-        let oldSession = session
+        let oldTask = task
         parked = false
         bytesSinceConnect = 0
         lastDataAt = Date()
@@ -319,20 +390,31 @@ final class PlaybackOriginStream {
         errorBody.removeAll(keepingCapacity: false)
         errorStatusCode = nil
 
-        let config = URLSessionConfiguration.ephemeral
-        config.requestCachePolicy = .reloadIgnoringLocalCacheData
-        config.urlCache = nil
-        config.httpMaximumConnectionsPerHost = 2
-        // The long-lived request is paused via task suspension for
-        // arbitrarily long stretches; the idle-based request timeout must
-        // never fire underneath it. Wedged transfers are detected by the
-        // stall watchdog instead.
-        config.timeoutIntervalForRequest = 3600
-        let delegateQueue = OperationQueue()
-        delegateQueue.maxConcurrentOperationCount = 1
-        delegateQueue.qualityOfService = .userInitiated
-        let delegate = ConnectionDelegate(stream: self, generation: gen)
-        let newSession = URLSession(configuration: config, delegate: delegate, delegateQueue: delegateQueue)
+        if session == nil {
+            // One session for the stream's whole lifetime. Invalidating a
+            // session destroys its connection pool, so per-attempt sessions
+            // would pay a fresh TCP+TLS handshake plus slow-start on every
+            // reconnect and retarget — the per-request cost this engine
+            // exists to eliminate. Replacement range GETs on the shared
+            // session reuse the warm connection where the transport allows.
+            let config = URLSessionConfiguration.ephemeral
+            config.requestCachePolicy = .reloadIgnoringLocalCacheData
+            config.urlCache = nil
+            config.httpMaximumConnectionsPerHost = 2
+            // The long-lived request is paused via task suspension for
+            // arbitrarily long stretches; the idle-based request timeout must
+            // never fire underneath it. Wedged transfers are detected by the
+            // stall watchdog instead.
+            config.timeoutIntervalForRequest = 3600
+            let delegateQueue = OperationQueue()
+            delegateQueue.maxConcurrentOperationCount = 1
+            delegateQueue.qualityOfService = .userInitiated
+            session = URLSession(
+                configuration: config,
+                delegate: ConnectionDelegate(stream: self),
+                delegateQueue: delegateQueue
+            )
+        }
 
         var request = URLRequest(url: originURL)
         request.httpMethod = "GET"
@@ -341,14 +423,14 @@ final class PlaybackOriginStream {
             request.setValue(value, forHTTPHeaderField: key)
         }
         request.setValue("bytes=\(cursor)-", forHTTPHeaderField: "Range")
-        let newTask = newSession.dataTask(with: request)
-        session = newSession
+        let newTask = session?.dataTask(with: request)
         task = newTask
+        currentTaskID = newTask?.taskIdentifier
         lock.unlock()
 
-        oldSession?.invalidateAndCancel()
+        oldTask?.cancel()
         Self.logger.info("[CMP-SOURCE-CACHE] origin stream connect offset=\(cursor, privacy: .public) gen=\(gen, privacy: .public)")
-        newTask.resume()
+        newTask?.resume()
     }
 
     private func startWatchdog() {
@@ -369,7 +451,7 @@ final class PlaybackOriginStream {
 
     private func reconnectIfStalled() {
         lock.lock()
-        let stalled = !cancelled && !finished && !parked && session != nil
+        let stalled = !cancelled && !finished && !parked && session != nil && task != nil
             && Date().timeIntervalSince(lastDataAt) > PlaybackOriginReconnectPolicy.stallSeconds
         lock.unlock()
         guard stalled else { return }
@@ -385,18 +467,19 @@ final class PlaybackOriginStream {
 
     // MARK: - Delegate plumbing (called on the session delegate queue)
 
-    fileprivate func handleResponse(_ response: URLResponse, generation gen: UInt64) -> Bool {
+    fileprivate func handleResponse(_ response: URLResponse, taskID: Int) -> Bool {
+        lock.lock()
+        guard taskID == currentTaskID, !cancelled else {
+            lock.unlock()
+            return false
+        }
+        let gen = generation
+        let cursor = writeCursor
+        lock.unlock()
         guard let http = response as? HTTPURLResponse else {
             connectionEnded(generation: gen, cause: .network, statusCode: nil)
             return false
         }
-        lock.lock()
-        guard gen == generation, !cancelled else {
-            lock.unlock()
-            return false
-        }
-        let cursor = writeCursor
-        lock.unlock()
 
         switch http.statusCode {
         case 206:
@@ -450,12 +533,13 @@ final class PlaybackOriginStream {
         callbacks.didReceiveResponse(self, total)
     }
 
-    fileprivate func handleData(_ data: Data, generation gen: UInt64) {
+    fileprivate func handleData(_ data: Data, taskID: Int) {
         lock.lock()
-        guard gen == generation, !cancelled else {
+        guard taskID == currentTaskID, !cancelled else {
             lock.unlock()
             return
         }
+        let gen = generation
         if errorStatusCode != nil {
             if errorBody.count < 4096 {
                 errorBody.append(data.prefix(4096 - errorBody.count))
@@ -468,6 +552,20 @@ final class PlaybackOriginStream {
             return
         }
         let start = writeCursor
+        let total = knownTotalLength
+        lock.unlock()
+
+        // Store before publishing the advanced cursor: a snapshot taken
+        // between the two would show these bytes as behind the cursor
+        // (never arriving on this stream) while they are still in flight to
+        // the cache, misrouting the demand onto a fresh connection.
+        callbacks.store(start, data, total)
+
+        lock.lock()
+        guard gen == generation, !cancelled else {
+            lock.unlock()
+            return
+        }
         writeCursor += Int64(data.count)
         let cursor = writeCursor
         let mark = demandMark
@@ -477,15 +575,31 @@ final class PlaybackOriginStream {
             everProductive = true
             unproductiveStreak = 0
         }
-        let total = knownTotalLength
+        let checkCachedRun = cursor >= skipCheckCursor
+        if checkCachedRun {
+            skipCheckCursor = cursor + Self.cachedRunCheckStrideBytes
+        }
         lock.unlock()
 
-        callbacks.store(start, data, total)
         callbacks.didStore(self, start...(cursor - 1))
 
         if let total, cursor >= total {
             finishStream(expectedGeneration: gen)
             return
+        }
+        if checkCachedRun {
+            let nextMissing = callbacks.nextMissingByte(cursor)
+            if nextMissing == nil {
+                // Everything from here to the known EOF is already cached;
+                // the stream's region is done.
+                finishStream(expectedGeneration: gen)
+                return
+            }
+            if let nextMissing, nextMissing - cursor >= Self.cachedRunSkipBytes {
+                Self.logger.info("[CMP-SOURCE-CACHE] origin stream skipping cached run \(cursor, privacy: .public)-\(nextMissing, privacy: .public)")
+                retarget(to: nextMissing, order: currentDemandOrder)
+                return
+            }
         }
         if !callbacks.mayContinueFilling(self, cursor, mark) {
             lock.lock()
@@ -509,12 +623,13 @@ final class PlaybackOriginStream {
         }
     }
 
-    fileprivate func handleCompletion(error: Error?, generation gen: UInt64) {
+    fileprivate func handleCompletion(error: Error?, taskID: Int) {
         lock.lock()
-        guard gen == generation, !cancelled, !finished else {
+        guard taskID == currentTaskID, !cancelled, !finished else {
             lock.unlock()
             return
         }
+        let gen = generation
         let status = errorStatusCode
         let body = String(data: errorBody, encoding: .utf8)
         let cursor = writeCursor
@@ -549,22 +664,34 @@ final class PlaybackOriginStream {
         connectionEnded(generation: gen, cause: .prematureEOF, statusCode: nil)
     }
 
-    private func finishStream(expectedGeneration: UInt64) {
+    /// Shared terminal teardown for finish/give-up. Returns false when this
+    /// generation already ended or the stream is already terminal, so each
+    /// caller fires its callback exactly once.
+    private func terminate(expectedGeneration: UInt64) -> Bool {
         lock.lock()
         guard generation == expectedGeneration, !finished, !cancelled else {
             lock.unlock()
-            return
+            return false
         }
         finished = true
         generation &+= 1
         let session = self.session
         self.session = nil
         self.task = nil
+        currentTaskID = nil
+        let reconnect = reconnectTask
+        reconnectTask = nil
         let watchdog = watchdogTask
         watchdogTask = nil
         lock.unlock()
         session?.invalidateAndCancel()
+        reconnect?.cancel()
         watchdog?.cancel()
+        return true
+    }
+
+    private func finishStream(expectedGeneration: UInt64) {
+        guard terminate(expectedGeneration: expectedGeneration) else { return }
         callbacks.didFinish(self)
     }
 
@@ -580,9 +707,9 @@ final class PlaybackOriginStream {
         }
         generation &+= 1
         let newGeneration = generation
-        let oldSession = session
-        session = nil
+        let oldTask = task
         task = nil
+        currentTaskID = nil
         parked = false
         if bytesSinceConnect < PlaybackOriginReconnectPolicy.productiveBytesFloor {
             unproductiveStreak += 1
@@ -592,7 +719,7 @@ final class PlaybackOriginStream {
         let streak = unproductiveStreak
         let productive = everProductive
         lock.unlock()
-        oldSession?.invalidateAndCancel()
+        oldTask?.cancel()
 
         // The streak was already advanced for this failure; decide() gets the
         // pre-failure count so caps mean "attempts before giving up".
@@ -621,21 +748,7 @@ final class PlaybackOriginStream {
         statusCode: Int?,
         expectedGeneration: UInt64
     ) {
-        lock.lock()
-        guard generation == expectedGeneration, !cancelled, !finished else {
-            lock.unlock()
-            return
-        }
-        finished = true
-        generation &+= 1
-        let session = self.session
-        self.session = nil
-        self.task = nil
-        let watchdog = watchdogTask
-        watchdogTask = nil
-        lock.unlock()
-        session?.invalidateAndCancel()
-        watchdog?.cancel()
+        guard terminate(expectedGeneration: expectedGeneration) else { return }
         Self.logger.warning("[CMP-SOURCE-CACHE] origin stream gave up cause=\(String(describing: cause), privacy: .public)")
         callbacks.didGiveUp(self, cause, statusCode)
     }
@@ -667,13 +780,15 @@ final class PlaybackOriginStream {
 
     // MARK: - URLSession delegate bridge
 
+    /// One delegate for the stream's single long-lived session. Staleness is
+    /// per data task: events carry the task identifier (unique within a
+    /// session) and the stream ignores anything that is not its current task,
+    /// so a cancelled attempt's late deliveries can never corrupt the cursor.
     private final class ConnectionDelegate: NSObject, URLSessionDataDelegate {
         private weak var stream: PlaybackOriginStream?
-        private let generation: UInt64
 
-        init(stream: PlaybackOriginStream, generation: UInt64) {
+        init(stream: PlaybackOriginStream) {
             self.stream = stream
-            self.generation = generation
         }
 
         func urlSession(
@@ -682,7 +797,7 @@ final class PlaybackOriginStream {
             didReceive response: URLResponse,
             completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
         ) {
-            guard let stream, stream.handleResponse(response, generation: generation) else {
+            guard let stream, stream.handleResponse(response, taskID: dataTask.taskIdentifier) else {
                 completionHandler(.cancel)
                 return
             }
@@ -690,11 +805,11 @@ final class PlaybackOriginStream {
         }
 
         func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
-            stream?.handleData(data, generation: generation)
+            stream?.handleData(data, taskID: dataTask.taskIdentifier)
         }
 
         func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-            stream?.handleCompletion(error: error, generation: generation)
+            stream?.handleCompletion(error: error, taskID: task.taskIdentifier)
         }
     }
 }

--- a/iosApp/iosApp/Screens/Player/PlaybackSourcePrefetchPolicy.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSourcePrefetchPolicy.swift
@@ -18,18 +18,4 @@ enum PlaybackSourcePrefetchPolicy {
 
         return Int64(min(offset, Double(Int64.max - 1)))
     }
-
-    static func shouldRetargetPrefetch(
-        activeStart: Int64,
-        requestedStart: Int64,
-        chunkBytes: Int
-    ) -> Bool {
-        guard chunkBytes > 0 else { return activeStart != requestedStart }
-
-        let active = max(0, activeStart)
-        let requested = max(0, requestedStart)
-        let distance = active >= requested ? active - requested : requested - active
-
-        return distance > Int64(chunkBytes * 2)
-    }
 }

--- a/iosApp/iosApp/Screens/Player/PlaybackSourceProxy.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSourceProxy.swift
@@ -49,8 +49,11 @@ enum PlaybackSourceResponseEnd: Equatable {
     ) -> PlaybackSourceResponseEnd {
         if wasCancelled { return .cancelled }
         if sawFetchError { return .fetchFailed }
+        // An exact range promising bytes past the real EOF (total unknown at
+        // request time) must classify as complete, not premature EOF.
+        let clampedEnd = responseEnd.map { end in totalLength.map { min(end, $0 - 1) } ?? end }
         guard sawEmptyFetch,
-              let expectedEnd = responseEnd ?? totalLength.map({ max(0, $0 - 1) }),
+              let expectedEnd = clampedEnd ?? totalLength.map({ max(0, $0 - 1) }),
               cursor <= expectedEnd else {
             return .complete
         }
@@ -691,8 +694,25 @@ private final class PlaybackSourceResource {
         let request = PlaybackSourceRangeRequest.parse(rangeHeader)
         let total = await awaitTotalLength(hint: request.start)
         let resolved = resolveRequest(request, totalLength: total)
-        let responseStatus = rangeHeader == nil ? 200 : 206
+        var responseStatus = rangeHeader == nil ? 200 : 206
         let responseEnd = resolved.end
+        if responseStatus == 206, total == nil, responseEnd == nil {
+            if resolved.start == 0 {
+                // No total and no finite end: nothing valid to put in a
+                // Content-Range, but a head-anchored range can be answered
+                // as a plain 200 (a server may always ignore Range).
+                responseStatus = 200
+            } else {
+                // Mid-file open-ended range against an origin that never
+                // reported a total: no valid 206 exists (Content-Range
+                // requires a last-byte-pos). Fail honestly instead of
+                // emitting a 206 the demuxer cannot size.
+                print("[CMP-SRV] get exit reason=no_total_for_range start=\(resolved.start)")
+                let refusal = "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                _ = await send(Data(refusal.utf8), on: connection, close: true)
+                return
+            }
+        }
 
         var header = "HTTP/1.1 \(responseStatus) \(HTTPURLResponse.localizedString(forStatusCode: responseStatus))\r\n"
         header += "Accept-Ranges: bytes\r\n"
@@ -701,6 +721,11 @@ private final class PlaybackSourceResource {
             let endLabel = responseEnd ?? (total - 1)
             header += "Content-Range: bytes \(resolved.start)-\(endLabel)/\(total)\r\n"
             header += "Content-Length: \(max(0, endLabel - resolved.start + 1))\r\n"
+        } else if let responseEnd, responseStatus == 206 {
+            // Total still unknown: an exact range can carry the RFC 9110
+            // unknown-complete-length form so the response stays sizeable.
+            header += "Content-Range: bytes \(resolved.start)-\(responseEnd)/*\r\n"
+            header += "Content-Length: \(max(0, responseEnd - resolved.start + 1))\r\n"
         } else if let total, responseStatus == 200 {
             header += "Content-Length: \(max(0, total - resolved.start))\r\n"
         }
@@ -738,19 +763,17 @@ private final class PlaybackSourceResource {
             }
             break
         }
-        // An exact range promising bytes past the real EOF (total unknown at
-        // request time) must classify as complete, not premature EOF.
         let knownTotal = currentTotalLength() ?? total
         let endCause = PlaybackSourceResponseEnd.classify(
             cursor: cursor,
-            responseEnd: responseEnd.map { end in knownTotal.map { min(end, $0 - 1) } ?? end },
+            responseEnd: responseEnd,
             totalLength: knownTotal,
             wasCancelled: Task.isCancelled,
             sawEmptyFetch: sawEmptyFetch,
             sawFetchError: sawFetchError
         )
         if case let .prematureEOF(offset, expectedEnd) = endCause {
-            let totalLabel = (discoveredTotalLength ?? total).map(String.init) ?? "unknown"
+            let totalLabel = knownTotal.map(String.init) ?? "unknown"
             Self.logger.warning(
                 "[CMP-SOURCE-CACHE] premature eof offset=\(offset, privacy: .public) expectedEnd=\(expectedEnd, privacy: .public) total=\(totalLabel, privacy: .public)"
             )
@@ -819,16 +842,22 @@ private final class PlaybackSourceResource {
         case .spawn:
             let stream = makeStream(startOffset: offset, order: order)
             streams.append(stream)
+            // Pair the gauge while still holding the lock: stop() snapshots
+            // `streams` and ends one request per member, so begin must not
+            // trail publication or a racing stop leaves the count stranded.
+            cache.beginOriginRequest()
             toStart = stream
         case .retarget(let id):
             toRetarget = live.first(where: { $0.id == id })
+        case .wait:
+            // Every slot is still connecting; the caller's waiter stays
+            // registered and is re-driven when a stream delivers its first
+            // bytes (streamDidStore) or leaves the pool (streamEnded).
+            break
         }
         stateLock.unlock()
         toNote?.noteDemand(offset: offset, order: order)
-        if let toStart {
-            cache.beginOriginRequest()
-            toStart.start()
-        }
+        toStart?.start()
         if let toRetarget {
             if toRetarget.retarget(to: offset, order: order) {
                 // The victim may have carried waiters for its old region;
@@ -871,11 +900,11 @@ private final class PlaybackSourceResource {
         if streams.count < PlaybackOriginStreamPolicy.maxStreams {
             let stream = makeStream(startOffset: offset, order: order)
             streams.append(stream)
+            cache.beginOriginRequest()
             toStart = stream
         }
         stateLock.unlock()
         if let toStart {
-            cache.beginOriginRequest()
             toStart.start()
         } else {
             ensureStream(for: offset)
@@ -1007,6 +1036,9 @@ private final class PlaybackSourceResource {
                 mayContinueFilling: { [weak self] stream, cursor, demandMark in
                     self?.mayContinueFilling(stream, cursor: cursor, demandMark: demandMark) ?? false
                 },
+                nextMissingByte: { [weak self] cursor in
+                    self?.cache.nextPrefetchStart(after: cursor)
+                },
                 store: { [weak self] start, data, total in
                     guard let self else { return }
                     self.cache.recordOriginTransfer(byteCount: data.count)
@@ -1019,12 +1051,37 @@ private final class PlaybackSourceResource {
     private func streamDidStore(_ range: ClosedRange<Int64>) {
         var resume: [CheckedContinuation<WaitOutcome, Never>] = []
         stateLock.lock()
+        guard !dataWaiters.isEmpty else {
+            stateLock.unlock()
+            return
+        }
         let satisfied = dataWaiters.filter {
             $0.value.offset >= range.lowerBound && $0.value.offset <= range.upperBound
         }.map(\.key)
         for id in satisfied {
             if let waiter = dataWaiters.removeValue(forKey: id) {
                 resume.append(waiter.continuation)
+            }
+        }
+        // Waiters no stream can ride were parked by a `.wait` routing
+        // decision (every slot was still connecting). This delivery may have
+        // made its stream a valid retarget victim, so re-drive them to
+        // re-route; ensureStream retargets on the redriven miss, which makes
+        // the stream ineligible again — at most one re-route per delivery.
+        if !dataWaiters.isEmpty {
+            let snapshots = streams.map { $0.snapshot() }
+            if snapshots.contains(where: { PlaybackOriginStreamPolicy.isRetargetable($0) }) {
+                let stranded = dataWaiters.filter {
+                    PlaybackOriginStreamPolicy.rideThroughTarget(
+                        offset: $0.value.offset,
+                        streams: snapshots
+                    ) == nil
+                }.map(\.key)
+                for id in stranded {
+                    if let waiter = dataWaiters.removeValue(forKey: id) {
+                        resume.append(waiter.continuation)
+                    }
+                }
             }
         }
         stateLock.unlock()
@@ -1096,6 +1153,17 @@ private final class PlaybackSourceResource {
             continuation.resume(returning: .failed)
         }
         guard let cause else { return }
+        // Surface the interruption only when the give-up actually failed a
+        // foreground waiter. A background stream (readahead, tail cues)
+        // dying while playback rides the forward cache must stay silent —
+        // the next cache miss simply routes to a fresh stream, and if that
+        // one also gives up its waiter fails and escalates here.
+        guard !failed.isEmpty else {
+            Self.logger.warning(
+                "[CMP-SOURCE-CACHE] background origin stream gave up cause=\(String(describing: cause), privacy: .public) status=\(statusCode ?? 0, privacy: .public); no foreground waiter affected"
+            )
+            return
+        }
         let reason: PlaybackSourceInterruptionReason?
         switch cause {
         case .network, .stalled:

--- a/iosApp/iosApp/Screens/Player/PlaybackSourceProxy.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSourceProxy.swift
@@ -65,10 +65,10 @@ final class PlaybackSourceCache {
     static var siloLoopbackMemoryBudgetBytes: Int {
         isConstrainedMemoryDevice ? 128 * 1024 * 1024 : 256 * 1024 * 1024
     }
-    static let sourcePrefetchChunkBytes = 2 * 1024 * 1024
-    static let highBitrateSourcePrefetchChunkBytes = 8 * 1024 * 1024
-    static let ultraBitrateSourcePrefetchChunkBytes = 16 * 1024 * 1024
     static let sourceDiskSpillBudgetBytes = 512 * 1024 * 1024
+    /// Streaming appends grow a span in place until it reaches this size,
+    /// then roll over to a new span so eviction stays reasonably granular.
+    static let maxAppendSpanBytes = 16 * 1024 * 1024
 
     static var isConstrainedMemoryDevice: Bool {
         #if os(tvOS)
@@ -237,6 +237,15 @@ final class PlaybackSourceCache {
         return data
     }
 
+    /// Whether the byte at `offset` is cached, without the read-head
+    /// side effects of `read`.
+    func contains(offset: Int64) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if spans.contains(where: { $0.start <= offset && $0.end >= offset }) { return true }
+        return diskSpans.contains(where: { $0.start <= offset && $0.end >= offset })
+    }
+
     func missingGap(start: Int64, desiredLength: Int, totalLimit: Int64?) -> Gap? {
         guard desiredLength > 0 else { return nil }
         let requestedEnd = min(
@@ -347,6 +356,20 @@ final class PlaybackSourceCache {
     }
 
     private func insertSpanLocked(_ incoming: Span) {
+        // Fast path for streaming appends: the incoming bytes start exactly
+        // where an existing span ends and overlap nothing else, so they can
+        // be appended in place instead of paying the full-copy merge.
+        if let idx = spans.firstIndex(where: { $0.end + 1 == incoming.start }),
+           spans[idx].data.count + incoming.data.count <= Self.maxAppendSpanBytes,
+           !spans.contains(where: { $0.start >= incoming.start && $0.start <= incoming.end }),
+           !diskSpans.contains(where: { rangesOverlap($0.range, incoming.range) }) {
+            spans[idx].data.append(incoming.data)
+            // The span is hot — keep its eviction age current so a stream
+            // that appended for 16 MiB isn't the next eviction victim.
+            spans[idx].createdAt = Date()
+            cachedBytes += incoming.data.count
+            return
+        }
         var start = incoming.start
         var data = incoming.data
         let incomingEnd = incoming.end
@@ -491,37 +514,17 @@ private struct PlaybackSourceRangeRequest {
     }
 }
 
-private struct PlaybackSourceHTTPStatusError: Error, CustomStringConvertible {
-    let statusCode: Int
-    let body: String?
-
-    var description: String {
-        if let body, !body.isEmpty {
-            return "origin HTTP \(statusCode): \(body)"
-        }
-        return "origin HTTP \(statusCode)"
-    }
-}
-
-private enum PlaybackSourceFetchError: Error, CustomStringConvertible {
-    case http(PlaybackSourceHTTPStatusError)
-    case network(Error)
-
-    var description: String {
-        switch self {
-        case .http(let error):
-            return error.description
-        case .network(let error):
-            return String(describing: error)
-        }
-    }
-}
-
 private final class PlaybackSourceResource {
     private static let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "com.continuum.app",
         category: "PlaybackSourceResource"
     )
+
+    enum WaitOutcome {
+        case available
+        case eof
+        case failed
+    }
 
     let token: String
     let originURL: URL
@@ -529,22 +532,22 @@ private final class PlaybackSourceResource {
     let cache: PlaybackSourceCache
     private let onPlaybackSessionMissing: (() -> Void)?
     private let onPlaybackSourceInterrupted: ((PlaybackSourceInterruptionReason) -> Void)?
-    private var chunkBytes: Int
-    private let session: URLSession
-    private let chunkLock = NSLock()
-    private let prefetchLock = NSLock()
-    private var prefetchTask: Task<Void, Never>?
-    private var prefetchTaskID: UUID?
-    private var prefetchStartOffset: Int64?
-    private var pendingPrefetchStartOffset: Int64?
+    private let stateLock = NSLock()
     private var cancelled = false
     private var discoveredTotalLength: Int64?
+    /// A successful origin response has been seen (even if it carried no
+    /// total), so total-length waiters need not block on the next one.
+    private var sawOriginResponse = false
+    private var streams: [PlaybackOriginStream] = []
+    private var demandCounter: UInt64 = 0
+    private var dataWaiters: [UUID: (offset: Int64, continuation: CheckedContinuation<WaitOutcome, Never>)] = [:]
+    private var totalWaiters: [UUID: CheckedContinuation<Int64?, Never>] = [:]
     /// Detached serve tasks hold strong `self` for their whole body, so an
     /// await that outlives the session (a send parked on TCP backpressure,
     /// a fetch racing session invalidation) kept the resource — and its
     /// cache budget — alive forever. `stop()` cancels every tracked task;
     /// `send` cancels its connection on task cancellation so the parked
-    /// completion fires. Guarded by `prefetchLock`.
+    /// completion fires. Guarded by `stateLock`.
     private var serveTasks: [UUID: Task<Void, Never>] = [:]
     private var completedServeTaskIDs: Set<UUID> = []
 
@@ -561,11 +564,6 @@ private final class PlaybackSourceResource {
         self.cache = cache
         self.onPlaybackSessionMissing = onPlaybackSessionMissing
         self.onPlaybackSourceInterrupted = onPlaybackSourceInterrupted
-        self.chunkBytes = PlaybackSourceCache.sourcePrefetchChunkBytes
-        let config = URLSessionConfiguration.ephemeral
-        config.requestCachePolicy = .reloadIgnoringLocalCacheData
-        config.urlCache = nil
-        self.session = URLSession(configuration: config)
     }
 
     deinit {
@@ -574,22 +572,31 @@ private final class PlaybackSourceResource {
     }
 
     func stop() {
-        prefetchLock.lock()
+        stateLock.lock()
         cancelled = true
-        let task = prefetchTask
-        prefetchTask = nil
-        prefetchTaskID = nil
-        prefetchStartOffset = nil
-        pendingPrefetchStartOffset = nil
+        let streamsToCancel = streams
+        streams.removeAll()
+        let dataResume = dataWaiters.values.map(\.continuation)
+        dataWaiters.removeAll()
+        let totalResume = Array(totalWaiters.values)
+        totalWaiters.removeAll()
         let serving = serveTasks
         serveTasks.removeAll()
         completedServeTaskIDs.removeAll()
-        prefetchLock.unlock()
-        task?.cancel()
+        stateLock.unlock()
+        for stream in streamsToCancel {
+            stream.cancel()
+            cache.endOriginRequest()
+        }
+        for continuation in totalResume {
+            continuation.resume(returning: nil)
+        }
+        for continuation in dataResume {
+            continuation.resume(returning: .failed)
+        }
         for (_, serveTask) in serving {
             serveTask.cancel()
         }
-        session.invalidateAndCancel()
     }
 
     func stats() -> PlaybackSourceProxyStats {
@@ -611,29 +618,18 @@ private final class PlaybackSourceResource {
     }
 
     func startPrefetch(at offset: Int64 = 0) {
-        schedulePrefetch(after: max(0, offset))
+        ensureStream(for: max(0, offset))
     }
 
     func setSourceBitrate(_ bps: Double?) {
         cache.setSourceBitrate(bps)
-        let chunk: Int
-        if let bps, bps >= 200_000_000 {
-            chunk = PlaybackSourceCache.ultraBitrateSourcePrefetchChunkBytes
-        } else if let bps, bps >= 80_000_000 {
-            chunk = PlaybackSourceCache.highBitrateSourcePrefetchChunkBytes
-        } else {
-            chunk = PlaybackSourceCache.sourcePrefetchChunkBytes
-        }
-        chunkLock.lock()
-        chunkBytes = chunk
-        chunkLock.unlock()
-        Self.logger.info("[CMP-SOURCE-CACHE] source bitrate=\(bps ?? 0, privacy: .public) chunkBytes=\(chunk, privacy: .public)")
+        Self.logger.info("[CMP-SOURCE-CACHE] source bitrate=\(bps ?? 0, privacy: .public)")
     }
 
     func handle(method: String, rangeHeader: String?, on connection: NWConnection) {
-        prefetchLock.lock()
+        stateLock.lock()
         let alreadyStopped = cancelled
-        prefetchLock.unlock()
+        stateLock.unlock()
         guard !alreadyStopped else {
             connection.cancel()
             return
@@ -657,7 +653,7 @@ private final class PlaybackSourceResource {
     /// registration to reconcile.
     private func registerServeTask(_ task: Task<Void, Never>, id: UUID) {
         var cancelNow = false
-        prefetchLock.lock()
+        stateLock.lock()
         if completedServeTaskIDs.remove(id) != nil {
             // Finished before registration — nothing to track.
         } else if cancelled {
@@ -665,29 +661,22 @@ private final class PlaybackSourceResource {
         } else {
             serveTasks[id] = task
         }
-        prefetchLock.unlock()
+        stateLock.unlock()
         if cancelNow {
             task.cancel()
         }
     }
 
     private func serveTaskFinished(_ id: UUID) {
-        prefetchLock.lock()
+        stateLock.lock()
         if serveTasks.removeValue(forKey: id) == nil, !cancelled {
             completedServeTaskIDs.insert(id)
         }
-        prefetchLock.unlock()
-    }
-
-    private func isCancelledFlag() -> Bool {
-        prefetchLock.lock()
-        let value = cancelled
-        prefetchLock.unlock()
-        return value
+        stateLock.unlock()
     }
 
     private func respondHead(on connection: NWConnection) async {
-        let total = await discoverTotalLength()
+        let total = await awaitTotalLength(hint: 0)
         var header = "HTTP/1.1 200 OK\r\n"
         if let total {
             header += "Content-Length: \(total)\r\n"
@@ -700,7 +689,7 @@ private final class PlaybackSourceResource {
 
     private func respondGet(rangeHeader: String?, on connection: NWConnection) async {
         let request = PlaybackSourceRangeRequest.parse(rangeHeader)
-        let total = await discoverTotalLength()
+        let total = await awaitTotalLength(hint: request.start)
         let resolved = resolveRequest(request, totalLength: total)
         let responseStatus = rangeHeader == nil ? 200 : 206
         let responseEnd = resolved.end
@@ -735,36 +724,27 @@ private final class PlaybackSourceResource {
                     return
                 }
                 cursor += Int64(cached.count)
-                schedulePrefetch(after: cursor)
+                noteDemandHint(at: cursor)
                 continue
             }
-            let chunkBytes = currentChunkBytes()
-            let fetchLength = responseEnd.map { Int(min(Int64(chunkBytes), max(1, $0 - cursor + 1))) } ?? chunkBytes
-            cache.recordCacheMiss(byteCount: Int64(fetchLength))
-            do {
-                let fetched = try await fetchRange(start: cursor, length: fetchLength)
-                guard !fetched.data.isEmpty else {
-                    sawEmptyFetch = true
-                    break
-                }
-                cache.store(start: fetched.start, data: fetched.data, totalLength: fetched.totalLength)
-                if let totalLength = fetched.totalLength {
-                    discoveredTotalLength = totalLength
-                    cache.setTotalLength(totalLength)
-                }
-            } catch {
+            cache.recordCacheMiss(byteCount: Int64(max(1, sendLength)))
+            switch await awaitData(at: cursor) {
+            case .available:
+                continue
+            case .eof:
+                sawEmptyFetch = true
+            case .failed:
                 sawFetchError = true
-                if !Self.isCancellationError(error) {
-                    Self.logger.info("[CMP-SOURCE-CACHE] foreground range fetch failed start=\(cursor, privacy: .public) error=\(String(describing: error), privacy: .public)")
-                    notifyForegroundInterruptionIfNeeded(error: error, offset: cursor)
-                }
-                break
             }
+            break
         }
+        // An exact range promising bytes past the real EOF (total unknown at
+        // request time) must classify as complete, not premature EOF.
+        let knownTotal = currentTotalLength() ?? total
         let endCause = PlaybackSourceResponseEnd.classify(
             cursor: cursor,
-            responseEnd: responseEnd,
-            totalLength: discoveredTotalLength ?? total,
+            responseEnd: responseEnd.map { end in knownTotal.map { min(end, $0 - 1) } ?? end },
+            totalLength: knownTotal,
             wasCancelled: Task.isCancelled,
             sawEmptyFetch: sawEmptyFetch,
             sawFetchError: sawFetchError
@@ -776,7 +756,7 @@ private final class PlaybackSourceResource {
             )
             onPlaybackSourceInterrupted?(.prematureEOF(offset: offset, expectedEnd: expectedEnd))
         }
-        schedulePrefetch(after: cursor)
+        noteDemandHint(at: cursor)
         print("[CMP-SRV] get exit reason=\(endCause) cursor=\(cursor)")
         _ = await send(nil, on: connection, close: true)
     }
@@ -799,162 +779,365 @@ private final class PlaybackSourceResource {
         }
     }
 
-    private func schedulePrefetch(after offset: Int64) {
-        prefetchLock.lock()
+    // MARK: - Origin stream orchestration
+
+    private func currentTotalLength() -> Int64? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return discoveredTotalLength
+    }
+
+    private func currentState() -> (cancelled: Bool, total: Int64?, sawResponse: Bool) {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return (cancelled, discoveredTotalLength, sawOriginResponse)
+    }
+
+    /// Route a byte demand that MISSED the cache onto a stream: ride an
+    /// existing one, spawn a second, or retarget the least-recently-demanded.
+    private func ensureStream(for offset: Int64) {
+        var toStart: PlaybackOriginStream?
+        var toNote: PlaybackOriginStream?
+        var toRetarget: PlaybackOriginStream?
+        var order: UInt64 = 0
+        stateLock.lock()
         guard !cancelled else {
-            prefetchLock.unlock()
+            stateLock.unlock()
             return
         }
-        if let prefetchTask, !prefetchTask.isCancelled {
-            if let prefetchStartOffset,
-               !PlaybackSourcePrefetchPolicy.shouldRetargetPrefetch(
-                    activeStart: prefetchStartOffset,
-                    requestedStart: offset,
-                    chunkBytes: currentChunkBytes()
-               ) {
-                prefetchLock.unlock()
-                return
-            }
-            pendingPrefetchStartOffset = offset
-            prefetchLock.unlock()
+        if let total = discoveredTotalLength, offset >= total {
+            stateLock.unlock()
             return
         }
-        let taskID = UUID()
-        prefetchTaskID = taskID
-        prefetchStartOffset = offset
-        prefetchTask = Task.detached(priority: .utility) { [weak self] in
-            await self?.prefetchLoop(start: offset, taskID: taskID)
+        demandCounter += 1
+        order = demandCounter
+        let live = streams
+        let snapshots = live.map { $0.snapshot() }
+        switch PlaybackOriginStreamPolicy.action(demandOffset: offset, streams: snapshots) {
+        case .rideThrough(let id):
+            toNote = live.first(where: { $0.id == id })
+        case .spawn:
+            let stream = makeStream(startOffset: offset, order: order)
+            streams.append(stream)
+            toStart = stream
+        case .retarget(let id):
+            toRetarget = live.first(where: { $0.id == id })
         }
-        prefetchLock.unlock()
-    }
-
-    private func prefetchLoop(start: Int64, taskID: UUID) async {
-        var cursor: Int64? = start
-        while !Task.isCancelled, cache.shouldPrefetch {
-            guard let fetchStart = cache.nextPrefetchStart(after: cursor) else { break }
-            do {
-                let fetched = try await fetchRange(start: fetchStart, length: currentChunkBytes())
-                guard !fetched.data.isEmpty else { break }
-                cache.store(start: fetched.start, data: fetched.data, totalLength: fetched.totalLength)
-                cursor = fetched.start + Int64(fetched.data.count)
-                if let totalLength = fetched.totalLength {
-                    discoveredTotalLength = totalLength
-                    cache.setTotalLength(totalLength)
-                    if cursor! >= totalLength { break }
-                }
-            } catch {
-                if !Self.isCancellationError(error) {
-                    Self.logger.info("[CMP-SOURCE-CACHE] prefetch failed start=\(fetchStart, privacy: .public) error=\(String(describing: error), privacy: .public)")
-                }
-                break
+        stateLock.unlock()
+        toNote?.noteDemand(offset: offset, order: order)
+        if let toStart {
+            cache.beginOriginRequest()
+            toStart.start()
+        }
+        if let toRetarget {
+            if toRetarget.retarget(to: offset, order: order) {
+                // The victim may have carried waiters for its old region;
+                // nothing fills toward them anymore. Re-drive every waiter
+                // so each re-misses and re-routes against the new layout.
+                redriveAllDataWaiters()
+            } else {
+                // The victim finished or gave up between the snapshot and
+                // the retarget; replace it with a fresh stream.
+                replaceDeadStream(toRetarget, spawningAt: offset, order: order)
             }
         }
-        clearPrefetchTask(taskID: taskID)
     }
 
-    private func clearPrefetchTask(taskID: UUID) {
-        let pending: Int64?
-        prefetchLock.lock()
-        if prefetchTaskID == taskID {
-            prefetchTask = nil
-            prefetchTaskID = nil
-            prefetchStartOffset = nil
-            pending = pendingPrefetchStartOffset
-            pendingPrefetchStartOffset = nil
+    private func redriveAllDataWaiters() {
+        stateLock.lock()
+        let resume = dataWaiters.values.map(\.continuation)
+        dataWaiters.removeAll()
+        stateLock.unlock()
+        for continuation in resume {
+            continuation.resume(returning: .available)
+        }
+    }
+
+    private func replaceDeadStream(
+        _ dead: PlaybackOriginStream,
+        spawningAt offset: Int64,
+        order: UInt64
+    ) {
+        var toStart: PlaybackOriginStream?
+        stateLock.lock()
+        guard !cancelled else {
+            stateLock.unlock()
+            return
+        }
+        if streams.contains(where: { $0 === dead }) {
+            streams.removeAll { $0 === dead }
+            cache.endOriginRequest()
+        }
+        if streams.count < PlaybackOriginStreamPolicy.maxStreams {
+            let stream = makeStream(startOffset: offset, order: order)
+            streams.append(stream)
+            toStart = stream
+        }
+        stateLock.unlock()
+        if let toStart {
+            cache.beginOriginRequest()
+            toStart.start()
         } else {
-            pending = nil
-        }
-        prefetchLock.unlock()
-        if let pending {
-            schedulePrefetch(after: pending)
+            ensureStream(for: offset)
         }
     }
 
-    private func currentChunkBytes() -> Int {
-        chunkLock.lock()
-        let value = chunkBytes
-        chunkLock.unlock()
-        return value
+    /// Record demand served from cache: refreshes the covering stream's
+    /// demand mark (which keeps it "primary" and unparks it when the budget
+    /// frees) but never spawns or retargets — cached reads must not steer
+    /// connections toward data we already have.
+    private func noteDemandHint(at offset: Int64) {
+        var toNote: PlaybackOriginStream?
+        var order: UInt64 = 0
+        stateLock.lock()
+        guard !cancelled else {
+            stateLock.unlock()
+            return
+        }
+        demandCounter += 1
+        order = demandCounter
+        let snapshots = streams.map { $0.snapshot() }
+        if let covering = PlaybackOriginStreamPolicy.coveringStream(offset: offset, streams: snapshots) {
+            toNote = streams.first(where: { $0.id == covering })
+        }
+        stateLock.unlock()
+        toNote?.noteDemand(offset: offset, order: order)
     }
 
-    private func discoverTotalLength() async -> Int64? {
-        if let discoveredTotalLength { return discoveredTotalLength }
-        do {
-            let fetched = try await fetchRange(start: 0, length: 1)
-            cache.store(start: fetched.start, data: fetched.data, totalLength: fetched.totalLength)
-            discoveredTotalLength = fetched.totalLength
-            cache.setTotalLength(fetched.totalLength)
-            return fetched.totalLength
-        } catch {
-            return nil
-        }
-    }
-
-    private func fetchRange(start: Int64, length: Int) async throws -> (start: Int64, data: Data, totalLength: Int64?) {
-        // Never create a task on a session that may already be invalidated
-        // — the async wrapper's continuation can otherwise hang forever.
-        try Task.checkCancellation()
-        guard !isCancelledFlag() else { throw CancellationError() }
-        let upper = max(start, start + Int64(max(1, length)) - 1)
-        var request = URLRequest(url: originURL)
-        request.httpMethod = "GET"
-        for (key, value) in originHeaders {
-            request.setValue(value, forHTTPHeaderField: key)
-        }
-        request.setValue("bytes=\(start)-\(upper)", forHTTPHeaderField: "Range")
-        cache.beginOriginRequest()
-        defer { cache.endOriginRequest() }
-        let data: Data
-        let response: URLResponse
-        do {
-            (data, response) = try await session.data(for: request)
-        } catch {
-            throw PlaybackSourceFetchError.network(error)
-        }
-        guard let http = response as? HTTPURLResponse else {
-            throw URLError(.badServerResponse)
-        }
-        guard (200...299).contains(http.statusCode) else {
-            let body = String(data: data, encoding: .utf8)
-            if Self.isPlaybackSessionMissing(statusCode: http.statusCode, body: body) {
-                onPlaybackSessionMissing?()
+    /// Suspend the serve loop until the byte at `offset` is cached, the file
+    /// ends before it, or the responsible stream gives up.
+    private func awaitData(at offset: Int64) async -> WaitOutcome {
+        let state = currentState()
+        if state.cancelled { return .failed }
+        if let total = state.total, offset >= total { return .eof }
+        let id = UUID()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { (continuation: CheckedContinuation<WaitOutcome, Never>) in
+                stateLock.lock()
+                if cancelled {
+                    stateLock.unlock()
+                    continuation.resume(returning: .failed)
+                    return
+                }
+                dataWaiters[id] = (offset, continuation)
+                stateLock.unlock()
+                // Route the demand only after the waiter is registered, so a
+                // stream give-up can never drain the pool between routing
+                // and registration and leave this waiter stranded.
+                ensureStream(for: offset)
+                // The bytes may also have landed between the cache miss and
+                // the registration above; re-check so the waiter can't sleep
+                // through its own wake-up.
+                if cache.contains(offset: offset) {
+                    resumeDataWaiter(id: id, outcome: .available)
+                } else if let total = currentTotalLength(), offset >= total {
+                    resumeDataWaiter(id: id, outcome: .eof)
+                }
             }
-            throw PlaybackSourceFetchError.http(PlaybackSourceHTTPStatusError(statusCode: http.statusCode, body: body))
+        } onCancel: {
+            resumeDataWaiter(id: id, outcome: .failed)
         }
-        let total = Self.totalLength(from: http, fallbackDataLength: data.count)
-        cache.recordOriginTransfer(byteCount: data.count)
-        return (start, data, total)
     }
 
-    private static func isPlaybackSessionMissing(statusCode: Int, body: String?) -> Bool {
-        guard statusCode == 404 else { return false }
-        let text = body ?? ""
-        return text.contains("playback_session_not_found")
-            || text.contains("Playback session not found")
+    private func resumeDataWaiter(id: UUID, outcome: WaitOutcome) {
+        stateLock.lock()
+        let waiter = dataWaiters.removeValue(forKey: id)
+        stateLock.unlock()
+        waiter?.continuation.resume(returning: outcome)
     }
 
-    private func notifyForegroundInterruptionIfNeeded(error: Error, offset: Int64) {
-        guard let reason = Self.interruptionReason(for: error) else { return }
-        Self.logger.warning(
-            "[CMP-SOURCE-CACHE] foreground source interruption offset=\(offset, privacy: .public) reason=\(String(describing: reason), privacy: .public)"
+    /// Total length comes from the first successful origin response
+    /// (Content-Range / Content-Length) — no dedicated probe round trip.
+    private func awaitTotalLength(hint: Int64) async -> Int64? {
+        let state = currentState()
+        if let known = state.total { return known }
+        if state.sawResponse || state.cancelled { return nil }
+        let id = UUID()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Int64?, Never>) in
+                stateLock.lock()
+                if cancelled || sawOriginResponse || discoveredTotalLength != nil {
+                    let value = discoveredTotalLength
+                    stateLock.unlock()
+                    continuation.resume(returning: value)
+                    return
+                }
+                totalWaiters[id] = continuation
+                stateLock.unlock()
+                // Register first, then route: if the routed stream gives up
+                // instantly, its drain finds this waiter instead of missing
+                // it (the drain resolves total waiters on any give-up).
+                ensureStream(for: max(0, hint))
+            }
+        } onCancel: {
+            resumeTotalWaiter(id: id)
+        }
+    }
+
+    private func resumeTotalWaiter(id: UUID) {
+        stateLock.lock()
+        let waiter = totalWaiters.removeValue(forKey: id)
+        let value = discoveredTotalLength
+        stateLock.unlock()
+        waiter?.resume(returning: value)
+    }
+
+    private func makeStream(startOffset: Int64, order: UInt64) -> PlaybackOriginStream {
+        PlaybackOriginStream(
+            originURL: originURL,
+            originHeaders: originHeaders,
+            startOffset: startOffset,
+            demandOrder: order,
+            callbacks: PlaybackOriginStream.Callbacks(
+                didStore: { [weak self] _, range in
+                    self?.streamDidStore(range)
+                },
+                didReceiveResponse: { [weak self] _, total in
+                    self?.streamReceivedResponse(total: total)
+                },
+                didDetectSessionMissing: { [weak self] _ in
+                    self?.onPlaybackSessionMissing?()
+                },
+                didFinish: { [weak self] stream in
+                    self?.streamEnded(stream, gaveUpWith: nil, statusCode: nil)
+                },
+                didGiveUp: { [weak self] stream, cause, statusCode in
+                    self?.streamEnded(stream, gaveUpWith: cause, statusCode: statusCode)
+                },
+                mayContinueFilling: { [weak self] stream, cursor, demandMark in
+                    self?.mayContinueFilling(stream, cursor: cursor, demandMark: demandMark) ?? false
+                },
+                store: { [weak self] start, data, total in
+                    guard let self else { return }
+                    self.cache.recordOriginTransfer(byteCount: data.count)
+                    self.cache.store(start: start, data: data, totalLength: total)
+                }
+            )
         )
-        onPlaybackSourceInterrupted?(reason)
     }
 
-    private static func interruptionReason(for error: Error) -> PlaybackSourceInterruptionReason? {
-        if case let PlaybackSourceFetchError.http(httpError) = error {
-            guard [502, 503, 504].contains(httpError.statusCode) else { return nil }
-            return .serverUnavailable(statusCode: httpError.statusCode)
+    private func streamDidStore(_ range: ClosedRange<Int64>) {
+        var resume: [CheckedContinuation<WaitOutcome, Never>] = []
+        stateLock.lock()
+        let satisfied = dataWaiters.filter {
+            $0.value.offset >= range.lowerBound && $0.value.offset <= range.upperBound
+        }.map(\.key)
+        for id in satisfied {
+            if let waiter = dataWaiters.removeValue(forKey: id) {
+                resume.append(waiter.continuation)
+            }
         }
-        if case let PlaybackSourceFetchError.network(underlying) = error,
-           !isCancellationError(underlying) {
-            return .networkUnavailable
+        stateLock.unlock()
+        for continuation in resume {
+            continuation.resume(returning: .available)
         }
-        if !isCancellationError(error),
-           (error as NSError).domain == NSURLErrorDomain {
-            return .networkUnavailable
+    }
+
+    private func streamReceivedResponse(total: Int64?) {
+        var resume: [CheckedContinuation<Int64?, Never>] = []
+        stateLock.lock()
+        sawOriginResponse = true
+        if let total, total > 0 {
+            discoveredTotalLength = max(discoveredTotalLength ?? 0, total)
         }
-        return nil
+        let value = discoveredTotalLength
+        resume = Array(totalWaiters.values)
+        totalWaiters.removeAll()
+        stateLock.unlock()
+        cache.setTotalLength(value)
+        for continuation in resume {
+            continuation.resume(returning: value)
+        }
+    }
+
+    /// A stream left the pool. Finished streams re-drive their waiters
+    /// (data may satisfy them or a new stream will be ensured); a give-up
+    /// fails them and surfaces the interruption exactly once.
+    private func streamEnded(
+        _ stream: PlaybackOriginStream,
+        gaveUpWith cause: PlaybackOriginReconnectPolicy.EndCause?,
+        statusCode: Int?
+    ) {
+        var redrive: [CheckedContinuation<WaitOutcome, Never>] = []
+        var failed: [CheckedContinuation<WaitOutcome, Never>] = []
+        var totalResume: [CheckedContinuation<Int64?, Never>] = []
+        stateLock.lock()
+        let wasTracked = streams.contains(where: { $0 === stream })
+        streams.removeAll { $0 === stream }
+        let survivors = streams.map { $0.snapshot() }
+        for (id, waiter) in dataWaiters {
+            // Waiters a surviving stream still covers re-drive and re-ride
+            // it; only waiters this stream was responsible for fail. A
+            // clean finish re-drives everyone.
+            if cause == nil
+                || PlaybackOriginStreamPolicy.coveringStream(offset: waiter.offset, streams: survivors) != nil {
+                redrive.append(waiter.continuation)
+            } else {
+                failed.append(waiter.continuation)
+            }
+            dataWaiters.removeValue(forKey: id)
+        }
+        if cause != nil {
+            totalResume = Array(totalWaiters.values)
+            totalWaiters.removeAll()
+        }
+        let total = discoveredTotalLength
+        stateLock.unlock()
+        if wasTracked {
+            cache.endOriginRequest()
+        }
+        for continuation in totalResume {
+            continuation.resume(returning: total)
+        }
+        for continuation in redrive {
+            continuation.resume(returning: .available)
+        }
+        for continuation in failed {
+            continuation.resume(returning: .failed)
+        }
+        guard let cause else { return }
+        let reason: PlaybackSourceInterruptionReason?
+        switch cause {
+        case .network, .stalled:
+            reason = .networkUnavailable
+        case .httpOutage(let code):
+            reason = .serverUnavailable(statusCode: code)
+        case .prematureEOF:
+            if let total {
+                reason = .prematureEOF(offset: stream.snapshot().writeCursor, expectedEnd: total - 1)
+            } else {
+                reason = nil
+            }
+        case .httpFatal, .rangeIgnored:
+            reason = nil
+        }
+        if let reason {
+            Self.logger.warning(
+                "[CMP-SOURCE-CACHE] origin interruption reason=\(String(describing: reason), privacy: .public) status=\(statusCode ?? 0, privacy: .public)"
+            )
+            onPlaybackSourceInterrupted?(reason)
+        }
+    }
+
+    private func mayContinueFilling(
+        _ stream: PlaybackOriginStream,
+        cursor: Int64,
+        demandMark: Int64
+    ) -> Bool {
+        stateLock.lock()
+        guard !cancelled else {
+            stateLock.unlock()
+            return false
+        }
+        let maxOrder = streams.map { $0.currentDemandOrder }.max() ?? 0
+        let isMostRecent = stream.currentDemandOrder >= maxOrder
+        stateLock.unlock()
+        return !PlaybackOriginStreamPolicy.shouldPause(
+            writeCursor: cursor,
+            demandMark: demandMark,
+            isMostRecentlyDemanded: isMostRecent,
+            globalBudgetAvailable: cache.shouldPrefetch
+        )
     }
 
     /// Cancellation-aware: a send parked on TCP backpressure (peer holds
@@ -978,31 +1161,6 @@ private final class PlaybackSourceResource {
         } onCancel: {
             connection.cancel()
         }
-    }
-
-    private static func totalLength(from response: HTTPURLResponse, fallbackDataLength: Int) -> Int64? {
-        if let contentRange = response.value(forHTTPHeaderField: "Content-Range"),
-           let slash = contentRange.lastIndex(of: "/") {
-            let suffix = contentRange[contentRange.index(after: slash)...]
-            if suffix != "*", let total = Int64(suffix) {
-                return total
-            }
-        }
-        if let length = response.value(forHTTPHeaderField: "Content-Length"),
-           let value = Int64(length),
-           response.statusCode == 200 {
-            return value
-        }
-        return fallbackDataLength > 0 ? nil : 0
-    }
-
-    private static func isCancellationError(_ error: Error) -> Bool {
-        if error is CancellationError { return true }
-        if case let PlaybackSourceFetchError.network(underlying) = error {
-            return isCancellationError(underlying)
-        }
-        let nsError = error as NSError
-        return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled
     }
 
     private static func makeToken() -> String {

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -2102,9 +2102,10 @@ class PlayerViewModel {
                 return SourceProxyPreparation(plan: plan, proxy: nil)
             }
             proxy.setSourceBitrate(sourceBitrateBps(for: plan))
-            if plan.engine != .siloPlayerLoopback {
-                proxy.startPrefetch(at: initialSourcePrefetchOffset(for: plan))
-            }
+            // Loopback included: opening the origin stream here overlaps the
+            // TCP/TLS connect and slow-start ramp with demuxer spawn, which
+            // is a full round trip saved on high-latency links.
+            proxy.startPrefetch(at: initialSourcePrefetchOffset(for: plan))
             Self.logger.info("[CMP-SOURCE-CACHE] enabled route=\(plan.engine.label, privacy: .public) budgetBytes=\(cacheBudget, privacy: .public)")
             let streamRequest = StreamRequest(
                 url: localURL,


### PR DESCRIPTION
## Problem

Users on **fast but high-latency** connections (gigabit fiber, ~150 ms+ RTT to the server) report buffering even on 1080p files, while the same files direct-play fine through the Jellycompat API in third-party clients. LAN testing (including high-bitrate 4K) never reproduces it.

**Root cause:** `PlaybackSourceProxy` fetched origin bytes as strictly sequential, fully-buffered 2–16 MiB range requests. Every chunk pays a fresh TCP slow-start ramp plus one RTT of dead air between requests, and the serve loop cannot forward a single byte until the entire chunk lands. At 150 ms RTT this caps effective throughput around **14 Mbps regardless of line speed** — right at the starvation edge for ordinary 1080p remuxes. Third-party clients issue one long-lived GET, pay slow-start once, and ride the congestion window at line rate.

## Fix

Replace the chunked fetcher with **long-lived streaming range GETs** (the design AetherEngine adopted after its own chunked reader collapsed on CDNs — "VLC-style single forward-streaming connection"):

- **Up to two origin streams** (playback + roamer) with a ride-through / spawn / retarget routing policy, so the matroska open pattern (head probe ↔ cues at tail) and demuxer recycling never churn the warm playback connection.
- **Incremental store:** URLSession deliveries land in the span cache as they arrive; a cache miss unblocks after ~1 RTT instead of a full-chunk transfer (previously up to seconds, brushing the demuxer's 10 s `rw_timeout`).
- **Backpressure parking:** at the readahead budget the data task suspends and TCP flow control parks the connection server-side; resume is instant, the connection is never closed/re-requested.
- **Reconnect with backoff + progress-aware give-up** replaces fail-on-first-error. A transient blip no longer tears down and rebuilds the player — playback rides the forward buffer silently. Interruptions (server outage / network loss / premature EOF / session missing) surface only after retries exhaust.
- **Waiter machinery:** serve loops await cache fills via registered continuations (register-first ordering; re-driven on retarget/finish; failed only for the responsible stream on give-up).
- **Cache:** adjacent streaming slabs append in place (16 MiB spans, eviction age refreshed) instead of paying the full-copy merge.
- Loopback playback starts the origin stream at plan time, overlapping connect + slow-start with demuxer spawn.

Removed: chunk-size escalation (8/16 MiB for high-bitrate sources — a LAN optimization that made remote misses strictly worse), the single-flight `.utility` prefetch loop, and the dedicated 1-byte total-length probe (total now comes from the first streaming response's `Content-Range`).

## Review hardening

An adversarial review pass on the rewrite surfaced and fixed: retarget stranding waiters of the victim stream, waiter registration racing a stream give-up, two park/unpark races (suspend now under lock + post-park recheck), terminal-stream revival leaking a live URLSession, give-up failing waiters riding healthy streams, and missing generation guards on finish/give-up. Lock hierarchy, continuation exactly-once semantics, 404 session-missing detection, and `PlaybackSourceResponseEnd.classify` semantics verified preserved.

## Testing

- iOS / tvOS / macOS builds green; **511 tests pass** (15 new: stream routing policy, reconnect policy, cache streaming append).
- Hardware-validated on Apple TV 4K (3rd gen) with a 47.8 GB DV P7→8.1 TrueHD title (~63 Mbps): clean startup, aggressive seeking, steady segment cadence, zero watchdog escalations or stream give-ups.
- Startup watchdog interplay checked: the ladder keys on local segment-serve progress (6 s stall window), not origin fetch patterns; streaming strictly reduces time-to-first-segment, so misfire risk goes down.

## Notes / follow-ups (separate PRs)

- No kill switch: the old chunked path is fully removed. Safety nets that remain: reconnect give-up → existing outage recovery, starvation watchdog → PlayerCore fallback.
- Bandwidth-aware quality selection (act on the already-computed `streamSpeed` ratio; auto/offered downshift to server transcode) — the complementary fix for users whose links genuinely can't sustain the file bitrate.
- Starvation fallback should route to a capped transcode instead of PlayerCore on the same full-bitrate URL when the trigger is network starvation.
- Master playlist declares `BANDWIDTH=18000000` while streams can run ~63 Mbps → cosmetic `-12318` per-segment complaints in AVPlayer's error log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced improved long-lived origin streaming with demand-driven buffering, including smarter stalling recovery, reconnect, and retry/give-up behavior.

* **Bug Fixes**
  * Fixed end-of-range handling near real EOF so completed ranges are classified correctly.
  * Enhanced cache streaming-append and span merging for smoother reads across adjacent/overlapping buffered ranges.
  * Restored source prefetch loopback behavior to reduce startup delays.

* **Tests**
  * Added/extended coverage for stream selection, reconnect/backoff decisions, and cache span merging/reads, plus a new EOF-range classification test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->