### PR TITLE
fix: harden HDR and TrueHD playback recovery

### DIFF
--- a/iosApp/Tests/LoopbackSegmentCutterTests.swift
+++ b/iosApp/Tests/LoopbackSegmentCutterTests.swift
@@ -6,6 +6,54 @@ final class LoopbackSegmentCutterTests: XCTestCase {
     // the 16 s entry is the end fence.
     private let boundaries: [Int64] = [0, 360_000, 720_000, 1_080_000, 1_440_000]
 
+    func testVideoSampleDurationsTelescopeToForwardDTSDelta() {
+        let dts: [Int64] = [0, 42, 83, 125, 167, 208, 250, 292, 333, 375]
+        var accumulated: Int64 = 0
+
+        for index in 0..<(dts.count - 1) {
+            let duration = LoopbackVideoSampleDurationPolicy.resolve(
+                existingDuration: 42,
+                dts: dts[index],
+                nextDTS: dts[index + 1],
+                fallback: 42
+            )
+            XCTAssertEqual(duration, dts[index + 1] - dts[index])
+            accumulated += duration
+        }
+
+        XCTAssertEqual(accumulated, dts.last! - dts.first!)
+    }
+
+    func testVideoSampleDurationFallsBackSafelyWithoutForwardDTS() {
+        XCTAssertEqual(
+            LoopbackVideoSampleDurationPolicy.resolve(
+                existingDuration: 40,
+                dts: 1_000,
+                nextDTS: nil,
+                fallback: 42
+            ),
+            40
+        )
+        XCTAssertEqual(
+            LoopbackVideoSampleDurationPolicy.resolve(
+                existingDuration: 0,
+                dts: 1_000,
+                nextDTS: 990,
+                fallback: 33
+            ),
+            33
+        )
+        XCTAssertEqual(
+            LoopbackVideoSampleDurationPolicy.resolve(
+                existingDuration: 0,
+                dts: Int64.min,
+                nextDTS: Int64.max,
+                fallback: 0
+            ),
+            1
+        )
+    }
+
     func testFirstKeyframeOpensSegmentZero() {
         var cutter = LoopbackSegmentCutter(boundaries: boundaries)
         XCTAssertEqual(cutter.index(pts: 0, isKeyframe: true), 0)

--- a/iosApp/Tests/LoopbackSegmentServerRangeTests.swift
+++ b/iosApp/Tests/LoopbackSegmentServerRangeTests.swift
@@ -2,6 +2,49 @@ import XCTest
 @testable import Silo
 
 final class LoopbackSegmentServerRangeTests: XCTestCase {
+    func testVODMissSendsHeadersBeforeSlowSegmentFinishes() async throws {
+        let store = LoopbackSegmentStore(generation: 909)
+        let server = LoopbackSegmentServer(segmentStore: store)
+        let segmentName = "seg_000002.m4s"
+        let payload = Data(repeating: 0xA5, count: 32 * 1024)
+
+        server.vodSegmentMissResolver = { _ in
+            Thread.sleep(forTimeInterval: LoopbackSegmentServer.vodEarlyResponseDelaySeconds + 0.75)
+            store.beginProgressiveSegment(named: segmentName)
+            store.appendProgressiveSegment(named: segmentName, bytes: payload.prefix(4_096))
+            _ = store.putSegment(name: segmentName, data: payload, duration: 4)
+            return store.resource(path: segmentName, waitForNearFuture: false)
+        }
+
+        try await server.start()
+        defer { server.stop() }
+        let url = URL(string: "http://127.0.0.1:\(server.port)/\(segmentName)")!
+        let started = CFAbsoluteTimeGetCurrent()
+        let earlyHeaderElapsed = LockedElapsed()
+        server.onEarlyVODResponseHeaders = { path in
+            XCTAssertEqual(path, segmentName)
+            earlyHeaderElapsed.set(CFAbsoluteTimeGetCurrent() - started)
+        }
+        let delegate = SegmentResponseTimingDelegate(startedAt: started)
+        let session = URLSession(
+            configuration: .ephemeral,
+            delegate: delegate,
+            delegateQueue: nil
+        )
+        defer { session.invalidateAndCancel() }
+
+        let result = try await delegate.fetch(url: url, using: session)
+        XCTAssertEqual(result.statusCode, 200)
+        XCTAssertNotNil(result.firstBodyElapsed)
+        XCTAssertNotNil(earlyHeaderElapsed.value)
+        XCTAssertLessThan(
+            (earlyHeaderElapsed.value ?? .infinity) + 0.4,
+            result.firstBodyElapsed ?? .infinity,
+            "headers must beat the delayed segment's first bytes"
+        )
+        XCTAssertEqual(result.data, payload)
+    }
+
     func testParsesClosedByteRangeForPartialContent() {
         XCTAssertEqual(
             LoopbackSegmentServer.parseByteRange("bytes=4-9", totalLength: 20),
@@ -14,5 +57,92 @@ final class LoopbackSegmentServerRangeTests: XCTestCase {
             LoopbackSegmentServer.parseByteRange("bytes=20-30", totalLength: 20),
             .notSatisfiable
         )
+    }
+}
+
+private final class LockedElapsed: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedValue: CFTimeInterval?
+
+    var value: CFTimeInterval? {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedValue
+    }
+
+    func set(_ value: CFTimeInterval) {
+        lock.lock()
+        storedValue = value
+        lock.unlock()
+    }
+}
+
+private final class SegmentResponseTimingDelegate: NSObject, URLSessionDataDelegate {
+    struct Result {
+        let statusCode: Int
+        let headerElapsed: CFTimeInterval
+        let firstBodyElapsed: CFTimeInterval?
+        let data: Data
+    }
+
+    private let startedAt: CFTimeInterval
+    private var statusCode = 0
+    private var headerElapsed: CFTimeInterval = 0
+    private var firstBodyElapsed: CFTimeInterval?
+    private var data = Data()
+    private var continuation: CheckedContinuation<Result, Error>?
+
+    init(startedAt: CFTimeInterval) {
+        self.startedAt = startedAt
+    }
+
+    func fetch(url: URL, using session: URLSession) async throws -> Result {
+        try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+            session.dataTask(with: url).resume()
+        }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+    ) {
+        statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+        headerElapsed = CFAbsoluteTimeGetCurrent() - startedAt
+        completionHandler(.allow)
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive data: Data
+    ) {
+        if firstBodyElapsed == nil {
+            firstBodyElapsed = CFAbsoluteTimeGetCurrent() - startedAt
+        }
+        self.data.append(data)
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: Error?
+    ) {
+        let continuation = continuation
+        self.continuation = nil
+        if let error {
+            continuation?.resume(throwing: error)
+        } else {
+            continuation?.resume(
+                returning: Result(
+                    statusCode: statusCode,
+                    headerElapsed: headerElapsed,
+                    firstBodyElapsed: firstBodyElapsed,
+                    data: data
+                )
+            )
+        }
     }
 }

--- a/iosApp/Tests/LoopbackStartupRecoveryPolicyTests.swift
+++ b/iosApp/Tests/LoopbackStartupRecoveryPolicyTests.swift
@@ -2,6 +2,114 @@ import XCTest
 @testable import Silo
 
 final class LoopbackStartupRecoveryPolicyTests: XCTestCase {
+    func testAudioSessionActivationStateRejectsStaleCompletionAndDeactivates() {
+        var state = AVPlayerAudioSessionActivationState()
+        let first = state.beginActivation()
+        let second = state.beginActivation()
+
+        XCTAssertTrue(first.needsActivation)
+        XCTAssertTrue(second.needsActivation)
+        XCTAssertFalse(state.finishActivation(id: first.id, succeeded: true))
+        XCTAssertTrue(state.finishActivation(id: second.id, succeeded: true))
+        XCTAssertTrue(state.cancelAndDeactivate())
+        XCTAssertFalse(state.isCurrent(id: second.id))
+    }
+
+    func testAudioSessionCoordinatorRunsBlockingOperationsOffMainThread() {
+        let activationFinished = expectation(description: "activation finished")
+        let deactivationFinished = expectation(description: "deactivation finished")
+        var activationWasOffMain = false
+        var deactivationWasOffMain = false
+        let coordinator = AVPlayerAudioSessionCoordinator(
+            workQueue: DispatchQueue(label: "test.audio-session.work"),
+            callbackQueue: .main,
+            activation: {
+                activationWasOffMain = !Thread.isMainThread
+            },
+            deactivation: {
+                deactivationWasOffMain = !Thread.isMainThread
+                deactivationFinished.fulfill()
+            }
+        )
+
+        coordinator.activate { error in
+            XCTAssertNil(error)
+            XCTAssertTrue(Thread.isMainThread)
+            activationFinished.fulfill()
+        }
+        wait(for: [activationFinished], timeout: 2)
+        coordinator.deactivate()
+        wait(for: [deactivationFinished], timeout: 2)
+
+        XCTAssertTrue(activationWasOffMain)
+        XCTAssertTrue(deactivationWasOffMain)
+    }
+
+    func testItemDeathPolicyRequiresConfirmationAndCapsReloads() {
+        var state = LoopbackItemDeathRecoveryState()
+        XCTAssertEqual(
+            state.record(position: 100, evidenceWeight: 1, userPaused: false),
+            .waitForConfirmation
+        )
+        XCTAssertEqual(
+            state.record(position: 100.5, evidenceWeight: 1, userPaused: false),
+            .reload(attempt: 1)
+        )
+        XCTAssertEqual(
+            state.record(position: 100.5, evidenceWeight: 2, userPaused: false),
+            .reload(attempt: 2)
+        )
+        XCTAssertEqual(
+            state.record(position: 100.5, evidenceWeight: 2, userPaused: false),
+            .reload(attempt: 3)
+        )
+        XCTAssertEqual(
+            state.record(position: 100.5, evidenceWeight: 2, userPaused: false),
+            .escalate
+        )
+    }
+
+    func testItemDeathPolicyNeverReloadsUserPause() {
+        var state = LoopbackItemDeathRecoveryState()
+        XCTAssertEqual(
+            state.record(position: 100, evidenceWeight: 2, userPaused: true),
+            .waitForConfirmation
+        )
+    }
+
+    func testItemDeathPolicyResetsAtDifferentPlaybackPosition() {
+        var state = LoopbackItemDeathRecoveryState()
+        XCTAssertEqual(
+            state.record(position: 100, evidenceWeight: 2, userPaused: false),
+            .reload(attempt: 1)
+        )
+        XCTAssertEqual(
+            state.record(position: 110, evidenceWeight: 2, userPaused: false),
+            .reload(attempt: 1)
+        )
+    }
+
+    func testItemDeathSignatures() {
+        XCTAssertTrue(
+            LoopbackItemDeathRecoveryState.isItemDeath(
+                statusCode: -12889,
+                errorDescription: ""
+            )
+        )
+        XCTAssertTrue(
+            LoopbackItemDeathRecoveryState.isItemDeath(
+                statusCode: nil,
+                errorDescription: "No response for media file"
+            )
+        )
+        XCTAssertFalse(
+            LoopbackItemDeathRecoveryState.isItemDeath(
+                statusCode: -12888,
+                errorDescription: "Playlist File unchanged"
+            )
+        )
+    }
+
     private func verdict(
         sinceProgress: Double,
         sinceStart: Double,

--- a/iosApp/Tests/PairingCoordinatorTests.swift
+++ b/iosApp/Tests/PairingCoordinatorTests.swift
@@ -120,6 +120,52 @@ private let pendingPoll = DeviceLoginPollResponse(
     status: "pending", pollAfter: 1, accessToken: nil, refreshToken: nil, expiresIn: nil, user: nil
 )
 
+// MARK: - Server session persistence
+
+@MainActor
+final class ServerSessionPersistenceTests: XCTestCase {
+    /// Companion authorization may install a different user's credentials for
+    /// an existing URL. That boundary must not inherit the previous account's
+    /// profile, while ordinary metadata upserts continue preserving it.
+    func testNewSessionUpsertClearsExistingProfile() {
+        let suiteName = "ServerSessionPersistenceTests.suite.\(UUID().uuidString)"
+        let standardName = "ServerSessionPersistenceTests.standard.\(UUID().uuidString)"
+        let suite = UserDefaults(suiteName: suiteName)!
+        let standard = UserDefaults(suiteName: standardName)!
+        defer {
+            suite.removePersistentDomain(forName: suiteName)
+            standard.removePersistentDomain(forName: standardName)
+        }
+
+        let registry = ServerRegistry(
+            defaults: SharedDefaults(suite: suite, standard: standard),
+            keychain: SharedKeychain(service: "ServerSessionPersistenceTests.\(UUID().uuidString)", accessGroup: nil)
+        )
+        let serverID = ServerRegistry.serverId(for: "https://home.example")
+        registry.addOrUpdate(ServerEntry(
+            id: serverID,
+            url: "https://home.example",
+            fetchedName: "Home",
+            userOverrideName: "My Server",
+            profileId: "OLD-PROFILE",
+            lastUsedAt: Date()
+        ))
+
+        registry.addOrUpdate(ServerEntry(
+            id: serverID,
+            url: "https://home.example",
+            fetchedName: "Home Renamed",
+            userOverrideName: nil,
+            profileId: nil,
+            lastUsedAt: Date()
+        ), preservingProfile: false)
+
+        XCTAssertNil(registry.entry(with: serverID)?.profileId)
+        XCTAssertEqual(registry.entry(with: serverID)?.userOverrideName, "My Server")
+        XCTAssertEqual(registry.entry(with: serverID)?.fetchedName, "Home Renamed")
+    }
+}
+
 // MARK: - Companion
 
 @MainActor

--- a/iosApp/Tests/PlaybackOriginOutageTests.swift
+++ b/iosApp/Tests/PlaybackOriginOutageTests.swift
@@ -285,15 +285,17 @@ final class LoopbackInterruptTokenDeadlineTests: XCTestCase {
         XCTAssertFalse(
             CoreMediaDemuxInterruptPolicy.shouldAbort(
                 cancelled: false,
-                playbackStopped: true,
+                userPaused: true,
                 secondsSinceProgress: 120,
                 timeoutSeconds: 10
             )
         )
+        // Startup and seek restarts run with the playback clock at rate 0
+        // without a user pause — the watchdog must stay armed there.
         XCTAssertTrue(
             CoreMediaDemuxInterruptPolicy.shouldAbort(
                 cancelled: false,
-                playbackStopped: false,
+                userPaused: false,
                 secondsSinceProgress: 10.1,
                 timeoutSeconds: 10
             )
@@ -301,7 +303,7 @@ final class LoopbackInterruptTokenDeadlineTests: XCTestCase {
         XCTAssertTrue(
             CoreMediaDemuxInterruptPolicy.shouldAbort(
                 cancelled: true,
-                playbackStopped: true,
+                userPaused: true,
                 secondsSinceProgress: 0,
                 timeoutSeconds: 10
             )

--- a/iosApp/Tests/PlaybackOriginOutageTests.swift
+++ b/iosApp/Tests/PlaybackOriginOutageTests.swift
@@ -281,6 +281,33 @@ final class PlaybackSourceProxyOutageTests: XCTestCase {
 /// 10 s base allowance measured from span start), racing the redriven bytes
 /// and forcing a visible reload.
 final class LoopbackInterruptTokenDeadlineTests: XCTestCase {
+    func testCoreMediaDemuxWatchdogIgnoresIntentionalPause() {
+        XCTAssertFalse(
+            CoreMediaDemuxInterruptPolicy.shouldAbort(
+                cancelled: false,
+                playbackStopped: true,
+                secondsSinceProgress: 120,
+                timeoutSeconds: 10
+            )
+        )
+        XCTAssertTrue(
+            CoreMediaDemuxInterruptPolicy.shouldAbort(
+                cancelled: false,
+                playbackStopped: false,
+                secondsSinceProgress: 10.1,
+                timeoutSeconds: 10
+            )
+        )
+        XCTAssertTrue(
+            CoreMediaDemuxInterruptPolicy.shouldAbort(
+                cancelled: true,
+                playbackStopped: true,
+                secondsSinceProgress: 0,
+                timeoutSeconds: 10
+            )
+        )
+    }
+
     private func makeToken(outage: @escaping () -> Bool) -> LoopbackInterruptToken {
         let token = LoopbackInterruptToken()
         token.setSourceOutageProvider(outage)

--- a/iosApp/Tests/PlaybackOriginStreamPolicyTests.swift
+++ b/iosApp/Tests/PlaybackOriginStreamPolicyTests.swift
@@ -102,6 +102,24 @@ final class PlaybackOriginRoutingPolicyTests: XCTestCase {
         XCTAssertEqual(PlaybackOriginRoutingPolicy.windowClaimBytes, 8 * 1024 * 1024)
         XCTAssertEqual(PlaybackOriginRoutingPolicy.rideThroughBytes, 8 * 1024 * 1024)
     }
+
+    func testInteractiveChunkAttemptUsesShortIndependentTimeout() {
+        let configuration = PlaybackOriginChunkFetcher.makeSessionConfiguration()
+        XCTAssertEqual(
+            configuration.timeoutIntervalForRequest,
+            PlaybackOriginChunkFetcher.interactiveRequestTimeoutSeconds
+        )
+        XCTAssertEqual(PlaybackOriginChunkFetcher.interactiveRequestTimeoutSeconds, 4.0)
+        XCTAssertEqual(
+            PlaybackOriginReconnectPolicy.decide(
+                cause: .network,
+                unproductiveStreak: 0,
+                everProductive: false
+            ),
+            .retry(afterSeconds: 0.5),
+            "a short interactive attempt must still flow into the longer reconnect/outage policy"
+        )
+    }
 }
 
 final class PlaybackOriginStreamPolicyTests: XCTestCase {

--- a/iosApp/Tests/SeekLatchTests.swift
+++ b/iosApp/Tests/SeekLatchTests.swift
@@ -2,6 +2,26 @@ import XCTest
 @testable import Silo
 
 final class SeekLatchTests: XCTestCase {
+    func testAVPlayerSeekDeadlineCompletesOnlyActiveGeneration() {
+        var state = AVPlayerSeekDeadlineState()
+        let first = state.begin()
+        let second = state.begin()
+
+        XCTAssertFalse(state.complete(first))
+        XCTAssertEqual(state.activeID, second)
+        XCTAssertTrue(state.complete(second))
+        XCTAssertNil(state.activeID)
+    }
+
+    func testAVPlayerSeekDeadlineCancelInvalidatesLateCompletion() {
+        var state = AVPlayerSeekDeadlineState()
+        let id = state.begin()
+        state.cancel()
+
+        XCTAssertNil(state.activeID)
+        XCTAssertFalse(state.complete(id))
+    }
+
     func testFirstSubmitStartsWorker() {
         let latch = SeekLatch()
         XCTAssertTrue(latch.submit(10))

--- a/iosApp/Tests/TrueHDPrimingPolicyTests.swift
+++ b/iosApp/Tests/TrueHDPrimingPolicyTests.swift
@@ -2,6 +2,86 @@ import XCTest
 @testable import Silo
 
 final class TrueHDPrimingPolicyTests: XCTestCase {
+    func testVODRestartBuffersSelectedAudioWhileVideoGateIsWaiting() {
+        XCTAssertTrue(
+            LoopbackVODPreGateAudioBufferPolicy.canBuffer(
+                isRestart: true,
+                isSelectedAudio: true,
+                isWaitingForVideoGate: true,
+                bufferedPackets: 4,
+                bufferedBytes: 4_096,
+                packetBytes: 1_024
+            )
+        )
+    }
+
+    func testVODPreGateBufferDoesNotApplyAfterGateOrToOtherStreams() {
+        XCTAssertFalse(
+            LoopbackVODPreGateAudioBufferPolicy.canBuffer(
+                isRestart: true,
+                isSelectedAudio: true,
+                isWaitingForVideoGate: false,
+                bufferedPackets: 0,
+                bufferedBytes: 0,
+                packetBytes: 1
+            )
+        )
+        XCTAssertFalse(
+            LoopbackVODPreGateAudioBufferPolicy.canBuffer(
+                isRestart: true,
+                isSelectedAudio: false,
+                isWaitingForVideoGate: true,
+                bufferedPackets: 0,
+                bufferedBytes: 0,
+                packetBytes: 1
+            )
+        )
+    }
+
+    func testVODPreGateBufferIsBoundedByPacketsAndBytes() {
+        XCTAssertFalse(
+            LoopbackVODPreGateAudioBufferPolicy.canBuffer(
+                isRestart: true,
+                isSelectedAudio: true,
+                isWaitingForVideoGate: true,
+                bufferedPackets: 3,
+                bufferedBytes: 3,
+                packetBytes: 1,
+                maxPackets: 3,
+                maxBytes: 10
+            )
+        )
+        XCTAssertFalse(
+            LoopbackVODPreGateAudioBufferPolicy.canBuffer(
+                isRestart: true,
+                isSelectedAudio: true,
+                isWaitingForVideoGate: true,
+                bufferedPackets: 0,
+                bufferedBytes: 9,
+                packetBytes: 2,
+                maxPackets: 3,
+                maxBytes: 10
+            )
+        )
+    }
+
+    func testVODPreGateReplayKeepsPacketOverlappingVideoGate() {
+        XCTAssertFalse(
+            LoopbackVODPreGateAudioBufferPolicy.shouldDropReplayedPacket(
+                dts: 900,
+                duration: 200,
+                gateDTS: 1_000
+            )
+        )
+        XCTAssertTrue(
+            LoopbackVODPreGateAudioBufferPolicy.shouldDropReplayedPacket(
+                dts: 800,
+                duration: 200,
+                gateDTS: 1_000
+            )
+        )
+    }
+
     func testTailPolicyDropsOldestPacketWhenPacketCapWouldBeExceeded() {
         let dropCount = DVPreVideoAudioTailPolicy.headDropCountBeforeAppending(
             existingByteSizes: [10, 10, 10],

--- a/iosApp/iosApp/Networking/ServerRegistry.swift
+++ b/iosApp/iosApp/Networking/ServerRegistry.swift
@@ -120,10 +120,12 @@ final class ServerRegistry {
     /// that only know the URL + fetched name don't clobber remembered
     /// session state.
     @discardableResult
-    func addOrUpdate(_ entry: ServerEntry) -> ServerEntry {
+    func addOrUpdate(_ entry: ServerEntry, preservingProfile: Bool = true) -> ServerEntry {
         var merged = entry
         if let existing = self.entries.first(where: { $0.id == entry.id }) {
-            if merged.profileId == nil { merged.profileId = existing.profileId }
+            if preservingProfile, merged.profileId == nil {
+                merged.profileId = existing.profileId
+            }
             if merged.userOverrideName == nil {
                 merged.userOverrideName = existing.userOverrideName
             }

--- a/iosApp/iosApp/Pairing/Receiver/ReceiverPairingCoordinator.swift
+++ b/iosApp/iosApp/Pairing/Receiver/ReceiverPairingCoordinator.swift
@@ -293,9 +293,14 @@ final class ReceiverPairingCoordinator {
     static func persistServer(url: String, fetchedName: String?, access: String, refresh: String) async {
         let id = ServerRegistry.serverId(for: url)
         let entry = ServerEntry(id: id, url: url, fetchedName: fetchedName, userOverrideName: nil, profileId: nil, lastUsedAt: Date())
-        ServerRegistry.shared.addOrUpdate(entry)
+        // Device authorization can replace the account for an already-saved
+        // server URL. Preserve its name, but never carry the previous account's
+        // profile selection across that credential boundary.
+        ServerRegistry.shared.addOrUpdate(entry, preservingProfile: false)
         await TokenStore.shared.setServerUrl(url)
         await TokenStore.shared.switchActiveServer(serverId: id)
+        await TokenStore.shared.setProfileId(nil)
+        await TokenStore.shared.setProfileToken(nil)
         await TokenStore.shared.saveTokens(accessToken: access, refreshToken: refresh)
         await ServerRegistry.shared.switchTo(serverId: id)
     }

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
@@ -132,11 +132,18 @@ final class AVPlayerAudioSessionCoordinator: @unchecked Sendable {
     private let lock = NSLock()
     private var state = AVPlayerAudioSessionActivationState()
 
+    /// One serial queue shared by every coordinator: AVAudioSession is a
+    /// process-wide singleton, so an old backend's teardown deactivation and
+    /// a new backend's activation must keep their submission order. Separate
+    /// per-instance queues would let a stale deactivation land after the next
+    /// playback's activation and silently kill its audio route.
+    private static let sharedWorkQueue = DispatchQueue(
+        label: "org.siloserver.silo.avplayer-audio-session",
+        qos: .userInitiated
+    )
+
     init(
-        workQueue: DispatchQueue = DispatchQueue(
-            label: "org.siloserver.silo.avplayer-audio-session",
-            qos: .userInitiated
-        ),
+        workQueue: DispatchQueue = AVPlayerAudioSessionCoordinator.sharedWorkQueue,
         callbackQueue: DispatchQueue = .main,
         activation: @escaping Operation,
         deactivation: @escaping Operation
@@ -455,6 +462,12 @@ final class AVPlayerBackend {
         case interactive(mediaTarget: Double)
         case initial(mediaTarget: Double)
     }
+    /// Kind of the seek behind the active deadline generation. When a new
+    /// deadline supersedes an in-flight `.initial` seek, its AVPlayer
+    /// completion arrives against a stale generation and is ignored, so the
+    /// supersede/cancel paths must release `isInitialSeekInFlight` here —
+    /// nothing else will, and `attemptInitialPlaybackStart` gates on it.
+    private var activeSeekDeadlineKind: SeekDeadlineKind?
     private var loopbackItemDeathRecoveryState = LoopbackItemDeathRecoveryState()
     private var isInitialSeekInFlight = false
     private var initialSeekRetryCount = 0
@@ -766,6 +779,8 @@ final class AVPlayerBackend {
         item: AVPlayerItem?
     ) -> UInt64 {
         seekDeadlineWorkItem?.cancel()
+        releaseSupersededInitialSeekGateIfNeeded()
+        activeSeekDeadlineKind = kind
         let id = seekDeadlineState.begin()
         let work = DispatchWorkItem { [weak self, weak item] in
             guard let self, !self.isDisposed else { return }
@@ -783,15 +798,24 @@ final class AVPlayerBackend {
         guard seekDeadlineState.complete(id) else { return false }
         seekDeadlineWorkItem?.cancel()
         seekDeadlineWorkItem = nil
+        activeSeekDeadlineKind = nil
         return true
     }
 
     private func cancelSeekDeadline() {
         seekDeadlineWorkItem?.cancel()
         seekDeadlineWorkItem = nil
+        releaseSupersededInitialSeekGateIfNeeded()
+        activeSeekDeadlineKind = nil
         seekDeadlineState.cancel()
         isSeekPending = false
         vodPendingSeekMediaTarget = nil
+    }
+
+    private func releaseSupersededInitialSeekGateIfNeeded() {
+        guard seekDeadlineState.activeID != nil,
+              case .some(.initial) = activeSeekDeadlineKind else { return }
+        isInitialSeekInFlight = false
     }
 
     private func handleSeekDeadline(

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
@@ -8,6 +8,194 @@ import UIKit
 import AppKit
 #endif
 
+struct AVPlayerSeekDeadlineState {
+    private var nextID: UInt64 = 0
+    private(set) var activeID: UInt64?
+
+    mutating func begin() -> UInt64 {
+        nextID &+= 1
+        if nextID == 0 { nextID = 1 }
+        activeID = nextID
+        return nextID
+    }
+
+    mutating func complete(_ id: UInt64) -> Bool {
+        guard activeID == id else { return false }
+        activeID = nil
+        return true
+    }
+
+    mutating func cancel() {
+        activeID = nil
+    }
+}
+
+struct LoopbackItemDeathRecoveryState {
+    enum Action: Equatable {
+        case waitForConfirmation
+        case reload(attempt: Int)
+        case escalate
+    }
+
+    static let matchingPositionToleranceSeconds = 2.0
+    static let evidenceRequired = 2
+    static let maximumReloads = 3
+
+    private var anchorPosition: Double?
+    private var evidence = 0
+    private var reloads = 0
+
+    static func isItemDeath(statusCode: Int?, errorDescription: String) -> Bool {
+        statusCode == -12889
+            || statusCode == -15628
+            || errorDescription.contains("-12889")
+            || errorDescription.contains("No response for media file")
+    }
+
+    mutating func record(
+        position: Double,
+        evidenceWeight: Int,
+        userPaused: Bool
+    ) -> Action {
+        guard !userPaused else { return .waitForConfirmation }
+        let normalized = position.isFinite ? max(0, position) : 0
+        if let anchorPosition,
+           abs(anchorPosition - normalized) > Self.matchingPositionToleranceSeconds {
+            evidence = 0
+            reloads = 0
+        }
+        anchorPosition = normalized
+        evidence += max(evidenceWeight, 1)
+        guard evidence >= Self.evidenceRequired else { return .waitForConfirmation }
+        evidence = 0
+        guard reloads < Self.maximumReloads else { return .escalate }
+        reloads += 1
+        return .reload(attempt: reloads)
+    }
+
+    mutating func reset() {
+        anchorPosition = nil
+        evidence = 0
+        reloads = 0
+    }
+}
+
+struct AVPlayerAudioSessionActivationState {
+    struct Request: Equatable {
+        let id: UInt64
+        let needsActivation: Bool
+    }
+
+    private var nextID: UInt64 = 0
+    private var active = false
+    private var activationPending = false
+
+    mutating func beginActivation() -> Request {
+        nextID &+= 1
+        if nextID == 0 { nextID = 1 }
+        let request = Request(id: nextID, needsActivation: !active)
+        activationPending = request.needsActivation
+        return request
+    }
+
+    mutating func finishActivation(id: UInt64, succeeded: Bool) -> Bool {
+        guard nextID == id else { return false }
+        activationPending = false
+        if succeeded { active = true }
+        return true
+    }
+
+    mutating func cancelAndDeactivate() -> Bool {
+        nextID &+= 1
+        if nextID == 0 { nextID = 1 }
+        let shouldDeactivate = active || activationPending
+        active = false
+        activationPending = false
+        return shouldDeactivate
+    }
+
+    func isCurrent(id: UInt64) -> Bool {
+        nextID == id
+    }
+}
+
+/// Serializes the blocking AVAudioSession category/activation calls away
+/// from the main thread. Generation tracking prevents an activation that
+/// finishes after teardown or source replacement from attaching a stale item.
+final class AVPlayerAudioSessionCoordinator: @unchecked Sendable {
+    typealias Operation = () throws -> Void
+
+    private let workQueue: DispatchQueue
+    private let callbackQueue: DispatchQueue
+    private let activation: Operation
+    private let deactivation: Operation
+    private let lock = NSLock()
+    private var state = AVPlayerAudioSessionActivationState()
+
+    init(
+        workQueue: DispatchQueue = DispatchQueue(
+            label: "org.siloserver.silo.avplayer-audio-session",
+            qos: .userInitiated
+        ),
+        callbackQueue: DispatchQueue = .main,
+        activation: @escaping Operation,
+        deactivation: @escaping Operation
+    ) {
+        self.workQueue = workQueue
+        self.callbackQueue = callbackQueue
+        self.activation = activation
+        self.deactivation = deactivation
+    }
+
+    func activate(completion: @escaping (Error?) -> Void) {
+        let request = locked { state.beginActivation() }
+        guard request.needsActivation else {
+            callbackQueue.async { [weak self] in
+                guard self?.isCurrent(id: request.id) == true else { return }
+                completion(nil)
+            }
+            return
+        }
+
+        workQueue.async { [weak self] in
+            guard let self else { return }
+            let error: Error?
+            do {
+                try self.activation()
+                error = nil
+            } catch let activationError {
+                error = activationError
+            }
+            let shouldDeliver = self.locked {
+                self.state.finishActivation(id: request.id, succeeded: error == nil)
+            }
+            guard shouldDeliver else { return }
+            callbackQueue.async { [weak self] in
+                guard self?.isCurrent(id: request.id) == true else { return }
+                completion(error)
+            }
+        }
+    }
+
+    func deactivate() {
+        let shouldDeactivate = locked { state.cancelAndDeactivate() }
+        guard shouldDeactivate else { return }
+        workQueue.async { [deactivation] in
+            try? deactivation()
+        }
+    }
+
+    private func isCurrent(id: UInt64) -> Bool {
+        locked { state.isCurrent(id: id) }
+    }
+
+    private func locked<T>(_ body: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return body()
+    }
+}
+
 final class AVPlayerBackend {
     enum SourceStrategy {
         case remoteHLS(url: URL, headers: [String: String])
@@ -45,6 +233,7 @@ final class AVPlayerBackend {
     private static let loopbackStartupStallWindowSeconds: TimeInterval = 6.0
     private static let loopbackStartupAbsoluteBackstopSeconds: TimeInterval = 60.0
     private static let loopbackSeekWindowTolerance: Double = 0.25
+    private static let seekCompletionDeadlineSeconds: TimeInterval = 15.0
 
     /// Default forward buffer applied once the initial-video-display gate
     /// releases. Used when the source bitrate is unknown. Keep this modest on
@@ -260,6 +449,13 @@ final class AVPlayerBackend {
     private var hasSeekedToStart = false
     private var isDisposed = false
     private var isSeekPending = false
+    private var seekDeadlineState = AVPlayerSeekDeadlineState()
+    private var seekDeadlineWorkItem: DispatchWorkItem?
+    private enum SeekDeadlineKind {
+        case interactive(mediaTarget: Double)
+        case initial(mediaTarget: Double)
+    }
+    private var loopbackItemDeathRecoveryState = LoopbackItemDeathRecoveryState()
     private var isInitialSeekInFlight = false
     private var initialSeekRetryCount = 0
     private var subtitleSession: SubtitleSession?
@@ -363,8 +559,31 @@ final class AVPlayerBackend {
     private var didEscalateLoopbackStall = false
     private var isUserPaused = false
     private var preserveSessionDirectory = false
-    private var audioSessionActive = false
     private var isPreservingTVDisplayCriteriaForReload = false
+
+    private let audioSessionCoordinator: AVPlayerAudioSessionCoordinator = {
+        #if os(macOS)
+        AVPlayerAudioSessionCoordinator(activation: {}, deactivation: {})
+        #else
+        AVPlayerAudioSessionCoordinator(
+            activation: {
+                let session = AVAudioSession.sharedInstance()
+                try session.setCategory(.playback, mode: .moviePlayback, options: [])
+                // Routing preference, not a claim: tells the system this app
+                // plays multichannel content so route negotiation (HDMI/AirPlay)
+                // prefers a multichannel-capable path. AetherEngine sets the
+                // same before its Atmos passthrough; PlayerCore already does.
+                try? session.setSupportsMultichannelContent(true)
+                try session.setActive(true, options: [])
+            },
+            deactivation: {
+                try AVAudioSession.sharedInstance().setActive(
+                    false, options: [.notifyOthersOnDeactivation]
+                )
+            }
+        )
+        #endif
+    }()
 
     private var statusObs: NSKeyValueObservation?
     private var rateObs: NSKeyValueObservation?
@@ -510,12 +729,22 @@ final class AVPlayerBackend {
         let time = CMTime(seconds: playerSeconds, preferredTimescale: 600)
         isSeekPending = true
         let seekItem = currentItem
+        let seekID = beginSeekDeadline(
+            kind: .interactive(mediaTarget: mediaSeconds),
+            item: seekItem
+        )
         Self.logger.info(
             "[CMP-SEEK] AVPlayer seek request media=\(mediaSeconds, privacy: .public) player=\(playerSeconds, privacy: .public) offset=\(self.mediaTimelineOffsetSeconds, privacy: .public)"
         )
         subtitleSession?.flushOnSeek()
         avPlayer.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero) { [weak self] finished in
             guard let self, !self.isDisposed else { return }
+            guard self.completeSeekDeadline(seekID) else {
+                Self.logger.info(
+                    "[CMP-SEEK] ignoring late/superseded AVPlayer seek completion id=\(seekID, privacy: .public)"
+                )
+                return
+            }
             guard seekItem === self.currentItem else { return }
             self.isSeekPending = false
             self.vodPendingSeekMediaTarget = nil
@@ -528,6 +757,98 @@ final class AVPlayerBackend {
             self.resyncControlledSubtitlesAfterSeek(mediaSeconds: mediaTime)
             self.onTimeChange?(landed)
             self.pumpSubtitleOverlay(referenceTime: mediaTime)
+        }
+    }
+
+    @discardableResult
+    private func beginSeekDeadline(
+        kind: SeekDeadlineKind,
+        item: AVPlayerItem?
+    ) -> UInt64 {
+        seekDeadlineWorkItem?.cancel()
+        let id = seekDeadlineState.begin()
+        let work = DispatchWorkItem { [weak self, weak item] in
+            guard let self, !self.isDisposed else { return }
+            self.handleSeekDeadline(id: id, kind: kind, item: item)
+        }
+        seekDeadlineWorkItem = work
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + Self.seekCompletionDeadlineSeconds,
+            execute: work
+        )
+        return id
+    }
+
+    private func completeSeekDeadline(_ id: UInt64) -> Bool {
+        guard seekDeadlineState.complete(id) else { return false }
+        seekDeadlineWorkItem?.cancel()
+        seekDeadlineWorkItem = nil
+        return true
+    }
+
+    private func cancelSeekDeadline() {
+        seekDeadlineWorkItem?.cancel()
+        seekDeadlineWorkItem = nil
+        seekDeadlineState.cancel()
+        isSeekPending = false
+        vodPendingSeekMediaTarget = nil
+    }
+
+    private func handleSeekDeadline(
+        id: UInt64,
+        kind: SeekDeadlineKind,
+        item: AVPlayerItem?
+    ) {
+        guard completeSeekDeadline(id), item === currentItem else { return }
+        isSeekPending = false
+        item?.cancelPendingSeeks()
+
+        switch kind {
+        case .interactive(let mediaTarget):
+            Self.logger.error(
+                "[CMP-SEEK] AVPlayer seek deadline mediaTarget=\(mediaTarget, privacy: .public) id=\(id, privacy: .public); re-enabling recovery"
+            )
+            if case .some(.siloLoopback(let spec)) = currentSourceStrategy {
+                if spec.servingMode == .vodPlan {
+                    Task { @MainActor [weak self] in
+                        guard let self, !self.isDisposed else { return }
+                        // Keep the target latched until the recovery helper
+                        // reads it; the frozen clock is still pre-seek.
+                        self.vodPendingSeekMediaTarget = mediaTarget
+                        self.performVODStallRecovery(
+                            attempt: 1,
+                            frozenPosition: self.playerTime(forMediaTime: mediaTarget)
+                        )
+                        self.vodPendingSeekMediaTarget = nil
+                    }
+                    return
+                } else if let item = currentItem {
+                    recoverLocalLoopbackStallIfNeeded(
+                        item: item,
+                        requireBufferedEdge: false,
+                        reason: "seek_deadline"
+                    )
+                }
+            } else if !isUserPaused {
+                avPlayer.play()
+            }
+            vodPendingSeekMediaTarget = nil
+
+        case .initial(let mediaTarget):
+            isInitialSeekInFlight = false
+            initialSeekRetryCount += 1
+            let retry = initialSeekRetryCount
+            Self.logger.error(
+                "[CMP-SEEK] initial AVPlayer seek deadline mediaTarget=\(mediaTarget, privacy: .public) retry=\(retry, privacy: .public)"
+            )
+            if retry <= 8, let item = currentItem {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self, weak item] in
+                    guard let self, let item, !self.isDisposed, item === self.currentItem else { return }
+                    self.attemptInitialPlaybackStart(for: item, trigger: "deadline-retry-\(retry)")
+                }
+            } else if let item = currentItem {
+                startPlaybackIfNeeded(for: item)
+            }
         }
     }
 
@@ -1150,12 +1471,45 @@ final class AVPlayerBackend {
             avPlayer.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero)
             avPlayer.play()
         } else {
-            guard let urlAsset = currentItem?.asset as? AVURLAsset else { return }
             cmpLog("[CMP-AVP] vod stall recovery in-place item reload anchorPlayer=\(anchorPlayer)")
-            prepareAssetPlayback(url: urlAsset.url, headers: [:])
-            avPlayer.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero)
+            guard let item = currentItem else { return }
+            reloadEstablishedLoopbackItem(item, at: anchorPlayer, reason: "vod_stall")
+        }
+    }
+
+    /// Rebuild only AVFoundation's item/loader state while preserving the
+    /// loopback producer, segment plan/store/server, display criteria, audio
+    /// session, selected tracks, and recovery budgets.
+    @MainActor
+    private func reloadEstablishedLoopbackItem(
+        _ oldItem: AVPlayerItem,
+        at playerSeconds: Double,
+        reason: String
+    ) {
+        guard oldItem === currentItem,
+              let asset = oldItem.asset as? AVURLAsset else { return }
+        cancelSeekDeadline()
+        oldItem.cancelPendingSeeks()
+        detachPerItemObservers()
+
+        let item = AVPlayerItem(asset: AVURLAsset(url: asset.url))
+        item.preferredForwardBufferDuration = max(
+            oldItem.preferredForwardBufferDuration,
+            Self.loopbackStartupForwardBuffer
+        )
+        item.canUseNetworkResourcesForLiveStreamingWhilePaused = false
+        currentItem = item
+        attachItemObservers(item)
+        avPlayer.replaceCurrentItem(with: item)
+
+        let target = CMTime(seconds: max(0, playerSeconds), preferredTimescale: 600)
+        avPlayer.seek(to: target, toleranceBefore: .zero, toleranceAfter: .zero)
+        if !isUserPaused {
             avPlayer.play()
         }
+        cmpLog(
+            "[CMP-AVP] established loopback item reloaded reason=\(reason) player=\(playerSeconds) url=\(asset.url.absoluteString)"
+        )
     }
 
     private func startSiloLoopback(
@@ -1490,8 +1844,9 @@ final class AVPlayerBackend {
         // The local loopback server is an in-app HTTP surface. Remote auth
         // headers are only for libavformat's source fetch and should not be
         // propagated into AVPlayer's localhost HLS requests.
-        prepareAssetPlayback(url: url, headers: [:])
-        issueVODResumePreSeekIfNeeded(context: "first_segment")
+        prepareAssetPlayback(url: url, headers: [:]) { [weak self] in
+            self?.issueVODResumePreSeekIfNeeded(context: "first_segment")
+        }
     }
 
     /// Resume: aim AVPlayer's very first media fetches at the resume
@@ -1511,8 +1866,23 @@ final class AVPlayerBackend {
         cmpLog("[CMP-AVP] vod resume pre-seek player=\(target) media=\(pendingStartTime) context=\(context)")
     }
 
-    private func prepareAssetPlayback(url: URL, headers: [String: String]) {
-        activateAudioSession()
+    private func prepareAssetPlayback(
+        url: URL,
+        headers: [String: String],
+        completion: (() -> Void)? = nil
+    ) {
+        activateAudioSession { [weak self] error in
+            guard let self, !self.isDisposed else { return }
+            if let error {
+                let message = "AVPlayer audio session setup failed: \(error.localizedDescription)"
+                cmpLog("[CMP-AVP] ERROR: \(message)")
+            }
+            self.finishPreparingAssetPlayback(url: url, headers: headers)
+            completion?()
+        }
+    }
+
+    private func finishPreparingAssetPlayback(url: URL, headers: [String: String]) {
         var options: [String: Any] = [:]
         if !headers.isEmpty {
             options["AVURLAssetHTTPHeaderFieldsKey"] = headers
@@ -1554,38 +1924,12 @@ final class AVPlayerBackend {
         installSubtitleDisplayLink()
     }
 
-    private func activateAudioSession() {
-        #if os(macOS)
-        return
-        #else
-        guard !audioSessionActive else { return }
-        let session = AVAudioSession.sharedInstance()
-        do {
-            try session.setCategory(.playback, mode: .moviePlayback, options: [])
-            // Routing preference, not a claim: tells the system this app
-            // plays multichannel content so route negotiation (HDMI/AirPlay)
-            // prefers a multichannel-capable path. AetherEngine sets the
-            // same before its Atmos passthrough; PlayerCore already does.
-            try? session.setSupportsMultichannelContent(true)
-            try session.setActive(true, options: [])
-            audioSessionActive = true
-        } catch {
-            let message = "AVPlayer audio session setup failed: \(error.localizedDescription)"
-            cmpLog("[CMP-AVP] ERROR: \(message)")
-        }
-        #endif
+    private func activateAudioSession(completion: @escaping (Error?) -> Void) {
+        audioSessionCoordinator.activate(completion: completion)
     }
 
     private func deactivateAudioSession() {
-        #if os(macOS)
-        return
-        #else
-        guard audioSessionActive else { return }
-        audioSessionActive = false
-        try? AVAudioSession.sharedInstance().setActive(
-            false, options: [.notifyOthersOnDeactivation]
-        )
-        #endif
+        audioSessionCoordinator.deactivate()
     }
 
     private func configureEmbeddedSubtitleExtraction(for strategy: SourceStrategy) {
@@ -2558,6 +2902,20 @@ final class AVPlayerBackend {
             cmpLog(
                 "[CMP-AVP] item errorLog status=\(event.errorStatusCode) domain=\(event.errorDomain) uri=\(event.uri ?? "-") comment=\(event.errorComment ?? "-")"
             )
+            if self.didFireFileLoaded,
+               LoopbackItemDeathRecoveryState.isItemDeath(
+                    statusCode: event.errorStatusCode,
+                    errorDescription: event.errorComment ?? ""
+               ) {
+                self.handleLoopbackItemDeathEvidence(
+                    item: item,
+                    statusCode: event.errorStatusCode,
+                    errorDescription: event.errorComment ?? "",
+                    evidenceWeight: event.errorStatusCode == -15628 ? 2 : 1,
+                    trigger: "error_log"
+                )
+                return
+            }
             if event.errorStatusCode == -15628,
                !self.didFireFileLoaded,
                case .siloLoopback = self.currentSourceStrategy {
@@ -2598,6 +2956,21 @@ final class AVPlayerBackend {
 
     private func recoverLocalLoopbackFailureIfNeeded(item: AVPlayerItem, error: Error?) {
         let description = String(describing: error)
+        let statusCode = item.errorLog()?.events.last?.errorStatusCode
+        if didFireFileLoaded,
+           LoopbackItemDeathRecoveryState.isItemDeath(
+                statusCode: statusCode,
+                errorDescription: description
+           ) {
+            handleLoopbackItemDeathEvidence(
+                item: item,
+                statusCode: statusCode,
+                errorDescription: description,
+                evidenceWeight: 2,
+                trigger: "failed_to_end"
+            )
+            return
+        }
         guard description.contains("Playlist File unchanged") || description.contains("-12888") else {
             return
         }
@@ -2612,6 +2985,47 @@ final class AVPlayerBackend {
             return
         }
         recoverLocalLoopbackStallIfNeeded(item: item, requireBufferedEdge: false, reason: "playlist_unchanged")
+    }
+
+    private func handleLoopbackItemDeathEvidence(
+        item: AVPlayerItem,
+        statusCode: Int?,
+        errorDescription: String,
+        evidenceWeight: Int,
+        trigger: String
+    ) {
+        guard case .some(.siloLoopback) = currentSourceStrategy,
+              item === currentItem,
+              didFireFileLoaded else { return }
+        let position = currentTime()
+        let action = loopbackItemDeathRecoveryState.record(
+            position: position,
+            evidenceWeight: evidenceWeight,
+            userPaused: isUserPaused
+        )
+        switch action {
+        case .waitForConfirmation:
+            Self.logger.info(
+                "[CMP-AVP] loopback item-death evidence waiting trigger=\(trigger, privacy: .public) status=\(statusCode ?? 0, privacy: .public) paused=\(self.isUserPaused ? 1 : 0, privacy: .public) pos=\(position, privacy: .public) error=\(errorDescription, privacy: .public)"
+            )
+        case .reload(let attempt):
+            Self.logger.error(
+                "[CMP-AVP] loopback item-death reload trigger=\(trigger, privacy: .public) status=\(statusCode ?? 0, privacy: .public) attempt=\(attempt, privacy: .public) pos=\(position, privacy: .public)"
+            )
+            Task { @MainActor [weak self, weak item] in
+                guard let self, let item, item === self.currentItem, !self.isDisposed else { return }
+                self.reloadEstablishedLoopbackItem(
+                    item,
+                    at: position,
+                    reason: "item_death_\(trigger)_\(attempt)"
+                )
+            }
+        case .escalate:
+            Self.logger.error(
+                "[CMP-AVP] loopback item-death reload budget exhausted status=\(statusCode ?? 0, privacy: .public) pos=\(position, privacy: .public)"
+            )
+            onLoopbackStallUnrecoverable?("loopback_item_death")
+        }
     }
 
     private func recoverLocalLoopbackStallIfNeeded(
@@ -2683,6 +3097,10 @@ final class AVPlayerBackend {
 
         isInitialSeekInFlight = true
         isSeekPending = true
+        let seekID = beginSeekDeadline(
+            kind: .initial(mediaTarget: mediaTarget),
+            item: item
+        )
         subtitleSession?.flushOnSeek()
         let time = CMTime(seconds: playerTarget, preferredTimescale: 600)
         Self.logger.info(
@@ -2690,6 +3108,12 @@ final class AVPlayerBackend {
         )
         avPlayer.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero) { [weak self] finished in
             guard let self, !self.isDisposed, item === self.currentItem else { return }
+            guard self.completeSeekDeadline(seekID) else {
+                Self.logger.info(
+                    "[CMP-SEEK] ignoring late/superseded initial seek completion id=\(seekID, privacy: .public)"
+                )
+                return
+            }
             self.isSeekPending = false
             self.isInitialSeekInFlight = false
 
@@ -3365,6 +3789,8 @@ final class AVPlayerBackend {
     }
 
     private func teardownMediaPipeline(clearDisplayCriteria: Bool = true) {
+        cancelSeekDeadline()
+        loopbackItemDeathRecoveryState.reset()
         if clearDisplayCriteria {
             clearTVDisplayCriteria(context: "teardown")
         } else {

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/LoopbackSegmentServer.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/LoopbackSegmentServer.swift
@@ -391,6 +391,7 @@ final class LoopbackSegmentServer {
                         // abort the read-until-close response so AVPlayer can
                         // retry instead of accepting a false successful EOF.
                         if case .found = result { return }
+                        cmpLog("[CMP-HLS] early VOD response aborted on terminal miss path=\(path)")
                         connection.cancel()
                         return
                     }

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/LoopbackSegmentServer.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/LoopbackSegmentServer.swift
@@ -31,6 +31,7 @@ final class LoopbackSegmentServer {
     deinit { print("[CMP-LIFE] deinit LoopbackSegmentServer") }
     private static let startupRequestLogLimit = 80
     private static let responseChunkBytes = 256 * 1024
+    static let vodEarlyResponseDelaySeconds: TimeInterval = 2.0
     private static let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "com.continuum.app",
         category: "LoopbackSegmentServer"
@@ -156,6 +157,19 @@ final class LoopbackSegmentServer {
             defer { lock.unlock() }
             if resumed { return false }
             resumed = true
+            return true
+        }
+    }
+
+    private final class ResponseClaim: @unchecked Sendable {
+        private let lock = NSLock()
+        private var claimed = false
+
+        func claim() -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !claimed else { return false }
+            claimed = true
             return true
         }
     }
@@ -332,6 +346,9 @@ final class LoopbackSegmentServer {
     /// and waits, bounded, for the bytes. Runs off the server's queue so a
     /// slow resolution never stalls playlist/init requests.
     var vodSegmentMissResolver: ((Int) -> LoopbackSegmentStore.ResourceResult)?
+    /// Test/diagnostic hook fired when the early read-until-close response is
+    /// committed, before the producer has necessarily published body bytes.
+    var onEarlyVODResponseHeaders: ((String) -> Void)?
 
     private func respondWithStoreResource(
         path: String,
@@ -348,9 +365,36 @@ final class LoopbackSegmentServer {
         case .missing, .gone:
             if let resolver = vodSegmentMissResolver,
                let index = LoopbackSegmentStore.segmentIndex(fromName: path) {
+                let responseClaim = ResponseClaim()
+                if method == .get {
+                    queue.asyncAfter(deadline: .now() + Self.vodEarlyResponseDelaySeconds) { [weak self] in
+                        guard let self, responseClaim.claim() else { return }
+                        cmpLog("[CMP-HLS] early VOD response headers path=\(path)")
+                        self.onEarlyVODResponseHeaders?(path)
+                        self.respondWithProgressiveStream(
+                            name: path,
+                            mime: self.mimeType(for: "m4s"),
+                            requestPath: path,
+                            method: method,
+                            range: rangeHeader,
+                            started: started,
+                            on: connection
+                        )
+                    }
+                }
                 DispatchQueue.global(qos: .userInitiated).async { [weak self] in
                     guard let self else { return }
-                    switch resolver(index) {
+                    let result = resolver(index)
+                    guard responseClaim.claim() else {
+                        // Headers already went out. A found resource is picked
+                        // up by the progressive pump; a terminal miss must
+                        // abort the read-until-close response so AVPlayer can
+                        // retry instead of accepting a false successful EOF.
+                        if case .found = result { return }
+                        connection.cancel()
+                        return
+                    }
+                    switch result {
                     case .found(let resource):
                         self.respondWithResource(
                             resource,
@@ -487,7 +531,8 @@ final class LoopbackSegmentServer {
             let (delta, complete) = store.readProgressiveSegment(
                 named: name,
                 from: offset,
-                deadline: min(overallDeadline, Date().addingTimeInterval(0.25))
+                deadline: min(overallDeadline, Date().addingTimeInterval(0.25)),
+                waitForStart: offset == 0
             )
             let nextOffset = offset + delta.count
             let finish: () -> Void = { [weak self] in

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/LoopbackSegmentStore.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/LoopbackSegmentStore.swift
@@ -403,7 +403,8 @@ final class LoopbackSegmentStore {
     func readProgressiveSegment(
         named name: String,
         from offset: Int,
-        deadline: Date
+        deadline: Date,
+        waitForStart: Bool = false
     ) -> (Data, Bool) {
         lock.lock()
         defer { lock.unlock() }
@@ -420,6 +421,13 @@ final class LoopbackSegmentStore {
                 return (data.subdata(in: offset..<data.count), true)
             }
             guard let partial = progressiveSegments[name] else {
+                if waitForStart, !evictedResources.contains(name) {
+                    guard Date() < deadline else {
+                        return (Data(), false)
+                    }
+                    lock.wait(until: deadline)
+                    continue
+                }
                 return (Data(), true)
             }
             if offset > partial.count {

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/LoopbackSegmentWriter.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/LoopbackSegmentWriter.swift
@@ -3115,6 +3115,7 @@ final class LoopbackSegmentWriter {
                         outStreamIndex: Int32(outIdx),
                         inputStreamIndex: inIdx
                     )
+                    try replayVODPreGateAudioPacketsIfNeeded()
                 } else {
                     rewritePacketForOutput(
                         pkt: pending,

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/LoopbackSegmentWriter.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/LoopbackSegmentWriter.swift
@@ -59,6 +59,64 @@ enum DVPreVideoAudioTailPolicy {
     }
 }
 
+/// Resolves the duration written for a look-behind video packet. Matroska
+/// commonly supplies a constant `DefaultDuration` even when its millisecond
+/// block timestamps produce a 41/42 ms DTS cadence. Prefer the forward DTS
+/// delta whenever it is usable so movenc's accumulated track duration cannot
+/// drift past the next real DTS at a fragment boundary.
+enum LoopbackVideoSampleDurationPolicy {
+    static func resolve(
+        existingDuration: Int64,
+        dts: Int64,
+        nextDTS: Int64?,
+        fallback: Int64
+    ) -> Int64 {
+        if let nextDTS, dts != Int64.min, nextDTS != Int64.min {
+            let (delta, overflow) = nextDTS.subtractingReportingOverflow(dts)
+            if !overflow, delta > 0 {
+                return delta
+            }
+        }
+        if existingDuration > 0 {
+            return existingDuration
+        }
+        return max(fallback, 1)
+    }
+}
+
+enum LoopbackVODPreGateAudioBufferPolicy {
+    static let maxPackets = 512
+    static let maxBytes = 8 * 1024 * 1024
+
+    static func canBuffer(
+        isRestart: Bool,
+        isSelectedAudio: Bool,
+        isWaitingForVideoGate: Bool,
+        bufferedPackets: Int,
+        bufferedBytes: Int,
+        packetBytes: Int,
+        maxPackets: Int = Self.maxPackets,
+        maxBytes: Int = Self.maxBytes
+    ) -> Bool {
+        guard isRestart, isSelectedAudio, isWaitingForVideoGate else { return false }
+        let bytes = max(packetBytes, 0)
+        return bufferedPackets < maxPackets && bufferedBytes + bytes <= maxBytes
+    }
+
+    static func shouldDropReplayedPacket(
+        dts: Int64,
+        duration: Int64,
+        gateDTS: Int64
+    ) -> Bool {
+        let span = max(duration, 0)
+        if span > 0 {
+            let (end, overflow) = dts.addingReportingOverflow(span)
+            return !overflow && end <= gateDTS
+        }
+        return dts < gateDTS
+    }
+}
+
 enum DVTrueHDMajorSyncScanner {
     private static let syncWord: [UInt8] = [0xF8, 0x72, 0x6F, 0xBA]
 
@@ -600,6 +658,14 @@ final class LoopbackSegmentWriter {
     /// duplicate audio DTS before handing packets to the MP4 muxer.
     private var lastMuxedDTSByStream: [Int32: Int64] = [:]
     private var lastMuxedPTSByStream: [Int32: Int64] = [:]
+    /// One-packet look-behind for video duration telescoping. The next
+    /// normalized video DTS supplies the pending packet's real duration.
+    private var pendingMuxVideoPacket: UnsafeMutablePointer<AVPacket>?
+    /// Audio packets encountered while a video packet is held. Deferring
+    /// them preserves the original video-before-audio submission order; the
+    /// queue is drained immediately after the held video is finalized.
+    private var pendingMuxAudioPackets: [UnsafeMutablePointer<AVPacket>] = []
+    private var lastResolvedVideoDurationByStream: [Int32: Int64] = [:]
     /// When the loopback starts from a resume point, FFmpeg seeks the source
     /// but source packet timestamps remain absolute. Subtract the first video
     /// timestamp so the generated localhost playlist begins at player time 0.
@@ -963,6 +1029,13 @@ final class LoopbackSegmentWriter {
     /// can size the decode-ramp seam. Mux thread only.
     private var vodPrerollDroppedVideo = 0
     private var vodPrerollDroppedAudio = 0
+    /// Selected-audio packets encountered while a restarted VOD producer is
+    /// still scanning forward to its accepted video keyframe. Wide-interleave
+    /// sources can put the matching audio earlier in file order; replaying it
+    /// after the gate opens prevents a persistent post-recovery A/V offset.
+    private var vodPreGateAudioPackets: [UnsafeMutablePointer<AVPacket>] = []
+    private var vodPreGateAudioBytes = 0
+    private var vodPreGateAudioOverflowLogged = false
 
     /// FFmpeg's mp4 muxer can only build the AC-3/E-AC-3/TrueHD sample-entry
     /// box (dac3/dec3/dmlp) after it has PARSED an audio packet, so under
@@ -1064,15 +1137,108 @@ final class LoopbackSegmentWriter {
         // continuous run's interleaver assigns that same overlapping frame
         // forward. Dropping it would lose exactly one frame per restart
         // (and break restart byte-identity with the continuous run).
-        let duration = max(0, pkt.pointee.duration)
-        let drops: Bool
-        if duration > 0 {
-            drops = pkt.pointee.dts + duration <= threshold
-        } else {
-            drops = pkt.pointee.dts < threshold
-        }
+        let drops = LoopbackVODPreGateAudioBufferPolicy.shouldDropReplayedPacket(
+            dts: pkt.pointee.dts,
+            duration: pkt.pointee.duration,
+            gateDTS: threshold
+        )
         if drops { vodPrerollDroppedAudio += 1 }
         return drops
+    }
+
+    private func bufferVODPreGateAudioIfNeeded(
+        pkt: UnsafeMutablePointer<AVPacket>,
+        inputIdx: Int
+    ) -> Bool {
+        let isRestart = vodActive && vodEffectiveBaseIndex > 0
+        let isSelectedAudio = inputIdx == selectedAudioStreamIndex
+        let waiting = vodAwaitingRestartKeyframe && vodFirstRoutedVideoDts == nil
+        let packetBytes = max(0, Int(pkt.pointee.size))
+        let canBuffer = LoopbackVODPreGateAudioBufferPolicy.canBuffer(
+            isRestart: isRestart,
+            isSelectedAudio: isSelectedAudio,
+            isWaitingForVideoGate: waiting,
+            bufferedPackets: vodPreGateAudioPackets.count,
+            bufferedBytes: vodPreGateAudioBytes,
+            packetBytes: packetBytes
+        )
+        guard canBuffer else {
+            if isRestart, isSelectedAudio, waiting,
+               !vodPreGateAudioOverflowLogged {
+                vodPreGateAudioOverflowLogged = true
+                print(
+                    "[CMP-AVP] vod pre-gate audio buffer full "
+                    + "packets=\(vodPreGateAudioPackets.count) "
+                    + "bytes=\(vodPreGateAudioBytes); dropping further preroll"
+                )
+            }
+            return false
+        }
+        guard let held = av_packet_clone(pkt) else { return false }
+        vodPreGateAudioPackets.append(held)
+        vodPreGateAudioBytes += packetBytes
+        return true
+    }
+
+    private func replayVODPreGateAudioPacketsIfNeeded() throws {
+        guard !vodAwaitingRestartKeyframe,
+              vodFirstRoutedVideoDts != nil,
+              !vodPreGateAudioPackets.isEmpty,
+              let outIdx = streamMap[selectedAudioStreamIndex] else { return }
+
+        var packets = vodPreGateAudioPackets.sorted {
+            Self.packetOrderingTimestamp($0) < Self.packetOrderingTimestamp($1)
+        }
+        let bufferedBytes = vodPreGateAudioBytes
+        vodPreGateAudioPackets.removeAll()
+        vodPreGateAudioBytes = 0
+
+        var replayed = 0
+        var dropped = 0
+        defer {
+            for packet in packets {
+                var free: UnsafeMutablePointer<AVPacket>? = packet
+                av_packet_free(&free)
+            }
+            packets.removeAll()
+        }
+
+        for packet in packets {
+            if vodShouldDropPacket(pkt: packet, inputIdx: selectedAudioStreamIndex) {
+                dropped += 1
+                continue
+            }
+            if let prefedMax = vodPrefedAudioMaxDts {
+                let dts = Self.packetOrderingTimestamp(packet)
+                if dts != Int64.min, dts <= prefedMax {
+                    dropped += 1
+                    continue
+                }
+                vodPrefedAudioMaxDts = nil
+            }
+
+            if selectedAudioOutputMode != .copy {
+                try transcodeAudioPacket(packet)
+            } else {
+                rewritePacketForOutput(
+                    pkt: packet,
+                    outStreamIndex: Int32(outIdx),
+                    inputStreamIndex: selectedAudioStreamIndex
+                )
+                try writePacketToMux(packet)
+            }
+            replayed += 1
+        }
+        print(
+            "[CMP-AVP] vod pre-gate audio replay buffered=\(packets.count) "
+            + "bytes=\(bufferedBytes) replayed=\(replayed) dropped=\(dropped)"
+        )
+    }
+
+    private static func packetOrderingTimestamp(
+        _ packet: UnsafeMutablePointer<AVPacket>
+    ) -> Int64 {
+        packet.pointee.dts != Int64.min ? packet.pointee.dts : packet.pointee.pts
     }
 
     private func prewarmVODCueIndexAndReseek() {
@@ -1418,22 +1584,21 @@ final class LoopbackSegmentWriter {
 
     /// Routes a video packet through the plan cutter and flushes the open
     /// fragment when the packet opens a new segment. Runs BEFORE
-    /// `rewritePacketForOutput` so the packet's PTS is still on the source
-    /// video time base — the same axis as the plan boundaries.
-    private func vodCutBeforeVideoPacketIfNeeded(pkt: UnsafeMutablePointer<AVPacket>) throws {
+    /// `rewritePacketForOutput` changes the packet to the output axis, so the
+    /// caller captures source PTS/keyframe state first and passes them here.
+    private func vodCutBeforeVideoPacketIfNeeded(sourcePTS: Int64, isKeyframe: Bool) throws {
         guard vodActive, vodCutter != nil else { return }
-        let isKeyframe = (pkt.pointee.flags & AV_PKT_FLAG_KEY) != 0
-        let target = vodCutter!.index(pts: pkt.pointee.pts, isKeyframe: isKeyframe)
+        let target = vodCutter!.index(pts: sourcePTS, isKeyframe: isKeyframe)
         // Progressive anchor: request an interim fragment flush roughly
-        // every 1.5 s of routed video. The flush runs after this packet is
-        // written (main loop), so the fragment includes it.
-        if vodProgressiveAccumulating, pkt.pointee.pts != Int64.min {
+        // every 1.5 s of routed video. The look-behind path performs the
+        // flush after this sample is actually written, so it is included.
+        if vodProgressiveAccumulating, sourcePTS != Int64.min {
             if vodLastInterimFlushPts == Int64.min {
-                vodLastInterimFlushPts = pkt.pointee.pts
-            } else if pkt.pointee.pts - vodLastInterimFlushPts
+                vodLastInterimFlushPts = sourcePTS
+            } else if sourcePTS - vodLastInterimFlushPts
                         >= ticks(forSeconds: 1.5, timeBase: vodVideoTimeBase) {
                 vodInterimFlushRequested = true
-                vodLastInterimFlushPts = pkt.pointee.pts
+                vodLastInterimFlushPts = sourcePTS
             }
         }
         if !vodHasRoutedVideo {
@@ -1692,6 +1857,10 @@ final class LoopbackSegmentWriter {
                     continue
                 }
 
+                if bufferVODPreGateAudioIfNeeded(pkt: pkt, inputIdx: inputIdx) {
+                    continue
+                }
+
                 if vodActive, vodShouldDropPacket(pkt: pkt, inputIdx: inputIdx) {
                     continue
                 }
@@ -1731,35 +1900,31 @@ final class LoopbackSegmentWriter {
                     } else {
                         try transformVideoPacketIfNeeded(pkt)
                     }
-                    try vodCutBeforeVideoPacketIfNeeded(pkt: pkt)
                 }
 
                 if isCancelled {
                     continue
                 }
-                rewritePacketForOutput(pkt: pkt, outStreamIndex: Int32(outIdx),
-                                       inputStreamIndex: inputIdx)
-                let wr: Int32
-                if LoopbackSegmentWriter.traceThroughput {
-                    let started = CFAbsoluteTimeGetCurrent()
-                    wr = av_interleaved_write_frame(outputCtx, pkt)
-                    throughputTiming.muxMs += (CFAbsoluteTimeGetCurrent() - started) * 1000
-                    throughputTiming.muxPackets += 1
+                if inputIdx == videoInputStreamIndex {
+                    try routeVideoPacketToMux(
+                        pkt,
+                        outStreamIndex: Int32(outIdx),
+                        inputStreamIndex: inputIdx
+                    )
+                    try replayVODPreGateAudioPacketsIfNeeded()
                 } else {
-                    wr = av_interleaved_write_frame(outputCtx, pkt)
-                }
-                try evaluateMuxWriteResult(wr)
-                if vodActive, !initSegmentWritten {
-                    try primeVODMoovAfterFirstAudioIfNeeded()
-                }
-                if vodInterimFlushRequested {
-                    vodInterimFlushRequested = false
-                    performVODInterimFragmentFlush()
+                    rewritePacketForOutput(
+                        pkt: pkt,
+                        outStreamIndex: Int32(outIdx),
+                        inputStreamIndex: inputIdx
+                    )
+                    try writePacketToMux(pkt)
                 }
             }
 
             if !isCancelled {
                 try finishTranscodedAudio()
+                try flushPendingMuxVideoPacket(nextDTS: nil)
                 if vodActive {
                     // The trailer flushes the final open fragment; name it.
                     vodClosingSegmentIndex = vodOpenSegmentIndex
@@ -2943,22 +3108,128 @@ final class LoopbackSegmentWriter {
             }
             guard let outIdx = streamMap[inIdx] else { continue }
             if vodActive, vodShouldDropPacket(pkt: pending, inputIdx: inIdx) { continue }
-            if inIdx == videoInputStreamIndex {
-                try vodCutBeforeVideoPacketIfNeeded(pkt: pending)
-            }
-            rewritePacketForOutput(pkt: pending,
-                                   outStreamIndex: Int32(outIdx),
-                                   inputStreamIndex: inIdx)
-            let wr = av_interleaved_write_frame(outCtx, pending)
             do {
-                try evaluateMuxWriteResult(wr)
+                if inIdx == videoInputStreamIndex {
+                    try routeVideoPacketToMux(
+                        pending,
+                        outStreamIndex: Int32(outIdx),
+                        inputStreamIndex: inIdx
+                    )
+                } else {
+                    rewritePacketForOutput(
+                        pkt: pending,
+                        outStreamIndex: Int32(outIdx),
+                        inputStreamIndex: inIdx
+                    )
+                    try writePacketToMux(pending)
+                }
             } catch {
                 Self.logger.error("pending \(label, privacy: .public) write failed")
                 throw error
             }
-            if vodActive, !initSegmentWritten {
-                try primeVODMoovAfterFirstAudioIfNeeded()
+        }
+    }
+
+    /// Rewrites and holds one video packet until the next normalized video
+    /// DTS is known. The previous packet is written before the current
+    /// sample's keyframe cut, keeping it in its original segment.
+    private func routeVideoPacketToMux(
+        _ pkt: UnsafeMutablePointer<AVPacket>,
+        outStreamIndex: Int32,
+        inputStreamIndex: Int
+    ) throws {
+        let sourcePTS = pkt.pointee.pts
+        let isKeyframe = (pkt.pointee.flags & AV_PKT_FLAG_KEY) != 0
+        rewritePacketForOutput(
+            pkt: pkt,
+            outStreamIndex: outStreamIndex,
+            inputStreamIndex: inputStreamIndex
+        )
+
+        try flushPendingMuxVideoPacket(nextDTS: pkt.pointee.dts)
+        try vodCutBeforeVideoPacketIfNeeded(sourcePTS: sourcePTS, isKeyframe: isKeyframe)
+
+        guard let held = av_packet_clone(pkt) else {
+            throw LoopbackWriterError.allocPacket
+        }
+        pendingMuxVideoPacket = held
+    }
+
+    private func flushPendingMuxVideoPacket(nextDTS: Int64?) throws {
+        guard let pending = pendingMuxVideoPacket else { return }
+        pendingMuxVideoPacket = nil
+        defer {
+            var free: UnsafeMutablePointer<AVPacket>? = pending
+            av_packet_free(&free)
+        }
+
+        let streamIndex = pending.pointee.stream_index
+        let fallback = lastResolvedVideoDurationByStream[streamIndex] ?? 1
+        let resolved = LoopbackVideoSampleDurationPolicy.resolve(
+            existingDuration: pending.pointee.duration,
+            dts: pending.pointee.dts,
+            nextDTS: nextDTS,
+            fallback: fallback
+        )
+        pending.pointee.duration = resolved
+        lastResolvedVideoDurationByStream[streamIndex] = resolved
+        try writePacketToMuxImmediately(pending, performPostWriteActions: false)
+        try flushPendingMuxAudioPackets(performPostWriteActions: false)
+        try performMuxPostWriteActions()
+    }
+
+    private func writePacketToMux(_ pkt: UnsafeMutablePointer<AVPacket>) throws {
+        if pendingMuxVideoPacket != nil {
+            guard let held = av_packet_clone(pkt) else {
+                throw LoopbackWriterError.allocPacket
             }
+            pendingMuxAudioPackets.append(held)
+            return
+        }
+        try writePacketToMuxImmediately(pkt)
+    }
+
+    private func flushPendingMuxAudioPackets(performPostWriteActions: Bool) throws {
+        while !pendingMuxAudioPackets.isEmpty {
+            let pending = pendingMuxAudioPackets.removeFirst()
+            defer {
+                var free: UnsafeMutablePointer<AVPacket>? = pending
+                av_packet_free(&free)
+            }
+            try writePacketToMuxImmediately(
+                pending,
+                performPostWriteActions: performPostWriteActions
+            )
+        }
+    }
+
+    private func writePacketToMuxImmediately(
+        _ pkt: UnsafeMutablePointer<AVPacket>,
+        performPostWriteActions: Bool = true
+    ) throws {
+        guard let outputCtx else { return }
+        let wr: Int32
+        if Self.traceThroughput {
+            let started = CFAbsoluteTimeGetCurrent()
+            wr = av_interleaved_write_frame(outputCtx, pkt)
+            throughputTiming.muxMs += (CFAbsoluteTimeGetCurrent() - started) * 1000
+            throughputTiming.muxPackets += 1
+        } else {
+            wr = av_interleaved_write_frame(outputCtx, pkt)
+        }
+        try evaluateMuxWriteResult(wr)
+        if performPostWriteActions {
+            try performMuxPostWriteActions()
+        }
+    }
+
+    private func performMuxPostWriteActions() throws {
+        if vodActive, !initSegmentWritten {
+            try primeVODMoovAfterFirstAudioIfNeeded()
+        }
+        if vodInterimFlushRequested {
+            vodInterimFlushRequested = false
+            performVODInterimFragmentFlush()
         }
     }
 
@@ -4273,9 +4544,8 @@ final class LoopbackSegmentWriter {
             encodedPacket.pointee.stream_index = Int32(audioOutputStreamIndex)
             av_packet_rescale_ts(encodedPacket, encoderCtx.pointee.time_base, outStream.pointee.time_base)
             normalizeMuxerTimestampsIfNeeded(pkt: encodedPacket, outStream: outStream)
-            let wr = av_interleaved_write_frame(outCtx, encodedPacket)
             do {
-                try evaluateMuxWriteResult(wr)
+                try writePacketToMux(encodedPacket)
             } catch {
                 av_packet_free(&packet)
                 throw error
@@ -5997,6 +6267,22 @@ final class LoopbackSegmentWriter {
     // MARK: - Teardown
 
     private func teardown() {
+        if let pendingMuxVideoPacket {
+            var free: UnsafeMutablePointer<AVPacket>? = pendingMuxVideoPacket
+            av_packet_free(&free)
+            self.pendingMuxVideoPacket = nil
+        }
+        for pending in pendingMuxAudioPackets {
+            var free: UnsafeMutablePointer<AVPacket>? = pending
+            av_packet_free(&free)
+        }
+        pendingMuxAudioPackets.removeAll()
+        for pending in vodPreGateAudioPackets {
+            var free: UnsafeMutablePointer<AVPacket>? = pending
+            av_packet_free(&free)
+        }
+        vodPreGateAudioPackets.removeAll()
+        vodPreGateAudioBytes = 0
         for pending in pendingVideoPackets {
             var free: UnsafeMutablePointer<AVPacket>? = pending
             av_packet_free(&free)
@@ -6061,6 +6347,7 @@ final class LoopbackSegmentWriter {
         }
         lastMuxedDTSByStream.removeAll()
         lastMuxedPTSByStream.removeAll()
+        lastResolvedVideoDurationByStream.removeAll()
     }
 
 }
@@ -6103,6 +6390,7 @@ private func ensureAudioFrameSize(codecpar: UnsafeMutablePointer<AVCodecParamete
 enum LoopbackWriterError: Error {
     case allocInput
     case allocOutput
+    case allocPacket
     case openInput(Int32)
     case seekInput(Int32)
     case findStreamInfo

--- a/iosApp/iosApp/Screens/Player/CoreMedia/PlayerCore.swift
+++ b/iosApp/iosApp/Screens/Player/CoreMedia/PlayerCore.swift
@@ -40,6 +40,17 @@ import AppKit
 import OSLog
 import VideoToolbox
 
+enum CoreMediaDemuxInterruptPolicy {
+    static func shouldAbort(
+        cancelled: Bool,
+        playbackStopped: Bool,
+        secondsSinceProgress: CFTimeInterval,
+        timeoutSeconds: CFTimeInterval
+    ) -> Bool {
+        cancelled || (!playbackStopped && secondsSinceProgress > timeoutSeconds)
+    }
+}
+
 final class PlayerCore: NSObject {
     private static let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "com.continuum.app.tvos",
@@ -1476,6 +1487,11 @@ final class PlayerCore: NSObject {
         guard !isDisposed else { return }
         userPaused = false
         wasPlayingWhenInterrupted = false
+        // A deliberate pause lets the demux queues fill and then throttles
+        // reads. Without rearming this clock, the first read after a pause
+        // longer than `demuxIOTimeoutSeconds` is immediately killed by the
+        // interrupt callback as a false I/O wedge (AVERROR_EXIT).
+        demuxLastProgressWall = CACurrentMediaTime()
         let time = currentPlaybackTime()
         setPlaybackTimeline(time: time, rate: currentRate)
         audioOutput.setRate(currentRate)
@@ -3166,9 +3182,13 @@ final class PlayerCore: NSObject {
         ctx.pointee.interrupt_callback.callback = { opaque in
             guard let opaque else { return 0 }
             let player = Unmanaged<PlayerCore>.fromOpaque(opaque).takeUnretainedValue()
-            if player.isCancelled { return 1 }
             let elapsed = CACurrentMediaTime() - player.demuxLastProgressWall
-            if elapsed > player.demuxIOTimeoutSeconds {
+            if CoreMediaDemuxInterruptPolicy.shouldAbort(
+                cancelled: player.isCancelled,
+                playbackStopped: player.playbackClock.rate == 0,
+                secondsSinceProgress: elapsed,
+                timeoutSeconds: player.demuxIOTimeoutSeconds
+            ) {
                 return 1 // Abort blocking read — demux loop surfaces as error.
             }
             return 0

--- a/iosApp/iosApp/Screens/Player/CoreMedia/PlayerCore.swift
+++ b/iosApp/iosApp/Screens/Player/CoreMedia/PlayerCore.swift
@@ -40,14 +40,17 @@ import AppKit
 import OSLog
 import VideoToolbox
 
+/// Only an explicit user pause suspends the I/O timeout. The playback clock
+/// also reads rate 0 during startup and seek restarts, and those windows
+/// rely on this abort as their only escape from a wedged `av_read_frame`.
 enum CoreMediaDemuxInterruptPolicy {
     static func shouldAbort(
         cancelled: Bool,
-        playbackStopped: Bool,
+        userPaused: Bool,
         secondsSinceProgress: CFTimeInterval,
         timeoutSeconds: CFTimeInterval
     ) -> Bool {
-        cancelled || (!playbackStopped && secondsSinceProgress > timeoutSeconds)
+        cancelled || (!userPaused && secondsSinceProgress > timeoutSeconds)
     }
 }
 
@@ -3185,7 +3188,7 @@ final class PlayerCore: NSObject {
             let elapsed = CACurrentMediaTime() - player.demuxLastProgressWall
             if CoreMediaDemuxInterruptPolicy.shouldAbort(
                 cancelled: player.isCancelled,
-                playbackStopped: player.playbackClock.rate == 0,
+                userPaused: player.userPaused,
                 secondsSinceProgress: elapsed,
                 timeoutSeconds: player.demuxIOTimeoutSeconds
             ) {

--- a/iosApp/iosApp/Screens/Player/PlaybackOriginChunkFetcher.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackOriginChunkFetcher.swift
@@ -8,6 +8,11 @@ import OSLog
 /// window connection. Each chunk is stored (and its waiters woken) when the
 /// response body completes — at most one chunk of latency for a probe read.
 final class PlaybackOriginChunkFetcher {
+    /// Interactive detour/probe fetches must fail fast enough for the source
+    /// window or outage coordinator to recover. Long outage survival is owned
+    /// by `PlaybackOriginReconnectPolicy`, not by one blocked range request.
+    static let interactiveRequestTimeoutSeconds: TimeInterval = 4.0
+
     struct Callbacks {
         /// Store delivered bytes (invoked on the session delegate queue).
         let store: (Int64, Data, Int64?) -> Void
@@ -98,14 +103,19 @@ final class PlaybackOriginChunkFetcher {
         // One keep-alive session for every chunk: per-request sessions pay a
         // fresh TCP+TLS handshake per probe, which is the cost this class
         // exists to avoid.
+        let config = Self.makeSessionConfiguration()
+        let created = URLSession(configuration: config)
+        session = created
+        return created
+    }
+
+    static func makeSessionConfiguration() -> URLSessionConfiguration {
         let config = URLSessionConfiguration.ephemeral
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
         config.httpMaximumConnectionsPerHost = 2
-        config.timeoutIntervalForRequest = 30
-        let created = URLSession(configuration: config)
-        session = created
-        return created
+        config.timeoutIntervalForRequest = interactiveRequestTimeoutSeconds
+        return config
     }
 
     private func run(id: UUID, range: Range<Int64>, attempt: Int) {

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -2814,6 +2814,15 @@ class PlayerViewModel {
         activeNotice = nil
         remoteDismissToken = nil
         hideControlsTask?.cancel()
+        skipDebounceTask?.cancel()
+        skipDebounceTask = nil
+        seekFilterTimeoutTask?.cancel()
+        seekFilterTimeoutTask = nil
+        tearDownHoldSeek()
+        isScrubbing = false
+        scrubPreviewTime = currentTime
+        seekOriginTime = nil
+        seekTargetTime = nil
         showControls = false
         showNextUpScreen = false
         nextUpEpisode = nil


### PR DESCRIPTION
## Summary

- Derive fragmented MP4 video sample durations from forward DTS and preserve mux ordering.
- Retain and replay bounded selected-audio preroll across VOD restart keyframe gates.
- Add bounded AVPlayer seeks, early VOD response headers, item-death reloads, and short interactive origin timeouts.
- Serialize AVAudioSession activation off the main thread.
- Avoid false CoreMedia demux timeouts after intentional pauses and clear stale scrub state on fresh/retry loads.

## Root causes

- Matroska default duration could diverge from the observed 41/42 ms DTS cadence, accumulating track drift.
- Restart demux ordering could discard selected audio before the first accepted video keyframe.
- AVPlayer seek completions and resource loading could remain pending indefinitely, while slow initial segment responses delayed AVPlayer too long.
- AVAudioSession category and activation work ran synchronously on the main thread.
- A deliberate pause aged the Compatibility Player I/O watchdog, and stale scrub-preview state could survive a retry.

## Validation

- 73 focused tests pass on the iPhone 17 Pro Simulator.
- The SiloTV scheme builds successfully for the tvOS Simulator.
- `git diff --check origin/main...HEAD` is clean.
- Computer User confirmed route selection and fallback behavior using an explicit 2160p HDR HEVC source with TrueHD 7.1 audio.

## Simulator limitation

Finding Dory does **not** prove end-to-end SiloPlayer playback in the Simulator:

1. `siloPlayerLoopback` was selected and began source/cache work.
2. Simulator AVPlayer rejected that route with AVFoundation `-11868` / CoreMedia `-17223`.
3. Rendering and manual seek checks occurred only after fallback to `playerCoreDirect` (Compatibility Player).

The local tests cover deterministic muxing, recovery-policy, timeout, seek, and loopback-server behavior. Dolby Vision, TrueHD/Atmos output, sustained high-bitrate A/V sync, and real SiloPlayer recovery still require validation on physical Apple TV hardware.

Closes #75
Closes #76
Closes #77
Closes #78
Closes #79
Closes #80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback recovery from VOD stalls, missing segments, and loopback item failures.
  * Reduced delays when waiting for unavailable VOD segments and improved response handling.
  * Prevented false playback timeouts after intentional pauses.
  * Improved seek and scrubbing cleanup when loading new content.
  * New device authorization no longer carries over the previous profile selection.
  * Improved VOD audio/video timing, buffering, and packet ordering.
* **Performance**
  * Interactive playback requests now use shorter timeouts for faster retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->