### PR TITLE
Fix Home rows after watched and dismissal actions

### DIFF
--- a/iosApp/Tests/HomeSectionsMutationTests.swift
+++ b/iosApp/Tests/HomeSectionsMutationTests.swift
@@ -1,0 +1,237 @@
+import Foundation
+import XCTest
+@testable import Silo
+
+final class HomeSectionsMutationTests: XCTestCase {
+    private enum TestError: Error {
+        case failed
+    }
+
+    func testRemovesItemOnlyFromContinueWatchingSections() throws {
+        let target = try makeItem(contentId: "target")
+        let other = try makeItem(contentId: "other")
+        let sections = [
+            makeSection(id: "continue", type: "continue_watching", totalCount: 2, items: [target, other]),
+            makeSection(id: "watchlist", type: "watchlist", totalCount: 1, items: [target]),
+        ]
+
+        let result = HomeSectionsMutation.removingContinueWatchingItem(
+            contentId: target.contentId,
+            from: sections
+        )
+
+        XCTAssertEqual(result[0].items.map(\.contentId), ["other"])
+        XCTAssertEqual(result[0].totalCount, 1)
+        XCTAssertEqual(result[1].items.map(\.contentId), ["target"])
+        XCTAssertEqual(result[1].totalCount, 1)
+    }
+
+    func testLegacyInProgressSectionUsesSameRemovalSemantics() throws {
+        let target = try makeItem(contentId: "target")
+        let section = makeSection(id: "progress", type: "in_progress", totalCount: 1, items: [target])
+
+        let result = HomeSectionsMutation.removingContinueWatchingItem(
+            contentId: target.contentId,
+            from: [section]
+        )
+
+        XCTAssertTrue(result[0].items.isEmpty)
+        XCTAssertEqual(result[0].totalCount, 0)
+    }
+
+    func testTotalCountIsClampedAtZero() throws {
+        let target = try makeItem(contentId: "target")
+        let section = makeSection(id: "continue", type: "continue_watching", totalCount: 0, items: [target])
+
+        let result = HomeSectionsMutation.removingContinueWatchingItem(
+            contentId: target.contentId,
+            from: [section]
+        )
+
+        XCTAssertEqual(result[0].totalCount, 0)
+    }
+
+    func testUnknownContentIdLeavesSectionUnchanged() throws {
+        let item = try makeItem(contentId: "other")
+        let section = makeSection(id: "continue", type: "continue_watching", totalCount: 1, items: [item])
+
+        let result = HomeSectionsMutation.removingContinueWatchingItem(
+            contentId: "missing",
+            from: [section]
+        )
+
+        XCTAssertEqual(result[0].items, section.items)
+        XCTAssertEqual(result[0].totalCount, section.totalCount)
+    }
+
+    func testCompletedItemIsRemovedFromPlaybackDrivenSections() throws {
+        let target = try makeItem(contentId: "target")
+        let other = try makeItem(contentId: "other")
+        let sections = [
+            makeSection(id: "continue", type: "continue_watching", totalCount: 2, items: [target, other]),
+            makeSection(id: "next", type: "next_up", totalCount: 1, items: [target]),
+            makeSection(id: "trending", type: "trending", totalCount: 1, items: [target]),
+        ]
+
+        let result = HomeSectionsMutation.removingCompletedItem(
+            contentId: target.contentId,
+            from: sections
+        )
+
+        XCTAssertEqual(result[0].items.map(\.contentId), ["other"])
+        XCTAssertEqual(result[0].totalCount, 1)
+        XCTAssertTrue(result[1].items.isEmpty)
+        XCTAssertEqual(result[1].totalCount, 0)
+        XCTAssertEqual(result[2].items.map(\.contentId), ["target"])
+        XCTAssertEqual(result[2].totalCount, 1)
+    }
+
+    @MainActor
+    func testSuccessfulDismissalUpdatesVisibleAndCachedSections() async throws {
+        let target = try makeItem(contentId: "target")
+        let other = try makeItem(contentId: "other")
+        let sections = [
+            makeSection(id: "continue", type: "continue_watching", totalCount: 2, items: [target, other]),
+        ]
+        ResponseCache.shared.set(SectionsResponse(sections: sections), for: CacheKey.homeSections)
+        defer { ResponseCache.shared.remove(CacheKey.homeSections) }
+
+        var receivedContentId: String?
+        var receivedProgressTimestamp: String?
+        let viewModel = HomeViewModel(
+            dismissContinueWatching: { contentId, progressUpdatedAt in
+                receivedContentId = contentId
+                receivedProgressTimestamp = progressUpdatedAt
+            }
+        )
+
+        await viewModel.dismissContinueWatchingItem(target)
+
+        let cached: SectionsResponse? = ResponseCache.shared.get(CacheKey.homeSections)
+        XCTAssertEqual(receivedContentId, "target")
+        XCTAssertEqual(receivedProgressTimestamp, target.progressUpdatedAt)
+        XCTAssertEqual(viewModel.sections[0].items.map(\.contentId), ["other"])
+        XCTAssertEqual(cached?.sections[0].items.map(\.contentId), ["other"])
+        XCTAssertNil(viewModel.actionError)
+    }
+
+    @MainActor
+    func testFailedDismissalPreservesStateAndSurfacesError() async throws {
+        let target = try makeItem(contentId: "target")
+        let sections = [
+            makeSection(id: "continue", type: "continue_watching", totalCount: 1, items: [target]),
+        ]
+        ResponseCache.shared.set(SectionsResponse(sections: sections), for: CacheKey.homeSections)
+        defer { ResponseCache.shared.remove(CacheKey.homeSections) }
+
+        let viewModel = HomeViewModel(
+            dismissContinueWatching: { _, _ in
+                throw TestError.failed
+            }
+        )
+
+        await viewModel.dismissContinueWatchingItem(target)
+
+        let cached: SectionsResponse? = ResponseCache.shared.get(CacheKey.homeSections)
+        XCTAssertEqual(viewModel.sections[0].items.map(\.contentId), ["target"])
+        XCTAssertEqual(cached?.sections[0].items.map(\.contentId), ["target"])
+        XCTAssertNotNil(viewModel.actionError)
+        XCTAssertTrue(viewModel.isShowingActionError)
+    }
+
+    @MainActor
+    func testSuccessfulWatchedUpdateRemovesItemFromNextUpAndCache() async throws {
+        let target = try makeItem(contentId: "target")
+        let other = try makeItem(contentId: "other")
+        let sections = [
+            makeSection(id: "next", type: "next_up", totalCount: 2, items: [target, other]),
+            makeSection(id: "trending", type: "trending", totalCount: 1, items: [target]),
+        ]
+        ResponseCache.shared.set(SectionsResponse(sections: sections), for: CacheKey.homeSections)
+        defer { ResponseCache.shared.remove(CacheKey.homeSections) }
+
+        var receivedContentId: String?
+        var receivedPlayed: Bool?
+        let viewModel = HomeViewModel(
+            setWatched: { contentId, played in
+                receivedContentId = contentId
+                receivedPlayed = played
+            },
+            fetchHomeSections: {
+                // A reconciliation failure must not undo the committed local
+                // update or require a manual pull-to-refresh.
+                throw TestError.failed
+            }
+        )
+
+        let succeeded = await viewModel.setWatched(target, played: true)
+
+        let cached: SectionsResponse? = ResponseCache.shared.get(CacheKey.homeSections)
+        XCTAssertTrue(succeeded)
+        XCTAssertEqual(receivedContentId, "target")
+        XCTAssertEqual(receivedPlayed, true)
+        XCTAssertEqual(viewModel.sections[0].items.map(\.contentId), ["other"])
+        XCTAssertEqual(viewModel.sections[0].totalCount, 1)
+        XCTAssertEqual(viewModel.sections[1].items.map(\.contentId), ["target"])
+        XCTAssertEqual(cached?.sections[0].items.map(\.contentId), ["other"])
+        XCTAssertEqual(cached?.sections[0].totalCount, 1)
+        XCTAssertEqual(cached?.sections[1].items.map(\.contentId), ["target"])
+        XCTAssertNil(viewModel.actionError)
+    }
+
+    @MainActor
+    func testFailedWatchedUpdatePreservesStateAndSurfacesError() async throws {
+        let target = try makeItem(contentId: "target")
+        let sections = [
+            makeSection(id: "next", type: "next_up", totalCount: 1, items: [target]),
+        ]
+        ResponseCache.shared.set(SectionsResponse(sections: sections), for: CacheKey.homeSections)
+        defer { ResponseCache.shared.remove(CacheKey.homeSections) }
+
+        let viewModel = HomeViewModel(
+            setWatched: { _, _ in
+                throw TestError.failed
+            }
+        )
+
+        let succeeded = await viewModel.setWatched(target, played: true)
+
+        let cached: SectionsResponse? = ResponseCache.shared.get(CacheKey.homeSections)
+        XCTAssertFalse(succeeded)
+        XCTAssertEqual(viewModel.sections[0].items.map(\.contentId), ["target"])
+        XCTAssertEqual(cached?.sections[0].items.map(\.contentId), ["target"])
+        XCTAssertNotNil(viewModel.actionError)
+        XCTAssertTrue(viewModel.isShowingActionError)
+    }
+
+    private func makeItem(contentId: String) throws -> SectionItem {
+        let json = """
+        {
+          "contentId": "\(contentId)",
+          "type": "movie",
+          "title": "Test Item",
+          "progressUpdatedAt": "2026-07-10T12:00:00Z"
+        }
+        """
+        return try JSONDecoder().decode(SectionItem.self, from: Data(json.utf8))
+    }
+
+    private func makeSection(
+        id: String,
+        type: String,
+        totalCount: Int?,
+        items: [SectionItem]
+    ) -> ResolvedSection {
+        ResolvedSection(
+            id: id,
+            sectionType: type,
+            title: id,
+            featured: false,
+            itemLimit: nil,
+            totalCount: totalCount,
+            isCustom: false,
+            customized: false,
+            items: items
+        )
+    }
+}

