### PR TITLE
Refine tvOS playback selection and direct navigation

### DIFF
--- a/iosApp/Tests/DetailVersionSelectionTests.swift
+++ b/iosApp/Tests/DetailVersionSelectionTests.swift
@@ -40,6 +40,32 @@ final class DetailVersionSelectionTests: XCTestCase {
         )
     }
 
+    func testVersionSelectorUsesDVForDolbyVisionMetadata() {
+        let version = decodedVersions("""
+        [
+          {
+            "file_id": 1,
+            "resolution": "2160p",
+            "codec_video": "hevc",
+            "codec_audio": "eac3",
+            "hdr": true,
+            "video_tracks": [
+              { "dolby_vision": "Profile 8.1" }
+            ]
+          }
+        ]
+        """)[0]
+
+        XCTAssertEqual(
+            DetailPlaybackFormatting.versionShortLabel(version),
+            "2160p · HEVC · DV · EAC3"
+        )
+        XCTAssertEqual(
+            DetailPlaybackFormatting.versionPrimaryText(version),
+            "2160p · HEVC · DV · EAC3"
+        )
+    }
+
     private func decodedVersions(_ json: String) -> [FileVersion] {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase

--- a/iosApp/Tests/DetailVersionSelectionTests.swift
+++ b/iosApp/Tests/DetailVersionSelectionTests.swift
@@ -21,6 +21,25 @@ final class DetailVersionSelectionTests: XCTestCase {
         )
     }
 
