### PR TITLE
Add manual Up Next action to tvOS player

### DIFF
--- a/iosApp/Tests/PlayerNextUpCompletionPolicyTests.swift
+++ b/iosApp/Tests/PlayerNextUpCompletionPolicyTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import Silo
+
+final class PlayerNextUpCompletionPolicyTests: XCTestCase {
+    func testEarlyManualPresentationPreservesCurrentPosition() {
+        let position = PlayerNextUpCompletionPolicy.progressPosition(
+            isNextUpPresented: true,
+            hasReachedEndOfFile: false,
+            currentTime: 300,
+            duration: 3_600,
+            promptSeconds: 30
+        )
+
+        XCTAssertEqual(position, 300)
+    }
+
+    func testPresentationInsidePromptWindowFinalizesAtDuration() {
+        let position = PlayerNextUpCompletionPolicy.progressPosition(
+            isNextUpPresented: true,
+            hasReachedEndOfFile: false,
+            currentTime: 3_575,
+            duration: 3_600,
+            promptSeconds: 30
+        )
+
+        XCTAssertEqual(position, 3_600)
+    }
+
+    func testEndOfFileFinalizesEvenOutsidePromptWindow() {
+        let position = PlayerNextUpCompletionPolicy.progressPosition(
+            isNextUpPresented: true,
+            hasReachedEndOfFile: true,
+            currentTime: 300,
+            duration: 3_600,
+            promptSeconds: 30
+        )
+
+        XCTAssertEqual(position, 3_600)
+    }
+
+    func testHiddenNextUpDoesNotFinalizeInsidePromptWindow() {
+        XCTAssertFalse(
+            PlayerNextUpCompletionPolicy.shouldFinalizeAsCompleted(
+                isNextUpPresented: false,
+                hasReachedEndOfFile: false,
+                currentTime: 3_575,
+                duration: 3_600,
+                promptSeconds: 30
+            )
+        )
+    }
+}

