### PR TITLE
fix(tvos): Menu exits player when paused instead of hiding controls

### DIFF
--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -207,6 +207,10 @@ struct PlayerView: View {
                 dismissPlayer()
             } else if viewModel.isHUDPresented {
                 viewModel.closeHUD()
+            } else if !viewModel.isPlaying {
+                // While paused, Menu exits the player instead of hiding the
+                // controls over a frozen frame.
+                dismissPlayer()
             } else if viewModel.showControls {
                 viewModel.dismissControls()
             } else {

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPlayerControls.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPlayerControls.swift
@@ -348,7 +348,13 @@ struct TVPlayerControls: View {
                     }
                 },
                 onExitWhenIdle: {
-                    viewModel.dismissControls()
+                    // While paused, Menu exits the player instead of hiding
+                    // the controls over a frozen frame.
+                    if viewModel.isPlaying {
+                        viewModel.dismissControls()
+                    } else {
+                        onDismiss()
+                    }
                 },
                 isTimelineScrubbing: $isTimelineScrubbing,
                 cancelOnBlur: cancelPendingScrub


### PR DESCRIPTION
## What changed
On tvOS, pressing Menu while playback is paused now exits the player back to the menu instead of just hiding the transport controls over a frozen frame.

- `TVPlayerControls`: the scrubber's `onExitWhenIdle` path (where focus usually sits when paused) now dismisses the player when paused, instead of `dismissControls()`.
- `PlayerView`: the shell-level `onExitCommand` fallback gets the same paused check, placed after the HUD branch so an open audio/subtitles panel still closes first.

## Why
When paused, hiding the controls leaves a frozen frame with no obvious way forward — exiting matches user expectation (and the Infuse/Apple TV pattern of Menu meaning "back out").

## Reviewer notes
- While playing, the existing stepping behavior (cancel seek → close HUD → hide controls → exit) is unchanged.
- SiloTV builds green on the tvOS simulator; installed and launched for a manual d-pad pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tvOS exit behavior in the player: pressing Exit/Menu now closes the player more reliably when playback is stopped.
  * When the scrubber is idle, exiting now leaves the player instead of only hiding controls on a paused or frozen screen.
  * Updated the player flow so controls still dismiss normally during active playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->