### PR TITLE
Use the phone profile for remote TV playback

### DIFF
--- a/docs/tvos-player/cast-remote.md
+++ b/docs/tvos-player/cast-remote.md
@@ -3,36 +3,70 @@
 Peer-to-peer LAN remote control: an iPhone discovers a Silo Apple TV on the
 local network, connects directly to it, and drives playback (launch, transport,
 tracks, quality, speed, aspect/HDR, **volume/mute**, **next episode**) from a
-native now-playing screen. There is no server involvement — the channel is
-Apple-only and LAN-local.
+native now-playing screen. Control stays LAN-local; launching new content uses
+the phone's Silo server to authorize a playback-scoped TV session. Apple and
+Android use the same wire protocol.
 
 ## Architecture
 
 | Layer | Type | Role |
 |-------|------|------|
-| Wire protocol | `Cast/SiloCastProtocol.swift` | Message enum + Codable framing; `version`, `serviceType = _silocast._tcp` |
-| Transport | `Cast/SiloCastSession.swift` | `actor` over `NWConnection` (TLS-PSK), TLV-framed JSON, **ordered outbound queue** |
-| Phone controller | `Cast/iOS/SiloCastController.swift` | `@Observable` session state machine: connect, heartbeat, auto-reconnect, command send |
-| Phone clock | `Cast/iOS/RemotePlaybackClock.swift` | Interpolates time between snapshots + optimistic transport overrides |
-| Phone UI | `Cast/iOS/SiloCastRemoteControlView.swift`, `SiloCastMiniBar.swift`, `SiloCastTargetPickerView.swift`, `SiloCastControlModeButton.swift`, `SiloCastArtwork.swift` | Now-playing remote, persistent mini-bar, target picker, artwork |
-| TV receiver | `Cast/tvOS/TVCastReceiver.swift` | `@Observable` singleton: `NWListener` advertise, accept, apply controls, broadcast state, standby |
-| TV standby | `Cast/tvOS/TVCastStandbyView.swift`, `TVCastStandbyState.swift` | "Ready for <phone>" screen when connected but idle |
+| Wire protocol | `Control/SiloControlProtocol.swift` | Message enum + Codable framing; v1/v2 negotiation, `serviceType = _silocast._tcp` |
+| Transport | `Control/SiloControlSession.swift` | `actor` over `NWConnection` (TLS-PSK), TLV-framed JSON, ordered outbound queue |
+| Phone controller | `Control/iOS/SiloControlClient.swift` | Connect, negotiate, authorize handoff, heartbeat, reconnect, command send |
+| TV receiver | `Control/tvOS/TVControlReceiver.swift` | Advertise, negotiate, authorize, launch, apply controls, broadcast state |
+| Temporary identity | `Control/tvOS/RemotePlaybackIdentityManager.swift` | Explicit device-login exchange, in-memory auth overlay, logout and restore |
 
 Player integration: the tvOS player registers with `TVCastReceiver` on appear
-(`PlayerView`); controls are applied via `PlayerViewModel.applySiloCastControl(_:)`
-and state is published via `PlayerViewModel.makeSiloCastPlaybackState(contentId:)`.
+(`PlayerView`); controls are applied via `PlayerViewModel.applySiloControlCommand(_:)`
+and state is published via `PlayerViewModel.makeSiloControlPlaybackState(contentId:)`.
 
 ## Message protocol
 
 `SiloCastMessage` (Codable, tagged by `type`, carries protocol `v`):
 
 - `hello` — identity exchange (role phone/tv, deviceName/id, serverId/Name, supportedVersions)
+- `handoff_offer` — phone offers its normalized server ID/URL and active profile
+- `handoff_challenge` — TV returns the server-issued user/match code
+- `handoff_ready` — TV confirms that its temporary phone profile is active
+- `handoff_cancel` — either peer cancels a stale, denied, or failed handoff
 - `launch` — phone asks the TV to start playing a `SiloCastPlaybackRequest`
 - `control` — `SiloCastControlCommand` (play/pause/seek/stop, select audio/subtitle, speed, quality, video gravity, HDR, **set_volume**, **set_muted**, **play_next**)
 - `state` — `SiloCastPlaybackState` snapshot (TV → phone, ~2 Hz while playing)
 - `error` — coded error (`server_mismatch`, `unauthorized`, `player_not_ready`, …)
 - `ping` / `pong` — heartbeat
 - `close` — graceful disconnect
+
+### v2 identity and lifecycle
+
+Opening the remote alone never changes identity. A same-server control-only
+connection controls the TV-owned playback already on screen. Before an updated
+phone launches new content, it must negotiate v2 and complete the handoff:
+
+1. The TV starts a `remote_playback`, temporary device login directly against
+   the phone's offered server URL. No bearer or profile credentials cross LAN.
+2. The signed-in phone verifies the match code and approves with its current
+   profile headers. This also proves an already-unlocked PIN profile.
+3. The TV polls for a dedicated session/profile token and installs it in a
+   process-only `TokenStore` overlay. Keychain and saved server entries are not
+   modified.
+4. Only after `handoff_ready` does the phone send `launch`. Progress, resume,
+   permissions, and preferences then resolve under the phone profile.
+5. Player teardown performs final progress work, best-effort logout, cache
+   clearing, and restoration of the TV's saved identity. Socket loss alone does
+   not restore; playback lifecycle is authoritative. Ready-without-launch is
+   abandoned after 60 seconds, and the server caps the session at 24 hours.
+
+When the player opens, the TV shows a non-focusable six-second notice naming the
+phone profile and device (for example, **Playing as Alex — From Nathan's
+iPhone**). Cross-server launches also include the temporary server name. The
+profile name is display metadata only; authorization remains bound to the
+server-approved profile ID.
+
+Updated phones refuse to launch through v1 receivers because v1 cannot prove
+phone-owned identity. Updated receivers still accept v1 launches from older
+phones during the compatibility window; those retain the legacy TV-owned
+identity behavior.
 
 ### Ordering
 All non-hello sends go through `SiloCastSession.enqueue(_:)`, drained by a single
@@ -41,8 +75,9 @@ stale snapshot can never overwrite a fresh one). The initial `hello` uses the
 awaitable `send(_:)` and is always sent before any `enqueue`.
 
 ### Liveness, takeover, reconnect
-- **Heartbeat:** each side pings every 3 s and tears down after ~12 s of no
-  inbound traffic. Any inbound message (state, command, ping, pong) counts as alive.
+- **Heartbeat:** each side pings every 3 s and tears down after ~12 s without
+  the corresponding `pong`; unrelated inbound traffic does not mask a broken
+  receive path.
 - **Takeover:** a new controller connection evicts the existing one
   (`closeActiveSession`) rather than being rejected — a dropped phone can always
   reconnect, and there is no single-session lockout.
@@ -81,14 +116,13 @@ Consequences, surfaced honestly in the UI:
 ## Security — known limitation (deferred)
 
 The cast channel uses **TLS-PSK with a single static pre-shared key compiled into
-every build** (`SiloCastSession.tlsParameters()`). The channel is therefore
-**encrypted but not authenticated**: the only authorization is the `serverId`
-match performed in the `hello` handshake. Hardening added in this work makes that
-check **fail-closed** (missing/empty/mismatched `serverId` is rejected; `.launch`
-and `.control` are refused until a session is `isAuthorized`; an unauthorized
-session is closed by a 5 s watchdog). That is consistency/defense-in-depth — it
-is **not** real authentication: any device on the LAN running a Silo build can
-control any Silo TV bound to the same server.
+every build** (`SiloControlSession.tlsParameters()`). The channel is therefore
+**encrypted but not peer-authenticated**. v2 improves credential handling and
+binds the temporary TV session to a server-approved phone user/profile, but a
+Silo-capable device on the LAN can still initiate a connection or handoff. The
+authenticated phone approval prevents that peer from receiving another user's
+credentials without the user's participation; it does not cryptographically
+pair the LAN devices.
 
 **Deferred follow-up (recommended):** derive a per-pair / per-server secret from
 the existing companion-pairing trust (`_silopair`, see the pairing flow) and bind
@@ -98,9 +132,8 @@ the TV. Until then, treat LAN access as the trust boundary.
 
 ## Testing
 
-Shared logic round-trips and the `RemotePlaybackClock` interpolation/optimistic
-math are documented as XCTest cases in `iosApp/Tests/SiloCastTests.swift`. Note:
-the XcodeGen project does **not** currently wire a unit-test target, so these are
-not compiled/executed — wiring a `SiloTests` target is a recommended follow-up.
+Protocol negotiation, v2 message round-trips, and `RemotePlaybackClock`
+interpolation/optimistic math live in `iosApp/Tests/SiloControlTests.swift` and
+run through the `SiloTests` target.
 End-to-end behavior is verified with two simulators sharing the host network
 (see the `companion-pairing-sim-test` notes for the Bonjour/TLS sim-to-sim setup).

--- a/iosApp/Tests/SiloControlTests.swift
+++ b/iosApp/Tests/SiloControlTests.swift
@@ -22,6 +22,58 @@ final class SiloControlTests: XCTestCase {
         XCTAssertEqual(try roundTrip(.control(mute)), .control(mute))
         XCTAssertEqual(try roundTrip(.control(.playNext)), .control(.playNext))
     }
