### PR TITLE
fix(home): strip ebook/manga items from server-built sections

### DIFF
--- a/iosApp/Tests/LibraryVisibilityTests.swift
+++ b/iosApp/Tests/LibraryVisibilityTests.swift
@@ -29,4 +29,64 @@ final class LibraryVisibilityTests: XCTestCase {
         XCTAssertFalse(SiloMediaType.isSupportedLibrary("book"))
         XCTAssertFalse(SiloMediaType.isSupportedLibrary("books"))
     }
+
+    func testSectionsResponseStripsItemsFromHiddenLibraryTypes() {
+        let json = """
+        {
+          "sections": [
+            {
+              "id": "continue",
+              "section_type": "continue_watching",
+              "title": "Continue Watching",
+              "items": [
+                { "content_id": "m1", "type": "movie", "title": "A Movie" },
+                { "content_id": "e1", "type": "ebook", "title": "An Ebook" },
+                { "content_id": "a1", "type": "audiobook", "title": "An Audiobook" }
+              ]
+            },
+            {
+              "id": "manga-recent",
+              "section_type": "recently_added",
+              "title": "Recently Added Manga",
+              "items": [
+                { "content_id": "g1", "type": "manga", "title": "A Manga" }
+              ]
+            }
+          ]
+        }
+        """
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+        let response = try! decoder.decode(SectionsResponse.self, from: Data(json.utf8))
+
+        XCTAssertEqual(response.sections.map(\.id), ["continue", "manga-recent"])
+        XCTAssertEqual(response.sections[0].items.map(\.contentId), ["m1", "a1"])
+        XCTAssertTrue(response.sections[1].items.isEmpty)
+    }
+
+    func testSectionsResponseMemberwiseInitAlsoStripsUnsupportedItems() throws {
+        let itemJson = """
+        { "content_id": "e1", "type": "ebook", "title": "An Ebook" }
+        """
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let item = try decoder.decode(SectionItem.self, from: Data(itemJson.utf8))
+
+        let response = SectionsResponse(sections: [
+            ResolvedSection(
+                id: "discover_0_similar",
+                sectionType: "similar",
+                title: "Because You Watched",
+                featured: false,
+                itemLimit: 1,
+                totalCount: 1,
+                isCustom: false,
+                customized: false,
+                items: [item]
+            )
+        ])
+
+        XCTAssertTrue(response.sections[0].items.isEmpty)
+    }
 }

--- a/iosApp/Tests/LibraryVisibilityTests.swift
+++ b/iosApp/Tests/LibraryVisibilityTests.swift
@@ -41,6 +41,9 @@ final class LibraryVisibilityTests: XCTestCase {
               "items": [
                 { "content_id": "m1", "type": "movie", "title": "A Movie" },
                 { "content_id": "e1", "type": "ebook", "title": "An Ebook" },
+                { "content_id": "ep1", "type": "episode", "title": "An Episode" },
+                { "content_id": "c1", "type": "comic", "title": "A Comic" },
+                { "content_id": "mu1", "type": "music", "title": "An Album" },
                 { "content_id": "a1", "type": "audiobook", "title": "An Audiobook" }
               ]
             },
@@ -61,7 +64,7 @@ final class LibraryVisibilityTests: XCTestCase {
         let response = try! decoder.decode(SectionsResponse.self, from: Data(json.utf8))
 
         XCTAssertEqual(response.sections.map(\.id), ["continue", "manga-recent"])
-        XCTAssertEqual(response.sections[0].items.map(\.contentId), ["m1", "a1"])
+        XCTAssertEqual(response.sections[0].items.map(\.contentId), ["m1", "ep1", "a1"])
         XCTAssertTrue(response.sections[1].items.isEmpty)
     }
 

--- a/iosApp/iosApp/Networking/Models.swift
+++ b/iosApp/iosApp/Networking/Models.swift
@@ -267,13 +267,17 @@ enum SiloMediaType {
         isMovieLibrary(type) || isSeries(type) || isAudiobookLibrary(type)
     }
 
