### PR TITLE
feat(apple): respect server section card image style

### DIFF
--- a/iosApp/Tests/LibraryVisibilityTests.swift
+++ b/iosApp/Tests/LibraryVisibilityTests.swift
@@ -1,6 +1,13 @@
 import XCTest
 import Foundation
+
+// Shared by SiloTests and SiloTVTests. Keep assertions limited to symbols that
+// exist in both app targets, typically shared networking/model code.
+#if os(tvOS)
+@testable import SiloTV
+#else
 @testable import Silo
+#endif
 
 final class LibraryVisibilityTests: XCTestCase {
     func testLibrariesResponseOnlyIncludesSupportedAppleLibraryTypes() {
@@ -67,6 +74,63 @@ final class LibraryVisibilityTests: XCTestCase {
         XCTAssertEqual(response.sections.map(\.id), ["continue", "manga-recent"])
         XCTAssertEqual(response.sections[0].items.map(\.contentId), ["m1", "ep1", "a1"])
         XCTAssertTrue(response.sections[1].items.isEmpty)
+    }
+
+    func testSectionsResponseDecodesServerCardImageStyleAndLandscapeArtwork() throws {
+        let json = """
+        {
+          "sections": [
+            {
+              "id": "editorial",
+              "section_type": "recently_added",
+              "title": "Editorial",
+              "card_image_style": "landscape",
+              "items": [
+                {
+                  "content_id": "m1",
+                  "type": "movie",
+                  "title": "A Movie",
+                  "landscape_card_url": "/images/m1-landscape.webp",
+                  "landscape_card_thumbhash": "landscape-thumb",
+                  "backdrop_url": "/images/m1-backdrop.webp",
+                  "backdrop_thumbhash": "backdrop-thumb"
+                }
+              ]
+            }
+          ]
+        }
+        """
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+        let response = try decoder.decode(SectionsResponse.self, from: Data(json.utf8))
+
+        XCTAssertEqual(response.sections[0].cardImageStyle, .landscape)
+        XCTAssertEqual(response.sections[0].items[0].landscapeCardUrl, "/images/m1-landscape.webp")
+        XCTAssertEqual(response.sections[0].items[0].landscapeCardThumbhash, "landscape-thumb")
+    }
+
+    func testSectionsResponseDefaultsMissingOrUnknownCardImageStyleToAuto() throws {
+        let json = """
+        {
+          "sections": [
+            { "id": "missing", "section_type": "recent", "title": "Missing", "items": [] },
+            {
+              "id": "unknown",
+              "section_type": "recent",
+              "title": "Unknown",
+              "card_image_style": "banner",
+              "items": []
+            }
+          ]
+        }
+        """
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+        let response = try decoder.decode(SectionsResponse.self, from: Data(json.utf8))
+
+        XCTAssertEqual(response.sections.map(\.cardImageStyle), [.auto, .auto])
     }
 
     func testSectionsResponseMemberwiseInitAlsoStripsUnsupportedItems() throws {

--- a/iosApp/Tests/LibraryVisibilityTests.swift
+++ b/iosApp/Tests/LibraryVisibilityTests.swift
@@ -133,6 +133,43 @@ final class LibraryVisibilityTests: XCTestCase {
         XCTAssertEqual(response.sections.map(\.cardImageStyle), [.auto, .auto])
     }
 
+    func testLandscapeRowsPreferStoredCardButStillOverlayBackdropFallback() {
+        XCTAssertEqual(
+            LandscapeRowArtwork.imageUrl(
+                cardUrl: "/images/stored-landscape.webp",
+                backdropUrl: "/images/backdrop.webp"
+            ),
+            "/images/stored-landscape.webp"
+        )
+        XCTAssertEqual(
+            LandscapeRowArtwork.imageUrl(
+                cardUrl: nil,
+                backdropUrl: "/images/backdrop.webp"
+            ),
+            "/images/backdrop.webp"
+        )
+        XCTAssertNil(
+            LandscapeRowArtwork.thumbhash(
+                cardThumbhash: "",
+                backdropThumbhash: nil
+            )
+        )
+
+        XCTAssertFalse(LandscapeRowArtwork.showsTitleOverlay(cardUrl: "/images/stored-landscape.webp"))
+        XCTAssertTrue(LandscapeRowArtwork.showsTitleOverlay(cardUrl: nil))
+        XCTAssertTrue(LandscapeRowArtwork.showsTitleOverlay(cardUrl: ""))
+    }
+
+    func testLandscapeCardOverlaysKeepBottomBadgesInTheCardCorner() {
+        let landscape = CardOverlays.layoutInsets(for: .bottomLeft, variant: .landscapeCard)
+        XCTAssertEqual(landscape.leading, 8)
+        XCTAssertEqual(landscape.bottom, 8)
+
+        let wide = CardOverlays.layoutInsets(for: .bottomLeft, variant: .wide)
+        XCTAssertEqual(wide.leading, 8)
+        XCTAssertEqual(wide.bottom, 24)
+    }
+
     func testSectionsResponseMemberwiseInitAlsoStripsUnsupportedItems() throws {
         let itemJson = """
         { "content_id": "e1", "type": "ebook", "title": "An Ebook" }

--- a/iosApp/Tests/LibraryVisibilityTests.swift
+++ b/iosApp/Tests/LibraryVisibilityTests.swift
@@ -170,6 +170,32 @@ final class LibraryVisibilityTests: XCTestCase {
         XCTAssertEqual(wide.bottom, 24)
     }
 
+    func testLiveCardOverlaysDoNotReserveSpaceForEmptyLabels() throws {
+        let definition = try XCTUnwrap(OverlayRegistry.def(for: .showStatus))
+        let prefs = OverlaySchema.buildDefaults()
+        let preset = OverlayPresets.preset(prefs.preset)
+        var data = OverlayData()
+
+        data.showStatus = " \n "
+        XCTAssertNil(OverlayBadgeRenderState.resolve(
+            def: definition,
+            data: data,
+            prefs: prefs,
+            preset: preset
+        ))
+
+        data.showStatus = "Continuing"
+        XCTAssertEqual(
+            OverlayBadgeRenderState.resolve(
+                def: definition,
+                data: data,
+                prefs: prefs,
+                preset: preset
+            )?.label,
+            "Continuing"
+        )
+    }
+
     func testSectionsResponseMemberwiseInitAlsoStripsUnsupportedItems() throws {
         let itemJson = """
         { "content_id": "e1", "type": "ebook", "title": "An Ebook" }

--- a/iosApp/iosApp/Components/EpisodeThumbCard.swift
+++ b/iosApp/iosApp/Components/EpisodeThumbCard.swift
@@ -147,16 +147,11 @@ struct EpisodeThumbCard: View {
 
             // Episode badge overlay (e.g. "S2 · E3")
             if let badge = episodeBadge {
-                Text(badge)
-                    .font(.continuumCaption)
-                    .fontWeight(.semibold)
-                    .foregroundColor(.white)
-                    .padding(.horizontal, badgeHPadding)
-                    .padding(.vertical, badgeVPadding)
-                    .background(
-                        Capsule().fill(Color.black.opacity(0.65))
-                    )
-                    .padding(badgeInset)
+                OverlayTextBadgeView(
+                    label: badge,
+                    preset: OverlayPresets.preset(overlayStore.prefs.preset)
+                )
+                .padding(CardOverlays.layoutInsets(for: .bottomLeft, variant: .landscapeCard))
             }
 
             // Progress bar (resume)
@@ -243,22 +238,6 @@ struct EpisodeThumbCard: View {
     }
 
     // MARK: - Metrics
-
-    private var badgeHPadding: CGFloat {
-        #if os(tvOS)
-        return 14
-        #else
-        return 8
-        #endif
-    }
-
-    private var badgeVPadding: CGFloat {
-        #if os(tvOS)
-        return 7
-        #else
-        return 4
-        #endif
-    }
 
     private var badgeInset: CGFloat {
         #if os(tvOS)

--- a/iosApp/iosApp/Components/MediaCard.swift
+++ b/iosApp/iosApp/Components/MediaCard.swift
@@ -4,6 +4,8 @@ import SwiftUI
 enum MediaCardAspect {
     /// 2:3 movie/series poster.
     case poster
+    /// 16:9 landscape card for server-configured rows.
+    case landscape
     /// 1:1 tile for audiobook covers.
     case square
 }
@@ -23,6 +25,11 @@ struct MediaCard: View {
     /// don't have an `OverlaySummary` available (e.g. people /
     /// collection thumbnails) leave this off.
     var overlayData: OverlayData? = nil
+    /// Optional transparent title/logo treatment for landscape placeholders.
+    /// Used only when a server row asks for landscape but no stored landscape
+    /// card or backdrop image exists yet.
+    var landscapeLogoUrl: String? = nil
+    var showLandscapeTitleOverlay: Bool = false
     let action: () -> Void
     /// tvOS-only shortcut invoked by the remote's Play/Pause button while
     /// this card owns focus. Select continues to invoke `action`.
@@ -75,6 +82,8 @@ struct MediaCard: View {
         switch aspect {
         case .poster:
             cardWidth * (ContinuumTheme.posterCardHeight / ContinuumTheme.posterCardWidth)
+        case .landscape:
+            cardWidth / ContinuumTheme.backdropAspectRatio
         case .square:
             cardWidth
         }
@@ -274,14 +283,30 @@ struct MediaCard: View {
                 contentMode: .fill
             )
                 .frame(width: cardWidth, height: cardHeight)
-                .clipped()
+            .clipped()
+            .clipShape(RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius))
+
+            if aspect == .landscape, showLandscapeTitleOverlay {
+                LinearGradient(
+                    colors: [.clear, .black.opacity(0.75)],
+                    startPoint: .center,
+                    endPoint: .bottom
+                )
+                .frame(width: cardWidth, height: cardHeight)
                 .clipShape(RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius))
+
+                landscapeTitleTreatment
+            }
 
             // Server / user-customized overlays (resolution, HDR, ratings, …)
             // sit under the watched check + progress bar so those built-in
             // affordances always win the same corner if they conflict.
             if let overlayData, overlayStore.enabled {
-                CardOverlays(data: overlayData, prefs: overlayStore.prefs, variant: .poster)
+                CardOverlays(
+                    data: overlayData,
+                    prefs: overlayStore.prefs,
+                    variant: aspect == .landscape ? .wide : .poster
+                )
                     .frame(width: cardWidth, height: cardHeight)
                     .clipShape(RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius))
             }
@@ -332,6 +357,34 @@ struct MediaCard: View {
             DownloadedBadgeOverlay(contentId: contentId, padding: checkBadgePadding)
             #endif
         }
+        .frame(width: cardWidth, height: cardHeight)
+    }
+
+    @ViewBuilder
+    private var landscapeTitleTreatment: some View {
+        VStack {
+            Spacer()
+            if let logo = landscapeLogoUrl, !logo.isEmpty {
+                AsyncImageView(
+                    url: logo,
+                    targetSize: CGSize(width: cardWidth * 0.7, height: cardHeight * 0.35),
+                    contentMode: .fit
+                )
+                .frame(maxWidth: cardWidth * 0.7, maxHeight: cardHeight * 0.35)
+            } else {
+                Text(title)
+                    .font(.continuumSubheadline)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.white)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 8)
+                    .background(Capsule().fill(Color.black.opacity(0.55)))
+            }
+        }
+        .padding(.horizontal, 18)
+        .padding(.bottom, 14)
         .frame(width: cardWidth, height: cardHeight)
     }
 

--- a/iosApp/iosApp/Components/MediaCard.swift
+++ b/iosApp/iosApp/Components/MediaCard.swift
@@ -26,8 +26,8 @@ struct MediaCard: View {
     /// collection thumbnails) leave this off.
     var overlayData: OverlayData? = nil
     /// Optional transparent title/logo treatment for landscape placeholders.
-    /// Used only when a server row asks for landscape but no stored landscape
-    /// card or backdrop image exists yet.
+    /// Used when a server row asks for landscape but no stored landscape card
+    /// exists yet.
     var landscapeLogoUrl: String? = nil
     var showLandscapeTitleOverlay: Bool = false
     let action: () -> Void
@@ -305,7 +305,7 @@ struct MediaCard: View {
                 CardOverlays(
                     data: overlayData,
                     prefs: overlayStore.prefs,
-                    variant: aspect == .landscape ? .wide : .poster
+                    variant: aspect == .landscape ? .landscapeCard : .poster
                 )
                     .frame(width: cardWidth, height: cardHeight)
                     .clipShape(RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius))
@@ -314,14 +314,14 @@ struct MediaCard: View {
             // Episode badge (e.g. "S2 · E10") for episodes shown as posters,
             // so new episodes of the same series stay distinguishable.
             if let episodeBadge {
-                Text(episodeBadge)
-                    .font(.continuumCaption)
-                    .fontWeight(.semibold)
-                    .foregroundColor(.white)
-                    .padding(.horizontal, episodeBadgeHPadding)
-                    .padding(.vertical, episodeBadgeVPadding)
-                    .background(Capsule().fill(Color.black.opacity(0.65)))
-                    .padding(episodeBadgeInset)
+                OverlayTextBadgeView(
+                    label: episodeBadge,
+                    preset: OverlayPresets.preset(overlayStore.prefs.preset)
+                )
+                    .padding(CardOverlays.layoutInsets(
+                        for: .bottomLeft,
+                        variant: aspect == .landscape ? .landscapeCard : .poster
+                    ))
                     .frame(width: cardWidth, height: cardHeight, alignment: .bottomLeading)
             }
 
@@ -437,29 +437,6 @@ struct MediaCard: View {
         #endif
     }
 
-    private var episodeBadgeHPadding: CGFloat {
-        #if os(tvOS)
-        return 14
-        #else
-        return 8
-        #endif
-    }
-
-    private var episodeBadgeVPadding: CGFloat {
-        #if os(tvOS)
-        return 7
-        #else
-        return 4
-        #endif
-    }
-
-    private var episodeBadgeInset: CGFloat {
-        #if os(tvOS)
-        return 14
-        #else
-        return 6
-        #endif
-    }
 }
 
 // MARK: - Zoom transition source helper

--- a/iosApp/iosApp/Components/MediaRow.swift
+++ b/iosApp/iosApp/Components/MediaRow.swift
@@ -10,6 +10,7 @@ import os
 /// rows use 1:1 tiles for audiobook covers.
 enum MediaRowLayout {
     case poster
+    case landscape
     case thumbnail
     case square
 }
@@ -54,7 +55,7 @@ struct MediaRow: View {
     /// marquee retains the last previewed item while focus is in chrome.
     var onItemFocus: ((SectionItem) -> Void)? = nil
     /// Optional width for poster/square cards — Skyline's dense landing
-    /// rows (§5.6) pass a compact width. Episode thumbs are unaffected.
+    /// rows (§5.6) pass a compact width. Wide cards are unaffected.
     var cardWidth: CGFloat? = nil
     /// Optional tvOS-only vertical padding override for the card strip.
     /// Standard rows keep the default breathing room for focus lift.
@@ -194,6 +195,26 @@ struct MediaRow: View {
                             cardWidthOverride: cardWidth,
                             episodeBadge: episodeBadge(for: item)
                         )
+                    case .landscape:
+                        MediaCard(
+                            title: posterTitle(for: item),
+                            posterUrl: landscapeImageUrl(for: item),
+                            thumbhash: landscapeThumbhash(for: item),
+                            year: item.year,
+                            progress: progressValue(for: item),
+                            userState: item.userState,
+                            overlayData: OverlayData.from(item),
+                            landscapeLogoUrl: item.logoUrl,
+                            showLandscapeTitleOverlay: shouldShowLandscapeTitleOverlay(for: item),
+                            action: { onItemTap(item.contentId) },
+                            focusedItemId: rowFocusBinding,
+                            contentId: item.contentId,
+                            onRemoveFromContinueWatching: continueWatchingRemovalAction(for: item),
+                            onSetWatched: watchedToggleAction(for: item),
+                            aspect: .landscape,
+                            cardWidthOverride: ContinuumTheme.thumbnailCardWidth,
+                            episodeBadge: episodeBadge(for: item)
+                        )
                     case .thumbnail:
                         EpisodeThumbCard(
                             item: item,
@@ -283,6 +304,36 @@ struct MediaRow: View {
     /// — the bare `title` is the episode title (often "TBA" when unannounced).
     private func posterTitle(for item: SectionItem) -> String {
         item.type.lowercased() == "episode" ? (item.seriesTitle ?? item.title) : item.title
+    }
+
+    private func landscapeImageUrl(for item: SectionItem) -> String {
+        if let card = item.landscapeCardUrl, !card.isEmpty {
+            return card
+        }
+        if let backdrop = item.backdropUrl, !backdrop.isEmpty {
+            return backdrop
+        }
+        return ""
+    }
+
+    private func landscapeThumbhash(for item: SectionItem) -> String? {
+        if let card = item.landscapeCardThumbhash, !card.isEmpty {
+            return card
+        }
+        if let backdrop = item.backdropThumbhash, !backdrop.isEmpty {
+            return backdrop
+        }
+        return nil
+    }
+
+    private func shouldShowLandscapeTitleOverlay(for item: SectionItem) -> Bool {
+        if let card = item.landscapeCardUrl, !card.isEmpty {
+            return false
+        }
+        if let backdrop = item.backdropUrl, !backdrop.isEmpty {
+            return false
+        }
+        return true
     }
 
     /// "S2 · E10" badge for an episode rendered as a poster, so new episodes

--- a/iosApp/iosApp/Components/MediaRow.swift
+++ b/iosApp/iosApp/Components/MediaRow.swift
@@ -15,6 +15,32 @@ enum MediaRowLayout {
     case square
 }
 
+enum LandscapeRowArtwork {
+    static func imageUrl(cardUrl: String?, backdropUrl: String?) -> String {
+        if let cardUrl, !cardUrl.isEmpty {
+            return cardUrl
+        }
+        if let backdropUrl, !backdropUrl.isEmpty {
+            return backdropUrl
+        }
+        return ""
+    }
+
+    static func thumbhash(cardThumbhash: String?, backdropThumbhash: String?) -> String? {
+        if let cardThumbhash, !cardThumbhash.isEmpty {
+            return cardThumbhash
+        }
+        if let backdropThumbhash, !backdropThumbhash.isEmpty {
+            return backdropThumbhash
+        }
+        return nil
+    }
+
+    static func showsTitleOverlay(cardUrl: String?) -> Bool {
+        !(cardUrl?.isEmpty == false)
+    }
+}
+
 /// A horizontal scrolling row of media cards with a title header.
 /// Plezy style: section title with optional icon, safe-area leading padding.
 struct MediaRow: View {
@@ -307,33 +333,21 @@ struct MediaRow: View {
     }
 
     private func landscapeImageUrl(for item: SectionItem) -> String {
-        if let card = item.landscapeCardUrl, !card.isEmpty {
-            return card
-        }
-        if let backdrop = item.backdropUrl, !backdrop.isEmpty {
-            return backdrop
-        }
-        return ""
+        LandscapeRowArtwork.imageUrl(
+            cardUrl: item.landscapeCardUrl,
+            backdropUrl: item.backdropUrl
+        )
     }
 
     private func landscapeThumbhash(for item: SectionItem) -> String? {
-        if let card = item.landscapeCardThumbhash, !card.isEmpty {
-            return card
-        }
-        if let backdrop = item.backdropThumbhash, !backdrop.isEmpty {
-            return backdrop
-        }
-        return nil
+        LandscapeRowArtwork.thumbhash(
+            cardThumbhash: item.landscapeCardThumbhash,
+            backdropThumbhash: item.backdropThumbhash
+        )
     }
 
     private func shouldShowLandscapeTitleOverlay(for item: SectionItem) -> Bool {
-        if let card = item.landscapeCardUrl, !card.isEmpty {
-            return false
-        }
-        if let backdrop = item.backdropUrl, !backdrop.isEmpty {
-            return false
-        }
-        return true
+        LandscapeRowArtwork.showsTitleOverlay(cardUrl: item.landscapeCardUrl)
     }
 
     /// "S2 · E10" badge for an episode rendered as a poster, so new episodes

--- a/iosApp/iosApp/Networking/Models.swift
+++ b/iosApp/iosApp/Networking/Models.swift
@@ -150,6 +150,20 @@ struct CatalogResponse: Codable {
 
 // MARK: - Home Sections
 
+enum SectionCardImageStyle: String, Codable {
+    case auto
+    case portrait
+    case landscape
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        self = SectionCardImageStyle(rawValue: rawValue) ?? .auto
+    }
+}
+
 struct SectionItem: Codable, Identifiable, Hashable {
     let contentId: String
     let type: String
@@ -180,6 +194,8 @@ struct SectionItem: Codable, Identifiable, Hashable {
     let posterThumbhash: String?
     let backdropUrl: String?
     let backdropThumbhash: String?
+    let landscapeCardUrl: String?
+    let landscapeCardThumbhash: String?
     let logoUrl: String?
     let userState: MediaItemUserState?
     let overlaySummary: OverlaySummary?
@@ -216,6 +232,8 @@ struct SectionItem: Codable, Identifiable, Hashable {
         posterThumbhash = try c.decodeIfPresent(String.self, forKey: .posterThumbhash)
         backdropUrl = try c.decodeIfPresent(String.self, forKey: .backdropUrl)
         backdropThumbhash = try c.decodeIfPresent(String.self, forKey: .backdropThumbhash)
+        landscapeCardUrl = try c.decodeIfPresent(String.self, forKey: .landscapeCardUrl)
+        landscapeCardThumbhash = try c.decodeIfPresent(String.self, forKey: .landscapeCardThumbhash)
         logoUrl = try c.decodeIfPresent(String.self, forKey: .logoUrl)
         userState = try c.decodeIfPresent(MediaItemUserState.self, forKey: .userState)
         overlaySummary = try c.decodeIfPresent(OverlaySummary.self, forKey: .overlaySummary)
@@ -316,6 +334,7 @@ struct ResolvedSection: Codable, Identifiable {
     let totalCount: Int?
     let isCustom: Bool?
     let customized: Bool?
+    let cardImageStyle: SectionCardImageStyle
     let items: [SectionItem]
 
     /// Whether this section is featured (defaults to false if nil).
@@ -330,6 +349,7 @@ struct ResolvedSection: Codable, Identifiable {
         totalCount: Int?,
         isCustom: Bool?,
         customized: Bool?,
+        cardImageStyle: SectionCardImageStyle = .auto,
         items: [SectionItem]
     ) {
         self.id = id
@@ -340,6 +360,7 @@ struct ResolvedSection: Codable, Identifiable {
         self.totalCount = totalCount
         self.isCustom = isCustom
         self.customized = customized
+        self.cardImageStyle = cardImageStyle
         self.items = items
     }
 
@@ -353,6 +374,7 @@ struct ResolvedSection: Codable, Identifiable {
         totalCount = try c.decodeIfPresent(Int.self, forKey: .totalCount)
         isCustom = try c.decodeIfPresent(Bool.self, forKey: .isCustom)
         customized = try c.decodeIfPresent(Bool.self, forKey: .customized)
+        cardImageStyle = try c.decodeIfPresent(SectionCardImageStyle.self, forKey: .cardImageStyle) ?? .auto
         items = try c.decodeIfPresent([SectionItem].self, forKey: .items) ?? []
     }
 }
@@ -391,6 +413,7 @@ struct SectionsResponse: Codable {
                 totalCount: section.totalCount,
                 isCustom: section.isCustom,
                 customized: section.customized,
+                cardImageStyle: section.cardImageStyle,
                 items: kept
             )
         }

--- a/iosApp/iosApp/Overlays/CardOverlays.swift
+++ b/iosApp/iosApp/Overlays/CardOverlays.swift
@@ -18,10 +18,10 @@ struct CardOverlays: View {
     var variant: Variant = .poster
 
     enum Variant {
-        case poster      // standard 2:3 poster card
-        case wide        // backdrop card (continue watching, hero) — leaves
-                         // headroom for the title block / progress bar.
-        case hero        // large backdrop (detail-page hero, featured carousel)
+        case poster        // standard 2:3 poster card
+        case landscapeCard // 16:9 library/home row card
+        case wide          // episode/thumb row card with room for title/progress
+        case hero          // large backdrop (detail-page hero, featured carousel)
     }
 
     var body: some View {
@@ -49,7 +49,7 @@ struct CardOverlays: View {
                     OverlayBadgeView(state: state, preset: preset)
                 }
             }
-            .padding(insets(for: position))
+            .padding(Self.layoutInsets(for: position, variant: variant))
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: anchor(for: position))
         }
     }
@@ -70,14 +70,15 @@ struct CardOverlays: View {
         }
     }
 
-    private func insets(for position: OverlayPosition) -> EdgeInsets {
-        // `wide` and `hero` variants leave more bottom room because a
-        // title block / progress bar typically sits under the image.
+    static func layoutInsets(for position: OverlayPosition, variant: Variant) -> EdgeInsets {
+        // `wide` and `hero` variants reserve bottom room for surfaces that
+        // pair the image with title/progress chrome. Landscape row cards keep
+        // badges pinned to the artwork corners.
         let bottomInset: CGFloat = {
             switch variant {
-            case .poster: return 8
-            case .wide:   return 24
-            case .hero:   return 16
+            case .poster, .landscapeCard: return 8
+            case .wide:                   return 24
+            case .hero:                   return 16
             }
         }()
         let sideInset: CGFloat = variant == .hero ? 16 : 8
@@ -163,15 +164,48 @@ struct OverlayBadgeView: View {
     let preset: OverlayPreset
 
     var body: some View {
+        OverlayBadgeChrome(
+            label: state.label,
+            iconId: state.iconId,
+            iconOnly: state.iconOnly,
+            accentColor: state.accentColor,
+            preset: preset
+        )
+    }
+}
+
+struct OverlayTextBadgeView: View {
+    let label: String
+    let preset: OverlayPreset
+
+    var body: some View {
+        OverlayBadgeChrome(
+            label: label,
+            iconId: nil,
+            iconOnly: false,
+            accentColor: nil,
+            preset: preset
+        )
+    }
+}
+
+private struct OverlayBadgeChrome: View {
+    let label: String
+    let iconId: OverlayIconId?
+    let iconOnly: Bool
+    let accentColor: Color?
+    let preset: OverlayPreset
+
+    var body: some View {
         HStack(spacing: 4) {
-            if let iconId = state.iconId {
+            if let iconId {
                 OverlayIcon(
                     iconId: iconId,
                     size: preset.iconSize,
-                    tint: preset.foregroundColor(state.accentColor)
+                    tint: preset.foregroundColor(accentColor)
                 )
             }
-            if !state.iconOnly || state.iconId == nil {
+            if !iconOnly || iconId == nil {
                 badgeText
             }
         }
@@ -184,10 +218,10 @@ struct OverlayBadgeView: View {
 
     @ViewBuilder
     private var badgeText: some View {
-        let text = Text(state.label)
+        let text = Text(label)
             .font(preset.font.weight(preset.textWeight))
             .tracking(preset.tracking)
-            .foregroundColor(preset.foregroundColor(state.accentColor))
+            .foregroundColor(preset.foregroundColor(accentColor))
         Group {
             if let textCase = preset.textCase {
                 text.textCase(textCase)
@@ -200,7 +234,7 @@ struct OverlayBadgeView: View {
 
     @ViewBuilder
     private var background: some View {
-        let color = preset.backgroundColor(state.accentColor)
+        let color = preset.backgroundColor(accentColor)
         if let material = preset.backdropMaterial {
             shape
                 .fill(material)
@@ -212,7 +246,7 @@ struct OverlayBadgeView: View {
 
     @ViewBuilder
     private var border: some View {
-        if let stroke = preset.borderColor(state.accentColor) {
+        if let stroke = preset.borderColor(accentColor) {
             shape.stroke(stroke, lineWidth: 1)
         }
     }

--- a/iosApp/iosApp/Overlays/CardOverlays.swift
+++ b/iosApp/iosApp/Overlays/CardOverlays.swift
@@ -110,15 +110,18 @@ struct OverlayBadgeRenderState: Equatable {
     let accentColor: Color?
 
     /// Resolve the badge as it would appear on a real card. Returns
-    /// `nil` when the overlay's data extractor returns no label —
-    /// signalling that the badge should not render.
+    /// `nil` when the overlay's data extractor returns no visible label —
+    /// signalling that the badge should not render or reserve stack space.
     static func resolve(
         def: OverlayDef,
         data: OverlayData,
         prefs: CardOverlayPrefs,
         preset: OverlayPreset
     ) -> OverlayBadgeRenderState? {
-        guard let label = def.getValue(data) else { return nil }
+        guard let label = def.getValue(data),
+              !label.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
         return build(def: def, label: label, data: data, prefs: prefs, preset: preset)
     }
 

--- a/iosApp/iosApp/Screens/Home/SectionRow.swift
+++ b/iosApp/iosApp/Screens/Home/SectionRow.swift
@@ -72,6 +72,16 @@ struct SectionRow: View {
     }
 
     private var layout: MediaRowLayout {
+        switch section.cardImageStyle {
+        case .landscape:
+            return .landscape
+        case .portrait:
+            if isAudiobookRow { return .square }
+            return .poster
+        case .auto:
+            break
+        }
+
         if isEpisodeRow { return .thumbnail }
         if isAudiobookRow { return .square }
         return .poster

--- a/iosApp/iosApp/tvOS/Screens/Components/TVMediaCard.swift
+++ b/iosApp/iosApp/tvOS/Screens/Components/TVMediaCard.swift
@@ -59,6 +59,8 @@ struct TVMediaCard: View {
         switch aspect {
         case .poster:
             cardWidth * 1.5
+        case .landscape:
+            cardWidth / ContinuumTheme.backdropAspectRatio
         case .square:
             cardWidth
         }
@@ -161,7 +163,11 @@ struct TVMediaCard: View {
             .clipShape(RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius))
 
             if let overlayData, overlayStore.enabled {
-                CardOverlays(data: overlayData, prefs: overlayStore.prefs, variant: .poster)
+                CardOverlays(
+                    data: overlayData,
+                    prefs: overlayStore.prefs,
+                    variant: aspect == .landscape ? .wide : .poster
+                )
                     .frame(width: cardWidth, height: cardHeight)
                     .clipShape(RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius))
             }

--- a/iosApp/iosApp/tvOS/Screens/Components/TVMediaCard.swift
+++ b/iosApp/iosApp/tvOS/Screens/Components/TVMediaCard.swift
@@ -166,7 +166,7 @@ struct TVMediaCard: View {
                 CardOverlays(
                     data: overlayData,
                     prefs: overlayStore.prefs,
-                    variant: aspect == .landscape ? .wide : .poster
+                    variant: aspect == .landscape ? .landscapeCard : .poster
                 )
                     .frame(width: cardWidth, height: cardHeight)
                     .clipShape(RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius))

--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -303,6 +303,24 @@ targets:
         TEST_HOST: "$(BUILT_PRODUCTS_DIR)/Silo.app/Silo"
         SWIFT_OBJC_BRIDGING_HEADER: iosApp/Screens/Player/CoreMedia/SiloPlayerBridging.h
 
+  # Focused tvOS unit-test bundle for shared home-section model behavior.
+  # Keep this narrow until the broader Tests/ suite is made tvOS-clean.
+  SiloTVTests:
+    type: bundle.unit-test
+    platform: tvOS
+    sources:
+      - path: Tests/LibraryVisibilityTests.swift
+    dependencies:
+      - target: SiloTV
+    settings:
+      base:
+        PRODUCT_NAME: SiloTVTests
+        GENERATE_INFOPLIST_FILE: "YES"
+        SDKROOT: appletvos
+        SUPPORTED_PLATFORMS: "appletvos appletvsimulator"
+        BUNDLE_LOADER: "$(TEST_HOST)"
+        TEST_HOST: "$(BUILT_PRODUCTS_DIR)/SiloTV.app/SiloTV"
+
 schemes:
   Silo:
     build:
@@ -340,10 +358,13 @@ schemes:
     build:
       targets:
         SiloTV: all
+        SiloTVTests: [test]
     run:
       config: Debug
     test:
       config: Debug
+      targets:
+        - SiloTVTests
     archive:
       config: Release
     analyze:


### PR DESCRIPTION
# feat(apple): respect server section card image style

Pairs with `Silo-Server/silo-server#338` / `pr/sections-card-image-style`.

## Problem

The server can now mark a Home or library section row as `auto`, `portrait`, or
`landscape`, but the Apple clients still choose row layout only from local
heuristics. That means a row configured as landscape on the server would render
as posters or episode thumbnails on iOS, macOS, and tvOS.

## Approach

Decode the server fields and thread them through the existing row layout path:

- Add `SectionCardImageStyle` to the Apple networking model and default missing
  or unknown values to `.auto` for old-server compatibility.
- Decode `landscape_card_url` and `landscape_card_thumbhash` on section items so
  Apple can use the stored 16:9 artwork from the server landscape-card follow-up.
- Make `SectionRow` honor explicit server values first: `.landscape` renders a
  16:9 row, `.portrait` renders poster cards except audiobook-only rows remain
  square, and `.auto` preserves the existing Apple heuristics for Next Up,
  Continue Watching, and audiobook rows.
- Add a landscape `MediaCard` aspect with the existing wide overlay variant.
  Landscape rows prefer stored landscape-card artwork, then backdrop. If neither
  artwork source exists, the card adds a small logo/title treatment over the
  placeholder rather than cropping poster art into 16:9. Episode landscape cards
  keep the same season/episode badge used by poster rows.
- Add a narrow `SiloTVTests` target to the generated `SiloTV` scheme so the
  shared section-decoding coverage can run on tvOS. The shared test file is
  annotated to stay limited to symbols available in both app targets.
- Keep this as client rendering only; no Apple-side per-device override is added.

## Verification

- `cd iosApp && xcodegen generate` — passes.
- `xcodebuild test -project Silo.xcodeproj -scheme SiloTV -destination 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=26.5' -derivedDataPath build/DerivedData -clonedSourcePackagesDirPath build/SourcePackages CODE_SIGNING_ALLOWED=NO` — passes, 9 tests.
- `xcodebuild build -project Silo.xcodeproj -scheme SiloMac -destination 'platform=macOS,arch=arm64' -derivedDataPath build/DerivedData -clonedSourcePackagesDirPath build/SourcePackages CODE_SIGNING_ALLOWED=NO` — passes.

## Risks & follow-up

- Explicit server `portrait` intentionally overrides Apple episode/continue-row
  heuristics, while preserving square audiobook tiling to avoid stretching
  square cover art.
- `auto` remains unchanged, so old servers and rows with no style field keep the
  current Apple behavior.
- This pairs cleanly with the server landscape-card artwork PR, but does not
  require it. Without stored landscape art, Apple falls back to backdrop; if
  there is no backdrop either, the title/logo treatment identifies the item
  rather than cropping poster art into a wide card.

## AI-use disclosure

Implemented with a combination of Claude Code and Codex assistance, with human oversight.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added landscape-style cards across home sections and media rows, including landscape artwork, logo/title overlay behavior, and updated card sizing.
  * Home sections now support a configurable card image style, including landscape.

* **Bug Fixes**
  * Improved artwork/thumbnail fallback when landscape art is missing.
  * Updated badge/overlay handling and spacing; badge labels now ignore whitespace-only values.

* **Tests**
  * Expanded section decoding and UI model behavior tests, including landscape defaults and badge rendering cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->