### PR TITLE
Refine first-run auth flow and pairing timing

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -39,7 +39,10 @@ struct ContentView: View {
         #if os(iOS)
         // Hold the pairing offer until the startup splash logo finishes so a
         // quickly-discovered TV doesn't pop the card over the animation.
-        .companionPairingCard(enabled: didFinishStartupSplash && router.authState != .loading)
+        .companionPairingCard(
+            enabled: didFinishStartupSplash && router.authState != .loading,
+            authState: router.authState
+        )
         #endif
         .modifier(DebugPlayerPresentationModifier(
             contentId: debugPlayContentId,

--- a/iosApp/iosApp/DesignSystem/Aurora/AuroraBackdrop.swift
+++ b/iosApp/iosApp/DesignSystem/Aurora/AuroraBackdrop.swift
@@ -41,8 +41,8 @@ struct AuroraBackdrop: View {
 
                 RadialGradient(
                     colors: [
-                        Color.auroraAccent.opacity(0.15 * variant.intensity),
-                        Color(hex: "#123442").opacity(0.10 * variant.intensity),
+                        Color.auroraAccent.opacity(0.08 * variant.intensity),
+                        Color(hex: "#18212A").opacity(0.08 * variant.intensity),
                         .clear,
                     ],
                     center: variant.glowCenter,

--- a/iosApp/iosApp/DesignSystem/Aurora/AuroraBackdrop.swift
+++ b/iosApp/iosApp/DesignSystem/Aurora/AuroraBackdrop.swift
@@ -2,25 +2,20 @@ import SwiftUI
 
 // MARK: - Variants
 //
-// Each first-run screen gets its own aurora composition — where the light
-// band sits, how warm/cool it is, and how bright — so the flow feels related
-// but never identical, while staying within one plum-night palette.
+// Each first-run screen gets a slightly different placement of Silo's cool
+// signal glow. The canvas stays mostly black so authentication transitions
+// naturally into the signed-in media experience.
 
 struct AuroraVariant {
-    /// Band rotation, degrees.
-    var rotation: Double
-    /// Vertical center of the light band, as a fraction of screen height.
-    var centerY: CGFloat
-    /// Hue rotation applied to the ribbons (warm 0 → cooler negative).
-    var hue: Angle
-    /// Overall brightness multiplier for the light.
+    var glowCenter: UnitPoint
+    var lineHeight: CGFloat
     var intensity: Double
 
-    static let welcome = AuroraVariant(rotation: -12, centerY: 0.24, hue: .degrees(0), intensity: 0.92)
-    static let server = AuroraVariant(rotation: -9, centerY: 0.32, hue: .degrees(-22), intensity: 0.55)
-    static let connecting = AuroraVariant(rotation: -6, centerY: 0.30, hue: .degrees(-6), intensity: 0.70)
-    static let signIn = AuroraVariant(rotation: -14, centerY: 0.22, hue: .degrees(8), intensity: 0.86)
-    static let profile = AuroraVariant(rotation: -10, centerY: 0.27, hue: .degrees(-16), intensity: 0.66)
+    static let welcome = AuroraVariant(glowCenter: UnitPoint(x: 0.72, y: 0.14), lineHeight: 0.38, intensity: 0.95)
+    static let server = AuroraVariant(glowCenter: UnitPoint(x: 0.18, y: 0.30), lineHeight: 0.56, intensity: 0.72)
+    static let connecting = AuroraVariant(glowCenter: UnitPoint(x: 0.50, y: 0.20), lineHeight: 0.46, intensity: 0.82)
+    static let signIn = AuroraVariant(glowCenter: UnitPoint(x: 0.78, y: 0.25), lineHeight: 0.47, intensity: 0.86)
+    static let profile = AuroraVariant(glowCenter: UnitPoint(x: 0.50, y: 0.42), lineHeight: 0.58, intensity: 0.72)
 }
 
 enum AuroraScrim {
@@ -42,40 +37,35 @@ struct AuroraBackdrop: View {
             let w = geo.size.width
             let h = geo.size.height
             ZStack {
-                LinearGradient(
-                    colors: [.auroraNightTop, .auroraNightMid, .auroraNightBottom],
-                    startPoint: .top, endPoint: .bottom)
+                Color.auroraNightBottom
 
-                AuroraStarfield()
-                    .opacity(0.7)
-                    .frame(height: h * 0.62)
-                    .frame(maxHeight: .infinity, alignment: .top)
-
-                // warm key-light bloom
                 RadialGradient(
-                    colors: [Color(hex: "#FFDCA6").opacity(0.42 * variant.intensity), .clear],
-                    center: UnitPoint(x: 0.7, y: variant.centerY - 0.03),
-                    startRadius: 0, endRadius: max(w, h) * 0.55)
-                    .blendMode(.screen)
+                    colors: [
+                        Color.auroraAccent.opacity(0.15 * variant.intensity),
+                        Color(hex: "#123442").opacity(0.10 * variant.intensity),
+                        .clear,
+                    ],
+                    center: variant.glowCenter,
+                    startRadius: 0,
+                    endRadius: max(w, h) * 0.72
+                )
 
-                ribbons(w: w, h: h)
-                    .blur(radius: 72)
-                    .hueRotation(variant.hue)
-                    .blendMode(.screen)
+                AuroraSignalField(lineHeight: variant.lineHeight)
                     .opacity(variant.intensity)
 
-                // vignette
                 RadialGradient(
-                    colors: [.clear, Color.black.opacity(0.6)],
-                    center: .center, startRadius: h * 0.22, endRadius: h * 0.9)
+                    colors: [.clear, Color.black.opacity(0.72)],
+                    center: variant.glowCenter,
+                    startRadius: h * 0.16,
+                    endRadius: h * 0.92
+                )
 
                 scrimView(w: w, h: h)
 
-                // top scrim keeps the wordmark + step chrome legible over light
                 LinearGradient(
-                    colors: [Color.auroraNightBottom.opacity(0.66), .clear],
+                    colors: [Color.black.opacity(0.54), .clear],
                     startPoint: .top, endPoint: .bottom)
-                    .frame(height: 240)
+                    .frame(height: 220)
                     .frame(maxHeight: .infinity, alignment: .top)
             }
             .frame(width: w, height: h)
@@ -84,48 +74,18 @@ struct AuroraBackdrop: View {
         .ignoresSafeArea()
     }
 
-    // Three soft, wide light bands stacked around the band center, rotated as
-    // one group. Heavy blur (applied by the caller) turns these into flowing
-    // aurora light rather than hard capsules.
-    private func ribbons(w: CGFloat, h: CGFloat) -> some View {
-        let cy = h * variant.centerY
-        return ZStack {
-            ribbon(colors: [Color(hex: "#FFD9A4"), Color(hex: "#FF90A8"), Color(hex: "#C490FF")],
-                   width: w * 1.7, height: 150)
-                .offset(y: 0)
-            ribbon(colors: [Color(hex: "#FFADC6"), Color(hex: "#9B8BFF")],
-                   width: w * 1.7, height: 116)
-                .offset(y: 96)
-            ribbon(colors: [Color(hex: "#C6F0E2"), Color(hex: "#8FE7CF")],
-                   width: w * 1.5, height: 92)
-                .offset(y: -120)
-                .opacity(0.7)
-        }
-        .rotationEffect(.degrees(variant.rotation))
-        .frame(width: w, height: h)
-        .offset(y: cy - h / 2)
-    }
-
-    private func ribbon(colors: [Color], width: CGFloat, height: CGFloat) -> some View {
-        Capsule()
-            .fill(LinearGradient(
-                colors: [.clear] + colors + [.clear],
-                startPoint: .leading, endPoint: .trailing))
-            .frame(width: width, height: height)
-    }
-
     @ViewBuilder
-    private func scrimView(w: CGFloat, h: CGFloat) -> some View {
+    private func scrimView(w _: CGFloat, h: CGFloat) -> some View {
         switch scrim {
         case .left:
             LinearGradient(stops: [
-                .init(color: Color.auroraNightBottom.opacity(0.9), location: 0),
-                .init(color: Color.auroraNightBottom.opacity(0.55), location: 0.3),
+                .init(color: Color.black.opacity(0.94), location: 0),
+                .init(color: Color.black.opacity(0.58), location: 0.34),
                 .init(color: .clear, location: 0.72),
             ], startPoint: .leading, endPoint: .trailing)
         case .soft:
             RadialGradient(
-                colors: [.clear, Color.auroraNightBottom.opacity(0.72)],
+                colors: [.clear, Color.black.opacity(0.76)],
                 center: .center, startRadius: h * 0.18, endRadius: h * 0.95)
         case .none:
             Color.clear
@@ -133,31 +93,38 @@ struct AuroraBackdrop: View {
     }
 }
 
-// MARK: - Starfield
+// MARK: - Signal field
 
-private struct AuroraStarfield: View {
+private struct AuroraSignalField: View {
+    let lineHeight: CGFloat
+
     var body: some View {
         Canvas { ctx, size in
-            var rng = SeededRNG(seed: 9_123_457)
-            for _ in 0..<64 {
-                let x = CGFloat(rng.next()) * size.width
-                let y = CGFloat(rng.next()) * size.height
-                let r = CGFloat(rng.next()) * 1.6 + 0.4
-                let o = rng.next() * 0.5 + 0.12
-                ctx.fill(
-                    Path(ellipseIn: CGRect(x: x, y: y, width: r * 2, height: r * 2)),
-                    with: .color(.white.opacity(o)))
+            let y = size.height * lineHeight
+            var path = Path()
+            path.move(to: CGPoint(x: -size.width * 0.05, y: y + 80))
+            path.addCurve(
+                to: CGPoint(x: size.width * 1.05, y: y - 30),
+                control1: CGPoint(x: size.width * 0.28, y: y - 120),
+                control2: CGPoint(x: size.width * 0.68, y: y + 100)
+            )
+            ctx.stroke(
+                path,
+                with: .linearGradient(
+                    Gradient(colors: [.clear, Color.auroraAccent.opacity(0.18), .clear]),
+                    startPoint: CGPoint(x: 0, y: y),
+                    endPoint: CGPoint(x: size.width, y: y)
+                ),
+                lineWidth: 1
+            )
+
+            for index in 0..<7 {
+                let x = size.width * (0.08 + CGFloat(index) * 0.15)
+                let dotY = y + sin(CGFloat(index) * 1.55) * 28
+                let rect = CGRect(x: x - 2, y: dotY - 2, width: 4, height: 4)
+                ctx.fill(Path(ellipseIn: rect), with: .color(Color.white.opacity(index == 4 ? 0.24 : 0.10)))
             }
         }
         .allowsHitTesting(false)
-    }
-}
-
-private struct SeededRNG {
-    var state: UInt64
-    init(seed: UInt64) { state = seed }
-    mutating func next() -> Double {
-        state = state &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
-        return Double(state >> 11) / Double(1 << 53)
     }
 }

--- a/iosApp/iosApp/DesignSystem/Aurora/AuroraStyle.swift
+++ b/iosApp/iosApp/DesignSystem/Aurora/AuroraStyle.swift
@@ -1,49 +1,121 @@
 import SwiftUI
 
-// MARK: - Aurora palette
+// MARK: - First-run palette
 //
-// The "Aurora" first-run direction: a warm, cinematic skin layered on the
-// existing Skyline tokens. Warm off-white ink instead of pure grey, a single
-// champagne-gold accent, and a deep plum night base behind the aurora
-// backdrop. These live alongside the Continuum palette and skin the first-run
-// flow (server → sign-in → profile) across iOS, tvOS, and macOS.
+// Authentication uses the same OLED-black, monochrome language as the signed-
+// in product. The existing Aurora names are retained to avoid a broad source
+// migration, but the tokens deliberately map onto Silo's core palette.
 
 extension Color {
-    /// Warm off-white primary text (#F3EFE9) — replaces #EDEDED for the Aurora flow.
-    static let auroraInk = Color(hex: "#F3EFE9")
-    /// Champagne-gold accent (#F3D3A0) — eyebrows, hairlines, focus glow, wordmark dot.
-    static let auroraAccent = Color(hex: "#F3D3A0")
-    /// Deep plum night sky, top → bottom.
-    static let auroraNightTop = Color(hex: "#1C1329")
-    static let auroraNightMid = Color(hex: "#0D0A17")
-    static let auroraNightBottom = Color(hex: "#070509")
-    /// Dark glass tint laid over the material blur.
-    static let auroraGlassTint = Color(hex: "#171019")
+    static let auroraInk = Color.continuumOnSurface
+    static let auroraAccent = Color.continuumAccent
+    static let auroraNightTop = Color(hex: "#081117")
+    static let auroraNightMid = Color(hex: "#030608")
+    static let auroraNightBottom = Color.continuumBackground
+    static let auroraGlassTint = Color.continuumSurfaceVariant
 
     static var auroraInkSecondary: Color { auroraInk.opacity(0.62) }
     static var auroraInkTertiary: Color { auroraInk.opacity(0.40) }
 }
 
-// MARK: - Eyebrow (gold hairline + mono caps label)
+// MARK: - Eyebrow
 
 struct AuroraEyebrow: View {
     let text: String
     var centered: Bool = false
 
     var body: some View {
-        HStack(spacing: 16) {
+        HStack(spacing: eyebrowSpacing) {
             Rectangle()
                 .fill(LinearGradient(
                     colors: [Color.auroraAccent, Color.auroraAccent.opacity(0)],
                     startPoint: .leading, endPoint: .trailing))
-                .frame(width: 46, height: 1)
+                .frame(width: lineWidth, height: 1)
             Text(text.uppercased())
-                .font(.system(size: 17, weight: .semibold, design: .monospaced))
-                .tracking(3.5)
+                .font(.system(size: fontSize, weight: .semibold, design: .monospaced))
+                .tracking(tracking)
                 .foregroundStyle(Color.auroraAccent)
         }
         .frame(maxWidth: centered ? .infinity : nil)
+        .accessibilityAddTraits(.isHeader)
     }
+
+    #if os(tvOS)
+    private let fontSize: CGFloat = 15
+    private let tracking: CGFloat = 2.6
+    private let lineWidth: CGFloat = 40
+    private let eyebrowSpacing: CGFloat = 14
+    #else
+    private let fontSize: CGFloat = 11
+    private let tracking: CGFloat = 1.5
+    private let lineWidth: CGFloat = 28
+    private let eyebrowSpacing: CGFloat = 10
+    #endif
+}
+
+// MARK: - Journey progress
+
+/// Keeps the server → account → profile journey visible without turning
+/// first run into a modal wizard. Completed steps use a checkmark so state is
+/// not communicated by color alone.
+struct AuroraJourneyProgress: View {
+    let currentStep: Int
+
+    private let labels = ["Server", "Account", "Profile"]
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 0) {
+            ForEach(Array(labels.enumerated()), id: \.offset) { index, label in
+                let step = index + 1
+
+                if index > 0 {
+                    Rectangle()
+                        .fill(step <= currentStep ? Color.auroraAccent : Color.continuumOutline)
+                        .frame(height: 1)
+                        .padding(.top, progressDotSize / 2)
+                        .accessibilityHidden(true)
+                }
+
+                VStack(spacing: 7) {
+                    ZStack {
+                        Circle()
+                            .fill(step <= currentStep ? Color.auroraAccent : Color.continuumSurfaceElevated)
+                        Circle()
+                            .stroke(step <= currentStep ? Color.auroraAccent : Color.continuumOutline, lineWidth: 1)
+                        if step < currentStep {
+                            Image(systemName: "checkmark")
+                                .font(.system(size: progressGlyphSize, weight: .bold))
+                                .foregroundStyle(Color.continuumBackground)
+                        } else {
+                            Text("\(step)")
+                                .font(.system(size: progressGlyphSize, weight: .bold, design: .monospaced))
+                                .foregroundStyle(step == currentStep ? Color.continuumBackground : Color.auroraInkSecondary)
+                        }
+                    }
+                    .frame(width: progressDotSize, height: progressDotSize)
+
+                    Text(label.uppercased())
+                        .font(.system(size: progressLabelSize, weight: .semibold, design: .monospaced))
+                        .tracking(1.2)
+                        .foregroundStyle(step == currentStep ? Color.auroraInk : Color.auroraInkTertiary)
+                }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("\(label), step \(step) of \(labels.count)")
+                .accessibilityValue(step < currentStep ? "Completed" : step == currentStep ? "Current" : "Not started")
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    #if os(tvOS)
+    private let progressDotSize: CGFloat = 30
+    private let progressGlyphSize: CGFloat = 13
+    private let progressLabelSize: CGFloat = 13
+    #else
+    private let progressDotSize: CGFloat = 24
+    private let progressGlyphSize: CGFloat = 10
+    private let progressLabelSize: CGFloat = 9
+    #endif
 }
 
 // MARK: - Liquid glass panel
@@ -54,39 +126,28 @@ struct AuroraGlassPanel: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .siloGlass(in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous),
-                       tint: Color.auroraGlassTint.opacity(0.5))
+            .siloGlass(in: RoundedRectangle(cornerRadius: cornerRadius),
+                       tint: Color.auroraGlassTint.opacity(0.72))
             .overlay {
-                // gradient hairline border
-                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                RoundedRectangle(cornerRadius: cornerRadius)
                     .strokeBorder(borderGradient, lineWidth: 1)
             }
-            .overlay {
-                // top sheen
-                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                    .fill(RadialGradient(
-                        colors: [.white.opacity(0.10), .clear],
-                        center: .top, startRadius: 0, endRadius: 440))
-                    .blendMode(.plusLighter)
-                    .allowsHitTesting(false)
-            }
             .background {
-                // soft gold halo for the recommended card
                 if emphasized {
-                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                        .fill(Color.auroraAccent.opacity(0.16))
-                        .blur(radius: 26)
-                        .padding(-6)
+                    RoundedRectangle(cornerRadius: cornerRadius)
+                        .fill(Color.auroraAccent.opacity(0.10))
+                        .blur(radius: 34)
+                        .padding(-4)
                 }
             }
-            .shadow(color: .black.opacity(0.75), radius: 60, x: 0, y: 40)
+            .shadow(color: .black.opacity(0.55), radius: 36, x: 0, y: 22)
     }
 
     private var borderGradient: LinearGradient {
         LinearGradient(
             colors: emphasized
-                ? [Color.auroraAccent.opacity(0.6), Color.auroraAccent.opacity(0.16), .white.opacity(0.04)]
-                : [.white.opacity(0.34), .white.opacity(0.06), .white.opacity(0.02)],
+                ? [Color.auroraAccent.opacity(0.42), .white.opacity(0.12), .white.opacity(0.04)]
+                : [.white.opacity(0.22), .white.opacity(0.08), .white.opacity(0.03)],
             startPoint: .top, endPoint: .bottom)
     }
 }
@@ -97,7 +158,7 @@ extension View {
     }
 }
 
-// MARK: - Primary button (warm cream pill + gold focus glow)
+// MARK: - Primary button
 
 struct AuroraPrimaryButtonStyle: ButtonStyle {
     var isLoading: Bool = false
@@ -111,50 +172,58 @@ private struct AuroraPrimaryBody: View {
     let configuration: ButtonStyle.Configuration
     let isLoading: Bool
     @Environment(\.isFocused) private var isFocused
+    @Environment(\.isEnabled) private var isEnabled
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         HStack(spacing: 10) {
             if isLoading {
                 ProgressView()
-                    .tint(Color(hex: "#20160A"))
+                    .tint(Color.continuumBackground)
                     .scaleEffect(0.8)
             }
             configuration.label
         }
-        .font(.system(size: 24, weight: .semibold))
-        .foregroundStyle(Color(hex: "#20160A"))
+        .font(.system(size: buttonFontSize, weight: .semibold))
+        .foregroundStyle(Color.continuumBackground)
         .frame(maxWidth: .infinity)
-        .padding(.vertical, 18)
-        .padding(.horizontal, 30)
+        .frame(minHeight: AuroraControl.height)
+        .padding(.horizontal, buttonHorizontalPadding)
         .background(
-            RoundedRectangle(cornerRadius: AuroraControl.corner, style: .continuous).fill(LinearGradient(
-                colors: [Color(hex: "#FDF7EC"), Color(hex: "#F1E3CD")],
-                startPoint: .top, endPoint: .bottom))
+            RoundedRectangle(cornerRadius: AuroraControl.corner)
+                .fill(Color.continuumOnSurface)
         )
         .overlay(
-            RoundedRectangle(cornerRadius: AuroraControl.corner, style: .continuous)
-                .stroke(.white, lineWidth: isFocused ? 3 : 0)
+            RoundedRectangle(cornerRadius: AuroraControl.corner)
+                .stroke(isFocused ? Color.auroraAccent : .clear, lineWidth: 3)
         )
         .overlay {
             if isFocused {
-                RoundedRectangle(cornerRadius: AuroraControl.corner, style: .continuous)
-                    .stroke(Color.auroraAccent.opacity(0.55), lineWidth: 8)
-                    .padding(-5)
-                    .blur(radius: 8)
+                RoundedRectangle(cornerRadius: AuroraControl.corner)
+                    .stroke(Color.auroraAccent.opacity(0.4), lineWidth: 6)
+                    .padding(-4)
+                    .blur(radius: 6)
             }
         }
-        .scaleEffect(isFocused && !reduceMotion ? 1.05 : 1.0)
+        .scaleEffect(isFocused && !reduceMotion ? 1.035 : 1.0)
         .shadow(
-            color: isFocused ? Color.auroraAccent.opacity(0.5) : .black.opacity(0.45),
-            radius: isFocused ? 26 : 16, y: 8)
-        .opacity(configuration.isPressed ? 0.85 : 1.0)
+            color: isFocused ? Color.auroraAccent.opacity(0.28) : .black.opacity(0.3),
+            radius: isFocused ? 20 : 10, y: 6)
+        .opacity(!isEnabled ? 0.4 : configuration.isPressed ? 0.75 : 1.0)
         .focusEffectDisabled()
         .animation(ContinuumTheme.springAnimation, value: isFocused)
     }
+
+    #if os(tvOS)
+    private let buttonFontSize: CGFloat = 24
+    private let buttonHorizontalPadding: CGFloat = 30
+    #else
+    private let buttonFontSize: CGFloat = 17
+    private let buttonHorizontalPadding: CGFloat = 20
+    #endif
 }
 
-// MARK: - Ghost button (tertiary — "Use a password instead")
+// MARK: - Secondary button
 
 struct AuroraGhostButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
@@ -180,19 +249,19 @@ private struct AuroraGhostBody: View {
     var body: some View {
         configuration.label
             .font(.system(size: fontSize, weight: .medium))
-            .foregroundStyle(isFocused ? Color.auroraNightBottom : Color.auroraInkSecondary)
+            .foregroundStyle(isFocused ? Color.continuumBackground : Color.auroraInkSecondary)
             .padding(.horizontal, hPadding)
             .padding(.vertical, vPadding)
             .background(
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                RoundedRectangle(cornerRadius: AuroraControl.corner)
                     .fill(isFocused ? Color.auroraInk : Color.white.opacity(0.06))
             )
             .overlay(
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                RoundedRectangle(cornerRadius: AuroraControl.corner)
                     .stroke(isFocused ? .white : .white.opacity(0.14),
                             lineWidth: isFocused ? 2 : 1)
             )
-            .scaleEffect(isFocused ? 1.04 : 1.0)
+            .scaleEffect(isFocused ? 1.025 : 1.0)
             .opacity(configuration.isPressed ? 0.7 : 1.0)
             .focusEffectDisabled()
             .animation(ContinuumTheme.springAnimation, value: isFocused)
@@ -211,8 +280,8 @@ struct AuroraStepRow: View {
                 .font(.system(size: 21, weight: .semibold, design: .monospaced))
                 .foregroundStyle(Color.auroraAccent)
                 .frame(width: 46, height: 46)
-                .background(Circle().fill(Color.auroraAccent.opacity(0.16)))
-                .overlay(Circle().stroke(Color.auroraAccent.opacity(0.34), lineWidth: 1))
+                .background(Circle().fill(Color.auroraAccent.opacity(0.12)))
+                .overlay(Circle().stroke(Color.auroraAccent.opacity(0.44), lineWidth: 1))
             Text(text)
                 .font(.system(size: 23, weight: .regular))
                 .foregroundStyle(Color.auroraInkSecondary)
@@ -230,11 +299,14 @@ enum AuroraControl {
     #else
     static let height: CGFloat = 52
     #endif
-    static let corner: CGFloat = 14
-    /// Warm cream fill used when a field/segment is focused.
-    static let activeFill = Color(hex: "#F4EEE2")
-    static let activeInk = Color(hex: "#1A1206")
-    static let activePlaceholder = Color(hex: "#4A4035")
+    #if os(tvOS)
+    static let corner: CGFloat = 12
+    #else
+    static let corner: CGFloat = 10
+    #endif
+    static let activeFill = Color.continuumOnSurface
+    static let activeInk = Color.continuumBackground
+    static let activePlaceholder = Color(hex: "#5E6269")
 }
 
 // MARK: - Aurora segmented option (equal-width, single-line chip)
@@ -246,19 +318,25 @@ struct AuroraSegment: View {
     var height: CGFloat = AuroraControl.height
 
     var body: some View {
-        Text(title)
-            .font(.system(size: 21, weight: .semibold))
+        HStack(spacing: 8) {
+            if isSelected {
+                Image(systemName: "checkmark")
+                    .font(.system(size: segmentCheckSize, weight: .bold))
+            }
+            Text(title)
+        }
+            .font(.system(size: segmentFontSize, weight: .semibold))
             .lineLimit(1)
             .minimumScaleFactor(0.7)
             .foregroundStyle(textColor)
             .frame(maxWidth: .infinity)
             .frame(height: height)
             .background(
-                RoundedRectangle(cornerRadius: AuroraControl.corner, style: .continuous)
+                RoundedRectangle(cornerRadius: AuroraControl.corner)
                     .fill(fill)
             )
             .overlay(
-                RoundedRectangle(cornerRadius: AuroraControl.corner, style: .continuous)
+                RoundedRectangle(cornerRadius: AuroraControl.corner)
                     .stroke(stroke, lineWidth: 1.5)
             )
             .animation(ContinuumTheme.springAnimation, value: isFocused)
@@ -270,10 +348,18 @@ struct AuroraSegment: View {
     }
     private var fill: Color {
         if isFocused { return AuroraControl.activeFill }
-        return isSelected ? Color.auroraAccent.opacity(0.18) : Color.white.opacity(0.06)
+        return isSelected ? Color.auroraAccent.opacity(0.14) : Color.white.opacity(0.06)
     }
     private var stroke: Color {
         if isFocused { return .clear }
-        return isSelected ? Color.auroraAccent.opacity(0.5) : Color.white.opacity(0.14)
+        return isSelected ? Color.auroraAccent.opacity(0.52) : Color.white.opacity(0.14)
     }
+
+    #if os(tvOS)
+    private let segmentFontSize: CGFloat = 21
+    private let segmentCheckSize: CGFloat = 16
+    #else
+    private let segmentFontSize: CGFloat = 15
+    private let segmentCheckSize: CGFloat = 11
+    #endif
 }

--- a/iosApp/iosApp/DesignSystem/Aurora/AuroraStyle.swift
+++ b/iosApp/iosApp/DesignSystem/Aurora/AuroraStyle.swift
@@ -8,7 +8,7 @@ import SwiftUI
 
 extension Color {
     static let auroraInk = Color.continuumOnSurface
-    static let auroraAccent = Color.continuumAccent
+    static let auroraAccent = Color.continuumBrandOrange
     static let auroraNightTop = Color(hex: "#081117")
     static let auroraNightMid = Color(hex: "#030608")
     static let auroraNightBottom = Color.continuumBackground

--- a/iosApp/iosApp/DesignSystem/Aurora/AuroraTextField.swift
+++ b/iosApp/iosApp/DesignSystem/Aurora/AuroraTextField.swift
@@ -9,7 +9,7 @@ import SwiftUI
 enum AuroraFieldContentType { case username, password, email, oneTimeCode, url }
 enum AuroraFieldKeyboard { case `default`, url, email, number }
 
-// MARK: - Field label (mono caps)
+// MARK: - Field label
 
 struct AuroraFieldLabel: View {
     let text: String
@@ -34,18 +34,18 @@ struct AuroraErrorLabel: View {
                 .fixedSize(horizontal: false, vertical: true)
         }
         .font(.continuumCaption)
-        .foregroundStyle(Color.continuumError)
+        .foregroundStyle(Color.requestRose)
         .frame(maxWidth: .infinity, alignment: .leading)
         .transition(.opacity)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Error: \(text)")
     }
 }
 
-// MARK: - Editable Aurora field (iOS/macOS)
+// MARK: - Editable first-run field (iOS/macOS)
 //
-// A real, editable field styled with the Aurora chrome. The placeholder is a
-// controlled overlay so we own its contrast on the plum background; the live
-// `TextField`/`SecureField` carries the caret, selection, and keyboard. When
-// focused it flips to the warm cream fill + gold ring used across the flow.
+// The placeholder is a controlled overlay so its contrast remains predictable;
+// the live `TextField`/`SecureField` owns caret, selection, and keyboard.
 
 struct AuroraTextField<F: Hashable>: View {
     let label: String
@@ -103,16 +103,16 @@ struct AuroraTextField<F: Hashable>: View {
             .padding(.horizontal, 16)
             .frame(height: AuroraControl.height)
             .background(
-                RoundedRectangle(cornerRadius: AuroraControl.corner, style: .continuous)
-                    .fill(isFocused ? AuroraControl.activeFill : Color.white.opacity(0.06))
+                    RoundedRectangle(cornerRadius: AuroraControl.corner)
+                    .fill(isFocused ? AuroraControl.activeFill : Color.continuumSurfaceElevated.opacity(0.82))
             )
             .overlay(
-                RoundedRectangle(cornerRadius: AuroraControl.corner, style: .continuous)
+                RoundedRectangle(cornerRadius: AuroraControl.corner)
                     .stroke(isFocused ? Color.auroraAccent : Color.white.opacity(0.16),
-                            lineWidth: isFocused ? 2 : 1.5)
+                            lineWidth: isFocused ? 2 : 1)
             )
-            .shadow(color: isFocused ? Color.auroraAccent.opacity(0.35) : .clear,
-                    radius: isFocused ? 16 : 0)
+            .shadow(color: isFocused ? Color.auroraAccent.opacity(0.22) : .clear,
+                    radius: isFocused ? 12 : 0)
             .animation(ContinuumTheme.springAnimation, value: isFocused)
         }
     }
@@ -150,7 +150,7 @@ struct AuroraTextField<F: Hashable>: View {
 
 // MARK: - Screen scaffold
 
-/// Aurora backdrop + a vertically scrollable, keyboard-friendly column capped
+/// Silo backdrop + a vertically scrollable, keyboard-friendly column capped
 /// to a comfortable reading width. Callers supply the wordmark + content.
 struct AuroraScreen<Content: View>: View {
     var variant: AuroraVariant

--- a/iosApp/iosApp/Pairing/Companion/CompanionPairingCardModifier.swift
+++ b/iosApp/iosApp/Pairing/Companion/CompanionPairingCardModifier.swift
@@ -11,6 +11,10 @@ struct CompanionPairingCardModifier: ViewModifier {
     /// While false, discovery still runs but the card is withheld — used to
     /// keep the pairing offer from popping over the startup splash animation.
     var enabled: Bool = true
+    /// Discovery can find a TV before this phone finishes signing in. Recheck
+    /// eligibility whenever auth advances so that already-discovered TV is
+    /// offered as soon as the new server token has been persisted.
+    var authState: AppRouter.AuthState
     @State private var browser = TVPairingBrowser()
     @State private var dismissed: Set<String> = []
     @State private var active: DiscoveredTV?
@@ -35,6 +39,12 @@ struct CompanionPairingCardModifier: ViewModifier {
             .onChange(of: enabled) { _, isEnabled in
                 // Splash just finished: offer any TV discovered in the meantime.
                 if isEnabled, let tv = candidate { latch(tv) }
+            }
+            .onChange(of: authState) { _, _ in
+                // The candidate may have been discovered while signed out. Its
+                // Bonjour identity does not change when login succeeds, so the
+                // candidate onChange above will not fire a second time.
+                if let tv = candidate { latch(tv) }
             }
             .onChange(of: active) { old, new in
                 // A card just closed (its TV is now in `dismissed`); offer the
@@ -75,8 +85,11 @@ struct CompanionPairingCardModifier: ViewModifier {
 }
 
 extension View {
-    func companionPairingCard(enabled: Bool = true) -> some View {
-        modifier(CompanionPairingCardModifier(enabled: enabled))
+    func companionPairingCard(
+        enabled: Bool = true,
+        authState: AppRouter.AuthState
+    ) -> some View {
+        modifier(CompanionPairingCardModifier(enabled: enabled, authState: authState))
     }
 }
 #endif

--- a/iosApp/iosApp/Screens/Auth/LoginView.swift
+++ b/iosApp/iosApp/Screens/Auth/LoginView.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 
 #if !os(tvOS)
-/// Password-first sign-in (Aurora). iOS/macOS only — tvOS uses `TVLoginView`,
+/// Password-first sign-in. iOS/macOS only — tvOS uses `TVLoginView`,
 /// which leads with QR device-login. Here the phone *is* the device, so we go
-/// straight to username/password over the plum backdrop.
+/// straight to username/password.
 struct LoginView: View {
     var router: AppRouter
     @State private var viewModel = LoginViewModel()
@@ -13,20 +13,33 @@ struct LoginView: View {
 
     var body: some View {
         AuroraScreen(variant: .signIn, scrim: .soft) {
-            SiloWordmarkView(width: 132)
+            SiloWordmarkView(width: 112)
+                .frame(maxWidth: .infinity)
+                .padding(.bottom, 26)
+
+            AuroraJourneyProgress(currentStep: 2)
+                .frame(maxWidth: 330)
                 .frame(maxWidth: .infinity)
                 .padding(.bottom, 30)
 
-            VStack(spacing: 12) {
-                AuroraEyebrow(text: "Step 02 — Sign in", centered: true)
+            VStack(spacing: 10) {
+                AuroraEyebrow(text: "Account", centered: true)
                 Text("Welcome back")
                     .font(.continuumTitle)
                     .foregroundStyle(Color.auroraInk)
                 if let host = hostLabel {
-                    Text(host)
-                        .font(.system(size: 14, weight: .regular, design: .monospaced))
-                        .foregroundStyle(Color.auroraInkTertiary)
+                    Label(host, systemImage: "server.rack")
+                        .font(.system(size: 13, weight: .regular, design: .monospaced))
+                        .foregroundStyle(Color.auroraInkSecondary)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 7)
+                        .background(Capsule().fill(Color.white.opacity(0.07)))
+                        .overlay(Capsule().stroke(Color.continuumOutline, lineWidth: 1))
                 }
+                Text("Sign in to choose a profile and start watching.")
+                    .font(.continuumBody)
+                    .foregroundStyle(Color.auroraInkSecondary)
+                    .multilineTextAlignment(.center)
             }
             .frame(maxWidth: .infinity)
             .padding(.bottom, 24)
@@ -69,17 +82,16 @@ struct LoginView: View {
                 .disabled(viewModel.isLoading)
                 .padding(.top, 4)
 
-                HStack(spacing: 14) {
-                    if viewModel.signupEnabled {
-                        Button("Create account") { router.navigate(to: .signup) }
-                            .buttonStyle(AuroraGhostButtonStyle())
-                    }
-                    Button("Change server") { router.resetToServerSetup() }
+                if viewModel.signupEnabled {
+                    Button("Create an account") { router.navigate(to: .signup) }
                         .buttonStyle(AuroraGhostButtonStyle())
+                        .frame(maxWidth: .infinity)
                 }
-                .frame(maxWidth: .infinity)
+
+                Button("Use a different server") { router.resetToServerSetup() }
+                    .buttonStyle(AuroraGhostButtonStyle())
+                    .frame(maxWidth: .infinity)
                 .disabled(viewModel.isLoading)
-                .padding(.top, 4)
             }
             .padding(22)
             .auroraGlass(cornerRadius: 24, emphasized: true)

--- a/iosApp/iosApp/Screens/Auth/ServerNeedsSetupView.swift
+++ b/iosApp/iosApp/Screens/Auth/ServerNeedsSetupView.swift
@@ -11,17 +11,24 @@ import AppKit
 /// a retry that re-probes the server.
 struct ServerNeedsSetupView: View {
     var router: AppRouter
+    @Environment(\.openURL) private var openURL
     @State private var isChecking = false
+    @State private var didCopy = false
     @State private var error: String?
 
     var body: some View {
         AuroraScreen(variant: .server, scrim: .soft) {
-            SiloWordmarkView(width: 132)
+            SiloWordmarkView(width: 112)
                 .frame(maxWidth: .infinity)
-                .padding(.bottom, 26)
+                .padding(.bottom, 24)
 
-            AuroraEyebrow(text: "Setup needed", centered: true)
-                .padding(.bottom, 18)
+            AuroraJourneyProgress(currentStep: 1)
+                .frame(maxWidth: 330)
+                .frame(maxWidth: .infinity)
+                .padding(.bottom, 28)
+
+            AuroraEyebrow(text: "Server setup", centered: true)
+                .padding(.bottom, 16)
 
             ZStack {
                 Circle().fill(Color.auroraAccent.opacity(0.14))
@@ -35,11 +42,11 @@ struct ServerNeedsSetupView: View {
             .padding(.bottom, 18)
 
             VStack(spacing: 12) {
-                Text("Finish setup in your browser")
+                Text("Your server needs one last step")
                     .font(.continuumTitle)
                     .foregroundStyle(Color.auroraInk)
                     .multilineTextAlignment(.center)
-                Text("This server doesn't have an account yet. Open it in a browser to create the first one, then come back here to sign in.")
+                Text("Open the server in a browser and create its first account. When you're done, return here and check again.")
                     .font(.continuumBody)
                     .foregroundStyle(Color.auroraInkSecondary)
                     .multilineTextAlignment(.center)
@@ -50,39 +57,46 @@ struct ServerNeedsSetupView: View {
 
             VStack(spacing: 16) {
                 if let setupURL {
-                    HStack(spacing: 10) {
-                        Text(setupURL)
-                            .font(.system(size: 15, weight: .regular, design: .monospaced))
-                            .foregroundStyle(Color.auroraInk)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                        Spacer(minLength: 0)
-                        Image(systemName: "doc.on.doc")
-                            .foregroundStyle(Color.auroraInkTertiary)
+                    Button(action: copyURL) {
+                        HStack(spacing: 10) {
+                            Text(setupURL)
+                                .font(.system(size: 15, weight: .regular, design: .monospaced))
+                                .foregroundStyle(Color.auroraInk)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                            Spacer(minLength: 0)
+                            Label(didCopy ? "Copied" : "Copy", systemImage: didCopy ? "checkmark" : "doc.on.doc")
+                                .font(.continuumCaption)
+                                .foregroundStyle(didCopy ? Color.continuumSuccess : Color.auroraInkSecondary)
+                        }
+                        .padding(.horizontal, 16)
+                        .frame(height: AuroraControl.height)
+                        .background(
+                            RoundedRectangle(cornerRadius: AuroraControl.corner)
+                                .fill(Color.continuumSurfaceElevated.opacity(0.82))
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: AuroraControl.corner)
+                                .stroke(Color.continuumOutline, lineWidth: 1)
+                        )
                     }
-                    .padding(.horizontal, 16)
-                    .frame(height: AuroraControl.height)
-                    .background(
-                        RoundedRectangle(cornerRadius: AuroraControl.corner, style: .continuous)
-                            .fill(Color.white.opacity(0.06))
-                    )
-                    .overlay(
-                        RoundedRectangle(cornerRadius: AuroraControl.corner, style: .continuous)
-                            .stroke(Color.white.opacity(0.16), lineWidth: 1.5)
-                    )
-                    .onTapGesture { copyURL() }
+                    .buttonStyle(.plain)
                 }
 
                 if let error {
                     AuroraErrorLabel(error)
                 }
 
-                Button {
-                    retry()
-                } label: {
-                    Text(isChecking ? "Checking…" : "I've done that — retry")
+                Button(action: openSetup) {
+                    Label("Open in browser", systemImage: "safari")
                 }
-                .buttonStyle(AuroraPrimaryButtonStyle(isLoading: isChecking))
+                .buttonStyle(AuroraPrimaryButtonStyle())
+                .disabled(setupURL == nil)
+
+                Button(action: retry) {
+                    Text(isChecking ? "Checking…" : "Check again")
+                }
+                .buttonStyle(AuroraGhostButtonStyle())
                 .disabled(isChecking)
 
                 Button("Change server") { router.resetToServerSetup() }
@@ -109,6 +123,13 @@ struct ServerNeedsSetupView: View {
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(setupURL, forType: .string)
         #endif
+        didCopy = true
+    }
+
+    private func openSetup() {
+        guard let setupURL,
+              let url = URL(string: setupURL) else { return }
+        openURL(url)
     }
 
     /// Re-probe the current server. If it's now set up, pop back to the login

--- a/iosApp/iosApp/Screens/Auth/ServerSetupView.swift
+++ b/iosApp/iosApp/Screens/Auth/ServerSetupView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
 #if !os(tvOS)
-/// First screen when no server is configured (Aurora). A single centered glass
-/// form over the plum backdrop — no phone-pairing card, because on iPhone the
+/// First screen when no server is configured. A single centered glass form —
+/// no phone-pairing card, because on iPhone the
 /// phone *is* the companion (the pairing card auto-overlays from `ContentView`
 /// when a TV is nearby). Protocol + port stay tucked under "Advanced options".
 struct ServerSetupView: View {
@@ -14,15 +14,26 @@ struct ServerSetupView: View {
 
     var body: some View {
         AuroraScreen(variant: .server, scrim: .soft) {
-            SiloWordmarkView(width: 132)
+            SiloWordmarkView(width: 112)
+                .frame(maxWidth: .infinity)
+                .padding(.bottom, 26)
+
+            AuroraJourneyProgress(currentStep: 1)
+                .frame(maxWidth: 330)
                 .frame(maxWidth: .infinity)
                 .padding(.bottom, 30)
 
-            VStack(spacing: 12) {
-                AuroraEyebrow(text: "Step 01 — Connect", centered: true)
-                Text("Add your server")
+            VStack(spacing: 10) {
+                AuroraEyebrow(text: "Connect", centered: true)
+                Text("Where is your Silo server?")
                     .font(.continuumTitle)
                     .foregroundStyle(Color.auroraInk)
+                    .multilineTextAlignment(.center)
+                Text("Enter the address you use to open Silo in a browser.")
+                    .font(.continuumBody)
+                    .foregroundStyle(Color.auroraInkSecondary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
             }
             .frame(maxWidth: .infinity)
             .padding(.bottom, 24)
@@ -31,7 +42,7 @@ struct ServerSetupView: View {
                 AuroraTextField(
                     label: "Server address",
                     text: $viewModel.host,
-                    placeholder: "media.example.com",
+                    placeholder: "silo.example.com",
                     focus: $focusedField,
                     equals: .host,
                     contentType: .url,
@@ -39,6 +50,10 @@ struct ServerSetupView: View {
                     submitLabel: .go,
                     onSubmit: { connect() }
                 )
+
+                Label("Silo tries secure HTTPS automatically.", systemImage: "lock.shield")
+                    .font(.continuumCaption)
+                    .foregroundStyle(Color.auroraInkSecondary)
 
                 advancedDisclosure
 
@@ -74,7 +89,7 @@ struct ServerSetupView: View {
             }
         } label: {
             HStack(spacing: 7) {
-                Text("Advanced options")
+                Text("Protocol and port")
                 Image(systemName: "chevron.down")
                     .font(.system(size: 13, weight: .semibold))
                     .rotationEffect(.degrees(viewModel.showsAdvancedOptions ? 180 : 0))

--- a/iosApp/iosApp/Screens/Auth/SignupView.swift
+++ b/iosApp/iosApp/Screens/Auth/SignupView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 #if !os(tvOS)
-/// Account registration (Aurora). Shown when signup is enabled on the server.
+/// Account registration. Shown when signup is enabled on the server.
 struct SignupView: View {
     var router: AppRouter
     @State private var viewModel = SignupViewModel()
@@ -11,16 +11,26 @@ struct SignupView: View {
 
     var body: some View {
         AuroraScreen(variant: .signIn, scrim: .soft) {
-            SiloWordmarkView(width: 132)
+            SiloWordmarkView(width: 112)
+                .frame(maxWidth: .infinity)
+                .padding(.bottom, 26)
+
+            AuroraJourneyProgress(currentStep: 2)
+                .frame(maxWidth: 330)
                 .frame(maxWidth: .infinity)
                 .padding(.bottom, 30)
 
-            VStack(spacing: 12) {
-                AuroraEyebrow(text: "Create account", centered: true)
+            VStack(spacing: 10) {
+                AuroraEyebrow(text: "Account", centered: true)
                 Text("Create your account")
                     .font(.continuumTitle)
                     .foregroundStyle(Color.auroraInk)
                     .multilineTextAlignment(.center)
+                Text("Your invite code connects this account to the right Silo household.")
+                    .font(.continuumBody)
+                    .foregroundStyle(Color.auroraInkSecondary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
             }
             .frame(maxWidth: .infinity)
             .padding(.bottom, 24)
@@ -42,6 +52,9 @@ struct SignupView: View {
                     isSecure: true, showsRevealToggle: true,
                     contentType: .password, onSubmit: { focusedField = .confirm }
                 )
+                Text("Use at least 8 characters.")
+                    .font(.continuumCaption)
+                    .foregroundStyle(Color.auroraInkSecondary)
                 AuroraTextField(
                     label: "Confirm password", text: $viewModel.confirmPassword, placeholder: "••••••",
                     focus: $focusedField, equals: .confirm,

--- a/iosApp/iosApp/Screens/Auth/TVLoginView.swift
+++ b/iosApp/iosApp/Screens/Auth/TVLoginView.swift
@@ -2,7 +2,7 @@
 import SwiftUI
 import UIKit
 
-/// Phone-first sign-in for tvOS (Aurora). The screen leads with the QR
+/// Phone-first sign-in for tvOS. The screen leads with the QR
 /// device-login pairing so the viewer never types on the remote: a bold
 /// hero + numbered steps on the left, a glass panel with the live QR and
 /// match code on the right. An on-screen username/password form is one
@@ -20,6 +20,7 @@ struct TVLoginView: View {
 
     private enum Field: Hashable {
         case usePassword
+        case retryPhone
         case changeServer
         case username
         case password
@@ -49,6 +50,8 @@ struct TVLoginView: View {
             if case .approved = newValue {
                 StartupContentPrefetcher.prefetchProfiles()
                 router.showProfileSelection()
+            } else if case .error = newValue {
+                focusedField = .retryPhone
             }
         }
         .onDisappear { qrVM.cancel() }
@@ -61,11 +64,13 @@ struct TVLoginView: View {
         HStack(spacing: 18) {
             SiloWordmarkView(width: 132)
             if let host = hostLabel {
-                Text(host)
+                Label(host, systemImage: "server.rack")
                     .font(.continuumCaption)
-                    .foregroundStyle(Color.auroraInkTertiary)
+                    .foregroundStyle(Color.auroraInkSecondary)
             }
             Spacer(minLength: 0)
+            AuroraJourneyProgress(currentStep: 2)
+                .frame(width: 430)
         }
     }
 
@@ -89,14 +94,14 @@ struct TVLoginView: View {
 
     private var heroColumn: some View {
         VStack(alignment: .leading, spacing: 0) {
-            AuroraEyebrow(text: "Step 02 — Sign in")
-            Text("Sign in with\nyour \(Text("phone").italic()).")
+            AuroraEyebrow(text: "Account")
+            Text("Scan. Confirm.\nStart watching.")
                 .font(.continuumHeroTitle)
                 .foregroundStyle(Color.auroraInk)
                 .multilineTextAlignment(.leading)
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(.top, 24)
-            Text("Point your phone at the code, confirm the number, then approve. Nothing to type on the remote.")
+            Text("Open your phone’s Camera and point it at the code. You won’t need to type a password on your TV.")
                 .font(.continuumBody)
                 .foregroundStyle(Color.auroraInkSecondary)
                 .lineSpacing(4)
@@ -105,9 +110,9 @@ struct TVLoginView: View {
                 .padding(.top, 22)
 
             VStack(alignment: .leading, spacing: 22) {
-                AuroraStepRow(number: 1, text: "Scan with your phone’s camera")
-                AuroraStepRow(number: 2, text: "Confirm the matching number")
-                AuroraStepRow(number: 3, text: "Approve on your phone — you’re in")
+                AuroraStepRow(number: 1, text: "Scan the QR code")
+                AuroraStepRow(number: 2, text: "Confirm the code matches")
+                AuroraStepRow(number: 3, text: "Approve this Apple TV")
             }
             .padding(.top, 42)
 
@@ -135,6 +140,10 @@ struct TVLoginView: View {
 
     private var qrPanel: some View {
         VStack(spacing: 28) {
+            Label("Scan with Camera", systemImage: "camera")
+                .font(.continuumSubheadline)
+                .foregroundStyle(Color.auroraInk)
+
             qrCodeArea
 
             if case .awaiting(let session) = qrVM.state {
@@ -152,13 +161,21 @@ struct TVLoginView: View {
                 .frame(width: 300, height: 1)
 
             VStack(spacing: 14) {
+                if case .error = qrVM.state {
+                    Button(action: restartPhoneSignIn) {
+                        Label("Try again", systemImage: "arrow.clockwise")
+                    }
+                    .buttonStyle(AuroraPrimaryButtonStyle())
+                    .focused($focusedField, equals: .retryPhone)
+                }
+
                 Button {
                     showPasswordForm = true
                     focusedField = .username
                 } label: {
                     HStack(spacing: 12) {
                         Image(systemName: "lock.fill").font(.system(size: 20, weight: .medium))
-                        Text("Use a password instead")
+                        Text("Sign in with a password")
                     }
                 }
                 .buttonStyle(AuroraGhostButtonStyle())
@@ -167,7 +184,7 @@ struct TVLoginView: View {
                 Button {
                     router.resetToServerSetup()
                 } label: {
-                    Text("Change server")
+                    Text("Use another server")
                 }
                 .buttonStyle(AuroraGhostButtonStyle())
                 .focused($focusedField, equals: .changeServer)
@@ -206,7 +223,7 @@ struct TVLoginView: View {
             VStack(spacing: 18) {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .font(.system(size: 40, weight: .semibold))
-                    .foregroundStyle(Color.continuumError)
+                    .foregroundStyle(Color.requestRose)
                 Text("Pairing code unavailable")
                     .font(.continuumSubheadline)
                     .foregroundStyle(Color.auroraInk)
@@ -224,8 +241,8 @@ struct TVLoginView: View {
         content()
             .frame(width: Self.qrSize, height: Self.qrSize)
             .padding(18)
-            .background(RoundedRectangle(cornerRadius: 22, style: .continuous).fill(Color.white))
-            .shadow(color: .black.opacity(0.5), radius: 30, y: 16)
+            .background(RoundedRectangle(cornerRadius: 18).fill(Color.white))
+            .shadow(color: .black.opacity(0.45), radius: 24, y: 14)
     }
 
     private func matchCodeTiles(_ code: String) -> some View {
@@ -252,13 +269,13 @@ struct TVLoginView: View {
                     .frame(width: isSep ? sepWidth : tileWidth, height: tileHeight)
                     .background {
                         if !isSep {
-                            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            RoundedRectangle(cornerRadius: 10)
                                 .fill(Color.white.opacity(0.06))
                         }
                     }
                     .overlay {
                         if !isSep {
-                            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            RoundedRectangle(cornerRadius: 10)
                                 .stroke(Color.white.opacity(0.16), lineWidth: 1)
                         }
                     }
@@ -273,10 +290,15 @@ struct TVLoginView: View {
             topBar
             Spacer(minLength: 28)
             VStack(alignment: .leading, spacing: 24) {
-                AuroraEyebrow(text: "Step 02 — Sign in")
-                Text("Sign in")
+                AuroraEyebrow(text: "Account")
+                Text("Sign in with a password")
                     .font(.continuumTitle)
                     .foregroundStyle(Color.auroraInk)
+                if let host = hostLabel {
+                    Text("Use the account credentials for \(host).")
+                        .font(.continuumBody)
+                        .foregroundStyle(Color.auroraInkSecondary)
+                }
 
                 fieldGroup(label: "Username") {
                     AuroraInputField(
@@ -318,10 +340,10 @@ struct TVLoginView: View {
                 if let error = loginVM.error {
                     HStack(spacing: 10) {
                         Image(systemName: "exclamationmark.circle.fill")
-                            .foregroundStyle(Color.continuumError)
+                            .foregroundStyle(Color.requestRose)
                         Text(error)
                             .font(.continuumCaption)
-                            .foregroundStyle(Color.continuumError)
+                            .foregroundStyle(Color.requestRose)
                     }
                     .transition(.opacity)
                 }
@@ -330,7 +352,7 @@ struct TVLoginView: View {
                     guard !loginVM.isLoading else { return }
                     Task { await loginVM.login(router: router) }
                 } label: {
-                    Text(loginVM.isLoading ? "Signing in…" : "Sign In")
+                    Text(loginVM.isLoading ? "Signing in…" : "Sign in")
                 }
                 .buttonStyle(AuroraPrimaryButtonStyle(isLoading: loginVM.isLoading))
                 .focused($focusedField, equals: .signIn)
@@ -343,7 +365,7 @@ struct TVLoginView: View {
                     } label: {
                         HStack(spacing: 10) {
                             Image(systemName: "qrcode").font(.system(size: 20, weight: .medium))
-                            Text("Back to phone sign-in")
+                            Text("Use phone sign-in")
                         }
                     }
                     .buttonStyle(AuroraGhostButtonStyle())
@@ -352,7 +374,7 @@ struct TVLoginView: View {
                     Button {
                         router.resetToServerSetup()
                     } label: {
-                        Text("Change server")
+                        Text("Use another server")
                     }
                     .buttonStyle(AuroraGhostButtonStyle())
                     .focused($focusedField, equals: .changeServer)
@@ -399,6 +421,13 @@ struct TVLoginView: View {
         let minutes = remaining / 60
         let seconds = remaining % 60
         return String(format: "Waiting for approval · %d:%02d", minutes, seconds)
+    }
+
+    private func restartPhoneSignIn() {
+        qrVM.cancel()
+        Task {
+            await qrVM.begin(deviceName: Self.deviceName, devicePlatform: "tvOS")
+        }
     }
 
     // MARK: - Constants

--- a/iosApp/iosApp/Screens/Auth/TVServerSetupView.swift
+++ b/iosApp/iosApp/Screens/Auth/TVServerSetupView.swift
@@ -1,9 +1,9 @@
 #if os(tvOS)
 import SwiftUI
 
-/// First-run server entry on tvOS (Aurora). The screen advertises on the LAN the
+/// First-run server entry on tvOS. The screen advertises on the LAN the
 /// moment it appears, so a nearby iPhone can set this TV up hands-off. Two paths
-/// sit side by side over the aurora backdrop: a live "Set up with iPhone" status
+/// sit side by side: a live "Set up with iPhone" status
 /// card and a fully functional manual-entry card (the emphasized, default-focused
 /// path). When a phone connects, the same screen swaps *in place* to the pairing
 /// panel — no cover, so nothing ever bleeds through behind it.
@@ -103,10 +103,13 @@ struct TVServerSetupView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
 
             VStack(spacing: 14) {
-                AuroraEyebrow(text: "Step 01 — Connect", centered: true)
-                Text("Add your server")
+                AuroraEyebrow(text: "Connect", centered: true)
+                Text("Connect this Apple TV")
                     .font(.continuumTitle)
                     .foregroundStyle(Color.auroraInk)
+                Text("Use your iPhone, or enter the server address with the remote.")
+                    .font(.continuumCaption)
+                    .foregroundStyle(Color.auroraInkSecondary)
             }
         }
         .frame(maxHeight: .infinity)
@@ -117,6 +120,8 @@ struct TVServerSetupView: View {
         HStack {
             SiloWordmarkView(width: 132)
             Spacer(minLength: 0)
+            AuroraJourneyProgress(currentStep: 1)
+                .frame(width: 430)
         }
     }
 
@@ -129,10 +134,10 @@ struct TVServerSetupView: View {
             SearchingBeacon()
                 .frame(maxWidth: .infinity, alignment: .center)
             Spacer(minLength: 20)
-            Text("Looking for your iPhone…")
+            Text("Looking for an iPhone…")
                 .font(.continuumHeadline)
                 .foregroundStyle(Color.auroraInk)
-            Text("Open Silo on your iPhone on the same Wi-Fi. It’ll offer to set up this Apple TV — the address and your account come across automatically.")
+            Text("Open Silo on an iPhone connected to the same Wi-Fi. Accept the setup card and Silo will securely bring over the server and account.")
                 .font(.continuumBody)
                 .foregroundStyle(Color.auroraInkSecondary)
                 .lineSpacing(4)
@@ -145,7 +150,7 @@ struct TVServerSetupView: View {
     }
 
     private var phoneSetupPill: some View {
-        Text("SET UP WITH IPHONE")
+        Text("RECOMMENDED · USE IPHONE")
             .font(.system(size: 14, weight: .semibold, design: .monospaced))
             .tracking(2)
             .foregroundStyle(Color.auroraInkSecondary)
@@ -178,7 +183,7 @@ struct TVServerSetupView: View {
 
     private var manualCard: some View {
         VStack(alignment: .leading, spacing: 22) {
-            Text("Enter it here")
+            Text("Enter the server address")
                 .font(.continuumHeadline)
                 .foregroundStyle(Color.auroraInk)
 
@@ -186,7 +191,7 @@ struct TVServerSetupView: View {
                 fieldLabel("Server address")
                 AuroraInputField(
                     text: $viewModel.host,
-                    placeholder: "media.example.com",
+                    placeholder: "silo.example.com",
                     focus: $focusedField,
                     equals: .host,
                     contentType: .URL,
@@ -194,13 +199,17 @@ struct TVServerSetupView: View {
                 )
             }
 
+            Label("Secure HTTPS is tried automatically.", systemImage: "lock.shield")
+                .font(.continuumCaption)
+                .foregroundStyle(Color.auroraInkSecondary)
+
             Button {
                 withAnimation(ContinuumTheme.springAnimation) {
                     viewModel.showsAdvancedOptions.toggle()
                 }
             } label: {
                 HStack(spacing: 10) {
-                    Text("Advanced options")
+                    Text("Protocol and port")
                     Image(systemName: "chevron.down")
                         .rotationEffect(.degrees(viewModel.showsAdvancedOptions ? 180 : 0))
                 }
@@ -232,10 +241,10 @@ struct TVServerSetupView: View {
             if let error = viewModel.error {
                 HStack(spacing: 10) {
                     Image(systemName: "exclamationmark.circle.fill")
-                        .foregroundStyle(Color.continuumError)
+                        .foregroundStyle(Color.requestRose)
                     Text(error)
                         .font(.continuumCaption)
-                        .foregroundStyle(Color.continuumError)
+                        .foregroundStyle(Color.requestRose)
                         .fixedSize(horizontal: false, vertical: true)
                 }
                 .transition(.opacity)
@@ -247,7 +256,7 @@ struct TVServerSetupView: View {
                 guard !viewModel.isLoading else { return }
                 Task { await viewModel.connect(router: router) }
             } label: {
-                Text(viewModel.isLoading ? "Connecting…" : "Connect")
+                Text(viewModel.isLoading ? "Connecting…" : "Connect to server")
             }
             .buttonStyle(AuroraPrimaryButtonStyle(isLoading: viewModel.isLoading))
             .focused($focusedField, equals: .connect)

--- a/iosApp/iosApp/Screens/Profiles/ProfileSelectionView.swift
+++ b/iosApp/iosApp/Screens/Profiles/ProfileSelectionView.swift
@@ -170,6 +170,10 @@ struct ProfileSelectionView: View {
 
     private var titleBlock: some View {
         VStack(spacing: 6) {
+            AuroraJourneyProgress(currentStep: 3)
+                .frame(maxWidth: journeyWidth)
+                .padding(.bottom, journeyBottomPadding)
+
             #if os(tvOS)
             Text("Who's watching?")
                 .font(.system(size: titleSize, weight: .semibold))
@@ -346,6 +350,8 @@ struct ProfileSelectionView: View {
     private let subtitleSize: CGFloat = 22
     private let chipSize: CGFloat = 18
     private let headerTopPadding: CGFloat = 100
+    private let journeyWidth: CGFloat = 430
+    private let journeyBottomPadding: CGFloat = 18
     private let tileMinWidth: CGFloat = 300
     private let tileMaxWidth: CGFloat = 340
     private let tileSpacing: CGFloat = 56
@@ -355,6 +361,8 @@ struct ProfileSelectionView: View {
     private let subtitleSize: CGFloat = 15
     private let chipSize: CGFloat = 13
     private let headerTopPadding: CGFloat = 24
+    private let journeyWidth: CGFloat = 330
+    private let journeyBottomPadding: CGFloat = 14
     private let tileMinWidth: CGFloat = 140
     private let tileMaxWidth: CGFloat = 180
     private let tileSpacing: CGFloat = 16

--- a/iosApp/iosApp/Theme/Colors.swift
+++ b/iosApp/iosApp/Theme/Colors.swift
@@ -29,6 +29,10 @@ extension Color {
     /// track; this matches the web client's blue-theme primary.
     static let continuumAccent = Color(hex: "#78AEFC")
 
+    /// Orange sampled from the canonical Silo wordmark artwork. Reserved for
+    /// branded moments so ordinary signed-in controls retain `continuumAccent`.
+    static let continuumBrandOrange = Color(hex: "#FD7403")
+
     /// Muted/secondary text — primary at 60% opacity (#99EDEDED)
     static let continuumSecondaryText = Color(hex: "#99EDEDED")
 

--- a/iosApp/iosApp/tvOS/Aurora/AuroraInputField.swift
+++ b/iosApp/iosApp/tvOS/Aurora/AuroraInputField.swift
@@ -2,12 +2,11 @@
 import SwiftUI
 import UIKit
 
-// MARK: - Aurora text field
+// MARK: - First-run text field
 //
 // A controlled field so we own the placeholder contrast and focus treatment
 // in both states. On tvOS a focused TextField gets a light system platter, so
-// the focused state is deliberately a warm cream fill with dark text + a gold
-// ring (reads as intentional, high contrast) rather than fighting it.
+// the focused state deliberately mirrors that high-contrast treatment.
 
 struct AuroraInputField<F: Hashable>: View {
     @Binding var text: String
@@ -53,16 +52,16 @@ struct AuroraInputField<F: Hashable>: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .frame(height: height)
         .background(
-            RoundedRectangle(cornerRadius: AuroraControl.corner, style: .continuous)
-                .fill(isFocused ? AuroraControl.activeFill : Color.white.opacity(0.06))
+            RoundedRectangle(cornerRadius: AuroraControl.corner)
+                .fill(isFocused ? AuroraControl.activeFill : Color.continuumSurfaceElevated.opacity(0.82))
         )
         .overlay(
-            RoundedRectangle(cornerRadius: AuroraControl.corner, style: .continuous)
+            RoundedRectangle(cornerRadius: AuroraControl.corner)
                 .stroke(isFocused ? Color.auroraAccent : Color.white.opacity(0.16),
-                        lineWidth: isFocused ? 3 : 1.5)
+                        lineWidth: isFocused ? 3 : 1)
         )
-        .shadow(color: isFocused ? Color.auroraAccent.opacity(0.4) : .clear,
-                radius: isFocused ? 20 : 0, y: 0)
+        .shadow(color: isFocused ? Color.auroraAccent.opacity(0.28) : .clear,
+                radius: isFocused ? 16 : 0, y: 0)
         .animation(ContinuumTheme.springAnimation, value: isFocused)
     }
 


### PR DESCRIPTION
## Summary
- Rework the first-run Aurora styling to use a darker monochrome palette with simplified signal-glow visuals
- Add a visible Server / Account / Profile journey indicator and update the login/setup screens to match the new flow
- Recheck companion pairing eligibility when auth state changes so already-discovered TVs surface after sign-in completes

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added step-by-step progress indicators throughout server setup, sign-in, signup, and profile selection.
  * Added clearer server connection guidance, HTTPS messaging, and improved setup actions.
  * Added tvOS QR sign-in recovery with a “Try again” option.
  * Added copy confirmation for server setup addresses.

* **Improvements**
  * Refreshed Aurora/Silo visual styling, colors, gradients, controls, and input fields.
  * Updated authentication and onboarding language for greater clarity.
  * Improved accessibility labels, focus behavior, loading states, and reduced-motion support.

* **Bug Fixes**
  * Companion pairing now refreshes correctly after authentication completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->