### PR TITLE
tvOS UI fixes + long-press favorite/watchlist card actions

### DIFF
--- a/iosApp/Tests/SubtitleAutoResolverTests.swift
+++ b/iosApp/Tests/SubtitleAutoResolverTests.swift
@@ -106,4 +106,31 @@ final class SubtitleAutoResolverTests: XCTestCase {
         ))
         XCTAssertEqual(result, .select(full))
     }
+
+    /// Tracks labelled CC/SDH in the title but missing the ffmpeg
+    /// hearing-impaired disposition flag are still demoted below a plain
+    /// track in the same language.
+    func testFullPickDemotesTitleOnlyCCTracks() {
+        let cc = track(id: 12, lang: "eng", title: "English (CC)")
+        let sdh = track(id: 13, lang: "eng", title: "English SDH")
+        let full = track(id: 14, lang: "eng", title: "English")
+        let result = SubtitleAutoResolver.resolve(inputs(
+            preferredLanguage: "en",
+            mode: .auto,
+            showForced: false,
+            tracks: [cc, sdh, full],
+            audioLanguage: "kor"
+        ))
+        XCTAssertEqual(result, .select(full))
+    }
+
+    /// The CC token check must not misread ordinary words containing
+    /// "cc" — a title like "Soccer Cut" is a normal dialogue track.
+    func testCCTokenDoesNotMatchInsideWords() {
+        XCTAssertFalse(SubtitleAutoResolver.titleIndicatesHearingImpaired("Soccer Cut"))
+        XCTAssertTrue(SubtitleAutoResolver.titleIndicatesHearingImpaired("English (CC)"))
+        XCTAssertTrue(SubtitleAutoResolver.titleIndicatesHearingImpaired("English [SDH]"))
+        XCTAssertTrue(SubtitleAutoResolver.titleIndicatesHearingImpaired("Closed Captions"))
+        XCTAssertFalse(SubtitleAutoResolver.titleIndicatesHearingImpaired(nil))
+    }
 }

--- a/iosApp/iosApp/Components/EpisodeThumbCard.swift
+++ b/iosApp/iosApp/Components/EpisodeThumbCard.swift
@@ -65,6 +65,24 @@ struct EpisodeThumbCard: View {
             playedOverride = nil
         }
         #else
+        Group {
+            if hasContextActions {
+                iosButton.contextMenu {
+                    contextActions
+                }
+            } else {
+                iosButton
+            }
+        }
+        .onChange(of: item.userState?.played) { _, _ in
+            playedOverride = nil
+        }
+        .frame(width: cardWidth)
+        #endif
+    }
+
+    #if !os(tvOS)
+    private var iosButton: some View {
         Button {
             router.pendingZoomSourceID = zoomInstanceID.uuidString
             action()
@@ -85,9 +103,8 @@ struct EpisodeThumbCard: View {
             .zoomTransitionSource(id: zoomInstanceID.uuidString, in: zoomNamespace)
         }
         .buttonStyle(.plain)
-        .frame(width: cardWidth)
-        #endif
     }
+    #endif
 
     // MARK: - Thumbnail
 
@@ -287,6 +304,7 @@ struct EpisodeThumbCard: View {
             button
         }
     }
+    #endif
 
     private var hasContextActions: Bool {
         onSetWatched != nil || onRemoveFromContinueWatching != nil
@@ -315,7 +333,6 @@ struct EpisodeThumbCard: View {
             }
         }
     }
-    #endif
 }
 
 #if os(tvOS)

--- a/iosApp/iosApp/Components/MediaCard.swift
+++ b/iosApp/iosApp/Components/MediaCard.swift
@@ -42,8 +42,14 @@ struct MediaCard: View {
     /// for episodes rendered in a poster row (e.g. "Recently Released
     /// Episodes"). `nil` for movies / series / audiobooks.
     var episodeBadge: String? = nil
+    /// Fires after a favorite/watchlist toggle from the card's context
+    /// menu commits server-side, with the item's new state. Favorites /
+    /// Watchlist grids use it to drop the card from the list in place.
+    var onUserStateChanged: ((MediaItemUserState) -> Void)? = nil
 
     @State private var playedOverride: Bool?
+    @State private var favoriteOverride: Bool?
+    @State private var watchlistOverride: Bool?
     @EnvironmentObject private var overlayStore: OverlayPrefsStore
     /// iOS 26 zoom transition namespace, shared from `MainTabView`. When
     /// present (and `contentId` is non-nil) the poster acts as the
@@ -89,12 +95,15 @@ struct MediaCard: View {
                     playedOverride = played
                     handler(played)
                 }
-            }
+            },
+            personalItems: hasPersonalActions ? personalMenuItems : nil
         ) {
             posterImage
         }
