### PR TITLE
fix(subtitles): render PGS/DVD bitmap subtitles exactly as authored

### DIFF
--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
@@ -226,63 +226,18 @@ final class AVPlayerBackend {
     private var subtitleSession: SubtitleSession?
     private var embeddedSubtitleExtractor: AVPlayerEmbeddedSubtitleExtractor?
     /// Change-detection key for the overlay's bitmap cue layers: overlay
-    /// size, the identity of each active cue image, and the
-    /// appearance-derived style. The display link pumps at vsync rate but
-    /// bitmap cues change on the order of seconds, so all layer work is
-    /// skipped while the key is unchanged.
+    /// size and the identity of each active cue image. The display link
+    /// pumps at vsync rate but bitmap cues change on the order of
+    /// seconds, so all layer work is skipped while the key is unchanged.
+    ///
+    /// Bitmap cues (PGS/DVD) render exactly as authored — position, size,
+    /// and background are part of the source pixels, so the user's text
+    /// appearance preferences deliberately do not apply here.
     private struct BitmapCueRenderKey: Equatable {
         let videoRect: CGRect
         let images: [ObjectIdentifier]
-        let style: BitmapCueStyle
     }
     private var lastBitmapCueRenderKey: BitmapCueRenderKey?
-    /// The subset of the user's subtitle appearance that applies to
-    /// pre-rendered bitmap cues (PGS/DVD). Font, text color, and outline
-    /// are baked into the source pixels and cannot be restyled without
-    /// OCR; size, vertical placement, and a backing box can be honored —
-    /// matching what the styled-text path gives the same preferences.
-    private struct BitmapCueStyle: Equatable {
-        /// Scale relative to authored size, from the font-size ladder
-        /// (user preset / default preset).
-        let scale: CGFloat
-        /// Vertical placement preset (bottom keeps authored positions).
-        let position: SubtitlePositionPreset
-        /// Backing-box color hex + opacity when the background style is
-        /// `.box`; nil leaves the authored transparent background.
-        let boxColorHex: String?
-        let boxOpacity: Int
-
-        /// Authored-size calibration: Blu-ray PGS is typically rendered a
-        /// notch larger than the text ladder's default rung, so authored
-        /// size (ladder ratio 1.0) read bigger than SRT at the same
-        /// preset. Shrink the whole bitmap ladder so the default preset
-        /// visually matches the text render.
-        private static let authoredSizeCompensation: CGFloat = 0.85
-
-        static func from(_ appearance: SubtitleAppearance?) -> BitmapCueStyle {
-            guard let sanitized = appearance?.sanitized() else {
-                return BitmapCueStyle(
-                    scale: authoredSizeCompensation,
-                    position: .bottom,
-                    boxColorHex: nil,
-                    boxOpacity: 0
-                )
-            }
-            let defaultPoints = SubtitleAppearance.default.fontSize.pointSize
-            let scale = authoredSizeCompensation * (defaultPoints > 0
-                ? CGFloat(sanitized.fontSize.pointSize / defaultPoints)
-                : 1)
-            let box = sanitized.backgroundStyle == .box
-            return BitmapCueStyle(
-                scale: scale,
-                position: sanitized.position,
-                boxColorHex: box ? sanitized.backgroundColor : nil,
-                boxOpacity: box ? sanitized.backgroundOpacity : 0
-            )
-        }
-    }
-    /// Last appearance pushed by the view model; feeds `BitmapCueStyle`.
-    private var bitmapCueAppearance: SubtitleAppearance?
     /// Whether a libass-composited frame may still be on the text layer.
     /// Lets the pump clear the layer exactly once on a text → bitmap
     /// transition instead of dispatching a no-op clear to main every vsync
@@ -653,9 +608,6 @@ final class AVPlayerBackend {
 
     func applySubtitleAppearance(_ appearance: SubtitleAppearance) {
         print("[CMP-SUB] applySubtitleAppearance size=\(appearance.fontSize.rawValue) session=\(subtitleSession == nil ? "nil" : "live")")
-        // Bitmap cues re-lay-out on the next pump tick: the appearance is
-        // part of the render key, so the change invalidates it naturally.
-        bitmapCueAppearance = appearance
         let syncOffset = subtitleSession?.currentParams.syncOffsetMs ?? 0
         let params = SubtitleStylingOverride.Parameters.from(
             appearance: appearance,
@@ -3321,150 +3273,36 @@ final class AVPlayerBackend {
             width: max(0, bounds.width - videoInsets.left - videoInsets.right),
             height: max(0, bounds.height - videoInsets.top - videoInsets.bottom)
         )
-        let style = BitmapCueStyle.from(bitmapCueAppearance)
         let key = BitmapCueRenderKey(
             videoRect: videoRect,
-            images: cues.map { ObjectIdentifier($0.image) },
-            style: style
+            images: cues.map { ObjectIdentifier($0.image) }
         )
         guard key != lastBitmapCueRenderKey else { return }
         lastBitmapCueRenderKey = key
-        let bottomShift = Self.bitmapBottomAnchorShift(for: cues, in: videoRect, style: style)
         let placements = cues.map { cue in
-            Self.bitmapCuePlacement(for: cue, in: videoRect, style: style, bottomShift: bottomShift)
+            Self.bitmapCuePlacement(for: cue, in: videoRect)
         }
         DispatchQueue.main.async {
             overlay.updateBitmapCues(placements)
         }
     }
 
-    /// Cues whose authored bottom edge falls in this band are treated as
-    /// bottom-anchored dialogue for margin normalization; anything higher
-    /// is a floating sign that keeps its authored placement.
-    private static let bitmapBottomAnchorBand: CGFloat = 0.75
-    /// The text path's "Bottom" MarginV expressed as a fraction of the
-    /// 1080-line ASS playfield (see `SubtitleStylingOverride`). PGS is
-    /// re-margined to the same distance so both subtitle kinds sit at the
-    /// same height at the default position.
-    #if os(tvOS)
-    private static let bitmapBottomMarginFraction: CGFloat = 60.0 / 1080.0
-    #else
-    private static let bitmapBottomMarginFraction: CGFloat = 30.0 / 1080.0
-    #endif
-
-    /// Vertical delta that moves the bottom-anchored cue group's authored
-    /// bottom edge onto the text path's bottom margin. Computed over the
-    /// whole group (not per cue) so multi-rect compositions keep their
-    /// authored line spacing; applied only for the default `.bottom`
-    /// preset — the other presets reposition absolutely.
-    private static func bitmapBottomAnchorShift(
-        for cues: [BitmapSubtitleCue],
-        in videoRect: CGRect,
-        style: BitmapCueStyle
-    ) -> CGFloat {
-        guard style.position == .bottom else { return 0 }
-        let anchoredMaxY = cues.map(\.normalizedFrame.maxY)
-            .filter { $0 >= bitmapBottomAnchorBand }
-            .max()
-        guard let groupMaxY = anchoredMaxY else { return 0 }
-        let authoredBottom = videoRect.minY + groupMaxY * videoRect.height
-        let targetBottom = videoRect.maxY - videoRect.height * bitmapBottomMarginFraction
-        return targetBottom - authoredBottom
-    }
-
-    /// Lay out one bitmap cue honoring the applicable appearance
-    /// preferences (size scale, vertical placement, backing box). Only
-    /// bottom-region cues follow the position preference — top/mid cues
-    /// are typically authored "signs & typesetting" overlays whose
-    /// placement is part of the content.
+    /// Lay out one bitmap cue exactly as authored: the normalized frame
+    /// mapped onto the displayed video rect. PGS/DVD compositions are
+    /// pre-rendered pictures — size, placement, and background are part
+    /// of the content, so no appearance preferences are applied.
     private static func bitmapCuePlacement(
         for cue: BitmapSubtitleCue,
-        in videoRect: CGRect,
-        style: BitmapCueStyle,
-        bottomShift: CGFloat = 0
+        in videoRect: CGRect
     ) -> BitmapCuePlacement {
-        var frame = CGRect(
-            x: videoRect.minX + cue.normalizedFrame.origin.x * videoRect.width,
-            y: videoRect.minY + cue.normalizedFrame.origin.y * videoRect.height,
-            width: cue.normalizedFrame.width * videoRect.width,
-            height: cue.normalizedFrame.height * videoRect.height
-        )
-        let bottomRegion = cue.normalizedFrame.midY >= 0.5
-
-        // Size: scale about the edge the cue is visually anchored to, so
-        // dialogue grows upward from its baseline and signs grow downward
-        // from their authored top.
-        if style.scale != 1, frame.width > 0, frame.height > 0 {
-            let scaled = CGSize(
-                width: frame.width * style.scale,
-                height: frame.height * style.scale
-            )
-            frame = CGRect(
-                x: frame.midX - scaled.width / 2,
-                y: bottomRegion ? frame.maxY - scaled.height : frame.minY,
-                width: scaled.width,
-                height: scaled.height
-            )
-        }
-
-        // Vertical placement (bottom-region cues only). The default
-        // "Bottom" re-margins bottom-anchored dialogue onto the text
-        // path's bottom margin (authored PGS usually sits a broadcast-safe
-        // notch higher than our SRT render); floating signs outside the
-        // anchor band keep their authored placement.
-        if bottomRegion {
-            switch style.position {
-            case .bottom:
-                if cue.normalizedFrame.maxY >= Self.bitmapBottomAnchorBand {
-                    frame.origin.y += bottomShift
-                }
-            case .lowerThird:
-                frame.origin.y = videoRect.minY + videoRect.height * 0.70 - frame.height
-            case .top:
-                frame.origin.y = videoRect.minY + videoRect.height * 0.05
-            }
-        }
-
-        // Clamp into the video rect after scaling/moving.
-        frame.origin.x = min(max(frame.origin.x, videoRect.minX), max(videoRect.minX, videoRect.maxX - frame.width))
-        frame.origin.y = min(max(frame.origin.y, videoRect.minY), max(videoRect.minY, videoRect.maxY - frame.height))
-
-        // Backing box, mirroring the text path's box style. Padding tracks
-        // the cue size so it reads like the text box at any scale.
-        var backgroundFrame = frame
-        var backgroundColor: CGColor?
-        var cornerRadius: CGFloat = 0
-        if let hex = style.boxColorHex,
-           let color = Self.cgColor(hex: hex, opacityPercent: style.boxOpacity) {
-            let padV = min(22, max(6, frame.height * 0.16))
-            let padH = min(30, max(8, frame.height * 0.24))
-            backgroundFrame = frame.insetBy(dx: -padH, dy: -padV)
-                .intersection(videoRect.insetBy(dx: -2, dy: -2))
-            backgroundColor = color
-            cornerRadius = min(8, padV * 0.5)
-        }
-
-        return BitmapCuePlacement(
+        BitmapCuePlacement(
             image: cue.image,
-            frame: frame,
-            backgroundFrame: backgroundFrame,
-            backgroundColor: backgroundColor,
-            cornerRadius: cornerRadius
-        )
-    }
-
-    /// Parse "#RRGGBB" into a CGColor with the given opacity percent.
-    private static func cgColor(hex: String, opacityPercent: Int) -> CGColor? {
-        var raw = hex.trimmingCharacters(in: .whitespacesAndNewlines)
-        if raw.hasPrefix("#") { raw.removeFirst() }
-        guard raw.count == 6, let value = UInt32(raw, radix: 16) else { return nil }
-        let alpha = CGFloat(max(0, min(100, opacityPercent))) / 100
-        guard alpha > 0 else { return nil }
-        return CGColor(
-            srgbRed: CGFloat((value >> 16) & 0xFF) / 255,
-            green: CGFloat((value >> 8) & 0xFF) / 255,
-            blue: CGFloat(value & 0xFF) / 255,
-            alpha: alpha
+            frame: CGRect(
+                x: videoRect.minX + cue.normalizedFrame.origin.x * videoRect.width,
+                y: videoRect.minY + cue.normalizedFrame.origin.y * videoRect.height,
+                width: cue.normalizedFrame.width * videoRect.width,
+                height: cue.normalizedFrame.height * videoRect.height
+            )
         )
     }
 

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -3982,6 +3982,16 @@ class PlayerViewModel {
         let externalSubtitleSnapshot = knownExternalSubtitles
         let selectedSubtitleSnapshot = selectedSubtitleId
         let selectedSecondarySubtitleSnapshot = selectedSecondarySubtitleId
+        // An embedded selection can't be re-established by trackId across
+        // the backend rebuild (ids aren't stable), and after a switch to
+        // transcode the same stream may resurface as a sidecar instead.
+        // Snapshot its attributes for fuzzy re-selection — the same
+        // mechanism interruption recovery and route fallback use.
+        let embeddedSubtitleSelectionSnapshot = selectedSubtitleId
+            .flatMap { selectedId in subtitleTracks.first(where: { $0.trackId == selectedId }) }
+            .flatMap { track in
+                SubtitleTrackIdSpace.isSyntheticNonEmbedded(track.trackId) ? nil : TrackSelectionSnapshot(track: track)
+            }
         let previousQualityId = activeQualityId
         if source == "quality" {
             activeQualityId = qualityId
@@ -4041,14 +4051,23 @@ class PlayerViewModel {
                 )
                 self.pendingExternalSubtitles = session.subtitleUrls ?? externalSubtitleSnapshot
                 self.knownExternalSubtitles = self.pendingExternalSubtitles
-                // Only a sidecar selection is re-established across the
-                // backend rebuild. An AI-live selection is intentionally
-                // dropped here (not restored as sidecar and not as embedded):
-                // its cues can't be replayed, so live re-selection is M4's
-                // responsibility via the live coordinator.
+                // Re-establish the subtitle selection across the backend
+                // rebuild. Sidecar ids are stable (urlIndex-derived) and
+                // restore by id; an embedded selection restores by fuzzy
+                // attribute match — against embedded tracks if the new
+                // route enumerates them, or against the sidecar rows the
+                // server extracts them into (see `appendSidecarTracks`).
+                // An AI-live selection is intentionally dropped here (not
+                // restored as sidecar and not as embedded): its cues can't
+                // be replayed, so live re-selection is M4's responsibility
+                // via the live coordinator.
                 if let selectedSubtitleSnapshot,
                    SubtitleTrackIdSpace.isSidecar(selectedSubtitleSnapshot) {
                     self.pendingSidecarSubtitleTrackId = selectedSubtitleSnapshot
+                }
+                self.pendingRecoveredSubtitleSelection = embeddedSubtitleSelectionSnapshot
+                if embeddedSubtitleSelectionSnapshot != nil {
+                    self.hasExplicitSubtitleChoice = true
                 }
                 self.pendingRecoveredSecondarySubtitleId = selectedSecondarySubtitleSnapshot
                 self.duration = session.durationSeconds ?? selectedVersion.duration ?? self.duration
@@ -6179,6 +6198,24 @@ class PlayerViewModel {
         }
 
         if restoredPrimarySidecar { return }
+
+        // A pre-restart embedded selection can resurface as a sidecar when
+        // the new route has the server extract embedded streams into
+        // `subtitle_urls` (direct → transcode switch). If the embedded
+        // snapshot is still pending — no embedded track matched it in
+        // `applyTrackList` — fuzzy-match it against the sidecar rows.
+        if let snapshot = pendingRecoveredSubtitleSelection,
+           let match = bestTrackMatch(
+               for: snapshot,
+               in: subtitleTracks.filter { SubtitleTrackIdSpace.isSidecar($0.trackId) }
+           ) {
+            pendingRecoveredSubtitleSelection = nil
+            if selectedSubtitleId != match.trackId {
+                selectedSubtitleId = match.trackId
+                applySubtitleTrackSelection(match.trackId)
+            }
+            return
+        }
 
         // If a forced sidecar is present, auto-select it. Forced tracks
         // (for non-native dialogue or song lyrics in anime) are meant

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleOverlayView.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleOverlayView.swift
@@ -34,22 +34,17 @@ private func withoutImplicitLayerAnimation(_ updates: () -> Void) {
 }
 
 /// One positioned bitmap subtitle cue. `frame` is the image rect in
-/// overlay points (top-left origin). `backgroundFrame` is the
-/// preference-driven backing box around it — equal to `frame` when no
-/// box is drawn. All layout math lives with the caller; the overlay
-/// only assigns layer geometry.
+/// overlay points (top-left origin). Bitmap cues render exactly as
+/// authored — no preference-driven restyling. All layout math lives
+/// with the caller; the overlay only assigns layer geometry.
 struct BitmapCuePlacement {
     let image: CGImage
     let frame: CGRect
-    let backgroundFrame: CGRect
-    let backgroundColor: CGColor?
-    let cornerRadius: CGFloat
 }
 
-/// Grow/shrink the host's sublayer list to exactly `count` cue layer
-/// pairs: a container (the preference-driven backing box) holding one
-/// image sublayer. Cue images are pre-cropped to their frames, so
-/// `.resize` maps the image 1:1 onto its layer. Callers wrap this in a
+/// Grow/shrink the host's sublayer list to exactly `count` cue image
+/// layers. Cue images are pre-cropped to their frames, so `.resize`
+/// maps the image 1:1 onto its layer. Callers wrap this in a
 /// no-animation transaction.
 private func syncBitmapCueLayerCount(_ count: Int, host: CALayer) {
     var current = host.sublayers?.count ?? 0
@@ -58,32 +53,18 @@ private func syncBitmapCueLayerCount(_ count: Int, host: CALayer) {
         current -= 1
     }
     while current < count {
-        let container = CALayer()
-        container.isOpaque = false
-        container.masksToBounds = false
         let image = CALayer()
         image.contentsGravity = .resize
         image.isOpaque = false
-        container.addSublayer(image)
-        host.addSublayer(container)
+        host.addSublayer(image)
         current += 1
     }
 }
 
-/// Assign one placement to its container/image layer pair. The image
-/// frame is expressed in the container's coordinate space.
-private func applyBitmapCuePlacement(_ placement: BitmapCuePlacement, to container: CALayer) {
-    container.frame = placement.backgroundFrame
-    container.backgroundColor = placement.backgroundColor
-    container.cornerRadius = placement.cornerRadius
-    guard let imageLayer = container.sublayers?.first else { return }
+/// Assign one placement to its image layer.
+private func applyBitmapCuePlacement(_ placement: BitmapCuePlacement, to imageLayer: CALayer) {
     imageLayer.contents = placement.image
-    imageLayer.frame = CGRect(
-        x: placement.frame.minX - placement.backgroundFrame.minX,
-        y: placement.frame.minY - placement.backgroundFrame.minY,
-        width: placement.frame.width,
-        height: placement.frame.height
-    )
+    imageLayer.frame = placement.frame
 }
 
 private func removeBitmapCueLayers(host: CALayer) {

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPlayerInfoHUD.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPlayerInfoHUD.swift
@@ -1,5 +1,31 @@
 #if os(tvOS)
+import QuartzCore
 import SwiftUI
+
+/// Coalesces duplicate d-pad move commands in the HUD's manual-movement
+/// handlers (the docs/tvos-focus.md bridging pattern). SwiftUI surfaces the
+/// Siri Remote's touch surface as discrete `.onMoveCommand` steps alongside
+/// ring clicks, so one physical gesture — a click with a resting-thumb
+/// micro-swipe, or a short swipe — can deliver two same-direction commands
+/// milliseconds apart. Native focus movement dampens that with gesture
+/// physics; manual row stepping does not, and each duplicate steps a whole
+/// row ("focus skips two items"). Dropping a same-direction command inside
+/// the window keeps one physical input to one step while staying below the
+/// ~100 ms cadence of held-press auto-repeat, so held scrolling is
+/// unaffected.
+struct HUDMoveCommandCoalescer {
+    private var lastDirection: MoveCommandDirection?
+    private var lastTime: CFTimeInterval = 0
+    private static let window: CFTimeInterval = 0.08
+
+    mutating func shouldStep(_ direction: MoveCommandDirection) -> Bool {
+        let now = CACurrentMediaTime()
+        let isDuplicate = direction == lastDirection && (now - lastTime) < Self.window
+        lastDirection = direction
+        lastTime = now
+        return !isDuplicate
+    }
+}
 
 /// Infuse-style floating top-center HUD. A pill-tab header (Info / Video /
 /// Audio / Subtitles / Chapters) selects which content pane renders below.
@@ -254,6 +280,7 @@ private struct HUDScrollablePane<Content: View>: View {
     let content: () -> Content
 
     @State private var scrollTargetIndex: Int = 0
+    @State private var moveCoalescer = HUDMoveCommandCoalescer()
     @FocusState private var isFocused: Bool
 
     init(
@@ -297,6 +324,7 @@ private struct HUDScrollablePane<Content: View>: View {
 
     private func handleMove(_ direction: MoveCommandDirection, proxy: ScrollViewProxy) {
         guard isFocused else { return }
+        guard moveCoalescer.shouldStep(direction) else { return }
 
         let nextIndex: Int
         switch direction {
@@ -930,6 +958,7 @@ private struct HUDPickerDialog: View {
     let onClose: () -> Void
 
     @FocusState private var focusedOptionID: String?
+    @State private var moveCoalescer = HUDMoveCommandCoalescer()
 
     var body: some View {
         VStack(alignment: .leading, spacing: 18) {
@@ -991,6 +1020,7 @@ private struct HUDPickerDialog: View {
     }
 
     private func handleMove(_ direction: MoveCommandDirection, proxy: ScrollViewProxy) {
+        guard moveCoalescer.shouldStep(direction) else { return }
         let ids = options.map(\.id)
         let index = focusedOptionID.flatMap { ids.firstIndex(of: $0) }
         switch direction {
@@ -1081,6 +1111,7 @@ private struct SubtitleAppearanceDialog: View {
     @State private var activePicker: HUDPickerPresentation?
     @State private var pickerReturnField: Field?
     @FocusState private var focusedField: Field?
+    @State private var moveCoalescer = HUDMoveCommandCoalescer()
 
     private enum Field: Hashable {
         case close
@@ -1384,6 +1415,7 @@ private struct SubtitleAppearanceDialog: View {
     ]
 
     private func handleRowMove(_ direction: MoveCommandDirection, proxy: ScrollViewProxy) {
+        guard moveCoalescer.shouldStep(direction) else { return }
         let index = focusedField.flatMap { Self.rowOrder.firstIndex(of: $0) }
         switch direction {
         case .up:
@@ -1502,6 +1534,7 @@ private struct AudioPane: View {
     let onMoveToTabs: () -> Void
 
     @FocusState private var focusedTrackID: String?
+    @State private var moveCoalescer = HUDMoveCommandCoalescer()
 
     var body: some View {
         HStack(alignment: .top, spacing: 48) {
@@ -1554,6 +1587,7 @@ private struct AudioPane: View {
     }
 
     private func handleTrackMove(_ direction: MoveCommandDirection, proxy: ScrollViewProxy) {
+        guard moveCoalescer.shouldStep(direction) else { return }
         let ids = trackIDs
         let index = focusedTrackID.flatMap { ids.firstIndex(of: $0) }
         switch direction {
@@ -1613,6 +1647,7 @@ private struct SubtitlesPane: View {
     @State private var activePicker: HUDPickerPresentation?
     @State private var pickerReturnField: Option?
     @FocusState private var focusedOption: Option?
+    @State private var moveCoalescer = HUDMoveCommandCoalescer()
 
     /// Identity for the options-column rows, used only to restore focus when
     /// a picker dialog, the appearance dialog, or the AI/search menu closes.
@@ -1861,6 +1896,7 @@ private struct SubtitlesPane: View {
     }
 
     private func handleTrackMove(_ direction: MoveCommandDirection, proxy: ScrollViewProxy) {
+        guard moveCoalescer.shouldStep(direction) else { return }
         let ids = trackListIDs
         let index = focusedTrackID.flatMap { ids.firstIndex(of: $0) }
         switch direction {
@@ -1890,6 +1926,7 @@ private struct SubtitlesPane: View {
     }
 
     private func handleOptionMove(_ direction: MoveCommandDirection, proxy: ScrollViewProxy) {
+        guard moveCoalescer.shouldStep(direction) else { return }
         let options = visibleOptions
         let index = focusedOption.flatMap { options.firstIndex(of: $0) }
         switch direction {
@@ -2066,6 +2103,7 @@ private struct ChaptersPane: View {
     let onMoveToTabs: () -> Void
 
     @FocusState private var focusedIndex: Int?
+    @State private var moveCoalescer = HUDMoveCommandCoalescer()
 
     private var currentIndex: Int? {
         viewModel.chapters.lastIndex(where: { $0.time <= viewModel.currentTime })
@@ -2103,6 +2141,7 @@ private struct ChaptersPane: View {
     }
 
     private func handleMove(_ direction: MoveCommandDirection, proxy: ScrollViewProxy) {
+        guard moveCoalescer.shouldStep(direction) else { return }
         let count = viewModel.chapters.count
         switch direction {
         case .up:


### PR DESCRIPTION
## Summary
Undo the appearance restyling of bitmap subtitles (PGS/DVD) and show them natively.

Previously, bitmap cues were run through a `BitmapCueStyle` derived from the user's text-subtitle appearance:
- rescaled by the font-size ladder ratio (plus a 0.85 "authored size" calibration)
- bottom-anchored dialogue re-margined onto the text path's bottom margin
- repositioned by the vertical placement preset (lower-third / top)
- wrapped in a preference-driven backing box

PGS compositions are pre-rendered pictures — size, placement, and background are authored into the source pixels. Restyling them fought the content. Now each cue's authored normalized frame maps straight onto the displayed video rect, untouched.

## Changes
- `AVPlayerBackend`: removed `BitmapCueStyle`, `bitmapCueAppearance`, the bottom-anchor shift, position/scale/box logic, and the hex→CGColor helper. `bitmapCuePlacement` is now a pure authored-frame → video-rect mapping. The render key no longer includes style.
- `SubtitleOverlayView`: `BitmapCuePlacement` reduces to `image` + `frame`; the per-cue container/box layer pair collapses to a single image layer.
- Net −181 lines.

Text subtitle styling (libass path) is unaffected — `applySubtitleAppearance` still feeds it.

## Test plan
- [x] tvOS: play a file with PGS subtitles — cues appear at authored size/position, no backing box
- [x] Changing subtitle appearance settings during PGS playback has no effect on PGS (still applies to text tracks)
- [x] Letterboxed content: PGS cues stay inside the picture as authored
- [x] iOS: PGS renders as authored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bitmap subtitle rendering so cues match the source (“exactly as authored”) and redraw only when the video area or active cue images change.
  * Simplified bitmap subtitle overlay composition by removing preference-based backing box behavior and applying cue images directly to their target frames.
* **New Features**
  * Preserved embedded subtitle selection across in-place transcode/HLS backend rebuilds, restoring the prior embedded track when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->