+
+    func testProtocolNegotiatesHighestCommonVersion() {
+        XCTAssertEqual(SiloControlProtocol.negotiatedVersion(with: [1]), 1)
+        XCTAssertEqual(SiloControlProtocol.negotiatedVersion(with: [1, 2]), 2)
+        XCTAssertNil(SiloControlProtocol.negotiatedVersion(with: [3]))
+    }
+
+    func testRemoteIdentityHandoffMessagesRoundTrip() throws {
+        let offer = SiloControlHandoffOffer(
+            requestId: "request-1",
+            serverId: "server-1",
+            serverURL: "https://silo.example",
+            serverName: "Home",
+            profileId: "profile-1",
+            profileName: "Alex"
+        )
+        let challenge = SiloControlHandoffChallenge(
+            requestId: "request-1",
+            userCode: "ABCD-EFGH",
+            matchCode: "WXYZ",
+            expiresAt: "2026-07-09T20:00:00Z"
+        )
+        let ready = SiloControlHandoffReady(
+            requestId: "request-1",
+            serverId: "server-1",
+            profileId: "profile-1",
+            sessionExpiresAt: "2026-07-10T20:00:00Z",
+            reused: false
+        )
+        let cancel = SiloControlHandoffCancel(
+            requestId: "request-1",
+            reason: "denied",
+            message: "The handoff was denied."
+        )
+
+        XCTAssertEqual(try roundTrip(.handoffOffer(offer)), .handoffOffer(offer))
+        XCTAssertEqual(try roundTrip(.handoffChallenge(challenge)), .handoffChallenge(challenge))
+        XCTAssertEqual(try roundTrip(.handoffReady(ready)), .handoffReady(ready))
+        XCTAssertEqual(try roundTrip(.handoffCancel(cancel)), .handoffCancel(cancel))
+    }
+
+    func testHandoffOfferDecodesWithoutDisplayMetadata() throws {
+        let data = Data(
+            #"{"type":"handoff_offer","v":2,"handoffOffer":{"requestId":"request-1","serverId":"server-1","serverURL":"https://silo.example","profileId":"profile-1"}}"#
+                .utf8
+        )
+        guard case .handoffOffer(let offer) = try JSONDecoder().decode(SiloControlMessage.self, from: data) else {
+            return XCTFail("Expected a handoff offer")
+        }
+        XCTAssertNil(offer.serverName)
+        XCTAssertNil(offer.profileName)
+    }
 }
 
 extension SiloControlTests {

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -67,6 +67,11 @@ struct ContentView: View {
             #endif
             router.expiredSession()
         }
+        #if os(tvOS)
+        .onReceive(NotificationCenter.default.publisher(for: .temporaryRemoteAuthExpired)) { _ in
+            TVControlReceiver.shared.temporaryAuthExpired()
+        }
+        #endif
         .task {
             // Debug: auto-play from launch argument -debugPlay <contentId>
             if let idx = CommandLine.arguments.firstIndex(of: "-debugPlay"),

--- a/iosApp/iosApp/Control/SiloControlProtocol.swift
+++ b/iosApp/iosApp/Control/SiloControlProtocol.swift
@@ -1,8 +1,13 @@
 import Foundation
 
 enum SiloControlProtocol {
-    static let version = 1
+    static let version = 2
+    static let supportedVersions = [1, 2]
     static let serviceType = "_silocast._tcp"
+
+    static func negotiatedVersion(with peer: [Int]) -> Int? {
+        supportedVersions.filter(peer.contains).max()
+    }
 }
 
 enum SiloControlPeerRole: String, Codable, Equatable, Sendable {
@@ -31,6 +36,37 @@ struct SiloControlPlaybackRequest: Codable, Equatable, Sendable {
 struct SiloControlLaunchRequest: Codable, Equatable, Sendable {
     let serverId: String
     let playback: SiloControlPlaybackRequest
+}
+
+struct SiloControlHandoffOffer: Codable, Equatable, Sendable {
+    let requestId: String
+    let serverId: String
+    let serverURL: String
+    let serverName: String?
+    let profileId: String
+    /// Display-only label for the verified profile ID. Older peers omit it.
+    let profileName: String?
+}
+
+struct SiloControlHandoffChallenge: Codable, Equatable, Sendable {
+    let requestId: String
+    let userCode: String
+    let matchCode: String
+    let expiresAt: String
+}
+
+struct SiloControlHandoffReady: Codable, Equatable, Sendable {
+    let requestId: String
+    let serverId: String
+    let profileId: String
+    let sessionExpiresAt: String
+    let reused: Bool
+}
+
+struct SiloControlHandoffCancel: Codable, Equatable, Sendable {
+    let requestId: String
+    let reason: String
+    let message: String?
 }
 
 struct SiloControlTrack: Codable, Equatable, Identifiable, Sendable {
@@ -189,6 +225,10 @@ struct SiloControlErrorMessage: Codable, Equatable, Sendable {
 
 enum SiloControlMessage: Equatable, Sendable {
     case hello(SiloControlHello)
+    case handoffOffer(SiloControlHandoffOffer)
+    case handoffChallenge(SiloControlHandoffChallenge)
+    case handoffReady(SiloControlHandoffReady)
+    case handoffCancel(SiloControlHandoffCancel)
     case launch(SiloControlLaunchRequest)
     case control(SiloControlCommand)
     case state(SiloControlPlaybackState)
@@ -202,10 +242,15 @@ extension SiloControlMessage: Codable {
     private enum CodingKeys: String, CodingKey {
         case type, v
         case hello, launch, control, state, error
+        case handoffOffer, handoffChallenge, handoffReady, handoffCancel
     }
 
     private enum Kind: String, Codable {
         case hello
+        case handoffOffer = "handoff_offer"
+        case handoffChallenge = "handoff_challenge"
+        case handoffReady = "handoff_ready"
+        case handoffCancel = "handoff_cancel"
         case launch
         case control
         case state
@@ -222,6 +267,18 @@ extension SiloControlMessage: Codable {
         case .hello(let hello):
             try c.encode(Kind.hello, forKey: .type)
             try c.encode(hello, forKey: .hello)
+        case .handoffOffer(let offer):
+            try c.encode(Kind.handoffOffer, forKey: .type)
+            try c.encode(offer, forKey: .handoffOffer)
+        case .handoffChallenge(let challenge):
+            try c.encode(Kind.handoffChallenge, forKey: .type)
+            try c.encode(challenge, forKey: .handoffChallenge)
+        case .handoffReady(let ready):
+            try c.encode(Kind.handoffReady, forKey: .type)
+            try c.encode(ready, forKey: .handoffReady)
+        case .handoffCancel(let cancel):
+            try c.encode(Kind.handoffCancel, forKey: .type)
+            try c.encode(cancel, forKey: .handoffCancel)
         case .launch(let launch):
             try c.encode(Kind.launch, forKey: .type)
             try c.encode(launch, forKey: .launch)
@@ -249,6 +306,14 @@ extension SiloControlMessage: Codable {
         switch kind {
         case .hello:
             self = .hello(try c.decode(SiloControlHello.self, forKey: .hello))
+        case .handoffOffer:
+            self = .handoffOffer(try c.decode(SiloControlHandoffOffer.self, forKey: .handoffOffer))
+        case .handoffChallenge:
+            self = .handoffChallenge(try c.decode(SiloControlHandoffChallenge.self, forKey: .handoffChallenge))
+        case .handoffReady:
+            self = .handoffReady(try c.decode(SiloControlHandoffReady.self, forKey: .handoffReady))
+        case .handoffCancel:
+            self = .handoffCancel(try c.decode(SiloControlHandoffCancel.self, forKey: .handoffCancel))
         case .launch:
             self = .launch(try c.decode(SiloControlLaunchRequest.self, forKey: .launch))
         case .control:

--- a/iosApp/iosApp/Control/iOS/SiloControlBrowser.swift
+++ b/iosApp/iosApp/Control/iOS/SiloControlBrowser.swift
@@ -8,12 +8,14 @@ struct SiloControlTarget: Identifiable, Equatable {
     let endpoint: NWEndpoint
     let serverId: String
     let serverName: String?
+    let protocolVersion: Int
     /// The TV's advertised "currently playing" flag (Bonjour TXT `playing`).
     /// False for TVs running an older build that doesn't advertise it.
     var isPlaying: Bool = false
 
     static func == (lhs: SiloControlTarget, rhs: SiloControlTarget) -> Bool {
         lhs.id == rhs.id && lhs.isPlaying == rhs.isPlaying
+            && lhs.serverId == rhs.serverId && lhs.protocolVersion == rhs.protocolVersion
     }
 }
 
@@ -34,13 +36,8 @@ final class SiloControlBrowser {
         browser.browseResultsChangedHandler = { [weak self] results, _ in
             Task { @MainActor in
                 guard let self else { return }
-                let activeServerId = ServerRegistry.shared.activeServerId
                 self.found = results
                     .compactMap { Self.makeTarget($0) }
-                    .filter { target in
-                        guard let activeServerId else { return false }
-                        return target.serverId == activeServerId
-                    }
                     .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
             }
         }
@@ -65,6 +62,7 @@ final class SiloControlBrowser {
             endpoint: result.endpoint,
             serverId: serverId,
             serverName: txt["serverName"],
+            protocolVersion: Int(txt["v"] ?? "1") ?? 1,
             isPlaying: txt["playing"] == "1"
         )
     }

--- a/iosApp/iosApp/Control/iOS/SiloControlClient.swift
+++ b/iosApp/iosApp/Control/iOS/SiloControlClient.swift
@@ -21,6 +21,29 @@ private struct PersistedControlTarget: Codable {
     let serverName: String?
 }
 
+private enum SiloControlHandoffError: LocalizedError {
+    case updateRequired
+    case timedOut
+    case cancelled(String)
+    case identityChanged
+    case invalidResponse
+
+    var errorDescription: String? {
+        switch self {
+        case .updateRequired:
+            return "Update Silo on the TV to play with your profile."
+        case .timedOut:
+            return "The TV took too long to prepare your profile."
+        case .cancelled(let message):
+            return message
+        case .identityChanged:
+            return "Your server or profile changed. Try playing again."
+        case .invalidResponse:
+            return "The TV could not verify your playback profile."
+        }
+    }
+}
+
 @MainActor
 @Observable
 final class SiloControlClient {
@@ -60,6 +83,11 @@ final class SiloControlClient {
     /// frames (and presenting the player twice) for the same in-flight
     /// connection.
     private var launchInFlight = false
+    private var negotiatedVersion: Int?
+    private var pendingHandoffRequestId: String?
+    private var handoffChallenge: SiloControlHandoffChallenge?
+    private var handoffReady: SiloControlHandoffReady?
+    private var handoffCancellation: SiloControlHandoffCancel?
     private var missedHeartbeats = 0
     private(set) var lastTarget: SiloControlTarget?
     private var backgroundTask: UIBackgroundTaskIdentifier = .invalid
@@ -78,12 +106,16 @@ final class SiloControlClient {
     }
 
     @discardableResult
-    func connect(to target: SiloControlTarget, origin: SiloControlConnectOrigin = .user) async -> Bool {
+    func connect(
+        to target: SiloControlTarget,
+        origin: SiloControlConnectOrigin = .user,
+        allowCrossServer: Bool = false
+    ) async -> Bool {
         guard let activeServerId = ServerRegistry.shared.activeServerId else {
             errorMessage = "Choose a server before controlling a TV."
             return false
         }
-        guard target.serverId == activeServerId else {
+        guard target.serverId == activeServerId || (allowCrossServer && target.protocolVersion >= 2) else {
             errorMessage = "That TV is connected to a different server."
             return false
         }
@@ -116,6 +148,8 @@ final class SiloControlClient {
         activeTarget = target
         lastTarget = target
         state = nil
+        negotiatedVersion = nil
+        resetPendingHandoff()
         // Connecting alone doesn't take over the screen — the mini-bar surfaces
         // the session. The full remote only auto-presents once content launches
         // (see `launch()`) or when the user taps the mini-bar.
@@ -136,7 +170,7 @@ final class SiloControlClient {
         }
         isConnecting = false
         let connected = self.connectionId == connectionId && self.session != nil
-        if connected {
+        if connected, target.serverId == activeServerId {
             persistLastTarget(target)
         }
         return connected
@@ -146,12 +180,14 @@ final class SiloControlClient {
         // Sending content to a TV always opens the remote — show it up front so
         // the connect handshake renders inside the cover, not behind a mini-bar.
         isShowingRemoteControl = true
-        guard await connect(to: target) else { return }
+        guard await connect(to: target, allowCrossServer: true) else { return }
         await launch(request)
     }
 
     func launch(_ request: SiloControlPlaybackRequest) async {
-        guard let activeServerId = ServerRegistry.shared.activeServerId else {
+        guard let activeServer = ServerRegistry.shared.activeServer,
+              let profileId = activeServer.profileId,
+              !profileId.isEmpty else {
             errorMessage = "Choose a server before controlling a TV."
             return
         }
@@ -171,11 +207,144 @@ final class SiloControlClient {
 
         let connectionId = self.connectionId
         do {
-            try await session.send(.launch(SiloControlLaunchRequest(serverId: activeServerId, playback: request)))
+            let profileName = (try? await AuthService.shared.getProfiles())?
+                .first(where: { $0.id == profileId })?
+                .name
+            let ready = try await prepareRemoteIdentity(
+                server: activeServer,
+                profileId: profileId,
+                profileName: profileName,
+                session: session
+            )
+            guard ready.serverId == activeServer.id, ready.profileId == profileId else {
+                throw SiloControlHandoffError.invalidResponse
+            }
+            adoptEffectiveTarget(server: activeServer)
+            try await session.send(.launch(SiloControlLaunchRequest(serverId: activeServer.id, playback: request)))
             isConnecting = false
         } catch {
             fail(error.localizedDescription, connectionId: connectionId)
         }
+    }
+
+    private func prepareRemoteIdentity(
+        server: ServerEntry,
+        profileId: String,
+        profileName: String?,
+        session: SiloControlSession
+    ) async throws -> SiloControlHandoffReady {
+        guard await waitForVersionNegotiation() == 2 else {
+            throw SiloControlHandoffError.updateRequired
+        }
+        guard await TokenStore.shared.getAccessToken() != nil else {
+            throw SiloControlHandoffError.identityChanged
+        }
+
+        let requestId = UUID().uuidString
+        pendingHandoffRequestId = requestId
+        handoffChallenge = nil
+        handoffReady = nil
+        handoffCancellation = nil
+
+        try await session.send(.handoffOffer(SiloControlHandoffOffer(
+            requestId: requestId,
+            serverId: server.id,
+            serverURL: server.url,
+            serverName: server.displayName,
+            profileId: profileId,
+            profileName: profileName
+        )))
+
+        let challenge = try await waitForHandoffChallenge(requestId: requestId)
+        do {
+            try ensureActiveIdentity(serverId: server.id, profileId: profileId)
+
+            let lookup: DeviceLookupResponse = try await HTTPClient.shared.get(
+                "/api/v1/auth/device",
+                query: ["code": challenge.userCode]
+            )
+            guard lookup.matchCode == challenge.matchCode,
+                  lookup.clientPurpose == "remote_playback",
+                  lookup.temporary == true else {
+                throw SiloControlHandoffError.invalidResponse
+            }
+
+            try ensureActiveIdentity(serverId: server.id, profileId: profileId)
+            try await HTTPClient.shared.postVoid(
+                "/api/v1/auth/device/approve-handoff",
+                body: DeviceApproveRequest(code: challenge.userCode)
+            )
+
+            let ready = try await waitForHandoffReady(requestId: requestId)
+            try ensureActiveIdentity(serverId: server.id, profileId: profileId)
+            resetPendingHandoff()
+            return ready
+        } catch {
+            try? await HTTPClient.shared.postVoid(
+                "/api/v1/auth/device/deny",
+                body: DeviceApproveRequest(code: challenge.userCode)
+            )
+            resetPendingHandoff()
+            throw error
+        }
+    }
+
+    private func waitForVersionNegotiation() async -> Int? {
+        for _ in 0..<100 {
+            if let negotiatedVersion { return negotiatedVersion }
+            try? await Task.sleep(for: .milliseconds(50))
+            if Task.isCancelled { return nil }
+        }
+        return nil
+    }
+
+    private func waitForHandoffChallenge(requestId: String) async throws -> SiloControlHandoffChallenge {
+        for _ in 0..<200 {
+            if let cancellation = handoffCancellation, cancellation.requestId == requestId {
+                throw SiloControlHandoffError.cancelled(cancellation.message ?? "The TV cancelled profile setup.")
+            }
+            if let challenge = handoffChallenge, challenge.requestId == requestId {
+                return challenge
+            }
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        throw SiloControlHandoffError.timedOut
+    }
+
+    private func waitForHandoffReady(requestId: String) async throws -> SiloControlHandoffReady {
+        for _ in 0..<600 {
+            if let cancellation = handoffCancellation, cancellation.requestId == requestId {
+                throw SiloControlHandoffError.cancelled(cancellation.message ?? "The TV cancelled profile setup.")
+            }
+            if let ready = handoffReady, ready.requestId == requestId {
+                return ready
+            }
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        throw SiloControlHandoffError.timedOut
+    }
+
+    private func ensureActiveIdentity(serverId: String, profileId: String) throws {
+        guard ServerRegistry.shared.activeServerId == serverId,
+              ServerRegistry.shared.activeProfileId == profileId else {
+            throw SiloControlHandoffError.identityChanged
+        }
+    }
+
+    private func adoptEffectiveTarget(server: ServerEntry) {
+        guard let target = activeTarget else { return }
+        let effective = SiloControlTarget(
+            id: target.id,
+            name: target.name,
+            endpoint: target.endpoint,
+            serverId: server.id,
+            serverName: server.displayName,
+            protocolVersion: target.protocolVersion,
+            isPlaying: true
+        )
+        activeTarget = effective
+        lastTarget = effective
+        persistLastTarget(effective)
     }
 
     func send(_ command: SiloControlCommand) {
@@ -364,8 +533,17 @@ final class SiloControlClient {
         // path dead, send path alive) keeps the session pinned open. See the
         // matching note in TVControlReceiver.handle.
         switch message {
-        case .hello:
-            break
+        case .hello(let hello):
+            negotiatedVersion = SiloControlProtocol.negotiatedVersion(with: hello.supportedVersions)
+        case .handoffChallenge(let challenge):
+            guard challenge.requestId == pendingHandoffRequestId else { return }
+            handoffChallenge = challenge
+        case .handoffReady(let ready):
+            guard ready.requestId == pendingHandoffRequestId else { return }
+            handoffReady = ready
+        case .handoffCancel(let cancel):
+            guard cancel.requestId == pendingHandoffRequestId else { return }
+            handoffCancellation = cancel
         case .state(let state):
             self.state = state
             clock.ingest(state)
@@ -402,7 +580,7 @@ final class SiloControlClient {
             session?.enqueue(.pong)
         case .pong:
             missedHeartbeats = 0
-        case .launch, .control:
+        case .launch, .control, .handoffOffer:
             break
         }
     }
@@ -485,6 +663,8 @@ final class SiloControlClient {
         isConnecting = false
         isAutoResuming = false
         sessionIsAutoResumed = false
+        negotiatedVersion = nil
+        resetPendingHandoff()
         detachNowPlaying()
         session = nil
         readTask?.cancel()
@@ -504,6 +684,8 @@ final class SiloControlClient {
         isReconnecting = false
         isAutoResuming = false
         sessionIsAutoResumed = false
+        negotiatedVersion = nil
+        resetPendingHandoff()
         pendingReconnectReason = nil
         lastTarget = nil
         session = nil
@@ -539,6 +721,8 @@ final class SiloControlClient {
         read?.cancel()
         state = nil
         activeTarget = nil
+        negotiatedVersion = nil
+        resetPendingHandoff()
         detachNowPlaying()
         endBackgroundRemoteControlGracePeriod()
         wasBackgroundedWithActiveSession = false
@@ -591,8 +775,15 @@ final class SiloControlClient {
             deviceId: device.id,
             serverId: server?.id,
             serverName: server?.displayName,
-            supportedVersions: [SiloControlProtocol.version]
+            supportedVersions: SiloControlProtocol.supportedVersions
         ))
+    }
+
+    private func resetPendingHandoff() {
+        pendingHandoffRequestId = nil
+        handoffChallenge = nil
+        handoffReady = nil
+        handoffCancellation = nil
     }
 
     private func updateNowPlaying(for state: SiloControlPlaybackState) {

--- a/iosApp/iosApp/Control/iOS/SiloControlTargetPickerView.swift
+++ b/iosApp/iosApp/Control/iOS/SiloControlTargetPickerView.swift
@@ -12,7 +12,7 @@ struct SiloControlTargetPickerView: View {
     var body: some View {
         NavigationStack {
             Group {
-                if !browser.found.isEmpty {
+                if !displayedTargets.isEmpty {
                     foundList
                 } else if searchTimedOut {
                     emptyState
@@ -36,7 +36,7 @@ struct SiloControlTargetPickerView: View {
             .onDisappear { browser.stop() }
         }
         .preferredColorScheme(.dark)
-        .presentationDetents(browser.found.count > 3 ? [.medium, .large] : [.medium])
+        .presentationDetents(displayedTargets.count > 3 ? [.medium, .large] : [.medium])
         .presentationDragIndicator(.visible)
         .presentationCornerRadius(24)
     }
@@ -60,7 +60,7 @@ struct SiloControlTargetPickerView: View {
     }
 
     private var foundList: some View {
-        List(browser.found) { target in
+        List(displayedTargets) { target in
             Button {
                 Task {
                     if let request {
@@ -80,12 +80,18 @@ struct SiloControlTargetPickerView: View {
 
                     VStack(alignment: .leading, spacing: 3) {
                         Text(target.name).font(.headline)
-                        if target.isPlaying {
+                        if request != nil, target.protocolVersion < 2 {
+                            Text("Update Silo on this TV to use your profile")
+                                .font(.subheadline)
+                                .foregroundStyle(Color.continuumSecondaryText)
+                        } else if target.isPlaying {
                             Text("Playing now")
                                 .font(.subheadline)
                                 .foregroundStyle(Color.continuumPrimary)
                         } else if let serverName = target.serverName {
-                            Text(serverName)
+                            Text(target.serverId == ServerRegistry.shared.activeServerId
+                                 ? serverName
+                                 : "Will temporarily use your server")
                                 .font(.subheadline)
                                 .foregroundStyle(Color.continuumSecondaryText)
                         }
@@ -100,9 +106,16 @@ struct SiloControlTargetPickerView: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .disabled(request != nil && target.protocolVersion < 2)
             .listRowBackground(Color.continuumSurface)
         }
         .scrollContentBackground(.hidden)
+    }
+
+    private var displayedTargets: [SiloControlTarget] {
+        guard request == nil else { return browser.found }
+        guard let activeServerId = ServerRegistry.shared.activeServerId else { return [] }
+        return browser.found.filter { $0.serverId == activeServerId }
     }
 }
 

--- a/iosApp/iosApp/Control/tvOS/RemotePlaybackIdentityManager.swift
+++ b/iosApp/iosApp/Control/tvOS/RemotePlaybackIdentityManager.swift
@@ -1,0 +1,203 @@
+#if os(tvOS)
+import Foundation
+
+@MainActor
+final class RemotePlaybackIdentityManager {
+    static let shared = RemotePlaybackIdentityManager()
+
+    struct ActiveIdentity: Equatable {
+        let generationID: UUID
+        let serverId: String
+        let serverURL: String
+        let serverName: String?
+        let profileId: String
+        let profileName: String?
+        let controllerDeviceId: String
+        let controllerDeviceName: String?
+        let usesDifferentServer: Bool
+        let sessionExpiresAt: Date
+    }
+
+    enum HandoffError: LocalizedError {
+        case invalidOffer
+        case unsupportedServer
+        case denied
+        case expired
+        case invalidResponse
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidOffer:
+                return "The phone sent an invalid server or profile."
+            case .unsupportedServer:
+                return "Update the phone's Silo server to use profile handoff."
+            case .denied:
+                return "Profile handoff was denied."
+            case .expired:
+                return "Profile handoff expired."
+            case .invalidResponse:
+                return "The server returned an invalid profile handoff."
+            }
+        }
+    }
+
+    private(set) var activeIdentity: ActiveIdentity?
+    private let api = PairingDeviceAPI()
+
+    private init() {}
+
+    var effectiveServerId: String? {
+        activeIdentity?.serverId ?? ServerRegistry.shared.activeServerId
+    }
+
+    var effectiveServerName: String? {
+        activeIdentity?.serverName ?? ServerRegistry.shared.activeServer?.displayName
+    }
+
+    func matches(_ offer: SiloControlHandoffOffer, controllerDeviceId: String) -> Bool {
+        guard let activeIdentity else { return false }
+        return activeIdentity.serverId == offer.serverId
+            && activeIdentity.profileId == offer.profileId
+            && activeIdentity.controllerDeviceId == controllerDeviceId
+    }
+
+    func prepare(
+        offer: SiloControlHandoffOffer,
+        controllerDeviceId: String,
+        controllerDeviceName: String?,
+        onChallenge: @escaping (SiloControlHandoffChallenge) async throws -> Void
+    ) async throws -> SiloControlHandoffReady {
+        let normalizedURL = ServerRegistry.normalize(url: offer.serverURL)
+        guard !normalizedURL.isEmpty,
+              !offer.profileId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              ServerRegistry.serverId(for: normalizedURL) == offer.serverId else {
+            throw HandoffError.invalidOffer
+        }
+
+        if matches(offer, controllerDeviceId: controllerDeviceId),
+           let activeIdentity {
+            return SiloControlHandoffReady(
+                requestId: offer.requestId,
+                serverId: activeIdentity.serverId,
+                profileId: activeIdentity.profileId,
+                sessionExpiresAt: Self.iso8601(activeIdentity.sessionExpiresAt),
+                reused: true
+            )
+        }
+
+        let capability = try await api.remotePlaybackCapability(serverURL: normalizedURL)
+        guard capability.remotePlaybackHandoff,
+              capability.protocolVersions.contains(SiloControlProtocol.version) else {
+            throw HandoffError.unsupportedServer
+        }
+
+        let device = AppleDeviceIdentity.current
+        let started = try await api.startRemotePlayback(
+            serverURL: normalizedURL,
+            deviceName: device.name,
+            devicePlatform: device.platform
+        )
+        guard started.clientPurpose == "remote_playback", started.temporary == true else {
+            throw HandoffError.unsupportedServer
+        }
+
+        try await onChallenge(SiloControlHandoffChallenge(
+            requestId: offer.requestId,
+            userCode: started.userCode,
+            matchCode: started.matchCode,
+            expiresAt: Self.iso8601(started.expiresAt)
+        ))
+
+        let deadline = Date().addingTimeInterval(TimeInterval(started.expiresIn))
+        while Date() < deadline {
+            try Task.checkCancellation()
+            let poll = try await api.poll(serverURL: normalizedURL, deviceCode: started.deviceCode)
+            try Task.checkCancellation()
+            switch DeviceLoginStatus(raw: poll.status) {
+            case .approved:
+                guard poll.temporary == true,
+                      poll.profileId == offer.profileId,
+                      let accessToken = poll.accessToken, !accessToken.isEmpty,
+                      let refreshToken = poll.refreshToken, !refreshToken.isEmpty,
+                      let profileToken = poll.profileToken, !profileToken.isEmpty else {
+                    throw HandoffError.invalidResponse
+                }
+                let expiresAt = poll.sessionExpiresAt.flatMap(Self.parseISO8601)
+                    ?? Date().addingTimeInterval(24 * 60 * 60)
+                await activate(TemporaryAuthScope(
+                    serverId: offer.serverId,
+                    serverURL: normalizedURL,
+                    accessToken: accessToken,
+                    refreshToken: refreshToken,
+                    profileId: offer.profileId,
+                    profileToken: profileToken,
+                    controllerDeviceId: controllerDeviceId,
+                    expiresAt: expiresAt
+                ),
+                    serverName: offer.serverName,
+                    profileName: offer.profileName,
+                    controllerDeviceName: controllerDeviceName
+                )
+                return SiloControlHandoffReady(
+                    requestId: offer.requestId,
+                    serverId: offer.serverId,
+                    profileId: offer.profileId,
+                    sessionExpiresAt: Self.iso8601(expiresAt),
+                    reused: false
+                )
+            case .denied:
+                throw HandoffError.denied
+            case .expired, .consumed:
+                throw HandoffError.expired
+            case .pending, .unknown:
+                try await Task.sleep(for: .seconds(max(1, poll.pollAfter ?? started.interval)))
+            }
+        }
+        throw HandoffError.expired
+    }
+
+    func end() async {
+        let hasTemporaryScope = await TokenStore.shared.hasTemporaryScope()
+        guard activeIdentity != nil || hasTemporaryScope else { return }
+        if hasTemporaryScope {
+            try? await HTTPClient.shared.postVoid("/api/v1/auth/logout")
+        }
+        await HTTPClient.shared.cancelInFlightRequests()
+        _ = await TokenStore.shared.endTemporaryScope()
+        activeIdentity = nil
+        AuthService.shared.clearCachesForTemporaryIdentityChange()
+    }
+
+    private func activate(
+        _ scope: TemporaryAuthScope,
+        serverName: String?,
+        profileName: String?,
+        controllerDeviceName: String?
+    ) async {
+        let usesDifferentServer = scope.serverId != ServerRegistry.shared.activeServerId
+        await HTTPClient.shared.cancelInFlightRequests()
+        AuthService.shared.clearCachesForTemporaryIdentityChange()
+        await TokenStore.shared.beginTemporaryScope(scope)
+        activeIdentity = ActiveIdentity(
+            generationID: UUID(),
+            serverId: scope.serverId,
+            serverURL: scope.serverURL,
+            serverName: serverName,
+            profileId: scope.profileId,
+            profileName: profileName,
+            controllerDeviceId: scope.controllerDeviceId,
+            controllerDeviceName: controllerDeviceName,
+            usesDifferentServer: usesDifferentServer,
+            sessionExpiresAt: scope.expiresAt
+        )
+    }
+
+    private static func iso8601(_ date: Date) -> String {
+        ISO8601DateFormatter().string(from: date)
+    }
+
+    private static func parseISO8601(_ value: String) -> Date? {
+        ISO8601DateFormatter().date(from: value)
+    }
+}
+#endif

--- a/iosApp/iosApp/Control/tvOS/TVControlReceiver.swift
+++ b/iosApp/iosApp/Control/tvOS/TVControlReceiver.swift
@@ -27,14 +27,24 @@ final class TVControlReceiver {
     private var stateTask: Task<Void, Never>?
     private var heartbeatTask: Task<Void, Never>?
     private var authWatchdogTask: Task<Void, Never>?
+    private var handoffTask: Task<Void, Never>?
+    private var readyTimeoutTask: Task<Void, Never>?
     private var missedHeartbeats = 0
     private var isAuthorized = false
+    private var didReceiveHello = false
+    private var negotiatedVersion: Int?
+    private var pendingHandoffRequestId: String?
+    private var remoteLaunchReady = false
     private static let heartbeatInterval: Duration = .seconds(3)
     private static let maxMissedHeartbeats = 3      // ~9–12s of silence ⇒ dead
     private static let authGracePeriod: Duration = .seconds(5)
     private weak var playerViewModel: PlayerViewModel?
     private var playerContentId: String?
+    private var playerHandoffGeneration: UUID?
+    private var pendingPlayerHandoffGeneration: UUID?
     private var remoteControllerName: String?
+    private var remoteControllerDeviceId: String?
+    private var remoteControllerServerId: String?
     private nonisolated static let logger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "com.continuum.app",
         category: "control.receiver"
@@ -48,15 +58,17 @@ final class TVControlReceiver {
             stop()
             return
         }
-        if listener != nil, advertisedServerId == server.id {
+        let serverId = RemotePlaybackIdentityManager.shared.effectiveServerId ?? server.id
+        let serverName = RemotePlaybackIdentityManager.shared.effectiveServerName ?? server.displayName
+        if listener != nil, advertisedServerId == serverId {
             return
         }
 
         stop()
-        startListener(server: server)
+        startListener(serverId: serverId, serverName: serverName)
     }
 
-    private func startListener(server: ServerEntry) {
+    private func startListener(serverId: String, serverName: String) {
         listenerGeneration += 1
         let generation = listenerGeneration
 
@@ -65,8 +77,8 @@ final class TVControlReceiver {
             "v": String(SiloControlProtocol.version),
             "name": device.name,
             "id": device.id,
-            "server": server.id,
-            "serverName": server.displayName,
+            "server": serverId,
+            "serverName": serverName,
             "playing": isPlaybackAdvertised ? "1" : "0"
         ])
 
@@ -101,7 +113,7 @@ final class TVControlReceiver {
             }
             listener.start(queue: .main)
             self.listener = listener
-            advertisedServerId = server.id
+            advertisedServerId = serverId
         } catch {
             Self.logger.error("failed to start control listener: \(String(describing: error), privacy: .public)")
         }
@@ -122,12 +134,17 @@ final class TVControlReceiver {
     private func setPlaybackAdvertised(_ playing: Bool) {
         guard isPlaybackAdvertised != playing else { return }
         isPlaybackAdvertised = playing
-        guard listener != nil, let server = ServerRegistry.shared.activeServer,
-              advertisedServerId == server.id else { return }
+        refreshAdvertisement()
+    }
+
+    private func refreshAdvertisement() {
+        guard listener != nil,
+              let serverId = RemotePlaybackIdentityManager.shared.effectiveServerId else { return }
+        let serverName = RemotePlaybackIdentityManager.shared.effectiveServerName ?? "Silo"
         listenerGeneration += 1
         listener?.cancel()
         listener = nil
-        startListener(server: server)
+        startListener(serverId: serverId, serverName: serverName)
     }
 
     func stop() {
@@ -142,9 +159,26 @@ final class TVControlReceiver {
         closeActiveSession(sendClose: true)
     }
 
+    func temporaryAuthExpired() {
+        sendError(code: "temporary_session_expired", message: "The phone profile session expired.")
+        let hadPlayer = playerViewModel != nil
+        stopRemotePlayback()
+        if !hadPlayer {
+            Task { @MainActor [weak self] in
+                await RemotePlaybackIdentityManager.shared.end()
+                self?.refreshAdvertisement()
+                self?.reconcileAuthorizationAfterRestore()
+            }
+        }
+    }
+
     func registerPlayer(_ viewModel: PlayerViewModel, contentId: String) {
+        readyTimeoutTask?.cancel()
+        readyTimeoutTask = nil
         playerViewModel = viewModel
         playerContentId = contentId
+        playerHandoffGeneration = pendingPlayerHandoffGeneration
+        pendingPlayerHandoffGeneration = nil
         standbyState = nil
         startStateUpdates()
         sendState()
@@ -152,14 +186,26 @@ final class TVControlReceiver {
     }
 
     func unregisterPlayer(_ viewModel: PlayerViewModel) {
-        guard playerViewModel === viewModel else { return }
+        guard playerViewModel == nil || playerViewModel === viewModel else { return }
+        let endingGeneration = playerHandoffGeneration
         playerViewModel = nil
         playerContentId = nil
+        playerHandoffGeneration = nil
         stateTask?.cancel()
         stateTask = nil
         refreshStandbyState()
         sendState()
         setPlaybackAdvertised(false)
+        if let endingGeneration,
+           RemotePlaybackIdentityManager.shared.activeIdentity?.generationID == endingGeneration {
+            Task { @MainActor [weak self, weak viewModel] in
+                await viewModel?.waitForCleanupCompletion()
+                await RemotePlaybackIdentityManager.shared.end()
+                self?.refreshAdvertisement()
+                self?.reconcileAuthorizationAfterRestore()
+                self?.refreshStandbyState()
+            }
+        }
     }
 
     private func accept(_ connection: NWConnection) async {
@@ -173,7 +219,12 @@ final class TVControlReceiver {
         activeSession = session
         activeConnectionId = connectionId
         isAuthorized = false
+        didReceiveHello = false
+        negotiatedVersion = nil
+        remoteLaunchReady = false
         remoteControllerName = nil
+        remoteControllerDeviceId = nil
+        remoteControllerServerId = nil
         refreshStandbyState()
         let stream = await session.open()
         startReadLoop(stream: stream, connectionId: connectionId)
@@ -185,7 +236,6 @@ final class TVControlReceiver {
 
         do {
             try await session.send(makeHello())
-            sendState()
         } catch {
             closeActiveSession(sendClose: false)
         }
@@ -225,21 +275,50 @@ final class TVControlReceiver {
         // path alive — keep the session pinned open forever.
         switch message {
         case .hello(let hello):
-            guard let serverId = hello.serverId, !serverId.isEmpty,
-                  let activeServerId = ServerRegistry.shared.activeServerId,
-                  serverId == activeServerId else {
-                sendError(code: "server_mismatch",
-                          message: "This Apple TV is connected to a different Silo server.")
+            guard hello.role == .phone,
+                  let version = SiloControlProtocol.negotiatedVersion(with: hello.supportedVersions),
+                  let serverId = hello.serverId, !serverId.isEmpty else {
+                sendError(code: "version_unsupported", message: "Update Silo on both devices to continue.")
                 closeActiveSession(sendClose: true)
                 return
             }
-            isAuthorized = true
+            didReceiveHello = true
+            negotiatedVersion = version
             authWatchdogTask?.cancel(); authWatchdogTask = nil
             remoteControllerName = hello.deviceName
-            refreshStandbyState()
+            remoteControllerDeviceId = hello.deviceId
+            remoteControllerServerId = serverId
+            if serverId == RemotePlaybackIdentityManager.shared.effectiveServerId {
+                isAuthorized = true
+                refreshStandbyState()
+                sendState()
+            } else if version >= 2 {
+                // A v2 cross-server controller may stay connected only long
+                // enough to complete server-mediated identity handoff.
+                isAuthorized = false
+                standbyState = nil
+            } else {
+                sendError(code: "server_mismatch",
+                          message: "This Apple TV is connected to a different Silo server.")
+                closeActiveSession(sendClose: true)
+            }
+        case .handoffOffer(let offer):
+            guard negotiatedVersion == 2, let controllerDeviceId = remoteControllerDeviceId else {
+                sendHandoffCancel(offer.requestId, reason: "version_unsupported", message: "Update Silo on both devices to continue.")
+                return
+            }
+            beginHandoff(offer, controllerDeviceId: controllerDeviceId, connectionId: connectionId)
+        case .handoffCancel(let cancel):
+            guard cancel.requestId == pendingHandoffRequestId else { return }
+            cancelPendingHandoff()
         case .launch(let launch):
             guard isAuthorized else {
                 sendError(code: "unauthorized", message: "Connect with a matching Silo account first.")
+                return
+            }
+            if negotiatedVersion == 2,
+               (!remoteLaunchReady || RemotePlaybackIdentityManager.shared.activeIdentity == nil) {
+                sendError(code: "handoff_required", message: "Prepare the phone profile before playing.")
                 return
             }
             handleLaunch(launch)
@@ -253,21 +332,116 @@ final class TVControlReceiver {
             activeSession?.enqueue(.pong)
         case .pong:
             missedHeartbeats = 0
-        case .state, .error:
+        case .state, .error, .handoffChallenge, .handoffReady:
             break
         case .close:
             closeActiveSession(sendClose: false)
         }
     }
 
+    private func beginHandoff(
+        _ offer: SiloControlHandoffOffer,
+        controllerDeviceId: String,
+        connectionId: UUID
+    ) {
+        cancelPendingHandoff()
+        pendingHandoffRequestId = offer.requestId
+        remoteLaunchReady = false
+
+        handoffTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                let manager = RemotePlaybackIdentityManager.shared
+                if manager.activeIdentity != nil,
+                   !manager.matches(offer, controllerDeviceId: controllerDeviceId) {
+                    let previousPlayer = self.playerViewModel
+                    self.stopRemotePlayback()
+                    await previousPlayer?.waitForCleanupCompletion()
+                    await manager.end()
+                }
+
+                let ready = try await manager.prepare(
+                    offer: offer,
+                    controllerDeviceId: controllerDeviceId,
+                    controllerDeviceName: self.remoteControllerName
+                ) { [weak self] challenge in
+                    guard let self,
+                          self.activeConnectionId == connectionId,
+                          self.pendingHandoffRequestId == offer.requestId,
+                          let session = self.activeSession else {
+                        throw CancellationError()
+                    }
+                    try await session.send(.handoffChallenge(challenge))
+                }
+
+                guard self.activeConnectionId == connectionId,
+                      self.pendingHandoffRequestId == offer.requestId else {
+                    await manager.end()
+                    return
+                }
+                self.pendingHandoffRequestId = nil
+                self.handoffTask = nil
+                self.isAuthorized = true
+                self.remoteLaunchReady = true
+                self.refreshAdvertisement()
+                self.activeSession?.enqueue(.handoffReady(ready))
+                self.armReadyTimeout(connectionId: connectionId)
+            } catch is CancellationError {
+                return
+            } catch {
+                guard self.activeConnectionId == connectionId else { return }
+                self.sendHandoffCancel(
+                    offer.requestId,
+                    reason: "handoff_failed",
+                    message: error.localizedDescription
+                )
+                self.pendingHandoffRequestId = nil
+                self.handoffTask = nil
+            }
+        }
+    }
+
+    private func armReadyTimeout(connectionId: UUID) {
+        readyTimeoutTask?.cancel()
+        readyTimeoutTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(60))
+            guard let self,
+                  self.activeConnectionId == connectionId,
+                  self.remoteLaunchReady,
+                  self.playerViewModel == nil else { return }
+            await RemotePlaybackIdentityManager.shared.end()
+            self.remoteLaunchReady = false
+            self.pendingPlayerHandoffGeneration = nil
+            self.isAuthorized = false
+            self.refreshAdvertisement()
+            self.sendError(code: "launch_timeout", message: "No content was launched, so the temporary profile was restored.")
+            self.closeActiveSession(sendClose: true)
+        }
+    }
+
+    private func cancelPendingHandoff() {
+        handoffTask?.cancel()
+        handoffTask = nil
+        pendingHandoffRequestId = nil
+    }
+
+    private func sendHandoffCancel(_ requestId: String, reason: String, message: String?) {
+        activeSession?.enqueue(.handoffCancel(SiloControlHandoffCancel(
+            requestId: requestId,
+            reason: reason,
+            message: message
+        )))
+    }
+
     private func handleLaunch(_ launch: SiloControlLaunchRequest) {
-        guard launch.serverId == ServerRegistry.shared.activeServerId else {
+        guard launch.serverId == RemotePlaybackIdentityManager.shared.effectiveServerId else {
             sendError(code: "server_mismatch", message: "This Apple TV is connected to a different Silo server.")
             return
         }
 
         let playback = launch.playback
         standbyState = nil
+        pendingPlayerHandoffGeneration = RemotePlaybackIdentityManager.shared.activeIdentity?.generationID
         router?.presentPlayer(
             contentId: playback.contentId,
             fileId: playback.fileId,
@@ -302,6 +476,7 @@ final class TVControlReceiver {
 
     private func handleConnectionClosed(connectionId: UUID) {
         guard activeConnectionId == connectionId else { return }
+        cancelPendingHandoff()
         activeSession = nil
         activeConnectionId = nil
         remoteControllerName = nil
@@ -312,10 +487,16 @@ final class TVControlReceiver {
         authWatchdogTask?.cancel(); authWatchdogTask = nil
         missedHeartbeats = 0
         isAuthorized = false
+        didReceiveHello = false
+        negotiatedVersion = nil
+        remoteLaunchReady = false
+        remoteControllerDeviceId = nil
+        remoteControllerServerId = nil
         standbyState = nil
     }
 
     private func closeActiveSession(sendClose: Bool) {
+        cancelPendingHandoff()
         let session = activeSession
         let read = readTask
         activeSession = nil
@@ -328,6 +509,11 @@ final class TVControlReceiver {
         authWatchdogTask?.cancel(); authWatchdogTask = nil
         missedHeartbeats = 0
         isAuthorized = false
+        didReceiveHello = false
+        negotiatedVersion = nil
+        remoteLaunchReady = false
+        remoteControllerDeviceId = nil
+        remoteControllerServerId = nil
         standbyState = nil
 
         guard let session else {
@@ -370,8 +556,18 @@ final class TVControlReceiver {
         }
         standbyState = TVControlStandbyState(
             controllerName: remoteControllerName,
-            serverName: ServerRegistry.shared.activeServer?.displayName
+            serverName: RemotePlaybackIdentityManager.shared.effectiveServerName
         )
+    }
+
+    private func reconcileAuthorizationAfterRestore() {
+        remoteLaunchReady = false
+        isAuthorized = remoteControllerServerId == RemotePlaybackIdentityManager.shared.effectiveServerId
+        if isAuthorized {
+            sendState()
+        } else {
+            standbyState = nil
+        }
     }
 
     private func startHeartbeat(connectionId: UUID) {
@@ -396,7 +592,7 @@ final class TVControlReceiver {
         authWatchdogTask?.cancel()
         authWatchdogTask = Task { @MainActor [weak self] in
             try? await Task.sleep(for: Self.authGracePeriod)
-            guard let self, self.activeConnectionId == connectionId, !self.isAuthorized else { return }
+            guard let self, self.activeConnectionId == connectionId, !self.didReceiveHello else { return }
             Self.logger.info("control: controller never authorized; closing session")
             self.closeActiveSession(sendClose: true)
         }
@@ -414,7 +610,7 @@ final class TVControlReceiver {
     }
 
     private func sendState() {
-        guard let session = activeSession else { return }
+        guard isAuthorized, let session = activeSession else { return }
         let state: SiloControlPlaybackState
         if let playerViewModel {
             state = playerViewModel.makeSiloControlPlaybackState(contentId: playerContentId)
@@ -464,14 +660,13 @@ final class TVControlReceiver {
 
     private func makeHello() -> SiloControlMessage {
         let device = AppleDeviceIdentity.current
-        let server = ServerRegistry.shared.activeServer
         return .hello(SiloControlHello(
             role: .tv,
             deviceName: device.name,
             deviceId: device.id,
-            serverId: server?.id,
-            serverName: server?.displayName,
-            supportedVersions: [SiloControlProtocol.version]
+            serverId: RemotePlaybackIdentityManager.shared.effectiveServerId,
+            serverName: RemotePlaybackIdentityManager.shared.effectiveServerName,
+            supportedVersions: SiloControlProtocol.supportedVersions
         ))
     }
 

--- a/iosApp/iosApp/Navigation/AppRouter.swift
+++ b/iosApp/iosApp/Navigation/AppRouter.swift
@@ -6,6 +6,9 @@ extension Notification.Name {
     /// screen — the registry entry is preserved so the user only has to
     /// re-enter credentials.
     static let continuumSessionExpired = Notification.Name("continuumSessionExpired")
+    /// Posted when a playback-only remote handoff session expires. The TV
+    /// restores its persistent identity instead of routing the app to login.
+    static let temporaryRemoteAuthExpired = Notification.Name("temporaryRemoteAuthExpired")
 }
 
 /// Central navigation controller for the Continuum iOS app.

--- a/iosApp/iosApp/Networking/DeviceLoginModels.swift
+++ b/iosApp/iosApp/Networking/DeviceLoginModels.swift
@@ -3,6 +3,8 @@ import Foundation
 struct DeviceLoginStartRequest: Codable {
     let deviceName: String?
     let devicePlatform: String?
+    var clientPurpose: String? = nil
+    var temporary: Bool? = nil
 }
 
 /// `deviceCode` is the TV-only secret used for polling; it must never be
@@ -19,6 +21,8 @@ struct DeviceLoginStartResponse: Codable, Equatable {
     let interval: Int
     let deviceName: String
     let devicePlatform: String
+    var clientPurpose: String? = nil
+    var temporary: Bool? = nil
 }
 
 struct DeviceLoginPollRequest: Codable {
@@ -35,6 +39,10 @@ struct DeviceLoginPollResponse: Codable {
     let refreshToken: String?
     let expiresIn: Int64?
     let user: AuthUser?
+    var profileId: String? = nil
+    var profileToken: String? = nil
+    var temporary: Bool? = nil
+    var sessionExpiresAt: String? = nil
 }
 
 enum DeviceLoginStatus: String {
@@ -63,4 +71,11 @@ struct DeviceLookupResponse: Codable {
     let deviceName: String?
     let devicePlatform: String?
     let status: String?
+    var clientPurpose: String? = nil
+    var temporary: Bool? = nil
+}
+
+struct DeviceLoginCapabilityResponse: Codable {
+    let remotePlaybackHandoff: Bool
+    let protocolVersions: [Int]
 }

--- a/iosApp/iosApp/Networking/HTTPClient.swift
+++ b/iosApp/iosApp/Networking/HTTPClient.swift
@@ -551,13 +551,16 @@ actor HTTPClient {
             } else {
                 let body = String(data: data, encoding: .utf8) ?? ""
                 Self.logger.error("Refresh failed: status=\(http.statusCode, privacy: .public) body=\(body, privacy: .private)")
-                await tokenStore.clearTokens()
+                let temporaryScopeExpired = await tokenStore.hasTemporaryScope()
+                if !temporaryScopeExpired {
+                    await tokenStore.clearTokens()
+                }
                 // Tell the UI to route back to login for the current
                 // server. The registry entry (URL + display name) is
                 // preserved so the user doesn't have to re-add it.
                 await MainActor.run {
                     NotificationCenter.default.post(
-                        name: .continuumSessionExpired,
+                        name: temporaryScopeExpired ? .temporaryRemoteAuthExpired : .continuumSessionExpired,
                         object: nil
                     )
                 }

--- a/iosApp/iosApp/Networking/TokenStore.swift
+++ b/iosApp/iosApp/Networking/TokenStore.swift
@@ -1,5 +1,16 @@
 import Foundation
 
+struct TemporaryAuthScope: Equatable, Sendable {
+    let serverId: String
+    let serverURL: String
+    var accessToken: String
+    var refreshToken: String
+    var profileId: String
+    var profileToken: String
+    let controllerDeviceId: String
+    let expiresAt: Date
+}
+
 /// Persistent, thread-safe store for Continuum session state.
 ///
 /// Mirrors the surface of the shared Kotlin `TokenManager`, but persists
@@ -60,6 +71,9 @@ actor TokenStore {
     private var cachedAccessToken: String?
     private var cachedRefreshToken: String?
     private var cachedProfileToken: String?
+    /// Playback-scoped credentials received by a TV through remote handoff.
+    /// They are process-only and never written into normal per-server slots.
+    private var temporaryScope: TemporaryAuthScope?
     /// Server the current cache was loaded for. Nil means the cache is
     /// invalid and must be re-read on next access.
     private var loadedForServerId: String?
@@ -107,16 +121,32 @@ actor TokenStore {
     }
 
     /// The current active server ID. Empty string if none.
-    func getActiveServerId() -> String { activeServerId }
+    func getActiveServerId() -> String { temporaryScope?.serverId ?? activeServerId }
+
+    func beginTemporaryScope(_ scope: TemporaryAuthScope) {
+        temporaryScope = scope
+    }
+
+    @discardableResult
+    func endTemporaryScope() -> TemporaryAuthScope? {
+        defer { temporaryScope = nil }
+        return temporaryScope
+    }
+
+    func getTemporaryScope() -> TemporaryAuthScope? { temporaryScope }
+
+    func hasTemporaryScope() -> Bool { temporaryScope != nil }
 
     // MARK: - Tokens
 
     func getAccessToken() -> String? {
+        if let temporaryScope { return temporaryScope.accessToken }
         ensureLoaded()
         return cachedAccessToken
     }
 
     func getRefreshToken() -> String? {
+        if let temporaryScope { return temporaryScope.refreshToken }
         ensureLoaded()
         return cachedRefreshToken
     }
@@ -146,6 +176,11 @@ actor TokenStore {
     }
 
     func saveTokens(accessToken: String, refreshToken: String) {
+        if temporaryScope != nil {
+            temporaryScope?.accessToken = accessToken
+            temporaryScope?.refreshToken = refreshToken
+            return
+        }
         guard !activeServerId.isEmpty else { return }
         ensureLoaded()
         cachedAccessToken = accessToken
@@ -159,6 +194,10 @@ actor TokenStore {
     /// stored tokens intact and leaves the active-server registry entry
     /// in place (sign-out keeps the URL / name).
     func clearTokens() {
+        if temporaryScope != nil {
+            temporaryScope = nil
+            return
+        }
         ensureLoaded()
         cachedAccessToken = nil
         cachedRefreshToken = nil
@@ -190,19 +229,29 @@ actor TokenStore {
     // MARK: - Profile
 
     func getProfileId() -> String? {
-        defaults.string(forKey: profileIdDefaultsKey)
+        if let temporaryScope { return temporaryScope.profileId }
+        return defaults.string(forKey: profileIdDefaultsKey)
     }
 
     func setProfileId(_ profileId: String?) {
+        if temporaryScope != nil {
+            if let profileId { temporaryScope?.profileId = profileId }
+            return
+        }
         defaults.set(profileId, forKey: profileIdDefaultsKey)
     }
 
     func getProfileToken() -> String? {
+        if let temporaryScope { return temporaryScope.profileToken }
         ensureLoaded()
         return cachedProfileToken
     }
 
     func setProfileToken(_ token: String?) {
+        if temporaryScope != nil {
+            if let token { temporaryScope?.profileToken = token }
+            return
+        }
         guard !activeServerId.isEmpty else { return }
         ensureLoaded()
         cachedProfileToken = token
@@ -217,7 +266,8 @@ actor TokenStore {
     // MARK: - Server URL
 
     func getServerUrl() -> String {
-        defaults.string(forKey: serverUrlDefaultsKey) ?? ""
+        if let temporaryScope { return temporaryScope.serverURL }
+        return defaults.string(forKey: serverUrlDefaultsKey) ?? ""
     }
 
     func setServerUrl(_ url: String) {

--- a/iosApp/iosApp/Pairing/PairingDeviceAPI.swift
+++ b/iosApp/iosApp/Pairing/PairingDeviceAPI.swift
@@ -66,6 +66,28 @@ struct PairingDeviceAPI: PairingDeviceAuthorizing {
                        body: DeviceLoginPollRequest(deviceCode: deviceCode))
     }
 
+    func remotePlaybackCapability(serverURL: String) async throws -> DeviceLoginCapabilityResponse {
+        try await get(serverURL, "/api/v1/auth/device/capability", query: [:], bearer: nil)
+    }
+
+    func startRemotePlayback(
+        serverURL: String,
+        deviceName: String,
+        devicePlatform: String
+    ) async throws -> DeviceLoginStartResponse {
+        try await post(
+            serverURL,
+            "/api/v1/auth/device/start",
+            bearer: nil,
+            body: DeviceLoginStartRequest(
+                deviceName: deviceName,
+                devicePlatform: devicePlatform,
+                clientPurpose: "remote_playback",
+                temporary: true
+            )
+        )
+    }
+
     // MARK: Companion (authenticated with the chosen server's token)
 
     func lookup(serverURL: String, bearer: String, userCode: String) async throws -> DeviceLookupResponse {
@@ -75,6 +97,32 @@ struct PairingDeviceAPI: PairingDeviceAuthorizing {
     func approve(serverURL: String, bearer: String, userCode: String) async throws {
         let _: EmptyResponse = try await post(serverURL, "/api/v1/auth/device/approve",
                                               bearer: bearer, body: DeviceApproveRequest(code: userCode))
+    }
+
+    func approveRemotePlayback(
+        serverURL: String,
+        bearer: String,
+        profileId: String,
+        profileToken: String?,
+        userCode: String
+    ) async throws {
+        let _: EmptyResponse = try await post(
+            serverURL,
+            "/api/v1/auth/device/approve-handoff",
+            bearer: bearer,
+            profileId: profileId,
+            profileToken: profileToken,
+            body: DeviceApproveRequest(code: userCode)
+        )
+    }
+
+    func denyRemotePlayback(serverURL: String, bearer: String, userCode: String) async throws {
+        let _: EmptyResponse = try await post(
+            serverURL,
+            "/api/v1/auth/device/deny",
+            bearer: bearer,
+            body: DeviceApproveRequest(code: userCode)
+        )
     }
 
     private struct EmptyResponse: Codable {}
@@ -91,18 +139,32 @@ struct PairingDeviceAPI: PairingDeviceAuthorizing {
         return try await send(request)
     }
 
-    private func post<B: Encodable, R: Decodable>(_ serverURL: String, _ path: String, bearer: String?, body: B) async throws -> R {
+    private func post<B: Encodable, R: Decodable>(
+        _ serverURL: String,
+        _ path: String,
+        bearer: String?,
+        profileId: String? = nil,
+        profileToken: String? = nil,
+        body: B
+    ) async throws -> R {
         guard let url = URL(string: serverURL.appending(path)) else { throw APIError.badURL }
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try encoder.encode(body)
-        applyHeaders(&request, bearer: bearer)
+        applyHeaders(&request, bearer: bearer, profileId: profileId, profileToken: profileToken)
         return try await send(request)
     }
 
-    private func applyHeaders(_ request: inout URLRequest, bearer: String?) {
+    private func applyHeaders(
+        _ request: inout URLRequest,
+        bearer: String?,
+        profileId: String? = nil,
+        profileToken: String? = nil
+    ) {
         if let bearer { request.setValue("Bearer \(bearer)", forHTTPHeaderField: "Authorization") }
+        if let profileId { request.setValue(profileId, forHTTPHeaderField: "X-Profile-Id") }
+        if let profileToken { request.setValue(profileToken, forHTTPHeaderField: "X-Profile-Token") }
         let device = AppleDeviceIdentity.current
         request.setValue(device.id, forHTTPHeaderField: "X-Silo-Device-Id")
         request.setValue(device.name, forHTTPHeaderField: "X-Silo-Device-Name")

--- a/iosApp/iosApp/Screens/Auth/AuthService.swift
+++ b/iosApp/iosApp/Screens/Auth/AuthService.swift
@@ -280,4 +280,12 @@ final class AuthService: @unchecked Sendable {
         ItemDetailCache.shared.clearAll()
         #endif
     }
+
+    /// A remote-playback handoff changes server/account/profile without
+    /// touching the persistent registry. Treat both entry and restoration as
+    /// full auth boundaries so cached user data cannot cross identities.
+    @MainActor
+    func clearCachesForTemporaryIdentityChange() {
+        clearAllCaches()
+    }
 }

--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -31,6 +31,9 @@ struct PlayerView: View {
     #if os(iOS)
     @State private var orientationCoordinator = PlayerOrientationCoordinator.shared
     #endif
+    #if os(tvOS)
+    @State private var remoteIdentityNotice: RemotePlaybackIdentityManager.ActiveIdentity?
+    #endif
 
     init(
         contentId: String,
@@ -175,9 +178,18 @@ struct PlayerView: View {
                     }
                     #endif
 
+                    #if os(tvOS)
+                    if let identity = remoteIdentityNotice {
+                        RemotePlaybackIdentityNotice(identity: identity)
+                            .transition(.opacity)
+                    } else if let notice = viewModel.activeNotice ?? viewModel.suspendedNotice {
+                        PlayerNoticeOverlay(notice: notice)
+                    }
+                    #else
                     if let notice = viewModel.activeNotice ?? viewModel.suspendedNotice {
                         PlayerNoticeOverlay(notice: notice)
                     }
+                    #endif
                 }
             }
         }
@@ -241,13 +253,26 @@ struct PlayerView: View {
             )
             #if os(tvOS)
             TVControlReceiver.shared.registerPlayer(viewModel, contentId: contentId)
+            withAnimation(.easeInOut(duration: 0.2)) {
+                remoteIdentityNotice = RemotePlaybackIdentityManager.shared.activeIdentity
+            }
             #endif
         }
+        #if os(tvOS)
+        .task(id: remoteIdentityNotice?.generationID) {
+            guard remoteIdentityNotice != nil else { return }
+            try? await Task.sleep(for: .seconds(6))
+            guard !Task.isCancelled else { return }
+            withAnimation(.easeInOut(duration: 0.2)) {
+                remoteIdentityNotice = nil
+            }
+        }
+        #endif
         .onDisappear {
+            viewModel.cleanup()
             #if os(tvOS)
             TVControlReceiver.shared.unregisterPlayer(viewModel)
             #endif
-            viewModel.cleanup()
             #if os(iOS)
             orientationCoordinator.deactivatePlayer()
             #endif

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -692,6 +692,7 @@ class PlayerViewModel {
     /// load cycles because this snapshot is a long-lived PlayerViewModel concern.
     private var realtimeUnavailabilityObserverToken: UUID?
     private var realtimeConnectivityObserverToken: UUID?
+    private var cleanupCompletionTask: Task<Void, Never>?
 
     /// Build the live-subtitle coordinator with adapters bound to this VM. The
     /// adapters touch the VM's playback + live-track + notice surface, so they
@@ -5425,7 +5426,7 @@ class PlayerViewModel {
         realtimeConnectivityObserverToken = nil
         let unavailabilityToken = realtimeUnavailabilityObserverToken
         realtimeUnavailabilityObserverToken = nil
-        Task {
+        cleanupCompletionTask = Task {
             // Remove our availability observer before tearing down the realtime
             // client; normal fresh-load unbinds preserve this observer.
             if let connectivityToken {
@@ -5439,6 +5440,17 @@ class PlayerViewModel {
                 await sessionBridge.stopSession(position: finalPosition, isPaused: true)
             }
         }
+    }
+
+    @MainActor
+    func waitForCleanupCompletion() async {
+        // onDisappear calls cleanup immediately before unregistering the TV
+        // receiver. Yield briefly if presentation teardown has not installed
+        // the final progress task yet.
+        for _ in 0..<100 where cleanupCompletionTask == nil {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        await cleanupCompletionTask?.value
     }
 
     /// Safety net: SwiftUI normally drives `cleanup()` from `PlayerView.onDisappear`,

--- a/iosApp/iosApp/Screens/Player/RemotePlaybackIdentityNotice.swift
+++ b/iosApp/iosApp/Screens/Player/RemotePlaybackIdentityNotice.swift
@@ -1,0 +1,64 @@
+#if os(tvOS)
+import SwiftUI
+
+struct RemotePlaybackIdentityNotice: View {
+    let identity: RemotePlaybackIdentityManager.ActiveIdentity
+
+    private var profileLabel: String {
+        let name = identity.profileName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let name, !name.isEmpty { return name }
+        return "your phone's profile"
+    }
+
+    private var sourceLabel: String {
+        let device = identity.controllerDeviceName?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let source: String
+        if let device, !device.isEmpty {
+            source = device
+        } else {
+            source = "your phone"
+        }
+        if identity.usesDifferentServer,
+           let server = identity.serverName?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !server.isEmpty {
+            return "From \(source) · \(server)"
+        }
+        return "From \(source)"
+    }
+
+    var body: some View {
+        Label {
+            VStack(alignment: .leading, spacing: ContinuumTheme.smallPadding) {
+                Text("Playing as \(profileLabel)")
+                    .font(.continuumSubheadline)
+                    .foregroundStyle(Color.continuumOnSurface)
+                    .lineLimit(1)
+
+                Text(sourceLabel)
+                    .font(.continuumBody)
+                    .foregroundStyle(Color.continuumSecondaryText)
+                    .lineLimit(1)
+            }
+        } icon: {
+            Image(systemName: "iphone")
+                .font(.title3)
+                .foregroundStyle(Color.continuumPrimary)
+                .accessibilityHidden(true)
+        }
+        .padding(.horizontal, ContinuumTheme.padding)
+        .padding(.vertical, ContinuumTheme.spacing)
+        .frame(maxWidth: 720)
+        .siloPlayerGlass(
+            in: RoundedRectangle(cornerRadius: ContinuumTheme.cardCornerRadius),
+            tint: Color.continuumPrimary.opacity(0.24)
+        )
+        .shadow(color: .black.opacity(0.28), radius: 24, y: 12)
+        .padding(.horizontal, ContinuumTheme.safePadding)
+        .padding(.top, ContinuumTheme.safePadding)
+        .allowsHitTesting(false)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Playing as \(profileLabel). \(sourceLabel).")
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

- negotiate Silo Cast protocol v2 for phone-initiated launches
- let tvOS acquire a process-only session for the phone's server and selected profile
- keep ordinary control of existing TV playback under the TV's identity
- restore the saved TV identity after the remotely launched player ends
- show a six-second, non-focusable “Playing as …” notice with the phone and profile names
- keep v1 receivers control-only for updated phones and document the lifecycle

## User impact

Launching content from an iPhone now attributes permissions, resume state, progress, and preferences to the iPhone's active profile—even when the Apple TV is signed into another account or server. The temporary credentials never enter the TV keychain.

The identity notice makes the switch explicit without interrupting playback or taking Siri Remote focus.

## Dependencies and parity

- Server API: [Silo-Server/silo-server#360](https://github.com/Silo-Server/silo-server/pull/360)
- Android implementation: [Silo-Server/silo-android#53](https://github.com/Silo-Server/silo-android/pull/53)

## Validation

- iOS Simulator build
- tvOS Simulator build
- `SiloControlTests`: 9 tests, 0 failures
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-server remote playback handoff between iOS and tvOS with temporary profile authorization.
  * Added protocol negotiation for improved compatibility between app versions.
  * Added tvOS notices showing when playback uses a remotely authorized profile or server.
  * Added automatic cleanup and restoration when temporary authorization expires.
* **Improvements**
  * Devices requiring an update are now clearly identified before remote playback.
  * Remote playback connections now provide more reliable authorization, launch, and teardown behavior.
* **Documentation**
  * Updated cast remote architecture, security considerations, volume controls, lifecycle behavior, and testing guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->