### PR TITLE
fix(loopback): derive master playlist BANDWIDTH from the source bitrate

### DIFF
--- a/iosApp/Tests/LocalHLSPlaylistPolicyTests.swift
+++ b/iosApp/Tests/LocalHLSPlaylistPolicyTests.swift
@@ -33,7 +33,9 @@ final class LocalHLSPlaylistPolicyTests: XCTestCase {
     }
 
     func testMasterBandwidthDeclaresSourceAverageWithPeakHeadroom() {
-        let bw = LocalHLSPlaylistPolicy.masterPlaylistBandwidth(sourceBitrateBps: 63_000_000)
+        let bw = LocalHLSPlaylistPolicy.masterPlaylistBandwidth(
+            sourceBitrateBps: 63_000_000, isAudioBridgedToLossless: false
+        )
         XCTAssertEqual(bw.average, 63_000_000)
         XCTAssertEqual(bw.peak, 126_000_000)
     }
@@ -41,23 +43,45 @@ final class LocalHLSPlaylistPolicyTests: XCTestCase {
     func testMasterBandwidthNeverDeclaresBelowLegacyFloor() {
         // Low-bitrate sources keep at least the legacy declaration so a
         // one-off oversized segment (FLAC audio burst) stays under it.
-        let bw = LocalHLSPlaylistPolicy.masterPlaylistBandwidth(sourceBitrateBps: 4_000_000)
+        let bw = LocalHLSPlaylistPolicy.masterPlaylistBandwidth(
+            sourceBitrateBps: 4_000_000, isAudioBridgedToLossless: false
+        )
         XCTAssertEqual(bw.average, 4_000_000)
         XCTAssertEqual(bw.peak, LocalHLSPlaylistPolicy.fallbackMasterBandwidthBps)
     }
 
-    func testMasterBandwidthFallsBackWhenSourceBitrateUnknown() {
-        XCTAssertEqual(
-            LocalHLSPlaylistPolicy.masterPlaylistBandwidth(sourceBitrateBps: nil).peak,
-            LocalHLSPlaylistPolicy.fallbackMasterBandwidthBps
+    func testMasterBandwidthBudgetsBridgedLosslessAudioIntoAverage() {
+        // The served variant carries re-encoded FLAC, not the source's lossy
+        // track; the declared average must not understate it (RFC 8216).
+        let bw = LocalHLSPlaylistPolicy.masterPlaylistBandwidth(
+            sourceBitrateBps: 20_000_000, isAudioBridgedToLossless: true
         )
-        XCTAssertNil(LocalHLSPlaylistPolicy.masterPlaylistBandwidth(sourceBitrateBps: nil).average)
-        XCTAssertNil(LocalHLSPlaylistPolicy.masterPlaylistBandwidth(sourceBitrateBps: 0).average)
-        XCTAssertNil(LocalHLSPlaylistPolicy.masterPlaylistBandwidth(sourceBitrateBps: .nan).average)
+        XCTAssertEqual(bw.average, 24_000_000)
+        XCTAssertEqual(bw.peak, 48_000_000)
+    }
+
+    func testMasterBandwidthFallsBackWhenSourceBitrateUnknown() {
+        let unknown = LocalHLSPlaylistPolicy.masterPlaylistBandwidth(
+            sourceBitrateBps: nil, isAudioBridgedToLossless: false
+        )
+        XCTAssertEqual(unknown.peak, LocalHLSPlaylistPolicy.fallbackMasterBandwidthBps)
+        XCTAssertNil(unknown.average)
+        XCTAssertNil(
+            LocalHLSPlaylistPolicy.masterPlaylistBandwidth(
+                sourceBitrateBps: 0, isAudioBridgedToLossless: false
+            ).average
+        )
+        XCTAssertNil(
+            LocalHLSPlaylistPolicy.masterPlaylistBandwidth(
+                sourceBitrateBps: .nan, isAudioBridgedToLossless: true
+            ).average
+        )
     }
 
     func testMasterBandwidthClampsAbsurdSourceBitrates() {
-        let bw = LocalHLSPlaylistPolicy.masterPlaylistBandwidth(sourceBitrateBps: 5e12)
+        let bw = LocalHLSPlaylistPolicy.masterPlaylistBandwidth(
+            sourceBitrateBps: 5e12, isAudioBridgedToLossless: true
+        )
         XCTAssertEqual(bw.average, 1_000_000_000)
         XCTAssertEqual(bw.peak, 2_000_000_000)
     }

--- a/iosApp/Tests/LocalHLSPlaylistPolicyTests.swift
+++ b/iosApp/Tests/LocalHLSPlaylistPolicyTests.swift
@@ -31,4 +31,34 @@ final class LocalHLSPlaylistPolicyTests: XCTestCase {
         XCTAssertEqual(LocalHLSPlaylistPolicy.playlistType(isFinal: true), .vod)
         XCTAssertEqual(LocalHLSPlaylistPolicy.playlistType(isFinal: true).hlsTag, "#EXT-X-PLAYLIST-TYPE:VOD")
     }
+
+    func testMasterBandwidthDeclaresSourceAverageWithPeakHeadroom() {
+        let bw = LocalHLSPlaylistPolicy.masterPlaylistBandwidth(sourceBitrateBps: 63_000_000)
+        XCTAssertEqual(bw.average, 63_000_000)
+        XCTAssertEqual(bw.peak, 126_000_000)
+    }
+
+    func testMasterBandwidthNeverDeclaresBelowLegacyFloor() {
+        // Low-bitrate sources keep at least the legacy declaration so a
+        // one-off oversized segment (FLAC audio burst) stays under it.
+        let bw = LocalHLSPlaylistPolicy.masterPlaylistBandwidth(sourceBitrateBps: 4_000_000)
+        XCTAssertEqual(bw.average, 4_000_000)
+        XCTAssertEqual(bw.peak, LocalHLSPlaylistPolicy.fallbackMasterBandwidthBps)
+    }
+
+    func testMasterBandwidthFallsBackWhenSourceBitrateUnknown() {
+        XCTAssertEqual(
+            LocalHLSPlaylistPolicy.masterPlaylistBandwidth(sourceBitrateBps: nil).peak,
+            LocalHLSPlaylistPolicy.fallbackMasterBandwidthBps
+        )
+        XCTAssertNil(LocalHLSPlaylistPolicy.masterPlaylistBandwidth(sourceBitrateBps: nil).average)
+        XCTAssertNil(LocalHLSPlaylistPolicy.masterPlaylistBandwidth(sourceBitrateBps: 0).average)
+        XCTAssertNil(LocalHLSPlaylistPolicy.masterPlaylistBandwidth(sourceBitrateBps: .nan).average)
+    }
+
+    func testMasterBandwidthClampsAbsurdSourceBitrates() {
+        let bw = LocalHLSPlaylistPolicy.masterPlaylistBandwidth(sourceBitrateBps: 5e12)
+        XCTAssertEqual(bw.average, 1_000_000_000)
+        XCTAssertEqual(bw.peak, 2_000_000_000)
+    }
 }

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/LocalHLSPlaylistPolicy.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/LocalHLSPlaylistPolicy.swift
@@ -26,4 +26,27 @@ enum LocalHLSPlaylistPolicy {
     static func playlistType(isFinal: Bool) -> PlaylistType {
         isFinal ? .vod : .liveSliding
     }
+
+    /// HLS `BANDWIDTH` declares the variant's peak segment bitrate; declaring
+    /// less makes AVFoundation log a -12318 "Segment exceeds specified
+    /// bandwidth" errorLog entry for every oversized segment. The true peak
+    /// is unknown when the master playlist is written, so declare the source
+    /// average with 2x headroom (remux copies the video through, so generated
+    /// bitrate tracks the source; FLAC audio bridging can locally exceed the
+    /// average). Overstating is harmless on a single-variant playlist — there
+    /// is no ABR decision to skew. Sources with no reported bitrate keep the
+    /// legacy 18 Mbps declaration.
+    static let fallbackMasterBandwidthBps = 18_000_000
+
+    static func masterPlaylistBandwidth(
+        sourceBitrateBps: Double?
+    ) -> (peak: Int, average: Int?) {
+        guard let sourceBitrateBps,
+              sourceBitrateBps.isFinite,
+              sourceBitrateBps > 0 else {
+            return (fallbackMasterBandwidthBps, nil)
+        }
+        let average = Int(min(sourceBitrateBps, 1_000_000_000))
+        return (max(fallbackMasterBandwidthBps, average * 2), average)
+    }
 }

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/LocalHLSPlaylistPolicy.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/LocalHLSPlaylistPolicy.swift
@@ -27,6 +27,15 @@ enum LocalHLSPlaylistPolicy {
         isFinal ? .vod : .liveSliding
     }
 
+    /// Legacy declaration, kept for sources with no reported bitrate.
+    static let fallbackMasterBandwidthBps = 18_000_000
+
+    /// Bridging a lossy source track to lossless FLAC can push the served
+    /// variant's average above the source container average (multichannel
+    /// FLAC runs ~2-4 Mbps vs ~768 kbps DTS), and RFC 8216 forbids
+    /// understating AVERAGE-BANDWIDTH; budget a conservative allowance.
+    static let bridgedLosslessAudioAllowanceBps: Double = 4_000_000
+
     /// HLS `BANDWIDTH` declares the variant's peak segment bitrate; declaring
     /// less makes AVFoundation log a -12318 "Segment exceeds specified
     /// bandwidth" errorLog entry for every oversized segment. The true peak
@@ -36,17 +45,18 @@ enum LocalHLSPlaylistPolicy {
     /// average). Overstating is harmless on a single-variant playlist — there
     /// is no ABR decision to skew. Sources with no reported bitrate keep the
     /// legacy 18 Mbps declaration.
-    static let fallbackMasterBandwidthBps = 18_000_000
-
     static func masterPlaylistBandwidth(
-        sourceBitrateBps: Double?
+        sourceBitrateBps: Double?,
+        isAudioBridgedToLossless: Bool
     ) -> (peak: Int, average: Int?) {
         guard let sourceBitrateBps,
               sourceBitrateBps.isFinite,
               sourceBitrateBps > 0 else {
             return (fallbackMasterBandwidthBps, nil)
         }
-        let average = Int(min(sourceBitrateBps, 1_000_000_000))
+        let servedBitrateBps = sourceBitrateBps
+            + (isAudioBridgedToLossless ? bridgedLosslessAudioAllowanceBps : 0)
+        let average = Int(min(servedBitrateBps, 1_000_000_000))
         return (max(fallbackMasterBandwidthBps, average * 2), average)
     }
 }

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/LoopbackSegmentWriter.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/LoopbackSegmentWriter.swift
@@ -5509,7 +5509,14 @@ final class LoopbackSegmentWriter {
     }
 
     private func emitMasterPlaylist() {
-        var inf = "#EXT-X-STREAM-INF:BANDWIDTH=18000000,CODECS=\"\(masterCodecString())\""
+        let bandwidth = LocalHLSPlaylistPolicy.masterPlaylistBandwidth(
+            sourceBitrateBps: sessionSpec.sourceBitrateBps
+        )
+        var inf = "#EXT-X-STREAM-INF:BANDWIDTH=\(bandwidth.peak)"
+        if let average = bandwidth.average {
+            inf += ",AVERAGE-BANDWIDTH=\(average)"
+        }
+        inf += ",CODECS=\"\(masterCodecString())\""
         if let supplemental = supplementalCodecString() {
             inf += ",SUPPLEMENTAL-CODECS=\"\(supplemental)\""
         }

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/LoopbackSegmentWriter.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/LoopbackSegmentWriter.swift
@@ -5510,7 +5510,8 @@ final class LoopbackSegmentWriter {
 
     private func emitMasterPlaylist() {
         let bandwidth = LocalHLSPlaylistPolicy.masterPlaylistBandwidth(
-            sourceBitrateBps: sessionSpec.sourceBitrateBps
+            sourceBitrateBps: sessionSpec.sourceBitrateBps,
+            isAudioBridgedToLossless: selectedAudioOutputMode.bridgesToLosslessFLAC
         )
         var inf = "#EXT-X-STREAM-INF:BANDWIDTH=\(bandwidth.peak)"
         if let average = bandwidth.average {

--- a/iosApp/iosApp/Screens/Player/PlaybackExecutionPlan.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackExecutionPlan.swift
@@ -65,6 +65,13 @@ struct LoopbackSessionSpec {
         case transcodeAC3
         case transcodeAAC
 
+        /// True when a (typically lossy) source track is re-encoded to
+        /// lossless FLAC, which can raise the served bitrate above the
+        /// source container average.
+        var bridgesToLosslessFLAC: Bool {
+            self == .transcodeFLAC || self == .requireFLAC
+        }
+
         var preferredCodecToken: String {
             switch self {
             case .copy:


### PR DESCRIPTION
## Problem

The SiloPlayer loopback route's local HLS master playlist hardcodes `BANDWIDTH=18000000`, but remuxed streams routinely exceed it (observed ~63 Mbps on a 47.8 GB DV P7 title). AVFoundation logs a `-12318 CoreMediaErrorDomain "Segment exceeds specified bandwidth for variant"` errorLog entry per segment — noise that pollutes error-log-driven diagnostics.

## Fix

`LocalHLSPlaylistPolicy.masterPlaylistBandwidth(sourceBitrateBps:)` (pure, tested) derives the declaration from the known source bitrate (`LoopbackSessionSpec.sourceBitrateBps`):

- `AVERAGE-BANDWIDTH` = source average (clamped to a 1 Gbps sanity cap)
- `BANDWIDTH` = 2× average (peak headroom for FLAC audio bridging bursts), never below the legacy 18 Mbps floor
- Unknown/invalid source bitrate → legacy `BANDWIDTH=18000000`, no AVERAGE-BANDWIDTH (unchanged behavior)

RESOLUTION / FRAME-RATE / CODECS / SUPPLEMENTAL-CODECS / VIDEO-RANGE emission is untouched, as is the `player.apple.loopback_master_start_enabled` kill switch (it gates whether playback starts from master.m3u8; this only changes attributes within it).

## Testing

- SiloTV (tvOS) build green; `LocalHLSPlaylistPolicyTests` 8/8 pass (4 new: headroom math, legacy floor, unknown-bitrate fallback, absurd-value clamp).
- Overstated BANDWIDTH on a single-variant local playlist has no ABR consequence — there is no second variant to choose.

Follow-up from #66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Master playlists now use calculated, source-based bandwidth values instead of fixed numbers, improving metadata accuracy.
  * When available, playlists can include `AVERAGE-BANDWIDTH` alongside peak `BANDWIDTH`, including scenarios involving bridged lossless audio.

* **Bug Fixes**
  * More robust handling for missing, zero, non-finite, and extremely large source bitrate values using sensible fallback and clamping.

* **Tests**
  * Added unit coverage validating average/peak bandwidth behavior across normal, fallback, bridged lossless, and extreme input cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->