-    /// Item types from libraries the Apple clients hide (see
-    /// ``isSupportedLibrary``). The server builds Home sections for every
-    /// library type, so these must be stripped client-side too or hidden
-    /// libraries leak rows into Home.
-    static func isUnsupportedSectionItem(_ type: String) -> Bool {
+    /// Section items are kept only when their type maps to a library type
+    /// the Apple clients support (see ``isSupportedLibrary``). The server
+    /// builds Home sections for every library type, so items from hidden
+    /// libraries (ebook, manga, comics, music, …) must be stripped
+    /// client-side or those libraries leak rows into Home.
+    static func isSupportedSectionItem(_ type: String) -> Bool {
+        if isMovieLibrary(type) || isSeries(type) || isAudiobook(type) {
+            return true
+        }
         switch normalized(type) {
-        case "ebook", "ebooks", "manga", "mangas":
+        case "episode", "episodes":
             return true
         default:
             return false
@@ -361,7 +365,7 @@ struct SectionsResponse: Codable {
     ) -> [ResolvedSection] {
         sections.map { section in
             let kept = section.items.filter {
-                !SiloMediaType.isUnsupportedSectionItem($0.type)
+                SiloMediaType.isSupportedSectionItem($0.type)
             }
             guard kept.count != section.items.count else { return section }
             return ResolvedSection(

--- a/iosApp/iosApp/Networking/Models.swift
+++ b/iosApp/iosApp/Networking/Models.swift
@@ -266,6 +266,19 @@ enum SiloMediaType {
     static func isSupportedLibrary(_ type: String) -> Bool {
         isMovieLibrary(type) || isSeries(type) || isAudiobookLibrary(type)
     }
+
+    /// Item types from libraries the Apple clients hide (see
+    /// ``isSupportedLibrary``). The server builds Home sections for every
+    /// library type, so these must be stripped client-side too or hidden
+    /// libraries leak rows into Home.
+    static func isUnsupportedSectionItem(_ type: String) -> Bool {
+        switch normalized(type) {
+        case "ebook", "ebooks", "manga", "mangas":
+            return true
+        default:
+            return false
+        }
+    }
 }
 
 extension BrowseItem {
@@ -330,12 +343,39 @@ struct SectionsResponse: Codable {
     let sections: [ResolvedSection]
 
     init(sections: [ResolvedSection]) {
-        self.sections = sections
+        self.sections = Self.strippingUnsupportedItems(sections)
     }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
-        sections = try c.decodeIfPresent([ResolvedSection].self, forKey: .sections) ?? []
+        let decoded = try c.decodeIfPresent([ResolvedSection].self, forKey: .sections) ?? []
+        sections = Self.strippingUnsupportedItems(decoded)
+    }
+
+    /// Mirror of `LibrariesResponse` gating: unsupported library types are
+    /// hidden from the library list, so their items must not surface through
+    /// server-built sections either. Sections emptied by the strip are kept —
+    /// every consumer already drops empty sections before rendering.
+    private static func strippingUnsupportedItems(
+        _ sections: [ResolvedSection]
+    ) -> [ResolvedSection] {
+        sections.map { section in
+            let kept = section.items.filter {
+                !SiloMediaType.isUnsupportedSectionItem($0.type)
+            }
+            guard kept.count != section.items.count else { return section }
+            return ResolvedSection(
+                id: section.id,
+                sectionType: section.sectionType,
+                title: section.title,
+                featured: section.featured,
+                itemLimit: section.itemLimit,
+                totalCount: section.totalCount,
+                isCustom: section.isCustom,
+                customized: section.customized,
+                items: kept
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
Ebook and manga rows were leaking onto the Home page even though those library types are hidden from the library list (reported via internal Discord thread with a screenshot). The server intentionally builds Home sections for every library type — including generated "Recently Added Ebooks/Manga" rows — so the client must apply the same gate to sections that it already applies to libraries.

## Fix
- Add `SiloMediaType.isUnsupportedSectionItem(_:)` flagging `ebook`/`manga` item types (plus plural variants), documented as the mirror of `isSupportedLibrary`.
- Gate `SectionsResponse` in both inits, matching the `LibrariesResponse` pattern:
  - the decode init covers Home sections, library sections, and cache hydration;
  - the memberwise init covers the recommendations Discover feed, which assembles sections manually.
- Sections emptied by the strip are kept — every consumer (iOS `HomeViewModel.regularSections`, tvOS `TVLibraryBrowseView`) already drops empty sections before rendering, so all-ebook/manga rows vanish cleanly on iOS, tvOS, and macOS.

## Testing
- Two new tests in `LibraryVisibilityTests`: a mixed Continue Watching row keeps movie + audiobook items and drops the ebook; an all-manga section decodes to empty; the memberwise init strips too.
- `xcodebuild test` on iPhone 17 Pro simulator: all 4 `LibraryVisibilityTests` pass. The change is in shared, platform-unconditional code.

## Notes
- `totalCount` on a mixed section can now slightly overstate the visible item count; harmless today (only feeds "see all" affordances).
- Android is unaffected by design — it ships an ebook reader and intentionally shows these libraries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Home and library sections now hide unsupported item types on Apple clients, so only compatible content appears in section lists.
  * Sections remain visible even when all items in them are filtered out, preventing unexpected section removal.
  * Added tests covering both decoded responses and manually created section data to ensure the filtering works consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->