--- a/iosApp/iosApp/Screens/Player/PlayerNextUpCompletionPolicy.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerNextUpCompletionPolicy.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+enum PlayerNextUpCompletionPolicy {
+    static func isInPromptWindow(
+        currentTime: Double,
+        duration: Double,
+        promptSeconds: Int
+    ) -> Bool {
+        guard promptSeconds > 0,
+              duration.isFinite,
+              duration > 0,
+              currentTime.isFinite else {
+            return false
+        }
+
+        let remaining = duration - currentTime
+        return remaining >= 0 && remaining <= Double(promptSeconds)
+    }
+
+    static func shouldFinalizeAsCompleted(
+        isNextUpPresented: Bool,
+        hasReachedEndOfFile: Bool,
+        currentTime: Double,
+        duration: Double,
+        promptSeconds: Int
+    ) -> Bool {
+        if hasReachedEndOfFile {
+            return true
+        }
+        guard isNextUpPresented else { return false }
+        return isInPromptWindow(
+            currentTime: currentTime,
+            duration: duration,
+            promptSeconds: promptSeconds
+        )
+    }
+
+    static func progressPosition(
+        isNextUpPresented: Bool,
+        hasReachedEndOfFile: Bool,
+        currentTime: Double,
+        duration: Double,
+        promptSeconds: Int
+    ) -> Double {
+        guard duration.isFinite, duration > 0 else {
+            return currentTime
+        }
+        return shouldFinalizeAsCompleted(
+            isNextUpPresented: isNextUpPresented,
+            hasReachedEndOfFile: hasReachedEndOfFile,
+            currentTime: currentTime,
+            duration: duration,
+            promptSeconds: promptSeconds
+        ) ? duration : currentTime
+    }
+}

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -1663,18 +1663,12 @@ class PlayerViewModel {
     }
 
     private func shouldShowNextUpBeforeEnd(at movieTime: Double) -> Bool {
-        let promptSeconds = settings.nextUpPromptSeconds
-        guard promptSeconds > 0,
-              duration.isFinite,
-              duration > 0,
-              movieTime.isFinite else {
-            return false
-        }
-        let remaining = duration - movieTime
-        guard remaining >= 0, remaining <= Double(promptSeconds) else {
-            return false
-        }
-        return canShowNextUpScreen
+        canShowNextUpScreen
+            && PlayerNextUpCompletionPolicy.isInPromptWindow(
+                currentTime: movieTime,
+                duration: duration,
+                promptSeconds: settings.nextUpPromptSeconds
+            )
     }
 
     func showNextUpNow() {
@@ -1826,13 +1820,13 @@ class PlayerViewModel {
     }
 
     private func completionProgressPositionForCurrentItem() -> Double {
-        guard duration.isFinite, duration > 0 else {
-            return currentTime
-        }
-        if showNextUpScreen || hasReachedEndOfFile {
-            return duration
-        }
-        return currentTime
+        PlayerNextUpCompletionPolicy.progressPosition(
+            isNextUpPresented: showNextUpScreen,
+            hasReachedEndOfFile: hasReachedEndOfFile,
+            currentTime: currentTime,
+            duration: duration,
+            promptSeconds: settings.nextUpPromptSeconds
+        )
     }
 
     private func attemptNativeDirectRouteRecovery(after message: String) -> Bool {
@@ -5402,7 +5396,13 @@ class PlayerViewModel {
         let stopServerSessionOnTeardown = offlinePlaybackContext == nil
         if let offline = offlinePlaybackContext {
             let finalOfflinePosition = completionProgressPositionForCurrentItem()
-            let endedNaturally = hasReachedEndOfFile || showNextUpScreen
+            let endedNaturally = PlayerNextUpCompletionPolicy.shouldFinalizeAsCompleted(
+                isNextUpPresented: showNextUpScreen,
+                hasReachedEndOfFile: hasReachedEndOfFile,
+                currentTime: currentTime,
+                duration: duration,
+                promptSeconds: settings.nextUpPromptSeconds
+            )
             // Strong capture on purpose: this is the last write of the
             // resume point and must not be dropped because the VM was
             // released between dismiss and the hop to the MainActor.

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -997,6 +997,14 @@ class PlayerViewModel {
         let hiddenIds = Set([lastLoadRequest?.contentId, nextUpEpisode?.contentId].compactMap { $0 })
         return nextUpOnDeckItems.filter { !hiddenIds.contains($0.contentId) }
     }
+
+    var canShowNextUpScreen: Bool {
+        nextUpEpisode != nil
+            || !nextUpCarouselItems.isEmpty
+            || isLoadingNextUpEpisode
+            || isLoadingNextUpOnDeck
+    }
+
     private var currentRouteCapabilities: ApplePlaybackRouteCapabilities {
         return activeExecutionPlan?.routeCapabilities ?? activeRouteKind.routeCapabilities
     }
@@ -1666,10 +1674,12 @@ class PlayerViewModel {
         guard remaining >= 0, remaining <= Double(promptSeconds) else {
             return false
         }
-        return nextUpEpisode != nil
-            || !nextUpCarouselItems.isEmpty
-            || isLoadingNextUpEpisode
-            || isLoadingNextUpOnDeck
+        return canShowNextUpScreen
+    }
+
+    func showNextUpNow() {
+        guard canShowNextUpScreen else { return }
+        beginNextUpPostroll(videoEnded: false)
     }
 
     private func beginNextUpPostroll(videoEnded: Bool) {

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPlayerTransportCluster.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPlayerTransportCluster.swift
@@ -23,7 +23,7 @@ struct TVPlayerTransportCluster: View {
     @FocusState.Binding var focusedButton: FocusTarget?
 
     enum FocusTarget: Hashable {
-        case skipBack, playPause, skipForward, options, dismiss
+        case skipBack, playPause, skipForward, nextUp, options, dismiss
     }
 
     var body: some View {
@@ -68,6 +68,14 @@ struct TVPlayerTransportCluster: View {
 
     private var secondaryRow: some View {
         HStack(spacing: 10) {
+            if viewModel.canShowNextUpScreen {
+                iconButton(
+                    systemName: "rectangle.stack.fill",
+                    focus: .nextUp,
+                    accessibilityLabel: "Show Up Next",
+                    action: viewModel.showNextUpNow
+                )
+            }
             iconButton(
                 systemName: "slider.horizontal.3",
                 focus: .options,


### PR DESCRIPTION
## Summary

- add an Up Next button to the tvOS transport when Next Up content is available or loading
- route manual presentation through the same existing postroll flow used by the automatic trigger
- share the availability predicate between the manual control and automatic timing path

## Validation

- `xcodebuild build -project Silo.xcodeproj -scheme SiloTV -destination "platform=tvOS Simulator,id=725C6034-1B19-45BE-BC94-46DDDEA14B03" CODE_SIGNING_ALLOWED=NO`
- launched the development build on tvOS 26.4 and played episodic content
- focused and activated the new transport control, confirming it opens the existing Next Up screen unchanged
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Show Up Next” control to the tvOS player transport controls when upcoming content is available.
  * Improved focus support for navigating to the Up Next action.

* **Bug Fixes**
  * Prevented the Up Next screen from opening unless the Up Next UI is actually available.
  * Refined Up Next completion/progress handling using a centralized policy (including prompt-window and end-of-file edge cases).

* **Tests**
  * Added unit tests covering the Up Next completion/progress policy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->