--- a/iosApp/iosApp/Components/EpisodeThumbCard.swift
+++ b/iosApp/iosApp/Components/EpisodeThumbCard.swift
@@ -18,7 +18,7 @@ struct EpisodeThumbCard: View {
     /// `MediaCard.focusedItemId` for the contract.
     var focusedItemId: FocusState<String?>.Binding? = nil
     var onRemoveFromContinueWatching: (() -> Void)? = nil
-    var onSetWatched: ((Bool) -> Void)? = nil
+    var onSetWatched: ((Bool) async -> Bool)? = nil
 
     @State private var playedOverride: Bool?
     @EnvironmentObject private var overlayStore: OverlayPrefsStore
@@ -319,8 +319,13 @@ struct EpisodeThumbCard: View {
         if let onSetWatched {
             Button {
                 let played = !isPlayed
-                playedOverride = played
-                onSetWatched(played)
+                Task { @MainActor in
+                    playedOverride = played
+                    let succeeded = await onSetWatched(played)
+                    if !succeeded {
+                        playedOverride = nil
+                    }
+                }
             } label: {
                 Label(
                     isPlayed ? "Mark as Unwatched" : "Mark as Watched",

--- a/iosApp/iosApp/Components/MediaCard.swift
+++ b/iosApp/iosApp/Components/MediaCard.swift
@@ -35,7 +35,7 @@ struct MediaCard: View {
 
     var contentId: String? = nil
     var onRemoveFromContinueWatching: (() -> Void)? = nil
-    var onSetWatched: ((Bool) -> Void)? = nil
+    var onSetWatched: ((Bool) async -> Bool)? = nil
     var aspect: MediaCardAspect = .poster
     /// Overrides the theme's default card width. Skyline's dense landing
     /// rows (§5.6) pass 208 so two rows + the marquee fit above the fold;
@@ -97,7 +97,11 @@ struct MediaCard: View {
             onSetWatched: onSetWatched.map { handler in
                 { played in
                     playedOverride = played
-                    handler(played)
+                    let succeeded = await handler(played)
+                    if !succeeded {
+                        playedOverride = nil
+                    }
+                    return succeeded
                 }
             },
             personalItems: hasPersonalActions ? personalMenuItems : nil
@@ -160,8 +164,13 @@ struct MediaCard: View {
         if let onSetWatched {
             Button {
                 let played = !isPlayed
-                playedOverride = played
-                onSetWatched(played)
+                Task { @MainActor in
+                    playedOverride = played
+                    let succeeded = await onSetWatched(played)
+                    if !succeeded {
+                        playedOverride = nil
+                    }
+                }
             } label: {
                 Label(
                     isPlayed ? "Mark as Unwatched" : "Mark as Watched",
@@ -437,7 +446,7 @@ private struct FocusableMediaCard<Content: View>: View {
     let itemId: String?
     let isWatched: Bool
     let onRemoveFromContinueWatching: (() -> Void)?
-    let onSetWatched: ((Bool) -> Void)?
+    let onSetWatched: ((Bool) async -> Bool)?
     /// Favorite / watchlist toggles, built by the owning card. `nil`
     /// when the card has no catalog identity or user state.
     let personalItems: PersonalListMenuItems?
@@ -502,7 +511,9 @@ private struct FocusableMediaCard<Content: View>: View {
     private var contextActions: some View {
         if let onSetWatched {
             Button {
-                onSetWatched(!isWatched)
+                Task { @MainActor in
+                    _ = await onSetWatched(!isWatched)
+                }
             } label: {
                 Label(
                     isWatched ? "Mark as Unwatched" : "Mark as Watched",

--- a/iosApp/iosApp/Components/MediaRow.swift
+++ b/iosApp/iosApp/Components/MediaRow.swift
@@ -40,7 +40,7 @@ struct MediaRow: View {
     /// focus engine isn't doing the moving.
     var focusRequest: Int = 0
     var onRemoveFromContinueWatching: ((SectionItem) -> Void)? = nil
-    var onSetWatched: ((SectionItem, Bool) -> Void)? = nil
+    var onSetWatched: ((SectionItem, Bool) async -> Bool)? = nil
     var onMoveUp: (() -> Void)? = nil
     /// tvOS-only: reports which of the row's items holds card focus —
     /// the Skyline focus marquee mirrors it. Fires on focus gain only;
@@ -267,9 +267,9 @@ struct MediaRow: View {
         return { onRemoveFromContinueWatching(item) }
     }
 
-    private func watchedToggleAction(for item: SectionItem) -> ((Bool) -> Void)? {
+    private func watchedToggleAction(for item: SectionItem) -> ((Bool) async -> Bool)? {
         guard let onSetWatched else { return nil }
-        return { played in onSetWatched(item, played) }
+        return { played in await onSetWatched(item, played) }
     }
 
     /// Caption for a poster card. Episodes are captioned with the series name

--- a/iosApp/iosApp/Screens/Home/HomeSectionsMutation.swift
+++ b/iosApp/iosApp/Screens/Home/HomeSectionsMutation.swift
@@ -1,0 +1,67 @@
+/// Pure transformations for profile-scoped Home section state.
+///
+/// Keeping the transformation independent from the view model lets the live
+/// screen and `ResponseCache` apply exactly the same update after a mutation.
+enum HomeSectionsMutation {
+    private static let continueWatchingSectionTypes: Set<String> = [
+        "continue_watching",
+        "in_progress",
+    ]
+    private static let completedItemSectionTypes: Set<String> = [
+        "continue_watching",
+        "in_progress",
+        "next_up",
+    ]
+
+    static func removingContinueWatchingItem(
+        contentId: String,
+        from sections: [ResolvedSection]
+    ) -> [ResolvedSection] {
+        removingItem(
+            contentId: contentId,
+            from: sections,
+            sectionTypes: continueWatchingSectionTypes
+        )
+    }
+
+    /// Removes a newly completed item from rows whose membership is derived
+    /// from playback state. Other Home rows can still show the same title.
+    static func removingCompletedItem(
+        contentId: String,
+        from sections: [ResolvedSection]
+    ) -> [ResolvedSection] {
+        removingItem(
+            contentId: contentId,
+            from: sections,
+            sectionTypes: completedItemSectionTypes
+        )
+    }
+
+    private static func removingItem(
+        contentId: String,
+        from sections: [ResolvedSection],
+        sectionTypes: Set<String>
+    ) -> [ResolvedSection] {
+        sections.map { section in
+            guard sectionTypes.contains(section.sectionType.lowercased()) else {
+                return section
+            }
+
+            let items = section.items.filter { $0.contentId != contentId }
+            let removedCount = section.items.count - items.count
+            guard removedCount > 0 else { return section }
+
+            return ResolvedSection(
+                id: section.id,
+                sectionType: section.sectionType,
+                title: section.title,
+                featured: section.featured,
+                itemLimit: section.itemLimit,
+                totalCount: section.totalCount.map { max(0, $0 - removedCount) },
+                isCustom: section.isCustom,
+                customized: section.customized,
+                items: items
+            )
+        }
+    }
+}

--- a/iosApp/iosApp/Screens/Home/HomeView.swift
+++ b/iosApp/iosApp/Screens/Home/HomeView.swift
@@ -39,11 +39,14 @@ struct HomeView: View {
     @Environment(AppRouter.self) private var router
 
     var body: some View {
-        // On iOS the header floats over the scroll content, which extends
-        // behind the status bar with a semi-transparent fill. On tvOS the
-        // app-level top bar (owned by `TVMainTabView`) handles profile +
-        // utility actions; Home renders the focus marquee over rows, with
-        // the backdrop tracking whichever card holds focus (§5.4).
+        @Bindable var viewModel = viewModel
+
+        Group {
+            // On iOS the header floats over the scroll content, which extends
+            // behind the status bar with a semi-transparent fill. On tvOS the
+            // app-level top bar (owned by `TVMainTabView`) handles profile +
+            // utility actions; Home renders the focus marquee over rows, with
+            // the backdrop tracking whichever card holds focus (§5.4).
         #if os(tvOS)
         // The shared Skyline feed uses the same layout component as the
         // library Browse tabs; Home supplies only the server-resolved Home rows.
@@ -54,7 +57,9 @@ struct HomeView: View {
                     focusRequest: homeFocusRequest,
                     isTopMenuFocused: isTopMenuFocused,
                     onTopMenuFocusRequest: onTopMenuFocusRequest,
-                    onItemTap: { navigateToDetail($0) }
+                    onItemTap: { navigateToDetail($0) },
+                    onRemoveFromContinueWatching: dismissContinueWatching,
+                    onSetWatched: setWatched
                 )
             } else if let error = viewModel.error {
                 ErrorView(state: error, onRetry: { Task { await viewModel.loadSections() } })
@@ -180,6 +185,15 @@ struct HomeView: View {
         }
         #endif
         #endif
+        }
+        .alert(
+            "Couldn’t Update Item",
+            isPresented: $viewModel.isShowingActionError
+        ) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(viewModel.actionError?.message ?? "The item could not be updated. Try again.")
+        }
     }
 
     // MARK: - Content
@@ -199,6 +213,8 @@ struct HomeView: View {
                         SectionRow(
                             section: section,
                             onItemTap: { navigateToDetail($0) },
+                            onRemoveFromContinueWatching: dismissContinueWatching,
+                            onSetWatched: setWatched,
                             prefersDefaultFocusOnFirstItem: index == 0,
                             onMoveUp: index == 0 ? onTopMenuFocusRequest : nil
                         )
@@ -300,6 +316,16 @@ struct HomeView: View {
 
     private func navigateToDetail(_ contentId: String) {
         router.navigate(to: .itemDetail(contentId: contentId))
+    }
+
+    private func dismissContinueWatching(_ item: SectionItem) {
+        Task {
+            await viewModel.dismissContinueWatchingItem(item)
+        }
+    }
+
+    private func setWatched(_ item: SectionItem, played: Bool) async -> Bool {
+        await viewModel.setWatched(item, played: played)
     }
 
     #if !os(tvOS)

--- a/iosApp/iosApp/Screens/Home/HomeViewModel.swift
+++ b/iosApp/iosApp/Screens/Home/HomeViewModel.swift
@@ -3,6 +3,13 @@ import Foundation
 @Observable
 @MainActor
 class HomeViewModel {
+    typealias DismissContinueWatching = (
+        _ contentId: String,
+        _ progressUpdatedAt: String
+    ) async throws -> Void
+    typealias SetWatched = (_ contentId: String, _ played: Bool) async throws -> Void
+    typealias FetchHomeSections = () async throws -> SectionsResponse
+
     var sections: [ResolvedSection] = []
     /// True only on the very first load when no cached data exists.
     /// Returning visits paint cached sections instantly and use
@@ -12,6 +19,21 @@ class HomeViewModel {
     /// painted content stays on screen.
     var isRefreshing = false
     var error: ErrorState?
+    private(set) var actionError: ErrorState?
+    private var pendingContinueWatchingDismissals = Set<String>()
+    private var pendingWatchedUpdates = Set<String>()
+    private let dismissContinueWatching: DismissContinueWatching
+    private let updateWatchedState: SetWatched
+    private let fetchHomeSections: FetchHomeSections
+
+    var isShowingActionError: Bool {
+        get { actionError != nil }
+        set {
+            if !newValue {
+                actionError = nil
+            }
+        }
+    }
 
     /// Sections for Home in server order, filtered to non-empty rows.
     /// `featured` sections render as ordinary rows in their server position —
@@ -20,7 +42,24 @@ class HomeViewModel {
         sections.filter { !$0.items.isEmpty }
     }
 
-    init() {
+    init(
+        dismissContinueWatching: @escaping DismissContinueWatching = { contentId, progressUpdatedAt in
+            try await ContinuumAPI.shared.dismissContinueWatchingItem(
+                contentId: contentId,
+                progressUpdatedAt: progressUpdatedAt
+            )
+        },
+        setWatched: @escaping SetWatched = { contentId, played in
+            try await ContinuumAPI.shared.setWatched(contentId: contentId, played: played)
+        },
+        fetchHomeSections: @escaping FetchHomeSections = {
+            try await StartupContentPrefetcher.fetchHomeSections()
+        }
+    ) {
+        self.dismissContinueWatching = dismissContinueWatching
+        self.updateWatchedState = setWatched
+        self.fetchHomeSections = fetchHomeSections
+
         // Hydrate from the shared cache so the first render after a
         // navigation paints last-known data without any network wait.
         if let cached: SectionsResponse = ResponseCache.shared.get(CacheKey.homeSections) {
@@ -55,8 +94,86 @@ class HomeViewModel {
         isRefreshing = false
     }
 
+    func dismissContinueWatchingItem(_ item: SectionItem) async {
+        guard let progressUpdatedAt = item.progressUpdatedAt,
+              pendingContinueWatchingDismissals.insert(item.contentId).inserted else {
+            return
+        }
+        defer { pendingContinueWatchingDismissals.remove(item.contentId) }
+
+        actionError = nil
+
+        do {
+            try await dismissContinueWatching(item.contentId, progressUpdatedAt)
+
+            // A Home request that started before the dismissal can contain the
+            // removed item. Invalidate that generation before committing the
+            // authoritative local/cache update so a late response cannot put it
+            // back on screen.
+            StartupContentPrefetcher.invalidateHomeSectionsInFlight()
+            sections = HomeSectionsMutation.removingContinueWatchingItem(
+                contentId: item.contentId,
+                from: sections
+            )
+            ResponseCache.shared.update(CacheKey.homeSections, as: SectionsResponse.self) { response in
+                response = SectionsResponse(
+                    sections: HomeSectionsMutation.removingContinueWatchingItem(
+                        contentId: item.contentId,
+                        from: response.sections
+                    )
+                )
+            }
+        } catch {
+            actionError = ErrorState(error)
+        }
+    }
+
+    /// Updates playback state through the server, then immediately removes a
+    /// completed item from membership-driven Home rows. A fresh Home fetch
+    /// reconciles replacement Next Up episodes and watched state elsewhere.
+    @discardableResult
+    func setWatched(_ item: SectionItem, played: Bool) async -> Bool {
+        guard pendingWatchedUpdates.insert(item.contentId).inserted else {
+            return false
+        }
+        defer { pendingWatchedUpdates.remove(item.contentId) }
+
+        actionError = nil
+
+        do {
+            try await updateWatchedState(item.contentId, played)
+
+            // Never join or apply a Home request that began before this
+            // mutation. It can carry the old Next Up membership.
+            StartupContentPrefetcher.invalidateHomeSectionsInFlight()
+
+            if played {
+                sections = HomeSectionsMutation.removingCompletedItem(
+                    contentId: item.contentId,
+                    from: sections
+                )
+                ResponseCache.shared.update(CacheKey.homeSections, as: SectionsResponse.self) { response in
+                    response = SectionsResponse(
+                        sections: HomeSectionsMutation.removingCompletedItem(
+                            contentId: item.contentId,
+                            from: response.sections
+                        )
+                    )
+                }
+            }
+
+            // The server may advance a series to its following episode. Keep
+            // the local removal if this reconciliation cannot be fetched.
+            await loadSections()
+            return true
+        } catch {
+            actionError = ErrorState(error)
+            return false
+        }
+    }
+
     private func fetchAndApplySections() async throws {
-        let response = try await StartupContentPrefetcher.fetchHomeSections()
+        let response = try await fetchHomeSections()
         sections = response.sections.filter { !$0.items.isEmpty }
         error = nil
     }

--- a/iosApp/iosApp/Screens/Home/SectionRow.swift
+++ b/iosApp/iosApp/Screens/Home/SectionRow.swift
@@ -92,7 +92,9 @@ struct SectionRow: View {
             prefersDefaultFocusOnFirstItem: prefersDefaultFocusOnFirstItem,
             focusRequest: focusRequest,
             onRemoveFromContinueWatching: isContinueWatching ? onRemoveFromContinueWatching : nil,
-            onSetWatched: onSetWatched,
+            onSetWatched: { item, played in
+                await setWatched(item, played: played)
+            },
             onMoveUp: onMoveUp,
             onItemFocus: onItemFocus,
             cardWidth: cardWidth,
@@ -110,6 +112,27 @@ struct SectionRow: View {
             backdropURL: item.backdropUrl
         )
         #endif
+    }
+
+    /// Home injects a model-owned mutation so its membership-driven rows and
+    /// cache update immediately. Shared SectionRow callers retain the original
+    /// direct API behavior when no owning model provides an action.
+    private func setWatched(_ item: SectionItem, played: Bool) async -> Bool {
+        if let onSetWatched {
+            return await onSetWatched(item, played)
+        }
+
+        do {
+            try await ContinuumAPI.shared.setWatched(
+                contentId: item.contentId,
+                played: played
+            )
+            NotificationCenter.default.post(name: .homeSectionsShouldRefresh, object: nil)
+            return true
+        } catch {
+            print("[SectionRow] Failed to update watched state for \(item.contentId): \(error)")
+            return false
+        }
     }
 
 }

--- a/iosApp/iosApp/Screens/Home/SectionRow.swift
+++ b/iosApp/iosApp/Screens/Home/SectionRow.swift
@@ -8,6 +8,8 @@ struct SectionRow: View {
     let section: ResolvedSection
     let onItemTap: (String) -> Void
     var onSeeAll: (() -> Void)? = nil
+    var onRemoveFromContinueWatching: ((SectionItem) -> Void)? = nil
+    var onSetWatched: ((SectionItem, Bool) async -> Bool)? = nil
     var prefersDefaultFocusOnFirstItem: Bool = false
     /// Programmatic focus kick forwarded to the underlying `MediaRow` — used
     /// when an unrelated view (e.g. the tvOS top menu) hands focus down into
@@ -89,8 +91,8 @@ struct SectionRow: View {
             layout: layout,
             prefersDefaultFocusOnFirstItem: prefersDefaultFocusOnFirstItem,
             focusRequest: focusRequest,
-            onRemoveFromContinueWatching: isContinueWatching ? { removeFromContinueWatching($0) } : nil,
-            onSetWatched: { setWatched($0, played: $1) },
+            onRemoveFromContinueWatching: isContinueWatching ? onRemoveFromContinueWatching : nil,
+            onSetWatched: onSetWatched,
             onMoveUp: onMoveUp,
             onItemFocus: onItemFocus,
             cardWidth: cardWidth,
@@ -110,30 +112,4 @@ struct SectionRow: View {
         #endif
     }
 
-    private func removeFromContinueWatching(_ item: SectionItem) {
-        guard let progressUpdatedAt = item.progressUpdatedAt else { return }
-
-        Task {
-            do {
-                try await ContinuumAPI.shared.dismissContinueWatchingItem(
-                    contentId: item.contentId,
-                    progressUpdatedAt: progressUpdatedAt
-                )
-                NotificationCenter.default.post(name: .homeSectionsShouldRefresh, object: nil)
-            } catch {
-                print("[Home] Failed to remove \(item.contentId) from Continue Watching: \(error)")
-            }
-        }
-    }
-
-    private func setWatched(_ item: SectionItem, played: Bool) {
-        Task {
-            do {
-                try await ContinuumAPI.shared.setWatched(contentId: item.contentId, played: played)
-                NotificationCenter.default.post(name: .homeSectionsShouldRefresh, object: nil)
-            } catch {
-                print("[Home] Failed to update watched state for \(item.contentId): \(error)")
-            }
-        }
-    }
 }

--- a/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
+++ b/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
@@ -21,6 +21,7 @@ enum StartupContentPrefetcher {
     private static var librarySectionsTasks: [Int: Task<SectionsResponse, Error>] = [:]
     private static var browseFirstPageTasks: [String: Task<CatalogResponse, Error>] = [:]
     private static var profileScopedGeneration = 0
+    private static var homeSectionsGeneration = 0
     private static var profilesGeneration = 0
 
     static func resetProfileScopedPrefetches() {
@@ -87,8 +88,18 @@ enum StartupContentPrefetcher {
         }
     }
 
+    /// Cancels only Home's current single-flight request and prevents any
+    /// waiter on that generation from applying its stale response. The shared
+    /// response cache is intentionally left intact for the caller to update.
+    static func invalidateHomeSectionsInFlight() {
+        homeSectionsGeneration += 1
+        homeSectionsTask?.cancel()
+        homeSectionsTask = nil
+    }
+
     static func fetchHomeSections() async throws -> SectionsResponse {
-        let generation = profileScopedGeneration
+        let profileGeneration = profileScopedGeneration
+        let homeGeneration = homeSectionsGeneration
         let task: Task<SectionsResponse, Error>
         if let homeSectionsTask {
             task = homeSectionsTask
@@ -101,15 +112,18 @@ enum StartupContentPrefetcher {
 
         do {
             let response = try await task.value
-            try validateProfileScopedGeneration(generation)
-            if profileScopedGeneration == generation {
+            try validateProfileScopedGeneration(profileGeneration)
+            try validateHomeSectionsGeneration(homeGeneration)
+            if profileScopedGeneration == profileGeneration,
+               homeSectionsGeneration == homeGeneration {
                 homeSectionsTask = nil
             }
             ResponseCache.shared.set(response, for: CacheKey.homeSections)
             prefetchHomeArtwork(for: response)
             return response
         } catch {
-            if profileScopedGeneration == generation {
+            if profileScopedGeneration == profileGeneration,
+               homeSectionsGeneration == homeGeneration {
                 homeSectionsTask = nil
             }
             throw error
@@ -446,6 +460,12 @@ enum StartupContentPrefetcher {
 
     private static func validateProfileScopedGeneration(_ generation: Int) throws {
         guard profileScopedGeneration == generation else {
+            throw CancellationError()
+        }
+    }
+
+    private static func validateHomeSectionsGeneration(_ generation: Int) throws {
+        guard homeSectionsGeneration == generation else {
             throw CancellationError()
         }
     }

--- a/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
+++ b/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
@@ -26,6 +26,10 @@ struct TVSkylineSectionFeed: View {
     let onTopMenuFocusRequest: (() -> Void)?
     /// Open a content item (detail).
     let onItemTap: (String) -> Void
+    /// Optional Home-only action. Library feeds leave this nil.
+    var onRemoveFromContinueWatching: ((SectionItem) -> Void)? = nil
+    /// Optional Home-only watched-state mutation. Library feeds leave this nil.
+    var onSetWatched: ((SectionItem, Bool) async -> Bool)? = nil
 
     /// Debounced focused-card state driving the marquee + backdrop.
     @State private var marqueeModel = TVFocusMarqueeModel()
@@ -129,6 +133,8 @@ struct TVSkylineSectionFeed: View {
         SectionRow(
             section: section,
             onItemTap: onItemTap,
+            onRemoveFromContinueWatching: onRemoveFromContinueWatching,
+            onSetWatched: onSetWatched,
             prefersDefaultFocusOnFirstItem: false,
             focusRequest: isFirstRow ? contentFocusToken : 0,
             onMoveUp: isFirstRow ? onTopMenuFocusRequest : nil,


### PR DESCRIPTION
## Summary
- move Continue Watching dismissal and watched-state mutations into `HomeViewModel`
- update visible Home sections and the shared cache after successful mutations
- remove completed items immediately from Continue Watching, In Progress, and Next Up, then reconcile replacement episodes from the server
- invalidate stale in-flight Home requests and roll back card state when a watched update fails
- share the behavior across iOS and tvOS Home feeds

## Testing
- `xcodebuild test -project Silo.xcodeproj -scheme Silo -destination 'platform=iOS Simulator,id=5AEC2DBA-2CA4-4AA0-8EC8-333376BA51BC' -only-testing:SiloTests/HomeSectionsMutationTests CODE_SIGNING_ALLOWED=NO` (9 tests passed)
- `xcodebuild build -project Silo.xcodeproj -scheme Silo -destination 'platform=iOS Simulator,id=5AEC2DBA-2CA4-4AA0-8EC8-333376BA51BC' CODE_SIGNING_ALLOWED=NO`
- `xcodebuild build -project Silo.xcodeproj -scheme SiloTV -destination 'platform=tvOS Simulator,id=462E76D9-A6F7-4CBA-B8A8-1274FB2CB00B' CODE_SIGNING_ALLOWED=NO`
- installed and launched the resulting iOS build on `Silo Validation iPhone`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled Continue Watching item dismissal and watched/unwatched updates across iOS and tvOS Home.
  * Actions now optimistically update the UI and keep Home in sync after server reconciliation.
  * Added user-facing alert when an item action can’t be completed.
* **Bug Fixes**
  * Reverted UI state when watched/dismiss actions fail.
  * Prevented older Home section responses from overwriting newer updates.
* **Tests**
  * Added unit/async coverage for removal, watched-state changes, duplicates, and failure/edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->