+    func testVersionSelectorUsesRichPrePlaySummary() {
+        let version = decodedVersions("""
+        [
+          {
+            "file_id": 1,
+            "resolution": "2160p",
+            "codec_video": "hevc",
+            "codec_audio": "truehd",
+            "hdr": true
+          }
+        ]
+        """)[0]
+
+        XCTAssertEqual(
+            DetailPlaybackFormatting.versionShortLabel(version),
+            "2160p · HEVC · HDR · TrueHD"
+        )
+    }
+
     private func decodedVersions(_ json: String) -> [FileVersion] {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
@@ -121,7 +140,7 @@ final class DetailVersionSelectionTests: XCTestCase {
             DetailPlaybackFormatting.subtitleValueLabel(
                 version: singleChoiceVersion,
                 selectedSubtitleTrackIndex: nil
-            ) == "SubRip - English"
+            ) == "English · SRT"
         )
 
         let multipleChoiceVersion = decodedVersions("""
@@ -217,10 +236,16 @@ final class DetailVersionSelectionTests: XCTestCase {
             version: version,
             selectedAudioTrackIndex: 0
         )
+        let annotatedAutoLabel = DetailPlaybackFormatting.audioValueLabel(
+            version: version,
+            selectedAudioTrackIndex: nil,
+            annotateAuto: true
+        )
 
         XCTAssertTrue(version.effectiveAudioTrackIndex == 1)
-        XCTAssertTrue(effectiveLabel == "TrueHD 7.1 - Japanese", "Expected effective track label; got \(effectiveLabel)")
-        XCTAssertTrue(selectedLabel == "AAC - English", "Selected ordinal should override effective track; got \(selectedLabel)")
+        XCTAssertTrue(effectiveLabel == "Japanese · TrueHD · 7.1", "Expected effective track label; got \(effectiveLabel)")
+        XCTAssertTrue(selectedLabel == "English · AAC", "Selected ordinal should override effective track; got \(selectedLabel)")
+        XCTAssertEqual(annotatedAutoLabel, "Auto: Japanese · TrueHD · 7.1")
 
         let defaultFallback = decodedVersions("""
         [
@@ -237,7 +262,7 @@ final class DetailVersionSelectionTests: XCTestCase {
             version: defaultFallback,
             selectedAudioTrackIndex: nil
         )
-        XCTAssertTrue(defaultLabel == "AC3 - Spanish", "Expected default track label; got \(defaultLabel)")
+        XCTAssertTrue(defaultLabel == "Spanish · AC3", "Expected default track label; got \(defaultLabel)")
 
         let firstFallback = decodedVersions("""
         [
@@ -254,7 +279,7 @@ final class DetailVersionSelectionTests: XCTestCase {
             version: firstFallback,
             selectedAudioTrackIndex: nil
         )
-        XCTAssertTrue(firstLabel == "AAC - English", "Expected first track fallback; got \(firstLabel)")
+        XCTAssertTrue(firstLabel == "English · AAC", "Expected first track fallback; got \(firstLabel)")
     }
 
     func testAudioLabelsSimplifyTechnicalTitles() {
@@ -285,9 +310,9 @@ final class DetailVersionSelectionTests: XCTestCase {
             selectedAudioTrackIndex: nil
         )
 
-        XCTAssertTrue(label == "EAC3 5.1 - English", "Expected simplified audio label; got \(label)")
-        XCTAssertTrue(options[0].title == "EAC3 5.1 - English")
-        XCTAssertTrue(options[0].detail == "Default · Preferred")
+        XCTAssertTrue(label == "English · EAC3 · 5.1", "Expected simplified audio label; got \(label)")
+        XCTAssertTrue(options[0].title == "English")
+        XCTAssertTrue(options[0].detail == "EAC3 · 5.1 · Default · Preferred")
     }
 
     func testSubtitleNilIndexDoesNotCollideWithOff() {
@@ -328,7 +353,8 @@ final class DetailVersionSelectionTests: XCTestCase {
 
         XCTAssertTrue(options.count == 1)
         XCTAssertTrue(options[0].selectionIndex == nil)
-        XCTAssertTrue(options[0].title == "SubRip - English")
+        XCTAssertTrue(options[0].title == "English")
+        XCTAssertTrue(options[0].detail == "SRT · External · Available in player")
         XCTAssertFalse(options[0].isSelectable)
         XCTAssertFalse(options[0].isSelected)
         XCTAssertTrue(
@@ -373,10 +399,11 @@ final class DetailVersionSelectionTests: XCTestCase {
         )
 
         XCTAssertTrue(options.count == 2)
-        XCTAssertTrue(options[0].title == "SDH - English", "Expected SDH language label; got \(options[0].title)")
-        XCTAssertTrue(options[0].detail == "SubRip · Default", "Expected subtitle type detail; got \(options[0].detail)")
-        XCTAssertTrue(options[1].title == "SubRip - Japanese", "Expected fallback subtitle type and language; got \(options[1].title)")
-        XCTAssertTrue(selectedLabel == "SDH - English", "Expected selected subtitle label; got \(selectedLabel)")
+        XCTAssertTrue(options[0].title == "English", "Expected language-first subtitle label; got \(options[0].title)")
+        XCTAssertTrue(options[0].detail == "SRT · SDH · Default", "Expected subtitle type detail; got \(options[0].detail)")
+        XCTAssertTrue(options[1].title == "Japanese", "Expected language-first subtitle label; got \(options[1].title)")
+        XCTAssertTrue(options[1].detail == "SRT", "Expected subtitle format detail; got \(options[1].detail)")
+        XCTAssertTrue(selectedLabel == "English (SDH) · SRT", "Expected selected subtitle label; got \(selectedLabel)")
     }
 
     func testUntaggedEditionDisplaysStandard() {

--- a/iosApp/Tests/DetailVersionSelectionTests.swift
+++ b/iosApp/Tests/DetailVersionSelectionTests.swift
@@ -406,6 +406,45 @@ final class DetailVersionSelectionTests: XCTestCase {
         XCTAssertTrue(selectedLabel == "English (SDH) · SRT", "Expected selected subtitle label; got \(selectedLabel)")
     }
 
+    func testSubtitleLabelsDoNotDuplicateTitleBasedMarkers() {
+        let version = decodedVersions("""
+        [
+          {
+            "file_id": 1,
+            "subtitle_tracks": [
+              {
+                "index": 2,
+                "title": "Signs and Songs Forced",
+                "codec": "srt",
+                "language": "eng",
+                "forced": false
+              },
+              {
+                "index": 3,
+                "title": "Director's Commentary (Hearing Impaired)",
+                "codec": "srt"
+              }
+            ]
+          }
+        ]
+        """)[0]
+
+        let options = DetailPlaybackFormatting.subtitleOptions(
+            version: version,
+            selectedSubtitleTrackIndex: 2,
+            preferredLanguage: nil
+        )
+
+        XCTAssertTrue(options[0].detail == "Signs and Songs Forced · SRT · Forced")
+        XCTAssertTrue(
+            DetailPlaybackFormatting.subtitleValueLabel(
+                version: version,
+                selectedSubtitleTrackIndex: 3
+            ) == "Director's Commentary (Hearing Impaired) · SRT",
+            "The hearing-impaired marker is already present in the detail title and should not be repeated"
+        )
+    }
+
     func testUntaggedEditionDisplaysStandard() {
         let versions = decodedVersions("""
         [

--- a/iosApp/iosApp/Components/EpisodeThumbCard.swift
+++ b/iosApp/iosApp/Components/EpisodeThumbCard.swift
@@ -11,6 +11,9 @@ struct EpisodeThumbCard: View {
     let item: SectionItem
     var showProgress: Bool = false
     let action: () -> Void
+    /// tvOS-only shortcut invoked by the remote's Play/Pause button while
+    /// this card owns focus. Select continues to invoke `action`.
+    var playAction: (() -> Void)? = nil
     /// tvOS-only: parent row's focus tracking binding. See
     /// `MediaCard.focusedItemId` for the contract.
     var focusedItemId: FocusState<String?>.Binding? = nil
@@ -290,6 +293,7 @@ struct EpisodeThumbCard: View {
         .buttonStyle(.card)
         .focused($isFocused)
         .applyRowFocus(focusedItemId, itemId: item.contentId)
+        .applyEpisodePlayPauseAction(playAction)
 
         thumbnailButtonWithContext(button)
     }
@@ -337,6 +341,15 @@ struct EpisodeThumbCard: View {
 
 #if os(tvOS)
 private extension View {
+    @ViewBuilder
+    func applyEpisodePlayPauseAction(_ action: (() -> Void)?) -> some View {
+        if let action {
+            self.onPlayPauseCommand(perform: action)
+        } else {
+            self
+        }
+    }
+
     /// Mirrors `MediaCard.applyRowFocus` so episode thumbs participate
     /// in the row's `defaultFocus(... priority: .userInitiated)` mechanism.
     @ViewBuilder

--- a/iosApp/iosApp/Components/MediaCard.swift
+++ b/iosApp/iosApp/Components/MediaCard.swift
@@ -24,6 +24,9 @@ struct MediaCard: View {
     /// collection thumbnails) leave this off.
     var overlayData: OverlayData? = nil
     let action: () -> Void
+    /// tvOS-only shortcut invoked by the remote's Play/Pause button while
+    /// this card owns focus. Select continues to invoke `action`.
+    var playAction: (() -> Void)? = nil
     /// tvOS-only: binding to the parent row's `@FocusState` so the parent
     /// can route default focus (`defaultFocus(_:_:priority: .userInitiated)`)
     /// to a specific card. Pass `nil` for callers that don't need row-level
@@ -86,6 +89,7 @@ struct MediaCard: View {
             year: year,
             cardWidth: cardWidth,
             action: action,
+            playAction: playAction,
             focusedItemId: focusedItemId,
             itemId: contentId,
             isWatched: isPlayed,
@@ -424,6 +428,7 @@ private struct FocusableMediaCard<Content: View>: View {
     let year: Int?
     let cardWidth: CGFloat
     let action: () -> Void
+    let playAction: (() -> Void)?
     /// Parent row's focus tracking binding. When paired with `itemId`,
     /// the button binds via `.focused(_, equals: itemId)` so the row's
     /// `defaultFocus(... priority: .userInitiated)` can land focus here
@@ -473,6 +478,7 @@ private struct FocusableMediaCard<Content: View>: View {
         .buttonStyle(.card)
         .focused($isFocused)
         .applyRowFocus(focusedItemId, itemId: itemId)
+        .applyPlayPauseAction(playAction)
 
         mediaButtonWithContext(button)
     }
@@ -520,6 +526,15 @@ private struct FocusableMediaCard<Content: View>: View {
 }
 
 private extension View {
+    @ViewBuilder
+    func applyPlayPauseAction(_ action: (() -> Void)?) -> some View {
+        if let action {
+            self.onPlayPauseCommand(perform: action)
+        } else {
+            self
+        }
+    }
+
     /// Conditionally binds this view to the parent row's `@FocusState`
     /// so `defaultFocus(... priority: .userInitiated)` upstream can land
     /// focus on it. No-op when either argument is nil (e.g., on iOS or

--- a/iosApp/iosApp/Components/MediaRow.swift
+++ b/iosApp/iosApp/Components/MediaRow.swift
@@ -20,6 +20,9 @@ struct MediaRow: View {
     let title: String
     let items: [SectionItem]
     let onItemTap: (String) -> Void
+    /// tvOS-only direct-play action for focused leaf items. Container items
+    /// intentionally receive no Play/Pause command and retain normal focus.
+    var onItemPlay: ((SectionItem) -> Void)? = nil
     var onSeeAll: (() -> Void)? = nil
     var showProgress: Bool = false
     var icon: String? = nil
@@ -176,6 +179,7 @@ struct MediaRow: View {
                             userState: item.userState,
                             overlayData: OverlayData.from(item),
                             action: { onItemTap(item.contentId) },
+                            playAction: playAction(for: item),
                             focusedItemId: rowFocusBinding,
                             contentId: item.contentId,
                             onRemoveFromContinueWatching: continueWatchingRemovalAction(for: item),
@@ -189,6 +193,7 @@ struct MediaRow: View {
                             item: item,
                             showProgress: showProgress,
                             action: { onItemTap(item.contentId) },
+                            playAction: playAction(for: item),
                             focusedItemId: rowFocusBinding,
                             onRemoveFromContinueWatching: continueWatchingRemovalAction(for: item),
                             onSetWatched: watchedToggleAction(for: item)
@@ -246,6 +251,15 @@ struct MediaRow: View {
               let dur = item.durationSeconds,
               dur > 0, pos > 0 else { return nil }
         return pos / dur
+    }
+
+    private func playAction(for item: SectionItem) -> (() -> Void)? {
+        #if os(tvOS)
+        guard SiloMediaType.isDirectlyPlayable(item.type), let onItemPlay else { return nil }
+        return { onItemPlay(item) }
+        #else
+        return nil
+        #endif
     }
 
     private func continueWatchingRemovalAction(for item: SectionItem) -> (() -> Void)? {

--- a/iosApp/iosApp/Navigation/AppRouter.swift
+++ b/iosApp/iosApp/Navigation/AppRouter.swift
@@ -60,6 +60,9 @@ class AppRouter {
         let subtitleTrackIndex: Int?
         let startFromBeginning: Bool
         let resumePosition: Double?
+        /// Optional detail destination to install behind the full-screen
+        /// player once playback has actually started.
+        let returnToContentId: String?
         /// Set for offline playback of a completed download.
         var offlineDownloadId: String? = nil
         /// Hints supplied by the originating screen (e.g. the detail page,
@@ -94,6 +97,7 @@ class AppRouter {
         subtitleTrackIndex: Int? = nil,
         startFromBeginning: Bool = false,
         resumePosition: Double? = nil,
+        returnToContentId: String? = nil,
         posterURL: String? = nil,
         backdropURL: String? = nil
     ) {
@@ -122,6 +126,7 @@ class AppRouter {
             subtitleTrackIndex: subtitleTrackIndex,
             startFromBeginning: startFromBeginning,
             resumePosition: resumePosition,
+            returnToContentId: returnToContentId,
             posterURL: posterURL,
             backdropURL: backdropURL
         )
@@ -151,6 +156,7 @@ class AppRouter {
             subtitleTrackIndex: nil,
             startFromBeginning: startFromBeginning,
             resumePosition: resumePosition,
+            returnToContentId: nil,
             offlineDownloadId: downloadId,
             posterURL: nil,
             backdropURL: nil

--- a/iosApp/iosApp/Networking/Models.swift
+++ b/iosApp/iosApp/Networking/Models.swift
@@ -254,6 +254,14 @@ enum SiloMediaType {
         }
     }
 
+    /// Leaf media that can be handed directly to the player. Container
+    /// types such as series and seasons still open their detail screen.
+    static func isDirectlyPlayable(_ type: String) -> Bool {
+        isMovieLibrary(type)
+            || isAudiobook(type)
+            || normalized(type) == "episode"
+    }
+
     static func isAudiobookLibrary(_ type: String) -> Bool {
         switch normalized(type) {
         case "audiobook", "audiobooks":

--- a/iosApp/iosApp/Screens/Browse/CatalogGrid.swift
+++ b/iosApp/iosApp/Screens/Browse/CatalogGrid.swift
@@ -9,6 +9,7 @@ struct CatalogGrid: View {
     let hasMore: Bool
     let onItemTap: (String) -> Void
     let onLoadMore: () -> Void
+    @Environment(AppRouter.self) private var router
 
     #if os(tvOS)
     private let columns = Array(
@@ -35,6 +36,7 @@ struct CatalogGrid: View {
                     userState: item.userState,
                     overlayData: OverlayData.from(item),
                     action: { onItemTap(item.contentId) },
+                    playAction: playAction(for: item),
                     contentId: item.contentId,
                     aspect: item.isAudiobook ? .square : .poster
                 )
@@ -56,5 +58,20 @@ struct CatalogGrid: View {
                 Spacer()
             }
         }
+    }
+
+    private func playAction(for item: BrowseItem) -> (() -> Void)? {
+        #if os(tvOS)
+        guard SiloMediaType.isDirectlyPlayable(item.type) else { return nil }
+        return {
+            router.presentPlayer(
+                contentId: item.contentId,
+                posterURL: item.posterUrl,
+                backdropURL: item.backdropUrl
+            )
+        }
+        #else
+        return nil
+        #endif
     }
 }

--- a/iosApp/iosApp/Screens/Collections/CollectionDetailView.swift
+++ b/iosApp/iosApp/Screens/Collections/CollectionDetailView.swift
@@ -55,6 +55,7 @@ struct CollectionDetailView: View {
                         action: {
                             router.navigate(to: .itemDetail(contentId: item.contentId))
                         },
+                        playAction: playAction(for: item),
                         contentId: item.contentId
                     )
                     .frame(maxWidth: .infinity)
@@ -62,6 +63,21 @@ struct CollectionDetailView: View {
             }
             .padding(ContinuumTheme.padding)
         }
+    }
+
+    private func playAction(for item: BrowseItem) -> (() -> Void)? {
+        #if os(tvOS)
+        guard SiloMediaType.isDirectlyPlayable(item.type) else { return nil }
+        return {
+            router.presentPlayer(
+                contentId: item.contentId,
+                posterURL: item.posterUrl,
+                backdropURL: item.backdropUrl
+            )
+        }
+        #else
+        return nil
+        #endif
     }
 
     private func loadItems() async {

--- a/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
+++ b/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
@@ -24,7 +24,7 @@ enum DetailPlaybackFormatting {
         let tokens = [
             nonEmpty(version.resolution),
             nonEmpty(normalizedVideoCodec(version.codecVideo)),
-            version.hdr == true ? "HDR" : nil,
+            dynamicRangeLabel(version),
             nonEmpty(normalizedAudioCodec(version.codecAudio)),
         ].compactMap { $0 }
         return tokens.isEmpty ? "Auto" : tokens.joined(separator: " · ")
@@ -43,7 +43,7 @@ enum DetailPlaybackFormatting {
         let tokens = [
             nonEmpty(version.resolution),
             nonEmpty(normalizedVideoCodec(version.codecVideo)),
-            version.hdr == true ? "HDR" : nil,
+            dynamicRangeLabel(version),
             nonEmpty(normalizedAudioCodec(version.codecAudio)),
         ].compactMap { $0 }
         if !tokens.isEmpty {
@@ -515,6 +515,13 @@ enum DetailPlaybackFormatting {
         if codec.contains("av1") { return "AV1" }
         if codec.contains("avc") || codec.contains("h264") { return "H.264" }
         return codec.uppercased()
+    }
+
+    private static func dynamicRangeLabel(_ version: FileVersion) -> String? {
+        if (version.videoTracks ?? []).contains(where: { nonEmpty($0.dolbyVision) != nil }) {
+            return "DV"
+        }
+        return version.hdr == true ? "HDR" : nil
     }
 
     static func normalizedAudioCodec(_ codec: String?) -> String? {

--- a/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
+++ b/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
@@ -479,7 +479,7 @@ enum DetailPlaybackFormatting {
         if let codec = normalizedSubtitleCodec(track.codec) {
             tokens.append(codec)
         }
-        if track.forced == true {
+        if isForced(track) {
             tokens.append("Forced")
         }
         if isHearingImpaired(track) {
@@ -639,11 +639,14 @@ enum DetailPlaybackFormatting {
     }
 
     private static func containsAccessibilityMarker(_ value: String) -> Bool {
-        let words = value
-            .lowercased()
+        let lowered = value.lowercased()
+        let words = lowered
             .split { !$0.isLetter }
             .map(String.init)
-        return words.contains("sdh") || words.contains("cc") || words.contains("hi")
+        return words.contains("sdh")
+            || words.contains("cc")
+            || words.contains("hi")
+            || lowered.contains("hearing impaired")
     }
 
     private static func isRedundantSubtitleTitle(_ title: String, track: SubtitleTrack) -> Bool {

--- a/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
+++ b/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
@@ -22,8 +22,10 @@ enum DetailPlaybackFormatting {
     static func versionShortLabel(_ version: FileVersion?) -> String {
         guard let version else { return "Auto" }
         let tokens = [
-            nonEmpty(version.resolution)?.uppercased(),
+            nonEmpty(version.resolution),
+            nonEmpty(normalizedVideoCodec(version.codecVideo)),
             version.hdr == true ? "HDR" : nil,
+            nonEmpty(normalizedAudioCodec(version.codecAudio)),
         ].compactMap { $0 }
         return tokens.isEmpty ? "Auto" : tokens.joined(separator: " · ")
     }
@@ -156,14 +158,14 @@ enum DetailPlaybackFormatting {
               let track = version.audioTracks?[safe: ordinal] else {
             return "Unknown"
         }
-        let title = audioTitle(track, ordinal: ordinal)
+        let summary = audioSummary(track, ordinal: ordinal)
         // With no explicit pick, the shown track is whatever Auto resolved to
-        // (preferred/default). Prefix "Auto -" so the row makes clear the
+        // (preferred/default). Prefix "Auto:" so the row makes clear the
         // choice was automatic rather than user-selected.
         if annotateAuto, selectedAudioTrackIndex == nil {
-            return "Auto - \(title)"
+            return "Auto: \(summary)"
         }
-        return title
+        return summary
     }
 
     /// Language of the track that `audioValueLabel` would display, used to
@@ -185,31 +187,21 @@ enum DetailPlaybackFormatting {
     }
 
     static func audioTitle(_ track: AudioTrack, ordinal: Int) -> String {
-        let format = [
-            nonEmpty(normalizedAudioCodec(track.codec)),
-            compactAudioLayout(track),
-        ].compactMap { $0 }.joined(separator: " ")
-        let language = languageDisplayName(track.language)
-
-        if let format = nonEmpty(format), let language {
-            return "\(format) - \(language)"
-        }
-        if let format = nonEmpty(format) {
-            return format
-        }
-        if let title = usefulAudioTitle(track.title) {
-            return [title, language].compactMap { $0 }.joined(separator: " - ")
-        }
-        if let language {
-            return language
-        }
+        if let language = languageDisplayName(track.language) { return language }
+        if let title = usefulAudioTitle(track) { return title }
         return "Track \(ordinal + 1)"
     }
 
     static func audioDetail(_ track: AudioTrack, ordinal: Int, version: FileVersion?) -> String {
         var tokens: [String] = []
-        if let title = usefulAudioTitle(track.title) {
+        if let title = usefulAudioTitle(track), title != audioTitle(track, ordinal: ordinal) {
             tokens.append(title)
+        }
+        if let codec = normalizedAudioCodec(track.codec) {
+            tokens.append(codec)
+        }
+        if let layout = compactAudioLayout(track) {
+            tokens.append(layout)
         }
         if track.isDefault == true {
             tokens.append("Default")
@@ -218,6 +210,15 @@ enum DetailPlaybackFormatting {
             tokens.append("Preferred")
         }
         return tokens.joined(separator: " · ")
+    }
+
+    private static func audioSummary(_ track: AudioTrack, ordinal: Int) -> String {
+        let tokens = [
+            languageDisplayName(track.language),
+            nonEmpty(normalizedAudioCodec(track.codec)),
+            compactAudioLayout(track),
+        ].compactMap { $0 }
+        return tokens.isEmpty ? audioTitle(track, ordinal: ordinal) : tokens.joined(separator: " · ")
     }
 
     /// Resolve the server-remembered subtitle override for display /
@@ -436,17 +437,17 @@ enum DetailPlaybackFormatting {
     ) -> String {
         if selectedSubtitleTrackIndex == nil {
             // When we can preview the auto-resolution, always spell it out as
-            // "Auto - <track>" (or "Auto - None"), even for a single track, so
+            // "Auto: <track>" (or "Auto: Off"), even for a single track, so
             // the row shows what will actually play rather than a bare "Auto".
             if let autoContext {
                 if let resolved = autoResolvedSubtitle(version: version, context: autoContext) {
-                    return "Auto - \(subtitleTitle(resolved.track, ordinal: resolved.ordinal))"
+                    return "Auto: \(subtitlePillSummary(resolved.track, ordinal: resolved.ordinal))"
                 }
-                return "Auto - None"
+                return "Auto: Off"
             }
             let tracks = version?.subtitleTracks ?? []
             if tracks.count == 1, let track = tracks.first {
-                return subtitleTitle(track, ordinal: 0)
+                return subtitlePillSummary(track, ordinal: 0)
             }
             return "Auto"
         }
@@ -461,31 +462,28 @@ enum DetailPlaybackFormatting {
             // selection). "On" reflects the active-but-unnamed selection.
             return "On"
         }
-        return subtitleTitle(match.element, ordinal: match.offset)
+        return subtitlePillSummary(match.element, ordinal: match.offset)
     }
 
     static func subtitleTitle(_ track: SubtitleTrack, ordinal: Int) -> String {
-        let type = subtitleType(track, ordinal: ordinal)
-        let language = languageDisplayName(track.language)
-        if let type, let language {
-            return "\(type) - \(language)"
-        }
-        if let type {
-            return type
-        }
-        if let language {
-            return language
-        }
+        if let language = languageDisplayName(track.language) { return language }
+        if let title = meaningfulSubtitleTitle(track) { return title }
         return "Track \(ordinal + 1)"
     }
 
     static func subtitleDetail(_ track: SubtitleTrack, isSelectable: Bool) -> String {
         var tokens: [String] = []
+        if let title = meaningfulSubtitleTitle(track) {
+            tokens.append(title)
+        }
         if let codec = normalizedSubtitleCodec(track.codec) {
             tokens.append(codec)
         }
         if track.forced == true {
             tokens.append("Forced")
+        }
+        if isHearingImpaired(track) {
+            tokens.append("SDH")
         }
         if track.isDefault == true {
             tokens.append("Default")
@@ -497,6 +495,18 @@ enum DetailPlaybackFormatting {
             tokens.append("Available in player")
         }
         return tokens.joined(separator: " · ")
+    }
+
+    private static func subtitlePillSummary(_ track: SubtitleTrack, ordinal: Int) -> String {
+        var name = subtitleTitle(track, ordinal: ordinal)
+        if isHearingImpaired(track), !containsAccessibilityMarker(name) {
+            name += " (SDH)"
+        }
+        if isForced(track), !name.localizedCaseInsensitiveContains("forced") {
+            name += " (Forced)"
+        }
+        guard let codec = normalizedSubtitleCodec(track.codec) else { return name }
+        return "\(name) · \(codec)"
     }
 
     static func normalizedVideoCodec(_ codec: String?) -> String? {
@@ -523,7 +533,7 @@ enum DetailPlaybackFormatting {
 
     static func normalizedSubtitleCodec(_ codec: String?) -> String? {
         guard let codec = codec?.lowercased(), !codec.isEmpty else { return nil }
-        if codec == "srt" || codec.contains("subrip") { return "SubRip" }
+        if codec == "srt" || codec.contains("subrip") { return "SRT" }
         if codec == "ass" || codec.contains("ass") { return "ASS" }
         if codec == "ssa" || codec.contains("ssa") { return "SSA" }
         if codec == "vtt" || codec.contains("webvtt") { return "WebVTT" }
@@ -586,8 +596,8 @@ enum DetailPlaybackFormatting {
         return nil
     }
 
-    private static func usefulAudioTitle(_ title: String?) -> String? {
-        guard let title = nonEmpty(title) else { return nil }
+    private static func usefulAudioTitle(_ track: AudioTrack) -> String? {
+        guard let title = nonEmpty(track.title) ?? nonEmpty(track.embeddedTitle) else { return nil }
         let lowered = title.lowercased()
         let technicalTerms = [
             "atsc",
@@ -604,6 +614,36 @@ enum DetailPlaybackFormatting {
             return nil
         }
         return displayTitle(title)
+    }
+
+    private static func meaningfulSubtitleTitle(_ track: SubtitleTrack) -> String? {
+        guard let title = nonEmpty(track.title) ?? nonEmpty(track.embeddedTitle),
+              !isRedundantSubtitleTitle(title, track: track) else {
+            return nil
+        }
+        let lowered = title.lowercased()
+        if lowered == "forced" || ["sdh", "cc", "hi", "hearing impaired"].contains(lowered) {
+            return nil
+        }
+        return displayTitle(title)
+    }
+
+    private static func isHearingImpaired(_ track: SubtitleTrack) -> Bool {
+        (track.hearingImpaired ?? false)
+            || SubtitleAutoResolver.titleIndicatesHearingImpaired(track.title ?? track.embeddedTitle)
+    }
+
+    private static func isForced(_ track: SubtitleTrack) -> Bool {
+        (track.forced ?? false)
+            || (track.title ?? track.embeddedTitle)?.localizedCaseInsensitiveContains("forced") == true
+    }
+
+    private static func containsAccessibilityMarker(_ value: String) -> Bool {
+        let words = value
+            .lowercased()
+            .split { !$0.isLetter }
+            .map(String.init)
+        return words.contains("sdh") || words.contains("cc") || words.contains("hi")
     }
 
     private static func isRedundantSubtitleTitle(_ title: String, track: SubtitleTrack) -> Bool {

--- a/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
@@ -22,6 +22,17 @@ class ItemDetailViewModel {
     var inWatchlist = false
     var isWatched = false
 
+    // tvOS pre-play selector state. ItemDetailCache retains this view model
+    // while the user enters playback or navigates to another item, so manual
+    // Version / Audio / Subtitle picks survive those round trips instead of
+    // being reset every time the detail task restarts.
+    var preferredVersionFileId: Int?
+    var preferredAudioTrackIndex: Int?
+    var preferredSubtitleTrackIndex: Int?
+    var preferredNextUpFileId: Int?
+    var preferredNextUpAudioTrackIndex: Int?
+    var preferredNextUpSubtitleTrackIndex: Int?
+
     // Track the series contentId for season/episode loading
     private var seriesContentId: String?
 

--- a/iosApp/iosApp/Screens/Home/SectionRow.swift
+++ b/iosApp/iosApp/Screens/Home/SectionRow.swift
@@ -26,6 +26,10 @@ struct SectionRow: View {
     /// Down at the row boundary — forwarded to `MediaRow` for the section pager.
     var onMoveDown: (() -> Void)? = nil
 
+    #if os(tvOS)
+    @Environment(AppRouter.self) private var router
+    #endif
+
     private var isContinueWatching: Bool {
         section.sectionType == "continue_watching" || section.sectionType == "in_progress"
     }
@@ -78,6 +82,7 @@ struct SectionRow: View {
             title: section.title,
             items: section.items,
             onItemTap: onItemTap,
+            onItemPlay: playItem,
             onSeeAll: onSeeAll,
             showProgress: showProgress,
             icon: isContinueWatching ? "play.circle.fill" : nil,
@@ -92,6 +97,17 @@ struct SectionRow: View {
             cardVerticalPadding: cardVerticalPadding,
             onMoveDown: onMoveDown
         )
+    }
+
+    private func playItem(_ item: SectionItem) {
+        #if os(tvOS)
+        router.presentPlayer(
+            contentId: item.contentId,
+            resumePosition: item.positionSeconds,
+            posterURL: item.posterUrl,
+            backdropURL: item.backdropUrl
+        )
+        #endif
     }
 
     private func removeFromContinueWatching(_ item: SectionItem) {

--- a/iosApp/iosApp/Screens/Personal/FavoritesView.swift
+++ b/iosApp/iosApp/Screens/Personal/FavoritesView.swift
@@ -64,6 +64,7 @@ struct FavoritesView: View {
                         action: {
                             router.navigate(to: .itemDetail(contentId: item.contentId))
                         },
+                        playAction: playAction(for: item),
                         contentId: item.contentId,
                         onUserStateChanged: { state in
                             guard !state.isFavorite else { return }
@@ -77,6 +78,21 @@ struct FavoritesView: View {
             }
             .padding(ContinuumTheme.padding)
         }
+    }
+
+    private func playAction(for item: BrowseItem) -> (() -> Void)? {
+        #if os(tvOS)
+        guard SiloMediaType.isDirectlyPlayable(item.type) else { return nil }
+        return {
+            router.presentPlayer(
+                contentId: item.contentId,
+                posterURL: item.posterUrl,
+                backdropURL: item.backdropUrl
+            )
+        }
+        #else
+        return nil
+        #endif
     }
 
     private func loadFavorites() async {

--- a/iosApp/iosApp/Screens/Personal/WatchlistView.swift
+++ b/iosApp/iosApp/Screens/Personal/WatchlistView.swift
@@ -64,6 +64,7 @@ struct WatchlistView: View {
                         action: {
                             router.navigate(to: .itemDetail(contentId: item.contentId))
                         },
+                        playAction: playAction(for: item),
                         contentId: item.contentId,
                         onUserStateChanged: { state in
                             guard !state.inWatchlist else { return }
@@ -77,6 +78,21 @@ struct WatchlistView: View {
             }
             .padding(ContinuumTheme.padding)
         }
+    }
+
+    private func playAction(for item: BrowseItem) -> (() -> Void)? {
+        #if os(tvOS)
+        guard SiloMediaType.isDirectlyPlayable(item.type) else { return nil }
+        return {
+            router.presentPlayer(
+                contentId: item.contentId,
+                posterURL: item.posterUrl,
+                backdropURL: item.backdropUrl
+            )
+        }
+        #else
+        return nil
+        #endif
     }
 
     private func loadWatchlist() async {

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
@@ -433,7 +433,18 @@ final class AVPlayerBackend {
     }
 
     let avPlayer = AVPlayer()
-    weak var subtitleOverlay: SubtitleOverlayView?
+    private let subtitleOverlayAttachments = SubtitleOverlayAttachmentRegistry()
+    var subtitleOverlay: SubtitleOverlayView? {
+        subtitleOverlayAttachments.currentOverlay
+    }
+
+    func attachSubtitleOverlay(_ overlay: SubtitleOverlayView, owner: AnyObject) {
+        subtitleOverlayAttachments.attach(owner: owner, overlay: overlay)
+    }
+
+    func detachSubtitleOverlay(owner: AnyObject) {
+        subtitleOverlayAttachments.detach(owner: owner)
+    }
     var subtitleRendererForOverlay: SubtitleRenderer? {
         subtitleSession?.underlyingRenderer
     }

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerSurface.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerSurface.swift
@@ -23,7 +23,7 @@ struct AVPlayerSurface: UIViewRepresentable {
         view.attach(backend: backend)
         view.setVideoGravity(videoGravity)
         view.attachSubtitleRenderer(backend.subtitleRendererForOverlay)
-        backend.subtitleOverlay = view.subtitleOverlay
+        backend.attachSubtitleOverlay(view.subtitleOverlay, owner: view)
         return view
     }
 
@@ -31,7 +31,11 @@ struct AVPlayerSurface: UIViewRepresentable {
         uiView.attach(backend: backend)
         uiView.setVideoGravity(videoGravity)
         uiView.attachSubtitleRenderer(backend.subtitleRendererForOverlay)
-        backend.subtitleOverlay = uiView.subtitleOverlay
+        backend.attachSubtitleOverlay(uiView.subtitleOverlay, owner: uiView)
+    }
+
+    static func dismantleUIView(_ uiView: AVPlayerLayerView, coordinator: ()) {
+        uiView.detachSubtitleOverlay()
     }
 }
 
@@ -77,6 +81,10 @@ final class AVPlayerLayerView: UIView {
 
     func attachSubtitleRenderer(_ renderer: SubtitleRenderer?) {
         subtitleOverlay.renderer = renderer
+    }
+
+    func detachSubtitleOverlay() {
+        backend?.detachSubtitleOverlay(owner: self)
     }
 
     override func layoutSubviews() {

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerSurface.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerSurface.swift
@@ -65,6 +65,7 @@ final class AVPlayerLayerView: UIView {
 
     func attach(backend: AVPlayerBackend) {
         if self.backend !== backend {
+            self.backend?.detachSubtitleOverlay(owner: self)
             self.backend = backend
             observeReadyForDisplay()
         }

--- a/iosApp/iosApp/Screens/Player/CoreMedia/PlayerCore.swift
+++ b/iosApp/iosApp/Screens/Player/CoreMedia/PlayerCore.swift
@@ -811,10 +811,21 @@ final class PlayerCore: NSObject {
     /// is reset (tracks/cache) per load via `teardown()`.
     private var subtitleSession: SubtitleSession?
 
-    /// Weak reference to the overlay view mounted by `PlayerSurface`.
-    /// Set by `PlayerSurfaceHostView.attach(player:)`. The display-link
-    /// tick pumps composited `CGImage`s into it.
-    weak var subtitleOverlay: SubtitleOverlayView?
+    /// Live overlay views mounted by `PlayerSurface`. Next Up transitions can
+    /// overlap a mini-player and full-screen surface, so ownership is tracked
+    /// rather than stored in one racy weak property.
+    private let subtitleOverlayAttachments = SubtitleOverlayAttachmentRegistry()
+    var subtitleOverlay: SubtitleOverlayView? {
+        subtitleOverlayAttachments.currentOverlay
+    }
+
+    func attachSubtitleOverlay(_ overlay: SubtitleOverlayView, owner: AnyObject) {
+        subtitleOverlayAttachments.attach(owner: owner, overlay: overlay)
+    }
+
+    func detachSubtitleOverlay(owner: AnyObject) {
+        subtitleOverlayAttachments.detach(owner: owner)
+    }
 
     /// Renderer handle exposed so the overlay view can receive frame-size
     /// notifications directly on layout.

--- a/iosApp/iosApp/Screens/Player/CoreMedia/PlayerSurface.swift
+++ b/iosApp/iosApp/Screens/Player/CoreMedia/PlayerSurface.swift
@@ -37,6 +37,10 @@ struct PlayerSurface: UIViewRepresentable {
         uiView.attach(player: player)
         uiView.setVideoGravity(videoGravity)
     }
+
+    static func dismantleUIView(_ uiView: PlayerSurfaceHostView, coordinator: ()) {
+        uiView.detachSubtitleOverlay()
+    }
 }
 
 /// UIView whose backing CALayer is AVSampleBufferDisplayLayer. The synchronizer
@@ -90,7 +94,7 @@ final class PlayerSurfaceHostView: UIView {
         // renderer reference is held weakly on the overlay so it
         // doesn't extend the session's lifetime beyond playback.
         subtitleOverlay.renderer = player.subtitleRendererForOverlay
-        player.subtitleOverlay = subtitleOverlay
+        player.attachSubtitleOverlay(subtitleOverlay, owner: self)
 
         // Track the video's presentation size so layoutSubviews() can pin
         // the subtitle overlay to the displayed video rect.
@@ -107,6 +111,10 @@ final class PlayerSurfaceHostView: UIView {
             self?.updateEDR(sigPeak: peak)
         }
         updateEDR(sigPeak: player.lastSigPeak)
+    }
+
+    func detachSubtitleOverlay() {
+        attachedPlayer?.detachSubtitleOverlay(owner: self)
     }
 
     func setVideoGravity(_ gravity: AVLayerVideoGravity) {

--- a/iosApp/iosApp/Screens/Player/CoreMedia/PlayerSurface.swift
+++ b/iosApp/iosApp/Screens/Player/CoreMedia/PlayerSurface.swift
@@ -87,6 +87,7 @@ final class PlayerSurfaceHostView: UIView {
 
     func attach(player: PlayerCore) {
         if attachedPlayer === player { return }
+        attachedPlayer?.detachSubtitleOverlay(owner: self)
         attachedPlayer = player
         player.attach(to: displayLayer)
 

--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -24,8 +24,10 @@ struct PlayerView: View {
     /// for artwork. Nil falls back to the prior fetch-on-prepare path.
     let posterURLHint: String?
     let backdropURLHint: String?
+    let onPlaybackStarted: (() -> Void)?
 
     @State private var viewModel = PlayerViewModel()
+    @State private var didNotifyPlaybackStarted = false
     @Environment(\.dismiss) var dismiss
     @Environment(\.scenePhase) private var scenePhase
     #if os(iOS)
@@ -44,7 +46,8 @@ struct PlayerView: View {
         resumePositionOverride: Double? = nil,
         offlineDownloadId: String? = nil,
         posterURLHint: String? = nil,
-        backdropURLHint: String? = nil
+        backdropURLHint: String? = nil,
+        onPlaybackStarted: (() -> Void)? = nil
     ) {
         self.contentId = contentId
         self.preferredFileId = preferredFileId
@@ -55,6 +58,7 @@ struct PlayerView: View {
         self.offlineDownloadId = offlineDownloadId
         self.posterURLHint = posterURLHint
         self.backdropURLHint = backdropURLHint
+        self.onPlaybackStarted = onPlaybackStarted
     }
 
     var body: some View {
@@ -232,6 +236,11 @@ struct PlayerView: View {
         #endif
         .onChange(of: scenePhase) { _, newPhase in
             viewModel.handleScenePhase(newPhase)
+        }
+        .onChange(of: viewModel.isPlaying) { _, isPlaying in
+            guard isPlaying, !didNotifyPlaybackStarted else { return }
+            didNotifyPlaybackStarted = true
+            onPlaybackStarted?()
         }
         .onChange(of: viewModel.remoteDismissToken) { _, newValue in
             guard newValue != nil else { return }

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleOverlayView.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleOverlayView.swift
@@ -19,12 +19,70 @@
 //
 
 import CoreGraphics
+import Foundation
 import QuartzCore
 #if canImport(UIKit)
 import UIKit
 #elseif canImport(AppKit)
 import AppKit
 #endif
+
+/// Tracks every live SwiftUI player surface for one playback backend.
+///
+/// The Next Up transition briefly keeps its mini-player and the returning
+/// full-screen player alive together. A single weak overlay property is racy:
+/// the outgoing surface can be the last writer and then deallocate, leaving the
+/// subtitle pump with `nil`. Keeping weak registrations lets detach restore the
+/// newest remaining surface instead.
+final class SubtitleOverlayAttachmentRegistry {
+    private final class Entry {
+        weak var owner: AnyObject?
+        weak var overlay: SubtitleOverlayView?
+        var sequence: UInt64
+
+        init(owner: AnyObject, overlay: SubtitleOverlayView, sequence: UInt64) {
+            self.owner = owner
+            self.overlay = overlay
+            self.sequence = sequence
+        }
+    }
+
+    private let lock = NSLock()
+    private var entries: [ObjectIdentifier: Entry] = [:]
+    private var sequence: UInt64 = 0
+
+    func attach(owner: AnyObject, overlay: SubtitleOverlayView) {
+        lock.lock()
+        defer { lock.unlock() }
+        pruneReleasedEntries()
+        sequence &+= 1
+        entries[ObjectIdentifier(owner)] = Entry(
+            owner: owner,
+            overlay: overlay,
+            sequence: sequence
+        )
+    }
+
+    func detach(owner: AnyObject) {
+        lock.lock()
+        defer { lock.unlock() }
+        entries.removeValue(forKey: ObjectIdentifier(owner))
+        pruneReleasedEntries()
+    }
+
+    var currentOverlay: SubtitleOverlayView? {
+        lock.lock()
+        defer { lock.unlock() }
+        pruneReleasedEntries()
+        return entries.values.max(by: { $0.sequence < $1.sequence })?.overlay
+    }
+
+    private func pruneReleasedEntries() {
+        entries = entries.filter { _, entry in
+            entry.owner != nil && entry.overlay != nil
+        }
+    }
+}
 
 private func withoutImplicitLayerAnimation(_ updates: () -> Void) {
     CATransaction.begin()

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPlayerInfoHUD.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPlayerInfoHUD.swift
@@ -1536,6 +1536,7 @@ private struct SubtitlesPane: View {
     @State private var activePicker: HUDPickerPresentation?
     @State private var pickerReturnField: Option?
     @FocusState private var focusedOption: Option?
+    @FocusState private var entryTrackFocused: Bool
 
     /// Identity for the options-column rows, used only to restore focus when
     /// a picker dialog, the appearance dialog, or the AI/search menu closes.
@@ -1564,6 +1565,10 @@ private struct SubtitlesPane: View {
                     .frame(width: 440, alignment: .topLeading)
                     .focusSection()
             }
+            // The Subtitles pill is geometrically closest to the Options
+            // column. Explicitly route Down into the leftmost Tracks column
+            // so entering this pane is consistent with the other track panes.
+            .defaultFocus($entryTrackFocused, true, priority: .userInitiated)
             .disabled(overlayActive)
             .opacity(overlayActive ? 0.28 : 1)
 
@@ -1690,6 +1695,7 @@ private struct SubtitlesPane: View {
                 ) {
                     viewModel.disableSubtitles()
                 }
+                .focused($entryTrackFocused)
                 ForEach(viewModel.orderedSubtitleTracks) { track in
                     HUDTrackRow(
                         name: track.primaryLabel,

--- a/iosApp/iosApp/macOS/AVPlayerSurface.swift
+++ b/iosApp/iosApp/macOS/AVPlayerSurface.swift
@@ -7,21 +7,22 @@ struct AVPlayerSurface: NSViewRepresentable {
 
     func makeNSView(context: Context) -> ContinuumMacPlayerView {
         let view = ContinuumMacPlayerView()
-        view.attach(player: backend.avPlayer)
-        view.attachSubtitleRenderer(backend.subtitleRendererForOverlay)
-        backend.subtitleOverlay = view.subtitleOverlay
+        view.attach(backend: backend)
         return view
     }
 
     func updateNSView(_ nsView: ContinuumMacPlayerView, context: Context) {
-        nsView.attach(player: backend.avPlayer)
-        nsView.attachSubtitleRenderer(backend.subtitleRendererForOverlay)
-        backend.subtitleOverlay = nsView.subtitleOverlay
+        nsView.attach(backend: backend)
+    }
+
+    static func dismantleNSView(_ nsView: ContinuumMacPlayerView, coordinator: ()) {
+        nsView.detachSubtitleOverlay()
     }
 }
 
 final class ContinuumMacPlayerView: AVPlayerView {
     let subtitleOverlay = SubtitleOverlayView()
+    private weak var backend: AVPlayerBackend?
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -39,13 +40,20 @@ final class ContinuumMacPlayerView: AVPlayerView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func attach(player: AVPlayer) {
-        if self.player === player { return }
-        self.player = player
+    func attach(backend: AVPlayerBackend) {
+        if self.backend !== backend {
+            self.backend?.detachSubtitleOverlay(owner: self)
+            self.backend = backend
+        }
+        if player !== backend.avPlayer {
+            player = backend.avPlayer
+        }
+        subtitleOverlay.renderer = backend.subtitleRendererForOverlay
+        backend.attachSubtitleOverlay(subtitleOverlay, owner: self)
     }
 
-    func attachSubtitleRenderer(_ renderer: SubtitleRenderer?) {
-        subtitleOverlay.renderer = renderer
+    func detachSubtitleOverlay() {
+        backend?.detachSubtitleOverlay(owner: self)
     }
 
     private func addSubtitleOverlay() {

--- a/iosApp/iosApp/macOS/PlayerSurface.swift
+++ b/iosApp/iosApp/macOS/PlayerSurface.swift
@@ -15,6 +15,10 @@ struct PlayerSurface: NSViewRepresentable {
     func updateNSView(_ nsView: PlayerSurfaceHostView, context: Context) {
         nsView.attach(player: player)
     }
+
+    static func dismantleNSView(_ nsView: PlayerSurfaceHostView, coordinator: ()) {
+        nsView.detachSubtitleOverlay()
+    }
 }
 
 final class PlayerSurfaceHostView: NSView {
@@ -45,10 +49,11 @@ final class PlayerSurfaceHostView: NSView {
 
     func attach(player: PlayerCore) {
         if attachedPlayer === player { return }
+        attachedPlayer?.detachSubtitleOverlay(owner: self)
         attachedPlayer = player
         player.attach(to: displayLayer)
         subtitleOverlay.renderer = player.subtitleRendererForOverlay
-        player.subtitleOverlay = subtitleOverlay
+        player.attachSubtitleOverlay(subtitleOverlay, owner: self)
 
         // Track the video's presentation size so layout() can pin the
         // subtitle overlay to the displayed video rect — keeps libass font
@@ -58,6 +63,10 @@ final class PlayerSurfaceHostView: NSView {
             self?.videoPresentationSize = size
             self?.needsLayout = true
         }
+    }
+
+    func detachSubtitleOverlay() {
+        attachedPlayer?.detachSubtitleOverlay(owner: self)
     }
 
     override func layout() {

--- a/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
@@ -120,7 +120,12 @@ struct TVMainTabView: View {
                 startFromBeginning: payload.startFromBeginning,
                 resumePositionOverride: payload.resumePosition,
                 posterURLHint: payload.posterURL,
-                backdropURLHint: payload.backdropURL
+                backdropURLHint: payload.backdropURL,
+                onPlaybackStarted: {
+                    guard let returnToContentId = payload.returnToContentId,
+                          router.presentedPlayer?.id == payload.id else { return }
+                    router.replaceCurrent(with: .itemDetail(contentId: returnToContentId))
+                }
             )
         }
         .confirmationDialog(

--- a/iosApp/iosApp/tvOS/Screens/Components/TVCatalogGrid.swift
+++ b/iosApp/iosApp/tvOS/Screens/Components/TVCatalogGrid.swift
@@ -31,6 +31,7 @@ struct TVCatalogGrid: View {
     @Namespace private var gridFocusNamespace
     @FocusState private var focusedItemId: String?
     @State private var lastAppliedFocusRequest = 0
+    @Environment(AppRouter.self) private var router
 
     private let columnSpacing: CGFloat = 40
     private let rowSpacing: CGFloat = 60
@@ -63,6 +64,7 @@ struct TVCatalogGrid: View {
                             userState: item.userState,
                             overlayData: OverlayData.from(item),
                             action: { onItemTap(item.contentId) },
+                            playAction: playAction(for: item),
                             cardWidth: cardWidth,
                             aspect: item.isAudiobook ? .square : .poster,
                             prefersDefaultFocus: prefersDefaultFocusOnFirstItem
@@ -117,6 +119,17 @@ struct TVCatalogGrid: View {
         let threshold = items.count - (prefetchRowsRemaining * columnCount)
         if index >= threshold {
             onNearEnd(index)
+        }
+    }
+
+    private func playAction(for item: BrowseItem) -> (() -> Void)? {
+        guard SiloMediaType.isDirectlyPlayable(item.type) else { return nil }
+        return {
+            router.presentPlayer(
+                contentId: item.contentId,
+                posterURL: item.posterUrl,
+                backdropURL: item.backdropUrl
+            )
         }
     }
 

--- a/iosApp/iosApp/tvOS/Screens/Components/TVMediaCard.swift
+++ b/iosApp/iosApp/tvOS/Screens/Components/TVMediaCard.swift
@@ -19,6 +19,9 @@ struct TVMediaCard: View {
     /// callers without per-item OverlaySummary should leave it off.
     var overlayData: OverlayData? = nil
     let action: () -> Void
+    /// Remote Play/Pause shortcut. When nil, the card does not intercept the
+    /// command (used for non-playable containers such as series).
+    var playAction: (() -> Void)? = nil
     /// Width of the poster. Defaults to the theme's standard poster size.
     /// Override with a smaller value in space-constrained grids (e.g. the
     /// Library tab where the alphabet rail forces cards to shrink).
@@ -134,12 +137,14 @@ struct TVMediaCard: View {
                 .focused($isFocused)
                 .applyDefaultFocusIfNeeded(prefersDefaultFocus, namespace: defaultFocusNamespace)
                 .applyRailFocus(focusBinding, contentId: focusContentId)
+                .applyTVCardPlayPauseAction(playAction)
         case .ring:
             Button(action: action) { posterImage }
                 .buttonStyle(TVPosterRingButtonStyle())
                 .focused($isFocused)
                 .applyDefaultFocusIfNeeded(prefersDefaultFocus, namespace: defaultFocusNamespace)
                 .applyRailFocus(focusBinding, contentId: focusContentId)
+                .applyTVCardPlayPauseAction(playAction)
         }
     }
 
@@ -215,6 +220,15 @@ struct TVMediaCard: View {
 }
 
 private extension View {
+    @ViewBuilder
+    func applyTVCardPlayPauseAction(_ action: (() -> Void)?) -> some View {
+        if let action {
+            self.onPlayPauseCommand(perform: action)
+        } else {
+            self
+        }
+    }
+
     /// Binds the inner button to a parent rail's `@FocusState` so the rail can
     /// route d-pad-entry default focus onto this specific card. No-op when the
     /// rail doesn't manage focus. Mirrors `MediaCard.applyRowFocus`.

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
@@ -8,26 +8,17 @@ import SwiftUI
 /// launcher.
 ///
 /// Pass `currentContentId` to highlight the episode currently represented
-/// by the surrounding detail experience. The rail will also scroll that
-/// card to the horizontal center on first appearance and make it the
-/// default focus target when the user d-pads down into the rail, so they
-/// land on the episode represented by the page's primary action rather
-/// than the first card in the season.
+/// by the surrounding detail experience. The rail scrolls that card to the
+/// horizontal center on first appearance, while d-pad entry remains fully
+/// spatial so focus lands beneath the control the user moved down from.
 struct TVEpisodeRail: View {
     let episodes: [EpisodeListItem]
     let onSelect: (String) -> Void
-    /// When non-nil, the matching card is visually highlighted, anchored
-    /// at first appearance, and made the default focus target when focus
-    /// first enters the rail.
+    /// When non-nil, the matching card is visually highlighted and anchored
+    /// at first appearance.
     var currentContentId: String? = nil
-    /// Incremented by the parent when Down is pressed from the season row.
-    /// A token (rather than a Bool) lets repeated handoffs request focus and
-    /// also survives the loading state where this rail is temporarily absent.
-    var focusRequest: Int = 0
 
     private let cardSpacing: CGFloat = 36
-    @FocusState private var focusedCardId: String?
-    @State private var lastAppliedFocusRequest = 0
 
     var body: some View {
         ScrollViewReader { proxy in
@@ -40,7 +31,6 @@ struct TVEpisodeRail: View {
                             onSelect: { onSelect(episode.contentId) }
                         )
                         .id(episode.contentId)
-                        .focused($focusedCardId, equals: episode.contentId)
                     }
                 }
                 .padding(.vertical, 32)
@@ -48,56 +38,16 @@ struct TVEpisodeRail: View {
             }
             .focusSection()
             .scrollClipDisabled()
-            .applyRailDefaultFocus(currentContentId, binding: $focusedCardId)
             .onAppear {
-                if let id = currentContentId {
-                    // Run on next tick so the LazyHStack has instantiated the
-                    // target cell before we try to anchor on it.
-                    DispatchQueue.main.async {
-                        withAnimation(.easeOut(duration: ContinuumTheme.normalDuration)) {
-                            proxy.scrollTo(id, anchor: .center)
-                        }
+                guard let id = currentContentId else { return }
+                // Run on next tick so the LazyHStack has instantiated the
+                // target cell before we try to anchor on it.
+                DispatchQueue.main.async {
+                    withAnimation(.easeOut(duration: ContinuumTheme.normalDuration)) {
+                        proxy.scrollTo(id, anchor: .center)
                     }
                 }
-                applyFocusRequest(focusRequest, proxy: proxy)
             }
-            .onChange(of: focusRequest) { _, request in
-                applyFocusRequest(request, proxy: proxy)
-            }
-        }
-    }
-
-    private func applyFocusRequest(_ request: Int, proxy: ScrollViewProxy) {
-        guard request > 0, request != lastAppliedFocusRequest else { return }
-        guard let target = episodes.first(where: { $0.contentId == currentContentId })?.contentId
-                ?? episodes.first?.contentId else { return }
-        lastAppliedFocusRequest = request
-
-        // The target may live outside the LazyHStack's mounted range. Scroll
-        // and assign focus together on the next run-loop turn so the card is
-        // present when the focus engine resolves the request.
-        DispatchQueue.main.async {
-            proxy.scrollTo(target, anchor: .center)
-            focusedCardId = target
-        }
-    }
-}
-
-private extension View {
-    /// Routes d-pad-driven focus arriving at the rail to the card matching
-    /// `currentContentId`. `prefersDefaultFocus` only fires for automatic
-    /// focus evaluations (scope first appears, structural changes); d-pad
-    /// entry is user-initiated and falls back to geometric proximity
-    /// unless we explicitly mark it `userInitiated`.
-    @ViewBuilder
-    func applyRailDefaultFocus(
-        _ currentContentId: String?,
-        binding: FocusState<String?>.Binding
-    ) -> some View {
-        if let currentContentId {
-            self.defaultFocus(binding, currentContentId, priority: .userInitiated)
-        } else {
-            self
         }
     }
 }

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
@@ -20,9 +20,14 @@ struct TVEpisodeRail: View {
     /// at first appearance, and made the default focus target when focus
     /// first enters the rail.
     var currentContentId: String? = nil
+    /// Incremented by the parent when Down is pressed from the season row.
+    /// A token (rather than a Bool) lets repeated handoffs request focus and
+    /// also survives the loading state where this rail is temporarily absent.
+    var focusRequest: Int = 0
 
     private let cardSpacing: CGFloat = 36
     @FocusState private var focusedCardId: String?
+    @State private var lastAppliedFocusRequest = 0
 
     var body: some View {
         ScrollViewReader { proxy in
@@ -45,15 +50,35 @@ struct TVEpisodeRail: View {
             .scrollClipDisabled()
             .applyRailDefaultFocus(currentContentId, binding: $focusedCardId)
             .onAppear {
-                guard let id = currentContentId else { return }
-                // Run on next tick so the LazyHStack has instantiated the
-                // target cell before we try to anchor on it.
-                DispatchQueue.main.async {
-                    withAnimation(.easeOut(duration: ContinuumTheme.normalDuration)) {
-                        proxy.scrollTo(id, anchor: .center)
+                if let id = currentContentId {
+                    // Run on next tick so the LazyHStack has instantiated the
+                    // target cell before we try to anchor on it.
+                    DispatchQueue.main.async {
+                        withAnimation(.easeOut(duration: ContinuumTheme.normalDuration)) {
+                            proxy.scrollTo(id, anchor: .center)
+                        }
                     }
                 }
+                applyFocusRequest(focusRequest, proxy: proxy)
             }
+            .onChange(of: focusRequest) { _, request in
+                applyFocusRequest(request, proxy: proxy)
+            }
+        }
+    }
+
+    private func applyFocusRequest(_ request: Int, proxy: ScrollViewProxy) {
+        guard request > 0, request != lastAppliedFocusRequest else { return }
+        guard let target = episodes.first(where: { $0.contentId == currentContentId })?.contentId
+                ?? episodes.first?.contentId else { return }
+        lastAppliedFocusRequest = request
+
+        // The target may live outside the LazyHStack's mounted range. Scroll
+        // and assign focus together on the next run-loop turn so the card is
+        // present when the focus engine resolves the request.
+        DispatchQueue.main.async {
+            proxy.scrollTo(target, anchor: .center)
+            focusedCardId = target
         }
     }
 }

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
@@ -14,11 +14,13 @@ import SwiftUI
 struct TVEpisodeRail: View {
     let episodes: [EpisodeListItem]
     let onSelect: (String) -> Void
+    var onFocusedEpisodeChange: ((String?) -> Void)? = nil
     /// When non-nil, the matching card is visually highlighted and anchored
     /// at first appearance.
     var currentContentId: String? = nil
 
     private let cardSpacing: CGFloat = 36
+    @FocusState private var focusedCardId: String?
 
     var body: some View {
         ScrollViewReader { proxy in
@@ -31,6 +33,7 @@ struct TVEpisodeRail: View {
                             onSelect: { onSelect(episode.contentId) }
                         )
                         .id(episode.contentId)
+                        .focused($focusedCardId, equals: episode.contentId)
                     }
                 }
                 .padding(.vertical, 32)
@@ -38,6 +41,12 @@ struct TVEpisodeRail: View {
             }
             .focusSection()
             .scrollClipDisabled()
+            .onChange(of: focusedCardId) { _, contentId in
+                onFocusedEpisodeChange?(contentId)
+            }
+            .onDisappear {
+                onFocusedEpisodeChange?(nil)
+            }
             .onAppear {
                 guard let id = currentContentId else { return }
                 // Run on next tick so the LazyHStack has instantiated the

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
@@ -427,11 +427,22 @@ struct TVItemDetailView: View {
                     router.navigate(to: .itemDetail(contentId: id))
                 },
                 onEpisodeTap: { id in
-                    // Episode → episode hops replace the current page so Back
-                    // exits to wherever the chain started (home, series page)
-                    // instead of unwinding every previously viewed episode.
-                    guard id != detail.contentId else { return }
-                    router.replaceCurrent(with: .itemDetail(contentId: id))
+                    let episode = viewModel.episodes.first { $0.contentId == id }
+                    let resumePosition = playableResumePosition(
+                        position: episode?.userData?.positionSeconds,
+                        duration: episode?.userData?.durationSeconds
+                    )
+
+                    // Present independently of the navigation stack. Once
+                    // playback reports that it is actually running, the
+                    // hidden detail route is replaced with this episode so
+                    // dismissing the player returns to what was just played.
+                    router.presentPlayer(
+                        contentId: id,
+                        startFromBeginning: false,
+                        resumePosition: resumePosition,
+                        returnToContentId: id == detail.contentId ? nil : id
+                    )
                 },
                 belowSynopsis: {
                     DescriptionTranslationView(viewModel: viewModel, contentId: detail.contentId)

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
@@ -428,6 +428,7 @@ struct TVItemDetailView: View {
                 },
                 onEpisodeTap: { id in
                     let episode = viewModel.episodes.first { $0.contentId == id }
+                    let isCurrentEpisode = id == detail.contentId
                     let resumePosition = playableResumePosition(
                         position: episode?.userData?.positionSeconds,
                         duration: episode?.userData?.durationSeconds
@@ -439,9 +440,12 @@ struct TVItemDetailView: View {
                     // dismissing the player returns to what was just played.
                     router.presentPlayer(
                         contentId: id,
+                        fileId: isCurrentEpisode ? playbackFileId(for: detail) : nil,
+                        audioTrackIndex: isCurrentEpisode ? preferredAudioTrackIndex : nil,
+                        subtitleTrackIndex: isCurrentEpisode ? preferredSubtitleTrackIndex : nil,
                         startFromBeginning: false,
                         resumePosition: resumePosition,
-                        returnToContentId: id == detail.contentId ? nil : id
+                        returnToContentId: isCurrentEpisode ? nil : id
                     )
                 },
                 belowSynopsis: {

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
@@ -13,16 +13,10 @@ struct TVItemDetailView: View {
     let contentId: String
 
     @State private var viewModel: ItemDetailViewModel
-    @State private var preferredVersionFileId: Int?
-    @State private var preferredAudioTrackIndex: Int?
-    @State private var preferredSubtitleTrackIndex: Int?
-    @State private var preferredNextUpFileId: Int?
-    @State private var preferredNextUpAudioTrackIndex: Int?
-    @State private var preferredNextUpSubtitleTrackIndex: Int?
     /// Set when the user explicitly resets subtitles to "Auto" this visit:
     /// the server override is cleared with a fire-and-forget DELETE, but the
     /// already-fetched detail still carries the old `effectiveSubtitle*`, so
-    /// the selector must stop feeding it to the "Auto - …" preview.
+    /// the selector must stop feeding it to the "Auto: …" preview.
     @State private var didClearSubtitleOverride = false
     @State private var didClearNextUpSubtitleOverride = false
     @State private var nextUpPlaybackDetail: ItemDetail?
@@ -66,12 +60,6 @@ struct TVItemDetailView: View {
             Self.focusLogger.debug("itemDetail.disappear contentId=\(contentId, privacy: .public) pathDepth=\(router.path.count, privacy: .public)")
         }
         .task(id: contentId) {
-            preferredVersionFileId = nil
-            preferredAudioTrackIndex = nil
-            preferredSubtitleTrackIndex = nil
-            preferredNextUpFileId = nil
-            preferredNextUpAudioTrackIndex = nil
-            preferredNextUpSubtitleTrackIndex = nil
             didClearSubtitleOverride = false
             didClearNextUpSubtitleOverride = false
             nextUpPlaybackDetail = nil
@@ -80,6 +68,39 @@ struct TVItemDetailView: View {
             await viewModel.loadDetail(contentId: contentId)
             seedSubtitleOverrideIfNeeded()
         }
+    }
+
+    // Selection state lives on the cached view model so a pushed player route
+    // or a temporary navigation away from this item cannot discard it. These
+    // nonmutating proxies keep the existing selector callbacks concise.
+    private var preferredVersionFileId: Int? {
+        get { viewModel.preferredVersionFileId }
+        nonmutating set { viewModel.preferredVersionFileId = newValue }
+    }
+
+    private var preferredAudioTrackIndex: Int? {
+        get { viewModel.preferredAudioTrackIndex }
+        nonmutating set { viewModel.preferredAudioTrackIndex = newValue }
+    }
+
+    private var preferredSubtitleTrackIndex: Int? {
+        get { viewModel.preferredSubtitleTrackIndex }
+        nonmutating set { viewModel.preferredSubtitleTrackIndex = newValue }
+    }
+
+    private var preferredNextUpFileId: Int? {
+        get { viewModel.preferredNextUpFileId }
+        nonmutating set { viewModel.preferredNextUpFileId = newValue }
+    }
+
+    private var preferredNextUpAudioTrackIndex: Int? {
+        get { viewModel.preferredNextUpAudioTrackIndex }
+        nonmutating set { viewModel.preferredNextUpAudioTrackIndex = newValue }
+    }
+
+    private var preferredNextUpSubtitleTrackIndex: Int? {
+        get { viewModel.preferredNextUpSubtitleTrackIndex }
+        nonmutating set { viewModel.preferredNextUpSubtitleTrackIndex = newValue }
     }
 
     @ViewBuilder

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
@@ -17,7 +17,7 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
     /// True once the user explicitly resets subtitles to "Auto" this visit.
     /// The server override was just cleared, but `detail.effectiveSubtitle*`
     /// still describes the old manual pick until the next refetch — suppress
-    /// it so the "Auto - …" preview doesn't echo the cleared selection.
+    /// it so the "Auto: …" preview doesn't echo the cleared selection.
     var subtitleOverrideCleared: Bool = false
     let seasons: [Season]
     let selectedSeason: Season?
@@ -51,7 +51,6 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
     // forbids static stored properties on this type.
     private let episodeSectionScrollId = "detail-episode-section"
     private let heroScrollId = "detail-hero"
-    @State private var episodeFocusRequest = 0
 
     var body: some View {
         ScrollViewReader { scrollProxy in
@@ -252,8 +251,7 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
                 TVSeasonChipRow(
                     seasons: seasons,
                     selectedSeasonId: selectedSeason?.id,
-                    onSelect: onSelectSeason,
-                    onMoveDown: requestEpisodeFocus
+                    onSelect: onSelectSeason
                 )
                 // Container binding — true while any chip has focus, driving
                 // the episode-section re-center in `detailFocusScroll`.
@@ -269,15 +267,10 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
                 TVEpisodeRail(
                     episodes: seasonEpisodes,
                     onSelect: onEpisodeTap,
-                    currentContentId: detail.contentId,
-                    focusRequest: episodeFocusRequest
+                    currentContentId: detail.contentId
                 )
             }
         }
-    }
-
-    private func requestEpisodeFocus() {
-        episodeFocusRequest &+= 1
     }
 
     private var episodeRailEyebrow: String {

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
@@ -51,6 +51,7 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
     // forbids static stored properties on this type.
     private let episodeSectionScrollId = "detail-episode-section"
     private let heroScrollId = "detail-hero"
+    @State private var focusedEpisodeContentId: String?
 
     var body: some View {
         ScrollViewReader { scrollProxy in
@@ -100,6 +101,7 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
                 episodeSectionId: episodeSectionScrollId,
                 heroId: heroScrollId
             )
+            .onPlayPauseCommand(perform: playFocusedEpisodeOrCurrent)
         }
     }
 
@@ -267,9 +269,23 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
                 TVEpisodeRail(
                     episodes: seasonEpisodes,
                     onSelect: onEpisodeTap,
+                    onFocusedEpisodeChange: { focusedEpisodeContentId = $0 },
                     currentContentId: detail.contentId
                 )
             }
+        }
+    }
+
+    /// Siri Remote Play/Pause is a page-level shortcut. A different episode
+    /// highlighted in the rail wins; every other focus zone plays the episode
+    /// represented by this detail page and preserves its selector overrides.
+    private func playFocusedEpisodeOrCurrent() {
+        guard detail.type == "episode" else { return }
+        if let focusedEpisodeContentId,
+           focusedEpisodeContentId != detail.contentId {
+            onEpisodeTap(focusedEpisodeContentId)
+        } else {
+            onPlay(false)
         }
     }
 

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
@@ -51,6 +51,7 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
     // forbids static stored properties on this type.
     private let episodeSectionScrollId = "detail-episode-section"
     private let heroScrollId = "detail-hero"
+    @State private var episodeFocusRequest = 0
 
     var body: some View {
         ScrollViewReader { scrollProxy in
@@ -251,7 +252,8 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
                 TVSeasonChipRow(
                     seasons: seasons,
                     selectedSeasonId: selectedSeason?.id,
-                    onSelect: onSelectSeason
+                    onSelect: onSelectSeason,
+                    onMoveDown: requestEpisodeFocus
                 )
                 // Container binding — true while any chip has focus, driving
                 // the episode-section re-center in `detailFocusScroll`.
@@ -267,10 +269,15 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
                 TVEpisodeRail(
                     episodes: seasonEpisodes,
                     onSelect: onEpisodeTap,
-                    currentContentId: detail.contentId
+                    currentContentId: detail.contentId,
+                    focusRequest: episodeFocusRequest
                 )
             }
         }
+    }
+
+    private func requestEpisodeFocus() {
+        episodeFocusRequest &+= 1
     }
 
     private var episodeRailEyebrow: String {

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVPlaybackSelectorRow.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVPlaybackSelectorRow.swift
@@ -32,7 +32,7 @@ struct TVPlaybackSelectorRow: View {
     var subtitleMode: String? = nil
     var subtitleSignature: SubtitleTrackSignature? = nil
     /// Profile/item "Show Forced Subtitles" preference — feeds the Auto
-    /// preview's forced-track branch so the row doesn't show "Auto - None"
+    /// preview's forced-track branch so the row doesn't show "Auto: Off"
     /// when playback would actually start with a forced track.
     var showForcedSubtitles: Bool = false
     let onSelectVersion: (Int?) -> Void
@@ -187,10 +187,11 @@ struct TVPlaybackSelectorRow: View {
 
     @ViewBuilder
     private var versionSelector: some View {
-        let value = DetailPlaybackFormatting.versionShortLabel(currentVersion)
+        let summary = DetailPlaybackFormatting.versionShortLabel(currentVersion)
+        let value = selectedVersionFileId == nil ? "Auto: \(summary)" : summary
         if shouldEnableVersionSelector {
             TVSelectorButton(
-                icon: "4k.tv",
+                icon: "tv",
                 label: "Version",
                 value: value
             ) {
@@ -211,7 +212,7 @@ struct TVPlaybackSelectorRow: View {
             }
             .focused($focusedSelector, equals: .version)
         } else {
-            TVSelectorValue(icon: "4k.tv", label: "Version", value: value)
+            TVSelectorValue(icon: "tv", label: "Version", value: value)
         }
     }
 

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonChip.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonChip.swift
@@ -82,7 +82,6 @@ struct TVSeasonChipRow: View {
     let seasons: [Season]
     let selectedSeasonId: String?
     let onSelect: (Season) -> Void
-    var onMoveDown: (() -> Void)? = nil
 
     @FocusState private var focusedSeasonId: String?
 
@@ -104,14 +103,6 @@ struct TVSeasonChipRow: View {
             }
             .scrollClipDisabled()
             .focusSection()
-            // Down is an intentional boundary handoff. After a season change
-            // the episode rail may be temporarily replaced by a loader, so
-            // native geometry has no target until the new episodes arrive.
-            .onMoveCommand { direction in
-                if direction == .down {
-                    onMoveDown?()
-                }
-            }
             .applyChipRowDefaultFocus(selectedSeasonId, binding: $focusedSeasonId)
             .onChange(of: selectedSeasonId) { _, newId in
                 guard let newId else { return }

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonChip.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonChip.swift
@@ -82,6 +82,7 @@ struct TVSeasonChipRow: View {
     let seasons: [Season]
     let selectedSeasonId: String?
     let onSelect: (Season) -> Void
+    var onMoveDown: (() -> Void)? = nil
 
     @FocusState private var focusedSeasonId: String?
 
@@ -103,6 +104,14 @@ struct TVSeasonChipRow: View {
             }
             .scrollClipDisabled()
             .focusSection()
+            // Down is an intentional boundary handoff. After a season change
+            // the episode rail may be temporarily replaced by a loader, so
+            // native geometry has no target until the new episodes arrive.
+            .onMoveCommand { direction in
+                if direction == .down {
+                    onMoveDown?()
+                }
+            }
             .applyChipRowDefaultFocus(selectedSeasonId, binding: $focusedSeasonId)
             .onChange(of: selectedSeasonId) { _, newId in
                 guard let newId else { return }

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
@@ -26,7 +26,7 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
     /// True once the user explicitly resets subtitles to "Auto" this visit.
     /// The server override was just cleared, but the next-up detail's
     /// `effectiveSubtitle*` still describes the old manual pick until the
-    /// next refetch — suppress it so the "Auto - …" preview doesn't echo the
+    /// next refetch — suppress it so the "Auto: …" preview doesn't echo the
     /// cleared selection.
     var nextUpSubtitleOverrideCleared: Bool = false
     let onPlayEpisode: (_ contentId: String, _ fileId: Int?, _ startFromBeginning: Bool) -> Void
@@ -63,7 +63,6 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
     /// instance, `selectedSeason` mutates — both re-focus Play, while never
     /// yanking focus back within the same season once the viewer moves on.
     @State private var autoFocusedSeasonKey: String?
-    @State private var episodeFocusRequest = 0
 
     var body: some View {
         ScrollViewReader { scrollProxy in
@@ -276,8 +275,7 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
                 TVSeasonChipRow(
                     seasons: seasons,
                     selectedSeasonId: selectedSeason?.id,
-                    onSelect: onSelectSeason,
-                    onMoveDown: requestEpisodeFocus
+                    onSelect: onSelectSeason
                 )
                 // Container binding — true while any chip has focus, driving
                 // the episode-section re-center in `detailFocusScroll`.
@@ -297,15 +295,10 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
                 TVEpisodeRail(
                     episodes: episodes,
                     onSelect: onEpisodeTap,
-                    currentContentId: nextUpEpisode?.contentId,
-                    focusRequest: episodeFocusRequest
+                    currentContentId: nextUpEpisode?.contentId
                 )
             }
         }
-    }
-
-    private func requestEpisodeFocus() {
-        episodeFocusRequest &+= 1
     }
 
     // MARK: - Cast

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
@@ -63,6 +63,7 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
     /// instance, `selectedSeason` mutates — both re-focus Play, while never
     /// yanking focus back within the same season once the viewer moves on.
     @State private var autoFocusedSeasonKey: String?
+    @State private var episodeFocusRequest = 0
 
     var body: some View {
         ScrollViewReader { scrollProxy in
@@ -275,7 +276,8 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
                 TVSeasonChipRow(
                     seasons: seasons,
                     selectedSeasonId: selectedSeason?.id,
-                    onSelect: onSelectSeason
+                    onSelect: onSelectSeason,
+                    onMoveDown: requestEpisodeFocus
                 )
                 // Container binding — true while any chip has focus, driving
                 // the episode-section re-center in `detailFocusScroll`.
@@ -295,10 +297,15 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
                 TVEpisodeRail(
                     episodes: episodes,
                     onSelect: onEpisodeTap,
-                    currentContentId: nextUpEpisode?.contentId
+                    currentContentId: nextUpEpisode?.contentId,
+                    focusRequest: episodeFocusRequest
                 )
             }
         }
+    }
+
+    private func requestEpisodeFocus() {
+        episodeFocusRequest &+= 1
     }
 
     // MARK: - Cast

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -21,7 +21,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     /// True once the user explicitly resets subtitles to "Auto" this visit.
     /// The server override was just cleared, but the next-up detail's
     /// `effectiveSubtitle*` still describes the old manual pick until the
-    /// next refetch — suppress it so the "Auto - …" preview doesn't echo the
+    /// next refetch — suppress it so the "Auto: …" preview doesn't echo the
     /// cleared selection.
     var nextUpSubtitleOverrideCleared: Bool = false
     let onSelectSeason: (Season) -> Void
@@ -57,7 +57,6 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     /// instance, `selectedSeason` mutates — both re-focus Play, while never
     /// yanking focus back within the same season once the viewer moves on.
     @State private var autoFocusedSeasonKey: String?
-    @State private var episodeFocusRequest = 0
 
     var body: some View {
         ScrollViewReader { scrollProxy in
@@ -285,8 +284,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         TVSeasonChipRow(
             seasons: seasons,
             selectedSeasonId: selectedSeason?.id,
-            onSelect: onSelectSeason,
-            onMoveDown: requestEpisodeFocus
+            onSelect: onSelectSeason
         )
         // Bound to the whole row: the binding flips true when any chip inside
         // gains focus, driving the episode-section re-center in `body`.
@@ -311,14 +309,9 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
             TVEpisodeRail(
                 episodes: episodes,
                 onSelect: onEpisodeTap,
-                currentContentId: nextUpEpisode?.contentId,
-                focusRequest: episodeFocusRequest
+                currentContentId: nextUpEpisode?.contentId
             )
         }
-    }
-
-    private func requestEpisodeFocus() {
-        episodeFocusRequest &+= 1
     }
 
     // MARK: - More Like This

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -57,6 +57,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     /// instance, `selectedSeason` mutates — both re-focus Play, while never
     /// yanking focus back within the same season once the viewer moves on.
     @State private var autoFocusedSeasonKey: String?
+    @State private var episodeFocusRequest = 0
 
     var body: some View {
         ScrollViewReader { scrollProxy in
@@ -284,7 +285,8 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         TVSeasonChipRow(
             seasons: seasons,
             selectedSeasonId: selectedSeason?.id,
-            onSelect: onSelectSeason
+            onSelect: onSelectSeason,
+            onMoveDown: requestEpisodeFocus
         )
         // Bound to the whole row: the binding flips true when any chip inside
         // gains focus, driving the episode-section re-center in `body`.
@@ -309,9 +311,14 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
             TVEpisodeRail(
                 episodes: episodes,
                 onSelect: onEpisodeTap,
-                currentContentId: nextUpEpisode?.contentId
+                currentContentId: nextUpEpisode?.contentId,
+                focusRequest: episodeFocusRequest
             )
         }
+    }
+
+    private func requestEpisodeFocus() {
+        episodeFocusRequest &+= 1
     }
 
     // MARK: - More Like This


### PR DESCRIPTION
## Summary

This PR collects a set of focused tvOS UI and playback-flow fixes made during device testing:

- improves entry focus in the in-player subtitle HUD
- makes version, audio, and subtitle selectors clearer and preserves local overrides across navigation
- restores native spatial focus between season and episode selectors
- lets episode cards and the remote Play/Pause button start playback directly
- adds direct Play/Pause shortcuts to focused playable cards throughout tvOS browsing
- preserves subtitle rendering when returning from the pre-end Next Up screen

## Playback selector presentation

- The Version selector now explicitly shows `Auto:` when selection is automatic.
- Replaces the resolution-specific `4k.tv` icon with the generic `tv` icon so non-4K content is represented correctly.
- Version summaries include available resolution, video codec, HDR, and audio codec information.
- Audio summaries prioritize language and then show codec and channel layout.
- Subtitle summaries prioritize language/title and include format plus Forced/SDH indicators where applicable.
- Normalizes SubRip labels to the familiar `SRT` name.
- Updates selector formatting tests for the richer summaries and auto-selection labels.
- Moves tvOS pre-play Version/Audio/Subtitle choices onto the cached item-detail view model, keeping manual choices intact after playback or temporary navigation away from an item.

## Focus and episode navigation

- Pressing Down from the top-level Subtitles HUD tab now enters the leftmost Tracks column at Off instead of landing in the Options column.
- Removes forced first/current-episode focus when moving down from the season selector. The tvOS focus engine can now choose the episode card spatially aligned with the selected season.
- Episode rails still scroll the current episode into view, but do not override directional focus.
- Selecting an episode card starts that episode immediately.
- The hidden detail route is updated only after playback actually starts, avoiding a visible “Now Viewing” change before the player appears.
- Exiting playback returns to the detail page for the episode that was played.
- On an episode detail page, the Siri Remote Play/Pause button plays the current episode from anywhere, except when another episode card is focused; in that case it plays the focused episode.

## Direct playback from browsing surfaces

Focused playable cards now handle the Siri Remote Play/Pause command independently from Select:

- Select continues to open item details.
- Play/Pause starts movies, episodes, and audiobooks immediately.
- Series and other container types continue opening their detail pages because they are not direct playback targets.
- This behavior is wired through Home rows, catalog/search grids, collections, Favorites, and Watchlist.

## Subtitle continuity through Next Up

The pre-end Next Up UI swaps the full-screen player surface for a mini-player and then mounts a new full-screen surface when Keep Watching is selected.

Device launch logs showed that playback and the selected subtitle track remained active, but the outgoing mini-player could remain the last writer to a single weak subtitle-overlay reference. Once that surface deallocated, the subtitle pump had no overlay and stopped rendering.

This PR replaces that single weak reference with a small weak attachment registry:

- every live player surface registers its subtitle overlay
- dismantled surfaces unregister explicitly
- when overlapping transition surfaces disappear, the backend falls back to the newest remaining live overlay
- the same lifecycle is used by both AVPlayer and CoreMedia routes

This fixes the ownership problem directly without restarting the video session or changing the selected subtitle track.

## Validation

- `git diff --check`
- Compile-only generic tvOS build:
  `xcodebuild build -project Silo.xcodeproj -scheme SiloTV -destination 'generic/platform=tvOS' -derivedDataPath /tmp/silo-apple-subtitle-fix CODE_SIGNING_ALLOWED=NO`
- Build succeeded. Runtime behavior remains ready for final Apple TV validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Play/Pause remote shortcuts for focused playable media and episodes on tvOS.
  * Playback can now return to the relevant detail page after starting.
  * Preserved version, audio, and subtitle selections while navigating.
  * Improved episode focus tracking and playback behavior.

* **Improvements**
  * Updated audio, subtitle, and version labels with clearer, consistent formatting.
  * Enhanced subtitle selector focus behavior on tvOS.
  * Improved subtitle overlay handling during player transitions and view updates.

* **Bug Fixes**
  * Corrected Auto subtitle and audio previews, including “Auto: Off” states and track details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->