### PR TITLE
Refine tvOS startup paint and top menu focus

### DIFF
--- a/iosApp/iosApp/Components/HeroBackdropPalette.swift
+++ b/iosApp/iosApp/Components/HeroBackdropPalette.swift
@@ -19,6 +19,17 @@ enum HeroBackdropPalette {
         .workingColorSpace: NSNull(),
     ])
 
+    /// Sampled tints keyed by backdrop URL. Sampling is deterministic per
+    /// URL, so surfaces seeded on cold entry can read a previously-warmed
+    /// tint synchronously and paint it on their first frame.
+    @MainActor private static var tintCache: [String: Color] = [:]
+
+    /// Synchronous lookup of a previously-sampled tint. `nil` when the
+    /// URL hasn't been sampled this session — fall back to `tintColor(for:)`.
+    @MainActor static func cachedTint(for url: URL) -> Color? {
+        tintCache[url.absoluteString]
+    }
+
     /// Fetch and sample a tint color for the given URL. Returns `nil`
     /// if the image can't be loaded or sampled — callers should fall
     /// back to the app background.
@@ -40,9 +51,13 @@ enum HeroBackdropPalette {
 
         do {
             let image = try await ImagePipeline.shared.image(for: request)
-            return await Task.detached(priority: .utility) {
+            let tint = await Task.detached(priority: .utility) {
                 sampleTint(from: image)
             }.value
+            if let tint {
+                await MainActor.run { tintCache[url.absoluteString] = tint }
+            }
+            return tint
         } catch {
             return nil
         }

--- a/iosApp/iosApp/Components/MediaRow.swift
+++ b/iosApp/iosApp/Components/MediaRow.swift
@@ -33,6 +33,12 @@ struct MediaRow: View {
     /// `.defaultFocus($focusedItemId, firstId, priority: .userInitiated)`;
     /// see CLAUDE.md's "tvOS default focus on d-pad entry" pattern.
     var prefersDefaultFocusOnFirstItem: Bool = false
+    /// Priority for the first-item default focus. `.userInitiated` (the
+    /// default) also snaps d-pad entry into the row onto the first card;
+    /// pass `.automatic` when only the engine's own resolutions (initial
+    /// focus on cold launch) should use the preference, keeping directional
+    /// entry geometric.
+    var defaultFocusPriority: DefaultFocusEvaluationPriority = .userInitiated
     /// Programmatic kick: when this value changes to non-zero, focus
     /// jumps to the first item. Used by callers (e.g. PlayerView) that
     /// shift focus from an unrelated view rather than via d-pad entry —
@@ -220,7 +226,8 @@ struct MediaRow: View {
         .applyDefaultFirstItemFocus(
             enabled: prefersDefaultFocusOnFirstItem,
             binding: $focusedItemId,
-            firstItemId: items.first?.contentId
+            firstItemId: items.first?.contentId,
+            priority: defaultFocusPriority
         )
         // The programmatic focus kick needs the scroll proxy (it scrolls the
         // strip home before claiming), so it hangs off the strip rather than
@@ -371,10 +378,11 @@ private extension View {
     func applyDefaultFirstItemFocus(
         enabled: Bool,
         binding: FocusState<String?>.Binding,
-        firstItemId: String?
+        firstItemId: String?,
+        priority: DefaultFocusEvaluationPriority
     ) -> some View {
         if enabled, let firstItemId {
-            self.defaultFocus(binding, firstItemId, priority: .userInitiated)
+            self.defaultFocus(binding, firstItemId, priority: priority)
         } else {
             self
         }

--- a/iosApp/iosApp/Screens/Home/SectionRow.swift
+++ b/iosApp/iosApp/Screens/Home/SectionRow.swift
@@ -11,6 +11,8 @@ struct SectionRow: View {
     var onRemoveFromContinueWatching: ((SectionItem) -> Void)? = nil
     var onSetWatched: ((SectionItem, Bool) async -> Bool)? = nil
     var prefersDefaultFocusOnFirstItem: Bool = false
+    /// Forwarded to `MediaRow` — see `MediaRow.defaultFocusPriority`.
+    var defaultFocusPriority: DefaultFocusEvaluationPriority = .userInitiated
     /// Programmatic focus kick forwarded to the underlying `MediaRow` — used
     /// when an unrelated view (e.g. the tvOS top menu) hands focus down into
     /// this row rather than the user d-padding into it.
@@ -90,6 +92,7 @@ struct SectionRow: View {
             icon: isContinueWatching ? "play.circle.fill" : nil,
             layout: layout,
             prefersDefaultFocusOnFirstItem: prefersDefaultFocusOnFirstItem,
+            defaultFocusPriority: defaultFocusPriority,
             focusRequest: focusRequest,
             onRemoveFromContinueWatching: isContinueWatching ? onRemoveFromContinueWatching : nil,
             onSetWatched: { item, played in

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPlayerControls.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPlayerControls.swift
@@ -426,7 +426,7 @@ struct TVPlayerControls: View {
             if viewModel.duration > 0 {
                 Text("−\(formatTime(remainingTime))")
                     .font(.system(size: 28, weight: .semibold, design: .rounded))
-                    .foregroundStyle(.white.opacity(0.7))
+                    .foregroundStyle(.white)
                     .monospacedDigit()
             }
         }

--- a/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
+++ b/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
@@ -2,7 +2,14 @@ import Foundation
 
 @MainActor
 enum StartupContentPrefetcher {
+    // tvOS paints a full-width first row plus the focus marquee's logo and
+    // backdrop on entry, so it needs a deeper artwork warmup than the
+    // phone-sized first screen.
+    #if os(tvOS)
+    private static let maxHomeArtworkURLs = 28
+    #else
     private static let maxHomeArtworkURLs = 12
+    #endif
     private static let maxSectionArtworkURLs = 12
     private static let maxBrowseArtworkURLs = 12
     private static let maxProfileArtworkURLs = 8
@@ -302,6 +309,11 @@ enum StartupContentPrefetcher {
         switch state {
         case .authenticated:
             prefetchAuthenticatedContent()
+            // The root top bar renders the active profile's avatar right
+            // after launch. Warm the list here (cold launch only) so it
+            // doesn't fill in late; sign-in / profile-selection flows have
+            // just fetched profiles, so they don't need this.
+            prefetchProfiles()
         case .needsProfile:
             prefetchProfiles()
         case .loading, .needsServerSetup, .needsLogin:

--- a/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
+++ b/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
@@ -402,10 +402,13 @@ enum StartupContentPrefetcher {
         // Warm the marquee's initial tint: tvOS seeds the marquee with the
         // first row's first item on cold entry, and a cached sample lets the
         // tint wash paint on the same frame as the backdrop instead of
-        // fading up from the black background once sampling finishes.
+        // fading up from the black background once sampling finishes. Other
+        // platforms render no marquee, so skip the fetch + sampling there.
+        #if os(tvOS)
         if let firstBackdrop = normalizedURL(from: contentSections.first?.items.first?.backdropUrl) {
             Task { _ = await HeroBackdropPalette.tintColor(for: firstBackdrop) }
         }
+        #endif
     }
 
     private static func prefetchSectionArtwork(for response: SectionsResponse, maxCount: Int) {

--- a/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
+++ b/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
@@ -398,6 +398,14 @@ enum StartupContentPrefetcher {
 
         guard !urls.isEmpty else { return }
         PosterImageCache.prefetcher.startPrefetching(with: urls)
+
+        // Warm the marquee's initial tint: tvOS seeds the marquee with the
+        // first row's first item on cold entry, and a cached sample lets the
+        // tint wash paint on the same frame as the backdrop instead of
+        // fading up from the black background once sampling finishes.
+        if let firstBackdrop = normalizedURL(from: contentSections.first?.items.first?.backdropUrl) {
+            Task { _ = await HeroBackdropPalette.tintColor(for: firstBackdrop) }
+        }
     }
 
     private static func prefetchSectionArtwork(for response: SectionsResponse, maxCount: Int) {

--- a/iosApp/iosApp/tvOS/Caching/CachedAsyncImage.swift
+++ b/iosApp/iosApp/tvOS/Caching/CachedAsyncImage.swift
@@ -30,6 +30,19 @@ struct CachedAsyncImage: View {
                         .aspectRatio(contentMode: contentMode)
                         .frame(width: geometry.size.width, height: geometry.size.height)
                         .clipped()
+                } else if state.error == nil, let warmed = prefetchedImage() {
+                    // The startup/grid prefetchers warm the memory cache under
+                    // the bare-URL key, while the request above is keyed by
+                    // URL + resize processor — a miss for Nuke's synchronous
+                    // first check. Painting the warmed full-size decode here
+                    // makes a prefetched card render finished on its first
+                    // frame; the downsampled result then swaps in with
+                    // identical pixels, so the handoff is invisible.
+                    Image(platformImage: warmed)
+                        .resizable()
+                        .aspectRatio(contentMode: contentMode)
+                        .frame(width: geometry.size.width, height: geometry.size.height)
+                        .clipped()
                 } else if state.error != nil {
                     placeholder(in: geometry.size)
                         .overlay {
@@ -46,6 +59,13 @@ struct CachedAsyncImage: View {
             .transition(.opacity)
             .animation(.easeOut(duration: ContinuumTheme.slowDuration), value: url)
         }
+    }
+
+    /// Synchronous memory-cache lookup for the unprocessed URL the
+    /// prefetchers warm. Cheap dictionary access — safe to call from `body`.
+    private func prefetchedImage() -> PlatformImage? {
+        guard let url = URL(string: url) else { return nil }
+        return ImagePipeline.shared.cache[ImageRequest(url: url)]?.image
     }
 
     // MARK: - Request construction

--- a/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
+++ b/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
@@ -340,6 +340,16 @@ final class TVFocusMarqueeModel {
         guard let urlString, !urlString.isEmpty, let url = URL(string: urlString) else { return }
         guard urlString != lastSampledTintURL else { return }
 
+        // A previously-sampled tint (startup prefetch, earlier focus visit)
+        // applies synchronously, so a cold-entry seed paints the wash on the
+        // same frame as the backdrop.
+        if let cached = HeroBackdropPalette.cachedTint(for: url) {
+            lastSampledTintURL = urlString
+            tintTask?.cancel()
+            tintColor = cached
+            return
+        }
+
         lastSampledTintURL = urlString
         tintTask?.cancel()
         tintTask = Task { [weak self] in

--- a/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
+++ b/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
@@ -278,6 +278,17 @@ final class TVFocusMarqueeModel {
     /// refetches details.
     private var enrichmentCache: [String: TVMarqueeEnrichment] = [:]
 
+    /// Cold-entry seed: display a candidate immediately, skipping the rest
+    /// debounce, so the page's first frame already carries a backdrop
+    /// instead of fading one in after focus settles. Only applies before
+    /// anything has displayed — later calls are no-ops and the focus-driven
+    /// `preview` path stays authoritative.
+    func seed(_ candidate: TVMarqueeContent) {
+        guard content == nil else { return }
+        debounceTask?.cancel()
+        display(candidate)
+    }
+
     /// Report card focus. Cancels any pending swap and schedules a new
     /// one at +150 ms; reporting the already-displayed content is a no-op.
     func preview(_ candidate: TVMarqueeContent) {
@@ -398,6 +409,10 @@ struct TVFocusMarquee: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
+    /// False until the first content has painted — the initial (seeded)
+    /// block snaps in; only content→content swaps crossfade.
+    @State private var hasDisplayedContent = false
+
     var body: some View {
         ZStack(alignment: .bottomLeading) {
             if let content {
@@ -418,9 +433,13 @@ struct TVFocusMarquee: View {
         .focusEffectDisabled()
         // The model swaps `content` outside any animation transaction, so
         // the crossfade is driven here, keyed on the item id (§4.2 240 ms).
-        // Reduce Motion drops the animation entirely → the swap snaps.
+        // Reduce Motion drops the animation entirely → the swap snaps. The
+        // very first content (cold-entry seed) also snaps, so the marquee is
+        // simply there on the page's first frame instead of fading in.
         .animation(
-            reduceMotion ? nil : .easeInOut(duration: ContinuumTheme.Skyline.marqueeCrossfadeDuration),
+            reduceMotion || !hasDisplayedContent
+                ? nil
+                : .easeInOut(duration: ContinuumTheme.Skyline.marqueeCrossfadeDuration),
             value: content?.id
         )
         // The §9 detail line lands after the block; fade it in on its own.
@@ -431,8 +450,12 @@ struct TVFocusMarquee: View {
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityDescription)
         .accessibilityAddTraits(.updatesFrequently)
+        .onAppear {
+            if content != nil { hasDisplayedContent = true }
+        }
         .onChange(of: content) { _, newValue in
             guard let newValue else { return }
+            hasDisplayedContent = true
             announce(newValue)
         }
     }
@@ -478,6 +501,24 @@ private struct TVMarqueeBlock: View {
     @State private var titleWrapsTwoLines = false
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    init(
+        content: TVMarqueeContent,
+        enrichment: TVMarqueeEnrichment? = nil,
+        scale: TVFocusMarquee.Scale
+    ) {
+        self.content = content
+        self.enrichment = enrichment
+        self.scale = scale
+        // A prefetched logo should be on the block's very first frame —
+        // waiting for onAppear paints one frame of text title first, which
+        // reads as a flash on cold entry. Synchronous memory-cache lookup.
+        if let logoUrl = content.logoUrl, !logoUrl.isEmpty,
+           let url = URL(string: logoUrl),
+           let cached = ImagePipeline.shared.cache[ImageRequest(url: url)] {
+            _logoImage = State(initialValue: cached.image)
+        }
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {

--- a/iosApp/iosApp/tvOS/Components/TVRootHeroBackdrop.swift
+++ b/iosApp/iosApp/tvOS/Components/TVRootHeroBackdrop.swift
@@ -76,8 +76,18 @@ struct TVRootHeroBackdrop: View {
             startPoint: .topTrailing,
             endPoint: .bottomLeading
         )
-        .animation(reduceMotion ? nil : .easeInOut(duration: crossfadeDuration), value: tintColor)
-        .animation(reduceMotion ? nil : .easeInOut(duration: 0.24), value: isVisible)
+        // The first tint (cold-entry seed with a prefetch-warmed sample)
+        // snaps in with the artwork; only tint→tint changes crossfade.
+        .animation(
+            reduceMotion || !hasDisplayedArtwork
+                ? nil
+                : .easeInOut(duration: crossfadeDuration),
+            value: tintColor
+        )
+        .animation(
+            reduceMotion || !hasDisplayedArtwork ? nil : .easeInOut(duration: 0.24),
+            value: isVisible
+        )
     }
 
     @ViewBuilder

--- a/iosApp/iosApp/tvOS/Components/TVRootHeroBackdrop.swift
+++ b/iosApp/iosApp/tvOS/Components/TVRootHeroBackdrop.swift
@@ -24,6 +24,11 @@ struct TVRootHeroBackdrop: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
+    /// False until the first artwork has painted. The very first backdrop
+    /// (cold entry, seeded before focus settles) should be there on frame
+    /// one — only artwork→artwork swaps get the ambient crossfade.
+    @State private var hasDisplayedArtwork = false
+
     /// Crisp art occupies the upper-right corner; the corner mask fades it
     /// out toward the leading edge and the bottom into the sampled wash.
     private let artWidthFraction: CGFloat = 0.64
@@ -48,6 +53,12 @@ struct TVRootHeroBackdrop: View {
         }
         .ignoresSafeArea()
         .allowsHitTesting(false)
+        .onAppear {
+            if artworkURL?.isEmpty == false { hasDisplayedArtwork = true }
+        }
+        .onChange(of: artworkURL) { _, url in
+            if url?.isEmpty == false { hasDisplayedArtwork = true }
+        }
     }
 
     /// Sampled-color wash: richest in the top-right behind the art, carried
@@ -96,7 +107,7 @@ struct TVRootHeroBackdrop: View {
                     alignment: .topTrailing
                 )
                 .transition(
-                    reduceMotion
+                    reduceMotion || !hasDisplayedArtwork
                         ? .identity
                         : .opacity.animation(.easeInOut(duration: crossfadeDuration))
                 )

--- a/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
+++ b/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
@@ -73,11 +73,15 @@ struct TVSkylineSectionFeed: View {
             )
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .onAppear { requestEntryFocus(focusRequest) }
+        .onAppear {
+            seedMarqueeFromFirstItem()
+            requestEntryFocus(focusRequest)
+        }
         .onChange(of: focusRequest) { _, request in requestEntryFocus(request) }
         // Rows mount only after the async section load; a deferred entry
         // token re-fires once they exist.
         .onChange(of: sections.map(\.id)) { _, _ in
+            seedMarqueeFromFirstItem()
             if let pending = pendingFocusRequest { requestEntryFocus(pending) }
         }
     }
@@ -135,7 +139,14 @@ struct TVSkylineSectionFeed: View {
             onItemTap: onItemTap,
             onRemoveFromContinueWatching: onRemoveFromContinueWatching,
             onSetWatched: onSetWatched,
-            prefersDefaultFocusOnFirstItem: false,
+            // Cold entry: let the engine's *initial* focus resolution land on
+            // the first card so it renders already focused instead of growing
+            // a few frames after the page paints. `.automatic` keeps d-pad
+            // movement between rows geometric — only system-initiated
+            // resolutions use the preference. The imperative entry token
+            // below is unchanged and covers every other entry path.
+            prefersDefaultFocusOnFirstItem: isFirstRow,
+            defaultFocusPriority: .automatic,
             focusRequest: isFirstRow ? contentFocusToken : 0,
             onMoveUp: isFirstRow ? onTopMenuFocusRequest : nil,
             onItemFocus: { item in
@@ -178,6 +189,19 @@ struct TVSkylineSectionFeed: View {
 
     private func previewFocusedItem(_ item: SectionItem, in section: ResolvedSection) {
         marqueeModel.preview(TVMarqueeContent(item: item, rowTitle: section.title))
+    }
+
+    /// Cold-entry backdrop: the marquee normally waits for the first card's
+    /// focus report plus the 150 ms rest debounce, which paints the hero as
+    /// a fade-in after the page is already visible. Entry focus always lands
+    /// on the first row's first card, so pre-display that item as soon as
+    /// sections exist; if focus somehow lands elsewhere, the focus-driven
+    /// preview corrects within the debounce window.
+    private func seedMarqueeFromFirstItem() {
+        guard marqueeModel.content == nil,
+              let section = sections.first,
+              let item = section.items.first else { return }
+        marqueeModel.seed(TVMarqueeContent(item: item, rowTitle: section.title))
     }
 
 }

--- a/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
@@ -826,11 +826,20 @@ struct TVMainTabView: View {
             return
         }
 
+        // Paint the avatar from the startup prefetch immediately; the fetch
+        // below reconciles (and joins the prefetch's request when it is
+        // still in flight rather than issuing a second one).
+        if currentProfile == nil,
+           let cached: [UserProfile] = ResponseCache.shared.get(CacheKey.profiles) {
+            currentProfile = cached.first(where: { $0.id == profileId })
+        }
+
         do {
-            let profiles = try await AuthService.shared.getProfiles()
+            let profiles = try await StartupContentPrefetcher.fetchProfiles()
             currentProfile = profiles.first(where: { $0.id == profileId })
         } catch {
-            currentProfile = nil
+            // Keep the cached avatar on a transient failure; it already
+            // matches the active profile id.
         }
     }
 

--- a/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
@@ -11,7 +11,15 @@ import SwiftUI
 struct TVMainTabView: View {
     @Bindable var router: AppRouter
     @State private var selectedRoot: TVRootDestination = .home
-    @State private var currentProfile: UserProfile?
+    /// Seeded from the startup prefetch so the bar's first frame already
+    /// shows the active profile's avatar instead of filling it in late.
+    @State private var currentProfile: UserProfile? = {
+        guard let profileId = AuthService.shared.profileId,
+              let cached: [UserProfile] = ResponseCache.shared.get(CacheKey.profiles) else {
+            return nil
+        }
+        return cached.first(where: { $0.id == profileId })
+    }()
     @State private var showServerPicker = false
     @State private var registry = ServerRegistry.shared
     /// Local, per-profile tab-visibility prefs (e.g. whether the Audiobooks
@@ -19,8 +27,12 @@ struct TVMainTabView: View {
     /// instant a toggle flips in Settings.
     @State private var navPrefs = TVNavPreferences.shared
     /// Visible libraries for the active profile; drives which type tabs
-    /// exist and which library each type tab scopes to.
-    @State private var libraries: [Library] = []
+    /// exist and which library each type tab scopes to. Seeded from the
+    /// startup prefetch so all type tabs are in the bar's first frame —
+    /// waiting for `.task` made the library tabs pop in a beat after the
+    /// splash lifted.
+    @State private var libraries: [Library] =
+        ResponseCache.shared.get(CacheKey.userLibraries, as: LibrariesResponse.self)?.libraries ?? []
     /// Per-type pill selection, session-only (§8): it survives tab
     /// switches but cold start always lands on Browse.
     @State private var pillSelections: [TVLibraryTabType: TVLibraryPill] = [:]
@@ -45,6 +57,13 @@ struct TVMainTabView: View {
     @State private var panelReturnFocus: TVTopMenuPanel?
     @State private var isTopMenuFocused = false
     @State private var isTopMenuFocusSuppressed = true
+    /// True while a route pushed *from the bar* (search, profile/For You
+    /// panel items) is on the stack. When the stack pops back to root,
+    /// focus returns to the bar — the explicit "next owner" choice
+    /// (docs/tvos-focus.md); leaving it to the engine landed on an
+    /// arbitrary row card. Card-pushed routes (detail pages) never set
+    /// this, so their pops keep the engine's restore-to-card behavior.
+    @State private var barOwnsFocusOnPopToRoot = false
     @State private var topMenuFocusRequest = 0
     /// Active focus hand-down token. Incremented whenever a root is
     /// selected so the freshly-swapped-in content imperatively claims
@@ -82,7 +101,7 @@ struct TVMainTabView: View {
                     panelHasFocus: panelHasFocus,
                     panelEntersFocus: panelEntersFocus,
                     onSelectRoot: selectRoot(_:),
-                    onSearch: { router.navigate(to: .search) },
+                    onSearch: { navigateFromBar(.search) },
                     onDwell: handleDwell(_:),
                     onEnterPanel: enterPanelFor,
                     onProfilePressed: openProfilePanelImmediately,
@@ -157,6 +176,29 @@ struct TVMainTabView: View {
             async let profileTask: Void = loadCurrentProfile()
             async let librariesTask: Void = loadLibraries()
             _ = await (profileTask, librariesTask)
+        }
+        .onChange(of: router.path.isEmpty) { _, isEmpty in
+            // Returning from a pushed route (Search, detail, settings)
+            // re-mounts the bar with whatever suppression it had when it
+            // unmounted — pushing from the bar leaves it *enabled*, so the
+            // engine's post-pop focus restore can land on the last bar
+            // element (e.g. the search icon) for a frame before the
+            // content-boundary Up handler re-pins the selected tab. Content
+            // owns focus after a pop, so re-assert the suppressed invariant;
+            // Up from content re-arms the bar explicitly as usual.
+            if isEmpty {
+                suppressTopMenuFocusForContentHandoff()
+                if barOwnsFocusOnPopToRoot {
+                    barOwnsFocusOnPopToRoot = false
+                    // Deferred one turn: the bar re-mounts in this same
+                    // transaction, so a synchronous request bump would be
+                    // its *initial* value and onChange(focusRequest) would
+                    // never fire.
+                    DispatchQueue.main.async {
+                        focusTopMenuIfVisible()
+                    }
+                }
+            }
         }
         .onChange(of: navPrefs.showAudiobooks) {
             // Turning a tab off while parked on it would otherwise orphan the
@@ -438,8 +480,8 @@ struct TVMainTabView: View {
             onPanelFocusChanged: { handlePanelFocusChanged($0) },
             onClose: { closePanel() },
             onExitToContent: { exitPanelToContent() },
-            onWatchlist: { closePanel(then: { router.navigate(to: .watchlist) }) },
-            onFavorites: { closePanel(then: { router.navigate(to: .favorites) }) },
+            onWatchlist: { closePanel(then: { navigateFromBar(.watchlist) }) },
+            onFavorites: { closePanel(then: { navigateFromBar(.favorites) }) },
             onRecommendations: { closePanel(then: { selectRoot(.recommendations) }) }
         )
     }
@@ -453,11 +495,11 @@ struct TVMainTabView: View {
             focusEntryToken: panelFocusEntryToken,
             onPanelFocusChanged: { handlePanelFocusChanged($0) },
             onSwitchProfile: { closePanel(then: switchProfile) },
-            onWatchlist: { closePanel(then: { router.navigate(to: .watchlist) }) },
-            onFavorites: { closePanel(then: { router.navigate(to: .favorites) }) },
-            onHistory: { closePanel(then: { router.navigate(to: .history) }) },
-            onRequests: { closePanel(then: { router.navigate(to: .requestsHub) }) },
-            onSettings: { closePanel(then: { router.navigate(to: .settings) }) },
+            onWatchlist: { closePanel(then: { navigateFromBar(.watchlist) }) },
+            onFavorites: { closePanel(then: { navigateFromBar(.favorites) }) },
+            onHistory: { closePanel(then: { navigateFromBar(.history) }) },
+            onRequests: { closePanel(then: { navigateFromBar(.requestsHub) }) },
+            onSettings: { closePanel(then: { navigateFromBar(.settings) }) },
             onSwitchServer: { closePanel(then: { showServerPicker = true }) },
             onSignOut: { closePanel(then: { router.signOutAndReset() }) }
         )
@@ -813,6 +855,15 @@ struct TVMainTabView: View {
     private func suppressTopMenuFocusForContentHandoff() {
         isTopMenuFocused = false
         isTopMenuFocusSuppressed = true
+    }
+
+    /// Push a route on behalf of a bar element (search button, profile /
+    /// For You panel rows). Marks the stack so popping back to root hands
+    /// focus to the bar instead of letting the engine free-resolve into
+    /// the row band.
+    private func navigateFromBar(_ route: Route) {
+        barOwnsFocusOnPopToRoot = true
+        router.navigate(to: route)
     }
 
     private func switchProfile() {

--- a/iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift
@@ -92,8 +92,9 @@ enum TVRootDestination: Hashable {
     }
 }
 
-/// Skyline top bar: wordmark left, type-derived tabs centered, search +
-/// profile avatar right (§5.1). The bar is custom on purpose — the system
+/// Skyline top bar: wordmark left, search + type-derived tabs centered
+/// (search sits just left of Home; the tabs stay screen-centered), profile
+/// avatar right (§5.1). The bar is custom on purpose — the system
 /// `TabView` sidebar steals leftward focus — and draws no background band;
 /// it floats over each page's own scrim and dims to 70% while focus is
 /// down in the content zone.
@@ -293,20 +294,26 @@ struct TVTopMenuBar: View {
 
     private var tabCluster: some View {
         HStack(spacing: ContinuumTheme.Skyline.tabSpacing) {
+            searchButton
+
             ForEach(Array(roots.enumerated()), id: \.element) { index, root in
                 rootButton(root, index: index, count: roots.count)
             }
+
+            // Invisible twin of the search button so the tab group itself
+            // stays centered on screen with search sitting to its left.
+            Color.clear
+                .frame(
+                    width: ContinuumTheme.Skyline.barIconSize,
+                    height: ContinuumTheme.Skyline.barIconSize
+                )
         }
         .frame(maxWidth: .infinity, alignment: .center)
         .frame(height: ContinuumTheme.Skyline.barHeight)
     }
 
     private var trailingCluster: some View {
-        HStack(spacing: ContinuumTheme.Skyline.barTrailingSpacing) {
-            searchButton
-
-            profileButton
-        }
+        profileButton
     }
 
     // MARK: - Tabs


### PR DESCRIPTION
## Summary
- **Player HUD**: remaining-time label now matches the elapsed-time opacity (was dimmed to 70%).
- **Startup paint**: everything visible on Home's first frame after the splash is now preloaded during the splash (non-blocking — the splash never waits on loads):
  - deeper tvOS artwork warmup (28 URLs incl. first row logo + backdrops) and a synchronous warmed-image branch in `CachedAsyncImage` so cards never flash black;
  - marquee seeded from the first row's first item (no focus-wait/debounce on cold entry), logo painted from cache, first backdrop + sampled tint wash snap in on frame one (subsequent swaps keep the §4.2 240 ms crossfade);
  - profiles prefetched on cold launch and `TVMainTabView` seeds `libraries`/`currentProfile` from the prefetch cache, so all type tabs and the avatar are in the bar's first frame instead of popping in late.
- **Nav bar layout**: search icon moved into the centered tab cluster, left of Home, balanced by an invisible trailing twin so the tabs stay screen-centered.
- **Focus ownership on pop** (per docs/tvos-focus.md "choose the next owner explicitly"):
  - popping back to root re-asserts bar suppression, so the engine's focus restore can't flash the last bar element;
  - routes pushed from the bar (Search; Settings/Watchlist/Favorites/History/Requests from the panels) hand focus back to the bar on pop instead of the engine free-resolving onto an arbitrary row card (focus was jumping up 1–2 rows);
  - detail routes pushed from cards are untouched — they still restore focus to the originating card.

## Test plan
- Cold-launch: Home fully painted the frame the splash ends (tabs, avatar, first row art, marquee logo/backdrop/tint), no black image flashes.
- Sweep left from Home → search icon; tab cluster visually centered.
- From a card a few rows down: Back → nav, enter Search, Menu out → focus lands on the Home tab, rows unmoved; same via profile → Settings.
- Open a detail page from a card, Menu out → focus returns to that card.
- Player HUD: elapsed and remaining time render at equal opacity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved tvOS startup performance with faster display of cached artwork, logos, profiles, and libraries.
  * Added smoother initial hero and marquee rendering with reduced first-frame flicker and unnecessary animations.
  * Improved initial focus behavior for the first home row and restored focus when navigating back.
  * Updated the top navigation layout to position Search alongside the main tabs.

* **Bug Fixes**
  * Improved hero tint reuse and artwork prefetching.
  * Remaining player time now displays in fully opaque white for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->