-        .onChange(of: userState?.played) { _, _ in
+        .onChange(of: userState) { _, _ in
             playedOverride = nil
+            favoriteOverride = nil
+            watchlistOverride = nil
         }
         #else
         Group {
@@ -114,8 +123,76 @@ struct MediaCard: View {
                 .buttonStyle(.plain)
             }
         }
+        .personalListContextMenu(hasPersonalActions ? personalMenuItems : nil)
+        .onChange(of: userState) { _, _ in
+            playedOverride = nil
+            favoriteOverride = nil
+            watchlistOverride = nil
+        }
         .frame(width: cardWidth)
         #endif
+    }
+
+    // MARK: - Favorite / watchlist context actions
+
+    /// Only cards backed by a catalog item (a `contentId` plus server
+    /// user state) get the favorite/watchlist menu — thumbnails without
+    /// user state (people, collections, discover results) don't.
+    private var hasPersonalActions: Bool {
+        contentId != nil && userState != nil
+    }
+
+    private var isFavorite: Bool {
+        favoriteOverride ?? (userState?.isFavorite == true)
+    }
+
+    private var isInWatchlist: Bool {
+        watchlistOverride ?? (userState?.inWatchlist == true)
+    }
+
+    private var personalMenuItems: PersonalListMenuItems {
+        PersonalListMenuItems(
+            isFavorite: isFavorite,
+            inWatchlist: isInWatchlist,
+            onToggleFavorite: togglePersonalFavorite,
+            onToggleWatchlist: togglePersonalWatchlist
+        )
+    }
+
+    private func togglePersonalFavorite() {
+        guard let contentId else { return }
+        let newValue = !isFavorite
+        let watchlist = isInWatchlist
+        favoriteOverride = newValue
+        Task {
+            if await PersonalListSync.setFavorite(
+                contentId: contentId, isFavorite: newValue, inWatchlist: watchlist
+            ) {
+                onUserStateChanged?(
+                    MediaItemUserState(played: isPlayed, isFavorite: newValue, inWatchlist: watchlist)
+                )
+            } else {
+                favoriteOverride = !newValue // Revert on failure
+            }
+        }
+    }
+
+    private func togglePersonalWatchlist() {
+        guard let contentId else { return }
+        let newValue = !isInWatchlist
+        let favorite = isFavorite
+        watchlistOverride = newValue
+        Task {
+            if await PersonalListSync.setWatchlist(
+                contentId: contentId, isFavorite: favorite, inWatchlist: newValue
+            ) {
+                onUserStateChanged?(
+                    MediaItemUserState(played: isPlayed, isFavorite: favorite, inWatchlist: newValue)
+                )
+            } else {
+                watchlistOverride = !newValue // Revert on failure
+            }
+        }
     }
 
     private var cardContent: some View {
@@ -309,6 +386,9 @@ private struct FocusableMediaCard<Content: View>: View {
     let isWatched: Bool
     let onRemoveFromContinueWatching: (() -> Void)?
     let onSetWatched: ((Bool) -> Void)?
+    /// Favorite / watchlist toggles, built by the owning card. `nil`
+    /// when the card has no catalog identity or user state.
+    let personalItems: PersonalListMenuItems?
     @ViewBuilder var content: () -> Content
 
     @FocusState private var isFocused: Bool
@@ -362,7 +442,7 @@ private struct FocusableMediaCard<Content: View>: View {
     }
 
     private var hasContextActions: Bool {
-        onSetWatched != nil || onRemoveFromContinueWatching != nil
+        onSetWatched != nil || onRemoveFromContinueWatching != nil || personalItems != nil
     }
 
     @ViewBuilder
@@ -376,6 +456,10 @@ private struct FocusableMediaCard<Content: View>: View {
                     systemImage: isWatched ? "circle" : "checkmark.circle"
                 )
             }
+        }
+
+        if let personalItems {
+            personalItems
         }
 
         if let onRemoveFromContinueWatching {

--- a/iosApp/iosApp/Components/MediaCard.swift
+++ b/iosApp/iosApp/Components/MediaCard.swift
@@ -107,6 +107,26 @@ struct MediaCard: View {
         }
         #else
         Group {
+            if hasIOSContextActions {
+                iosCardButton.contextMenu {
+                    iosContextActions
+                }
+            } else {
+                iosCardButton
+            }
+        }
+        .onChange(of: userState) { _, _ in
+            playedOverride = nil
+            favoriteOverride = nil
+            watchlistOverride = nil
+        }
+        .frame(width: cardWidth)
+        #endif
+    }
+
+    #if !os(tvOS)
+    private var iosCardButton: some View {
+        Group {
             if let contentId {
                 Button {
                     router.pendingZoomSourceID = zoomInstanceID.uuidString
@@ -123,15 +143,42 @@ struct MediaCard: View {
                 .buttonStyle(.plain)
             }
         }
-        .personalListContextMenu(hasPersonalActions ? personalMenuItems : nil)
-        .onChange(of: userState) { _, _ in
-            playedOverride = nil
-            favoriteOverride = nil
-            watchlistOverride = nil
-        }
-        .frame(width: cardWidth)
-        #endif
     }
+
+    private var hasIOSContextActions: Bool {
+        hasPersonalActions || onSetWatched != nil || onRemoveFromContinueWatching != nil
+    }
+
+    /// Same action set (and ordering) as the tvOS `FocusableMediaCard` menu:
+    /// watched toggle, favorite/watchlist, then the destructive remove.
+    @ViewBuilder
+    private var iosContextActions: some View {
+        if let onSetWatched {
+            Button {
+                let played = !isPlayed
+                playedOverride = played
+                onSetWatched(played)
+            } label: {
+                Label(
+                    isPlayed ? "Mark as Unwatched" : "Mark as Watched",
+                    systemImage: isPlayed ? "circle" : "checkmark.circle"
+                )
+            }
+        }
+
+        if hasPersonalActions {
+            personalMenuItems
+        }
+
+        if let onRemoveFromContinueWatching {
+            Button(role: .destructive) {
+                onRemoveFromContinueWatching()
+            } label: {
+                Label("Remove from Continue Watching", systemImage: "xmark.circle")
+            }
+        }
+    }
+    #endif
 
     // MARK: - Favorite / watchlist context actions
 

--- a/iosApp/iosApp/Components/MediaRow.swift
+++ b/iosApp/iosApp/Components/MediaRow.swift
@@ -61,6 +61,7 @@ struct MediaRow: View {
     /// identity per page, so the kick has to land on `onAppear`, not only
     /// on a `focusRequest` change).
     @State private var lastAppliedFocusRequest = 0
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     private static let focusLogger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "com.continuum.app",
         category: "TVFocus"
@@ -76,8 +77,6 @@ struct MediaRow: View {
         #if os(tvOS)
         .focusSection()
         .modifier(TVRowMoveHandler(onMoveUp: onMoveUp, onMoveDown: onMoveDown))
-        .onAppear { applyFocusRequest(focusRequest) }
-        .onChange(of: focusRequest) { _, request in applyFocusRequest(request) }
         .onChange(of: focusedItemId) { _, newValue in
             guard let newValue,
                   let item = items.first(where: { $0.contentId == newValue }) else { return }
@@ -88,13 +87,42 @@ struct MediaRow: View {
     }
 
     #if os(tvOS)
-    private func applyFocusRequest(_ request: Int) {
+    private func applyFocusRequest(_ request: Int, proxy: ScrollViewProxy) {
         guard request > 0, request != lastAppliedFocusRequest,
               let firstItem = items.first else { return }
         lastAppliedFocusRequest = request
+        // Scroll home first, claim a turn later: a row parked deep in its
+        // strip keeps the first card unmounted (LazyHStack) or clipped, and
+        // the focus engine silently drops @FocusState writes to views it
+        // can't focus. The instant scroll mounts/unclips the card; the
+        // deferred write then lands on a focusable target.
+        withAnimation(reduceMotion ? nil : .easeInOut(duration: ContinuumTheme.slowDuration)) {
+            proxy.scrollTo(firstItem.id, anchor: .leading)
+        }
+        DispatchQueue.main.async {
+            Self.focusLogger.debug("mediaRow.applyFocus request=\(request, privacy: .public) first=\(firstItem.contentId, privacy: .public)")
+            claimFirstItemFocus(firstItem)
+        }
+    }
+
+    /// Write the claim, then verify it actually stuck and re-assert if not.
+    /// A single write races two things that both win by coming later: the
+    /// engine's remembered-focus repair after the top bar resigns, and the
+    /// geometric re-repairs it makes while the feed's scroll-to-top slides
+    /// rows (and their cards) under whatever it had focused. @FocusState
+    /// reflects *actual* focus, so a rejected/overridden write reads back as
+    /// a different value — retry until the scroll settles and ours is last.
+    private func claimFirstItemFocus(_ firstItem: SectionItem, attempt: Int = 0) {
         focusedItemId = firstItem.contentId
-        Self.focusLogger.debug("mediaRow.applyFocus request=\(request, privacy: .public) first=\(firstItem.contentId, privacy: .public)")
         onItemFocus?(firstItem)
+        // Window must outlast the ~300ms animated ride home plus the engine's
+        // settling repairs, or the last mid-flight repair wins after all.
+        guard attempt < 8 else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
+            guard focusedItemId != firstItem.contentId else { return }
+            Self.focusLogger.debug("mediaRow.reclaimFocus attempt=\(attempt + 1, privacy: .public) first=\(firstItem.contentId, privacy: .public)")
+            claimFirstItemFocus(firstItem, attempt: attempt + 1)
+        }
     }
     #endif
 
@@ -128,6 +156,12 @@ struct MediaRow: View {
     // MARK: - Content
 
     private var scrollContent: some View {
+        ScrollViewReader { rowProxy in
+            scrollStrip(rowProxy)
+        }
+    }
+
+    private func scrollStrip(_ rowProxy: ScrollViewProxy) -> some View {
         ScrollView(.horizontal, showsIndicators: false) {
             LazyHStack(spacing: cardSpacing) {
                 ForEach(items) { item in
@@ -162,11 +196,19 @@ struct MediaRow: View {
                     }
                 }
             }
+            #if !os(tvOS)
             .padding(.horizontal, ContinuumTheme.safePadding)
+            #endif
             .padding(.vertical, verticalCardPadding)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         #if os(tvOS)
+        // The leading gutter must be a content *margin*, not padding inside
+        // the scroll content: programmatic `scrollTo(anchor: .leading)` and
+        // the engine's scroll-to-focused both align to the margin-inset
+        // viewport, so with inner padding they overshoot left by the gutter
+        // width and then visibly drift back to the rest position.
+        .contentMargins(.horizontal, ContinuumTheme.safePadding, for: .scrollContent)
         // tvOS focus lift expands cards on focus — give them breathing room
         // so they don't clip against the row above/below.
         .scrollClipDisabled()
@@ -175,6 +217,11 @@ struct MediaRow: View {
             binding: $focusedItemId,
             firstItemId: items.first?.contentId
         )
+        // The programmatic focus kick needs the scroll proxy (it scrolls the
+        // strip home before claiming), so it hangs off the strip rather than
+        // the row's outer stack.
+        .onAppear { applyFocusRequest(focusRequest, proxy: rowProxy) }
+        .onChange(of: focusRequest) { _, request in applyFocusRequest(request, proxy: rowProxy) }
         #endif
     }
 

--- a/iosApp/iosApp/Components/PersonalListActions.swift
+++ b/iosApp/iosApp/Components/PersonalListActions.swift
@@ -50,11 +50,12 @@ extension View {
 @MainActor
 enum PersonalListSync {
     /// Returns false when the server call failed — the caller reverts
-    /// its optimistic UI state.
+    /// its optimistic UI state. The sibling flag is only a write-back
+    /// fallback; a fresher cached value for it wins (see `writeBack`).
     static func setFavorite(contentId: String, isFavorite: Bool, inWatchlist: Bool) async -> Bool {
         do {
             try await ContinuumAPI.shared.toggleFavorite(contentId: contentId, isFavorite: isFavorite)
-            writeBack(contentId: contentId, isFavorite: isFavorite, inWatchlist: inWatchlist)
+            writeBack(contentId: contentId, isFavorite: isFavorite, fallbackInWatchlist: inWatchlist)
             return true
         } catch {
             return false
@@ -64,17 +65,33 @@ enum PersonalListSync {
     static func setWatchlist(contentId: String, isFavorite: Bool, inWatchlist: Bool) async -> Bool {
         do {
             try await ContinuumAPI.shared.toggleWatchlist(contentId: contentId, isInWatchlist: inWatchlist)
-            writeBack(contentId: contentId, isFavorite: isFavorite, inWatchlist: inWatchlist)
+            writeBack(contentId: contentId, inWatchlist: inWatchlist, fallbackIsFavorite: isFavorite)
             return true
         } catch {
             return false
         }
     }
 
-    private static func writeBack(contentId: String, isFavorite: Bool, inWatchlist: Bool) {
+    /// Merges the toggled flag over the cached pair rather than writing the
+    /// caller's full snapshot: two quick toggles race their server round
+    /// trips, and the slower write must not revert the sibling flag the
+    /// faster one already committed to the cache. The caller's snapshot is
+    /// only used when nothing is cached yet.
+    private static func writeBack(
+        contentId: String,
+        isFavorite: Bool? = nil,
+        inWatchlist: Bool? = nil,
+        fallbackIsFavorite: Bool = false,
+        fallbackInWatchlist: Bool = false
+    ) {
+        let key = CacheKey.itemUserState(contentId)
+        let cached: UserItemState? = ResponseCache.shared.get(key)
         ResponseCache.shared.set(
-            UserItemState(isFavorite: isFavorite, inWatchlist: inWatchlist),
-            for: CacheKey.itemUserState(contentId)
+            UserItemState(
+                isFavorite: isFavorite ?? cached?.isFavorite ?? fallbackIsFavorite,
+                inWatchlist: inWatchlist ?? cached?.inWatchlist ?? fallbackInWatchlist
+            ),
+            for: key
         )
         ResponseCache.shared.remove(CacheKey.favorites)
         ResponseCache.shared.remove(CacheKey.watchlist)

--- a/iosApp/iosApp/Components/PersonalListActions.swift
+++ b/iosApp/iosApp/Components/PersonalListActions.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+/// The favorite / watchlist entries shared by the media-card context
+/// menus (long press on iOS/macOS, long press on the touch surface on
+/// tvOS). Labels reflect the caller's current membership state; the
+/// caller owns the optimistic flip and the API call.
+struct PersonalListMenuItems: View {
+    let isFavorite: Bool
+    let inWatchlist: Bool
+    let onToggleFavorite: () -> Void
+    let onToggleWatchlist: () -> Void
+
+    var body: some View {
+        Group {
+            Button(action: onToggleFavorite) {
+                Label(
+                    isFavorite ? "Remove from Favorites" : "Add to Favorites",
+                    systemImage: isFavorite ? "heart.slash" : "heart"
+                )
+            }
+            Button(action: onToggleWatchlist) {
+                Label(
+                    inWatchlist ? "Remove from Watchlist" : "Add to Watchlist",
+                    systemImage: inWatchlist ? "bookmark.slash" : "bookmark"
+                )
+            }
+        }
+    }
+}
+
+extension View {
+    /// Attaches a long-press context menu with the given favorite /
+    /// watchlist items, or leaves the view untouched when `nil` — so
+    /// cards without a catalog identity never get an empty menu.
+    @ViewBuilder
+    func personalListContextMenu(_ items: PersonalListMenuItems?) -> some View {
+        if let items {
+            contextMenu { items }
+        } else {
+            self
+        }
+    }
+}
+
+/// Server sync behind the card context-menu toggles. Mirrors
+/// `ItemDetailViewModel.toggleFavorite/toggleWatchlist`: on success it
+/// writes back the cached per-item user-state pair (so a subsequent
+/// detail visit renders the right buttons immediately) and drops the
+/// derived list caches so Favorites / Watchlist / Home refetch fresh.
+@MainActor
+enum PersonalListSync {
+    /// Returns false when the server call failed — the caller reverts
+    /// its optimistic UI state.
+    static func setFavorite(contentId: String, isFavorite: Bool, inWatchlist: Bool) async -> Bool {
+        do {
+            try await ContinuumAPI.shared.toggleFavorite(contentId: contentId, isFavorite: isFavorite)
+            writeBack(contentId: contentId, isFavorite: isFavorite, inWatchlist: inWatchlist)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    static func setWatchlist(contentId: String, isFavorite: Bool, inWatchlist: Bool) async -> Bool {
+        do {
+            try await ContinuumAPI.shared.toggleWatchlist(contentId: contentId, isInWatchlist: inWatchlist)
+            writeBack(contentId: contentId, isFavorite: isFavorite, inWatchlist: inWatchlist)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    private static func writeBack(contentId: String, isFavorite: Bool, inWatchlist: Bool) {
+        ResponseCache.shared.set(
+            UserItemState(isFavorite: isFavorite, inWatchlist: inWatchlist),
+            for: CacheKey.itemUserState(contentId)
+        )
+        ResponseCache.shared.remove(CacheKey.favorites)
+        ResponseCache.shared.remove(CacheKey.watchlist)
+        ResponseCache.shared.remove(CacheKey.homeSections)
+    }
+}

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -33,7 +33,7 @@ struct ContentView: View {
         #endif
         .environmentObject(overlayPrefs)
         .preferredColorScheme(.dark)
-        #if os(tvOS)
+        #if os(tvOS) && DEBUG
         .modifier(TVFocusDebugActivationModifier())
         #endif
         #if os(iOS)

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -33,6 +33,9 @@ struct ContentView: View {
         #endif
         .environmentObject(overlayPrefs)
         .preferredColorScheme(.dark)
+        #if os(tvOS)
+        .modifier(TVFocusDebugActivationModifier())
+        #endif
         #if os(iOS)
         // Hold the pairing offer until the startup splash logo finishes so a
         // quickly-discovered TV doesn't pop the card over the animation.

--- a/iosApp/iosApp/Navigation/AppRouter.swift
+++ b/iosApp/iosApp/Navigation/AppRouter.swift
@@ -162,6 +162,16 @@ class AppRouter {
         path.append(route)
     }
 
+    /// Swap the top route instead of pushing, so sideways hops between
+    /// sibling pages (e.g. episode → episode on the tvOS detail rail) don't
+    /// stack up — Back exits the chain in one step.
+    func replaceCurrent(with route: Route) {
+        if !path.isEmpty {
+            path.removeLast()
+        }
+        path.append(route)
+    }
+
     /// Pop the top route from the stack.
     func goBack() {
         guard !path.isEmpty else { return }

--- a/iosApp/iosApp/Networking/Models.swift
+++ b/iosApp/iosApp/Networking/Models.swift
@@ -395,6 +395,7 @@ struct ItemDetail: Codable {
     /// per-movie subtitle override is stored, so it doubles as the
     /// "user picked a track" marker for selector seeding.
     let effectiveSubtitleMode: String?
+    let effectiveShowForcedSubtitles: Bool?
     let effectiveSubtitleTrackSignature: SubtitleTrackSignature?
     let overlaySummary: OverlaySummary?
     let audiobook: AudiobookDetail?

--- a/iosApp/iosApp/Screens/Calendar/CalendarDayShelf.swift
+++ b/iosApp/iosApp/Screens/Calendar/CalendarDayShelf.swift
@@ -15,6 +15,11 @@ struct CalendarDayShelf: View {
     /// the week strip's day selection to hand focus down to the row it
     /// just scrolled to.
     var focusRequest: Int = 0
+    /// tvOS: called when the focus engine can't resolve an up-move out of
+    /// this shelf natively — which happens when the days above are empty
+    /// "Nothing scheduled" stubs (nothing focusable) and the week strip has
+    /// scrolled off-screen. The host hands focus back up explicitly.
+    var onMoveUp: (() -> Void)? = nil
 
     @FocusState private var focusedItemId: String?
     #if os(tvOS)
@@ -40,6 +45,7 @@ struct CalendarDayShelf: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         #if os(tvOS)
         .focusSection()
+        .modifier(TVShelfMoveHandler(onMoveUp: onMoveUp))
         // `onAppear` covers the shelf being created lazily by the
         // scroll-to-day jump; `onChange` covers shelves already realized.
         .onAppear { applyFocusRequest(focusRequest) }
@@ -134,6 +140,26 @@ struct CalendarDayShelf: View {
 }
 
 #if os(tvOS)
+/// Attaches an `onMoveCommand` only when a handler is supplied, so shelves
+/// that don't need the boundary hook never sit in the focus engine's way —
+/// same pattern as `MediaRow`'s `TVRowMoveHandler`. Bubbled moves in other
+/// directions are dead ends the engine already failed to resolve, so
+/// consuming them changes nothing.
+private struct TVShelfMoveHandler: ViewModifier {
+    let onMoveUp: (() -> Void)?
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if let onMoveUp {
+            content.onMoveCommand { direction in
+                if direction == .up { onMoveUp() }
+            }
+        } else {
+            content
+        }
+    }
+}
+
 private extension View {
     /// Routes both initial and d-pad-entry focus to the shelf's first
     /// card — same `.userInitiated` defaultFocus pattern as `MediaRow`.

--- a/iosApp/iosApp/Screens/Calendar/CalendarView.swift
+++ b/iosApp/iosApp/Screens/Calendar/CalendarView.swift
@@ -18,6 +18,12 @@ struct CalendarView: View {
     /// scrolls to that day's shelf and kicks focus onto its first card.
     @State private var shelfFocusRequest = 0
     @State private var shelfFocusDay: Date?
+    /// Focus hand-back for the boundary up-move: a shelf whose up-press the
+    /// focus engine couldn't resolve (empty days above, strip off-screen)
+    /// asks the week strip to reclaim focus.
+    @State private var stripFocusRequest = 0
+    /// Scroll target for the ride home to the strip/filter area.
+    private static let topContentId = "calendar-top"
     #endif
 
     var body: some View {
@@ -79,7 +85,7 @@ struct CalendarView: View {
                     .padding(.bottom, ContinuumTheme.padding)
                     .frame(maxWidth: .infinity, alignment: .leading)
 
-                    shelfArea
+                    shelfArea(proxy: proxy)
                 }
                 .padding(.bottom, ContinuumTheme.largePadding)
             }
@@ -205,6 +211,7 @@ struct CalendarView: View {
                     }
                     .padding(.horizontal, ContinuumTheme.safePadding)
                     .focusSection()
+                    .id(Self.topContentId)
 
                     CalendarWeekStrip(
                         week: viewModel.week,
@@ -215,10 +222,11 @@ struct CalendarView: View {
                         onSelectDay: { selectDay($0, proxy: proxy) },
                         onPreviousWeek: { viewModel.goToPreviousWeek() },
                         onNextWeek: { viewModel.goToNextWeek() },
-                        onToday: { Task { await viewModel.goToToday() } }
+                        onToday: { Task { await viewModel.goToToday() } },
+                        focusRequest: stripFocusRequest
                     )
 
-                    shelfArea
+                    shelfArea(proxy: proxy)
                 }
                 .padding(.top, TVTopMenuLayout.contentTopInset)
                 .padding(.bottom, ContinuumTheme.largePadding)
@@ -230,7 +238,7 @@ struct CalendarView: View {
     // MARK: - Shared shelf area
 
     @ViewBuilder
-    private var shelfArea: some View {
+    private func shelfArea(proxy: ScrollViewProxy) -> some View {
         if let error = viewModel.error {
             ErrorView(state: error, onRetry: { Task { await viewModel.load() } })
                 .frame(minHeight: 320)
@@ -248,7 +256,8 @@ struct CalendarView: View {
                         router.navigate(to: .itemDetail(contentId: event.navigationContentId))
                     },
                     prefersDefaultFocusOnFirstItem: day == firstNonEmptyDay,
-                    focusRequest: shelfFocusRequest(for: day)
+                    focusRequest: shelfFocusRequest(for: day),
+                    onMoveUp: shelfMoveUpHandler(for: day, proxy: proxy)
                 )
                 .id(day)
                 .padding(.bottom, shelfBottomPadding)
@@ -364,6 +373,40 @@ struct CalendarView: View {
         return 0
         #endif
     }
+
+    /// tvOS: boundary up-move escape hatch. When the focus engine can't
+    /// resolve an up-press out of a shelf natively — the days above are
+    /// empty "Nothing scheduled" stubs and the week strip has scrolled
+    /// off-screen — the press bubbles to the shelf's `onMoveCommand` and
+    /// lands here: hop to the previous day with events, or ride home to
+    /// the week strip when nothing focusable is above.
+    private func shelfMoveUpHandler(for day: Date, proxy: ScrollViewProxy) -> (() -> Void)? {
+        #if os(tvOS)
+        guard viewModel.hasEvents(on: day) else { return nil }
+        return { handleShelfMoveUp(from: day, proxy: proxy) }
+        #else
+        return nil
+        #endif
+    }
+
+    #if os(tvOS)
+    private func handleShelfMoveUp(from day: Date, proxy: ScrollViewProxy) {
+        if let previous = viewModel.week.days.last(where: {
+            $0 < day && viewModel.hasEvents(on: $0)
+        }) {
+            withAnimation(ContinuumTheme.springAnimation) {
+                proxy.scrollTo(previous, anchor: .top)
+            }
+            shelfFocusDay = previous
+            shelfFocusRequest += 1
+        } else {
+            withAnimation(ContinuumTheme.springAnimation) {
+                proxy.scrollTo(Self.topContentId, anchor: .top)
+            }
+            stripFocusRequest += 1
+        }
+    }
+    #endif
 
     /// Load the active profile so the iOS top bar can render its avatar.
     /// Non-fatal on failure — the bar falls back to a generic icon.

--- a/iosApp/iosApp/Screens/Calendar/CalendarWeekStrip.swift
+++ b/iosApp/iosApp/Screens/Calendar/CalendarWeekStrip.swift
@@ -19,9 +19,16 @@ struct CalendarWeekStrip: View {
     let onPreviousWeek: () -> Void
     let onNextWeek: () -> Void
     let onToday: () -> Void
+    /// tvOS: programmatic focus kick — when this changes to a new non-zero
+    /// token, focus rides home onto the selected day's button. Used by the
+    /// shelf area's boundary up-move when nothing focusable sits between a
+    /// shelf and the strip.
+    var focusRequest: Int = 0
 
     #if os(tvOS)
     @FocusState private var focusedControl: StripControl?
+    /// Each kick token claims focus exactly once (see `CalendarDayShelf`).
+    @State private var lastAppliedFocusRequest = 0
     #endif
 
     var body: some View {
@@ -131,6 +138,39 @@ struct CalendarWeekStrip: View {
         .padding(.horizontal, ContinuumTheme.safePadding)
         .focusSection()
         .animation(ContinuumTheme.springAnimation, value: isCurrentWeek)
+        .onChange(of: focusRequest) { _, request in applyFocusRequest(request) }
+        .onAppear { applyFocusRequest(focusRequest) }
+    }
+
+    private func applyFocusRequest(_ request: Int) {
+        guard request > 0, request != lastAppliedFocusRequest else { return }
+        lastAppliedFocusRequest = request
+        // The kick arrives together with a scroll-to-top; the strip may
+        // still be sliding into view, and the focus engine silently drops
+        // writes to off-screen targets. Claim, verify, re-claim until the
+        // scroll settles — same pattern as `MediaRow.claimFirstItemFocus`.
+        let target = StripControl.day(selectedStripDay)
+        DispatchQueue.main.async {
+            claimFocus(on: target)
+        }
+    }
+
+    private func claimFocus(on control: StripControl, attempt: Int = 0) {
+        focusedControl = control
+        guard attempt < 8 else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
+            guard focusedControl != control else { return }
+            claimFocus(on: control, attempt: attempt + 1)
+        }
+    }
+
+    /// The strip's day-button focus values are the exact `week.days` dates;
+    /// `selectedDay` is same-day but not guaranteed same-instant, so resolve
+    /// it back to the matching strip date before claiming focus.
+    private var selectedStripDay: Date {
+        week.days.first { Calendar.current.isDate($0, inSameDayAs: selectedDay) }
+            ?? week.days.first
+            ?? selectedDay
     }
 
     private func chevronButton(

--- a/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
+++ b/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
@@ -354,7 +354,11 @@ enum DetailPlaybackFormatting {
             return (forced.element, forced.offset)
         }
         if let full = pool.first(where: {
-            !($0.element.forced ?? false) && !($0.element.hearingImpaired ?? false)
+            !($0.element.forced ?? false)
+                && !($0.element.hearingImpaired ?? false)
+                && !SubtitleAutoResolver.titleIndicatesHearingImpaired(
+                    $0.element.title ?? $0.element.embeddedTitle
+                )
         }) {
             return (full.element, full.offset)
         }

--- a/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
+++ b/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
@@ -290,9 +290,9 @@ enum DetailPlaybackFormatting {
     /// for the "Auto" (no explicit override) case, applied to the detail
     /// payload's `SubtitleTrack` list. Returns nil when Auto resolves to no
     /// subtitles (mode off, no preference, or audio already in the preferred
-    /// language). Mirrors `SubtitleAutoResolver.resolve` with the inputs the
-    /// detail page can supply — `showForced` defaults off, which only affects
-    /// the forced-vs-full-dialogue tiebreak.
+    /// language). Mirrors `SubtitleAutoResolver.resolve` branch-for-branch
+    /// with the inputs the detail page can supply, including where
+    /// `showForced` does and does not apply.
     private static func autoResolvedSubtitle(
         version: FileVersion?,
         context: SubtitleAutoContext
@@ -319,13 +319,25 @@ enum DetailPlaybackFormatting {
         if rawLang.isEmpty { return nil }
 
         // Auto mode hides subs when the audio already matches the preferred
-        // subtitle language (e.g. English audio + English sub preference).
+        // subtitle language (e.g. English audio + English sub preference) —
+        // unless forced subs are wanted, in which case the language-matching
+        // forced (signs-only) track is exactly what plays.
         if mode == .auto, let audio = context.audioLanguage,
            SubtitleAutoResolver.languagesMatch(audio, rawLang) {
+            if context.showForced,
+               let forced = tracks.enumerated().first(where: { _, track in
+                   (track.forced ?? false)
+                       && track.language.map { SubtitleAutoResolver.languagesMatch($0, rawLang) } == true
+               }) {
+                return (forced.element, forced.offset)
+            }
             return nil
         }
 
-        if let pick = bestLanguageMatch(rawLang, in: tracks, preferForced: context.showForced) {
+        // The user wants readable subs in this language: always the
+        // full-dialogue track — `showForced` must NOT steal this pick
+        // (mirrors the resolver's preferForced: false here).
+        if let pick = bestLanguageMatch(rawLang, in: tracks, preferForced: false) {
             return pick
         }
 

--- a/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
+++ b/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
@@ -145,7 +145,8 @@ enum DetailPlaybackFormatting {
 
     static func audioValueLabel(
         version: FileVersion?,
-        selectedAudioTrackIndex: Int?
+        selectedAudioTrackIndex: Int?,
+        annotateAuto: Bool = false
     ) -> String {
         guard let version,
               let ordinal = resolvedAudioOrdinal(
@@ -155,7 +156,32 @@ enum DetailPlaybackFormatting {
               let track = version.audioTracks?[safe: ordinal] else {
             return "Unknown"
         }
-        return audioTitle(track, ordinal: ordinal)
+        let title = audioTitle(track, ordinal: ordinal)
+        // With no explicit pick, the shown track is whatever Auto resolved to
+        // (preferred/default). Prefix "Auto -" so the row makes clear the
+        // choice was automatic rather than user-selected.
+        if annotateAuto, selectedAudioTrackIndex == nil {
+            return "Auto - \(title)"
+        }
+        return title
+    }
+
+    /// Language of the track that `audioValueLabel` would display, used to
+    /// feed the subtitle auto-resolver (Auto mode hides subs when the audio
+    /// is already in the preferred subtitle language).
+    static func resolvedAudioLanguage(
+        version: FileVersion?,
+        selectedAudioTrackIndex: Int?
+    ) -> String? {
+        guard let version,
+              let ordinal = resolvedAudioOrdinal(
+                  version: version,
+                  selectedAudioTrackIndex: selectedAudioTrackIndex
+              ),
+              let track = version.audioTracks?[safe: ordinal] else {
+            return nil
+        }
+        return track.language
     }
 
     static func audioTitle(_ track: AudioTrack, ordinal: Int) -> String {
@@ -260,6 +286,84 @@ enum DetailPlaybackFormatting {
         return best?.0
     }
 
+    /// Preview the track the player's `SubtitleAutoResolver` would auto-select
+    /// for the "Auto" (no explicit override) case, applied to the detail
+    /// payload's `SubtitleTrack` list. Returns nil when Auto resolves to no
+    /// subtitles (mode off, no preference, or audio already in the preferred
+    /// language). Mirrors `SubtitleAutoResolver.resolve` with the inputs the
+    /// detail page can supply — `showForced` defaults off, which only affects
+    /// the forced-vs-full-dialogue tiebreak.
+    private static func autoResolvedSubtitle(
+        version: FileVersion?,
+        context: SubtitleAutoContext
+    ) -> (track: SubtitleTrack, ordinal: Int)? {
+        let tracks = version?.subtitleTracks ?? []
+        guard !tracks.isEmpty else { return nil }
+
+        let mode = SubtitleMode(rawValue: context.mode ?? "") ?? .auto
+        if mode == .off { return nil }
+
+        if let signature = context.signature,
+           let match = bestSignatureMatch(signature, in: tracks),
+           let ordinal = tracks.firstIndex(where: { $0.id == match.id }) {
+            return (match, ordinal)
+        }
+
+        guard let rawLang = context.preferredLanguage else {
+            if mode == .always {
+                return bestLanguageMatch(nil, in: tracks, preferForced: context.showForced)
+            }
+            return nil
+        }
+
+        if rawLang.isEmpty { return nil }
+
+        // Auto mode hides subs when the audio already matches the preferred
+        // subtitle language (e.g. English audio + English sub preference).
+        if mode == .auto, let audio = context.audioLanguage,
+           SubtitleAutoResolver.languagesMatch(audio, rawLang) {
+            return nil
+        }
+
+        if let pick = bestLanguageMatch(rawLang, in: tracks, preferForced: context.showForced) {
+            return pick
+        }
+
+        if context.showForced,
+           let forced = tracks.enumerated().first(where: { $0.element.forced == true }) {
+            return (forced.element, forced.offset)
+        }
+        return nil
+    }
+
+    /// Language-scored pick mirroring `SubtitleAutoResolver.bestLanguageMatch`
+    /// over `SubtitleTrack`. Prefers full-dialogue (non-forced, non-SDH) unless
+    /// `preferForced` is set. Carries the array offset through as the ordinal.
+    private static func bestLanguageMatch(
+        _ language: String?,
+        in tracks: [SubtitleTrack],
+        preferForced: Bool
+    ) -> (track: SubtitleTrack, ordinal: Int)? {
+        let pool = tracks.enumerated().filter { _, track in
+            guard let language else { return true }
+            guard let trackLang = track.language else { return false }
+            return SubtitleAutoResolver.languagesMatch(trackLang, language)
+        }
+        guard !pool.isEmpty else { return nil }
+        if preferForced, let forced = pool.first(where: { $0.element.forced == true }) {
+            return (forced.element, forced.offset)
+        }
+        if let full = pool.first(where: {
+            !($0.element.forced ?? false) && !($0.element.hearingImpaired ?? false)
+        }) {
+            return (full.element, full.offset)
+        }
+        if let nonForced = pool.first(where: { !($0.element.forced ?? false) }) {
+            return (nonForced.element, nonForced.offset)
+        }
+        return (pool[0].element, pool[0].offset)
+    }
+
     static func subtitleOptions(
         version: FileVersion?,
         selectedSubtitleTrackIndex: Int?,
@@ -297,11 +401,33 @@ enum DetailPlaybackFormatting {
         }
     }
 
+    /// Inputs needed to preview what the player's subtitle auto-resolver
+    /// would land on, so the selector can annotate "Auto" with the concrete
+    /// track (or "None"). Mirrors `SubtitleAutoResolver.Inputs` with the
+    /// subset the detail payload can supply.
+    struct SubtitleAutoContext {
+        var preferredLanguage: String?
+        var mode: String?
+        var signature: SubtitleTrackSignature?
+        var audioLanguage: String?
+        var showForced: Bool = false
+    }
+
     static func subtitleValueLabel(
         version: FileVersion?,
-        selectedSubtitleTrackIndex: Int?
+        selectedSubtitleTrackIndex: Int?,
+        autoContext: SubtitleAutoContext? = nil
     ) -> String {
         if selectedSubtitleTrackIndex == nil {
+            // When we can preview the auto-resolution, always spell it out as
+            // "Auto - <track>" (or "Auto - None"), even for a single track, so
+            // the row shows what will actually play rather than a bare "Auto".
+            if let autoContext {
+                if let resolved = autoResolvedSubtitle(version: version, context: autoContext) {
+                    return "Auto - \(subtitleTitle(resolved.track, ordinal: resolved.ordinal))"
+                }
+                return "Auto - None"
+            }
             let tracks = version?.subtitleTracks ?? []
             if tracks.count == 1, let track = tracks.first {
                 return subtitleTitle(track, ordinal: 0)

--- a/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
@@ -195,6 +195,7 @@ class ItemDetailViewModel {
                 intro: watchDetail.intro,
                 credits: watchDetail.credits,
                 effectiveSubtitleMode: watchDetail.effectiveSubtitleMode,
+                effectiveShowForcedSubtitles: watchDetail.effectiveShowForcedSubtitles,
                 effectiveSubtitleTrackSignature: watchDetail.effectiveSubtitleTrackSignature,
                 overlaySummary: item.overlaySummary,
                 audiobook: item.audiobook,

--- a/iosApp/iosApp/Screens/Detail/MovieDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/MovieDetailContent.swift
@@ -287,14 +287,12 @@ struct MovieDetailContent<BelowOverview: View>: View {
     }
 
     private var similarSection: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            PhoneSectionHeader(title: "More Like This")
-                .padding(.horizontal, ContinuumTheme.safePadding)
-            PhoneSimilarRail(
-                contentId: detail.contentId,
-                onSelect: onNavigateToItem
-            )
-        }
+        // Header lives inside the rail so it disappears with the cards when
+        // recommendations are disabled or empty.
+        PhoneSimilarRail(
+            contentId: detail.contentId,
+            onSelect: onNavigateToItem
+        )
     }
 
     // MARK: - Details

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneSimilarRail.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneSimilarRail.swift
@@ -11,7 +11,9 @@ import SwiftUI
 /// The rail self-loads its data when the parent provides a
 /// `contentId`. Hidden when the request fails or returns nothing —
 /// recommendations are non-essential, so a missing rail is preferable
-/// to an error placeholder.
+/// to an error placeholder. The section header lives in here (not the
+/// parent) for the same reason: when recommendations are disabled or
+/// empty, an orphaned "More Like This" title must vanish with the cards.
 struct PhoneSimilarRail: View {
     let contentId: String
     let onSelect: (String) -> Void
@@ -23,12 +25,22 @@ struct PhoneSimilarRail: View {
     var body: some View {
         Group {
             if isLoading {
-                loadingPlaceholder
+                section { loadingPlaceholder }
             } else if !items.isEmpty {
-                rail
+                section { rail }
             }
         }
         .task(id: contentId) { await load() }
+    }
+
+    private func section(@ViewBuilder content: () -> some View) -> some View {
+        // Header-to-content gap matches the parents' former
+        // `VStack(spacing: 14)` so the page rhythm is unchanged.
+        VStack(alignment: .leading, spacing: 14) {
+            PhoneSectionHeader(title: "More Like This")
+                .padding(.horizontal, ContinuumTheme.safePadding)
+            content()
+        }
     }
 
     // MARK: - Rail

--- a/iosApp/iosApp/Screens/Detail/SeriesDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/SeriesDetailContent.swift
@@ -223,14 +223,12 @@ struct SeriesDetailContent<BelowOverview: View>: View {
     }
 
     private var similarSection: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            PhoneSectionHeader(title: "More Like This")
-                .padding(.horizontal, ContinuumTheme.safePadding)
-            PhoneSimilarRail(
-                contentId: detail.contentId,
-                onSelect: onNavigateToItem
-            )
-        }
+        // Header lives inside the rail so it disappears with the cards when
+        // recommendations are disabled or empty.
+        PhoneSimilarRail(
+            contentId: detail.contentId,
+            onSelect: onNavigateToItem
+        )
     }
 
     // MARK: - Episodes

--- a/iosApp/iosApp/Screens/Personal/FavoritesView.swift
+++ b/iosApp/iosApp/Screens/Personal/FavoritesView.swift
@@ -64,7 +64,13 @@ struct FavoritesView: View {
                         action: {
                             router.navigate(to: .itemDetail(contentId: item.contentId))
                         },
-                        contentId: item.contentId
+                        contentId: item.contentId,
+                        onUserStateChanged: { state in
+                            guard !state.isFavorite else { return }
+                            withAnimation {
+                                items.removeAll { $0.contentId == item.contentId }
+                            }
+                        }
                     )
                     .frame(maxWidth: .infinity)
                 }

--- a/iosApp/iosApp/Screens/Personal/WatchlistView.swift
+++ b/iosApp/iosApp/Screens/Personal/WatchlistView.swift
@@ -64,7 +64,13 @@ struct WatchlistView: View {
                         action: {
                             router.navigate(to: .itemDetail(contentId: item.contentId))
                         },
-                        contentId: item.contentId
+                        contentId: item.contentId,
+                        onUserStateChanged: { state in
+                            guard !state.inWatchlist else { return }
+                            withAnimation {
+                                items.removeAll { $0.contentId == item.contentId }
+                            }
+                        }
                     )
                     .frame(maxWidth: .infinity)
                 }

--- a/iosApp/iosApp/Screens/Player/PlaybackPrefsResolver.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackPrefsResolver.swift
@@ -185,13 +185,29 @@ struct SubtitleAutoResolver {
         if preferForced, let forced = pool.first(where: { $0.isForced }) {
             return forced
         }
-        if let nonForced = pool.first(where: { !$0.isForced && !$0.isHearingImpaired }) {
+        if let nonForced = pool.first(where: {
+            !$0.isForced && !$0.isHearingImpaired && !titleIndicatesHearingImpaired($0.title)
+        }) {
             return nonForced
         }
         if let nonForced = pool.first(where: { !$0.isForced }) {
             return nonForced
         }
         return pool.first
+    }
+
+    /// CC/SDH detection from the track title, for files that label the
+    /// track ("English (CC)", "English SDH") without setting the ffmpeg
+    /// hearing-impaired disposition flag. "cc"/"sdh" must match as whole
+    /// tokens — a bare substring check would hit words like "soccer".
+    static func titleIndicatesHearingImpaired(_ title: String?) -> Bool {
+        guard let title, !title.isEmpty else { return false }
+        let lowered = title.lowercased()
+        if lowered.contains("hearing impaired") || lowered.contains("closed caption") {
+            return true
+        }
+        let tokens = lowered.split(whereSeparator: { !$0.isLetter && !$0.isNumber })
+        return tokens.contains("cc") || tokens.contains("sdh")
     }
 
     /// Loose ISO 639 comparison. Accepts mixed 2-letter / 3-letter

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -6386,12 +6386,46 @@ class PlayerViewModel {
         showControls = true
         guard !isBackgroundSuspended else { return }
         hideControlsTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(nanoseconds: Self.autoHideSeconds * 1_000_000_000)
-            guard !Task.isCancelled else { return }
+            while true {
+                try? await Task.sleep(nanoseconds: Self.autoHideSeconds * 1_000_000_000)
+                guard !Task.isCancelled else { return }
+                #if os(iOS)
+                // A native Menu offers no isPresented hook, so the hide
+                // deadline checks for a live menu platter instead of the
+                // menus pinning the overlay: wait out an open menu, then
+                // give the overlay a fresh full window before hiding.
+                if Self.isSystemMenuPresented() {
+                    while Self.isSystemMenuPresented() {
+                        try? await Task.sleep(nanoseconds: 500_000_000)
+                        guard !Task.isCancelled else { return }
+                    }
+                    continue
+                }
+                #endif
+                break
+            }
             guard let self, self.isPlaying else { return }
             withAnimation { self.showControls = false }
         }
     }
+
+    #if os(iOS)
+    /// True while a UIKit menu platter is on screen. SwiftUI `Menu`s are
+    /// UIContextMenuInteraction-backed, and the presented platter lives in
+    /// a window (or a window's immediate subview) whose class name carries
+    /// "ContextMenu" — there is no public presentation hook to observe.
+    private static func isSystemMenuPresented() -> Bool {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap(\.windows)
+            .contains { window in
+                NSStringFromClass(type(of: window)).contains("ContextMenu")
+                    || window.subviews.contains {
+                        NSStringFromClass(type(of: $0)).contains("ContextMenu")
+                    }
+            }
+    }
+    #endif
 
     private func pauseForForegroundInterruptionIfNeeded() {
         guard !isBackgroundSuspended else { return }

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -1187,7 +1187,19 @@ class PlayerViewModel {
         }
         cb.onPauseChange = { [weak self] paused in
             guard let self, !self.isDisposed else { return }
+            let wasPlaying = self.isPlaying
             self.isPlaying = !paused
+            // A pause from any source (remote button, transport button,
+            // Siri, interruption) surfaces the transport overlay and pins
+            // it — no auto-hide runs while paused, so it stays up until
+            // the user acts. Resuming re-arms the auto-hide so a resume
+            // from an external source (Now Playing, Siri) doesn't leave
+            // the overlay stuck on-screen.
+            if paused, wasPlaying, !self.isLoading, !self.hasReachedEndOfFile {
+                self.pinControlsVisible()
+            } else if !paused, self.showControls, !self.isHUDPresented {
+                self.scheduleHideControls()
+            }
             self.nowPlaying.update(
                 title: self.title,
                 duration: self.duration,

--- a/iosApp/iosApp/Screens/Player/iOS/MobilePlayerControls.swift
+++ b/iosApp/iosApp/Screens/Player/iOS/MobilePlayerControls.swift
@@ -531,10 +531,6 @@ struct MobilePlayerControls: View {
             }
         }
         .buttonBorderShape(.capsule)
-        // A native Menu offers no isPresented hook, so pin the controls the
-        // moment the label is tapped; `switchQuality` re-arms auto-hide
-        // when a choice lands, and any later overlay tap does too.
-        .simultaneousGesture(TapGesture().onEnded { viewModel.pinControlsVisible() })
         .accessibilityLabel("Playback Quality")
         .accessibilityValue(qualityValueText)
     }
@@ -565,6 +561,25 @@ struct MobilePlayerControls: View {
     /// stay sheets; they're multi-step workflows, not pickers.
     private func trackSelectionMenu(style: ActionRowStyle) -> some View {
         Menu {
+            trackSelectionMenuContent
+        } label: {
+            menuPillLabel(
+                systemImage: "captions.bubble",
+                title: style == .icons
+                    ? nil
+                    : (style == .compact ? "Audio & Subs" : "Audio & Subtitles")
+            )
+        }
+        .menuStyle(.button)
+        // Bottom-anchored menus open upward and reverse their items by
+        // default; fixed order keeps Audio on top, reading down.
+        .menuOrder(.fixed)
+        .buttonStyle(.glass)
+        .buttonBorderShape(style == .icons ? .circle : .capsule)
+    }
+
+    @ViewBuilder
+    private var trackSelectionMenuContent: some View {
             if !viewModel.audioTracks.isEmpty {
                 Section("Audio") {
                     ForEach(viewModel.audioTracks) { track in
@@ -625,30 +640,25 @@ struct MobilePlayerControls: View {
                     }
                 }
             }
-        } label: {
-            menuPillLabel(
-                systemImage: "captions.bubble",
-                title: style == .icons
-                    ? nil
-                    : (style == .compact ? "Audio & Subs" : "Audio & Subtitles")
-            )
-        }
-        .menuStyle(.button)
-        // Bottom-anchored menus open upward and reverse their items by
-        // default; fixed order keeps Audio on top, reading down.
-        .menuOrder(.fixed)
-        .buttonStyle(.glass)
-        .buttonBorderShape(style == .icons ? .circle : .capsule)
-        // A native Menu offers no isPresented hook, so pin the controls the
-        // moment the label is tapped; the track-selection methods re-arm
-        // auto-hide when a choice lands, and any later overlay tap does too.
-        .simultaneousGesture(TapGesture().onEnded { viewModel.pinControlsVisible() })
     }
 
     /// Submenu for the secondary subtitle slot, titled with the current pick
     /// so the parent menu shows the state without opening it.
     private var secondarySubtitlesSubmenu: some View {
         Menu {
+            secondarySubtitlesSubmenuContent
+        } label: {
+            Text("Secondary Subtitles")
+            if let current = viewModel.availableSecondarySubtitleTracks.first(
+                where: { $0.trackId == viewModel.selectedSecondarySubtitleId }
+            ) {
+                Text(current.languageFirstPrimaryLabel)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var secondarySubtitlesSubmenuContent: some View {
             trackMenuRow(
                 title: "Off",
                 subtitle: nil,
@@ -668,14 +678,6 @@ struct MobilePlayerControls: View {
                     viewModel.selectSecondarySubtitle(track)
                 }
             }
-        } label: {
-            Text("Secondary Subtitles")
-            if let current = viewModel.availableSecondarySubtitleTracks.first(
-                where: { $0.trackId == viewModel.selectedSecondarySubtitleId }
-            ) {
-                Text(current.languageFirstPrimaryLabel)
-            }
-        }
     }
 
     /// Menu row with the Quality-menu selection idiom (leading checkmark)
@@ -756,7 +758,6 @@ struct MobilePlayerControls: View {
         .menuOrder(.fixed)
         .buttonStyle(.glass)
         .buttonBorderShape(style == .icons ? .circle : .capsule)
-        .simultaneousGesture(TapGesture().onEnded { viewModel.pinControlsVisible() })
     }
 
     private func chapterMenuTitle(_ chapter: PlayerChapterInfo) -> String {

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPlayerControls.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPlayerControls.swift
@@ -22,6 +22,10 @@ struct TVPlayerControls: View {
     /// commit. Without this, opening the HUD with an in-flight scrub preview
     /// would seek to that preview as a side-effect.
     @State private var cancelPendingScrub: Bool = false
+    /// Mirrors the scrubber's explicit timeline-scrub mode (Select on the
+    /// puck). Held here so the transport cluster can leave the focus graph
+    /// while the scrub is modal.
+    @State private var isTimelineScrubbing: Bool = false
 
     // Focus states. SwiftUI's focus engine only holds focus on one
     // focusable at a time, so selecting one of these implicitly clears the
@@ -296,6 +300,7 @@ struct TVPlayerControls: View {
                 onExitWhenIdle: {
                     viewModel.dismissControls()
                 },
+                isTimelineScrubbing: $isTimelineScrubbing,
                 cancelOnBlur: cancelPendingScrub
             )
             timeRow
@@ -307,6 +312,10 @@ struct TVPlayerControls: View {
                     isScrubberFocused = true
                 },
                 onDismiss: onDismiss,
+                // Timeline scrub is modal: with the transport buttons out of
+                // the focus graph, a Down press/swipe has no target below the
+                // scrubber, so the focus engine leaves the puck alone.
+                allowsFocus: !isTimelineScrubbing,
                 focusedButton: $focusedTransportButton
             )
         }

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPlayerControls.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPlayerControls.swift
@@ -26,6 +26,16 @@ struct TVPlayerControls: View {
     /// puck). Held here so the transport cluster can leave the focus graph
     /// while the scrub is modal.
     @State private var isTimelineScrubbing: Bool = false
+    /// True while the scrubber owns focus. The transport row leaves the
+    /// focus graph for that duration so a Down press has no native target:
+    /// the engine otherwise moves focus geometrically — to whichever button
+    /// happens to sit under the playhead — *before* the scrubber's
+    /// `onMoveCommand` fires, and the play/pause seed then reads as a
+    /// visible hop off the wrong button. Released on the Down hand-off (so
+    /// the seed has a focusable target) and whenever the scrubber blurs for
+    /// any other reason (intro skip, HUD) so direction moves into the row
+    /// keep working from elsewhere.
+    @State private var trapsTransportFocus = false
 
     // Focus states. SwiftUI's focus engine only holds focus on one
     // focusable at a time, so selecting one of these implicitly clears the
@@ -108,6 +118,7 @@ struct TVPlayerControls: View {
         // the user's focus) out from under them mid-interaction.
         .onChange(of: isScrubberFocused) { _, focused in
             if focused { rearmAutoHideOnFocusMove() }
+            trapsTransportFocus = focused
         }
         .onChange(of: focusedTransportButton) { _, target in
             if target != nil { rearmAutoHideOnFocusMove() }
@@ -294,8 +305,17 @@ struct TVPlayerControls: View {
                 viewModel: viewModel,
                 isFocused: $isScrubberFocused,
                 onMoveToTransport: {
-                    isScrubberFocused = false
-                    focusedTransportButton = .playPause
+                    // This fires only because the trap kept the transport row
+                    // out of the focus graph (no native Down target). Restore
+                    // the row first, then seed play/pause on the next turn —
+                    // a claim in the same transaction as the structural
+                    // re-enable gets dropped by the engine. Focus stays on
+                    // the scrubber for that frame, so there is no visible
+                    // intermediate stop.
+                    trapsTransportFocus = false
+                    DispatchQueue.main.async {
+                        focusedTransportButton = .playPause
+                    }
                 },
                 onExitWhenIdle: {
                     viewModel.dismissControls()
@@ -308,14 +328,17 @@ struct TVPlayerControls: View {
                 viewModel: viewModel,
                 onOpenHUD: { openHUD() },
                 onMoveToScrubber: {
-                    focusedTransportButton = nil
+                    // Same single-write rule as onMoveToTransport: nulling the
+                    // transport focus first invites a geometric repair hop.
                     isScrubberFocused = true
                 },
                 onDismiss: onDismiss,
-                // Timeline scrub is modal: with the transport buttons out of
-                // the focus graph, a Down press/swipe has no target below the
-                // scrubber, so the focus engine leaves the puck alone.
-                allowsFocus: !isTimelineScrubbing,
+                // Timeline scrub is modal, and a focused scrubber traps Down:
+                // with the transport buttons out of the focus graph, a Down
+                // press/swipe has no native target below the scrubber, so the
+                // hand-off goes through onMoveToTransport instead of the
+                // engine's geometric pick.
+                allowsFocus: !isTimelineScrubbing && !trapsTransportFocus,
                 focusedButton: $focusedTransportButton
             )
         }

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPlayerScrubber.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPlayerScrubber.swift
@@ -15,6 +15,12 @@ struct TVPlayerScrubber: View {
     let onMoveToTransport: () -> Void
     let onExitWhenIdle: () -> Void
 
+    /// Explicit timeline-scrub mode (Select on the puck). Owned by the shell
+    /// so it can drop the transport row out of the focus graph while the
+    /// scrub is modal — otherwise a Down press/swipe moves focus there
+    /// natively, before `onMoveCommand` ever fires.
+    @Binding var isTimelineScrubbing: Bool
+
     /// When true, blurring the scrubber cancels the in-progress scrub rather
     /// than committing it. The shell flips this on before opening a sheet so
     /// the focus-lost path doesn't turn into an accidental seek.
@@ -27,15 +33,14 @@ struct TVPlayerScrubber: View {
     private static let timelineAutoSeekTickNanos: UInt64 = 100_000_000
     private static let timelineAutoSeekBaseStep: Double = 2
     private static let timelineAutoSeekRates = [-32, -16, -8, -4, -2, -1, 1, 2, 4, 8, 16, 32]
-    @State private var isTimelineScrubbing = false
     @State private var timelineAutoSeekRate = 0
     @State private var timelineAutoSeekTask: Task<Void, Never>?
 
     /// Trackpad-drag scrubbing. Translation from one full edge-to-edge swipe
     /// on the Siri Remote surface is ~1000pt, so this maps a full swipe to
-    /// roughly 40% of the timeline — several swipes cross a whole movie
-    /// without a light drag overshooting by minutes.
-    private static let panPointsForFullTimeline: CGFloat = 2400
+    /// roughly 8% of the timeline — a light drag lands within seconds of
+    /// where it started instead of jumping minutes.
+    private static let panPointsForFullTimeline: CGFloat = 12000
     /// Accumulated translation required before a drag starts moving the
     /// playhead; the finger contact from a d-pad click always jitters a few
     /// points and must not nudge the preview.
@@ -419,6 +424,10 @@ struct TVPlayerScrubber: View {
         case .up:
             break
         case .down:
+            // While a scrub is in flight, a downward swipe is almost always
+            // drag spillover, not an intent to leave — trapping it keeps the
+            // preview alive until the user commits (Select) or cancels (Menu).
+            guard !isTimelineScrubbing, !viewModel.isScrubbing else { return }
             onMoveToTransport()
         @unknown default:
             break

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPlayerScrubber.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPlayerScrubber.swift
@@ -31,6 +31,19 @@ struct TVPlayerScrubber: View {
     @State private var timelineAutoSeekRate = 0
     @State private var timelineAutoSeekTask: Task<Void, Never>?
 
+    /// Trackpad-drag scrubbing. Translation from one full edge-to-edge swipe
+    /// on the Siri Remote surface is ~1000pt, so this maps a full swipe to
+    /// roughly 40% of the timeline — several swipes cross a whole movie
+    /// without a light drag overshooting by minutes.
+    private static let panPointsForFullTimeline: CGFloat = 2400
+    /// Accumulated translation required before a drag starts moving the
+    /// playhead; the finger contact from a d-pad click always jitters a few
+    /// points and must not nudge the preview.
+    private static let panDeadzone: CGFloat = 12
+    @State private var isPanScrubbing = false
+    @State private var panEngaged = false
+    @State private var panAccumulated: CGFloat = 0
+
     // Visual metrics pulled out as compile-time constants so layout doesn't
     // re-evaluate them each pass. Chapter ticks rely on `trackHeight` so the
     // track and ticks stay visually aligned.
@@ -84,11 +97,27 @@ struct TVPlayerScrubber: View {
             .focused($isFocused)
             .onTapGesture { commitScrub() }
             .background {
-                TVDirectionalPressGestureView(
-                    isActive: isFocused && !viewModel.isHoldSeeking && timelineAutoSeekRate == 0,
-                    onArrowTap: handleArrowTap,
-                    onArrowHoldBegin: handleArrowHoldBegin
-                )
+                ZStack {
+                    TVDirectionalPressGestureView(
+                        isActive: isFocused && !viewModel.isHoldSeeking && timelineAutoSeekRate == 0,
+                        onArrowTap: handleArrowTap,
+                        onArrowHoldBegin: handleArrowHoldBegin
+                    )
+                    // Continuous trackpad drag while the puck is selected —
+                    // Select enters timeline-scrub mode, then swipes stream
+                    // through here instead of stepping ±10s/30s per move
+                    // command.
+                    TVPanCaptureView(
+                        isActive: isFocused && isTimelineScrubbing && !isTimelineAutoSeeking,
+                        onPanBegan: {
+                            isPanScrubbing = true
+                            panEngaged = false
+                            panAccumulated = 0
+                        },
+                        onPanChanged: handlePanChanged,
+                        onPanEnded: { isPanScrubbing = false }
+                    )
+                }
                 .frame(width: 1, height: 1)
             }
             .onChange(of: isFocused) { _, focused in
@@ -351,20 +380,40 @@ struct TVPlayerScrubber: View {
         }
     }
 
+    /// Continuous trackpad drag: translation maps linearly onto the
+    /// timeline. A deadzone filters out the contact jitter from clicks; once
+    /// crossed, every subsequent delta moves the preview directly.
+    private func handlePanChanged(_ deltaX: CGFloat) {
+        guard isTimelineScrubbing, viewModel.duration > 0 else { return }
+        if !panEngaged {
+            panAccumulated += deltaX
+            guard abs(panAccumulated) >= Self.panDeadzone else { return }
+            panEngaged = true
+        }
+        let base = viewModel.isScrubbing ? viewModel.scrubPreviewTime : viewModel.currentTime
+        let deltaSeconds = Double(deltaX / Self.panPointsForFullTimeline) * viewModel.duration
+        let target = min(max(base + deltaSeconds, 0), viewModel.duration)
+        viewModel.updateScrub(fraction: target / viewModel.duration)
+    }
+
     private func handleMove(_ direction: MoveCommandDirection) {
+        // While a trackpad drag is in flight the same swipe also surfaces
+        // here as discrete left/right move commands — the pan owns the
+        // playhead, so the fixed-step path must stay quiet.
+        let panOwnsTimeline = isPanScrubbing && isTimelineScrubbing && !isTimelineAutoSeeking
         switch direction {
         case .left:
             guard viewModel.duration > 0 else { return }
             if isTimelineAutoSeeking {
                 adjustTimelineAutoSeekRate(delta: -1)
-            } else if isTimelineScrubbing {
+            } else if isTimelineScrubbing, !panOwnsTimeline {
                 stepTimeline(by: -Self.scrubBackwardStep)
             }
         case .right:
             guard viewModel.duration > 0 else { return }
             if isTimelineAutoSeeking {
                 adjustTimelineAutoSeekRate(delta: 1)
-            } else if isTimelineScrubbing {
+            } else if isTimelineScrubbing, !panOwnsTimeline {
                 stepTimeline(by: Self.scrubForwardStep)
             }
         case .up:

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPlayerTransportCluster.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPlayerTransportCluster.swift
@@ -15,6 +15,10 @@ struct TVPlayerTransportCluster: View {
     let onOpenHUD: () -> Void
     let onMoveToScrubber: () -> Void
     let onDismiss: () -> Void
+    /// False while the scrubber's timeline-scrub mode is active — pulls every
+    /// button out of the focus graph so a Down press/swipe on the puck finds
+    /// no target and focus stays on the scrub.
+    var allowsFocus: Bool = true
 
     @FocusState.Binding var focusedButton: FocusTarget?
 
@@ -117,7 +121,7 @@ struct TVPlayerTransportCluster: View {
             )
             .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: isFocused)
             .contentShape(Circle())
-            .focusable(true)
+            .focusable(allowsFocus)
             .focused($focusedButton, equals: focus)
             .onTapGesture(perform: action)
             .accessibilityLabel(accessibilityLabel)

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPressCaptureView.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPressCaptureView.swift
@@ -81,6 +81,109 @@ struct TVDirectionalPressGestureView: UIViewRepresentable {
     }
 }
 
+/// Window-level trackpad pan bridge. SwiftUI on tvOS only surfaces the Siri
+/// Remote touch surface as discrete `.onMoveCommand` steps, so continuous
+/// drag-the-playhead scrubbing needs a `UIPanGestureRecognizer` reading the
+/// indirect touch stream. Attached to the window (like
+/// `TVDirectionalPressGestureView`) so SwiftUI keeps owning focus while the
+/// pan translation streams through the callbacks.
+struct TVPanCaptureView: UIViewRepresentable {
+    var isActive: Bool
+    var onPanBegan: () -> Void = {}
+    /// Incremental horizontal translation (points) since the last change.
+    var onPanChanged: (CGFloat) -> Void = { _ in }
+    var onPanEnded: () -> Void = {}
+
+    func makeUIView(context: Context) -> PanCaptureUIView {
+        let view = PanCaptureUIView()
+        apply(to: view)
+        return view
+    }
+
+    func updateUIView(_ uiView: PanCaptureUIView, context: Context) {
+        apply(to: uiView)
+    }
+
+    private func apply(to view: PanCaptureUIView) {
+        view.isActive = isActive
+        view.onPanBegan = onPanBegan
+        view.onPanChanged = onPanChanged
+        view.onPanEnded = onPanEnded
+    }
+}
+
+final class PanCaptureUIView: UIView, UIGestureRecognizerDelegate {
+    var isActive: Bool = false
+    var onPanBegan: () -> Void = {}
+    var onPanChanged: (CGFloat) -> Void = { _ in }
+    var onPanEnded: () -> Void = {}
+
+    private weak var attachedWindow: UIWindow?
+    private var panRecognizer: UIPanGestureRecognizer?
+    private var lastTranslationX: CGFloat = 0
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        attachRecognizerIfNeeded()
+    }
+
+    deinit {
+        detachRecognizer()
+    }
+
+    private func attachRecognizerIfNeeded() {
+        guard let window, attachedWindow !== window else { return }
+        detachRecognizer()
+        attachedWindow = window
+
+        let pan = UIPanGestureRecognizer(target: self, action: #selector(handlePan(_:)))
+        pan.allowedTouchTypes = [NSNumber(value: UITouch.TouchType.indirect.rawValue)]
+        pan.delegate = self
+        window.addGestureRecognizer(pan)
+        panRecognizer = pan
+    }
+
+    private func detachRecognizer() {
+        if let attachedWindow, let panRecognizer {
+            attachedWindow.removeGestureRecognizer(panRecognizer)
+        }
+        panRecognizer = nil
+        attachedWindow = nil
+    }
+
+    @objc private func handlePan(_ recognizer: UIPanGestureRecognizer) {
+        switch recognizer.state {
+        case .began:
+            guard isActive else { return }
+            lastTranslationX = recognizer.translation(in: attachedWindow).x
+            onPanBegan()
+        case .changed:
+            guard isActive else { return }
+            let x = recognizer.translation(in: attachedWindow).x
+            onPanChanged(x - lastTranslationX)
+            lastTranslationX = x
+        case .ended, .cancelled, .failed:
+            // Deliver the end even if `isActive` dropped mid-gesture (e.g.
+            // the scrub was cancelled under the finger) so the SwiftUI side
+            // never gets stuck thinking a pan is still in flight.
+            onPanEnded()
+        default:
+            break
+        }
+    }
+
+    override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        isActive
+    }
+
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        true
+    }
+}
+
 final class DirectionalPressGestureUIView: UIView, UIGestureRecognizerDelegate {
     var isActive: Bool = false
     var onArrowTap: (TVPressCaptureView.ArrowDirection) -> Void = { _ in }

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPressCaptureView.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPressCaptureView.swift
@@ -124,7 +124,13 @@ final class PanCaptureUIView: UIView, UIGestureRecognizerDelegate {
 
     override func didMoveToWindow() {
         super.didMoveToWindow()
-        attachRecognizerIfNeeded()
+        // Leaving the window (nil) must tear the recognizer off the old
+        // window deterministically rather than waiting for deinit.
+        if window == nil {
+            detachRecognizer()
+        } else {
+            attachRecognizerIfNeeded()
+        }
     }
 
     deinit {
@@ -201,7 +207,14 @@ final class DirectionalPressGestureUIView: UIView, UIGestureRecognizerDelegate {
 
     override func didMoveToWindow() {
         super.didMoveToWindow()
-        attachRecognizersIfNeeded()
+        // Same teardown contract as PanCaptureUIView: leaving the window
+        // detaches from the old window immediately, not at deinit.
+        if window == nil {
+            cancelAllRepeatTimers()
+            detachRecognizers()
+        } else {
+            attachRecognizersIfNeeded()
+        }
     }
 
     deinit {

--- a/iosApp/iosApp/Theme/ContinuumTheme.swift
+++ b/iosApp/iosApp/Theme/ContinuumTheme.swift
@@ -142,11 +142,11 @@ struct ContinuumTheme {
         static let barHeight: CGFloat = 64
         /// Gap between tab capsules in the bar's center cluster.
         static let tabSpacing: CGFloat = 8
-        static let tabLabelSize: CGFloat = 23
-        static let tabPaddingHorizontal: CGFloat = 26
-        static let tabPaddingVertical: CGFloat = 11
+        static let tabLabelSize: CGFloat = 26
+        static let tabPaddingHorizontal: CGFloat = 29
+        static let tabPaddingVertical: CGFloat = 12
         /// Square hit target of the search button and the profile avatar.
-        static let barIconSize: CGFloat = 52
+        static let barIconSize: CGFloat = 58
         /// Gap between the search button and the avatar.
         static let barTrailingSpacing: CGFloat = 22
         static let wordmarkSize: CGFloat = 26

--- a/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
+++ b/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
@@ -31,10 +31,18 @@ struct TVSkylineSectionFeed: View {
     @State private var marqueeModel = TVFocusMarqueeModel()
     /// Token handed to row 1 so its first card claims focus on shell entry.
     @State private var contentFocusToken = 0
+    /// Snaps the row band back to the first section before a focus claim.
+    /// The band clips rows outside the viewport, and tvOS refuses to focus a
+    /// clipped view — so when entry focus fires while the user is parked on a
+    /// lower row (e.g. re-clicking the current tab in the top menu), the first
+    /// card's claim silently no-ops unless the band is scrolled home first.
+    @State private var entryScrollToken = 0
     /// Entry tokens that arrived before any row mounted — sections load
     /// async, so the initial hand-down would land on nothing.
     @State private var pendingFocusRequest: Int?
     @State private var lastAppliedRequest = 0
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         ZStack(alignment: .top) {
@@ -84,20 +92,32 @@ struct TVSkylineSectionFeed: View {
                 visibleBandHeight - ContinuumTheme.Skyline.rowBandBottomInset
             )
 
-            ScrollView(.vertical, showsIndicators: false) {
-                LazyVStack(alignment: .leading, spacing: ContinuumTheme.Skyline.rowBandPreviewSpacing) {
-                    ForEach(Array(sections.enumerated()), id: \.element.id) { index, section in
-                        featuredRow(section, isFirstRow: index == 0)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .id(section.id)
+            ScrollViewReader { scrollProxy in
+                ScrollView(.vertical, showsIndicators: false) {
+                    LazyVStack(alignment: .leading, spacing: ContinuumTheme.Skyline.rowBandPreviewSpacing) {
+                        ForEach(Array(sections.enumerated()), id: \.element.id) { index, section in
+                            featuredRow(section, isFirstRow: index == 0)
+                                .fixedSize(horizontal: false, vertical: true)
+                                .id(section.id)
+                        }
+                    }
+                    .scrollTargetLayout()
+                    // Allows the final row to top-align like every prior row,
+                    // with a blank preview area underneath instead of clamping.
+                    .padding(.bottom, trailingPreviewPadding)
+                }
+                .scrollTargetBehavior(.viewAligned)
+                // Animated ride home; the first card's focus claim is
+                // re-asserted by MediaRow until the scroll settles, so the
+                // animation can't lose the claim to mid-flight focus repairs.
+                .onChange(of: entryScrollToken) { _, _ in
+                    if let firstId = sections.first?.id {
+                        withAnimation(reduceMotion ? nil : .easeInOut(duration: ContinuumTheme.slowDuration)) {
+                            scrollProxy.scrollTo(firstId, anchor: .top)
+                        }
                     }
                 }
-                .scrollTargetLayout()
-                // Allows the final row to top-align like every prior row,
-                // with a blank preview area underneath instead of clamping.
-                .padding(.bottom, trailingPreviewPadding)
             }
-            .scrollTargetBehavior(.viewAligned)
             .frame(width: proxy.size.width, height: visibleBandHeight, alignment: .topLeading)
             .clipped()
             .frame(width: proxy.size.width, height: proxy.size.height, alignment: .bottomLeading)
@@ -141,7 +161,13 @@ struct TVSkylineSectionFeed: View {
         if isTopMenuFocused { return }
         guard request != lastAppliedRequest else { return }
         lastAppliedRequest = request
-        contentFocusToken += 1
+        // Scroll the band home first, then claim on the next turn: the claim
+        // is a @FocusState write on the first row's first card, which the
+        // engine drops while that card is still clipped out of the viewport.
+        entryScrollToken += 1
+        DispatchQueue.main.async {
+            contentFocusToken += 1
+        }
     }
 
     private func previewFocusedItem(_ item: SectionItem, in section: ResolvedSection) {

--- a/iosApp/iosApp/tvOS/Debug/TVDebugSettings.swift
+++ b/iosApp/iosApp/tvOS/Debug/TVDebugSettings.swift
@@ -1,0 +1,33 @@
+#if os(tvOS)
+import Foundation
+import Observation
+
+/// Device-local debug switches for the Apple TV client. Unlike
+/// `AppNavPreferences` these are not profile-scoped: a debugging aid
+/// applies to the device being debugged, not the signed-in user.
+@Observable
+final class TVDebugSettings {
+    static let shared = TVDebugSettings()
+
+    /// Whether the d-pad focus-destination overlay is drawn on screen
+    /// (see `TVFocusDebugOverlay`).
+    private(set) var showFocusTargets: Bool
+
+    @ObservationIgnored private let defaults: SharedDefaults
+
+    private static let showFocusTargetsKey = "skyline.debug.showFocusTargets"
+
+    init(defaults: SharedDefaults = .shared) {
+        self.defaults = defaults
+        // Launch-arg override (same convention as -debugPlay) so the
+        // overlay can be exercised on screens that precede sign-in.
+        self.showFocusTargets = defaults.bool(forKey: Self.showFocusTargetsKey)
+            || CommandLine.arguments.contains("-debugFocusTargets")
+    }
+
+    func setShowFocusTargets(_ value: Bool) {
+        showFocusTargets = value
+        defaults.set(value, forKey: Self.showFocusTargetsKey)
+    }
+}
+#endif

--- a/iosApp/iosApp/tvOS/Debug/TVDebugSettings.swift
+++ b/iosApp/iosApp/tvOS/Debug/TVDebugSettings.swift
@@ -1,4 +1,4 @@
-#if os(tvOS)
+#if os(tvOS) && DEBUG
 import Foundation
 import Observation
 

--- a/iosApp/iosApp/tvOS/Debug/TVFocusDebugOverlay.swift
+++ b/iosApp/iosApp/tvOS/Debug/TVFocusDebugOverlay.swift
@@ -1,0 +1,722 @@
+#if os(tvOS)
+import SwiftUI
+import UIKit
+
+/// Debug overlay that marks where the tvOS focus engine will land for
+/// each d-pad direction from the currently focused control.
+///
+/// UIKit exposes no public "next focused item in direction" query, so the
+/// primary path asks the engine itself through runtime-resolved private
+/// classes (`FocusEngineQuery`): it builds the same `_UIFocusMovementRequest`
+/// a d-pad press produces and runs it through the focus system's movement
+/// performer, which honors focus guides, occlusion, and group rules. Two
+/// cases fall back to a geometric heuristic over every `UIFocusItem` in
+/// the window: the private internals going missing (OS change), and the
+/// engine reporting a failed movement — on tvOS SwiftUI resolves failed
+/// moves itself via `.focusSection()` hops that aren't queryable from
+/// UIKit. Heuristic markers carry a `?` badge so a guess isn't mistaken
+/// for engine output.
+///
+/// Lives in its own passthrough window (`TVFocusDebugOverlayController`)
+/// so it renders above full-screen covers and can never receive focus or
+/// touches itself.
+struct TVFocusDebugOverlay: View {
+    @State private var snapshot = FocusDebugSnapshot()
+
+    /// Layout can settle after the focus notification fires (scroll-to
+    /// animations, lazy grids); a slow tick keeps the markers honest.
+    private let settleTick = Timer.publish(every: 0.75, on: .main, in: .common)
+        .autoconnect()
+
+    var body: some View {
+        ZStack {
+            if let focused = snapshot.focusedFrame {
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(
+                        .white.opacity(0.85),
+                        style: StrokeStyle(lineWidth: 3, dash: [10, 8])
+                    )
+                    .frame(width: focused.width, height: focused.height)
+                    .position(x: focused.midX, y: focused.midY)
+            }
+
+            ForEach(snapshot.targets) { target in
+                marker(for: target)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .ignoresSafeArea()
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+        .onAppear { refresh() }
+        .onReceive(
+            NotificationCenter.default.publisher(
+                for: UIFocusSystem.didUpdateNotification
+            )
+        ) { _ in refresh() }
+        .onReceive(settleTick) { _ in refresh() }
+    }
+
+    private func marker(for target: FocusDebugSnapshot.Target) -> some View {
+        let rect = target.frame
+        let color = target.direction.color
+        let suffix = target.isHeuristic ? " ?" : (target.isScrollRegion ? " · SCROLLS" : "")
+        return RoundedRectangle(cornerRadius: 12)
+            .stroke(
+                color,
+                style: target.isScrollRegion
+                    ? StrokeStyle(lineWidth: 4, dash: [12, 8])
+                    : StrokeStyle(lineWidth: 5)
+            )
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(color.opacity(0.14))
+            )
+            .overlay(alignment: .topLeading) {
+                Text(target.direction.badge + suffix)
+                    .font(.system(size: 21, weight: .bold, design: .monospaced))
+                    .foregroundColor(.black)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 3)
+                    .background(color, in: Capsule())
+                    .offset(x: 8, y: -16)
+            }
+            .frame(width: rect.width, height: rect.height)
+            .position(x: rect.midX, y: rect.midY)
+    }
+
+    private func refresh() {
+        let next = FocusDebugSnapshot.capture()
+        if next != snapshot {
+            snapshot = next
+        }
+    }
+}
+
+// MARK: - Snapshot
+
+struct FocusDebugSnapshot: Equatable {
+    /// Frame of the currently focused item, in window coordinates.
+    var focusedFrame: CGRect?
+    /// Predicted destination per direction (directions with no candidate
+    /// are absent).
+    var targets: [Target] = []
+
+    struct Target: Equatable, Identifiable {
+        let direction: Direction
+        let frame: CGRect
+        /// True when the frame came from the geometric fallback rather
+        /// than the real focus engine.
+        var isHeuristic = false
+        /// True when the engine answered with a scroll placeholder: the
+        /// destination control isn't materialized yet, so the marker is a
+        /// strip at the edge the next row/column will scroll in from.
+        var isScrollRegion = false
+        var id: Direction { direction }
+    }
+
+    enum Direction: CaseIterable {
+        case up, down, left, right
+
+        var badge: String {
+            switch self {
+            case .up: return "▲ UP"
+            case .down: return "▼ DOWN"
+            case .left: return "◀ LEFT"
+            case .right: return "▶ RIGHT"
+            }
+        }
+
+        var focusHeading: UIFocusHeading {
+            switch self {
+            case .up: return .up
+            case .down: return .down
+            case .left: return .left
+            case .right: return .right
+            }
+        }
+
+        var color: Color {
+            switch self {
+            case .up: return .green
+            case .down: return .orange
+            case .left: return .cyan
+            case .right: return .pink
+            }
+        }
+    }
+
+    // MARK: Capture
+
+    @MainActor
+    static func capture() -> FocusDebugSnapshot {
+        guard let window = appKeyWindow(),
+              let focusedItem = UIFocusSystem.focusSystem(for: window)?.focusedItem
+        else {
+            return FocusDebugSnapshot()
+        }
+
+        var frames: [(item: UIFocusItem, frame: CGRect)] = []
+        var visitedContainers = Set<ObjectIdentifier>()
+        var seenItems = Set<ObjectIdentifier>()
+        collectFocusItems(
+            in: window,
+            window: window,
+            frames: &frames,
+            visitedContainers: &visitedContainers,
+            seenItems: &seenItems,
+            depth: 0
+        )
+
+        let focusedFrame = frames.first { $0.item === focusedItem }?.frame
+            ?? (focusedItem as? UIView)?.convert(
+                (focusedItem as? UIView)?.bounds ?? .zero, to: window
+            )
+        guard let focusedFrame else { return FocusDebugSnapshot() }
+
+        // The plausibility filter applies to guesses too: SwiftUI vends
+        // scroll-anchor items with region-sized frames, and a heuristic
+        // that considers them repaints the same giant box the engine
+        // placeholder filter just rejected.
+        let candidates = frames
+            .filter { $0.item !== focusedItem }
+            .map(\.frame)
+            .filter { isPlausibleTargetFrame($0, in: window) }
+
+        let targets = Direction.allCases.compactMap { direction -> Target? in
+            // Primary path: ask the actual focus engine. A non-nil answer
+            // is exact. A nil answer means UIKit's search failed; the
+            // geometric heuristic then guesses (marked `?`). Known gap:
+            // SwiftUI catches failed moves and performs its own
+            // `.focusSection()` hop (verified: a real Up press from a home
+            // card fires `movementDidFailNotification`, then SwiftUI moves
+            // focus into the top menu) — but SwiftUI vends only the active
+            // section's items to UIKit, so neither the engine nor the
+            // heuristic can see those destinations. No marker is drawn for
+            // a cross-section hop.
+            if FocusEngineQuery.isAvailable,
+               let item = FocusEngineQuery.nextFocusedItem(
+                   from: focusedItem,
+                   heading: direction.focusHeading,
+                   in: window
+               ), item !== focusedItem {
+                let frame = frames.first { $0.item === item }?.frame
+                    ?? (item as? UIView).map { $0.convert($0.bounds, to: window) }
+                    ?? frameByWalkingContainers(of: item, in: window)
+                if let frame {
+                    if isRealControl(item), isPlausibleTargetFrame(frame, in: window) {
+                        return Target(direction: direction, frame: frame)
+                    }
+                    // Placeholder answer: the destination is inside
+                    // unmaterialized scrollable content, so no API can
+                    // name the control yet. Mark the edge of the region
+                    // the next row/column scrolls in from instead.
+                    if let strip = scrollStrip(
+                        direction: direction,
+                        region: frame,
+                        focused: focusedFrame,
+                        in: window
+                    ) {
+                        return Target(
+                            direction: direction, frame: strip, isScrollRegion: true
+                        )
+                    }
+                }
+            }
+
+            // Engine found nothing — the moment SwiftUI performs its
+            // section hop into the top menu. The bar publishes where that
+            // hop deterministically lands (the selected tab), so draw it
+            // as a real target. Guarded to "hint is above the focused
+            // item" so a focused tab never points at itself.
+            if direction == .up,
+               let hint = TVFocusDebugHints.shared.topMenuSelectedTabFrame,
+               hint.midY < focusedFrame.minY,
+               isPlausibleTargetFrame(hint, in: window) {
+                return Target(direction: .up, frame: hint)
+            }
+
+            return bestCandidate(
+                from: focusedFrame, among: candidates, direction: direction
+            ).map { Target(direction: direction, frame: $0, isHeuristic: true) }
+        }
+
+        return FocusDebugSnapshot(focusedFrame: focusedFrame, targets: targets)
+    }
+
+    /// When the destination lies in scrollable content that isn't
+    /// materialized yet, the engine answers with a placeholder ("dummy")
+    /// item whose frame is the entire scroll-and-search region rather
+    /// than the control focus will actually land on (UIKit scrolls and
+    /// re-resolves afterwards). Drawing that literally paints a huge box
+    /// over the screen — filter placeholders by class name and by
+    /// implausibly large frames, and let the geometric heuristic guess
+    /// the concrete control instead.
+    private static func isRealControl(_ item: UIFocusItem) -> Bool {
+        let className = String(describing: type(of: item)).lowercased()
+        return !className.contains("dummy") && !className.contains("placeholder")
+    }
+
+    /// A compact marker for scroll-placeholder answers: focused-control
+    /// sized, aligned with the focused control on the cross axis, hugging
+    /// the region edge nearest the focused control — where the next
+    /// row/column surfaces when the scroll happens.
+    private static func scrollStrip(
+        direction: Direction,
+        region: CGRect,
+        focused: CGRect,
+        in window: UIWindow
+    ) -> CGRect? {
+        let visible = region.intersection(window.bounds)
+        guard !visible.isEmpty else { return nil }
+        let thickness: CGFloat = 72
+
+        var strip: CGRect
+        switch direction {
+        case .up:
+            strip = CGRect(
+                x: focused.minX, y: visible.maxY - thickness,
+                width: focused.width, height: thickness
+            )
+        case .down:
+            strip = CGRect(
+                x: focused.minX, y: visible.minY,
+                width: focused.width, height: thickness
+            )
+        case .left:
+            strip = CGRect(
+                x: visible.maxX - thickness, y: focused.minY,
+                width: thickness, height: focused.height
+            )
+        case .right:
+            strip = CGRect(
+                x: visible.minX, y: focused.minY,
+                width: thickness, height: focused.height
+            )
+        }
+
+        strip = strip.intersection(window.bounds)
+        return strip.isEmpty ? nil : strip
+    }
+
+    private static func isPlausibleTargetFrame(
+        _ frame: CGRect, in window: UIWindow
+    ) -> Bool {
+        let bounds = window.bounds
+        guard bounds.width > 0, bounds.height > 0 else { return false }
+        let visible = frame.intersection(bounds)
+        guard !visible.isEmpty else { return false }
+        let areaShare = (visible.width * visible.height)
+            / (bounds.width * bounds.height)
+        return areaShare < 0.3
+            && visible.width < bounds.width * 0.85
+            && visible.height < bounds.height * 0.85
+    }
+
+    /// Last-resort frame lookup for engine-returned items that are not
+    /// `UIView`s and were missed by the container sweep: `item.frame` is
+    /// defined in its containing container's coordinate space, and the
+    /// nearest ancestor environment exposing a container is that space.
+    private static func frameByWalkingContainers(
+        of item: UIFocusItem, in window: UIWindow
+    ) -> CGRect? {
+        var environment = item.parentFocusEnvironment
+        var hops = 0
+        while let current = environment, hops < 30 {
+            if let container = current.focusItemContainer {
+                let frame = container.coordinateSpace.convert(
+                    item.frame, to: window.coordinateSpace
+                )
+                if frame.intersects(window.bounds) { return frame }
+            }
+            environment = current.parentFocusEnvironment
+            hops += 1
+        }
+        return nil
+    }
+
+    private static func appKeyWindow() -> UIWindow? {
+        let scenes = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+        let scene = scenes.first { $0.activationState == .foregroundActive }
+            ?? scenes.first
+        return scene?.keyWindow ?? scene?.windows.first { !$0.isHidden }
+    }
+
+    /// Walks both the view hierarchy and nested `UIFocusItemContainer`s:
+    /// UIKit-backed items surface via subview walking while SwiftUI hosts
+    /// non-view focus items behind container queries, so one traversal
+    /// alone misses items. Duplicates are dropped via `seenItems`.
+    private static func collectFocusItems(
+        in view: UIView,
+        window: UIWindow,
+        frames: inout [(item: UIFocusItem, frame: CGRect)],
+        visitedContainers: inout Set<ObjectIdentifier>,
+        seenItems: inout Set<ObjectIdentifier>,
+        depth: Int
+    ) {
+        guard depth < 60, !view.isHidden, view.alpha > 0.01 else { return }
+
+        collectFromContainer(
+            view,
+            window: window,
+            frames: &frames,
+            visitedContainers: &visitedContainers,
+            seenItems: &seenItems,
+            depth: depth
+        )
+
+        for subview in view.subviews {
+            collectFocusItems(
+                in: subview,
+                window: window,
+                frames: &frames,
+                visitedContainers: &visitedContainers,
+                seenItems: &seenItems,
+                depth: depth + 1
+            )
+        }
+    }
+
+    private static func collectFromContainer(
+        _ container: UIFocusItemContainer,
+        window: UIWindow,
+        frames: inout [(item: UIFocusItem, frame: CGRect)],
+        visitedContainers: inout Set<ObjectIdentifier>,
+        seenItems: inout Set<ObjectIdentifier>,
+        depth: Int
+    ) {
+        guard depth < 60,
+              visitedContainers.insert(ObjectIdentifier(container)).inserted
+        else { return }
+
+        let region = window.coordinateSpace.convert(
+            window.bounds, to: container.coordinateSpace
+        )
+        for item in container.focusItems(in: region) {
+            let frame = container.coordinateSpace.convert(
+                item.frame, to: window.coordinateSpace
+            )
+            if item.canBecomeFocused,
+               frame.intersects(window.bounds),
+               seenItems.insert(ObjectIdentifier(item)).inserted {
+                frames.append((item, frame))
+            }
+            if let nested = item as? UIFocusItemContainer, !(item is UIView) {
+                collectFromContainer(
+                    nested,
+                    window: window,
+                    frames: &frames,
+                    visitedContainers: &visitedContainers,
+                    seenItems: &seenItems,
+                    depth: depth + 1
+                )
+            }
+        }
+    }
+
+    // MARK: Directional heuristic
+
+    /// Approximates the focus engine's choice: the candidate must lie
+    /// beyond the focused frame in the movement direction; nearer edges
+    /// win, axis overlap beats offset, and centered candidates break ties.
+    private static func bestCandidate(
+        from focused: CGRect,
+        among candidates: [CGRect],
+        direction: Direction
+    ) -> CGRect? {
+        var best: (frame: CGRect, score: CGFloat)?
+
+        for candidate in candidates {
+            let edgeDistance: CGFloat
+            let axisGap: CGFloat
+            let centerOffset: CGFloat
+
+            switch direction {
+            case .up:
+                guard candidate.midY < focused.minY else { continue }
+                edgeDistance = max(0, focused.minY - candidate.maxY)
+                axisGap = max(
+                    0,
+                    max(candidate.minX, focused.minX)
+                        - min(candidate.maxX, focused.maxX)
+                )
+                centerOffset = abs(candidate.midX - focused.midX)
+            case .down:
+                guard candidate.midY > focused.maxY else { continue }
+                edgeDistance = max(0, candidate.minY - focused.maxY)
+                axisGap = max(
+                    0,
+                    max(candidate.minX, focused.minX)
+                        - min(candidate.maxX, focused.maxX)
+                )
+                centerOffset = abs(candidate.midX - focused.midX)
+            case .left:
+                guard candidate.midX < focused.minX else { continue }
+                edgeDistance = max(0, focused.minX - candidate.maxX)
+                axisGap = max(
+                    0,
+                    max(candidate.minY, focused.minY)
+                        - min(candidate.maxY, focused.maxY)
+                )
+                centerOffset = abs(candidate.midY - focused.midY)
+            case .right:
+                guard candidate.midX > focused.maxX else { continue }
+                edgeDistance = max(0, candidate.minX - focused.maxX)
+                axisGap = max(
+                    0,
+                    max(candidate.minY, focused.minY)
+                        - min(candidate.maxY, focused.maxY)
+                )
+                centerOffset = abs(candidate.midY - focused.midY)
+            }
+
+            let score = edgeDistance + axisGap * 3 + centerOffset * 0.25
+            if best == nil || score < best!.score {
+                best = (candidate, score)
+            }
+        }
+
+        return best?.frame
+    }
+}
+
+// MARK: - App-provided hints
+
+/// Destinations the app knows but no focus API can report. SwiftUI
+/// resolves cross-section hops (content → top menu) with internal state
+/// UIKit never sees; the landing rule is deterministic app behavior
+/// (the selected tab), so the owning view publishes it here and the
+/// overlay draws it when the engine reports no candidate.
+@MainActor
+final class TVFocusDebugHints {
+    static let shared = TVFocusDebugHints()
+
+    /// Global frame of the top menu bar's selected tab while the bar is
+    /// on screen and the debug overlay is enabled; nil otherwise.
+    var topMenuSelectedTabFrame: CGRect?
+}
+
+/// Background publisher attached to the selected top-menu tab. Renders
+/// nothing; keeps `TVFocusDebugHints` current while the tab is selected
+/// and clears it when the tab deselects or the bar leaves the screen.
+struct TVFocusDebugTabFramePublisher: View {
+    let isSelected: Bool
+
+    var body: some View {
+        if isSelected, TVDebugSettings.shared.showFocusTargets {
+            GeometryReader { proxy in
+                Color.clear
+                    .onAppear {
+                        TVFocusDebugHints.shared.topMenuSelectedTabFrame =
+                            proxy.frame(in: .global)
+                    }
+                    .onChange(of: proxy.frame(in: .global)) { _, frame in
+                        TVFocusDebugHints.shared.topMenuSelectedTabFrame = frame
+                    }
+                    .onDisappear {
+                        TVFocusDebugHints.shared.topMenuSelectedTabFrame = nil
+                    }
+            }
+        }
+    }
+}
+
+// MARK: - Engine query
+
+/// Asks the real tvOS focus engine what a d-pad move would focus, by
+/// reconstructing the private request UIKit's event recognizer builds:
+///
+///   request  = _UIFocusMovementRequest(initWithFocusSystem:)
+///   itemInfo = _UIFocusItemInfo(infoWithItem: focusedItem)
+///   movement = _UIFocusMovementInfo(initWithHeading:velocity:isInitial:
+///                shouldLoadScrollableContainer:groupFilter:inputType:)
+///   context  = focusSystem._movementPerformer
+///                .contextForFocusMovement(request)   // full pipeline
+///   next     = (context as UIFocusUpdateContext).nextFocusedItem
+///
+/// The performer runs the engine's complete candidate search — including
+/// the exhaustive-search and focus-section escalations a bare
+/// `_UIFocusMap` query skips — without applying the movement. If the
+/// performer is unavailable, a direct map query
+/// (`_nextFocusedItemForFocusMovementRequest:`) is the lesser fallback.
+///
+/// Everything resolves through the ObjC runtime — nothing links against
+/// private symbols — and every step is guarded, so an OS that renames any
+/// of it just flips `isAvailable` and the overlay degrades to the
+/// geometric heuristic. Debug tooling only; never ships behavior.
+@MainActor
+private enum FocusEngineQuery {
+    private static let requestClass = NSClassFromString("_UIFocusMovementRequest") as? NSObject.Type
+    private static let movementClass = NSClassFromString("_UIFocusMovementInfo") as? NSObject.Type
+    private static let itemInfoClass = NSClassFromString("_UIFocusItemInfo") as? NSObject.Type
+    private static let mapClass = NSClassFromString("_UIFocusMap") as? NSObject.Type
+
+    private static let requestInitSel = NSSelectorFromString("initWithFocusSystem:")
+    private static let itemInfoSel = NSSelectorFromString("infoWithItem:")
+    private static let setItemInfoSel = NSSelectorFromString("setFocusedItemInfo:")
+    private static let setMovementSel = NSSelectorFromString("setMovementInfo:")
+    private static let movementInitSel = NSSelectorFromString(
+        "initWithHeading:velocity:isInitial:shouldLoadScrollableContainer:groupFilter:inputType:"
+    )
+    private static let mapInitSel = NSSelectorFromString("initWithFocusSystem:rootEnvironment:")
+    private static let nextItemSel = NSSelectorFromString("_nextFocusedItemForFocusMovementRequest:")
+
+    private static let allocSel = NSSelectorFromString("alloc")
+    private static let performerSel = NSSelectorFromString("_movementPerformer")
+    private static let contextSel = NSSelectorFromString("contextForFocusMovement:")
+    private static let nextFocusedItemSel = NSSelectorFromString("nextFocusedItem")
+
+    static let isAvailable: Bool = {
+        guard let requestClass, let movementClass, let itemInfoClass
+        else { return false }
+        let requestOK = requestClass.instancesRespond(to: requestInitSel)
+            && requestClass.instancesRespond(to: setItemInfoSel)
+            && requestClass.instancesRespond(to: setMovementSel)
+            && movementClass.instancesRespond(to: movementInitSel)
+            && (itemInfoClass as AnyObject).responds(to: itemInfoSel)
+        let performerOK = UIFocusSystem.instancesRespond(to: performerSel)
+        let mapOK = mapClass.map {
+            $0.instancesRespond(to: mapInitSel) && $0.instancesRespond(to: nextItemSel)
+        } ?? false
+        return requestOK && (performerOK || mapOK)
+    }()
+
+    /// `alloc` runs through `perform` because Swift hides `NSObject.alloc`.
+    /// The +1 from alloc is deliberately left outstanding
+    /// (`takeUnretainedValue`) for the subsequent init to consume; the
+    /// init's +1 result is what `takeRetainedValue` balances.
+    private static func allocInstance(of cls: NSObject.Type) -> NSObject? {
+        (cls as AnyObject).perform(allocSel)?.takeUnretainedValue() as? NSObject
+    }
+
+    static func nextFocusedItem(
+        from focusedItem: UIFocusItem,
+        heading: UIFocusHeading,
+        in window: UIWindow
+    ) -> UIFocusItem? {
+        guard isAvailable,
+              let movementClass, let itemInfoClass, let requestClass,
+              let focusSystem = UIFocusSystem.focusSystem(for: window)
+        else { return nil }
+
+        guard let requestAlloc = allocInstance(of: requestClass),
+              let request = requestAlloc
+                  .perform(requestInitSel, with: focusSystem)?
+                  .takeRetainedValue() as? NSObject
+        else { return nil }
+
+        // Class factory method returns autoreleased (+0).
+        guard let itemInfo = (itemInfoClass as AnyObject)
+            .perform(itemInfoSel, with: focusedItem)?
+            .takeUnretainedValue()
+        else { return nil }
+        _ = request.perform(setItemInfoSel, with: itemInfo)
+
+        // IMP cast: six mixed-type arguments are beyond perform(_:with:).
+        // Signature: (heading: NSUInteger, velocity: CGFloat, isInitial:
+        // BOOL, shouldLoadScrollableContainer: BOOL, groupFilter: id,
+        // inputType: NSInteger). shouldLoadScrollableContainer matches a
+        // real d-pad press so scrollable candidates are considered.
+        typealias MovementInit = @convention(c) (
+            AnyObject, Selector, UInt, CGFloat, ObjCBool, ObjCBool, AnyObject?, Int
+        ) -> Unmanaged<AnyObject>?
+        guard let movementAlloc = allocInstance(of: movementClass),
+              let movementImp = movementAlloc.method(for: movementInitSel)
+        else { return nil }
+        let movementInit = unsafeBitCast(movementImp, to: MovementInit.self)
+        guard let movement = movementInit(
+            movementAlloc, movementInitSel,
+            UInt(heading.rawValue), 0, false, true, nil, 0
+        )?.takeRetainedValue() else { return nil }
+        _ = request.perform(setMovementSel, with: movement)
+
+        // Primary: the focus system's own movement performer builds the
+        // full update context (with every escalation the real d-pad press
+        // goes through) without applying the movement.
+        if UIFocusSystem.instancesRespond(to: performerSel),
+           let performer = focusSystem.perform(performerSel)?
+               .takeUnretainedValue() as? NSObject,
+           performer.responds(to: contextSel) {
+            let context = performer.perform(contextSel, with: request)?
+                .takeUnretainedValue()
+            if let context = context as? UIFocusUpdateContext {
+                return context.nextFocusedItem
+            }
+            if let context = context as? NSObject,
+               context.responds(to: nextFocusedItemSel) {
+                return context.perform(nextFocusedItemSel)?
+                    .takeUnretainedValue() as? UIFocusItem
+            }
+            return nil
+        }
+
+        // Fallback: bare focus-map query (first-pass search only; misses
+        // the exhaustive/section escalations).
+        guard let mapClass else { return nil }
+        typealias MapInit = @convention(c) (
+            AnyObject, Selector, AnyObject?, AnyObject?
+        ) -> Unmanaged<AnyObject>?
+        guard let mapAlloc = allocInstance(of: mapClass),
+              let mapImp = mapAlloc.method(for: mapInitSel)
+        else { return nil }
+        let mapInit = unsafeBitCast(mapImp, to: MapInit.self)
+        guard let map = mapInit(
+            mapAlloc, mapInitSel, focusSystem, window
+        )?.takeRetainedValue() as? NSObject else { return nil }
+
+        return map.perform(nextItemSel, with: request)?
+            .takeUnretainedValue() as? UIFocusItem
+    }
+}
+
+// MARK: - Overlay window
+
+/// Hosts `TVFocusDebugOverlay` in its own always-on-top passthrough
+/// window so the markers draw over full-screen covers (player, pickers)
+/// and never participate in hit testing or focus.
+@MainActor
+final class TVFocusDebugOverlayController {
+    static let shared = TVFocusDebugOverlayController()
+
+    private var window: UIWindow?
+
+    func setEnabled(_ enabled: Bool) {
+        if enabled {
+            guard window == nil else { return }
+            let scenes = UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+            guard let scene = scenes.first(where: {
+                $0.activationState == .foregroundActive
+            }) ?? scenes.first else { return }
+
+            let host = UIHostingController(rootView: TVFocusDebugOverlay())
+            host.view.backgroundColor = .clear
+
+            let overlay = UIWindow(windowScene: scene)
+            overlay.windowLevel = .alert + 100
+            overlay.isUserInteractionEnabled = false
+            overlay.backgroundColor = .clear
+            overlay.rootViewController = host
+            overlay.isHidden = false
+            window = overlay
+        } else {
+            window?.isHidden = true
+            window = nil
+        }
+    }
+}
+
+/// Root-level activation hook: mirrors the persisted debug setting into
+/// the overlay window's lifecycle.
+struct TVFocusDebugActivationModifier: ViewModifier {
+    @State private var debugSettings = TVDebugSettings.shared
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: debugSettings.showFocusTargets, initial: true) { _, enabled in
+                TVFocusDebugOverlayController.shared.setEnabled(enabled)
+            }
+    }
+}
+#endif

--- a/iosApp/iosApp/tvOS/Debug/TVFocusDebugOverlay.swift
+++ b/iosApp/iosApp/tvOS/Debug/TVFocusDebugOverlay.swift
@@ -1,4 +1,4 @@
-#if os(tvOS)
+#if os(tvOS) && DEBUG
 import SwiftUI
 import UIKit
 

--- a/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
@@ -731,6 +731,7 @@ struct TVMainTabView: View {
     // MARK: - Root selection & focus
 
     private func selectRoot(_ root: TVRootDestination) {
+        let isReselect = root == selectedRoot
         router.popToRoot()
 
         suppressTopMenuFocusForContentHandoff()
@@ -754,7 +755,21 @@ struct TVMainTabView: View {
         // the menu relinquishes its focus (TVTopMenuBar.onChange(isFocusSuppressed)),
         // so without an active hand-down the new content never claims focus and
         // the remote goes dead until the user blindly swipes.
-        contentFocusRequest += 1
+        if isReselect {
+            // Re-selecting the current tab keeps the content view alive (same
+            // `.id`), so a synchronous bump lands the row's focus claim in the
+            // same transaction as the bar's disable + focus teardown — and the
+            // engine's repair from the resigning tab button wins, leaving focus
+            // stranded in the menu. Defer one turn so the first card's claim is
+            // applied after the bar has fully resigned; a fresh tab doesn't need
+            // this because its content mounts a render later and claims in
+            // onAppear anyway.
+            DispatchQueue.main.async {
+                contentFocusRequest += 1
+            }
+        } else {
+            contentFocusRequest += 1
+        }
     }
 
     /// Re-arm the top bar's focus. `focusing` overrides which element the

--- a/iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift
@@ -415,7 +415,7 @@ struct TVTopMenuBar: View {
 
         return Button(action: onSearch) {
             Image(systemName: "magnifyingglass")
-                .font(.system(size: 24, weight: .semibold))
+                .font(.system(size: 27, weight: .semibold))
                 .foregroundStyle(isFocused ? Color.continuumBackground : .white.opacity(0.62))
                 .frame(
                     width: ContinuumTheme.Skyline.barIconSize,

--- a/iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift
@@ -350,8 +350,10 @@ struct TVTopMenuBar: View {
         // the selected tab, but that rule is invisible to the focus
         // engine — the selected tab publishes its frame so the overlay
         // can mark it as the Up destination. Renders nothing when the
-        // overlay setting is off.
+        // overlay setting is off; debug builds only.
+        #if DEBUG
         .background(TVFocusDebugTabFramePublisher(isSelected: selectedRoot == root))
+        #endif
         .accessibilityLabel("\(root.title), tab, \(index + 1) of \(count)")
         .accessibilityHint(rootPanelHint(for: root))
         .accessibilityAddTraits(isSelected ? .isSelected : [])

--- a/iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift
@@ -346,6 +346,12 @@ struct TVTopMenuBar: View {
         // Panel-bearing tabs publish their bounds so the shell can center the
         // anchored dropdown under them (§5.3); other tabs have no panel.
         .modifier(TVTopMenuAnchorPublisher(panel: rootPanel(root)))
+        // Debug-overlay hint: SwiftUI's content→menu section hop lands on
+        // the selected tab, but that rule is invisible to the focus
+        // engine — the selected tab publishes its frame so the overlay
+        // can mark it as the Up destination. Renders nothing when the
+        // overlay setting is off.
+        .background(TVFocusDebugTabFramePublisher(isSelected: selectedRoot == root))
         .accessibilityLabel("\(root.title), tab, \(index + 1) of \(count)")
         .accessibilityHint(rootPanelHint(for: root))
         .accessibilityAddTraits(isSelected ? .isSelected : [])

--- a/iosApp/iosApp/tvOS/Screens/Components/TVCatalogGrid.swift
+++ b/iosApp/iosApp/tvOS/Screens/Components/TVCatalogGrid.swift
@@ -62,7 +62,8 @@ struct TVCatalogGrid: View {
                     prefersDefaultFocus: prefersDefaultFocusOnFirstItem && indexed.index == 0,
                     defaultFocusNamespace: gridFocusNamespace,
                     focusBinding: $focusedItemId,
-                    focusContentId: item.contentId
+                    focusContentId: item.contentId,
+                    contentId: item.contentId
                 )
                 .frame(maxWidth: .infinity)
                 .onAppear { onCellAppear(index: indexed.index) }

--- a/iosApp/iosApp/tvOS/Screens/Components/TVMediaCard.swift
+++ b/iosApp/iosApp/tvOS/Screens/Components/TVMediaCard.swift
@@ -38,6 +38,9 @@ struct TVMediaCard: View {
     /// card's outer VStack silently no-ops. Mirrors `MediaCard.focusedItemId`.
     var focusBinding: FocusState<String?>.Binding? = nil
     var focusContentId: String? = nil
+    /// Catalog identity for the long-press favorite/watchlist menu.
+    /// `nil` (or a nil `userState`) leaves the card without a menu.
+    var contentId: String? = nil
 
     enum FocusTreatment {
         case nativeCard
@@ -45,6 +48,8 @@ struct TVMediaCard: View {
     }
 
     @FocusState private var isFocused: Bool
+    @State private var favoriteOverride: Bool?
+    @State private var watchlistOverride: Bool?
     @EnvironmentObject private var overlayStore: OverlayPrefsStore
 
     private var cardHeight: CGFloat {
@@ -59,9 +64,65 @@ struct TVMediaCard: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             posterButton
+                .personalListContextMenu(hasPersonalActions ? personalMenuItems : nil)
             caption
         }
         .frame(width: cardWidth)
+        .onChange(of: userState) { _, _ in
+            favoriteOverride = nil
+            watchlistOverride = nil
+        }
+    }
+
+    // MARK: - Favorite / watchlist context actions
+
+    private var hasPersonalActions: Bool {
+        contentId != nil && userState != nil
+    }
+
+    private var isFavorite: Bool {
+        favoriteOverride ?? (userState?.isFavorite == true)
+    }
+
+    private var isInWatchlist: Bool {
+        watchlistOverride ?? (userState?.inWatchlist == true)
+    }
+
+    private var personalMenuItems: PersonalListMenuItems {
+        PersonalListMenuItems(
+            isFavorite: isFavorite,
+            inWatchlist: isInWatchlist,
+            onToggleFavorite: togglePersonalFavorite,
+            onToggleWatchlist: togglePersonalWatchlist
+        )
+    }
+
+    private func togglePersonalFavorite() {
+        guard let contentId else { return }
+        let newValue = !isFavorite
+        let watchlist = isInWatchlist
+        favoriteOverride = newValue
+        Task {
+            if await PersonalListSync.setFavorite(
+                contentId: contentId, isFavorite: newValue, inWatchlist: watchlist
+            ) == false {
+                favoriteOverride = !newValue // Revert on failure
+            }
+        }
+    }
+
+    private func togglePersonalWatchlist() {
+        guard let contentId else { return }
+        let newValue = !isInWatchlist
+        let favorite = isFavorite
+        watchlistOverride = newValue
+        Task {
+            if await PersonalListSync.setWatchlist(
+                contentId: contentId, isFavorite: favorite, inWatchlist: newValue
+            ) == false {
+                watchlistOverride = !newValue // Revert on failure
+            }
+        }
     }
 
     @ViewBuilder

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVDetailFactsSection.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVDetailFactsSection.swift
@@ -13,6 +13,16 @@ struct TVDetailFactsSection: View {
     private let rowGap: CGFloat = 20
     private let maxCreditNames = 3
 
+    // The facts grid is pure text with no actionable child, so nothing here
+    // is a native focus target. On tvOS the scroll view can only bring a
+    // *focusable* view into view, so without this the Details block is
+    // unreachable — pressing Down from the Cast rail finds no target below
+    // and the section never scrolls on-screen. Making the whole block one
+    // passive focus target (Select is a no-op) lets the engine land on it
+    // and scroll it fully into view, the same idiom `TVSelectorValue` uses
+    // for single-option pills.
+    @FocusState private var isFocused: Bool
+
     var body: some View {
         let facts = assembleFacts()
         if !facts.isEmpty {
@@ -38,6 +48,18 @@ struct TVDetailFactsSection: View {
                 }
             }
             .frame(maxWidth: 1400, alignment: .leading)
+            // Focus highlight bleeds outward via negative padding so the
+            // facts text stays aligned with the "Details" header above it.
+            .background(
+                RoundedRectangle(cornerRadius: ContinuumTheme.smallCornerRadius, style: .continuous)
+                    .fill(Color.white.opacity(isFocused ? 0.06 : 0))
+                    .padding(.horizontal, -28)
+                    .padding(.vertical, -14)
+            )
+            .contentShape(Rectangle())
+            .focusable(true)
+            .focused($isFocused)
+            .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: isFocused)
         }
     }
 

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVDetailFocusScroll.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVDetailFocusScroll.swift
@@ -1,0 +1,113 @@
+#if os(tvOS)
+import SwiftUI
+
+extension View {
+    /// Shared scroll choreography for the tvOS detail pages (movie/episode,
+    /// series, season). Apply to the detail page's vertical ScrollView.
+    ///
+    /// Only multi-season pages need help: the short season chip row
+    /// intercepts the down move, so the focus engine's minimal reveal scroll
+    /// stops with the episode rail below the fold. Single-season pages never
+    /// misframe — focus lands straight on the tall episode card and the
+    /// engine's reveal produces the deep centered framing natively.
+    ///
+    /// Any scroll we issue races the engine's own reveal, which is *deferred
+    /// while d-pad input streams in* and can land late and clobber a single
+    /// write. So both triggers re-assert their target across a window long
+    /// enough to outlast the deferred reveal; every assert re-checks that the
+    /// triggering row still owns focus so a stale one can never yank the page.
+    ///
+    /// Returning up to the Play / Start Over / circle-button row restores the
+    /// page-entry framing (hero pinned to the top) the same way.
+    func detailFocusScroll(
+        proxy: ScrollViewProxy,
+        seasonRowFocused: Bool,
+        actionRowFocused: Bool,
+        episodeSectionId: String,
+        heroId: String
+    ) -> some View {
+        modifier(
+            DetailFocusScrollModifier(
+                proxy: proxy,
+                seasonRowFocused: seasonRowFocused,
+                actionRowFocused: actionRowFocused,
+                episodeSectionId: episodeSectionId,
+                heroId: heroId
+            )
+        )
+    }
+}
+
+private struct DetailFocusScrollModifier: ViewModifier {
+    let proxy: ScrollViewProxy
+    let seasonRowFocused: Bool
+    let actionRowFocused: Bool
+    let episodeSectionId: String
+    let heroId: String
+
+    private enum Region {
+        case seasonRow
+        case actionRow
+    }
+
+    /// Live mirror of the focus state plus a generation counter, shared with
+    /// the scheduled scroll closures. A class so those escaping closures read
+    /// the *current* values at fire time instead of stale captured copies —
+    /// that's what lets a pending assert bail out once the user has moved on.
+    private final class AssertState {
+        var generation = 0
+        var focusedRegion: Region?
+    }
+
+    @State private var state = AssertState()
+
+    /// Match the pace of the focus engine's own reveal scrolls; the theme's
+    /// 0.2s `normalDuration` read as an abrupt snap next to them.
+    private static let scrollAnimation = Animation.easeInOut(duration: 0.45)
+
+    /// Dense early asserts so motion starts immediately even when the first
+    /// write is clobbered, then sparse late ones to outlast the engine's
+    /// input-deferred reveal after rapid d-pad sequences.
+    private static let assertDelays: [Double] = [0.02, 0.15, 0.45, 0.8, 1.1]
+
+    func body(content: Content) -> some View {
+        // Mirror focus into the shared state on every render so in-flight
+        // asserts observe focus moves that happen mid-window.
+        state.focusedRegion = currentRegion
+        return content
+            .onChange(of: seasonRowFocused) { _, focused in
+                guard focused else { return }
+                assertScroll(to: episodeSectionId, anchor: .center, while: .seasonRow)
+            }
+            .onChange(of: actionRowFocused) { _, focused in
+                guard focused else { return }
+                assertScroll(to: heroId, anchor: .top, while: .actionRow)
+            }
+    }
+
+    private var currentRegion: Region? {
+        if seasonRowFocused { return .seasonRow }
+        if actionRowFocused { return .actionRow }
+        return nil
+    }
+
+    /// Re-assert the scroll target across the delay window. Every assert
+    /// re-checks that the triggering region still owns focus (and that no
+    /// newer trigger superseded it) so a stale assert can never yank the page
+    /// after the user moves on. Asserts are idempotent — same target, so
+    /// whichever one lands last just holds the position.
+    private func assertScroll(to id: String, anchor: UnitPoint, while region: Region) {
+        state.generation &+= 1
+        let generation = state.generation
+        for delay in Self.assertDelays {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [state] in
+                guard state.generation == generation,
+                      state.focusedRegion == region else { return }
+                withAnimation(Self.scrollAnimation) {
+                    proxy.scrollTo(id, anchor: anchor)
+                }
+            }
+        }
+    }
+}
+#endif

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVDetailHero.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVDetailHero.swift
@@ -121,7 +121,10 @@ struct TVDetailHero<Actions: View, BelowSynopsis: View>: View {
         }
         .padding(.leading, ContinuumTheme.safePadding)
         .padding(.trailing, ContinuumTheme.safePadding)
-        .padding(.bottom, 120)
+        // Keep this tight: the detail pages' outer VStack already adds its
+        // own spacing between the hero and the first content section, so a
+        // large inset here reads as a dead band under the selector row.
+        .padding(.bottom, 48)
     }
 
     private var editorialColumn: some View {

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
@@ -752,6 +752,7 @@ struct TVItemDetailView: View {
                 intro: watchDetail.intro,
                 credits: watchDetail.credits,
                 effectiveSubtitleMode: watchDetail.effectiveSubtitleMode,
+                effectiveShowForcedSubtitles: watchDetail.effectiveShowForcedSubtitles,
                 effectiveSubtitleTrackSignature: watchDetail.effectiveSubtitleTrackSignature,
                 overlaySummary: item.overlaySummary,
                 audiobook: item.audiobook,

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
@@ -375,8 +375,10 @@ struct TVItemDetailView: View {
                     )
                 },
                 onSelectSeason: { season in
-                    guard season.id != detail.contentId else { return }
-                    router.navigate(to: .itemDetail(contentId: season.contentId))
+                    // Swap the episode rail in place (series-page behavior)
+                    // instead of pushing the season's own detail page.
+                    guard season.id != viewModel.selectedSeason?.id else { return }
+                    Task { await viewModel.selectSeason(season) }
                 },
                 onToggleFavorite: { Task { await viewModel.toggleFavorite() } },
                 onToggleWatchlist: { Task { await viewModel.toggleWatchlist() } },
@@ -390,7 +392,11 @@ struct TVItemDetailView: View {
                     router.navigate(to: .itemDetail(contentId: id))
                 },
                 onEpisodeTap: { id in
-                    router.navigate(to: .itemDetail(contentId: id))
+                    // Episode → episode hops replace the current page so Back
+                    // exits to wherever the chain started (home, series page)
+                    // instead of unwinding every previously viewed episode.
+                    guard id != detail.contentId else { return }
+                    router.replaceCurrent(with: .itemDetail(contentId: id))
                 },
                 belowSynopsis: {
                     DescriptionTranslationView(viewModel: viewModel, contentId: detail.contentId)

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
@@ -19,6 +19,12 @@ struct TVItemDetailView: View {
     @State private var preferredNextUpFileId: Int?
     @State private var preferredNextUpAudioTrackIndex: Int?
     @State private var preferredNextUpSubtitleTrackIndex: Int?
+    /// Set when the user explicitly resets subtitles to "Auto" this visit:
+    /// the server override is cleared with a fire-and-forget DELETE, but the
+    /// already-fetched detail still carries the old `effectiveSubtitle*`, so
+    /// the selector must stop feeding it to the "Auto - …" preview.
+    @State private var didClearSubtitleOverride = false
+    @State private var didClearNextUpSubtitleOverride = false
     @State private var nextUpPlaybackDetail: ItemDetail?
     @State private var isLoadingNextUpPlaybackDetail = false
     @State private var didLoadNextUpPlaybackDetail = false
@@ -66,6 +72,8 @@ struct TVItemDetailView: View {
             preferredNextUpFileId = nil
             preferredNextUpAudioTrackIndex = nil
             preferredNextUpSubtitleTrackIndex = nil
+            didClearSubtitleOverride = false
+            didClearNextUpSubtitleOverride = false
             nextUpPlaybackDetail = nil
             isLoadingNextUpPlaybackDetail = false
             didLoadNextUpPlaybackDetail = false
@@ -97,6 +105,7 @@ struct TVItemDetailView: View {
                 selectedNextUpAudioTrackIndex: preferredNextUpAudioTrackIndex,
                 selectedNextUpSubtitleTrackIndex: preferredNextUpSubtitleTrackIndex,
                 nextUpPlaybackDetail: nextUpPlaybackDetail,
+                nextUpSubtitleOverrideCleared: didClearNextUpSubtitleOverride,
                 onPlayEpisode: { id, fileId, startFromBeginning in
                     let episode = viewModel.episodes.first { $0.contentId == id }
                     let resumePosition = startFromBeginning
@@ -160,6 +169,7 @@ struct TVItemDetailView: View {
                     )
                 },
                 onSelectNextUpSubtitleTrack: { index in
+                    didClearNextUpSubtitleOverride = (index == nil)
                     preferredNextUpSubtitleTrackIndex = sanitizedSubtitleTrackIndex(
                         for: nextUpPlaybackDetail,
                         versionFileId: preferredNextUpFileId,
@@ -208,6 +218,7 @@ struct TVItemDetailView: View {
                 nextUpPlaybackDetail: nextUpPlaybackDetail,
                 isLoadingNextUpPlaybackDetail: isLoadingNextUpPlaybackDetail,
                 didLoadNextUpPlaybackDetail: didLoadNextUpPlaybackDetail,
+                nextUpSubtitleOverrideCleared: didClearNextUpSubtitleOverride,
                 onSelectSeason: { season in
                     Task { await viewModel.selectSeason(season) }
                 },
@@ -266,6 +277,7 @@ struct TVItemDetailView: View {
                     )
                 },
                 onSelectNextUpSubtitleTrack: { index in
+                    didClearNextUpSubtitleOverride = (index == nil)
                     preferredNextUpSubtitleTrackIndex = sanitizedSubtitleTrackIndex(
                         for: nextUpPlaybackDetail,
                         versionFileId: preferredNextUpFileId,
@@ -307,6 +319,7 @@ struct TVItemDetailView: View {
                 selectedVersionFileId: preferredVersionFileId,
                 selectedAudioTrackIndex: preferredAudioTrackIndex,
                 selectedSubtitleTrackIndex: preferredSubtitleTrackIndex,
+                subtitleOverrideCleared: didClearSubtitleOverride,
                 seasons: viewModel.seasons,
                 selectedSeason: viewModel.selectedSeason,
                 seasonEpisodes: viewModel.episodes,
@@ -361,6 +374,7 @@ struct TVItemDetailView: View {
                     )
                 },
                 onSelectSubtitleTrack: { index in
+                    didClearSubtitleOverride = (index == nil)
                     preferredSubtitleTrackIndex = sanitizedSubtitleTrackIndex(
                         for: detail,
                         versionFileId: preferredVersionFileId,
@@ -597,6 +611,7 @@ struct TVItemDetailView: View {
             preferredNextUpFileId = nil
             preferredNextUpAudioTrackIndex = nil
             preferredNextUpSubtitleTrackIndex = nil
+            didClearNextUpSubtitleOverride = false
             return
         }
 
@@ -606,6 +621,7 @@ struct TVItemDetailView: View {
         preferredNextUpFileId = nil
         preferredNextUpAudioTrackIndex = nil
         preferredNextUpSubtitleTrackIndex = nil
+        didClearNextUpSubtitleOverride = false
 
         do {
             let item = try await ContinuumAPI.shared.itemDetail(contentId: nextUp.contentId)
@@ -650,6 +666,7 @@ struct TVItemDetailView: View {
             preferredNextUpFileId = nil
             preferredNextUpAudioTrackIndex = nil
             preferredNextUpSubtitleTrackIndex = nil
+            didClearNextUpSubtitleOverride = false
             return
         }
 
@@ -659,6 +676,7 @@ struct TVItemDetailView: View {
         preferredNextUpFileId = nil
         preferredNextUpAudioTrackIndex = nil
         preferredNextUpSubtitleTrackIndex = nil
+        didClearNextUpSubtitleOverride = false
 
         do {
             let item = try await ContinuumAPI.shared.itemDetail(contentId: nextUp.contentId)

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
@@ -14,6 +14,11 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
     let selectedVersionFileId: Int?
     let selectedAudioTrackIndex: Int?
     let selectedSubtitleTrackIndex: Int?
+    /// True once the user explicitly resets subtitles to "Auto" this visit.
+    /// The server override was just cleared, but `detail.effectiveSubtitle*`
+    /// still describes the old manual pick until the next refetch — suppress
+    /// it so the "Auto - …" preview doesn't echo the cleared selection.
+    var subtitleOverrideCleared: Bool = false
     let seasons: [Season]
     let selectedSeason: Season?
     let seasonEpisodes: [EpisodeListItem]
@@ -110,8 +115,8 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
                 selectedVersionFileId: selectedVersionFileId,
                 selectedAudioTrackIndex: selectedAudioTrackIndex,
                 selectedSubtitleTrackIndex: selectedSubtitleTrackIndex,
-                subtitleMode: detail.effectiveSubtitleMode,
-                subtitleSignature: detail.effectiveSubtitleTrackSignature,
+                subtitleMode: subtitleOverrideCleared ? nil : detail.effectiveSubtitleMode,
+                subtitleSignature: subtitleOverrideCleared ? nil : detail.effectiveSubtitleTrackSignature,
                 onSelectVersion: onSelectVersion,
                 onSelectAudioTrack: onSelectAudioTrack,
                 onSelectSubtitleTrack: onSelectSubtitleTrack

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
@@ -172,6 +172,13 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
         // Container binding — flips true when any button in the row has
         // focus, driving the scroll-to-top in `detailFocusScroll`.
         .focused($actionRowFocused)
+        // Mirror of the selector row's full-width focus section: the subtitle
+        // pill below can extend past the last circle button, and an Up press
+        // from that overhang would otherwise skip this row for the synopsis.
+        // Full-width bounds put the row under every selector pill so Up lands
+        // on the nearest action button. Buttons stay left-aligned.
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .focusSection()
     }
 
     // MARK: - More menu

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
@@ -117,6 +117,7 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
                 selectedSubtitleTrackIndex: selectedSubtitleTrackIndex,
                 subtitleMode: subtitleOverrideCleared ? nil : detail.effectiveSubtitleMode,
                 subtitleSignature: subtitleOverrideCleared ? nil : detail.effectiveSubtitleTrackSignature,
+                showForcedSubtitles: detail.effectiveShowForcedSubtitles ?? false,
                 onSelectVersion: onSelectVersion,
                 onSelectAudioTrack: onSelectAudioTrack,
                 onSelectSubtitleTrack: onSelectSubtitleTrack

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
@@ -88,6 +88,8 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
                 selectedVersionFileId: selectedVersionFileId,
                 selectedAudioTrackIndex: selectedAudioTrackIndex,
                 selectedSubtitleTrackIndex: selectedSubtitleTrackIndex,
+                subtitleMode: detail.effectiveSubtitleMode,
+                subtitleSignature: detail.effectiveSubtitleTrackSignature,
                 onSelectVersion: onSelectVersion,
                 onSelectAudioTrack: onSelectAudioTrack,
                 onSelectSubtitleTrack: onSelectSubtitleTrack

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
@@ -296,13 +296,12 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
     }
 
     private var similarSection: some View {
-        VStack(alignment: .leading, spacing: 28) {
-            TVSectionHeader(title: "More Like This")
-            TVSimilarRail(
-                contentId: detail.contentId,
-                onSelect: onNavigateToItem
-            )
-        }
+        // Header lives inside the rail so it disappears with the cards when
+        // recommendations are disabled or empty.
+        TVSimilarRail(
+            contentId: detail.contentId,
+            onSelect: onNavigateToItem
+        )
     }
 
     // MARK: - Cast

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
@@ -261,6 +261,13 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
     }
 
     private var episodeRailEyebrow: String {
+        // Track the chip selection — the rail can show a different season
+        // than the episode's own once the viewer switches in place.
+        if let season = selectedSeason {
+            return season.seasonNumber > 0
+                ? "Season \(season.seasonNumber)"
+                : (season.title ?? "Specials")
+        }
         if let seasonNumber = detail.seasonNumber, seasonNumber > 0 {
             return "Season \(seasonNumber)"
         }

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
@@ -35,45 +35,67 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
 
     @Namespace private var detailFocusNamespace
     @FocusState private var playFocused: Bool
+    /// True while focus sits anywhere inside the season chip row — drives the
+    /// episode-section re-center in `detailFocusScroll`.
+    @FocusState private var seasonRowFocused: Bool
+    /// True while focus sits anywhere in the hero's primary action row —
+    /// drives the scroll back to the page-entry (hero at top) framing.
+    @FocusState private var actionRowFocused: Bool
+
+    // Plain constants (not `static`) — the generic BelowSynopsis parameter
+    // forbids static stored properties on this type.
+    private let episodeSectionScrollId = "detail-episode-section"
+    private let heroScrollId = "detail-hero"
 
     var body: some View {
-        ScrollView(.vertical, showsIndicators: false) {
-            VStack(alignment: .leading, spacing: 48) {
-                TVDetailHero(
-                    title: detail.title,
-                    seriesTitle: detail.type == "episode" ? detail.seriesTitle : nil,
-                    logoUrl: detail.logoUrl,
-                    backdropUrl: detail.backdropUrl,
-                    eyebrow: detail.type == "episode" ? nil : TVHeroMetadata.eyebrow(from: detail),
-                    sourceTokens: TVHeroMetadata.movieSourceTokens(from: detail),
-                    ratingChip: TVHeroMetadata.contentRatingChip(from: detail),
-                    overview: detail.overview,
-                    tagline: detail.tagline,
-                    factsLine: TVHeroMetadata.movieFactsLine(from: detail, version: currentVersion),
-                    starringText: TVHeroMetadata.starringText(from: detail),
-                    actions: { actionColumn },
-                    belowSynopsis: belowSynopsis
-                )
+        ScrollViewReader { scrollProxy in
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 48) {
+                    TVDetailHero(
+                        title: detail.title,
+                        seriesTitle: detail.type == "episode" ? detail.seriesTitle : nil,
+                        logoUrl: detail.logoUrl,
+                        backdropUrl: detail.backdropUrl,
+                        eyebrow: detail.type == "episode" ? nil : TVHeroMetadata.eyebrow(from: detail),
+                        sourceTokens: TVHeroMetadata.movieSourceTokens(from: detail),
+                        ratingChip: TVHeroMetadata.contentRatingChip(from: detail),
+                        overview: detail.overview,
+                        tagline: detail.tagline,
+                        factsLine: TVHeroMetadata.movieFactsLine(from: detail, version: currentVersion),
+                        starringText: TVHeroMetadata.starringText(from: detail),
+                        actions: { actionColumn },
+                        belowSynopsis: belowSynopsis
+                    )
+                    .id(heroScrollId)
 
-                VStack(alignment: .leading, spacing: 72) {
-                    if showsEpisodeRail {
-                        episodesSection
+                    VStack(alignment: .leading, spacing: 72) {
+                        if showsEpisodeRail {
+                            episodesSection
+                                .id(episodeSectionScrollId)
+                        }
+                        if let cast = detail.cast, !cast.isEmpty {
+                            castSection(cast: cast)
+                        }
+                        detailsSection
+                        if showsSimilarRail {
+                            similarSection
+                        }
                     }
-                    if let cast = detail.cast, !cast.isEmpty {
-                        castSection(cast: cast)
-                    }
-                    detailsSection
-                    if showsSimilarRail {
-                        similarSection
-                    }
+                    .padding(.horizontal, ContinuumTheme.safePadding)
+                    .padding(.bottom, 160)
                 }
-                .padding(.horizontal, ContinuumTheme.safePadding)
-                .padding(.bottom, 160)
             }
+            .ignoresSafeArea()
+            .focusScope(detailFocusNamespace)
+            .defaultFocus($playFocused, true, priority: .userInitiated)
+            .detailFocusScroll(
+                proxy: scrollProxy,
+                seasonRowFocused: seasonRowFocused,
+                actionRowFocused: actionRowFocused,
+                episodeSectionId: episodeSectionScrollId,
+                heroId: heroScrollId
+            )
         }
-        .ignoresSafeArea()
-        .focusScope(detailFocusNamespace)
-        .defaultFocus($playFocused, true, priority: .userInitiated)
     }
 
     // MARK: - Hero actions
@@ -142,6 +164,9 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
                 moreMenu
             }
         }
+        // Container binding — flips true when any button in the row has
+        // focus, driving the scroll-to-top in `detailFocusScroll`.
+        .focused($actionRowFocused)
     }
 
     // MARK: - More menu
@@ -215,6 +240,9 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
                     selectedSeasonId: selectedSeason?.id,
                     onSelect: onSelectSeason
                 )
+                // Container binding — true while any chip has focus, driving
+                // the episode-section re-center in `detailFocusScroll`.
+                .focused($seasonRowFocused)
             }
             if isLoadingEpisodes {
                 HStack {

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVPlaybackSelectorRow.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVPlaybackSelectorRow.swift
@@ -41,34 +41,39 @@ struct TVPlaybackSelectorRow: View {
 
     var body: some View {
         if hasAnySelector {
-            HStack(spacing: Layout.selectorSpacing) {
-                if shouldShowEditionSelector {
-                    editionSelector
+            selectorRow
+                // Stretch the focus section to the full action-area width even
+                // though the buttons sit on the left. Entering a focus section
+                // is resolved by the section's *bounds* overlapping the move
+                // vector, so a full-width section sits under every top-row
+                // control — including the far-right circle buttons (List /
+                // Watched / More). A Down press from any of them then lands on
+                // the nearest selector instead of skipping the row. Buttons
+                // stay left-aligned.
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .focusScope(selectorFocusScope)
+                .focusSection()
+                .modifier(SelectorDefaultFocus(focus: defaultSelectorFocus, binding: $focusedSelector))
+                .task {
+                    await ProfilePrefsStore.shared.hydrateIfNeeded()
+                    preferredSubtitleLanguage = ProfilePrefsStore.shared.preferredSubtitleLanguage
                 }
-                if shouldShowVersionValue {
-                    versionSelector
-                }
-                if shouldShowAudioValue {
-                    audioSelector
-                }
-                if shouldShowSubtitleValue {
-                    subtitleSelector
-                }
+        }
+    }
+
+    private var selectorRow: some View {
+        HStack(spacing: Layout.selectorSpacing) {
+            if shouldShowEditionSelector {
+                editionSelector
             }
-            // Stretch the focus section to the full action-area width even
-            // though the buttons sit on the left. Entering a focus section is
-            // resolved by the section's *bounds* overlapping the move vector,
-            // so a full-width section sits under every top-row control —
-            // including the far-right circle buttons (List / Watched / More).
-            // A Down press from any of them then lands on the nearest selector
-            // instead of skipping the row. Buttons stay left-aligned.
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .focusScope(selectorFocusScope)
-            .focusSection()
-            .modifier(SelectorDefaultFocus(focus: defaultSelectorFocus, binding: $focusedSelector))
-            .task {
-                await ProfilePrefsStore.shared.hydrateIfNeeded()
-                preferredSubtitleLanguage = ProfilePrefsStore.shared.preferredSubtitleLanguage
+            if shouldShowVersionValue {
+                versionSelector
+            }
+            if shouldShowAudioValue {
+                audioSelector
+            }
+            if shouldShowSubtitleValue {
+                subtitleSelector
             }
         }
     }
@@ -349,33 +354,27 @@ private struct TVSelectorButton<MenuContent: View>: View {
     }
 }
 
-/// Static version of the selector pill for single-choice playback metadata.
+/// Single-choice version of the selector pill. Still focusable so the box can
+/// be highlighted ("hovered") on tvOS even when there is only one option;
+/// pressing Select is a no-op since there is nothing to choose. Shares the
+/// interactive pill's styling and focus treatment so the row reads uniformly.
 private struct TVSelectorValue: View {
     let icon: String
     let label: String
     let value: String
 
     var body: some View {
-        HStack(spacing: 12) {
-            Image(systemName: icon).font(.system(size: 22, weight: .semibold))
-            Text(label.uppercased())
-                .font(.system(size: 18, weight: .bold))
-                .tracking(1.0)
-                .opacity(0.6)
-            Text(value).font(.system(size: 22, weight: .semibold)).lineLimit(1)
+        Button { } label: {
+            HStack(spacing: 12) {
+                Image(systemName: icon).font(.system(size: 22, weight: .semibold))
+                Text(label.uppercased())
+                    .font(.system(size: 18, weight: .bold))
+                    .tracking(1.0)
+                    .opacity(0.6)
+                Text(value).font(.system(size: 22, weight: .semibold)).lineLimit(1)
+            }
         }
-        .foregroundColor(.white)
-        .padding(.horizontal, 40)
-        .padding(.vertical, 22)
-        .overlay(
-            RoundedRectangle(cornerRadius: ContinuumTheme.smallCornerRadius, style: .continuous)
-                .stroke(Color.white.opacity(0.24), lineWidth: 1.2)
-        )
-        .background(
-            RoundedRectangle(cornerRadius: ContinuumTheme.smallCornerRadius, style: .continuous)
-                .fill(Color.black.opacity(0.52))
-        )
-        .shadow(color: .black.opacity(0.14), radius: 4, y: 2)
+        .buttonStyle(TVPillButtonStyle(kind: .secondary, focusTreatment: .compact))
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("\(label), \(value)")
     }

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVPlaybackSelectorRow.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVPlaybackSelectorRow.swift
@@ -31,6 +31,10 @@ struct TVPlaybackSelectorRow: View {
     /// "Auto" will land on. Defaulted so callers without it keep a bare "Auto".
     var subtitleMode: String? = nil
     var subtitleSignature: SubtitleTrackSignature? = nil
+    /// Profile/item "Show Forced Subtitles" preference — feeds the Auto
+    /// preview's forced-track branch so the row doesn't show "Auto - None"
+    /// when playback would actually start with a forced track.
+    var showForcedSubtitles: Bool = false
     let onSelectVersion: (Int?) -> Void
     let onSelectAudioTrack: (Int?) -> Void
     let onSelectSubtitleTrack: (Int?) -> Void
@@ -270,7 +274,8 @@ struct TVPlaybackSelectorRow: View {
             audioLanguage: DetailPlaybackFormatting.resolvedAudioLanguage(
                 version: currentVersion,
                 selectedAudioTrackIndex: selectedAudioTrackIndex
-            )
+            ),
+            showForced: showForcedSubtitles
         )
     }
 

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVPlaybackSelectorRow.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVPlaybackSelectorRow.swift
@@ -58,6 +58,20 @@ struct TVPlaybackSelectorRow: View {
                 .focusScope(selectorFocusScope)
                 .focusSection()
                 .modifier(SelectorDefaultFocus(focus: defaultSelectorFocus, binding: $focusedSelector))
+                .onChange(of: focusedSelector) { _, newValue in
+                    // The restore default (see `restoreFocus`) must only
+                    // outlive the menu dismissal it serves. Once focus leaves
+                    // the row — up to the action row, or into an opening menu
+                    // — repoint it at the leading pill so re-entering the row
+                    // lands like untouched geometry instead of jumping back
+                    // to the last-modified selector. Swap the value rather
+                    // than clearing it: `SelectorDefaultFocus` branches on
+                    // nil, and re-identifying the row subtree would tear down
+                    // an open Menu.
+                    if newValue == nil, defaultSelectorFocus != nil {
+                        defaultSelectorFocus = firstSelector
+                    }
+                }
                 .task {
                     await ProfilePrefsStore.shared.hydrateIfNeeded()
                     preferredSubtitleLanguage = ProfilePrefsStore.shared.preferredSubtitleLanguage
@@ -80,6 +94,15 @@ struct TVPlaybackSelectorRow: View {
                 subtitleSelector
             }
         }
+    }
+
+    /// Leading visible pill — where entry into the row should land once the
+    /// post-menu restore default has served its purpose.
+    private var firstSelector: SelectorFocus {
+        if shouldShowEditionSelector { return .edition }
+        if shouldShowVersionValue { return .version }
+        if shouldShowAudioValue { return .audio }
+        return .subtitles
     }
 
     private var hasAnySelector: Bool {

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVPlaybackSelectorRow.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVPlaybackSelectorRow.swift
@@ -27,6 +27,10 @@ struct TVPlaybackSelectorRow: View {
     let selectedVersionFileId: Int?
     let selectedAudioTrackIndex: Int?
     let selectedSubtitleTrackIndex: Int?
+    /// Server-resolved subtitle policy for this item, used to preview what
+    /// "Auto" will land on. Defaulted so callers without it keep a bare "Auto".
+    var subtitleMode: String? = nil
+    var subtitleSignature: SubtitleTrackSignature? = nil
     let onSelectVersion: (Int?) -> Void
     let onSelectAudioTrack: (Int?) -> Void
     let onSelectSubtitleTrack: (Int?) -> Void
@@ -197,7 +201,8 @@ struct TVPlaybackSelectorRow: View {
     private var audioSelector: some View {
         let value = DetailPlaybackFormatting.audioValueLabel(
             version: currentVersion,
-            selectedAudioTrackIndex: selectedAudioTrackIndex
+            selectedAudioTrackIndex: selectedAudioTrackIndex,
+            annotateAuto: true
         )
         if shouldEnableAudioSelector {
             TVSelectorButton(
@@ -234,11 +239,24 @@ struct TVPlaybackSelectorRow: View {
 
     // MARK: - Subtitles
 
+    private var subtitleAutoContext: DetailPlaybackFormatting.SubtitleAutoContext {
+        DetailPlaybackFormatting.SubtitleAutoContext(
+            preferredLanguage: preferredSubtitleLanguage,
+            mode: subtitleMode,
+            signature: subtitleSignature,
+            audioLanguage: DetailPlaybackFormatting.resolvedAudioLanguage(
+                version: currentVersion,
+                selectedAudioTrackIndex: selectedAudioTrackIndex
+            )
+        )
+    }
+
     @ViewBuilder
     private var subtitleSelector: some View {
         let value = DetailPlaybackFormatting.subtitleValueLabel(
             version: currentVersion,
-            selectedSubtitleTrackIndex: selectedSubtitleTrackIndex
+            selectedSubtitleTrackIndex: selectedSubtitleTrackIndex,
+            autoContext: subtitleAutoContext
         )
         if shouldEnableSubtitleSelector {
             TVSelectorButton(

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
@@ -40,6 +40,17 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
 
     @Namespace private var detailFocusNamespace
     @FocusState private var playFocused: Bool
+    /// True while focus sits anywhere inside the season chip row — drives the
+    /// episode-section re-center in `detailFocusScroll`.
+    @FocusState private var seasonRowFocused: Bool
+    /// True while focus sits anywhere in the hero's primary action row —
+    /// drives the scroll back to the page-entry (hero at top) framing.
+    @FocusState private var actionRowFocused: Bool
+
+    // Plain constants (not `static`) — the generic BelowSynopsis parameter
+    // forbids static stored properties on this type.
+    private let episodeSectionScrollId = "season-episode-section"
+    private let heroScrollId = "season-hero"
     /// Season whose next-up Play button has already auto-claimed focus. Keyed on
     /// the season (not a bare Bool) so we auto-focus Play once per season: the
     /// first async next-up resolve AND an in-place season switch — same view
@@ -48,44 +59,55 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
     @State private var autoFocusedSeasonKey: String?
 
     var body: some View {
-        ScrollView(.vertical, showsIndicators: false) {
-            VStack(alignment: .leading, spacing: 48) {
-                TVDetailHero(
-                    title: detail.title,
-                    seriesTitle: nil,
-                    logoUrl: nil,
-                    backdropUrl: detail.backdropUrl,
-                    eyebrow: detail.seriesTitle,
-                    sourceTokens: sourceTokens,
-                    ratingChip: nil,
-                    overview: detail.overview,
-                    tagline: detail.tagline,
-                    factsLine: [],
-                    starringText: TVHeroMetadata.starringText(from: detail),
-                    actions: { actionColumn },
-                    belowSynopsis: belowSynopsis
-                )
+        ScrollViewReader { scrollProxy in
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 48) {
+                    TVDetailHero(
+                        title: detail.title,
+                        seriesTitle: nil,
+                        logoUrl: nil,
+                        backdropUrl: detail.backdropUrl,
+                        eyebrow: detail.seriesTitle,
+                        sourceTokens: sourceTokens,
+                        ratingChip: nil,
+                        overview: detail.overview,
+                        tagline: detail.tagline,
+                        factsLine: [],
+                        starringText: TVHeroMetadata.starringText(from: detail),
+                        actions: { actionColumn },
+                        belowSynopsis: belowSynopsis
+                    )
+                    .id(heroScrollId)
 
-                VStack(alignment: .leading, spacing: 72) {
-                    episodeSection
-                    if let cast = detail.cast, !cast.isEmpty {
-                        castSection(cast: cast)
+                    VStack(alignment: .leading, spacing: 72) {
+                        episodeSection
+                            .id(episodeSectionScrollId)
+                        if let cast = detail.cast, !cast.isEmpty {
+                            castSection(cast: cast)
+                        }
+                        detailsSection
                     }
-                    detailsSection
+                    .padding(.horizontal, ContinuumTheme.safePadding)
+                    .padding(.bottom, 160)
                 }
-                .padding(.horizontal, ContinuumTheme.safePadding)
-                .padding(.bottom, 160)
             }
-        }
-        .ignoresSafeArea()
-        .focusScope(detailFocusNamespace)
-        .defaultFocus($playFocused, true, priority: .userInitiated)
-        .onChange(of: nextUpEpisode?.contentId) { _, newValue in
-            guard newValue != nil else { return }
-            let seasonKey = selectedSeason?.contentId ?? ""
-            guard autoFocusedSeasonKey != seasonKey else { return }
-            autoFocusedSeasonKey = seasonKey
-            playFocused = true
+            .ignoresSafeArea()
+            .focusScope(detailFocusNamespace)
+            .defaultFocus($playFocused, true, priority: .userInitiated)
+            .onChange(of: nextUpEpisode?.contentId) { _, newValue in
+                guard newValue != nil else { return }
+                let seasonKey = selectedSeason?.contentId ?? ""
+                guard autoFocusedSeasonKey != seasonKey else { return }
+                autoFocusedSeasonKey = seasonKey
+                playFocused = true
+            }
+            .detailFocusScroll(
+                proxy: scrollProxy,
+                seasonRowFocused: seasonRowFocused,
+                actionRowFocused: actionRowFocused,
+                episodeSectionId: episodeSectionScrollId,
+                heroId: heroScrollId
+            )
         }
     }
 
@@ -162,6 +184,9 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
                 moreMenu
             }
         }
+        // Container binding — flips true when any button in the row has
+        // focus, driving the scroll-to-top in `detailFocusScroll`.
+        .focused($actionRowFocused)
     }
 
     private var hasMoreMenu: Bool {
@@ -238,6 +263,9 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
                     selectedSeasonId: selectedSeason?.id,
                     onSelect: onSelectSeason
                 )
+                // Container binding — true while any chip has focus, driving
+                // the episode-section re-center in `detailFocusScroll`.
+                .focused($seasonRowFocused)
             }
             if isLoadingEpisodes {
                 HStack {

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
@@ -132,6 +132,7 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
                     selectedSubtitleTrackIndex: selectedNextUpSubtitleTrackIndex,
                     subtitleMode: nextUpSubtitleOverrideCleared ? nil : nextUpPlaybackDetail?.effectiveSubtitleMode,
                     subtitleSignature: nextUpSubtitleOverrideCleared ? nil : nextUpPlaybackDetail?.effectiveSubtitleTrackSignature,
+                    showForcedSubtitles: nextUpPlaybackDetail?.effectiveShowForcedSubtitles ?? false,
                     onSelectVersion: onSelectNextUpVersion,
                     onSelectAudioTrack: onSelectNextUpAudioTrack,
                     onSelectSubtitleTrack: onSelectNextUpSubtitleTrack

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
@@ -102,6 +102,8 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
                     selectedVersionFileId: selectedNextUpFileId,
                     selectedAudioTrackIndex: selectedNextUpAudioTrackIndex,
                     selectedSubtitleTrackIndex: selectedNextUpSubtitleTrackIndex,
+                    subtitleMode: nextUpPlaybackDetail?.effectiveSubtitleMode,
+                    subtitleSignature: nextUpPlaybackDetail?.effectiveSubtitleTrackSignature,
                     onSelectVersion: onSelectNextUpVersion,
                     onSelectAudioTrack: onSelectNextUpAudioTrack,
                     onSelectSubtitleTrack: onSelectNextUpSubtitleTrack

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
@@ -193,6 +193,13 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
         // Container binding — flips true when any button in the row has
         // focus, driving the scroll-to-top in `detailFocusScroll`.
         .focused($actionRowFocused)
+        // Mirror of the selector row's full-width focus section: the subtitle
+        // pill below can extend past the last circle button, and an Up press
+        // from that overhang would otherwise skip this row for the synopsis.
+        // Full-width bounds put the row under every selector pill so Up lands
+        // on the nearest action button. Buttons stay left-aligned.
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .focusSection()
     }
 
     private var hasMoreMenu: Bool {

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
@@ -23,6 +23,12 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
     let selectedNextUpAudioTrackIndex: Int?
     let selectedNextUpSubtitleTrackIndex: Int?
     let nextUpPlaybackDetail: ItemDetail?
+    /// True once the user explicitly resets subtitles to "Auto" this visit.
+    /// The server override was just cleared, but the next-up detail's
+    /// `effectiveSubtitle*` still describes the old manual pick until the
+    /// next refetch — suppress it so the "Auto - …" preview doesn't echo the
+    /// cleared selection.
+    var nextUpSubtitleOverrideCleared: Bool = false
     let onPlayEpisode: (_ contentId: String, _ fileId: Int?, _ startFromBeginning: Bool) -> Void
     let onEpisodeTap: (_ contentId: String) -> Void
     let onSelectSeason: (Season) -> Void
@@ -124,8 +130,8 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
                     selectedVersionFileId: selectedNextUpFileId,
                     selectedAudioTrackIndex: selectedNextUpAudioTrackIndex,
                     selectedSubtitleTrackIndex: selectedNextUpSubtitleTrackIndex,
-                    subtitleMode: nextUpPlaybackDetail?.effectiveSubtitleMode,
-                    subtitleSignature: nextUpPlaybackDetail?.effectiveSubtitleTrackSignature,
+                    subtitleMode: nextUpSubtitleOverrideCleared ? nil : nextUpPlaybackDetail?.effectiveSubtitleMode,
+                    subtitleSignature: nextUpSubtitleOverrideCleared ? nil : nextUpPlaybackDetail?.effectiveSubtitleTrackSignature,
                     onSelectVersion: onSelectNextUpVersion,
                     onSelectAudioTrack: onSelectNextUpAudioTrack,
                     onSelectSubtitleTrack: onSelectNextUpSubtitleTrack

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -18,6 +18,12 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     let nextUpPlaybackDetail: ItemDetail?
     let isLoadingNextUpPlaybackDetail: Bool
     let didLoadNextUpPlaybackDetail: Bool
+    /// True once the user explicitly resets subtitles to "Auto" this visit.
+    /// The server override was just cleared, but the next-up detail's
+    /// `effectiveSubtitle*` still describes the old manual pick until the
+    /// next refetch — suppress it so the "Auto - …" preview doesn't echo the
+    /// cleared selection.
+    var nextUpSubtitleOverrideCleared: Bool = false
     let onSelectSeason: (Season) -> Void
     let onPlayEpisode: (_ contentId: String, _ fileId: Int?, _ startFromBeginning: Bool) -> Void
     let onEpisodeTap: (_ contentId: String) -> Void
@@ -130,8 +136,8 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                     selectedVersionFileId: selectedNextUpFileId,
                     selectedAudioTrackIndex: selectedNextUpAudioTrackIndex,
                     selectedSubtitleTrackIndex: selectedNextUpSubtitleTrackIndex,
-                    subtitleMode: nextUpPlaybackDetail?.effectiveSubtitleMode,
-                    subtitleSignature: nextUpPlaybackDetail?.effectiveSubtitleTrackSignature,
+                    subtitleMode: nextUpSubtitleOverrideCleared ? nil : nextUpPlaybackDetail?.effectiveSubtitleMode,
+                    subtitleSignature: nextUpSubtitleOverrideCleared ? nil : nextUpPlaybackDetail?.effectiveSubtitleTrackSignature,
                     onSelectVersion: onSelectNextUpVersion,
                     onSelectAudioTrack: onSelectNextUpAudioTrack,
                     onSelectSubtitleTrack: onSelectNextUpSubtitleTrack

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -316,13 +316,12 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     // MARK: - More Like This
 
     private var similarSection: some View {
-        VStack(alignment: .leading, spacing: 28) {
-            TVSectionHeader(title: "More Like This")
-            TVSimilarRail(
-                contentId: detail.contentId,
-                onSelect: onNavigateToItem
-            )
-        }
+        // Header lives inside the rail so it disappears with the cards when
+        // recommendations are disabled or empty.
+        TVSimilarRail(
+            contentId: detail.contentId,
+            onSelect: onNavigateToItem
+        )
     }
 
     // MARK: - Cast

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -35,6 +35,16 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
 
     @Namespace private var detailFocusNamespace
     @FocusState private var playFocused: Bool
+    /// True while focus sits anywhere inside the season chip row. Used to
+    /// scroll the episode section to the same centered framing the focus
+    /// engine produces when the (taller) episode rail itself is focused —
+    /// otherwise landing on the short chip row only reveals the chips and
+    /// leaves the episodes below the fold.
+    @FocusState private var seasonRowFocused: Bool
+    /// True while focus sits anywhere in the hero's primary action row
+    /// (Play / Start Over / circle buttons). Backing up into it restores the
+    /// page-entry framing by scrolling the hero back to the top.
+    @FocusState private var actionRowFocused: Bool
     /// Season whose next-up Play button has already auto-claimed focus. Keyed on
     /// the season (not a bare Bool) so we auto-focus Play once per season: the
     /// first async next-up resolve AND an in-place season switch — same view
@@ -43,46 +53,66 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     @State private var autoFocusedSeasonKey: String?
 
     var body: some View {
-        ScrollView(.vertical, showsIndicators: false) {
-            VStack(alignment: .leading, spacing: 48) {
-                TVDetailHero(
-                    title: detail.title,
-                    seriesTitle: nil,
-                    logoUrl: detail.logoUrl,
-                    backdropUrl: detail.backdropUrl,
-                    eyebrow: TVHeroMetadata.eyebrow(from: detail),
-                    sourceTokens: TVHeroMetadata.seriesSourceTokens(from: detail),
-                    ratingChip: TVHeroMetadata.contentRatingChip(from: detail),
-                    overview: detail.overview,
-                    tagline: detail.tagline,
-                    factsLine: TVHeroMetadata.seriesFactsLine(from: detail),
-                    starringText: TVHeroMetadata.starringText(from: detail),
-                    actions: { actionColumn },
-                    belowSynopsis: belowSynopsis
-                )
+        ScrollViewReader { scrollProxy in
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 48) {
+                    heroView
+                        .id(heroScrollId)
 
-                VStack(alignment: .leading, spacing: 72) {
-                    episodeSection
-                    if let cast = detail.cast, !cast.isEmpty {
-                        castSection(cast: cast)
+                    VStack(alignment: .leading, spacing: 72) {
+                        episodeSection
+                            .id(episodeSectionScrollId)
+                        if let cast = detail.cast, !cast.isEmpty {
+                            castSection(cast: cast)
+                        }
+                        detailsSection
+                        similarSection
                     }
-                    detailsSection
-                    similarSection
+                    .padding(.horizontal, ContinuumTheme.safePadding)
+                    .padding(.bottom, 160)
                 }
-                .padding(.horizontal, ContinuumTheme.safePadding)
-                .padding(.bottom, 160)
             }
+            .ignoresSafeArea()
+            .focusScope(detailFocusNamespace)
+            .defaultFocus($playFocused, true, priority: .userInitiated)
+            .onChange(of: nextUpEpisode?.contentId) { _, newValue in
+                guard newValue != nil else { return }
+                let seasonKey = selectedSeason?.contentId ?? ""
+                guard autoFocusedSeasonKey != seasonKey else { return }
+                autoFocusedSeasonKey = seasonKey
+                playFocused = true
+            }
+            .detailFocusScroll(
+                proxy: scrollProxy,
+                seasonRowFocused: seasonRowFocused,
+                actionRowFocused: actionRowFocused,
+                episodeSectionId: episodeSectionScrollId,
+                heroId: heroScrollId
+            )
         }
-        .ignoresSafeArea()
-        .focusScope(detailFocusNamespace)
-        .defaultFocus($playFocused, true, priority: .userInitiated)
-        .onChange(of: nextUpEpisode?.contentId) { _, newValue in
-            guard newValue != nil else { return }
-            let seasonKey = selectedSeason?.contentId ?? ""
-            guard autoFocusedSeasonKey != seasonKey else { return }
-            autoFocusedSeasonKey = seasonKey
-            playFocused = true
-        }
+    }
+
+    // Plain constants (not `static`) — the generic BelowSynopsis parameter
+    // forbids static stored properties on this type.
+    private let episodeSectionScrollId = "series-episode-section"
+    private let heroScrollId = "series-hero"
+
+    private var heroView: some View {
+        TVDetailHero(
+            title: detail.title,
+            seriesTitle: nil,
+            logoUrl: detail.logoUrl,
+            backdropUrl: detail.backdropUrl,
+            eyebrow: TVHeroMetadata.eyebrow(from: detail),
+            sourceTokens: TVHeroMetadata.seriesSourceTokens(from: detail),
+            ratingChip: TVHeroMetadata.contentRatingChip(from: detail),
+            overview: detail.overview,
+            tagline: detail.tagline,
+            factsLine: TVHeroMetadata.seriesFactsLine(from: detail),
+            starringText: TVHeroMetadata.starringText(from: detail),
+            actions: { actionColumn },
+            belowSynopsis: belowSynopsis
+        )
     }
 
     // MARK: - Hero actions
@@ -156,6 +186,9 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                 action: onToggleWatched
             )
         }
+        // Container binding — flips true when any button in the row has
+        // focus, driving the scroll-to-top in `body`.
+        .focused($actionRowFocused)
     }
 
     /// Best "Play" target for the series: an in-progress episode if there
@@ -239,6 +272,9 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
             selectedSeasonId: selectedSeason?.id,
             onSelect: onSelectSeason
         )
+        // Bound to the whole row: the binding flips true when any chip inside
+        // gains focus, driving the episode-section re-center in `body`.
+        .focused($seasonRowFocused)
     }
 
     @ViewBuilder

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -195,6 +195,13 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         // Container binding — flips true when any button in the row has
         // focus, driving the scroll-to-top in `body`.
         .focused($actionRowFocused)
+        // Mirror of the selector row's full-width focus section: the subtitle
+        // pill below can extend past the last circle button, and an Up press
+        // from that overhang would otherwise skip this row for the synopsis.
+        // Full-width bounds put the row under every selector pill so Up lands
+        // on the nearest action button. Buttons stay left-aligned.
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .focusSection()
     }
 
     /// Best "Play" target for the series: an in-progress episode if there

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -138,6 +138,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                     selectedSubtitleTrackIndex: selectedNextUpSubtitleTrackIndex,
                     subtitleMode: nextUpSubtitleOverrideCleared ? nil : nextUpPlaybackDetail?.effectiveSubtitleMode,
                     subtitleSignature: nextUpSubtitleOverrideCleared ? nil : nextUpPlaybackDetail?.effectiveSubtitleTrackSignature,
+                    showForcedSubtitles: nextUpPlaybackDetail?.effectiveShowForcedSubtitles ?? false,
                     onSelectVersion: onSelectNextUpVersion,
                     onSelectAudioTrack: onSelectNextUpAudioTrack,
                     onSelectSubtitleTrack: onSelectNextUpSubtitleTrack

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -100,6 +100,8 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                     selectedVersionFileId: selectedNextUpFileId,
                     selectedAudioTrackIndex: selectedNextUpAudioTrackIndex,
                     selectedSubtitleTrackIndex: selectedNextUpSubtitleTrackIndex,
+                    subtitleMode: nextUpPlaybackDetail?.effectiveSubtitleMode,
+                    subtitleSignature: nextUpPlaybackDetail?.effectiveSubtitleTrackSignature,
                     onSelectVersion: onSelectNextUpVersion,
                     onSelectAudioTrack: onSelectNextUpAudioTrack,
                     onSelectSubtitleTrack: onSelectNextUpSubtitleTrack

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSimilarRail.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSimilarRail.swift
@@ -9,7 +9,10 @@ import SwiftUI
 ///
 /// The rail self-loads on appear and silently hides if the request
 /// fails or returns nothing — recommendations are non-essential, so a
-/// missing rail is preferable to an error placeholder.
+/// missing rail is preferable to an error placeholder. The section
+/// header lives in here (not the parent) for the same reason: when
+/// recommendations are disabled or empty, an orphaned "More Like This"
+/// title must vanish along with the cards.
 struct TVSimilarRail: View {
     let contentId: String
     let onSelect: (String) -> Void
@@ -21,16 +24,26 @@ struct TVSimilarRail: View {
 
     private let cardSpacing: CGFloat = 32
     private let railVerticalPadding: CGFloat = 24
+    /// Header-to-content gap, matching the other detail sections'
+    /// `VStack(spacing: 28)` so the page rhythm stays uniform.
+    private let headerSpacing: CGFloat = 28
 
     var body: some View {
         Group {
             if isLoading {
-                loadingPlaceholder
+                section { loadingPlaceholder }
             } else if !items.isEmpty {
-                rail
+                section { rail }
             }
         }
         .task(id: contentId) { await load() }
+    }
+
+    private func section(@ViewBuilder content: () -> some View) -> some View {
+        VStack(alignment: .leading, spacing: headerSpacing) {
+            TVSectionHeader(title: "More Like This")
+            content()
+        }
     }
 
     // MARK: - Rail

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsView.swift
@@ -15,6 +15,7 @@ import SwiftUI
 /// geometrically. No manual focus mutation (see docs/tvos-focus.md).
 struct TVSettingsView: View {
     @State private var viewModel = TVSettingsViewModel()
+    @State private var debugSettings = TVDebugSettings.shared
     @State private var showSignOutConfirm = false
     @State private var selectedCategory: TVSettingsCategory = .general
     @FocusState private var railFocus: RailItem?
@@ -253,6 +254,20 @@ struct TVSettingsView: View {
             TVSettingsSectionHeader("ABOUT")
 
             TVSettingsInfoRow(title: "App Version", value: Self.appVersion)
+
+            TVSettingsSectionHeader("DEBUGGING")
+
+            TVSettingsToggleRow(
+                title: "Show Focus Targets",
+                isOn: debugSettings.showFocusTargets
+            ) {
+                debugSettings.setShowFocusTargets(!debugSettings.showFocusTargets)
+            }
+
+            TVSettingsFooter(
+                "Overlays the predicted d-pad destination in each direction "
+                    + "from the focused control. Stored on this Apple TV."
+            )
         }
     }
 

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsView.swift
@@ -15,8 +15,10 @@ import SwiftUI
 /// geometrically. No manual focus mutation (see docs/tvos-focus.md).
 struct TVSettingsView: View {
     @State private var viewModel = TVSettingsViewModel()
-    @State private var debugSettings = TVDebugSettings.shared
     @State private var showSignOutConfirm = false
+    #if DEBUG
+    @State private var debugSettings = TVDebugSettings.shared
+    #endif
     @State private var selectedCategory: TVSettingsCategory = .general
     @FocusState private var railFocus: RailItem?
     @Environment(AppRouter.self) private var router
@@ -255,6 +257,7 @@ struct TVSettingsView: View {
 
             TVSettingsInfoRow(title: "App Version", value: Self.appVersion)
 
+            #if DEBUG
             TVSettingsSectionHeader("DEBUGGING")
 
             TVSettingsToggleRow(
@@ -266,8 +269,10 @@ struct TVSettingsView: View {
 
             TVSettingsFooter(
                 "Overlays the predicted d-pad destination in each direction "
-                    + "from the focused control. Stored on this Apple TV."
+                    + "from the focused control. Stored on this Apple TV. "
+                    + "Debug builds only."
             )
+            #endif
         }
     }
 


### PR DESCRIPTION
## Summary

A batch of tvOS navigation/player UI fixes, plus a new cross-platform feature: long-press context-menu actions on media cards to add/remove items from Favorites and Watchlist.

### New: card context-menu favorite/watchlist actions (iOS + tvOS)
- Long-pressing a poster card now offers **Add/Remove from Favorites** and **Add/Remove from Watchlist** on Home rows, Library grids, and the Favorites/Watchlist screens.
- The menu appears only on cards with a catalog identity (`contentId` + server `userState`), so people/collection/discover thumbnails are unaffected.
- Toggles are optimistic with revert-on-failure, write back the cached per-item user state (detail screens render the new state immediately), and invalidate the Favorites/Watchlist/Home caches.
- Removing an item from within the Favorites or Watchlist grid animates the card out in place.
- New shared `PersonalListActions.swift` (menu items + `PersonalListSync`); wired into `MediaCard` (iOS + tvOS), `TVMediaCard`/`TVCatalogGrid` (tvOS library).

### tvOS navigation & detail fixes
- Calendar: d-pad Up no longer sticks when navigating past empty days.
- Home re-click: rides focus back to the first card with an animation.
- Player: Down from the scrubber lands directly on play/pause; scrubber trackpad drag slowed 5x and made modal against Down; HUD pinned while paused with trackpad drag scrubbing.
- Detail pages: season switching in place, episode-section centering on chip focus, full-width action-row focus section, tightened hero spacing, selector fixes (single-option selectors focusable, auto-resolved track annotations, stale Auto-preview echo fixed, post-menu default focus retired correctly).
- Top menu bar: tabs/icons scaled up ~12%.
- Subtitles: CC/SDH-titled tracks missing the hearing-impaired flag are demoted in auto-selection.
- Debug: d-pad focus target overlay behind a server-settings toggle (compiled out of Release).

## Things to test / verify

### Favorite/watchlist menu (the new feature)
- [ ] **iOS Home**: long-press a poster in any row → menu shows both actions with labels matching the item's current state; toggling updates the heart/bookmark state on the item's detail page.
- [ ] **iOS Library**: same via the browse grid.
- [ ] **tvOS Home rows**: long-press select on a card → favorite/watchlist actions appear alongside the existing "Mark as Watched" / "Remove from Continue Watching" items.
- [ ] **tvOS Library grid**: long-press select on a poster → menu appears and toggles work.
- [ ] **Favorites screen (iOS + tvOS)**: "Remove from Favorites" animates the card out of the grid immediately.
- [ ] **Watchlist screen (iOS + tvOS)**: "Remove from Watchlist" animates the card out immediately.
- [ ] Add an item to the watchlist from Home, then open the Watchlist screen → the item is there (cache invalidation).
- [ ] Toggle favorite on a card, then open that item's detail page → the heart button reflects the new state without a refresh.
- [ ] Cards without user state (people, collection thumbnails, request/discover results) show **no** context menu.
- [ ] Kill the server / go offline and toggle → the menu label reverts (optimistic state rolls back on failure).
- [ ] **iOS Continue Watching**: long-press an episode still → menu shows Mark as Watched/Unwatched + Remove from Continue Watching; remove refreshes the row.
- [ ] **iOS movie posters in Continue Watching / home rows**: long-press → watched toggle, favorite/watchlist, and (on CW rows) remove, all in one menu.
- [ ] Calendar "Following" picks up newly favorited/watchlisted items (following = favorites ∪ watchlist ∪ watch progress).

### iOS player HUD + menus
- [ ] Open Audio & Subtitles (also Quality / Chapters) and idle 10+ seconds → HUD and menu stay up, no snap-to-top fade.
- [ ] Dismiss a menu without selecting → HUD auto-hides ~5s after the menu closes (no longer stuck on-screen).
- [ ] Select a track/quality/chapter → menu closes, HUD auto-hides ~5s later.
- [ ] HUD with no menu opened still auto-hides after 5s; tvOS HUD behavior unchanged.

### tvOS navigation fixes
- [ ] Calendar week strip: d-pad Up from a day shelf past empty days doesn't get stuck.
- [ ] Pressing Home while on Home scrolls back and lands focus on the first card.
- [ ] Player: Down from the scrubber lands on play/pause; trackpad drag scrubbing feels controllable while paused; HUD stays pinned while paused.
- [ ] Detail page: switching seasons keeps you in place; Up from the selector row can't skip the action row; audio/subtitle selector shows "(Auto)" annotations and single-option selectors are focusable.
- [ ] Release build does not contain the focus debug overlay (Debug-only, behind the server-settings toggle).

### Known (pre-existing, not addressed here)
- Immediately after dismissing a card's long-press menu on tvOS, a d-pad press within ~0.5s can be misrouted (e.g. Down goes right) — this is system dismissal-transition behavior that also affects the pre-existing menus; waiting for the transition to settle avoids it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added long-press actions to mark titles as favorites or add/remove them from the watchlist.
  * Improved tvOS navigation with smoother focus, scrolling, and scrubber interaction across lists and detail screens.
  * Added clearer “Auto” labels in playback settings when subtitles or audio are automatically selected.

* **Bug Fixes**
  * Fixed subtitle auto-selection so CC/SDH tracks are less likely to be chosen over standard dialogue tracks.
  * Updated personal lists to refresh immediately after changes, including removing items from Favorites or Watchlist when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

