### PR TITLE
SiloPlayer: seek cache — disk spill on by default with NAND wear guard

### DIFF
--- a/iosApp/Tests/PlaybackSourceCacheDiskSpillTests.swift
+++ b/iosApp/Tests/PlaybackSourceCacheDiskSpillTests.swift
@@ -15,10 +15,13 @@ final class PlaybackSourceCacheDiskSpillTests: XCTestCase {
         )
     }
 
-    private func fill(_ cache: PlaybackSourceCache, spans: Int, startingAt base: Int64 = 0) {
-        for i in 0..<spans {
+    /// Stores `spans` distinct spans; the default 2× spacing keeps them
+    /// non-adjacent so the append fast path can't merge them.
+    private func fill(_ cache: PlaybackSourceCache, spans: Range<Int>, spacing: Int? = nil) {
+        let stride = spacing ?? spanBytes * 2
+        for i in spans {
             cache.store(
-                start: base + Int64(i * spanBytes),
+                start: Int64(i * stride),
                 data: Data(repeating: UInt8(truncatingIfNeeded: i + 1), count: spanBytes),
                 totalLength: nil
             )
@@ -27,15 +30,8 @@ final class PlaybackSourceCacheDiskSpillTests: XCTestCase {
 
     func testEvictedSpanIsServedFromDisk() {
         let cache = makeCache()
-        // Distinct non-adjacent spans so the append fast path can't merge
-        // them; overflow the 4 KiB memory budget to force eviction + spill.
-        for i in 0..<8 {
-            cache.store(
-                start: Int64(i * spanBytes * 2),
-                data: Data(repeating: UInt8(i + 1), count: spanBytes),
-                totalLength: nil
-            )
-        }
+        // Overflow the 4 KiB memory budget to force eviction + spill.
+        fill(cache, spans: 0..<8)
         let stats = cache.stats()
         XCTAssertGreaterThan(stats.diskSpillBytes, 0, "eviction should spill to disk")
         XCTAssertEqual(stats.diskBytesWritten, stats.diskSpillBytes)
@@ -51,13 +47,7 @@ final class PlaybackSourceCacheDiskSpillTests: XCTestCase {
             diskSpillEnabled: false,
             diskBudgetBytes: 16 * 1024
         )
-        for i in 0..<8 {
-            cache.store(
-                start: Int64(i * spanBytes * 2),
-                data: Data(repeating: UInt8(i + 1), count: spanBytes),
-                totalLength: nil
-            )
-        }
+        fill(cache, spans: 0..<8)
         let stats = cache.stats()
         XCTAssertEqual(stats.diskSpillBytes, 0)
         XCTAssertEqual(stats.diskBytesWritten, 0)
@@ -70,26 +60,11 @@ final class PlaybackSourceCacheDiskSpillTests: XCTestCase {
         // start and force one more spill — the victim must be the farthest
         // span, not the seek-back neighborhood.
         let cache = makeCache(maxBytes: 2 * spanBytes, diskBudgetBytes: Int64(4 * spanBytes))
-        for i in 0..<6 {
-            cache.store(
-                start: Int64(i * spanBytes * 2),
-                data: Data(repeating: UInt8(i + 1), count: spanBytes),
-                totalLength: nil
-            )
-        }
+        fill(cache, spans: 0..<6)
         // Playhead near start: reading span 0 (from disk) sets lastReadEnd.
         XCTAssertNotNil(cache.read(start: 0, maxLength: spanBytes))
         // Force another spill over the full disk budget.
-        cache.store(
-            start: Int64(6 * spanBytes * 2),
-            data: Data(repeating: 7, count: spanBytes),
-            totalLength: nil
-        )
-        cache.store(
-            start: Int64(7 * spanBytes * 2),
-            data: Data(repeating: 8, count: spanBytes),
-            totalLength: nil
-        )
+        fill(cache, spans: 6..<8)
         // Span 0 is at the playhead — it must survive disk eviction.
         XCTAssertEqual(cache.read(start: 0, maxLength: spanBytes), Data(repeating: 1, count: spanBytes))
         XCTAssertLessThanOrEqual(cache.stats().diskSpillBytes, Int64(4 * spanBytes))
@@ -100,25 +75,13 @@ final class PlaybackSourceCacheDiskSpillTests: XCTestCase {
         // anchor on the *recent* read position or a backward seek's
         // neighborhood gets evicted while stale forward spans survive.
         let cache = makeCache(maxBytes: 2 * spanBytes, diskBudgetBytes: Int64(4 * spanBytes))
-        for i in 0..<6 {
-            cache.store(
-                start: Int64(i * spanBytes * 2),
-                data: Data(repeating: UInt8(i + 1), count: spanBytes),
-                totalLength: nil
-            )
-        }
+        fill(cache, spans: 0..<6)
         // Play far forward (pins the high-water mark high)...
         XCTAssertNotNil(cache.read(start: Int64(5 * spanBytes * 2), maxLength: spanBytes))
         // ...then seek back to the start.
         XCTAssertNotNil(cache.read(start: 0, maxLength: spanBytes))
         // Force disk eviction with two more spills.
-        for i in 6..<8 {
-            cache.store(
-                start: Int64(i * spanBytes * 2),
-                data: Data(repeating: UInt8(i + 1), count: spanBytes),
-                totalLength: nil
-            )
-        }
+        fill(cache, spans: 6..<8)
         // The seek-back neighborhood must survive despite the stale
         // high-water mark sitting far ahead.
         XCTAssertEqual(cache.read(start: 0, maxLength: spanBytes), Data(repeating: 1, count: spanBytes))
@@ -130,13 +93,7 @@ final class PlaybackSourceCacheDiskSpillTests: XCTestCase {
         let diskBudget = Int64(2 * spanBytes)
         let writeBudget = diskBudget * PlaybackSourceCache.diskWriteBudgetMultiplier
         let cache = makeCache(maxBytes: 2 * spanBytes, diskBudgetBytes: diskBudget)
-        for i in 0..<32 {
-            cache.store(
-                start: Int64(i * spanBytes * 2),
-                data: Data(repeating: UInt8(truncatingIfNeeded: i + 1), count: spanBytes),
-                totalLength: nil
-            )
-        }
+        fill(cache, spans: 0..<32)
         let stats = cache.stats()
         XCTAssertLessThanOrEqual(stats.diskBytesWritten, writeBudget, "session writes must respect the wear budget")
         XCTAssertLessThanOrEqual(stats.diskSpillBytes, diskBudget)

--- a/iosApp/Tests/PlaybackSourceCacheDiskSpillTests.swift
+++ b/iosApp/Tests/PlaybackSourceCacheDiskSpillTests.swift
@@ -95,6 +95,35 @@ final class PlaybackSourceCacheDiskSpillTests: XCTestCase {
         XCTAssertLessThanOrEqual(cache.stats().diskSpillBytes, Int64(4 * spanBytes))
     }
 
+    func testBackwardSeekMovesDiskEvictionAnchor() {
+        // lastReadEnd is a monotonic high-water mark; disk eviction must
+        // anchor on the *recent* read position or a backward seek's
+        // neighborhood gets evicted while stale forward spans survive.
+        let cache = makeCache(maxBytes: 2 * spanBytes, diskBudgetBytes: Int64(4 * spanBytes))
+        for i in 0..<6 {
+            cache.store(
+                start: Int64(i * spanBytes * 2),
+                data: Data(repeating: UInt8(i + 1), count: spanBytes),
+                totalLength: nil
+            )
+        }
+        // Play far forward (pins the high-water mark high)...
+        XCTAssertNotNil(cache.read(start: Int64(5 * spanBytes * 2), maxLength: spanBytes))
+        // ...then seek back to the start.
+        XCTAssertNotNil(cache.read(start: 0, maxLength: spanBytes))
+        // Force disk eviction with two more spills.
+        for i in 6..<8 {
+            cache.store(
+                start: Int64(i * spanBytes * 2),
+                data: Data(repeating: UInt8(i + 1), count: spanBytes),
+                totalLength: nil
+            )
+        }
+        // The seek-back neighborhood must survive despite the stale
+        // high-water mark sitting far ahead.
+        XCTAssertEqual(cache.read(start: 0, maxLength: spanBytes), Data(repeating: 1, count: spanBytes))
+    }
+
     func testWriteBudgetStopsSpillAndChurn() {
         // Write budget = multiplier × diskBudget. Give a tiny disk budget so
         // the write budget is exhausted quickly, then verify writes stop.

--- a/iosApp/Tests/PlaybackSourceCacheDiskSpillTests.swift
+++ b/iosApp/Tests/PlaybackSourceCacheDiskSpillTests.swift
@@ -1,0 +1,131 @@
+import XCTest
+@testable import Silo
+
+final class PlaybackSourceCacheDiskSpillTests: XCTestCase {
+    private let spanBytes = 1024
+
+    private func makeCache(
+        maxBytes: Int = 4 * 1024,
+        diskBudgetBytes: Int64 = 16 * 1024
+    ) -> PlaybackSourceCache {
+        PlaybackSourceCache(
+            maxBytes: maxBytes,
+            diskSpillEnabled: true,
+            diskBudgetBytes: diskBudgetBytes
+        )
+    }
+
+    private func fill(_ cache: PlaybackSourceCache, spans: Int, startingAt base: Int64 = 0) {
+        for i in 0..<spans {
+            cache.store(
+                start: base + Int64(i * spanBytes),
+                data: Data(repeating: UInt8(truncatingIfNeeded: i + 1), count: spanBytes),
+                totalLength: nil
+            )
+        }
+    }
+
+    func testEvictedSpanIsServedFromDisk() {
+        let cache = makeCache()
+        // Distinct non-adjacent spans so the append fast path can't merge
+        // them; overflow the 4 KiB memory budget to force eviction + spill.
+        for i in 0..<8 {
+            cache.store(
+                start: Int64(i * spanBytes * 2),
+                data: Data(repeating: UInt8(i + 1), count: spanBytes),
+                totalLength: nil
+            )
+        }
+        let stats = cache.stats()
+        XCTAssertGreaterThan(stats.diskSpillBytes, 0, "eviction should spill to disk")
+        XCTAssertEqual(stats.diskBytesWritten, stats.diskSpillBytes)
+        // The oldest span (start 0) was evicted from memory; bytes must
+        // round-trip identically from the disk span.
+        let read = cache.read(start: 0, maxLength: spanBytes)
+        XCTAssertEqual(read, Data(repeating: 1, count: spanBytes))
+    }
+
+    func testDiskSpillDisabledWritesNothing() {
+        let cache = PlaybackSourceCache(
+            maxBytes: 4 * 1024,
+            diskSpillEnabled: false,
+            diskBudgetBytes: 16 * 1024
+        )
+        for i in 0..<8 {
+            cache.store(
+                start: Int64(i * spanBytes * 2),
+                data: Data(repeating: UInt8(i + 1), count: spanBytes),
+                totalLength: nil
+            )
+        }
+        let stats = cache.stats()
+        XCTAssertEqual(stats.diskSpillBytes, 0)
+        XCTAssertEqual(stats.diskBytesWritten, 0)
+        XCTAssertEqual(stats.diskBudgetBytes, 0)
+        XCTAssertNil(cache.read(start: 0, maxLength: spanBytes), "evicted span must be gone without spill")
+    }
+
+    func testDiskEvictionPrefersSpansFarthestFromPlayhead() {
+        // Disk budget of 4 spans; spill 4, then anchor the playhead near the
+        // start and force one more spill — the victim must be the farthest
+        // span, not the seek-back neighborhood.
+        let cache = makeCache(maxBytes: 2 * spanBytes, diskBudgetBytes: Int64(4 * spanBytes))
+        for i in 0..<6 {
+            cache.store(
+                start: Int64(i * spanBytes * 2),
+                data: Data(repeating: UInt8(i + 1), count: spanBytes),
+                totalLength: nil
+            )
+        }
+        // Playhead near start: reading span 0 (from disk) sets lastReadEnd.
+        XCTAssertNotNil(cache.read(start: 0, maxLength: spanBytes))
+        // Force another spill over the full disk budget.
+        cache.store(
+            start: Int64(6 * spanBytes * 2),
+            data: Data(repeating: 7, count: spanBytes),
+            totalLength: nil
+        )
+        cache.store(
+            start: Int64(7 * spanBytes * 2),
+            data: Data(repeating: 8, count: spanBytes),
+            totalLength: nil
+        )
+        // Span 0 is at the playhead — it must survive disk eviction.
+        XCTAssertEqual(cache.read(start: 0, maxLength: spanBytes), Data(repeating: 1, count: spanBytes))
+        XCTAssertLessThanOrEqual(cache.stats().diskSpillBytes, Int64(4 * spanBytes))
+    }
+
+    func testWriteBudgetStopsSpillAndChurn() {
+        // Write budget = multiplier × diskBudget. Give a tiny disk budget so
+        // the write budget is exhausted quickly, then verify writes stop.
+        let diskBudget = Int64(2 * spanBytes)
+        let writeBudget = diskBudget * PlaybackSourceCache.diskWriteBudgetMultiplier
+        let cache = makeCache(maxBytes: 2 * spanBytes, diskBudgetBytes: diskBudget)
+        for i in 0..<32 {
+            cache.store(
+                start: Int64(i * spanBytes * 2),
+                data: Data(repeating: UInt8(truncatingIfNeeded: i + 1), count: spanBytes),
+                totalLength: nil
+            )
+        }
+        let stats = cache.stats()
+        XCTAssertLessThanOrEqual(stats.diskBytesWritten, writeBudget, "session writes must respect the wear budget")
+        XCTAssertLessThanOrEqual(stats.diskSpillBytes, diskBudget)
+    }
+
+    func testRetentionBudgetClampParity() {
+        // The source-cache budget must match the segment store's policy.
+        let cap: Int64 = 2 << 30
+        let floor: Int64 = 512 << 20
+        XCTAssertEqual(PlaybackDiskBudget.retentionBudget(availableBytes: nil), cap)
+        XCTAssertEqual(PlaybackDiskBudget.retentionBudget(availableBytes: 0), cap)
+        XCTAssertEqual(PlaybackDiskBudget.retentionBudget(availableBytes: -1), cap)
+        XCTAssertEqual(PlaybackDiskBudget.retentionBudget(availableBytes: 100 << 20), floor)
+        XCTAssertEqual(PlaybackDiskBudget.retentionBudget(availableBytes: 4 << 30), 1 << 30)
+        XCTAssertEqual(PlaybackDiskBudget.retentionBudget(availableBytes: 100 << 30), cap)
+        XCTAssertEqual(
+            AVPlayerBackend.vodRetentionBudget(availableBytes: 4 << 30),
+            PlaybackDiskBudget.retentionBudget(availableBytes: 4 << 30)
+        )
+    }
+}

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
@@ -1066,17 +1066,10 @@ final class AVPlayerBackend {
         return Self.vodRetentionBudget(availableBytes: freeDiskSpaceBytes())
     }
 
-    /// Pure clamp for the VOD retention budget: quarter of the available
-    /// temp-volume capacity, capped at 2 GiB, floored at 512 MiB. An
-    /// unknown or non-positive capacity reading means the query is broken,
-    /// not that the disk is full — use the cap, never 0: a zero budget
-    /// disables pruning outright and deadlocks the producer once the spill
-    /// gate fills.
+    /// Pure clamp for the VOD retention budget; shared with the source
+    /// cache's spill budget so both spill tiers size against the same policy.
     static func vodRetentionBudget(availableBytes: Int64?) -> Int64 {
-        let cap: Int64 = 2 << 30
-        let floor: Int64 = 512 << 20
-        guard let availableBytes, availableBytes > 0 else { return cap }
-        return min(cap, max(floor, availableBytes / 4))
+        PlaybackDiskBudget.retentionBudget(availableBytes: availableBytes)
     }
 
     /// Swaps the producer (writer only — the store, server, and player item
@@ -2380,8 +2373,7 @@ final class AVPlayerBackend {
     }
 
     private static func freeDiskSpaceBytes() -> Int64? {
-        let attributes = try? FileManager.default.attributesOfFileSystem(forPath: NSHomeDirectory())
-        return (attributes?[.systemFreeSize] as? NSNumber)?.int64Value
+        PlaybackDiskBudget.freeDiskSpaceBytes()
     }
 
     private static func volumeAvailableCapacityBytes() -> Int64? {

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/LoopbackSegmentStore.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/LoopbackSegmentStore.swift
@@ -173,6 +173,7 @@ final class LoopbackSegmentStore {
         self.memoryBudgetBytes = memoryBudgetBytes
         self.debugDirectory = debugDirectory
         self.spillPolicy = spillPolicy
+        _ = PlaybackDiskBudget.sweepOrphanedSpillDirectories
         if spillPolicy.isEnabled {
             let dir = FileManager.default.temporaryDirectory
                 .appendingPathComponent("continuum-dv-hls", isDirectory: true)

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/LoopbackSegmentStore.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/LoopbackSegmentStore.swift
@@ -400,8 +400,10 @@ final class LoopbackSegmentStore {
                 guard offset <= segment.data.count else { return (Data(), true) }
                 return (segment.data.subdata(in: offset..<segment.data.count), true)
             }
+            // mmap + .uncached: spilled segments are immutable after their
+            // atomic write; let the kernel page them instead of the heap.
             if let url = spilledSegments[name],
-               let data = try? Data(contentsOf: url) {
+               let data = try? Data(contentsOf: url, options: [.alwaysMapped, .uncached]) {
                 guard offset <= data.count else { return (Data(), true) }
                 return (data.subdata(in: offset..<data.count), true)
             }

--- a/iosApp/iosApp/Screens/Player/PlaybackDiskBudget.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackDiskBudget.swift
@@ -30,9 +30,12 @@ enum PlaybackDiskBudget {
 
     /// One-shot per process: delete spill directories left behind by a
     /// force-killed predecessor (their deinit cleanup never ran, and a
-    /// stranded directory can hold up to the full retention budget). Runs
-    /// before the first spilling cache of this process creates its own
-    /// directory, so everything found here is orphaned. `static let`
+    /// stranded directory can hold up to the full retention budget).
+    /// Enumeration happens synchronously on first access — before the first
+    /// spilling cache of this process creates its own directory, so
+    /// everything captured here is orphaned — but the deletions (the slow
+    /// part for a multi-GiB tree) run on a utility queue so session startup
+    /// is never blocked on reclaiming a predecessor's space. `static let`
     /// initialization makes the sweep thread-safe and exactly-once.
     static let sweepOrphanedSpillDirectories: Void = {
         let fm = FileManager.default
@@ -41,12 +44,13 @@ enum PlaybackDiskBudget {
             parents.append(caches.appendingPathComponent("continuum-source-cache", isDirectory: true))
         }
         parents.append(fm.temporaryDirectory.appendingPathComponent("continuum-dv-hls", isDirectory: true))
-        for parent in parents {
-            guard let children = try? fm.contentsOfDirectory(at: parent, includingPropertiesForKeys: nil) else {
-                continue
-            }
-            for child in children {
-                try? fm.removeItem(at: child)
+        let orphans = parents.flatMap { parent in
+            (try? fm.contentsOfDirectory(at: parent, includingPropertiesForKeys: nil)) ?? []
+        }
+        guard !orphans.isEmpty else { return }
+        DispatchQueue.global(qos: .utility).async {
+            for orphan in orphans {
+                try? FileManager.default.removeItem(at: orphan)
             }
         }
     }()

--- a/iosApp/iosApp/Screens/Player/PlaybackDiskBudget.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackDiskBudget.swift
@@ -27,4 +27,27 @@ enum PlaybackDiskBudget {
         guard let availableBytes, availableBytes > 0 else { return cap }
         return min(cap, max(floor, availableBytes / 4))
     }
+
+    /// One-shot per process: delete spill directories left behind by a
+    /// force-killed predecessor (their deinit cleanup never ran, and a
+    /// stranded directory can hold up to the full retention budget). Runs
+    /// before the first spilling cache of this process creates its own
+    /// directory, so everything found here is orphaned. `static let`
+    /// initialization makes the sweep thread-safe and exactly-once.
+    static let sweepOrphanedSpillDirectories: Void = {
+        let fm = FileManager.default
+        var parents: [URL] = []
+        if let caches = fm.urls(for: .cachesDirectory, in: .userDomainMask).first {
+            parents.append(caches.appendingPathComponent("continuum-source-cache", isDirectory: true))
+        }
+        parents.append(fm.temporaryDirectory.appendingPathComponent("continuum-dv-hls", isDirectory: true))
+        for parent in parents {
+            guard let children = try? fm.contentsOfDirectory(at: parent, includingPropertiesForKeys: nil) else {
+                continue
+            }
+            for child in children {
+                try? fm.removeItem(at: child)
+            }
+        }
+    }()
 }

--- a/iosApp/iosApp/Screens/Player/PlaybackDiskBudget.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackDiskBudget.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Shared disk-budget policy for the playback caches that spill to the
+/// temp/caches volume (the origin source cache and the loopback segment
+/// store). Both tiers size their retention against the same clamp so disk
+/// pressure behaves predictably when they are active together.
+enum PlaybackDiskBudget {
+    /// Free space on the volume backing the app sandbox.
+    /// `volumeAvailableCapacityForImportantUsage` is unavailable on tvOS and
+    /// the plain capacity key can report 0 for the sandboxed temp volume
+    /// there, so use the filesystem-attributes helper (valid on every
+    /// platform).
+    static func freeDiskSpaceBytes() -> Int64? {
+        let attributes = try? FileManager.default.attributesOfFileSystem(forPath: NSHomeDirectory())
+        return (attributes?[.systemFreeSize] as? NSNumber)?.int64Value
+    }
+
+    /// Pure clamp for a spill retention budget: quarter of the available
+    /// volume capacity, capped at 2 GiB, floored at 512 MiB. An unknown or
+    /// non-positive capacity reading means the query is broken, not that the
+    /// disk is full — use the cap, never 0: a zero budget disables pruning
+    /// outright and deadlocks a budget-gated producer once the spill gate
+    /// fills.
+    static func retentionBudget(availableBytes: Int64?) -> Int64 {
+        let cap: Int64 = 2 << 30
+        let floor: Int64 = 512 << 20
+        guard let availableBytes, availableBytes > 0 else { return cap }
+        return min(cap, max(floor, availableBytes / 4))
+    }
+}

--- a/iosApp/iosApp/Screens/Player/PlaybackSourceProxy.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSourceProxy.swift
@@ -155,6 +155,11 @@ final class PlaybackSourceCache {
     private var loggedWriteBudgetExhausted = false
     private var recentTransfers: [(time: Date, bytes: Int)] = []
     private var lastReadEnd: Int64?
+    /// Most recent read position (not a high-water mark). `lastReadEnd` is
+    /// monotonic for forward-buffer accounting, so after a backward seek it
+    /// stays pinned ahead of the bytes actually being served — disk eviction
+    /// must anchor here instead, or it protects the wrong neighborhood.
+    private var lastReadPosition: Int64?
     private var sourceBitrateBps: Double?
     private let diskSpillEnabled: Bool
     private let diskBudgetBytes: Int64
@@ -264,6 +269,7 @@ final class PlaybackSourceCache {
                 let data = file.subdata(in: offset..<(offset + length))
                 cacheHitBytes += Int64(data.count)
                 lastReadEnd = max(lastReadEnd ?? 0, start + Int64(data.count) - 1)
+                lastReadPosition = start + Int64(data.count) - 1
                 return data
             }
             return nil
@@ -274,6 +280,7 @@ final class PlaybackSourceCache {
         let data = span.data.subdata(in: offset..<(offset + length))
         cacheHitBytes += Int64(data.count)
         lastReadEnd = max(lastReadEnd ?? 0, start + Int64(data.count) - 1)
+        lastReadPosition = start + Int64(data.count) - 1
         return data
     }
 
@@ -500,7 +507,7 @@ final class PlaybackSourceCache {
     /// thing evicted. POSIX keeps any concurrently mapped file valid after
     /// unlink, and the ledger mutation is under `lock`, so readers are safe.
     private func makeRoomOnDiskLocked(for incomingBytes: Int64) {
-        let playhead = lastReadEnd ?? 0
+        let playhead = lastReadPosition ?? lastReadEnd ?? 0
         while diskSpillBytes + incomingBytes > diskBudgetBytes, !diskSpans.isEmpty {
             guard let victimIndex = diskSpans.indices.max(by: { a, b in
                 distanceFromPlayhead(diskSpans[a], playhead: playhead)

--- a/iosApp/iosApp/Screens/Player/PlaybackSourceProxy.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSourceProxy.swift
@@ -180,6 +180,7 @@ final class PlaybackSourceCache {
         self.diskSpillEnabled = Self.resolveDiskSpillEnabled(diskSpillEnabled)
         self.diskBudgetBytes = diskBudgetBytes
             ?? PlaybackDiskBudget.retentionBudget(availableBytes: PlaybackDiskBudget.freeDiskSpaceBytes())
+        _ = PlaybackDiskBudget.sweepOrphanedSpillDirectories
         if self.diskSpillEnabled {
             let dir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?
                 .appendingPathComponent("continuum-source-cache", isDirectory: true)

--- a/iosApp/iosApp/Screens/Player/PlaybackSourceProxy.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSourceProxy.swift
@@ -16,6 +16,8 @@ struct PlaybackSourceProxyStats: Equatable {
     let cacheMissBytes: Int64
     let activeOriginRequestCount: Int
     let diskSpillBytes: Int64
+    let diskBudgetBytes: Int64
+    let diskBytesWritten: Int64
 }
 
 enum PlaybackSourceInterruptionReason: Equatable {
@@ -68,7 +70,17 @@ final class PlaybackSourceCache {
     static var siloLoopbackMemoryBudgetBytes: Int {
         isConstrainedMemoryDevice ? 128 * 1024 * 1024 : 256 * 1024 * 1024
     }
-    static let sourceDiskSpillBudgetBytes = 512 * 1024 * 1024
+    /// Session NAND-write budget multiplier over the disk retention budget.
+    /// Spill writes the stream to flash once per watched-and-evicted byte, so
+    /// an unbounded budget writes a 70 GB remux to NAND every viewing.
+    /// Constrained devices (small-NAND Apple TVs) get half the allowance.
+    static var diskWriteBudgetMultiplier: Int64 {
+        isConstrainedMemoryDevice ? 1 : 2
+    }
+    /// When the retention budget holds less than this much content, the
+    /// wear-per-benefit ratio is poor (a 2 GiB budget is ~4 min of a
+    /// Blu-ray remux) — the write budget is halved for such sources.
+    static let diskWriteBudgetBitrateGateSeconds: Double = 600
     /// Streaming appends grow a span in place until it reaches this size,
     /// then roll over to a new span so eviction stays reasonably granular.
     static let maxAppendSpanBytes = 16 * 1024 * 1024
@@ -94,6 +106,8 @@ final class PlaybackSourceCache {
         let cacheMissBytes: Int64
         let activeOriginRequestCount: Int
         let diskSpillBytes: Int64
+        let diskBudgetBytes: Int64
+        let diskBytesWritten: Int64
     }
 
     struct Gap {
@@ -137,18 +151,36 @@ final class PlaybackSourceCache {
     private var cacheMissBytes: Int64 = 0
     private var activeOriginRequestCount = 0
     private var diskSpillBytes: Int64 = 0
+    private var diskBytesWritten: Int64 = 0
+    private var loggedWriteBudgetExhausted = false
     private var recentTransfers: [(time: Date, bytes: Int)] = []
     private var lastReadEnd: Int64?
     private var sourceBitrateBps: Double?
     private let diskSpillEnabled: Bool
+    private let diskBudgetBytes: Int64
     private let diskDirectory: URL?
 
-    init(maxBytes: Int = PlaybackSourceCache.defaultMemoryBudgetBytes) {
+    /// Env vars remain as dev overrides in both directions; the shipped
+    /// default comes from the caller (user "Seek Cache" setting, default on).
+    private static func resolveDiskSpillEnabled(_ requested: Bool) -> Bool {
+        let env = ProcessInfo.processInfo.environment
+        if env["SILO_DISABLE_SOURCE_DISK_SPILL"] == "1" { return false }
+        if env["SILO_ENABLE_SOURCE_DISK_SPILL"] == "1" { return true }
+        return requested
+    }
+
+    init(
+        maxBytes: Int = PlaybackSourceCache.defaultMemoryBudgetBytes,
+        diskSpillEnabled: Bool = true,
+        diskBudgetBytes: Int64? = nil
+    ) {
         self.maxBytes = maxBytes
         self.highWaterBytes = maxBytes
         self.lowWaterBytes = max(0, maxBytes - 64 * 1024 * 1024)
-        self.diskSpillEnabled = ProcessInfo.processInfo.environment["SILO_ENABLE_SOURCE_DISK_SPILL"] == "1"
-        if diskSpillEnabled {
+        self.diskSpillEnabled = Self.resolveDiskSpillEnabled(diskSpillEnabled)
+        self.diskBudgetBytes = diskBudgetBytes
+            ?? PlaybackDiskBudget.retentionBudget(availableBytes: PlaybackDiskBudget.freeDiskSpaceBytes())
+        if self.diskSpillEnabled {
             let dir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?
                 .appendingPathComponent("continuum-source-cache", isDirectory: true)
                 .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -219,8 +251,12 @@ final class PlaybackSourceCache {
         lock.lock()
         defer { lock.unlock() }
         guard let span = spans.first(where: { $0.start <= start && $0.end >= start }) else {
+            // mmap + .uncached keeps disk hits out of the heap footprint: the
+            // kernel pages the span in and out under memory pressure; only
+            // the requested slice below is copied. Spans are immutable after
+            // their atomic write, so there is no torn-read window.
             if let diskSpan = diskSpans.first(where: { $0.start <= start && $0.end >= start }),
-               let file = try? Data(contentsOf: diskSpan.url) {
+               let file = try? Data(contentsOf: diskSpan.url, options: [.alwaysMapped, .uncached]) {
                 let offset = Int(start - diskSpan.start)
                 let length = min(maxLength, file.count - offset)
                 guard length > 0 else { return nil }
@@ -352,7 +388,9 @@ final class PlaybackSourceCache {
             cacheHitBytes: cacheHitBytes,
             cacheMissBytes: cacheMissBytes,
             activeOriginRequestCount: activeOriginRequestCount,
-            diskSpillBytes: diskSpillBytes
+            diskSpillBytes: diskSpillBytes,
+            diskBudgetBytes: diskSpillEnabled ? diskBudgetBytes : 0,
+            diskBytesWritten: diskBytesWritten
         )
         lock.unlock()
         return snapshot
@@ -420,21 +458,62 @@ final class PlaybackSourceCache {
         }
     }
 
+    /// Session write budget: bounds total NAND writes (retention budget only
+    /// bounds what is *stored*). Once spent, spill stops for the rest of the
+    /// session — including the evict-to-make-room churn — so a long watch
+    /// costs at most a few GiB of flash writes instead of the full stream.
+    private func diskWriteBudgetLocked() -> Int64 {
+        var budget = diskBudgetBytes * Self.diskWriteBudgetMultiplier
+        if let bps = sourceBitrateBps, bps > 0,
+           Double(diskBudgetBytes) / (bps / 8) < Self.diskWriteBudgetBitrateGateSeconds {
+            budget /= 2
+        }
+        return budget
+    }
+
     private func spillToDiskIfEnabledLocked(_ span: Span) {
-        guard diskSpillEnabled,
-              let diskDirectory,
-              diskSpillBytes + Int64(span.data.count) <= Int64(Self.sourceDiskSpillBudgetBytes) else {
+        guard diskSpillEnabled, let diskDirectory else { return }
+        guard diskBytesWritten + Int64(span.data.count) <= diskWriteBudgetLocked() else {
+            if !loggedWriteBudgetExhausted {
+                loggedWriteBudgetExhausted = true
+                print("[CMP-SOURCE-CACHE] spill write-budget exhausted written=\(diskBytesWritten) retained=\(diskSpillBytes) budget=\(diskWriteBudgetLocked())")
+            }
             return
         }
+        makeRoomOnDiskLocked(for: Int64(span.data.count))
+        guard diskSpillBytes + Int64(span.data.count) <= diskBudgetBytes else { return }
         let name = "\(span.start)-\(span.end).bin"
         let url = diskDirectory.appendingPathComponent(name)
         do {
             try span.data.write(to: url, options: .atomic)
             diskSpans.append(DiskSpan(start: span.start, length: span.data.count, url: url, createdAt: Date()))
             diskSpillBytes += Int64(span.data.count)
+            diskBytesWritten += Int64(span.data.count)
         } catch {
             // Spill is opportunistic; active playback can always refetch.
         }
+    }
+
+    /// Frees disk retention for an incoming spill by deleting the spans
+    /// farthest from the playhead first, so a seek-back target is the last
+    /// thing evicted. POSIX keeps any concurrently mapped file valid after
+    /// unlink, and the ledger mutation is under `lock`, so readers are safe.
+    private func makeRoomOnDiskLocked(for incomingBytes: Int64) {
+        let playhead = lastReadEnd ?? 0
+        while diskSpillBytes + incomingBytes > diskBudgetBytes, !diskSpans.isEmpty {
+            guard let victimIndex = diskSpans.indices.max(by: { a, b in
+                distanceFromPlayhead(diskSpans[a], playhead: playhead)
+                    < distanceFromPlayhead(diskSpans[b], playhead: playhead)
+            }) else { return }
+            let victim = diskSpans.remove(at: victimIndex)
+            diskSpillBytes -= Int64(victim.length)
+            try? FileManager.default.removeItem(at: victim.url)
+        }
+    }
+
+    private func distanceFromPlayhead(_ span: DiskSpan, playhead: Int64) -> Int64 {
+        if span.range.contains(playhead) { return 0 }
+        return min(abs(span.start - playhead), abs(span.end - playhead))
     }
 
     private func forwardCachedBytesLocked() -> Int64 {
@@ -616,7 +695,9 @@ private final class PlaybackSourceResource {
             cacheHitBytes: snapshot.cacheHitBytes,
             cacheMissBytes: snapshot.cacheMissBytes,
             activeOriginRequestCount: snapshot.activeOriginRequestCount,
-            diskSpillBytes: snapshot.diskSpillBytes
+            diskSpillBytes: snapshot.diskSpillBytes,
+            diskBudgetBytes: snapshot.diskBudgetBytes,
+            diskBytesWritten: snapshot.diskBytesWritten
         )
     }
 

--- a/iosApp/iosApp/Screens/Player/PlaybackStats.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackStats.swift
@@ -46,6 +46,7 @@ struct PlaybackStats: Equatable {
     var sourceCacheMissBytes: Int64?
     var sourceActiveOriginRequestCount: Int?
     var sourceDiskSpillBytes: Int64?
+    var sourceDiskBytesWritten: Int64?
     var sourceOriginBytesTransferred: Int64?
     var sourceOriginBitrateBps: Double?
     var generatedAheadSeconds: Double?
@@ -211,6 +212,9 @@ extension PlaybackStats {
         }
         if let sourceDiskSpillBytes {
             rows.append(("Source disk spill", ByteCountFormatter.string(fromByteCount: sourceDiskSpillBytes, countStyle: .file)))
+        }
+        if let sourceDiskBytesWritten, sourceDiskBytesWritten > 0 {
+            rows.append(("Source disk written", ByteCountFormatter.string(fromByteCount: sourceDiskBytesWritten, countStyle: .file)))
         }
         if let sourceOriginBytesTransferred {
             rows.append(("Source origin bytes", ByteCountFormatter.string(fromByteCount: sourceOriginBytesTransferred, countStyle: .file)))

--- a/iosApp/iosApp/Screens/Player/PlayerSettings.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerSettings.swift
@@ -47,6 +47,7 @@ private enum PlayerDeviceSettingKey: String, CaseIterable {
     case subtitleAppearance = "subtitle_appearance"
     case hdrEnabled = "player.hdr_enabled"
     case dvProfile7HDR10Fallback = "player.dv_profile7_hdr10_fallback"
+    case seekCacheEnabled = "player.seek_cache_enabled"
     case playbackSpeed = "player.playback_speed"
     case audioSyncMs = "player.audio_sync_ms"
     case subtitleSyncMs = "player.subtitle_sync_ms"
@@ -85,6 +86,14 @@ final class PlayerSettings {
 
     var preferProfile7HDR10Fallback: Bool {
         didSet { defaults.set(preferProfile7HDR10Fallback, forKey: Self.cacheKey(Keys.dvProfile7HDR10Fallback)) }
+    }
+
+    /// Spill streamed bytes to temporary disk storage during playback so
+    /// large forward/backward seeks are served locally. Governs the source
+    /// cache only; the loopback segment store's spill is load-bearing for the
+    /// DV route and stays on regardless.
+    var seekCacheEnabled: Bool {
+        didSet { defaults.set(seekCacheEnabled, forKey: Self.cacheKey(Keys.seekCacheEnabled)) }
     }
 
     var subtitleAppearance: SubtitleAppearance {
@@ -196,6 +205,7 @@ final class PlayerSettings {
             Keys.autoSkipCredits: false,
             Keys.hdrEnabled: true,
             Keys.dvProfile7HDR10Fallback: false,
+            Keys.seekCacheEnabled: true,
             Keys.subtitleAppearance: SubtitleAppearance.default.jsonString,
             Keys.subtitleUsesDeviceAppearanceOverride: false,
             Keys.subtitleMatchesSystemAppearance: false,
@@ -226,6 +236,11 @@ final class PlayerSettings {
             defaults,
             key: Keys.dvProfile7HDR10Fallback,
             defaultValue: false
+        )
+        seekCacheEnabled = Self.cachedBool(
+            defaults,
+            key: Keys.seekCacheEnabled,
+            defaultValue: true
         )
         subtitleAppearance = SubtitleAppearance.decode(from: defaults.string(forKey: Self.cacheKey(Keys.subtitleAppearance)))
         subtitleUsesDeviceAppearanceOverride = Self.cachedBool(
@@ -371,6 +386,11 @@ final class PlayerSettings {
         enqueueDeviceSetting(.dvProfile7HDR10Fallback, operation: .set(boolString(enabled)))
     }
 
+    func setSeekCacheEnabled(_ enabled: Bool) {
+        seekCacheEnabled = enabled
+        enqueueDeviceSetting(.seekCacheEnabled, operation: .set(boolString(enabled)))
+    }
+
     func setPlaybackSpeed(_ rate: Double) {
         let normalized = max(0.25, min(rate, 3.0))
         playbackSpeed = normalized
@@ -504,6 +524,11 @@ final class PlayerSettings {
             in: effectiveByKey,
             fallback: false
         )
+        seekCacheEnabled = effectiveBool(
+            for: .seekCacheEnabled,
+            in: effectiveByKey,
+            fallback: true
+        )
         playbackSpeed = effectiveDouble(for: .playbackSpeed, in: effectiveByKey, fallback: 1.0)
         audioSyncMs = effectiveInt(for: .audioSyncMs, in: effectiveByKey, fallback: 0)
         subtitleSyncMs = effectiveInt(for: .subtitleSyncMs, in: effectiveByKey, fallback: 0)
@@ -593,6 +618,11 @@ final class PlayerSettings {
             defaults,
             key: Keys.dvProfile7HDR10Fallback,
             defaultValue: false
+        )
+        seekCacheEnabled = Self.cachedBool(
+            defaults,
+            key: Keys.seekCacheEnabled,
+            defaultValue: true
         )
         playbackSpeed = Self.cachedDouble(defaults, key: Keys.playbackSpeed, defaultValue: 1.0)
         audioSyncMs = defaults.integer(forKey: Self.cacheKey(Keys.audioSyncMs))
@@ -791,6 +821,7 @@ final class PlayerSettings {
         static let autoSkipCredits = "skipCredits"
         static let hdrEnabled = "player.hdrEnabled"
         static let dvProfile7HDR10Fallback = "player.dvProfile7HDR10Fallback"
+        static let seekCacheEnabled = "player.seekCacheEnabled"
         static let subtitleAppearance = "player.subtitleAppearance"
         static let subtitleUsesDeviceAppearanceOverride = "player.subtitleUsesDeviceAppearanceOverride"
         static let subtitleMatchesSystemAppearance = "player.subtitleMatchesSystemAppearance"

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -2072,7 +2072,10 @@ class PlayerViewModel {
         let proxy = PlaybackSourceProxy(
             originURL: plan.sourceStreamRequest.url,
             originHeaders: plan.sourceStreamRequest.headers,
-            cache: PlaybackSourceCache(maxBytes: cacheBudget),
+            cache: PlaybackSourceCache(
+                maxBytes: cacheBudget,
+                diskSpillEnabled: PlayerSettings.shared.seekCacheEnabled
+            ),
             onPlaybackSessionMissing: { [weak self] in
                 Task { @MainActor [weak self] in
                     guard let self else { return }
@@ -5502,6 +5505,7 @@ class PlayerViewModel {
         stats.sourceCacheMissBytes = sourceStats.cacheMissBytes
         stats.sourceActiveOriginRequestCount = sourceStats.activeOriginRequestCount
         stats.sourceDiskSpillBytes = sourceStats.diskSpillBytes
+        stats.sourceDiskBytesWritten = sourceStats.diskBytesWritten
         stats.sourceOriginBytesTransferred = sourceStats.originBytesTransferred
         stats.sourceOriginBitrateBps = sourceStats.currentOriginBitrateBps
     }

--- a/iosApp/iosApp/Screens/Settings/PlaybackSettingsView.swift
+++ b/iosApp/iosApp/Screens/Settings/PlaybackSettingsView.swift
@@ -70,11 +70,21 @@ struct PlaybackSettingsView: View {
             ))
             .foregroundStyle(Color.continuumOnSurface)
             .tint(.continuumAccent)
+
+            Toggle("Seek Cache", isOn: Binding(
+                get: { viewModel.seekCacheEnabled },
+                set: { enabled in
+                    viewModel.seekCacheEnabled = enabled
+                    Task { await viewModel.setSeekCacheEnabled(enabled) }
+                }
+            ))
+            .foregroundStyle(Color.continuumOnSurface)
+            .tint(.continuumAccent)
         } header: {
             Text("Streaming")
                 .foregroundStyle(Color.continuumSecondaryText)
         } footer: {
-            Text("The fallback plays Dolby Vision Profile 7 as HDR10 on this device.")
+            Text("The fallback plays Dolby Vision Profile 7 as HDR10 on this device. Seek Cache keeps recently streamed video in temporary storage during playback so skipping forward and back is instant; it is cleared when playback ends.")
                 .foregroundStyle(Color.continuumSecondaryText)
         }
         .listRowBackground(Color.continuumSurfaceElevated)

--- a/iosApp/iosApp/Screens/Settings/SettingsViewModel.swift
+++ b/iosApp/iosApp/Screens/Settings/SettingsViewModel.swift
@@ -33,6 +33,7 @@ class SettingsViewModel {
     var skipIntros: Bool = PlayerSettings.shared.autoSkipIntro
     var skipCredits: Bool = PlayerSettings.shared.autoSkipCredits
     var preferProfile7HDR10Fallback: Bool = PlayerSettings.shared.preferProfile7HDR10Fallback
+    var seekCacheEnabled: Bool = PlayerSettings.shared.seekCacheEnabled
 
     // Subtitle styling (local — applies to renderer overrides, not the
     // language/behavior selection that lives server-side).
@@ -85,6 +86,7 @@ class SettingsViewModel {
         skipIntros = PlayerSettings.shared.autoSkipIntro
         skipCredits = PlayerSettings.shared.autoSkipCredits
         preferProfile7HDR10Fallback = PlayerSettings.shared.preferProfile7HDR10Fallback
+        seekCacheEnabled = PlayerSettings.shared.seekCacheEnabled
         subtitleSize = UserDefaults.standard.string(forKey: "subtitleSize") ?? "medium"
         subtitleAppearance = PlayerSettings.shared.subtitleAppearance
         subtitleUsesDeviceAppearanceOverride = PlayerSettings.shared.subtitleUsesDeviceAppearanceOverride
@@ -152,6 +154,12 @@ class SettingsViewModel {
     }
 
     @MainActor
+    func setSeekCacheEnabled(_ enabled: Bool) async {
+        PlayerSettings.shared.setSeekCacheEnabled(enabled)
+        seekCacheEnabled = PlayerSettings.shared.seekCacheEnabled
+    }
+
+    @MainActor
     func resetPlaybackDeviceSettings() async {
         await PlayerSettings.shared.resetAllDeviceSettings()
         preferredQuality = PlayerSettings.shared.preferredQuality
@@ -161,6 +169,7 @@ class SettingsViewModel {
         skipIntros = PlayerSettings.shared.autoSkipIntro
         skipCredits = PlayerSettings.shared.autoSkipCredits
         preferProfile7HDR10Fallback = PlayerSettings.shared.preferProfile7HDR10Fallback
+        seekCacheEnabled = PlayerSettings.shared.seekCacheEnabled
         subtitleAppearance = PlayerSettings.shared.subtitleAppearance
         subtitleUsesDeviceAppearanceOverride = PlayerSettings.shared.subtitleUsesDeviceAppearanceOverride
     }

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVPlaybackSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVPlaybackSettingsView.swift
@@ -44,7 +44,16 @@ struct TVPlaybackSettingsPane: View {
             Task { await viewModel.setPreferProfile7HDR10Fallback(value) }
         }
 
-        TVSettingsFooter("The fallback plays Dolby Vision Profile 7 as HDR10 on this Apple TV.")
+        TVSettingsToggleRow(
+            title: "Seek Cache",
+            isOn: viewModel.seekCacheEnabled
+        ) {
+            let value = !viewModel.seekCacheEnabled
+            viewModel.seekCacheEnabled = value
+            Task { await viewModel.setSeekCacheEnabled(value) }
+        }
+
+        TVSettingsFooter("The fallback plays Dolby Vision Profile 7 as HDR10 on this Apple TV. Seek Cache keeps recently streamed video in temporary storage during playback so skipping forward and back is instant.")
     }
 
     @ViewBuilder

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsViewModel.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsViewModel.swift
@@ -35,6 +35,7 @@ final class TVSettingsViewModel {
     var skipIntros: Bool = PlayerSettings.shared.autoSkipIntro
     var skipCredits: Bool = PlayerSettings.shared.autoSkipCredits
     var preferProfile7HDR10Fallback: Bool = PlayerSettings.shared.preferProfile7HDR10Fallback
+    var seekCacheEnabled: Bool = PlayerSettings.shared.seekCacheEnabled
 
     // Subtitle styling (local — applies to renderer overrides, not the
     // language/behavior selection that lives server-side).
@@ -112,6 +113,7 @@ final class TVSettingsViewModel {
         skipIntros = PlayerSettings.shared.autoSkipIntro
         skipCredits = PlayerSettings.shared.autoSkipCredits
         preferProfile7HDR10Fallback = PlayerSettings.shared.preferProfile7HDR10Fallback
+        seekCacheEnabled = PlayerSettings.shared.seekCacheEnabled
         subtitleSize = UserDefaults.standard.string(forKey: "subtitleSize") ?? "medium"
         subtitleAppearance = PlayerSettings.shared.subtitleAppearance
         subtitleUsesDeviceAppearanceOverride = PlayerSettings.shared.subtitleUsesDeviceAppearanceOverride
@@ -179,6 +181,12 @@ final class TVSettingsViewModel {
     }
 
     @MainActor
+    func setSeekCacheEnabled(_ enabled: Bool) async {
+        PlayerSettings.shared.setSeekCacheEnabled(enabled)
+        seekCacheEnabled = PlayerSettings.shared.seekCacheEnabled
+    }
+
+    @MainActor
     func resetPlaybackDeviceSettings() async {
         await PlayerSettings.shared.resetAllDeviceSettings()
         preferredQuality = PlayerSettings.shared.preferredQuality
@@ -188,6 +196,7 @@ final class TVSettingsViewModel {
         skipIntros = PlayerSettings.shared.autoSkipIntro
         skipCredits = PlayerSettings.shared.autoSkipCredits
         preferProfile7HDR10Fallback = PlayerSettings.shared.preferProfile7HDR10Fallback
+        seekCacheEnabled = PlayerSettings.shared.seekCacheEnabled
         subtitleAppearance = PlayerSettings.shared.subtitleAppearance
         subtitleUsesDeviceAppearanceOverride = PlayerSettings.shared.subtitleUsesDeviceAppearanceOverride
     }


### PR DESCRIPTION
## What

Makes the playback source cache spill to temporary disk storage by default (previously dormant behind `SILO_ENABLE_SOURCE_DISK_SPILL`), so large forward/backward seeks are served from local storage instead of refetching from origin. Follows the AetherEngine pattern (small RAM window, disk-backed retention, mmap reads).

- **Dynamic disk budget** `min(2 GiB, free/4, floor 512 MiB)` via new `PlaybackDiskBudget`, shared with the loopback segment store so both spill tiers size against one policy (existing `AVPlayerBackend.vodRetentionBudget` delegates to it).
- **Real disk eviction**, farthest-from-playhead first — a seek-back target is the last thing dropped. Previously disk spans were never deleted: once the fixed 512 MiB budget filled, spill silently stopped for the session.
- **NAND wear guard**: per-session write budget of 2× the retention budget (1× on constrained Apple TVs), halved when the budget holds under ~10 min of content. Once spent, spilling *and* evict-to-make-room churn stop. Worst case for a 70 GB remux drops from ~70 GB of flash writes per watch to ~2–4 GiB.
- **mmap reads** (`.alwaysMapped, .uncached`) for disk hits in both spill tiers, so a large cache pages through the kernel instead of the heap.
- **User setting "Seek Cache"** (default ON) in Playback Settings → Streaming on iOS/tvOS/macOS, server-persisted as `player.seek_cache_enabled`. Governs the source cache only — the segment store's spill stays on (load-bearing for the DV loopback route). Env vars remain as dev overrides in both directions.
- **Orphan sweep at startup**: a force-killed process never runs deinit cleanup and strands its spill directories (observed on-device); a once-per-process sweep clears leftovers from both tiers, fixing the same pre-existing hole for `continuum-dv-hls` generations.
- `diskBudgetBytes`/`diskBytesWritten` surfaced in cache stats and the playback stats overlay ("Source disk written").

## Why

PR #66's streaming fetch fills the RAM window fast (6×+ realtime), but the window is only 256/128 MiB — far seeks past it always went back to origin. Disk retention buys instant seek-back within ~2 GiB of recently streamed content. The wear guard exists because unbounded spill would write each stream to flash once per watch, which matters on small-NAND Apple TVs.

## Validation

- iOS, tvOS, macOS builds green; **526 tests pass** including 5 new `PlaybackSourceCacheDiskSpillTests` (disk round-trip integrity, playhead-aware eviction, write-budget enforcement, spill-off parity with old behavior, budget-clamp parity with the segment store).
- **Hardware-validated** on the living-room Apple TV 4K (3rd gen) with a 4K DV Profile 7 remux: post-seek segment serves 0.2–0.9 ms from local storage, far seeks ~1.3–3 s (producer-restart path, unchanged), footprint 488–535 MiB against the ~487 MiB pre-change baseline, zero decode errors / +0.3 ms audio drift over the session.

## Reviewer notes

- The write-budget exhaustion path logs one `[CMP-SOURCE-CACHE] spill write-budget exhausted` line per session; not yet observed on hardware (session ended before budget spent).
- mmap'd files deleted by eviction while a reader holds the mapping are safe (POSIX keeps mappings valid after unlink; ledger mutation is under the cache lock).
- Known pre-existing issue surfaced during validation, tracked separately: resume-after-force-kill can wedge on "buffering" (repros without this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Seek Cache** toggle to playback settings on iPhone/iPad and tvOS to control local seek support.
  * Keep Seek Cache behavior consistent across devices and server-applied settings.

* **Improvements**
  * Enhanced disk-spill budgeting/eviction and added “source disk written” telemetry in playback stats.
  * Improved disk-backed read behavior to reduce memory impact.
  * Expanded streaming help text to document Seek Cache clearing.

* **Bug Fixes**
  * Better retention behavior during seeking and automatic cleanup of orphaned spill data.

* **Tests**
  * Added coverage for disk-spill, eviction, budget clamping, and seeking scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->