### PR TITLE
feat(apple): detect and label Dolby media formats

### DIFF
--- a/iosApp/Tests/DetailVersionSelectionTests.swift
+++ b/iosApp/Tests/DetailVersionSelectionTests.swift
@@ -400,11 +400,43 @@ final class DetailVersionSelectionTests: XCTestCase {
         ]
         """)
 
-        XCTAssertEqual(DetailPlaybackFormatting.heroVideoBadgeLabel(versions[0]), "4K DV")
+        XCTAssertEqual(DetailPlaybackFormatting.heroVideoBadgeLabel(versions[0]), "4K Dolby Vision")
         XCTAssertEqual(DetailPlaybackFormatting.heroVideoBadgeLabel(versions[1]), "4K HDR")
         XCTAssertEqual(DetailPlaybackFormatting.heroVideoBadgeLabel(versions[2]), "HD")
         XCTAssertEqual(DetailPlaybackFormatting.heroVideoBadgeLabel(versions[3]), "HDR")
         XCTAssertNil(DetailPlaybackFormatting.heroVideoBadgeLabel(versions[4]))
+    }
+
+    func testHomeVideoBadgesCombineWhenTheyShareACorner() throws {
+        let prefs = OverlaySchema.buildDefaults()
+        let ids = OverlayRegistry.enabled(at: .topLeft, in: prefs).map(\.id)
+
+        XCTAssertTrue(ids.contains(.resolutionHdr))
+        XCTAssertFalse(ids.contains(.resolution))
+        XCTAssertFalse(ids.contains(.hdr))
+
+        let combined = try XCTUnwrap(OverlayRegistry.def(for: .resolutionHdr))
+        var data = OverlayData()
+        data.resolution = "2160p"
+        data.hdr = "DV HDR10"
+        XCTAssertEqual(combined.getValue(data), "4K Dolby Vision")
+        data.resolution = nil
+        XCTAssertEqual(combined.getValue(data), "Dolby Vision")
+        data.resolution = "2160p"
+        data.hdr = nil
+        XCTAssertEqual(combined.getValue(data), "4K")
+    }
+
+    func testHomeVideoBadgesStaySeparateInDifferentCorners() {
+        var prefs = OverlaySchema.buildDefaults()
+        prefs.items[.hdr]?.position = .topRight
+
+        let topLeft = OverlayRegistry.enabled(at: .topLeft, in: prefs).map(\.id)
+        let topRight = OverlayRegistry.enabled(at: .topRight, in: prefs).map(\.id)
+        XCTAssertTrue(topLeft.contains(.resolution))
+        XCTAssertTrue(topRight.contains(.hdr))
+        XCTAssertFalse(topLeft.contains(.resolutionHdr))
+        XCTAssertFalse(topRight.contains(.resolutionHdr))
     }
 
     func testEffectiveAudioLabelPrefersServerEffectiveTrack() {

--- a/iosApp/Tests/DetailVersionSelectionTests.swift
+++ b/iosApp/Tests/DetailVersionSelectionTests.swift
@@ -370,6 +370,43 @@ final class DetailVersionSelectionTests: XCTestCase {
         XCTAssertEqual(DetailPlaybackFormatting.dynamicRangeBadgeLabel(versions[2]), "DV")
     }
 
+    func testHeroVideoBadgeCombinesResolutionAndDynamicRange() {
+        let versions = decodedVersions("""
+        [
+          {
+            "file_id": 1,
+            "resolution": "2160p",
+            "hdr": true,
+            "video_tracks": [
+              { "codec": "hevc", "dv_profile": 8 }
+            ]
+          },
+          {
+            "file_id": 2,
+            "resolution": "2160p",
+            "hdr": true
+          },
+          {
+            "file_id": 3,
+            "resolution": "1080p"
+          },
+          {
+            "file_id": 4,
+            "hdr": true
+          },
+          {
+            "file_id": 5
+          }
+        ]
+        """)
+
+        XCTAssertEqual(DetailPlaybackFormatting.heroVideoBadgeLabel(versions[0]), "4K DV")
+        XCTAssertEqual(DetailPlaybackFormatting.heroVideoBadgeLabel(versions[1]), "4K HDR")
+        XCTAssertEqual(DetailPlaybackFormatting.heroVideoBadgeLabel(versions[2]), "HD")
+        XCTAssertEqual(DetailPlaybackFormatting.heroVideoBadgeLabel(versions[3]), "HDR")
+        XCTAssertNil(DetailPlaybackFormatting.heroVideoBadgeLabel(versions[4]))
+    }
+
     func testEffectiveAudioLabelPrefersServerEffectiveTrack() {
         let versions = decodedVersions("""
         [

--- a/iosApp/Tests/DetailVersionSelectionTests.swift
+++ b/iosApp/Tests/DetailVersionSelectionTests.swift
@@ -475,9 +475,9 @@ final class DetailVersionSelectionTests: XCTestCase {
         var data = OverlayData()
         data.resolution = "2160p"
         data.hdr = "DV HDR10"
-        XCTAssertEqual(combined.getValue(data), "4K Dolby Vision")
+        XCTAssertEqual(combined.getValue(data), "4K DV")
         data.resolution = nil
-        XCTAssertEqual(combined.getValue(data), "Dolby Vision")
+        XCTAssertEqual(combined.getValue(data), "DV")
         data.resolution = "2160p"
         data.hdr = nil
         XCTAssertEqual(combined.getValue(data), "4K")

--- a/iosApp/Tests/DetailVersionSelectionTests.swift
+++ b/iosApp/Tests/DetailVersionSelectionTests.swift
@@ -280,6 +280,33 @@ final class DetailVersionSelectionTests: XCTestCase {
         XCTAssertTrue(options[1].isSelected)
     }
 
+    func testAudioProfileCanMarkAtmosWithoutTitleHint() throws {
+        let versions = decodedVersions("""
+        [
+          {
+            "file_id": 1,
+            "audio_tracks": [
+              {
+                "codec": "eac3",
+                "profile": "Dolby Digital Plus + Dolby Atmos",
+                "layout": "5.1",
+                "channels": 6,
+                "default": true
+              }
+            ]
+          }
+        ]
+        """)
+
+        let track = try XCTUnwrap(versions[0].audioTracks?.first)
+        XCTAssertEqual(track.profile, "Dolby Digital Plus + Dolby Atmos")
+        XCTAssertTrue(DetailPlaybackFormatting.audioTrackIsAtmos(track))
+        XCTAssertEqual(
+            DetailPlaybackFormatting.audioValueLabel(version: versions[0], selectedAudioTrackIndex: nil),
+            "EAC3 Atmos"
+        )
+    }
+
     func testEffectiveAudioLabelPrefersServerEffectiveTrack() {
         let versions = decodedVersions("""
         [

--- a/iosApp/Tests/DetailVersionSelectionTests.swift
+++ b/iosApp/Tests/DetailVersionSelectionTests.swift
@@ -113,6 +113,12 @@ final class DetailVersionSelectionTests: XCTestCase {
         return try! decoder.decode([FileVersion].self, from: Data(json.utf8))
     }
 
+    private func decodedWatchDetail(_ json: String) throws -> WatchDetail {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(WatchDetail.self, from: Data(json.utf8))
+    }
+
     func testEditionsGroupVersionsByEditionLabel() {
         let versions = decodedVersions("""
         [
@@ -405,6 +411,56 @@ final class DetailVersionSelectionTests: XCTestCase {
         XCTAssertEqual(DetailPlaybackFormatting.heroVideoBadgeLabel(versions[2]), "HD")
         XCTAssertEqual(DetailPlaybackFormatting.heroVideoBadgeLabel(versions[3]), "HDR")
         XCTAssertNil(DetailPlaybackFormatting.heroVideoBadgeLabel(versions[4]))
+    }
+
+    func testPlayerMetadataUsesCombinedVideoAndSelectedAtmosCarrier() throws {
+        let detail = try decodedWatchDetail("""
+        {
+          "content_id": "episode-1",
+          "type": "episode",
+          "title": "The Episode",
+          "versions": [
+            {
+              "file_id": 1,
+              "resolution": "2160p",
+              "codec_video": "hevc",
+              "hdr": true,
+              "effective_audio_track_index": 0,
+              "video_tracks": [
+                { "codec": "hevc", "dv_profile": 8 }
+              ],
+              "audio_tracks": [
+                { "codec": "eac3", "profile": "Dolby Digital Plus + Dolby Atmos" },
+                { "codec": "truehd", "profile": "Dolby TrueHD + Dolby Atmos" }
+              ]
+            }
+          ]
+        }
+        """)
+        let session = PlaybackSessionResponse(
+            sessionId: "test-session",
+            userId: nil,
+            profileId: nil,
+            mediaFileId: 1,
+            playMethod: "direct",
+            position: 0,
+            isPaused: false,
+            streamUrl: "https://example.invalid/stream",
+            audioTrackIndex: 1,
+            durationSeconds: 60,
+            subtitleUrls: nil,
+            playbackInfo: nil
+        )
+        let prepared = PreparedPlayback(
+            watchDetail: detail,
+            selectedVersion: try XCTUnwrap(detail.versions.first),
+            session: session
+        )
+
+        XCTAssertEqual(
+            prepared.playerMetadata().badges,
+            ["4K Dolby Vision", "HEVC", "TrueHD Atmos"]
+        )
     }
 
     func testHomeVideoBadgesCombineWhenTheyShareACorner() throws {

--- a/iosApp/Tests/DetailVersionSelectionTests.swift
+++ b/iosApp/Tests/DetailVersionSelectionTests.swift
@@ -481,6 +481,8 @@ final class DetailVersionSelectionTests: XCTestCase {
         data.resolution = "2160p"
         data.hdr = nil
         XCTAssertEqual(combined.getValue(data), "4K")
+        data.hdr = "HLG"
+        XCTAssertEqual(combined.getValue(data), "4K HLG")
     }
 
     func testHomeVideoBadgesStaySeparateInDifferentCorners() {

--- a/iosApp/Tests/DetailVersionSelectionTests.swift
+++ b/iosApp/Tests/DetailVersionSelectionTests.swift
@@ -303,8 +303,71 @@ final class DetailVersionSelectionTests: XCTestCase {
         XCTAssertTrue(DetailPlaybackFormatting.audioTrackIsAtmos(track))
         XCTAssertEqual(
             DetailPlaybackFormatting.audioValueLabel(version: versions[0], selectedAudioTrackIndex: nil),
-            "EAC3 Atmos"
+            "DD+ Atmos"
         )
+    }
+
+    func testAtmosLabelsDistinguishCodecFamily() throws {
+        let versions = decodedVersions("""
+        [
+          {
+            "file_id": 1,
+            "audio_tracks": [
+              { "codec": "eac3", "profile": "Dolby Digital Plus + Dolby Atmos", "language": "eng" },
+              { "codec": "truehd", "profile": "Dolby TrueHD + Dolby Atmos" },
+              { "codec": "opus", "title": "English Atmos" },
+              { "codec": "eac3", "profile": "Dolby Digital Plus" }
+            ]
+          }
+        ]
+        """)
+        let tracks = try XCTUnwrap(versions[0].audioTracks)
+
+        XCTAssertEqual(DetailPlaybackFormatting.atmosBadgeLabel(tracks[0]), "DD+ Atmos")
+        XCTAssertEqual(DetailPlaybackFormatting.atmosBadgeLabel(tracks[1]), "TrueHD Atmos")
+        XCTAssertEqual(DetailPlaybackFormatting.atmosBadgeLabel(tracks[2]), "Atmos")
+        XCTAssertNil(DetailPlaybackFormatting.atmosBadgeLabel(tracks[3]))
+        XCTAssertEqual(DetailPlaybackFormatting.audioTitle(tracks[0], ordinal: 0), "English")
+        XCTAssertEqual(
+            DetailPlaybackFormatting.audioDetail(tracks[0], ordinal: 0, version: versions[0]),
+            "DD+ Atmos"
+        )
+    }
+
+    func testDynamicRangeLabelsPreferDolbyVisionEvidence() {
+        let versions = decodedVersions("""
+        [
+          {
+            "file_id": 1,
+            "resolution": "2160p",
+            "hdr": true,
+            "video_tracks": [
+              { "codec": "hevc", "dv_profile": 8, "video_range_type": "DOVIWithHDR10" }
+            ]
+          },
+          {
+            "file_id": 2,
+            "resolution": "2160p",
+            "hdr": true,
+            "video_tracks": [
+              { "codec": "hevc", "video_range_type": "HDR10" }
+            ]
+          },
+          {
+            "file_id": 3,
+            "resolution": "2160p",
+            "hdr": false,
+            "video_tracks": [
+              { "codec": "hevc", "dolby_vision": "Profile 5" }
+            ]
+          }
+        ]
+        """)
+
+        XCTAssertEqual(DetailPlaybackFormatting.dynamicRangeBadgeLabel(versions[0]), "DV")
+        XCTAssertEqual(DetailPlaybackFormatting.versionShortLabel(versions[0]), "2160p · DV")
+        XCTAssertEqual(DetailPlaybackFormatting.dynamicRangeBadgeLabel(versions[1]), "HDR")
+        XCTAssertEqual(DetailPlaybackFormatting.dynamicRangeBadgeLabel(versions[2]), "DV")
     }
 
     func testEffectiveAudioLabelPrefersServerEffectiveTrack() {

--- a/iosApp/Tests/HDRDisplayCriteriaPolicyTests.swift
+++ b/iosApp/Tests/HDRDisplayCriteriaPolicyTests.swift
@@ -205,7 +205,8 @@ final class HDRDisplayCriteriaPolicyTests: XCTestCase {
                     frameRate: "23.976", bitrate: nil, profile: nil,
                     level: nil, bitDepth: nil, colorRange: nil, colorSpace: nil,
                     colorPrimaries: nil, colorTransfer: colorTransfer,
-                    videoRange: videoRange, dolbyVision: nil, title: nil,
+                    videoRange: videoRange, videoRangeType: nil,
+                    dolbyVision: nil, dvProfile: nil, title: nil,
                     language: nil
                 )
             ],

--- a/iosApp/Tests/OfflinePlaybackMappingTests.swift
+++ b/iosApp/Tests/OfflinePlaybackMappingTests.swift
@@ -87,7 +87,9 @@ final class OfflinePlaybackMappingTests: XCTestCase {
             colorPrimaries: "bt2020",
             colorTransfer: colorTransfer,
             videoRange: nil,
+            videoRangeType: nil,
             dolbyVision: dolbyVisionProfile.map(String.init),
+            dvProfile: dolbyVisionProfile,
             title: nil,
             language: nil
         )

--- a/iosApp/Tests/PlaybackMediaFixtureTests.swift
+++ b/iosApp/Tests/PlaybackMediaFixtureTests.swift
@@ -132,6 +132,7 @@ final class PlaybackMediaFixtureTests: XCTestCase {
                 audioTracks: [AudioTrack(
                     index: 0,
                     codec: "aac",
+                    profile: nil,
                     channels: 2,
                     channelLayout: "stereo",
                     bitrate: 96_000,
@@ -205,7 +206,8 @@ final class PlaybackMediaFixtureTests: XCTestCase {
                     frameRate: "60.000", bitrate: 40_000, profile: "Main 10",
                     level: 153, bitDepth: 10, colorRange: "pc", colorSpace: nil,
                     colorPrimaries: nil, colorTransfer: nil,
-                    videoRange: "DolbyVision", dolbyVision: "Profile 5",
+                    videoRange: "DolbyVision", videoRangeType: nil,
+                    dolbyVision: "Profile 5", dvProfile: 5,
                     title: nil, language: nil
                 )
             ],

--- a/iosApp/Tests/PlaybackProtocolV3Tests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3Tests.swift
@@ -1626,6 +1626,7 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         AudioTrack(
             index: index,
             codec: codec,
+            profile: nil,
             channels: 6,
             channelLayout: "5.1",
             bitrate: 640_000,

--- a/iosApp/iosApp/Downloads/LocalMediaProbe.swift
+++ b/iosApp/iosApp/Downloads/LocalMediaProbe.swift
@@ -81,10 +81,12 @@ enum LocalMediaProbe {
                 // `color_transfer` is missing — which it is not here. Deriving
                 // our own would risk disagreeing with the server's vocabulary.
                 videoRange: nil,
+                videoRangeType: nil,
                 // A bare profile number: `dolbyVisionProfile(from:)` parses
                 // that first, and leaving it nil when no configuration record
                 // is present is what keeps `versionHasDolbyVision` honest.
                 dolbyVision: dolbyVision.map { String($0.profile) },
+                dvProfile: dolbyVision.map { Int($0.profile) },
                 title: nil,
                 language: nil
             ))

--- a/iosApp/iosApp/Downloads/OfflinePlayback.swift
+++ b/iosApp/iosApp/Downloads/OfflinePlayback.swift
@@ -176,6 +176,7 @@ enum OfflinePlaybackBuilder {
                 AudioTrack(
                     index: nil,
                     codec: track.codec,
+                    profile: nil,
                     channels: track.channels,
                     channelLayout: track.layout,
                     bitrate: track.bitrate,

--- a/iosApp/iosApp/Networking/Models.swift
+++ b/iosApp/iosApp/Networking/Models.swift
@@ -928,7 +928,9 @@ struct VideoTrack: Codable, Identifiable, Hashable {
     let colorPrimaries: String?
     let colorTransfer: String?
     let videoRange: String?
+    let videoRangeType: String?
     let dolbyVision: String?
+    let dvProfile: Int?
     let title: String?
     let language: String?
     var id: Int { index ?? 0 }

--- a/iosApp/iosApp/Networking/Models.swift
+++ b/iosApp/iosApp/Networking/Models.swift
@@ -937,6 +937,7 @@ struct VideoTrack: Codable, Identifiable, Hashable {
 struct AudioTrack: Codable, Identifiable, Hashable {
     let index: Int?
     let codec: String?
+    let profile: String?
     let channels: Int?
     /// Server field is `layout`, not `channel_layout`.
     let channelLayout: String?
@@ -955,6 +956,7 @@ struct AudioTrack: Codable, Identifiable, Hashable {
     enum CodingKeys: String, CodingKey {
         case index
         case codec
+        case profile
         case channels
         case channelLayout = "layout"
         case bitrate

--- a/iosApp/iosApp/Overlays/OverlayExtractors.swift
+++ b/iosApp/iosApp/Overlays/OverlayExtractors.swift
@@ -103,7 +103,7 @@ extension OverlayData {
     static let movieSample = OverlayData(
         resolution: "2160p",
         hdr: "DV HDR10",
-        audio: "DD+ Atmos",
+        audio: "Atmos",
         audioChannels: "7.1",
         videoCodec: "H.265",
         container: "MKV",

--- a/iosApp/iosApp/Overlays/OverlayExtractors.swift
+++ b/iosApp/iosApp/Overlays/OverlayExtractors.swift
@@ -103,7 +103,7 @@ extension OverlayData {
     static let movieSample = OverlayData(
         resolution: "2160p",
         hdr: "DV HDR10",
-        audio: "Atmos",
+        audio: "DD+ Atmos",
         audioChannels: "7.1",
         videoCodec: "H.265",
         container: "MKV",

--- a/iosApp/iosApp/Overlays/OverlayRegistry.swift
+++ b/iosApp/iosApp/Overlays/OverlayRegistry.swift
@@ -142,10 +142,8 @@ private extension OverlayRegistry {
 
     static func audioIcon(_ value: String?) -> OverlayIconId? {
         guard let value, !value.isEmpty else { return nil }
-        // `contains` instead of equality so "TrueHD Atmos" / "Dolby
-        // TrueHD Atmos" (Blu-ray remux labelling) still picks the brand
-        // mark. The server preserves carrier-specific labels when it can,
-        // with plain "Atmos" retained as the conservative fallback.
+        // `contains` keeps the Atmos mark correct for cached payloads from
+        // server versions that included the carrier in this compact field.
         return value.lowercased().contains("atmos") ? .atmos : .volume
     }
 

--- a/iosApp/iosApp/Overlays/OverlayRegistry.swift
+++ b/iosApp/iosApp/Overlays/OverlayRegistry.swift
@@ -117,7 +117,7 @@ private extension OverlayRegistry {
         guard let value, !value.isEmpty else { return nil }
         let lowered = value.lowercased()
         return lowered.contains("dv") || lowered.contains("dolby vision")
-            ? "Dolby Vision"
+            ? "DV"
             : "HDR"
     }
 
@@ -183,7 +183,7 @@ private extension OverlayRegistry {
             id: .resolutionHdr,
             category: .tech,
             label: "Resolution + HDR",
-            description: "Single badge combining resolution and dynamic range (e.g. \"4K Dolby Vision\").",
+            description: "Single badge combining resolution and dynamic range (e.g. \"4K DV\").",
             defaultPosition: .topLeft,
             defaultEnabled: false,
             iconCapable: true,

--- a/iosApp/iosApp/Overlays/OverlayRegistry.swift
+++ b/iosApp/iosApp/Overlays/OverlayRegistry.swift
@@ -144,8 +144,8 @@ private extension OverlayRegistry {
         guard let value, !value.isEmpty else { return nil }
         // `contains` instead of equality so "TrueHD Atmos" / "Dolby
         // TrueHD Atmos" (Blu-ray remux labelling) still picks the brand
-        // mark. The server normalizes most strings to plain "Atmos",
-        // but some passthrough surfaces preserve the upstream label.
+        // mark. The server preserves carrier-specific labels when it can,
+        // with plain "Atmos" retained as the conservative fallback.
         return value.lowercased().contains("atmos") ? .atmos : .volume
     }
 

--- a/iosApp/iosApp/Overlays/OverlayRegistry.swift
+++ b/iosApp/iosApp/Overlays/OverlayRegistry.swift
@@ -49,7 +49,10 @@ enum OverlayRegistry {
     /// hand-edited or written by an older client — are tolerated: the
     /// first occurrence wins, later ones are dropped, no trap.
     static func enabled(at position: OverlayPosition, in prefs: CardOverlayPrefs) -> [OverlayDef] {
+        let implicitCombined = implicitlyCombinesVideoBadges(at: position, in: prefs)
         let candidates = all.enumerated().filter { _, def in
+            if implicitCombined && def.id == .resolutionHdr { return true }
+            if implicitCombined && (def.id == .resolution || def.id == .hdr) { return false }
             guard let cfg = prefs.items[def.id] else { return false }
             if isSuppressed(def.id, by: prefs) { return false }
             return cfg.enabled && cfg.position == position
@@ -62,16 +65,33 @@ enum OverlayRegistry {
             prefs.order.enumerated().map { ($1, $0) },
             uniquingKeysWith: { first, _ in first }
         )
+        let overlayRank: (OverlayId) -> Int = { id in
+            if implicitCombined && id == .resolutionHdr {
+                return min(rank[.resolution] ?? Int.max, rank[.hdr] ?? Int.max)
+            }
+            return rank[id] ?? Int.max
+        }
         return candidates
             .sorted { lhs, rhs in
-                let lhsRank = rank[lhs.element.id] ?? Int.max
-                let rhsRank = rank[rhs.element.id] ?? Int.max
+                let lhsRank = overlayRank(lhs.element.id)
+                let rhsRank = overlayRank(rhs.element.id)
                 if lhsRank != rhsRank { return lhsRank < rhsRank }
                 // Equal ranks (typically both unranked at Int.max) →
                 // fall back to registry order.
                 return lhs.offset < rhs.offset
             }
             .map(\.element)
+    }
+
+    private static func implicitlyCombinesVideoBadges(
+        at position: OverlayPosition,
+        in prefs: CardOverlayPrefs
+    ) -> Bool {
+        if prefs.items[.resolutionHdr]?.enabled == true { return false }
+        guard let resolution = prefs.items[.resolution],
+              let hdr = prefs.items[.hdr] else { return false }
+        return resolution.enabled && hdr.enabled &&
+            resolution.position == position && hdr.position == position
     }
 }
 
@@ -93,9 +113,12 @@ private extension OverlayRegistry {
         }
     }
 
-    static func compactHdrSuffix(_ value: String?) -> String? {
+    static func combinedDynamicRangeLabel(_ value: String?) -> String? {
         guard let value, !value.isEmpty else { return nil }
-        return value.contains("DV") ? "DV" : "HDR"
+        let lowered = value.lowercased()
+        return lowered.contains("dv") || lowered.contains("dolby vision")
+            ? "Dolby Vision"
+            : "HDR"
     }
 
     /// Mirrors web's `hdrIcon`: only exact wordmark matches get a brand
@@ -160,14 +183,16 @@ private extension OverlayRegistry {
             id: .resolutionHdr,
             category: .tech,
             label: "Resolution + HDR",
-            description: "Single badge combining resolution and dynamic range (e.g. \"4K DV\").",
+            description: "Single badge combining resolution and dynamic range (e.g. \"4K Dolby Vision\").",
             defaultPosition: .topLeft,
             defaultEnabled: false,
             iconCapable: true,
             getValue: { data in
-                guard let res = prettyResolution(data.resolution) else { return nil }
-                if let hdr = compactHdrSuffix(data.hdr) { return "\(res) \(hdr)" }
-                return res
+                let parts = [
+                    prettyResolution(data.resolution),
+                    combinedDynamicRangeLabel(data.hdr),
+                ].compactMap { $0 }
+                return parts.isEmpty ? nil : parts.joined(separator: " ")
             },
             getIcon: { resolutionHdrIcon($0.hdr) }
         ),

--- a/iosApp/iosApp/Overlays/OverlayRegistry.swift
+++ b/iosApp/iosApp/Overlays/OverlayRegistry.swift
@@ -118,7 +118,7 @@ private extension OverlayRegistry {
         let lowered = value.lowercased()
         return lowered.contains("dv") || lowered.contains("dolby vision")
             ? "DV"
-            : "HDR"
+            : value
     }
 
     /// Mirrors web's `hdrIcon`: only exact wordmark matches get a brand

--- a/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
+++ b/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
@@ -556,6 +556,16 @@ enum DetailPlaybackFormatting {
         return codec.uppercased()
     }
 
+    /// True when the track carries Dolby Atmos. The server frequently omits it
+    /// from `channelLayout` (5.1 bed only), so also check the human title and
+    /// the embedded stream title for "atmos"/"joc".
+    static func audioTrackIsAtmos(_ track: AudioTrack) -> Bool {
+        [track.profile, track.channelLayout, track.title, track.embeddedTitle].contains { value in
+            guard let lowered = value?.lowercased() else { return false }
+            return lowered.contains("atmos") || lowered.contains("joc")
+        }
+    }
+
     static func normalizedSubtitleCodec(_ codec: String?) -> String? {
         guard let codec = codec?.lowercased(), !codec.isEmpty else { return nil }
         if codec == "srt" || codec.contains("subrip") { return "SRT" }
@@ -578,6 +588,7 @@ enum DetailPlaybackFormatting {
     }
 
     private static func compactAudioLayout(_ track: AudioTrack) -> String? {
+        if audioTrackIsAtmos(track) { return "Atmos" }
         if let layout = nonEmpty(track.channelLayout) {
             let lowered = layout.lowercased()
             if lowered.contains("atmos") { return "Atmos" }

--- a/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
+++ b/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
@@ -570,12 +570,21 @@ enum DetailPlaybackFormatting {
     static func heroVideoBadgeLabel(resolution: String?, dynamicRange: String?) -> String? {
         let normalizedResolution: String? = {
             guard let raw = resolution?.lowercased() else { return nil }
-            if raw.contains("2160") || raw.contains("4k") { return "4K" }
+            if raw.contains("4320") || raw.contains("8k") { return "8K" }
+            if raw.contains("2160") || raw.contains("4k") || raw.contains("uhd") { return "4K" }
             if raw.contains("1080") || raw.contains("720") { return "HD" }
             if raw.contains("480") { return "SD" }
             return nil
         }()
-        let parts = [normalizedResolution, nonEmpty(dynamicRange)].compactMap { $0 }
+        let normalizedDynamicRange: String? = {
+            guard let value = nonEmpty(dynamicRange) else { return nil }
+            let lowered = value.lowercased()
+            if lowered.contains("dolby vision") || lowered.contains("dovi") || lowered.contains("dv") {
+                return "Dolby Vision"
+            }
+            return value
+        }()
+        let parts = [normalizedResolution, normalizedDynamicRange].compactMap { $0 }
         return parts.isEmpty ? nil : parts.joined(separator: " ")
     }
 

--- a/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
+++ b/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
@@ -24,7 +24,7 @@ enum DetailPlaybackFormatting {
         let tokens = [
             nonEmpty(version.resolution),
             nonEmpty(normalizedVideoCodec(version.codecVideo)),
-            dynamicRangeLabel(version),
+            dynamicRangeBadgeLabel(version),
             nonEmpty(normalizedAudioCodec(version.codecAudio)),
         ].compactMap { $0 }
         return tokens.isEmpty ? "Auto" : tokens.joined(separator: " · ")
@@ -43,7 +43,7 @@ enum DetailPlaybackFormatting {
         let tokens = [
             nonEmpty(version.resolution),
             nonEmpty(normalizedVideoCodec(version.codecVideo)),
-            dynamicRangeLabel(version),
+            dynamicRangeBadgeLabel(version),
             nonEmpty(normalizedAudioCodec(version.codecAudio)),
         ].compactMap { $0 }
         if !tokens.isEmpty {
@@ -197,11 +197,15 @@ enum DetailPlaybackFormatting {
         if let title = usefulAudioTitle(track), title != audioTitle(track, ordinal: ordinal) {
             tokens.append(title)
         }
-        if let codec = normalizedAudioCodec(track.codec) {
-            tokens.append(codec)
-        }
-        if let layout = compactAudioLayout(track) {
-            tokens.append(layout)
+        if let atmos = atmosBadgeLabel(track) {
+            tokens.append(atmos)
+        } else {
+            if let codec = normalizedAudioCodec(track.codec) {
+                tokens.append(codec)
+            }
+            if let layout = compactAudioLayout(track) {
+                tokens.append(layout)
+            }
         }
         if track.isDefault == true {
             tokens.append("Default")
@@ -213,11 +217,15 @@ enum DetailPlaybackFormatting {
     }
 
     private static func audioSummary(_ track: AudioTrack, ordinal: Int) -> String {
-        let tokens = [
-            languageDisplayName(track.language),
-            nonEmpty(normalizedAudioCodec(track.codec)),
-            compactAudioLayout(track),
-        ].compactMap { $0 }
+        var tokens = [languageDisplayName(track.language)].compactMap { $0 }
+        if let atmos = atmosBadgeLabel(track) {
+            tokens.append(atmos)
+        } else {
+            tokens += [
+                nonEmpty(normalizedAudioCodec(track.codec)),
+                compactAudioLayout(track),
+            ].compactMap { $0 }
+        }
         return tokens.isEmpty ? audioTitle(track, ordinal: ordinal) : tokens.joined(separator: " · ")
     }
 
@@ -535,8 +543,18 @@ enum DetailPlaybackFormatting {
         return codec.uppercased()
     }
 
-    private static func dynamicRangeLabel(_ version: FileVersion) -> String? {
-        if (version.videoTracks ?? []).contains(where: { nonEmpty($0.dolbyVision) != nil }) {
+    static func videoTrackIsDolbyVision(_ track: VideoTrack) -> Bool {
+        if nonEmpty(track.dolbyVision) != nil || (track.dvProfile ?? 0) > 0 {
+            return true
+        }
+        return [track.videoRange, track.videoRangeType].compactMap(nonEmpty).contains { value in
+            let normalized = value.lowercased()
+            return normalized.contains("dolbyvision") || normalized.contains("dovi")
+        }
+    }
+
+    static func dynamicRangeBadgeLabel(_ version: FileVersion) -> String? {
+        if (version.videoTracks ?? []).contains(where: videoTrackIsDolbyVision) {
             return "DV"
         }
         return version.hdr == true ? "HDR" : nil
@@ -563,6 +581,16 @@ enum DetailPlaybackFormatting {
         [track.profile, track.channelLayout, track.title, track.embeddedTitle].contains { value in
             guard let lowered = value?.lowercased() else { return false }
             return lowered.contains("atmos") || lowered.contains("joc")
+        }
+    }
+
+    static func atmosBadgeLabel(_ track: AudioTrack) -> String? {
+        guard audioTrackIsAtmos(track) else { return nil }
+
+        switch normalizedAudioCodec(track.codec) {
+        case "EAC3": return "DD+ Atmos"
+        case "TrueHD": return "TrueHD Atmos"
+        default: return "Atmos"
         }
     }
 

--- a/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
+++ b/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
@@ -560,6 +560,25 @@ enum DetailPlaybackFormatting {
         return version.hdr == true ? "HDR" : nil
     }
 
+    static func heroVideoBadgeLabel(_ version: FileVersion) -> String? {
+        heroVideoBadgeLabel(
+            resolution: version.resolution,
+            dynamicRange: dynamicRangeBadgeLabel(version)
+        )
+    }
+
+    static func heroVideoBadgeLabel(resolution: String?, dynamicRange: String?) -> String? {
+        let normalizedResolution: String? = {
+            guard let raw = resolution?.lowercased() else { return nil }
+            if raw.contains("2160") || raw.contains("4k") { return "4K" }
+            if raw.contains("1080") || raw.contains("720") { return "HD" }
+            if raw.contains("480") { return "SD" }
+            return nil
+        }()
+        let parts = [normalizedResolution, nonEmpty(dynamicRange)].compactMap { $0 }
+        return parts.isEmpty ? nil : parts.joined(separator: " ")
+    }
+
     static func normalizedAudioCodec(_ codec: String?) -> String? {
         guard let codec = codec?.lowercased(), !codec.isEmpty else { return nil }
         if codec.contains("eac3") || codec.contains("e-ac-3") || codec.contains("ec-3") {

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneHeroMetadata.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneHeroMetadata.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// A token in the hero's facts row. `.text` items get a middle-dot
 /// separator between them; `.rating` renders a green check + maturity
-/// label; `.chip` renders an outlined uppercase pill (4K / HDR / ATMOS / CC).
+/// label; `.chip` renders an outlined pill (4K Dolby Vision / DD+ Atmos / CC).
 enum PhoneHeroFactToken: Hashable {
     case text(String)
     case rating(String)

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneHeroMetadata.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneHeroMetadata.swift
@@ -168,9 +168,8 @@ enum PhoneHeroMetadata {
     private static func qualityTokens(from detail: ItemDetail, version selectedVersion: FileVersion? = nil) -> [PhoneHeroFactToken] {
         guard let version = selectedVersion ?? preferredVersion(from: detail) else { return [] }
         var tokens: [PhoneHeroFactToken] = []
-        if let res = resolutionLabel(version.resolution) { tokens.append(.chip(res)) }
-        if let dynamicRange = DetailPlaybackFormatting.dynamicRangeBadgeLabel(version) {
-            tokens.append(.chip(dynamicRange))
+        if let video = DetailPlaybackFormatting.heroVideoBadgeLabel(version) {
+            tokens.append(.chip(video))
         }
         if let audio = primaryAudioLabel(version: version) { tokens.append(.chip(audio)) }
         if hasSubtitles(version: version) { tokens.append(.chip("CC")) }
@@ -184,15 +183,6 @@ enum PhoneHeroMetadata {
             return lastVersion
         }
         return versions.first
-    }
-
-    private static func resolutionLabel(_ raw: String?) -> String? {
-        guard let raw = raw?.lowercased() else { return nil }
-        if raw.contains("2160") || raw.contains("4k") { return "4K" }
-        if raw.contains("1080") { return "HD" }
-        if raw.contains("720") { return "HD" }
-        if raw.contains("480") { return "SD" }
-        return nil
     }
 
     private static func primaryAudioLabel(version: FileVersion) -> String? {

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneHeroMetadata.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneHeroMetadata.swift
@@ -169,8 +169,8 @@ enum PhoneHeroMetadata {
         guard let version = selectedVersion ?? preferredVersion(from: detail) else { return [] }
         var tokens: [PhoneHeroFactToken] = []
         if let res = resolutionLabel(version.resolution) { tokens.append(.chip(res)) }
-        if version.hdr == true {
-            tokens.append(.chip(dolbyVisionLabel(version: version) ?? "HDR"))
+        if let dynamicRange = DetailPlaybackFormatting.dynamicRangeBadgeLabel(version) {
+            tokens.append(.chip(dynamicRange))
         }
         if let audio = primaryAudioLabel(version: version) { tokens.append(.chip(audio)) }
         if hasSubtitles(version: version) { tokens.append(.chip("CC")) }
@@ -195,21 +195,13 @@ enum PhoneHeroMetadata {
         return nil
     }
 
-    private static func dolbyVisionLabel(version: FileVersion) -> String? {
-        let videoTracks = version.videoTracks ?? []
-        if videoTracks.contains(where: { ($0.dolbyVision ?? "").isEmpty == false }) {
-            return "DOLBY VISION"
-        }
-        return nil
-    }
-
     private static func primaryAudioLabel(version: FileVersion) -> String? {
         let tracks = version.audioTracks ?? []
         let defaultTrack = tracks.first(where: { $0.isDefault == true }) ?? tracks.first
         guard let track = defaultTrack else { return nil }
 
+        if let atmos = DetailPlaybackFormatting.atmosBadgeLabel(track) { return atmos }
         if let layout = track.channelLayout?.lowercased() {
-            if layout.contains("atmos") { return "ATMOS" }
             if layout.contains("7.1") { return "7.1" }
             if layout.contains("5.1") { return "5.1" }
             if layout.contains("stereo") || layout == "2.0" { return nil }

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
@@ -1404,6 +1404,7 @@ final class AVPlayerBackend {
                     title: track.title,
                     lang: track.lang,
                     codec: track.codec,
+                    audioProfile: track.audioProfile,
                     audioChannelsLayout: track.audioChannelsLayout,
                     audioChannelCount: track.audioChannelCount,
                     bitrate: track.bitrate,
@@ -4700,10 +4701,7 @@ final class AVPlayerBackend {
 
     private static func loopbackPreservesAtmos(for track: PlayerTrack) -> Bool {
         guard normalizedCodecToken(track.codec) == "eac3" else { return false }
-        let title = track.title?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased()
-        return title?.contains("atmos") == true || title?.contains("joc") == true
+        return track.hasAtmosHint
     }
 
     private static func normalizedCodecToken(_ raw: String?) -> String? {

--- a/iosApp/iosApp/Screens/Player/ApplePlaybackRoutePlanner.swift
+++ b/iosApp/iosApp/Screens/Player/ApplePlaybackRoutePlanner.swift
@@ -1118,6 +1118,7 @@ private extension ApplePlaybackRoutePlanner {
                 title: track.title,
                 lang: track.lang,
                 codec: track.codec,
+                audioProfile: track.audioProfile,
                 audioChannelsLayout: track.audioChannelsLayout,
                 audioChannelCount: track.audioChannelCount,
                 bitrate: track.bitrate,
@@ -1181,8 +1182,7 @@ private extension ApplePlaybackRoutePlanner {
         guard normalizedToken(track.codec)?.replacingOccurrences(of: "-", with: "") == "eac3" else {
             return false
         }
-        let titleToken = normalizedToken(track.title)
-        return titleToken?.contains("atmos") == true || titleToken?.contains("joc") == true
+        return track.hasAtmosHint
     }
 
     static func loopbackSourceFrameRate(for version: FileVersion) -> Float? {
@@ -1247,6 +1247,7 @@ private extension PlayerTrack {
             title: audioTrack.title,
             lang: audioTrack.language,
             codec: audioTrack.codec,
+            audioProfile: audioTrack.profile,
             audioChannelsLayout: audioTrack.channelLayout,
             audioChannelCount: audioTrack.channels,
             bitrate: audioTrack.bitrate.map(Int64.init),

--- a/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
@@ -57,8 +57,8 @@ struct PreparedPlayback {
         if let resolution = selectedVersion.resolution, !resolution.isEmpty {
             badges.append(PlayerMetadata.badgeLabel(forResolution: resolution))
         }
-        if selectedVersion.hdr == true {
-            badges.append("HDR")
+        if let dynamicRange = DetailPlaybackFormatting.dynamicRangeBadgeLabel(selectedVersion) {
+            badges.append(dynamicRange)
         }
         if let codec = selectedVersion.codecVideo?.uppercased(), !codec.isEmpty {
             badges.append(codec)

--- a/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
@@ -54,16 +54,24 @@ struct PreparedPlayback {
         }()
 
         var badges: [String] = []
-        if let resolution = selectedVersion.resolution, !resolution.isEmpty {
-            badges.append(PlayerMetadata.badgeLabel(forResolution: resolution))
-        }
-        if let dynamicRange = DetailPlaybackFormatting.dynamicRangeBadgeLabel(selectedVersion) {
-            badges.append(dynamicRange)
+        if let video = DetailPlaybackFormatting.heroVideoBadgeLabel(selectedVersion) {
+            badges.append(video)
         }
         if let codec = selectedVersion.codecVideo?.uppercased(), !codec.isEmpty {
             badges.append(codec)
         }
-        if let layout = primaryAudioLayout?.uppercased(), !layout.isEmpty {
+        let audioTrack: AudioTrack? = {
+            guard let ordinal = DetailPlaybackFormatting.resolvedAudioOrdinal(
+                version: selectedVersion,
+                selectedAudioTrackIndex: session.audioTrackIndex
+            ), let tracks = selectedVersion.audioTracks,
+               tracks.indices.contains(ordinal) else { return nil }
+            return tracks[ordinal]
+        }()
+        if let audioTrack,
+           let atmos = DetailPlaybackFormatting.atmosBadgeLabel(audioTrack) {
+            badges.append(atmos)
+        } else if let layout = primaryAudioLayout?.uppercased(), !layout.isEmpty {
             badges.append(layout)
         } else if let audioCodec = selectedVersion.codecAudio?.uppercased(), !audioCodec.isEmpty {
             badges.append(audioCodec)
@@ -112,7 +120,7 @@ struct PlayerMetadata: Equatable {
     /// Short plot description. Surfaced as secondary text below the title.
     var overview: String?
     /// Tagged media attributes rendered as pills in the hero strip:
-    /// "4K" / "HDR" / "DV" / "HEVC" / "5.1" etc.
+    /// "4K Dolby Vision" / "HEVC" / "DD+ Atmos" / "5.1" etc.
     var badges: [String]
 
     static let empty = PlayerMetadata(
@@ -123,18 +131,6 @@ struct PlayerMetadata: Equatable {
         overview: nil,
         badges: []
     )
-
-    /// Map raw resolution strings ("1920x1080", "1080p", "2160p") to the
-    /// short marketing label shown in the overlay ("4K" / "FHD" / "HD" / "SD").
-    static func badgeLabel(forResolution raw: String) -> String {
-        let lower = raw.lowercased()
-        if lower.contains("2160") || lower.contains("4k") { return "4K" }
-        if lower.contains("1440") { return "QHD" }
-        if lower.contains("1080") { return "FHD" }
-        if lower.contains("720") { return "HD" }
-        if lower.contains("480") { return "SD" }
-        return raw.uppercased()
-    }
 }
 
 enum PlaybackDeliveryStrategy {

--- a/iosApp/iosApp/Screens/Player/PlayerTrack.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerTrack.swift
@@ -19,6 +19,9 @@ struct PlayerTrack: Identifiable, Equatable, Hashable {
     let title: String?
     let lang: String?
     let codec: String?
+    /// Container/server-reported audio profile (for example Atmos/JOC hints
+    /// that are absent from the channel layout).
+    let audioProfile: String?
     /// Channel layout string (e.g. "stereo", "5.1(side)").
     let audioChannelsLayout: String?
     /// Numeric channel count when the demuxer reported it.
@@ -34,10 +37,55 @@ struct PlayerTrack: Identifiable, Equatable, Hashable {
     let ffIndex: Int?
     let srcId: Int?
 
+    init(
+        trackId: Int64,
+        kind: Kind,
+        title: String?,
+        lang: String?,
+        codec: String?,
+        audioProfile: String? = nil,
+        audioChannelsLayout: String?,
+        audioChannelCount: Int?,
+        bitrate: Int64?,
+        isDefault: Bool,
+        isForced: Bool,
+        isHearingImpaired: Bool,
+        isVisualImpaired: Bool,
+        isExternal: Bool,
+        isSelected: Bool,
+        ffIndex: Int?,
+        srcId: Int?
+    ) {
+        self.trackId = trackId
+        self.kind = kind
+        self.title = title
+        self.lang = lang
+        self.codec = codec
+        self.audioProfile = audioProfile
+        self.audioChannelsLayout = audioChannelsLayout
+        self.audioChannelCount = audioChannelCount
+        self.bitrate = bitrate
+        self.isDefault = isDefault
+        self.isForced = isForced
+        self.isHearingImpaired = isHearingImpaired
+        self.isVisualImpaired = isVisualImpaired
+        self.isExternal = isExternal
+        self.isSelected = isSelected
+        self.ffIndex = ffIndex
+        self.srcId = srcId
+    }
+
     var id: String { "\(kind.rawValue)-\(trackId)" }
 
     var normalizedTitle: String? {
         Self.normalizedText(title)
+    }
+
+    var hasAtmosHint: Bool {
+        [audioProfile, audioChannelsLayout, title].contains { value in
+            guard let token = Self.normalizedText(value)?.lowercased() else { return false }
+            return token.contains("atmos") || token.contains("joc")
+        }
     }
 
     var normalizedLanguageCode: String? {

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -7258,6 +7258,7 @@ class PlayerViewModel {
                 title: track.title,
                 lang: track.language,
                 codec: track.codec,
+                audioProfile: track.profile,
                 audioChannelsLayout: track.channelLayout,
                 audioChannelCount: track.channels,
                 bitrate: track.bitrate.map(Int64.init),
@@ -7284,6 +7285,7 @@ class PlayerViewModel {
                 title: track.title,
                 lang: track.lang,
                 codec: track.codec,
+                audioProfile: track.audioProfile,
                 audioChannelsLayout: track.audioChannelsLayout,
                 audioChannelCount: track.audioChannelCount,
                 bitrate: track.bitrate,
@@ -7342,8 +7344,7 @@ class PlayerViewModel {
         guard normalizedToken(track.codec)?.replacingOccurrences(of: "-", with: "") == "eac3" else {
             return false
         }
-        let titleToken = normalizedToken(track.title)
-        return titleToken?.contains("atmos") == true || titleToken?.contains("joc") == true
+        return track.hasAtmosHint
     }
 
     private func makeLoopbackSessionSpec(

--- a/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
+++ b/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
@@ -23,7 +23,7 @@ struct TVMarqueeContent: Equatable {
     /// Optional server logo art that may replace the text title once
     /// cached — the title always renders as text first.
     let logoUrl: String?
-    /// Codec/HDR + content-rating chips (`4K · DOLBY VISION · ATMOS · TV-MA`).
+    /// Quality + content-rating chips (`4K DOLBY VISION · DD+ ATMOS · TV-MA`).
     let badges: [String]
     /// Dot-joined meta tokens after the badges: year · genre · runtime,
     /// or `S2 E7 · episode title · 45 min · 23 min left` for episodes.

--- a/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
+++ b/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
@@ -113,33 +113,21 @@ extension TVMarqueeContent {
 
     // MARK: Formatting
 
-    /// Badge chips from the section payload's `OverlaySummary` — the
-    /// marquee shows the headline trio (resolution, dynamic range,
-    /// audio), uppercased to the §4.1 badge style.
+    /// Badge chips from the section payload's `OverlaySummary` — video
+    /// quality is combined into one label and audio preserves its carrier.
     private static func badges(from summary: OverlaySummary?) -> [String] {
         guard let summary else { return [] }
         var badges: [String] = []
-        if let resolution = prettyResolution(summary.resolution) {
-            badges.append(resolution)
-        }
-        if let hdr = nonEmpty(summary.hdr) {
-            badges.append(hdr.localizedCaseInsensitiveContains("dv") || hdr.localizedCaseInsensitiveContains("dolby")
-                ? "DOLBY VISION"
-                : hdr.uppercased())
+        if let video = DetailPlaybackFormatting.heroVideoBadgeLabel(
+            resolution: summary.resolution,
+            dynamicRange: summary.hdr
+        ) {
+            badges.append(video.uppercased())
         }
         if let audio = nonEmpty(summary.audio) {
-            badges.append(audio.localizedCaseInsensitiveContains("atmos") ? "ATMOS" : audio.uppercased())
+            badges.append(audio.uppercased())
         }
         return badges
-    }
-
-    private static func prettyResolution(_ value: String?) -> String? {
-        guard let value = nonEmpty(value) else { return nil }
-        switch value.lowercased() {
-        case "2160p", "4k", "uhd": return "4K"
-        case "4320p", "8k": return "8K"
-        default: return value.uppercased()
-        }
     }
 
     private static func episodeToken(season: Int?, episode: Int?) -> String? {

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVDetailHero.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVDetailHero.swift
@@ -570,8 +570,8 @@ enum TVHeroMetadata {
         if let res = resolutionLabel(version.resolution) {
             tokens.append(.chip(res))
         }
-        if version.hdr == true {
-            tokens.append(.chip(dolbyVisionLabel(version: version) ?? "HDR"))
+        if let dynamicRange = DetailPlaybackFormatting.dynamicRangeBadgeLabel(version) {
+            tokens.append(.chip(dynamicRange))
         }
         if let audio = primaryAudioLabel(version: version) {
             tokens.append(.chip(audio))
@@ -600,21 +600,13 @@ enum TVHeroMetadata {
         return nil
     }
 
-    private static func dolbyVisionLabel(version: FileVersion) -> String? {
-        let videoTracks = version.videoTracks ?? []
-        if videoTracks.contains(where: { ($0.dolbyVision ?? "").isEmpty == false }) {
-            return "DOLBY VISION"
-        }
-        return nil
-    }
-
     private static func primaryAudioLabel(version: FileVersion) -> String? {
         let tracks = version.audioTracks ?? []
         let defaultTrack = tracks.first(where: { $0.isDefault == true }) ?? tracks.first
         guard let track = defaultTrack else { return nil }
 
+        if let atmos = DetailPlaybackFormatting.atmosBadgeLabel(track) { return atmos }
         if let layout = track.channelLayout?.lowercased() {
-            if layout.contains("atmos") { return "ATMOS" }
             if layout.contains("7.1") { return "7.1" }
             if layout.contains("5.1") { return "5.1" }
             if layout.contains("stereo") || layout == "2.0" { return nil }

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVDetailHero.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVDetailHero.swift
@@ -567,11 +567,8 @@ enum TVHeroMetadata {
     private static func qualityTokens(from detail: ItemDetail, version selectedVersion: FileVersion? = nil) -> [TVHeroFactToken] {
         guard let version = selectedVersion ?? preferredVersion(from: detail) else { return [] }
         var tokens: [TVHeroFactToken] = []
-        if let res = resolutionLabel(version.resolution) {
-            tokens.append(.chip(res))
-        }
-        if let dynamicRange = DetailPlaybackFormatting.dynamicRangeBadgeLabel(version) {
-            tokens.append(.chip(dynamicRange))
+        if let video = DetailPlaybackFormatting.heroVideoBadgeLabel(version) {
+            tokens.append(.chip(video))
         }
         if let audio = primaryAudioLabel(version: version) {
             tokens.append(.chip(audio))
@@ -589,15 +586,6 @@ enum TVHeroMetadata {
             return lastVersion
         }
         return versions.first
-    }
-
-    private static func resolutionLabel(_ raw: String?) -> String? {
-        guard let raw = raw?.lowercased() else { return nil }
-        if raw.contains("2160") || raw.contains("4k") { return "4K" }
-        if raw.contains("1080") { return "HD" }
-        if raw.contains("720") { return "HD" }
-        if raw.contains("480") { return "SD" }
-        return nil
     }
 
     private static func primaryAudioLabel(version: FileVersion) -> String? {

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVDetailHero.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVDetailHero.swift
@@ -28,7 +28,7 @@ struct TVDetailHero<Actions: View, BelowSynopsis: View>: View {
     let overview: String?
     /// Inline facts row shown above the action buttons. Mixes plain text
     /// (year / runtime / maturity) and outlined quality chips
-    /// (4K / HDR / ATMOS / CC).
+    /// (4K Dolby Vision / DD+ Atmos / CC).
     let factsLine: [TVHeroFactToken]
     /// Optional "Starring A, B, C" line floated on the right of the hero
     /// at mid-height. Hidden when nil.
@@ -420,7 +420,7 @@ private struct TVHeroEyebrow: View {
 
 /// A token in the combined facts row. `.text` items get pipe separators
 /// between them; `.rating` renders a green check + maturity label;
-/// `.chip` renders an outlined pill (e.g. 4K / HDR / ATMOS).
+/// `.chip` renders an outlined pill (e.g. 4K Dolby Vision / DD+ Atmos).
 enum TVHeroFactToken: Hashable {
     case text(String)
     case rating(String)


### PR DESCRIPTION
## Problem

Some streams expose Dolby Atmos only in the audio stream `profile`, while Dolby Vision may be represented by `dolby_vision`, `dv_profile`, `video_range`, or `video_range_type`. The Apple client could therefore render profile-only Atmos as plain 5.1/EAC3, reduce Dolby Vision to generic HDR, show resolution and dynamic range as separate badges, or collapse a known carrier to generic `ATMOS` during playback.

## Approach

Decode the optional audio-profile and Dolby Vision fields already emitted by the server. Preserve the audio profile through `PlayerTrack` and loopback planning so profile-only EAC3 Atmos keeps the existing `preservesAtmos`/`mayClaimAtmos` behavior.

Centralize detail formatting in `DetailPlaybackFormatting`: EAC3 Atmos renders as `DD+ Atmos`, TrueHD Atmos as `TrueHD Atmos`, and unknown Atmos codecs retain the conservative `Atmos` fallback. Dolby Vision evidence takes precedence over generic HDR.

Phone and tvOS detail heroes use one full video chip such as `4K Dolby Vision` or `4K HDR`. Compact home-card overlays use `4K DV` and `Atmos`; combined non-Dolby formats preserve specific labels such as `4K HDR10` and `4K HLG`. Carrier-specific audio labels are reserved for roomier detail and player metadata. Deliberately placing resolution and HDR overlays in different corners keeps them separate. The focused-card marquee and in-player hero strip combine video quality and preserve the precise Atmos carrier. The player strip follows the selected session audio track, falling back to the server-effective/default track when needed. No stored overlay preference is rewritten.

Offline media constructors retain existing behavior by leaving unavailable profile and Dolby Vision metadata unset.

## Verification

- Regenerated the Xcode project with `xcodegen generate`.
- `SiloTV` builds successfully for the tvOS Simulator with code signing disabled.
- Focused test coverage is included for profile-only Atmos, codec-specific Atmos labels, Dolby Vision precedence, combined quality badges including HLG preservation, and selected-track player metadata.
- `git diff --check origin/main...HEAD` passes.
- Diff and commit metadata scans found no local paths, hostnames, private addresses, credentials, or personal data.

This does not claim device-level Atmos output testing.

## Risks & follow-up

The overlay change is presentation-only and preserves intentional different-corner layouts. The compact server summary remains `Atmos`; detail and player carrier labels derive from full audio-track metadata instead. Runtime decoder diagnostics also remain unchanged so they continue to describe the actual output stream rather than source-file metadata.

## AI-use disclosure

Implemented with a combination of Claude Code and Codex assistance, with human oversight.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Dolby Vision and HDR badges across detail pages, hero areas, overlays, and the player.
  * Added more accurate Atmos detection and codec-specific labels, including DD+ Atmos and TrueHD Atmos.
  * Combined video quality badges now display resolution and dynamic range more consistently.
  * Audio profile metadata is preserved during playback and offline media handling.

* **Bug Fixes**
  * Improved Atmos preservation when selecting and routing audio tracks.
  * Corrected badge precedence and merging for combined quality overlays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->