### PR TITLE
Refine tvOS settings, servers, authentication, and content interactions

### DIFF
--- a/iosApp/Tests/PairingCoordinatorTests.swift
+++ b/iosApp/Tests/PairingCoordinatorTests.swift
@@ -109,7 +109,7 @@ private func expectEventually(
 }
 
 private func entry(_ id: String, name: String) -> ServerEntry {
-    ServerEntry(id: id, url: "https://\(id).example", fetchedName: name, userOverrideName: nil, profileId: nil, lastUsedAt: Date())
+    ServerEntry(id: id, url: "https://\(id).example", fetchedName: name, profileId: nil, lastUsedAt: Date())
 }
 
 private let approvedPoll = DeviceLoginPollResponse(
@@ -127,7 +127,7 @@ final class ServerSessionPersistenceTests: XCTestCase {
     /// Companion authorization may install a different user's credentials for
     /// an existing URL. That boundary must not inherit the previous account's
     /// profile, while ordinary metadata upserts continue preserving it.
-    func testNewSessionUpsertClearsExistingProfile() {
+    func testNewSessionUpsertClearsExistingProfileAndRefreshesServerName() {
         let suiteName = "ServerSessionPersistenceTests.suite.\(UUID().uuidString)"
         let standardName = "ServerSessionPersistenceTests.standard.\(UUID().uuidString)"
         let suite = UserDefaults(suiteName: suiteName)!
@@ -146,7 +146,6 @@ final class ServerSessionPersistenceTests: XCTestCase {
             id: serverID,
             url: "https://home.example",
             fetchedName: "Home",
-            userOverrideName: "My Server",
             profileId: "OLD-PROFILE",
             lastUsedAt: Date()
         ))
@@ -155,14 +154,13 @@ final class ServerSessionPersistenceTests: XCTestCase {
             id: serverID,
             url: "https://home.example",
             fetchedName: "Home Renamed",
-            userOverrideName: nil,
             profileId: nil,
             lastUsedAt: Date()
         ), preservingProfile: false)
 
         XCTAssertNil(registry.entry(with: serverID)?.profileId)
-        XCTAssertEqual(registry.entry(with: serverID)?.userOverrideName, "My Server")
         XCTAssertEqual(registry.entry(with: serverID)?.fetchedName, "Home Renamed")
+        XCTAssertEqual(registry.entry(with: serverID)?.displayName, "Home Renamed")
     }
 }
 

--- a/iosApp/iosApp/Components/MediaRow.swift
+++ b/iosApp/iosApp/Components/MediaRow.swift
@@ -270,7 +270,7 @@ struct MediaRow: View {
     }
 
     private func continueWatchingRemovalAction(for item: SectionItem) -> (() -> Void)? {
-        guard item.progressUpdatedAt != nil, let onRemoveFromContinueWatching else { return nil }
+        guard let onRemoveFromContinueWatching else { return nil }
         return { onRemoveFromContinueWatching(item) }
     }
 

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -112,6 +112,19 @@ struct ContentView: View {
                 #endif
             }
         }
+        .task(id: serverRegistry.activeServerId) {
+            // `activeServerId` changes before ServerRegistry finishes its
+            // async token retarget. Complete that boundary here before any
+            // server-scoped overlay request, then clear and rehydrate even
+            // when the destination remains `.authenticated`.
+            await TokenStore.shared.switchActiveServer(
+                serverId: serverRegistry.activeServerId ?? ""
+            )
+            overlayPrefs.clear()
+            if router.authState == .authenticated {
+                await overlayPrefs.hydrateIfNeeded()
+            }
+        }
         .onChange(of: scenePhase) { _, newPhase in
             #if os(iOS)
             switch newPhase {

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ContentView: View {
     @State private var router = AppRouter()
+    @State private var serverRegistry = ServerRegistry.shared
     @State private var audioStore = AudioPlaybackStore()
     #if os(iOS)
     @State private var siloControl = SiloControlClient()
@@ -27,6 +28,10 @@ struct ContentView: View {
 
     var body: some View {
         authContent
+        // A server change is a hard data boundary even when both servers map
+        // to the same auth state. Re-key the routed subtree so profile, home,
+        // library, focus, and modal state cannot survive from the old server.
+        .id(serverRegistry.activeServerId)
         .environment(audioStore)
         #if os(iOS)
         .environment(siloControl)

--- a/iosApp/iosApp/Navigation/AppRouter.swift
+++ b/iosApp/iosApp/Navigation/AppRouter.swift
@@ -244,16 +244,15 @@ class AppRouter {
                 await ServerRegistry.shared.remove(serverId: serverId)
             }
             await MainActor.run {
-                self.path = NavigationPath()
                 let auth = AuthService.shared
                 if !auth.hasServer {
-                    self.authState = .needsServerSetup
+                    self.resetToServerSetup()
                 } else if !auth.isLoggedIn {
-                    self.authState = .needsLogin
+                    self.resetToLogin()
                 } else if !auth.hasProfile {
-                    self.authState = .needsProfile
+                    self.showProfileSelection()
                 } else {
-                    self.authState = .authenticated
+                    self.resetToHome()
                 }
             }
         }

--- a/iosApp/iosApp/Navigation/AppRouter.swift
+++ b/iosApp/iosApp/Navigation/AppRouter.swift
@@ -233,6 +233,32 @@ class AppRouter {
         }
     }
 
+    /// Sign out and forget the active server entirely. If another saved
+    /// server becomes active, re-enter its existing auth state; otherwise
+    /// return to server setup.
+    func signOutRemoveServerAndReset() {
+        Task {
+            let serverId = ServerRegistry.shared.activeServerId
+            await AuthService.shared.signOut()
+            if let serverId {
+                await ServerRegistry.shared.remove(serverId: serverId)
+            }
+            await MainActor.run {
+                self.path = NavigationPath()
+                let auth = AuthService.shared
+                if !auth.hasServer {
+                    self.authState = .needsServerSetup
+                } else if !auth.isLoggedIn {
+                    self.authState = .needsLogin
+                } else if !auth.hasProfile {
+                    self.authState = .needsProfile
+                } else {
+                    self.authState = .authenticated
+                }
+            }
+        }
+    }
+
     /// A refresh failed for the active server. Keep the registry entry,
     /// drop tokens (already done by the refresh path), and route to the
     /// login screen so the user can re-enter credentials. If no server

--- a/iosApp/iosApp/Networking/OverlayPrefsStore.swift
+++ b/iosApp/iosApp/Networking/OverlayPrefsStore.swift
@@ -50,6 +50,9 @@ final class OverlayPrefsStore: ObservableObject {
 
     private var hasHydrated = false
     private var adminDefaultsRaw: String?
+    /// Invalidates an older refresh when the active server changes or a newer
+    /// refresh starts, preventing late responses from repopulating stale prefs.
+    private var refreshGeneration: UInt = 0
 
     /// In-flight write task, if any. While non-nil, additional
     /// `setPrefs(_:)` calls just replace `pendingSnapshot` instead of
@@ -98,20 +101,27 @@ final class OverlayPrefsStore: ObservableObject {
     ///   cards render *something* (registry defaults at worst) rather
     ///   than blocking the UI on the retry.
     func refresh() async {
+        refreshGeneration &+= 1
+        let generation = refreshGeneration
         isLoading = true
         lastError = nil
-        defer { isLoading = false }
+        defer {
+            if generation == refreshGeneration {
+                isLoading = false
+            }
+        }
 
         let api = ContinuumAPI.shared
         var resolvedEnabled = true
         var resolvedAdminDefaults: String?
+        var resolvedError: String?
         var configFetchFailed = false
         do {
             let config = try await api.overlayConfig()
             resolvedEnabled = config.enabled
             resolvedAdminDefaults = config.defaults
         } catch {
-            lastError = (error as? LocalizedError)?.errorDescription
+            resolvedError = (error as? LocalizedError)?.errorDescription
                 ?? String(describing: error)
             configFetchFailed = true
         }
@@ -124,10 +134,13 @@ final class OverlayPrefsStore: ObservableObject {
         } catch HTTPError.http(let code, _) where code == 404 {
             userRaw = nil
         } catch {
-            lastError = (error as? LocalizedError)?.errorDescription
+            resolvedError = (error as? LocalizedError)?.errorDescription
                 ?? String(describing: error)
             userFetchFailed = true
         }
+
+        guard generation == refreshGeneration else { return }
+        lastError = resolvedError
 
         // Preserve cached config state on transient failures. The
         // sentinel `resolvedEnabled = true` is only valid when the
@@ -264,6 +277,10 @@ final class OverlayPrefsStore: ObservableObject {
     /// complete it but the catch block in `flushPendingWrites`
     /// checks `Task.isCancelled` before touching state.
     func clear() {
+        // Let a new server start hydrating immediately while any old network
+        // request winds down; its generation guard prevents stale application.
+        refreshGeneration &+= 1
+        isLoading = false
         pendingWrite?.cancel()
         pendingWrite = nil
         pendingSnapshot = nil

--- a/iosApp/iosApp/Networking/ServerRegistry.swift
+++ b/iosApp/iosApp/Networking/ServerRegistry.swift
@@ -4,8 +4,8 @@ import OSLog
 /// A single Silo server the user has added to the device.
 ///
 /// The registry stores one of these per remembered server. Tokens live in
-/// Keychain keyed by `id`, never in the entry itself. `userOverrideName`
-/// wins over the server-advertised `fetchedName` when both are present.
+/// Keychain keyed by `id`, never in the entry itself. The display name is
+/// always server-administered through the advertised `fetchedName`.
 struct ServerEntry: Codable, Identifiable, Equatable, Hashable {
     /// Stable client-derived ID: base64url of the normalized URL's UTF-8
     /// bytes. Reversible — but the registry treats it as opaque.
@@ -18,9 +18,6 @@ struct ServerEntry: Codable, Identifiable, Equatable, Hashable {
     /// Filled on first successful connect and refreshed opportunistically.
     var fetchedName: String?
 
-    /// User-provided override. Wins over `fetchedName`.
-    var userOverrideName: String?
-
     /// Remembered profile for this server. Set after `selectProfile`.
     var profileId: String?
 
@@ -28,9 +25,8 @@ struct ServerEntry: Codable, Identifiable, Equatable, Hashable {
     /// list; not part of identity.
     var lastUsedAt: Date
 
-    /// Display label for lists/menus. User override → fetched name → URL.
+    /// Display label for lists/menus. Server-advertised name → URL.
     var displayName: String {
-        if let name = userOverrideName, !name.isEmpty { return name }
         if let name = fetchedName, !name.isEmpty { return name }
         return url
     }
@@ -115,19 +111,15 @@ final class ServerRegistry {
 
     // MARK: - Mutations
 
-    /// Insert or update an entry. Preserves existing `profileId` and
-    /// `userOverrideName` if the incoming entry left them nil, so callers
-    /// that only know the URL + fetched name don't clobber remembered
-    /// session state.
+    /// Insert or update an entry. Preserves an existing `profileId` when the
+    /// incoming entry leaves it nil, so callers that only know the URL and
+    /// fetched name do not clobber remembered session state.
     @discardableResult
     func addOrUpdate(_ entry: ServerEntry, preservingProfile: Bool = true) -> ServerEntry {
         var merged = entry
         if let existing = self.entries.first(where: { $0.id == entry.id }) {
             if preservingProfile, merged.profileId == nil {
                 merged.profileId = existing.profileId
-            }
-            if merged.userOverrideName == nil {
-                merged.userOverrideName = existing.userOverrideName
             }
             if merged.fetchedName == nil { merged.fetchedName = existing.fetchedName }
         }
@@ -143,13 +135,6 @@ final class ServerRegistry {
     func setProfileId(_ profileId: String?, for serverId: String) {
         guard let idx = entries.firstIndex(where: { $0.id == serverId }) else { return }
         entries[idx].profileId = profileId
-        persist()
-    }
-
-    func rename(serverId: String, userOverrideName: String?) {
-        guard let idx = entries.firstIndex(where: { $0.id == serverId }) else { return }
-        let trimmed = userOverrideName?.trimmingCharacters(in: .whitespacesAndNewlines)
-        entries[idx].userOverrideName = (trimmed?.isEmpty ?? true) ? nil : trimmed
         persist()
     }
 
@@ -360,7 +345,6 @@ final class ServerRegistry {
             id: id,
             url: normalized,
             fetchedName: nil,
-            userOverrideName: nil,
             profileId: defaults.string(forKey: "profileId"),
             lastUsedAt: Date()
         )

--- a/iosApp/iosApp/Networking/ServerRegistry.swift
+++ b/iosApp/iosApp/Networking/ServerRegistry.swift
@@ -171,7 +171,7 @@ final class ServerRegistry {
         // not be able to land on the new server's token slot. See
         // `HTTPClient.cancelInFlightRequests` for the ordering contract.
         await HTTPClient.shared.cancelInFlightRequests()
-        await StartupContentPrefetcher.resetAllPrefetches()
+        await AuthService.shared.clearCachesForServerChange()
 
         let entry = entries.first(where: { $0.id == serverId })!
         defaults.set(entry.url, forKey: "serverUrl")
@@ -220,9 +220,16 @@ final class ServerRegistry {
     /// next-most-recent server becomes active; if none remain, the active
     /// slot is cleared.
     func remove(serverId: String) async {
+        let removesActiveServer = activeServerId == serverId
+        if removesActiveServer {
+            // Stop old-server responses and clear every process-wide cache
+            // before publishing the fallback ID to observing views.
+            await HTTPClient.shared.cancelInFlightRequests()
+            await AuthService.shared.clearCachesForServerChange()
+        }
         await TokenStore.shared.deleteTokens(for: serverId)
         entries.removeAll(where: { $0.id == serverId })
-        if activeServerId == serverId {
+        if removesActiveServer {
             let fallback = entries.sorted { $0.lastUsedAt > $1.lastUsedAt }.first
             activeServerId = fallback?.id
             if let fallback {

--- a/iosApp/iosApp/Networking/ServerRegistry.swift
+++ b/iosApp/iosApp/Networking/ServerRegistry.swift
@@ -121,7 +121,9 @@ final class ServerRegistry {
             if preservingProfile, merged.profileId == nil {
                 merged.profileId = existing.profileId
             }
-            if merged.fetchedName == nil { merged.fetchedName = existing.fetchedName }
+            if merged.fetchedName == nil || merged.fetchedName?.isEmpty == true {
+                merged.fetchedName = existing.fetchedName
+            }
         }
         if let idx = self.entries.firstIndex(where: { $0.id == entry.id }) {
             self.entries[idx] = merged

--- a/iosApp/iosApp/Pairing/Receiver/ReceiverPairingCoordinator.swift
+++ b/iosApp/iosApp/Pairing/Receiver/ReceiverPairingCoordinator.swift
@@ -292,7 +292,7 @@ final class ReceiverPairingCoordinator {
     /// Commit the now-trusted server + tokens. Runs only after a successful poll.
     static func persistServer(url: String, fetchedName: String?, access: String, refresh: String) async {
         let id = ServerRegistry.serverId(for: url)
-        let entry = ServerEntry(id: id, url: url, fetchedName: fetchedName, userOverrideName: nil, profileId: nil, lastUsedAt: Date())
+        let entry = ServerEntry(id: id, url: url, fetchedName: fetchedName, profileId: nil, lastUsedAt: Date())
         // Device authorization can replace the account for an already-saved
         // server URL. Preserve its name, but never carry the previous account's
         // profile selection across that credential boundary.

--- a/iosApp/iosApp/Screens/Auth/AuthService.swift
+++ b/iosApp/iosApp/Screens/Auth/AuthService.swift
@@ -287,4 +287,12 @@ final class AuthService: @unchecked Sendable {
     func clearCachesForTemporaryIdentityChange() {
         clearAllCaches()
     }
+
+    /// A server switch is the same hard identity boundary as sign-out for
+    /// process-wide response and prefetch caches, even when both servers are
+    /// already authenticated and the router's auth state does not change.
+    @MainActor
+    func clearCachesForServerChange() {
+        clearAllCaches()
+    }
 }

--- a/iosApp/iosApp/Screens/Auth/AuthService.swift
+++ b/iosApp/iosApp/Screens/Auth/AuthService.swift
@@ -100,7 +100,6 @@ final class AuthService: @unchecked Sendable {
             id: id,
             url: normalized,
             fetchedName: fetchedName,
-            userOverrideName: nil,
             profileId: nil,
             lastUsedAt: Date()
         )

--- a/iosApp/iosApp/Screens/Auth/TVLoginView.swift
+++ b/iosApp/iosApp/Screens/Auth/TVLoginView.swift
@@ -304,6 +304,7 @@ struct TVLoginView: View {
                     AuroraInputField(
                         text: $loginVM.username,
                         placeholder: "yourname",
+                        inputTitle: "Username",
                         focus: $focusedField,
                         equals: .username,
                         contentType: .username
@@ -317,6 +318,7 @@ struct TVLoginView: View {
                         AuroraInputField(
                             text: $loginVM.password,
                             placeholder: "••••••",
+                            inputTitle: "Password",
                             focus: $focusedField,
                             equals: .password,
                             isSecure: !showPassword,

--- a/iosApp/iosApp/Screens/Auth/TVLoginView.swift
+++ b/iosApp/iosApp/Screens/Auth/TVLoginView.swift
@@ -310,7 +310,8 @@ struct TVLoginView: View {
                         contentType: .username
                     )
                     // Advance to the password field once the username is entered.
-                    .onSubmit { focusedField = .password }
+                    .submitLabel(.next)
+                    .onSubmit { moveFocusAfterTextEntry(to: .password) }
                 }
 
                 fieldGroup(label: "Password") {
@@ -325,7 +326,8 @@ struct TVLoginView: View {
                             contentType: .password
                         )
                         // Hand focus to the Sign In button once the password is entered.
-                        .onSubmit { focusedField = .signIn }
+                        .submitLabel(.done)
+                        .onSubmit { moveFocusAfterTextEntry(to: .signIn) }
 
                         Button {
                             showPassword.toggle()
@@ -335,6 +337,7 @@ struct TVLoginView: View {
                         }
                         .buttonStyle(TVAuthIconButtonStyle())
                         .focused($focusedField, equals: .togglePassword)
+                        .disabled(!canFocusPasswordToggle)
                         .accessibilityLabel(showPassword ? "Hide password" : "Show password")
                     }
                 }
@@ -429,6 +432,17 @@ struct TVLoginView: View {
         qrVM.cancel()
         Task {
             await qrVM.begin(deviceName: Self.deviceName, devicePlatform: "tvOS")
+        }
+    }
+
+    private var canFocusPasswordToggle: Bool {
+        focusedField == .password || focusedField == .togglePassword
+    }
+
+    private func moveFocusAfterTextEntry(to field: Field) {
+        Task { @MainActor in
+            await Task.yield()
+            focusedField = field
         }
     }
 

--- a/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
@@ -372,6 +372,9 @@ class ItemDetailViewModel {
     func setEpisodeWatched(contentId: String, played: Bool) async -> Bool {
         do {
             try await ContinuumAPI.shared.setWatched(contentId: contentId, played: played)
+            if contentId == detail?.contentId {
+                isWatched = played
+            }
             invalidateRelatedCaches(contentId: contentId)
             if let seriesId = seriesContentId, let seasonNumber = selectedSeason?.seasonNumber {
                 await loadEpisodes(seriesId: seriesId, seasonNumber: seasonNumber)

--- a/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
@@ -18,6 +18,11 @@ class ItemDetailViewModel {
     var episodeFavoriteStates: [String: Bool] = [:]
     var isLoadingEpisodes = false
 
+    /// Protects local context-menu updates from older favorite lookups that
+    /// finish after the user has already changed an episode's state.
+    private var episodeFavoriteMutationVersions: [String: Int] = [:]
+    private var episodeFavoriteRefreshGeneration = 0
+
     // User actions
     var isFavorite = false
     var inWatchlist = false
@@ -263,7 +268,11 @@ class ItemDetailViewModel {
         await loadEpisodes(seriesId: seriesId, seasonNumber: season.seasonNumber)
     }
 
-    func loadEpisodes(seriesId: String, seasonNumber: Int) async {
+    func loadEpisodes(
+        seriesId: String,
+        seasonNumber: Int,
+        refreshFavoriteStates: Bool = true
+    ) async {
         let key = CacheKey.itemEpisodes(seriesId: seriesId, seasonNumber: seasonNumber)
         // Hydrate from cache so the rail paints immediately, then
         // refresh silently in the background.
@@ -285,34 +294,57 @@ class ItemDetailViewModel {
             // we hydrated from cache.
         }
         isLoadingEpisodes = false
-        if detail?.type == "episode" {
+        if refreshFavoriteStates {
             await refreshEpisodeFavoriteStates(for: episodes)
-        } else {
-            episodeFavoriteStates = [:]
         }
     }
 
-    private func refreshEpisodeFavoriteStates(for episodes: [EpisodeListItem]) async {
-        let states = await withTaskGroup(of: (String, Bool).self) { group in
-            for episode in episodes {
-                group.addTask {
-                    let isFavorite = (try? await ContinuumAPI.shared.isFavorite(
-                        contentId: episode.contentId
-                    )) ?? false
-                    return (episode.contentId, isFavorite)
-                }
-            }
+    private func refreshEpisodeFavoriteStates(
+        for episodes: [EpisodeListItem],
+        maxConcurrent: Int = 6
+    ) async {
+        episodeFavoriteRefreshGeneration += 1
+        let generation = episodeFavoriteRefreshGeneration
+        let mutationVersionsAtStart = episodeFavoriteMutationVersions
+        var states: [String: Bool] = [:]
 
-            var states: [String: Bool] = [:]
-            for await (contentId, isFavorite) in group {
-                states[contentId] = isFavorite
+        // Query in small batches so a long season cannot fan out an
+        // unbounded number of requests against the server.
+        for batchStart in stride(from: 0, to: episodes.count, by: maxConcurrent) {
+            let batchEnd = min(batchStart + maxConcurrent, episodes.count)
+            let batch = Array(episodes[batchStart..<batchEnd])
+            let batchStates = await withTaskGroup(of: (String, Bool?).self) { group in
+                for episode in batch {
+                    group.addTask {
+                        let isFavorite = try? await ContinuumAPI.shared.isFavorite(
+                            contentId: episode.contentId
+                        )
+                        return (episode.contentId, isFavorite)
+                    }
+                }
+
+                var results: [String: Bool] = [:]
+                for await (contentId, isFavorite) in group {
+                    if let isFavorite {
+                        results[contentId] = isFavorite
+                    }
+                }
+                return results
             }
-            return states
+            states.merge(batchStates) { _, refreshed in refreshed }
         }
 
         let currentIds = Set(self.episodes.map(\.contentId))
-        guard currentIds == Set(episodes.map(\.contentId)) else { return }
-        episodeFavoriteStates = states
+        guard generation == episodeFavoriteRefreshGeneration,
+              currentIds == Set(episodes.map(\.contentId)) else { return }
+
+        var mergedStates = episodeFavoriteStates.filter { currentIds.contains($0.key) }
+        for (contentId, isFavorite) in states {
+            guard episodeFavoriteMutationVersions[contentId]
+                    == mutationVersionsAtStart[contentId] else { continue }
+            mergedStates[contentId] = isFavorite
+        }
+        episodeFavoriteStates = mergedStates
     }
 
     // MARK: - User Actions
@@ -377,7 +409,11 @@ class ItemDetailViewModel {
             }
             invalidateRelatedCaches(contentId: contentId)
             if let seriesId = seriesContentId, let seasonNumber = selectedSeason?.seasonNumber {
-                await loadEpisodes(seriesId: seriesId, seasonNumber: seasonNumber)
+                await loadEpisodes(
+                    seriesId: seriesId,
+                    seasonNumber: seasonNumber,
+                    refreshFavoriteStates: false
+                )
             }
             return true
         } catch {
@@ -392,6 +428,7 @@ class ItemDetailViewModel {
                 self.isFavorite = isFavorite
                 writeBackUserState(contentId: contentId)
             }
+            episodeFavoriteMutationVersions[contentId, default: 0] += 1
             episodeFavoriteStates[contentId] = isFavorite
             invalidateRelatedCaches(contentId: contentId)
             return true

--- a/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
@@ -15,6 +15,7 @@ class ItemDetailViewModel {
     var seasons: [Season] = []
     var selectedSeason: Season?
     var episodes: [EpisodeListItem] = []
+    var episodeFavoriteStates: [String: Bool] = [:]
     var isLoadingEpisodes = false
 
     // User actions
@@ -284,6 +285,34 @@ class ItemDetailViewModel {
             // we hydrated from cache.
         }
         isLoadingEpisodes = false
+        if detail?.type == "episode" {
+            await refreshEpisodeFavoriteStates(for: episodes)
+        } else {
+            episodeFavoriteStates = [:]
+        }
+    }
+
+    private func refreshEpisodeFavoriteStates(for episodes: [EpisodeListItem]) async {
+        let states = await withTaskGroup(of: (String, Bool).self) { group in
+            for episode in episodes {
+                group.addTask {
+                    let isFavorite = (try? await ContinuumAPI.shared.isFavorite(
+                        contentId: episode.contentId
+                    )) ?? false
+                    return (episode.contentId, isFavorite)
+                }
+            }
+
+            var states: [String: Bool] = [:]
+            for await (contentId, isFavorite) in group {
+                states[contentId] = isFavorite
+            }
+            return states
+        }
+
+        let currentIds = Set(self.episodes.map(\.contentId))
+        guard currentIds == Set(episodes.map(\.contentId)) else { return }
+        episodeFavoriteStates = states
     }
 
     // MARK: - User Actions
@@ -337,6 +366,34 @@ class ItemDetailViewModel {
             invalidateRelatedCaches(contentId: contentId)
         } catch {
             isWatched.toggle() // Revert on failure
+        }
+    }
+
+    func setEpisodeWatched(contentId: String, played: Bool) async -> Bool {
+        do {
+            try await ContinuumAPI.shared.setWatched(contentId: contentId, played: played)
+            invalidateRelatedCaches(contentId: contentId)
+            if let seriesId = seriesContentId, let seasonNumber = selectedSeason?.seasonNumber {
+                await loadEpisodes(seriesId: seriesId, seasonNumber: seasonNumber)
+            }
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    func setEpisodeFavorite(contentId: String, isFavorite: Bool) async -> Bool {
+        do {
+            try await ContinuumAPI.shared.toggleFavorite(contentId: contentId, isFavorite: isFavorite)
+            if contentId == detail?.contentId {
+                self.isFavorite = isFavorite
+                writeBackUserState(contentId: contentId)
+            }
+            episodeFavoriteStates[contentId] = isFavorite
+            invalidateRelatedCaches(contentId: contentId)
+            return true
+        } catch {
+            return false
         }
     }
 

--- a/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
@@ -431,6 +431,11 @@ class ItemDetailViewModel {
             if contentId == detail?.contentId {
                 self.isFavorite = isFavorite
                 writeBackUserState(contentId: contentId)
+            } else {
+                // The sibling's cached watchlist value is not loaded here, so
+                // discard its combined user-state entry rather than pairing
+                // the new favorite value with unrelated detail-item state.
+                ResponseCache.shared.remove(CacheKey.itemUserState(contentId))
             }
             episodeFavoriteMutationVersions[contentId, default: 0] += 1
             episodeFavoriteStates[contentId] = isFavorite

--- a/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
@@ -407,7 +407,11 @@ class ItemDetailViewModel {
             if contentId == detail?.contentId {
                 isWatched = played
             }
-            invalidateRelatedCaches(contentId: contentId)
+            invalidateRelatedCaches(
+                contentId: contentId,
+                seriesId: seriesContentId,
+                seasonNumber: selectedSeason?.seasonNumber
+            )
             if let seriesId = seriesContentId, let seasonNumber = selectedSeason?.seasonNumber {
                 await loadEpisodes(
                     seriesId: seriesId,
@@ -449,12 +453,16 @@ class ItemDetailViewModel {
     /// watched). Drops the cached payloads so the next visit fetches
     /// fresh — painted content keeps showing in the meantime via the
     /// existing `detail` binding.
-    private func invalidateRelatedCaches(contentId: String) {
+    private func invalidateRelatedCaches(
+        contentId: String,
+        seriesId: String? = nil,
+        seasonNumber: Int? = nil
+    ) {
         ResponseCache.shared.remove(CacheKey.itemDetail(contentId))
-        if let seriesId = detail?.seriesId {
+        if let seriesId = seriesId ?? detail?.seriesId {
             ResponseCache.shared.remove(CacheKey.itemDetail(seriesId))
             ResponseCache.shared.remove(CacheKey.itemSeasons(seriesId))
-            if let seasonNumber = detail?.seasonNumber {
+            if let seasonNumber = seasonNumber ?? detail?.seasonNumber {
                 ResponseCache.shared.remove(
                     CacheKey.itemEpisodes(seriesId: seriesId, seasonNumber: seasonNumber)
                 )

--- a/iosApp/iosApp/Screens/Home/HomeViewModel.swift
+++ b/iosApp/iosApp/Screens/Home/HomeViewModel.swift
@@ -95,13 +95,14 @@ class HomeViewModel {
     }
 
     func dismissContinueWatchingItem(_ item: SectionItem) async {
-        guard let progressUpdatedAt = item.progressUpdatedAt,
-              pendingContinueWatchingDismissals.insert(item.contentId).inserted else {
+        guard pendingContinueWatchingDismissals.insert(item.contentId).inserted else {
             return
         }
         defer { pendingContinueWatchingDismissals.remove(item.contentId) }
 
         actionError = nil
+        let progressUpdatedAt = item.progressUpdatedAt
+            ?? ISO8601DateFormatter().string(from: Date())
 
         do {
             try await dismissContinueWatching(item.contentId, progressUpdatedAt)

--- a/iosApp/iosApp/Screens/People/PersonDetailView.swift
+++ b/iosApp/iosApp/Screens/People/PersonDetailView.swift
@@ -36,6 +36,7 @@ final class PersonDetailViewModel {
     var error: ErrorState?
     var hasMore = true
     var selectedFilter: PersonMediaFilter = .all
+    var availableFilters = PersonMediaFilter.allCases
     var totalItems: Int?
     var isRefreshingMetadata = false
 
@@ -102,7 +103,9 @@ final class PersonDetailViewModel {
                 person = try await ContinuumAPI.shared.person(id: personId)
             }
             scheduleMetadataRefreshIfNeeded(for: person)
+            async let availability: Void = refreshAvailableFilters(generation: currentGeneration)
             await fetchPage(reset: true, generation: currentGeneration)
+            await availability
         } catch {
             guard currentGeneration == generation else { return }
             self.error = ErrorState(error)
@@ -240,6 +243,34 @@ final class PersonDetailViewModel {
         } catch {
             guard currentGeneration == generation else { return }
             self.error = ErrorState(error)
+        }
+    }
+
+    private func refreshAvailableFilters(generation currentGeneration: Int) async {
+        async let movies = catalogHasItems(type: "movie")
+        async let series = catalogHasItems(type: "series")
+        let results = await (movies, series)
+        guard currentGeneration == generation else { return }
+
+        var filters: [PersonMediaFilter] = [.all]
+        if results.0 != false { filters.append(.movies) }
+        if results.1 != false { filters.append(.series) }
+        availableFilters = filters
+    }
+
+    /// `nil` means the availability check failed. In that case the filter
+    /// remains visible rather than hiding content based on a network error.
+    private func catalogHasItems(type: String) async -> Bool? {
+        do {
+            let response = try await ContinuumAPI.shared.personCatalogItems(
+                personId: personId,
+                type: type,
+                offset: 0,
+                limit: 1
+            )
+            return !response.items.isEmpty || (response.total ?? 0) > 0
+        } catch {
+            return nil
         }
     }
 
@@ -421,7 +452,7 @@ private struct TVPersonDetailContent: View {
                 Spacer()
             }
 
-            PersonFilterBar(selected: viewModel.selectedFilter) { filter in
+            PersonFilterBar(filters: viewModel.availableFilters, selected: viewModel.selectedFilter) { filter in
                 Task { await viewModel.applyFilter(filter) }
             }
         }
@@ -551,7 +582,7 @@ private struct PhonePersonDetailContent: View {
             }
             .padding(.horizontal, ContinuumTheme.padding)
 
-            PersonFilterBar(selected: viewModel.selectedFilter) { filter in
+            PersonFilterBar(filters: viewModel.availableFilters, selected: viewModel.selectedFilter) { filter in
                 Task { await viewModel.applyFilter(filter) }
             }
             .padding(.horizontal, ContinuumTheme.padding)
@@ -638,13 +669,14 @@ private struct PersonMetadataRefreshIndicator: View {
 }
 
 private struct PersonFilterBar: View {
+    let filters: [PersonMediaFilter]
     let selected: PersonMediaFilter
     let onSelect: (PersonMediaFilter) -> Void
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 8) {
-                ForEach(PersonMediaFilter.allCases) { filter in
+                ForEach(filters) { filter in
                     PersonFilterButton(
                         title: filter.title,
                         isSelected: filter == selected,

--- a/iosApp/iosApp/Screens/Player/PlayerSettings.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerSettings.swift
@@ -121,6 +121,18 @@ final class PlayerSettings {
         }
     }
 
+    /// Server/profile fallback used while this device's custom appearance
+    /// override is off. Kept separate so refreshing the effective value does
+    /// not destroy the user's locally cached custom style.
+    private var inheritedSubtitleAppearance: SubtitleAppearance {
+        didSet {
+            defaults.set(
+                inheritedSubtitleAppearance.sanitized().jsonString,
+                forKey: Self.cacheKey(Keys.inheritedSubtitleAppearance)
+            )
+        }
+    }
+
     var subtitleUsesDeviceAppearanceOverride: Bool {
         didSet {
             defaults.set(
@@ -149,7 +161,10 @@ final class PlayerSettings {
 
     /// The appearance the player should actually render with.
     var effectiveSubtitleAppearance: SubtitleAppearance {
-        subtitleMatchesSystemAppearance ? subtitleSystemAppearance : subtitleAppearance
+        if subtitleMatchesSystemAppearance { return subtitleSystemAppearance }
+        return subtitleUsesDeviceAppearanceOverride
+            ? subtitleAppearance
+            : inheritedSubtitleAppearance
     }
 
     var subtitleFontSize: Double {
@@ -225,6 +240,7 @@ final class PlayerSettings {
             Keys.dvProfile7HDR10Fallback: false,
             Keys.seekCacheEnabled: true,
             Keys.subtitleAppearance: SubtitleAppearance.default.jsonString,
+            Keys.inheritedSubtitleAppearance: SubtitleAppearance.default.jsonString,
             Keys.subtitleUsesDeviceAppearanceOverride: false,
             Keys.subtitleMatchesSystemAppearance: false,
             Keys.subtitleFontSize: 44.0,
@@ -262,6 +278,9 @@ final class PlayerSettings {
             defaultValue: true
         )
         subtitleAppearance = SubtitleAppearance.decode(from: defaults.string(forKey: Self.cacheKey(Keys.subtitleAppearance)))
+        inheritedSubtitleAppearance = SubtitleAppearance.decode(
+            from: defaults.string(forKey: Self.cacheKey(Keys.inheritedSubtitleAppearance))
+        )
         subtitleUsesDeviceAppearanceOverride = Self.cachedBool(
             defaults,
             key: Keys.subtitleUsesDeviceAppearanceOverride,
@@ -570,10 +589,15 @@ final class PlayerSettings {
 
         if let entry = effectiveByKey[PlayerDeviceSettingKey.subtitleAppearance.rawValue] {
             subtitleUsesDeviceAppearanceOverride = entry.hasDeviceOverride
-            subtitleAppearance = SubtitleAppearance.decode(from: entry.effectiveValue)
+            let effectiveAppearance = SubtitleAppearance.decode(from: entry.effectiveValue)
+            if entry.hasDeviceOverride {
+                subtitleAppearance = effectiveAppearance
+            } else {
+                inheritedSubtitleAppearance = effectiveAppearance
+            }
         } else {
             subtitleUsesDeviceAppearanceOverride = false
-            subtitleAppearance = .default
+            inheritedSubtitleAppearance = .default
         }
     }
 
@@ -670,6 +694,9 @@ final class PlayerSettings {
             defaultValue: false
         )
         subtitleAppearance = SubtitleAppearance.decode(from: defaults.string(forKey: Self.cacheKey(Keys.subtitleAppearance)))
+        inheritedSubtitleAppearance = SubtitleAppearance.decode(
+            from: defaults.string(forKey: Self.cacheKey(Keys.inheritedSubtitleAppearance))
+        )
     }
 
     @MainActor
@@ -857,6 +884,7 @@ final class PlayerSettings {
         static let dvProfile7HDR10Fallback = "player.dvProfile7HDR10Fallback"
         static let seekCacheEnabled = "player.seekCacheEnabled"
         static let subtitleAppearance = "player.subtitleAppearance"
+        static let inheritedSubtitleAppearance = "player.inheritedSubtitleAppearance"
         static let subtitleUsesDeviceAppearanceOverride = "player.subtitleUsesDeviceAppearanceOverride"
         static let subtitleMatchesSystemAppearance = "player.subtitleMatchesSystemAppearance"
         static let subtitleFontSize = "player.subtitleFontSize"

--- a/iosApp/iosApp/Screens/Profiles/PINEntryView.swift
+++ b/iosApp/iosApp/Screens/Profiles/PINEntryView.swift
@@ -8,7 +8,7 @@ struct PINEntryView: View {
 
     @State private var pin: String = ""
     @State private var isShaking: Bool = false
-    @Namespace private var padNamespace
+    @FocusState private var focusedPadKey: String?
     @Environment(\.dismiss) private var dismiss
 
     private let maxDigits = 4
@@ -81,7 +81,14 @@ struct PINEntryView: View {
             .shadow(color: .black.opacity(0.45), radius: 36, y: 18)
             .focusSection()
         }
-        .onExitCommand(perform: cancel)
+        .onExitCommand(perform: handleExit)
+        .task {
+            // The profile grid is disabled in the same update that inserts
+            // this overlay. Wait for it to relinquish focus, then hand the
+            // single native keypad graph to its center key.
+            await Task.yield()
+            focusedPadKey = "5"
+        }
     }
     #endif
 
@@ -123,8 +130,8 @@ struct PINEntryView: View {
             ForEach(1...9, id: \.self) { digit in
                 NumberPadButton(
                     label: "\(digit)",
-                    prefersDefaultFocus: digit == 1,
-                    defaultFocusNamespace: padNamespace
+                    focus: $focusedPadKey,
+                    focusValue: "\(digit)"
                 ) {
                     appendDigit("\(digit)")
                 }
@@ -132,19 +139,25 @@ struct PINEntryView: View {
 
             Color.clear.frame(height: NumberPadButton.size)
 
-            NumberPadButton(label: "0") {
+            NumberPadButton(
+                label: "0",
+                focus: $focusedPadKey,
+                focusValue: "0"
+            ) {
                 appendDigit("0")
             }
 
-            NumberPadButton(label: "delete.backward", isSystemImage: true) {
+            NumberPadButton(
+                label: "delete.backward",
+                isSystemImage: true,
+                focus: $focusedPadKey,
+                focusValue: "delete"
+            ) {
                 deleteDigit()
             }
         }
         #if os(tvOS)
         .frame(width: 360)
-        // Seed first focus on the "1" key so the pad opens ready for input
-        // rather than letting the engine pick a key geometrically.
-        .focusScope(padNamespace)
         #endif
     }
 
@@ -158,6 +171,14 @@ struct PINEntryView: View {
             onCancel()
         } else {
             dismiss()
+        }
+    }
+
+    private func handleExit() {
+        if pin.isEmpty {
+            cancel()
+        } else {
+            deleteDigit()
         }
     }
 
@@ -190,8 +211,8 @@ struct PINEntryView: View {
 private struct NumberPadButton: View {
     let label: String
     var isSystemImage: Bool = false
-    var prefersDefaultFocus: Bool = false
-    var defaultFocusNamespace: Namespace.ID? = nil
+    var focus: FocusState<String?>.Binding? = nil
+    var focusValue: String? = nil
     let action: () -> Void
     static var size: CGFloat {
         #if os(tvOS)
@@ -201,7 +222,17 @@ private struct NumberPadButton: View {
         #endif
     }
 
+    @ViewBuilder
     var body: some View {
+        if let focus, let focusValue {
+            button
+                .focused(focus, equals: focusValue)
+        } else {
+            button
+        }
+    }
+
+    private var button: some View {
         Button(action: action) {
             if isSystemImage {
                 Image(systemName: label)
@@ -211,11 +242,12 @@ private struct NumberPadButton: View {
                     .font(.continuumPIN)
             }
         }
-        .buttonStyle(NumberPadButtonStyle())
-        #if os(tvOS)
-        // Lets a single key (the "1") claim initial focus on the PIN pad.
-        .applyDefaultFocusIfNeeded(prefersDefaultFocus, namespace: defaultFocusNamespace)
-        #endif
+        .buttonStyle(NumberPadButtonStyle(isFocused: isFocused))
+    }
+
+    private var isFocused: Bool {
+        guard let focusValue else { return false }
+        return focus?.wrappedValue == focusValue
     }
 
     private var symbolSize: CGFloat {
@@ -228,14 +260,16 @@ private struct NumberPadButton: View {
 }
 
 private struct NumberPadButtonStyle: ButtonStyle {
+    let isFocused: Bool
+
     func makeBody(configuration: Configuration) -> some View {
-        NumberPadButtonBody(configuration: configuration)
+        NumberPadButtonBody(configuration: configuration, isFocused: isFocused)
     }
 }
 
 private struct NumberPadButtonBody: View {
     let configuration: ButtonStyle.Configuration
-    @Environment(\.isFocused) private var isFocused
+    let isFocused: Bool
 
     var body: some View {
         configuration.label

--- a/iosApp/iosApp/Screens/Profiles/ProfileSelectionView.swift
+++ b/iosApp/iosApp/Screens/Profiles/ProfileSelectionView.swift
@@ -9,7 +9,11 @@ struct ProfileSelectionView: View {
     @State private var viewModel = ProfileSelectionViewModel()
     @State private var pinEntryContext: PINEntryContext?
     @State private var showCreateProfile: Bool = false
+    @State private var showSignOutConfirm: Bool = false
     @Namespace private var profileFocusNamespace
+    #if os(tvOS)
+    @FocusState private var isSignOutFocused: Bool
+    #endif
 
     private enum PINEntryPurpose: String {
         case profileSelection
@@ -35,8 +39,8 @@ struct ProfileSelectionView: View {
 
             pickerContent
                 #if os(tvOS)
-                .disabled(isPINEntryPresented)
-                .accessibilityHidden(isPINEntryPresented)
+                .disabled(isPINEntryPresented || showSignOutConfirm)
+                .accessibilityHidden(isPINEntryPresented || showSignOutConfirm)
                 #endif
         }
         .task {
@@ -44,7 +48,7 @@ struct ProfileSelectionView: View {
         }
         #if os(tvOS)
         .overlay {
-            pinEntryOverlay
+            profileOverlay
         }
         #endif
         #if os(tvOS)
@@ -206,7 +210,11 @@ struct ProfileSelectionView: View {
     /// for the identity moment.
     private var signOutChip: some View {
         Button {
+            #if os(tvOS)
+            showSignOutConfirm = true
+            #else
             router.signOutAndReset()
+            #endif
         } label: {
             HStack(spacing: 6) {
                 Text("Sign Out")
@@ -216,6 +224,9 @@ struct ProfileSelectionView: View {
             }
         }
         .buttonStyle(GhostChipButtonStyle())
+        #if os(tvOS)
+        .focused($isSignOutFocused)
+        #endif
     }
 
     /// Companion to `signOutChip`. Routes to the server picker so the
@@ -305,14 +316,36 @@ struct ProfileSelectionView: View {
         Task { await viewModel.clearTemporaryManagementContextIfNeeded() }
     }
 
+    #if os(tvOS)
     @ViewBuilder
-    private var pinEntryOverlay: some View {
-        if let context = pinEntryContext {
+    private var profileOverlay: some View {
+        if showSignOutConfirm {
+            TVSettingsConfirmationOverlay(
+                title: "Sign Out",
+                message: "Choose whether to keep or remove this server from this Apple TV.",
+                confirmTitle: "Sign Out",
+                additionalDestructiveTitle: "Sign Out & Remove Server",
+                cancel: dismissSignOutConfirmation,
+                confirm: router.signOutAndReset,
+                additionalDestructiveAction: router.signOutRemoveServerAndReset
+            )
+            .transition(.opacity)
+            .zIndex(10)
+        } else if let context = pinEntryContext {
             pinEntryContent(for: context)
                 .transition(.opacity.combined(with: .scale(scale: 0.96)))
                 .zIndex(10)
         }
     }
+
+    private func dismissSignOutConfirmation() {
+        showSignOutConfirm = false
+        Task { @MainActor in
+            await Task.yield()
+            isSignOutFocused = true
+        }
+    }
+    #endif
 
     private func pinEntryContent(for context: PINEntryContext) -> some View {
         PINEntryView(

--- a/iosApp/iosApp/Screens/Servers/ServerListView.swift
+++ b/iosApp/iosApp/Screens/Servers/ServerListView.swift
@@ -3,8 +3,8 @@ import SwiftUI
 /// Picker + management UI for the set of saved Silo servers.
 ///
 /// Shared between iOS and tvOS with minor platform-specific tweaks:
-/// - iOS: Navigation `List` with swipe-to-delete and long-press rename.
-/// - tvOS: focus-aware tile row; rename via an on-screen alert.
+/// - iOS: Navigation `List` with swipe-to-delete.
+/// - tvOS: focusable read-only server summary with a separate remove action.
 ///
 /// Switching a server asks the `AppRouter` to re-evaluate auth state so
 /// the user lands on login or profile-select for the new server (or on
@@ -12,8 +12,6 @@ import SwiftUI
 struct ServerListView: View {
     @Environment(AppRouter.self) private var router
     @State private var registry = ServerRegistry.shared
-    @State private var renameTarget: ServerEntry?
-    @State private var renameInput: String = ""
     @State private var removeTarget: ServerEntry?
     #if os(tvOS)
     @FocusState private var focusedRow: TVRow?
@@ -21,57 +19,30 @@ struct ServerListView: View {
 
     var body: some View {
         #if os(tvOS)
-        tvOSContent
-            .continuumBackground()
-            .fullScreenCover(item: $renameTarget) { entry in
-                TVServerRenameSheet(entry: entry)
+        ZStack {
+            tvOSContent
+                .disabled(removeTarget != nil)
+
+            if let entry = removeTarget {
+                TVSettingsConfirmationOverlay(
+                    title: "Remove this server?",
+                    message: "Sign-in credentials for \(entry.displayName) will be forgotten on this device.",
+                    confirmTitle: "Remove",
+                    cancel: { dismissRemoveConfirmation(for: entry) },
+                    confirm: { remove(entry) }
+                )
+                .transition(.opacity.combined(with: .scale(scale: 0.96)))
+                .zIndex(1)
             }
-            .alert(
-                "Remove this server?",
-                isPresented: Binding(
-                    get: { removeTarget != nil },
-                    set: { if !$0 { removeTarget = nil } }
-                ),
-                presenting: removeTarget
-            ) { entry in
-                Button("Remove", role: .destructive) {
-                    remove(entry)
-                }
-                Button("Cancel", role: .cancel) { removeTarget = nil }
-            } message: { entry in
-                Text("Sign-in credentials for \(entry.displayName) will be forgotten on this device.")
-            }
+        }
+        .continuumBackground()
+        .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: removeTarget)
         #else
         contentList
             .navigationTitle("Servers")
             .continuumNavigationTitleDisplayMode(.inline)
             .continuumBackground()
             .continuumScrollContentBackgroundHidden()
-            .alert(
-                "Rename server",
-                isPresented: Binding(
-                    get: { renameTarget != nil },
-                    set: { if !$0 { renameTarget = nil } }
-                ),
-                presenting: renameTarget
-            ) { entry in
-                #if !os(tvOS)
-                TextField("Name", text: $renameInput)
-                #endif
-                Button("Save") {
-                    registry.rename(serverId: entry.id, userOverrideName: renameInput)
-                    renameTarget = nil
-                }
-                if entry.userOverrideName != nil {
-                    Button("Reset to server-provided name", role: .destructive) {
-                        registry.rename(serverId: entry.id, userOverrideName: nil)
-                        renameTarget = nil
-                    }
-                }
-                Button("Cancel", role: .cancel) { renameTarget = nil }
-            } message: { _ in
-                Text("Override the server-provided name with a label just for this device.")
-            }
             .alert(
                 "Remove this server?",
                 isPresented: Binding(
@@ -114,7 +85,7 @@ struct ServerListView: View {
                     Text("Manage Servers")
                         .font(.system(size: 38, weight: .semibold))
                         .foregroundColor(.continuumOnSurface)
-                    Text("Switch between saved Silo servers or add another connection.")
+                    Text("Manage saved Silo servers or add another connection.")
                         .font(.system(size: 20))
                         .foregroundColor(.continuumSecondaryText)
                 }
@@ -151,7 +122,7 @@ struct ServerListView: View {
                 .buttonStyle(TVSettingsPaneRowStyle())
                 .focused($focusedRow, equals: .add)
 
-                TVSettingsFooter("Press and hold a saved server to rename or remove it. Selecting the active server refreshes its sign-in state.")
+                TVSettingsFooter("Select the trash icon to remove a saved server.")
             }
             .frame(maxWidth: 1080, alignment: .leading)
             .padding(.bottom, 64)
@@ -167,54 +138,43 @@ struct ServerListView: View {
     }
 
     private func tvOSRow(for entry: ServerEntry) -> some View {
-        Button {
-            switchTo(entry)
-        } label: {
-            HStack(spacing: 18) {
-                Image(systemName: entry.id == registry.activeServerId
-                      ? "checkmark.circle.fill"
-                      : "server.rack")
-                    .font(.system(size: 24, weight: .medium))
-                    .frame(width: 34)
-
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(entry.displayName)
-                        .font(.system(size: 26, weight: .medium))
-                        .lineLimit(1)
-                    Text(entry.url)
-                        .font(.system(size: 19))
-                        .opacity(0.62)
-                        .lineLimit(1)
-                }
-
-                Spacer(minLength: 16)
-
-                if entry.id == registry.activeServerId {
-                    Text("Active")
-                        .font(.system(size: 19, weight: .semibold))
-                        .opacity(0.72)
-                }
+        HStack(spacing: 12) {
+            Button(action: {}) {
+                TVServerSummaryLabel(
+                    entry: entry,
+                    isActive: entry.id == registry.activeServerId
+                )
             }
-        }
-        .buttonStyle(TVSettingsPaneRowStyle())
-        .focused($focusedRow, equals: .server(entry.id))
-        .contextMenu {
+            .buttonStyle(TVSettingsPaneRowStyle())
+            .focused($focusedRow, equals: .server(entry.id))
+            .accessibilityHint("Server names are managed by the server administrator")
+
             Button {
-                renameTarget = entry
-            } label: {
-                Label("Rename", systemImage: "pencil")
-            }
-            Button(role: .destructive) {
                 removeTarget = entry
             } label: {
-                Label("Remove Server", systemImage: "trash")
+                Image(systemName: "trash")
+                    .font(.system(size: 24, weight: .semibold))
+                    .frame(maxWidth: .infinity, minHeight: 49)
             }
+            .buttonStyle(TVSettingsPaneRowStyle(isDestructive: true))
+            .frame(width: 92)
+            .focused($focusedRow, equals: .remove(entry.id))
+            .accessibilityLabel("Remove \(entry.displayName)")
         }
     }
 
     private enum TVRow: Hashable {
         case server(String)
+        case remove(String)
         case add
+    }
+
+    private func dismissRemoveConfirmation(for entry: ServerEntry) {
+        removeTarget = nil
+        Task { @MainActor in
+            await Task.yield()
+            focusedRow = .remove(entry.id)
+        }
     }
     #endif
 
@@ -271,19 +231,6 @@ struct ServerListView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .contextMenu {
-            Button {
-                renameInput = entry.userOverrideName ?? entry.fetchedName ?? ""
-                renameTarget = entry
-            } label: {
-                Label("Rename", systemImage: "pencil")
-            }
-            Button(role: .destructive) {
-                removeTarget = entry
-            } label: {
-                Label("Remove Server", systemImage: "trash")
-            }
-        }
         #if !os(tvOS)
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
             Button(role: .destructive) {
@@ -291,13 +238,6 @@ struct ServerListView: View {
             } label: {
                 Label("Remove", systemImage: "trash")
             }
-            Button {
-                renameInput = entry.userOverrideName ?? entry.fetchedName ?? ""
-                renameTarget = entry
-            } label: {
-                Label("Rename", systemImage: "pencil")
-            }
-            .tint(.continuumOnSurface)
         }
         #endif
     }
@@ -344,65 +284,37 @@ struct ServerListView: View {
 }
 
 #if os(tvOS)
-private struct TVServerRenameSheet: View {
+private struct TVServerSummaryLabel: View {
     let entry: ServerEntry
-
-    @Environment(\.dismiss) private var dismiss
-    @State private var name: String
-    @FocusState private var focusedField: Field?
-
-    init(entry: ServerEntry) {
-        self.entry = entry
-        _name = State(initialValue: entry.userOverrideName ?? entry.fetchedName ?? "")
-    }
+    let isActive: Bool
 
     var body: some View {
-        NavigationStack {
-            VStack(alignment: .leading, spacing: 28) {
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("SERVER")
-                        .font(.system(size: 15, weight: .semibold, design: .monospaced))
-                        .tracking(2)
-                        .foregroundColor(.continuumSecondaryText)
-                    Text("Rename Server")
-                        .font(.system(size: 42, weight: .semibold))
-                        .foregroundColor(.continuumOnSurface)
-                    Text("Override the server-provided name with a label just for this Apple TV.")
-                        .font(.system(size: 21))
-                        .foregroundColor(.continuumSecondaryText)
-                }
+        HStack(spacing: 18) {
+            Image(systemName: isActive ? "checkmark.circle.fill" : "server.rack")
+                .font(.system(size: 24, weight: .medium))
+                .frame(width: 34)
 
-                TextField("Server Name", text: $name)
-                    .textContentType(.name)
-                    .font(.system(size: 26))
-                    .focused($focusedField, equals: .name)
-
-                HStack(spacing: 18) {
-                    Button("Cancel") { dismiss() }
-                    Button("Save") {
-                        ServerRegistry.shared.rename(serverId: entry.id, userOverrideName: name)
-                        dismiss()
-                    }
-                    .disabled(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-
-                    if entry.userOverrideName != nil {
-                        Button("Use Server Name", role: .destructive) {
-                            ServerRegistry.shared.rename(serverId: entry.id, userOverrideName: nil)
-                            dismiss()
-                        }
-                    }
-                }
+            VStack(alignment: .leading, spacing: 4) {
+                Text(entry.displayName)
+                    .font(.system(size: 26, weight: .medium))
+                    .lineLimit(1)
+                Text(entry.url)
+                    .font(.system(size: 19))
+                    .opacity(0.62)
+                    .lineLimit(1)
             }
-            .frame(maxWidth: 900, maxHeight: .infinity, alignment: .center)
-            .padding(.horizontal, 80)
-            .background(Color.continuumBackground.ignoresSafeArea())
-            .defaultFocus($focusedField, .name)
-            .onExitCommand { dismiss() }
-        }
-    }
 
-    private enum Field: Hashable {
-        case name
+            Spacer(minLength: 16)
+
+            if isActive {
+                Text("Active")
+                    .font(.system(size: 19, weight: .semibold))
+                    .opacity(0.72)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
+        .accessibilityValue(isActive ? "Active" : "Saved")
     }
 }
 #endif

--- a/iosApp/iosApp/Screens/Servers/ServerListView.swift
+++ b/iosApp/iosApp/Screens/Servers/ServerListView.swift
@@ -127,7 +127,10 @@ struct ServerListView: View {
 
     private func tvOSRow(for entry: ServerEntry) -> some View {
         HStack(spacing: 12) {
-            Button(action: {}) {
+            Button {
+                guard entry.id != registry.activeServerId else { return }
+                switchTo(entry)
+            } label: {
                 TVServerSummaryLabel(
                     entry: entry,
                     isActive: entry.id == registry.activeServerId
@@ -135,7 +138,11 @@ struct ServerListView: View {
             }
             .buttonStyle(TVSettingsPaneRowStyle())
             .focused($focusedRow, equals: .server(entry.id))
-            .accessibilityHint("Server names are managed by the server administrator")
+            .accessibilityHint(
+                entry.id == registry.activeServerId
+                    ? "Current server. Server names are managed by the server administrator"
+                    : "Switch to this server. Server names are managed by the server administrator"
+            )
 
             Button {
                 removeTarget = entry

--- a/iosApp/iosApp/Screens/Servers/ServerListView.swift
+++ b/iosApp/iosApp/Screens/Servers/ServerListView.swift
@@ -52,19 +52,7 @@ struct ServerListView: View {
                 presenting: removeTarget
             ) { entry in
                 Button("Remove", role: .destructive) {
-                    let wasActive = entry.id == registry.activeServerId
-                    Task {
-                        await registry.remove(serverId: entry.id)
-                        await MainActor.run {
-                            removeTarget = nil
-                            // Removing the active server leaves the app
-                            // pointed at a fallback (or none). Re-enter
-                            // the auth state machine so the user lands
-                            // in the right place instead of on a stale
-                            // main-app screen.
-                            if wasActive { refreshAuthState() }
-                        }
-                    }
+                    remove(entry)
                 }
                 Button("Cancel", role: .cancel) { removeTarget = nil }
             } message: { entry in

--- a/iosApp/iosApp/Screens/Servers/ServerListView.swift
+++ b/iosApp/iosApp/Screens/Servers/ServerListView.swift
@@ -15,13 +15,36 @@ struct ServerListView: View {
     @State private var renameTarget: ServerEntry?
     @State private var renameInput: String = ""
     @State private var removeTarget: ServerEntry?
+    #if os(tvOS)
+    @FocusState private var focusedRow: TVRow?
+    #endif
 
     var body: some View {
+        #if os(tvOS)
+        tvOSContent
+            .continuumBackground()
+            .fullScreenCover(item: $renameTarget) { entry in
+                TVServerRenameSheet(entry: entry)
+            }
+            .alert(
+                "Remove this server?",
+                isPresented: Binding(
+                    get: { removeTarget != nil },
+                    set: { if !$0 { removeTarget = nil } }
+                ),
+                presenting: removeTarget
+            ) { entry in
+                Button("Remove", role: .destructive) {
+                    remove(entry)
+                }
+                Button("Cancel", role: .cancel) { removeTarget = nil }
+            } message: { entry in
+                Text("Sign-in credentials for \(entry.displayName) will be forgotten on this device.")
+            }
+        #else
         contentList
             .navigationTitle("Servers")
-            #if !os(tvOS)
             .continuumNavigationTitleDisplayMode(.inline)
-            #endif
             .continuumBackground()
             .continuumScrollContentBackgroundHidden()
             .alert(
@@ -76,7 +99,124 @@ struct ServerListView: View {
             } message: { entry in
                 Text("Sign-in credentials for \(entry.displayName) will be forgotten on this device.")
             }
+        #endif
     }
+
+    #if os(tvOS)
+    private var tvOSContent: some View {
+        ScrollView(.vertical, showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 8) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("CONNECTION")
+                        .font(.system(size: 15, weight: .semibold, design: .monospaced))
+                        .tracking(2)
+                        .foregroundColor(.continuumSecondaryText)
+                    Text("Manage Servers")
+                        .font(.system(size: 38, weight: .semibold))
+                        .foregroundColor(.continuumOnSurface)
+                    Text("Switch between saved Silo servers or add another connection.")
+                        .font(.system(size: 20))
+                        .foregroundColor(.continuumSecondaryText)
+                }
+                .padding(.horizontal, 24)
+                .padding(.bottom, 18)
+
+                TVSettingsSectionHeader("SAVED SERVERS")
+
+                if registry.sortedEntries.isEmpty {
+                    TVSettingsFooter("No servers have been saved on this Apple TV.")
+                } else {
+                    ForEach(registry.sortedEntries) { entry in
+                        tvOSRow(for: entry)
+                    }
+                }
+
+                TVSettingsSectionHeader("CONNECTIONS")
+
+                Button {
+                    router.navigate(to: .serverSetup)
+                } label: {
+                    HStack(spacing: 16) {
+                        Image(systemName: "plus")
+                            .font(.system(size: 22, weight: .semibold))
+                            .frame(width: 28)
+                        Text("Add Server")
+                            .font(.system(size: 26))
+                        Spacer(minLength: 0)
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 18, weight: .semibold))
+                            .opacity(0.55)
+                    }
+                }
+                .buttonStyle(TVSettingsPaneRowStyle())
+                .focused($focusedRow, equals: .add)
+
+                TVSettingsFooter("Press and hold a saved server to rename or remove it. Selecting the active server refreshes its sign-in state.")
+            }
+            .frame(maxWidth: 1080, alignment: .leading)
+            .padding(.bottom, 64)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .safeAreaPadding(.horizontal, ContinuumTheme.Skyline.safeAreaX)
+        .safeAreaPadding(.top, 64)
+        .defaultFocus($focusedRow, defaultTVRow)
+    }
+
+    private var defaultTVRow: TVRow {
+        registry.sortedEntries.first.map { .server($0.id) } ?? .add
+    }
+
+    private func tvOSRow(for entry: ServerEntry) -> some View {
+        Button {
+            switchTo(entry)
+        } label: {
+            HStack(spacing: 18) {
+                Image(systemName: entry.id == registry.activeServerId
+                      ? "checkmark.circle.fill"
+                      : "server.rack")
+                    .font(.system(size: 24, weight: .medium))
+                    .frame(width: 34)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(entry.displayName)
+                        .font(.system(size: 26, weight: .medium))
+                        .lineLimit(1)
+                    Text(entry.url)
+                        .font(.system(size: 19))
+                        .opacity(0.62)
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 16)
+
+                if entry.id == registry.activeServerId {
+                    Text("Active")
+                        .font(.system(size: 19, weight: .semibold))
+                        .opacity(0.72)
+                }
+            }
+        }
+        .buttonStyle(TVSettingsPaneRowStyle())
+        .focused($focusedRow, equals: .server(entry.id))
+        .contextMenu {
+            Button {
+                renameTarget = entry
+            } label: {
+                Label("Rename", systemImage: "pencil")
+            }
+            Button(role: .destructive) {
+                removeTarget = entry
+            } label: {
+                Label("Remove Server", systemImage: "trash")
+            }
+        }
+    }
+
+    private enum TVRow: Hashable {
+        case server(String)
+        case add
+    }
+    #endif
 
     private var contentList: some View {
         List {
@@ -175,6 +315,17 @@ struct ServerListView: View {
         }
     }
 
+    private func remove(_ entry: ServerEntry) {
+        let wasActive = entry.id == registry.activeServerId
+        Task {
+            await registry.remove(serverId: entry.id)
+            await MainActor.run {
+                removeTarget = nil
+                if wasActive { refreshAuthState() }
+            }
+        }
+    }
+
     /// Recompute auth state for the (possibly new) active server and
     /// drop any in-tab navigation that belonged to the previous server.
     private func refreshAuthState() {
@@ -191,3 +342,67 @@ struct ServerListView: View {
         }
     }
 }
+
+#if os(tvOS)
+private struct TVServerRenameSheet: View {
+    let entry: ServerEntry
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var name: String
+    @FocusState private var focusedField: Field?
+
+    init(entry: ServerEntry) {
+        self.entry = entry
+        _name = State(initialValue: entry.userOverrideName ?? entry.fetchedName ?? "")
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .leading, spacing: 28) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("SERVER")
+                        .font(.system(size: 15, weight: .semibold, design: .monospaced))
+                        .tracking(2)
+                        .foregroundColor(.continuumSecondaryText)
+                    Text("Rename Server")
+                        .font(.system(size: 42, weight: .semibold))
+                        .foregroundColor(.continuumOnSurface)
+                    Text("Override the server-provided name with a label just for this Apple TV.")
+                        .font(.system(size: 21))
+                        .foregroundColor(.continuumSecondaryText)
+                }
+
+                TextField("Server Name", text: $name)
+                    .textContentType(.name)
+                    .font(.system(size: 26))
+                    .focused($focusedField, equals: .name)
+
+                HStack(spacing: 18) {
+                    Button("Cancel") { dismiss() }
+                    Button("Save") {
+                        ServerRegistry.shared.rename(serverId: entry.id, userOverrideName: name)
+                        dismiss()
+                    }
+                    .disabled(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+                    if entry.userOverrideName != nil {
+                        Button("Use Server Name", role: .destructive) {
+                            ServerRegistry.shared.rename(serverId: entry.id, userOverrideName: nil)
+                            dismiss()
+                        }
+                    }
+                }
+            }
+            .frame(maxWidth: 900, maxHeight: .infinity, alignment: .center)
+            .padding(.horizontal, 80)
+            .background(Color.continuumBackground.ignoresSafeArea())
+            .defaultFocus($focusedField, .name)
+            .onExitCommand { dismiss() }
+        }
+    }
+
+    private enum Field: Hashable {
+        case name
+    }
+}
+#endif

--- a/iosApp/iosApp/Screens/Settings/SettingsViewModel.swift
+++ b/iosApp/iosApp/Screens/Settings/SettingsViewModel.swift
@@ -43,13 +43,10 @@ class SettingsViewModel {
     var subtitleUsesDeviceAppearanceOverride: Bool = PlayerSettings.shared.subtitleUsesDeviceAppearanceOverride
     var subtitleMatchesSystemAppearance: Bool = PlayerSettings.shared.subtitleMatchesSystemAppearance
 
-    /// What the player will actually render with — the system caption
-    /// style while Match Device Settings is on, otherwise the edited
-    /// appearance. Drives the preview.
+    /// What the player will actually render with: system captions, the
+    /// device override, or the inherited server appearance.
     var effectiveSubtitleAppearance: SubtitleAppearance {
-        subtitleMatchesSystemAppearance
-            ? PlayerSettings.shared.subtitleSystemAppearance
-            : subtitleAppearance
+        PlayerSettings.shared.effectiveSubtitleAppearance
     }
 
     // Server-backed profile prefs editor. Each editor field is either

--- a/iosApp/iosApp/tvOS/Aurora/AuroraInputField.swift
+++ b/iosApp/iosApp/tvOS/Aurora/AuroraInputField.swift
@@ -11,6 +11,7 @@ import UIKit
 struct AuroraInputField<F: Hashable>: View {
     @Binding var text: String
     var placeholder: String
+    var inputTitle: String? = nil
     var focus: FocusState<F?>.Binding
     var equals: F
     var isSecure: Bool = false
@@ -45,7 +46,7 @@ struct AuroraInputField<F: Hashable>: View {
                 .textInputAutocapitalization(.never)
                 .tint(.clear)
                 .opacity(0.02)
-                .accessibilityLabel(placeholder)
+                .accessibilityLabel(inputTitle ?? placeholder)
         }
         .font(.system(size: 26))
         .padding(.horizontal, 22)
@@ -80,9 +81,9 @@ struct AuroraInputField<F: Hashable>: View {
     @ViewBuilder
     private var fieldView: some View {
         if isSecure {
-            SecureField("", text: $text)
+            SecureField(inputTitle ?? placeholder, text: $text)
         } else {
-            TextField("", text: $text)
+            TextField(inputTitle ?? placeholder, text: $text)
         }
     }
 }

--- a/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
@@ -21,6 +21,7 @@ struct TVMainTabView: View {
         return cached.first(where: { $0.id == profileId })
     }()
     @State private var showServerPicker = false
+    @State private var showSignOutConfirm = false
     @State private var registry = ServerRegistry.shared
     /// Local, per-profile tab-visibility prefs (e.g. whether the Audiobooks
     /// tab is opted in). Observed so the bar re-derives `visibleRoots` the
@@ -122,6 +123,20 @@ struct TVMainTabView: View {
         .overlayPreferenceValue(TVTopMenuAnchorKey.self) { anchors in
             panelOverlay(anchors: anchors)
         }
+        .allowsHitTesting(!showSignOutConfirm)
+        .overlay {
+            if showSignOutConfirm {
+                TVSettingsConfirmationOverlay(
+                    title: "Sign Out",
+                    message: "You will be returned to the login screen.",
+                    confirmTitle: "Sign Out",
+                    cancel: dismissSignOutConfirmation,
+                    confirm: router.signOutAndReset
+                )
+                .transition(.opacity)
+            }
+        }
+        .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: showSignOutConfirm)
         .ignoresSafeArea(edges: [.top, .horizontal])
         .tint(.continuumOnSurface)
         .fullScreenCover(isPresented: Binding(
@@ -501,8 +516,16 @@ struct TVMainTabView: View {
             onRequests: { closePanel(then: { navigateFromBar(.requestsHub) }) },
             onSettings: { closePanel(then: { navigateFromBar(.settings) }) },
             onSwitchServer: { closePanel(then: { showServerPicker = true }) },
-            onSignOut: { closePanel(then: { router.signOutAndReset() }) }
+            onSignOut: { closePanel(then: { showSignOutConfirm = true }) }
         )
+    }
+
+    private func dismissSignOutConfirmation() {
+        showSignOutConfirm = false
+        Task { @MainActor in
+            await Task.yield()
+            focusTopMenuIfVisible(focusing: .profile)
+        }
     }
 
     // MARK: - Panel control (§5.3 / §5.8)

--- a/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
@@ -217,6 +217,17 @@ struct TVMainTabView: View {
                 }
             }
         }
+        .onChange(of: router.requestedTab) { _, requestedTab in
+            guard let requestedTab else { return }
+            router.requestedTab = nil
+
+            // tvOS owns a custom root selector rather than MainTabView's
+            // AppTab binding. Settings uses this one-shot request so its
+            // final Menu/Back exits to Home regardless of the prior root.
+            if requestedTab == .home {
+                selectRoot(.home)
+            }
+        }
         .onChange(of: navPrefs.showAudiobooks) {
             // Turning a tab off while parked on it would otherwise orphan the
             // page with no matching tab in the bar; snap back to Home.

--- a/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
@@ -128,10 +128,12 @@ struct TVMainTabView: View {
             if showSignOutConfirm {
                 TVSettingsConfirmationOverlay(
                     title: "Sign Out",
-                    message: "You will be returned to the login screen.",
+                    message: "Choose whether to keep or remove this server from this Apple TV.",
                     confirmTitle: "Sign Out",
+                    additionalDestructiveTitle: "Sign Out & Remove Server",
                     cancel: dismissSignOutConfirmation,
-                    confirm: router.signOutAndReset
+                    confirm: router.signOutAndReset,
+                    additionalDestructiveAction: router.signOutRemoveServerAndReset
                 )
                 .transition(.opacity)
             }

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
@@ -117,10 +117,20 @@ struct TVEpisodeCard: View {
         }
         .buttonStyle(EpisodeCardStyle())
 
-        if onSetWatched != nil || onSetFavorite != nil {
-            button.contextMenu { contextActions }
-        } else {
-            button
+        Group {
+            if onSetWatched != nil || onSetFavorite != nil {
+                button.contextMenu { contextActions }
+            } else {
+                button
+            }
+        }
+        .onChange(of: episode.userData?.played) { _, refreshedValue in
+            guard let playedOverride, refreshedValue == playedOverride else { return }
+            self.playedOverride = nil
+        }
+        .onChange(of: initialIsFavorite) { _, refreshedValue in
+            guard let favoriteOverride, refreshedValue == favoriteOverride else { return }
+            self.favoriteOverride = nil
         }
     }
 
@@ -140,7 +150,7 @@ struct TVEpisodeCard: View {
                 playedOverride = played
                 Task {
                     if await onSetWatched(episode.contentId, played) == false {
-                        playedOverride = !played
+                        playedOverride = nil
                     }
                 }
             } label: {
@@ -157,7 +167,7 @@ struct TVEpisodeCard: View {
                 favoriteOverride = newValue
                 Task {
                     if await onSetFavorite(episode.contentId, newValue) == false {
-                        favoriteOverride = !newValue
+                        favoriteOverride = nil
                     }
                 }
             } label: {

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
@@ -15,9 +15,14 @@ struct TVEpisodeRail: View {
     let episodes: [EpisodeListItem]
     let onSelect: (String) -> Void
     var onFocusedEpisodeChange: ((String?) -> Void)? = nil
+    var onSetWatched: ((_ contentId: String, _ played: Bool) async -> Bool)? = nil
+    var onSetFavorite: ((_ contentId: String, _ isFavorite: Bool) async -> Bool)? = nil
     /// When non-nil, the matching card is visually highlighted and anchored
     /// at first appearance.
     var currentContentId: String? = nil
+    var currentContentIsFavorite = false
+    var favoriteStates: [String: Bool] = [:]
+    var prefersCurrentContentFocus = false
 
     private let cardSpacing: CGFloat = 36
     @FocusState private var focusedCardId: String?
@@ -30,7 +35,12 @@ struct TVEpisodeRail: View {
                         TVEpisodeCard(
                             episode: episode,
                             isCurrent: currentContentId == episode.contentId,
-                            onSelect: { onSelect(episode.contentId) }
+                            onSelect: { onSelect(episode.contentId) },
+                            onSetWatched: onSetWatched,
+                            initialIsFavorite: currentContentId == episode.contentId
+                                ? currentContentIsFavorite
+                                : favoriteStates[episode.contentId] ?? false,
+                            onSetFavorite: onSetFavorite
                         )
                         .id(episode.contentId)
                         .focused($focusedCardId, equals: episode.contentId)
@@ -40,6 +50,10 @@ struct TVEpisodeRail: View {
                 .padding(.horizontal, ContinuumTheme.safePadding)
             }
             .focusSection()
+            .applyCurrentEpisodeDefaultFocus(
+                prefersCurrentContentFocus ? currentContentId : nil,
+                binding: $focusedCardId
+            )
             .scrollClipDisabled()
             .onChange(of: focusedCardId) { _, contentId in
                 onFocusedEpisodeChange?(contentId)
@@ -61,19 +75,40 @@ struct TVEpisodeRail: View {
     }
 }
 
+private extension View {
+    @ViewBuilder
+    func applyCurrentEpisodeDefaultFocus(
+        _ contentId: String?,
+        binding: FocusState<String?>.Binding
+    ) -> some View {
+        if let contentId {
+            defaultFocus(binding, contentId, priority: .userInitiated)
+        } else {
+            self
+        }
+    }
+}
+
 struct TVEpisodeCard: View {
     let episode: EpisodeListItem
     var isCurrent: Bool = false
     let onSelect: () -> Void
+    var onSetWatched: ((_ contentId: String, _ played: Bool) async -> Bool)? = nil
+    var initialIsFavorite = false
+    var onSetFavorite: ((_ contentId: String, _ isFavorite: Bool) async -> Bool)? = nil
+
+    @State private var playedOverride: Bool?
+    @State private var favoriteOverride: Bool?
 
     private let cardWidth: CGFloat = 460
     private let stillHeight: CGFloat = 260
     private let stillCornerRadius: CGFloat = 10
 
     var body: some View {
-        Button(action: onSelect) {
+        let button = Button(action: onSelect) {
             EpisodeCardLabel(
                 episode: episode,
+                isPlayed: isPlayed,
                 isCurrent: isCurrent,
                 cardWidth: cardWidth,
                 stillHeight: stillHeight,
@@ -81,11 +116,63 @@ struct TVEpisodeCard: View {
             )
         }
         .buttonStyle(EpisodeCardStyle())
+
+        if onSetWatched != nil || onSetFavorite != nil {
+            button.contextMenu { contextActions }
+        } else {
+            button
+        }
+    }
+
+    private var isPlayed: Bool {
+        playedOverride ?? episode.userData?.played ?? false
+    }
+
+    private var isFavorite: Bool {
+        favoriteOverride ?? initialIsFavorite
+    }
+
+    @ViewBuilder
+    private var contextActions: some View {
+        if let onSetWatched {
+            Button {
+                let played = !isPlayed
+                playedOverride = played
+                Task {
+                    if await onSetWatched(episode.contentId, played) == false {
+                        playedOverride = !played
+                    }
+                }
+            } label: {
+                Label(
+                    isPlayed ? "Mark as Unwatched" : "Mark as Watched",
+                    systemImage: isPlayed ? "circle" : "checkmark.circle"
+                )
+            }
+        }
+
+        if let onSetFavorite {
+            Button {
+                let newValue = !isFavorite
+                favoriteOverride = newValue
+                Task {
+                    if await onSetFavorite(episode.contentId, newValue) == false {
+                        favoriteOverride = !newValue
+                    }
+                }
+            } label: {
+                Label(
+                    isFavorite ? "Remove from Favorites" : "Add to Favorites",
+                    systemImage: isFavorite ? "heart.slash" : "heart"
+                )
+            }
+        }
     }
 }
 
 private struct EpisodeCardLabel: View {
     let episode: EpisodeListItem
+    let isPlayed: Bool
     let isCurrent: Bool
     let cardWidth: CGFloat
     let stillHeight: CGFloat
@@ -186,12 +273,12 @@ private struct EpisodeCardLabel: View {
                     .frame(width: cardWidth, height: stillHeight)
             }
 
-            if episode.userData?.played == true {
+            if isPlayed {
                 Color.black.opacity(0.35)
                     .frame(width: cardWidth, height: stillHeight)
             }
 
-            if episode.userData?.played == true {
+            if isPlayed {
                 VStack {
                     HStack {
                         Spacer()

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
@@ -344,6 +344,7 @@ struct TVItemDetailView: View {
                 seasons: viewModel.seasons,
                 selectedSeason: viewModel.selectedSeason,
                 seasonEpisodes: viewModel.episodes,
+                episodeFavoriteStates: viewModel.episodeFavoriteStates,
                 isLoadingEpisodes: viewModel.isLoadingEpisodes,
                 onPlay: { startFromBeginning in
                     let resumePosition = startFromBeginning ? nil : playableResumePosition(for: detail)
@@ -447,6 +448,12 @@ struct TVItemDetailView: View {
                         resumePosition: resumePosition,
                         returnToContentId: isCurrentEpisode ? nil : id
                     )
+                },
+                onSetEpisodeWatched: { id, played in
+                    await viewModel.setEpisodeWatched(contentId: id, played: played)
+                },
+                onSetEpisodeFavorite: { id, isFavorite in
+                    await viewModel.setEpisodeFavorite(contentId: id, isFavorite: isFavorite)
                 },
                 belowSynopsis: {
                     DescriptionTranslationView(viewModel: viewModel, contentId: detail.contentId)

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
@@ -121,6 +121,7 @@ struct TVItemDetailView: View {
                 seasons: viewModel.seasons,
                 selectedSeason: viewModel.selectedSeason,
                 episodes: viewModel.episodes,
+                episodeFavoriteStates: viewModel.episodeFavoriteStates,
                 isLoadingEpisodes: viewModel.isLoadingEpisodes,
                 selectedNextUpFileId: preferredNextUpFileId,
                 selectedNextUpAudioTrackIndex: preferredNextUpAudioTrackIndex,
@@ -158,6 +159,12 @@ struct TVItemDetailView: View {
                 },
                 onEpisodeTap: { id in
                     router.navigate(to: .itemDetail(contentId: id))
+                },
+                onSetEpisodeWatched: { id, played in
+                    await viewModel.setEpisodeWatched(contentId: id, played: played)
+                },
+                onSetEpisodeFavorite: { id, isFavorite in
+                    await viewModel.setEpisodeFavorite(contentId: id, isFavorite: isFavorite)
                 },
                 onSelectSeason: { season in
                     guard season.id != detail.contentId else { return }
@@ -232,6 +239,7 @@ struct TVItemDetailView: View {
                 seasons: viewModel.seasons,
                 selectedSeason: viewModel.selectedSeason,
                 episodes: viewModel.episodes,
+                episodeFavoriteStates: viewModel.episodeFavoriteStates,
                 isLoadingEpisodes: viewModel.isLoadingEpisodes,
                 selectedNextUpFileId: preferredNextUpFileId,
                 selectedNextUpAudioTrackIndex: preferredNextUpAudioTrackIndex,
@@ -270,6 +278,12 @@ struct TVItemDetailView: View {
                 },
                 onEpisodeTap: { id in
                     router.navigate(to: .itemDetail(contentId: id))
+                },
+                onSetEpisodeWatched: { id, played in
+                    await viewModel.setEpisodeWatched(contentId: id, played: played)
+                },
+                onSetEpisodeFavorite: { id, isFavorite in
+                    await viewModel.setEpisodeFavorite(contentId: id, isFavorite: isFavorite)
                 },
                 onSelectNextUpVersion: { fileId in
                     preferredNextUpFileId = fileId

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
@@ -22,6 +22,7 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
     let seasons: [Season]
     let selectedSeason: Season?
     let seasonEpisodes: [EpisodeListItem]
+    let episodeFavoriteStates: [String: Bool]
     let isLoadingEpisodes: Bool
     let onPlay: (_ startFromBeginning: Bool) -> Void
     let onSelectVersion: (Int?) -> Void
@@ -34,6 +35,8 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
     let onPersonTap: (String) -> Void
     let onNavigateToItem: (String) -> Void
     let onEpisodeTap: (String) -> Void
+    let onSetEpisodeWatched: (_ contentId: String, _ played: Bool) async -> Bool
+    let onSetEpisodeFavorite: (_ contentId: String, _ isFavorite: Bool) async -> Bool
     /// On-view description-translation affordance, built at the detail call
     /// site (which owns the view model) and rendered under the synopsis.
     @ViewBuilder let belowSynopsis: () -> BelowSynopsis
@@ -270,7 +273,12 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
                     episodes: seasonEpisodes,
                     onSelect: onEpisodeTap,
                     onFocusedEpisodeChange: { focusedEpisodeContentId = $0 },
-                    currentContentId: detail.contentId
+                    onSetWatched: onSetEpisodeWatched,
+                    onSetFavorite: onSetEpisodeFavorite,
+                    currentContentId: detail.contentId,
+                    currentContentIsFavorite: isFavorite,
+                    favoriteStates: episodeFavoriteStates,
+                    prefersCurrentContentFocus: true
                 )
                 .padding(.horizontal, -ContinuumTheme.safePadding)
             }

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
@@ -272,6 +272,7 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
                     onFocusedEpisodeChange: { focusedEpisodeContentId = $0 },
                     currentContentId: detail.contentId
                 )
+                .padding(.horizontal, -ContinuumTheme.safePadding)
             }
         }
     }

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
@@ -18,6 +18,7 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
     let seasons: [Season]
     let selectedSeason: Season?
     let episodes: [EpisodeListItem]
+    let episodeFavoriteStates: [String: Bool]
     let isLoadingEpisodes: Bool
     let selectedNextUpFileId: Int?
     let selectedNextUpAudioTrackIndex: Int?
@@ -31,6 +32,8 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
     var nextUpSubtitleOverrideCleared: Bool = false
     let onPlayEpisode: (_ contentId: String, _ fileId: Int?, _ startFromBeginning: Bool) -> Void
     let onEpisodeTap: (_ contentId: String) -> Void
+    let onSetEpisodeWatched: (_ contentId: String, _ played: Bool) async -> Bool
+    let onSetEpisodeFavorite: (_ contentId: String, _ isFavorite: Bool) async -> Bool
     let onSelectSeason: (Season) -> Void
     let onSelectNextUpVersion: (Int?) -> Void
     let onSelectNextUpAudioTrack: (Int?) -> Void
@@ -295,7 +298,10 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
                 TVEpisodeRail(
                     episodes: episodes,
                     onSelect: onEpisodeTap,
-                    currentContentId: nextUpEpisode?.contentId
+                    onSetWatched: onSetEpisodeWatched,
+                    onSetFavorite: onSetEpisodeFavorite,
+                    currentContentId: nextUpEpisode?.contentId,
+                    favoriteStates: episodeFavoriteStates
                 )
             }
         }

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
@@ -301,6 +301,9 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
                     onSetWatched: onSetEpisodeWatched,
                     onSetFavorite: onSetEpisodeFavorite,
                     currentContentId: nextUpEpisode?.contentId,
+                    currentContentIsFavorite: nextUpEpisode.map {
+                        episodeFavoriteStates[$0.contentId] ?? false
+                    } ?? false,
                     favoriteStates: episodeFavoriteStates
                 )
             }

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -11,6 +11,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     let seasons: [Season]
     let selectedSeason: Season?
     let episodes: [EpisodeListItem]
+    let episodeFavoriteStates: [String: Bool]
     let isLoadingEpisodes: Bool
     let selectedNextUpFileId: Int?
     let selectedNextUpAudioTrackIndex: Int?
@@ -27,6 +28,8 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     let onSelectSeason: (Season) -> Void
     let onPlayEpisode: (_ contentId: String, _ fileId: Int?, _ startFromBeginning: Bool) -> Void
     let onEpisodeTap: (_ contentId: String) -> Void
+    let onSetEpisodeWatched: (_ contentId: String, _ played: Bool) async -> Bool
+    let onSetEpisodeFavorite: (_ contentId: String, _ isFavorite: Bool) async -> Bool
     let onSelectNextUpVersion: (Int?) -> Void
     let onSelectNextUpAudioTrack: (Int?) -> Void
     let onSelectNextUpSubtitleTrack: (Int?) -> Void
@@ -309,7 +312,10 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
             TVEpisodeRail(
                 episodes: episodes,
                 onSelect: onEpisodeTap,
-                currentContentId: nextUpEpisode?.contentId
+                onSetWatched: onSetEpisodeWatched,
+                onSetFavorite: onSetEpisodeFavorite,
+                currentContentId: nextUpEpisode?.contentId,
+                favoriteStates: episodeFavoriteStates
             )
         }
     }

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -315,6 +315,9 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                 onSetWatched: onSetEpisodeWatched,
                 onSetFavorite: onSetEpisodeFavorite,
                 currentContentId: nextUpEpisode?.contentId,
+                currentContentIsFavorite: nextUpEpisode.map {
+                    episodeFavoriteStates[$0.contentId] ?? false
+                } ?? false,
                 favoriteStates: episodeFavoriteStates
             )
         }

--- a/iosApp/iosApp/tvOS/Screens/Libraries/TVLibraryCollectionsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Libraries/TVLibraryCollectionsView.swift
@@ -21,6 +21,7 @@ struct TVLibraryCollectionsView: View {
     @State private var hasPendingFocusClaim = false
     @State private var lastShellFocusRequest = 0
     @State private var contentFocusToken = 0
+    @FocusState private var isEmptyContentFocused: Bool
 
     @Environment(AppRouter.self) private var router
     @Namespace private var collectionsFocusNamespace
@@ -51,16 +52,8 @@ struct TVLibraryCollectionsView: View {
 
     @ViewBuilder
     private var gridContent: some View {
-        if isLoadingCollections && collectionSections.isEmpty {
-            Color.clear
-                .frame(maxWidth: .infinity, minHeight: 300)
-        } else if collectionSections.isEmpty {
-            EmptyStateView(
-                icon: "square.stack",
-                title: "No collections yet",
-                subtitle: "Collections created on the server will appear here."
-            )
-            .frame(maxWidth: .infinity, minHeight: 400)
+        if collectionSections.isEmpty {
+            emptyContent
         } else {
             // Only the very first card of the first NON-EMPTY section
             // claims default focus when the tab appears. Skipping empty
@@ -128,6 +121,37 @@ struct TVLibraryCollectionsView: View {
             }
             .focusScope(collectionsFocusNamespace)
             .focusSection()
+        }
+    }
+
+    private var emptyContent: some View {
+        ZStack {
+            if isLoadingCollections {
+                Color.clear
+            } else {
+                EmptyStateView(
+                    icon: "square.stack",
+                    title: "No collections yet",
+                    subtitle: "Collections created on the server will appear here."
+                )
+            }
+        }
+        .frame(maxWidth: .infinity, minHeight: 400)
+        .contentShape(Rectangle())
+        .focusable(true)
+        .focused($isEmptyContentFocused)
+        .focusEffectDisabled()
+        .accessibilityLabel(isLoadingCollections ? "Loading collections" : "No collections yet")
+        .onMoveCommand { direction in
+            if direction == .up {
+                onMoveUp?()
+            }
+        }
+        .task(id: focusRequest) {
+            guard !isTopMenuFocused else { return }
+            await Task.yield()
+            guard collectionSections.isEmpty, !isTopMenuFocused else { return }
+            isEmptyContentFocused = true
         }
     }
 

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVGeneralSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVGeneralSettingsView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 /// top-menu / header customization would live.
 struct TVGeneralSettingsPane: View {
     @State private var navPrefs = TVNavPreferences.shared
+    let detailFocus: FocusState<TVSettingsDetailFocus?>.Binding
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -23,6 +24,7 @@ struct TVGeneralSettingsPane: View {
             ) {
                 navPrefs.setShowAudiobooks(!navPrefs.showAudiobooks)
             }
+            .focused(detailFocus, equals: .top)
 
             TVSettingsFooter("Adds an Audiobooks tab to the top menu when your server has an audiobook library. Hidden by default.")
         }

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVPlaybackSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVPlaybackSettingsView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 /// covers (plain sheets render as narrow clipped cards on tvOS 26).
 struct TVPlaybackSettingsPane: View {
     @Bindable var viewModel: TVSettingsViewModel
+    let detailFocus: FocusState<TVSettingsDetailFocus?>.Binding
     @State private var activePicker: PickerKind?
 
     var body: some View {
@@ -29,6 +30,7 @@ struct TVPlaybackSettingsPane: View {
             title: "Quality",
             value: TVSettingsOptions.label(for: viewModel.preferredQuality, in: TVSettingsOptions.quality)
         ) { activePicker = .quality }
+        .focused(detailFocus, equals: .top)
 
         TVSettingsPickerRow(
             title: "Audio Language",

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsComponents.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsComponents.swift
@@ -310,6 +310,7 @@ struct TVSettingsInfoRow: View {
             RoundedRectangle(cornerRadius: 14, style: .continuous)
                 .strokeBorder(Color.continuumChromeRestingBorder, lineWidth: 1)
         )
+        .accessibilityElement(children: .combine)
     }
 }
 

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsComponents.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsComponents.swift
@@ -348,6 +348,80 @@ struct TVSettingsFooter: View {
     }
 }
 
+// MARK: - Confirmation overlay
+
+/// Settings-styled destructive confirmation used instead of the native tvOS
+/// alert, whose app-wide tint can leave focused Cancel text without contrast.
+struct TVSettingsConfirmationOverlay: View {
+    let title: String
+    let message: String
+    let confirmTitle: String
+    let cancel: () -> Void
+    let confirm: () -> Void
+
+    @FocusState private var focusedAction: Action?
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.62)
+                .ignoresSafeArea()
+                .onTapGesture(perform: cancel)
+
+            VStack(spacing: 28) {
+                VStack(spacing: 12) {
+                    Text(title)
+                        .font(.system(size: 38, weight: .semibold))
+                        .foregroundColor(.continuumOnSurface)
+
+                    Text(message)
+                        .font(.system(size: 22))
+                        .foregroundColor(.continuumSecondaryText)
+                        .multilineTextAlignment(.center)
+                }
+
+                HStack(spacing: 16) {
+                    Button(action: cancel) {
+                        Text("Cancel")
+                            .font(.system(size: 24, weight: .semibold))
+                            .frame(maxWidth: .infinity, alignment: .center)
+                    }
+                        .buttonStyle(TVSettingsPaneRowStyle())
+                        .frame(width: 260)
+                        .focused($focusedAction, equals: .cancel)
+
+                    Button(action: confirm) {
+                        Text(confirmTitle)
+                            .font(.system(size: 24, weight: .semibold))
+                            .frame(maxWidth: .infinity, alignment: .center)
+                    }
+                        .buttonStyle(TVSettingsPaneRowStyle(isDestructive: true))
+                        .frame(width: 260)
+                        .focused($focusedAction, equals: .confirm)
+                }
+            }
+            .padding(.horizontal, 48)
+            .padding(.vertical, 42)
+            .background(
+                RoundedRectangle(cornerRadius: 30, style: .continuous)
+                    .fill(Color.continuumSurfaceElevated)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 30, style: .continuous)
+                    .strokeBorder(Color.continuumChromeRestingBorder, lineWidth: 1)
+            )
+            .focusSection()
+            .defaultFocus($focusedAction, .cancel, priority: .userInitiated)
+            .onExitCommand(perform: cancel)
+        }
+        .onAppear { focusedAction = .cancel }
+    }
+
+    private enum Action: Hashable {
+        case cancel
+        case confirm
+    }
+}
+
 // MARK: - Picker sheet
 
 /// Modal option picker presented by `.fullScreenCover(item:)` (tvOS 26

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsComponents.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsComponents.swift
@@ -356,8 +356,10 @@ struct TVSettingsConfirmationOverlay: View {
     let title: String
     let message: String
     let confirmTitle: String
+    var additionalDestructiveTitle: String? = nil
     let cancel: () -> Void
     let confirm: () -> Void
+    var additionalDestructiveAction: (() -> Void)? = nil
 
     @FocusState private var focusedAction: Action?
 
@@ -386,17 +388,33 @@ struct TVSettingsConfirmationOverlay: View {
                             .frame(maxWidth: .infinity, alignment: .center)
                     }
                         .buttonStyle(TVSettingsPaneRowStyle())
-                        .frame(width: 260)
+                        .frame(width: buttonWidth)
                         .focused($focusedAction, equals: .cancel)
 
                     Button(action: confirm) {
                         Text(confirmTitle)
                             .font(.system(size: 24, weight: .semibold))
                             .frame(maxWidth: .infinity, alignment: .center)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.72)
                     }
                         .buttonStyle(TVSettingsPaneRowStyle(isDestructive: true))
-                        .frame(width: 260)
+                        .frame(width: buttonWidth)
                         .focused($focusedAction, equals: .confirm)
+
+                    if let additionalDestructiveTitle,
+                       let additionalDestructiveAction {
+                        Button(action: additionalDestructiveAction) {
+                            Text(additionalDestructiveTitle)
+                                .font(.system(size: 24, weight: .semibold))
+                                .frame(maxWidth: .infinity, alignment: .center)
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.65)
+                        }
+                        .buttonStyle(TVSettingsPaneRowStyle(isDestructive: true))
+                        .frame(width: buttonWidth)
+                        .focused($focusedAction, equals: .additionalDestructive)
+                    }
                 }
             }
             .padding(.horizontal, 48)
@@ -419,6 +437,11 @@ struct TVSettingsConfirmationOverlay: View {
     private enum Action: Hashable {
         case cancel
         case confirm
+        case additionalDestructive
+    }
+
+    private var buttonWidth: CGFloat {
+        additionalDestructiveTitle == nil ? 260 : 320
     }
 }
 

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsComponents.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsComponents.swift
@@ -134,12 +134,13 @@ private struct TVSettingsRailRowBody: View {
 
     private var foreground: Color {
         if isDestructive {
-            return isFocused ? Color(hex: "#D22F3F") : .continuumError
+            return isFocused ? .white : .continuumError
         }
         return isFocused ? .continuumBackground : .continuumOnSurface
     }
 
     private var fill: Color {
+        if isDestructive && isFocused { return .continuumError }
         if isFocused { return .continuumOnSurface }
         if isSelected { return .continuumChromeSelectedFill }
         return .clear

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsComponents.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsComponents.swift
@@ -248,28 +248,67 @@ struct TVSettingsToggleRow: View {
     }
 }
 
-/// Read-only fact row (server name, version). Focusable so the d-pad
-/// flows through it naturally, but activating it does nothing — same as
-/// the About rows in the system Settings app.
+/// Visually groups controls owned by a parent setting. Inactive groups
+/// stay in the focus graph so their values remain inspectable, but the
+/// owner is responsible for ignoring edits until `enabled` is true.
+struct TVSettingsNestedGroup<Content: View>: View {
+    let enabled: Bool
+    let content: Content
+
+    init(enabled: Bool, @ViewBuilder content: () -> Content) {
+        self.enabled = enabled
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            content
+        }
+        .padding(8)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(Color.white.opacity(0.025))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .strokeBorder(Color.white.opacity(0.07), lineWidth: 1)
+        )
+        .padding(.leading, 24)
+        .opacity(enabled ? 1 : 0.42)
+        .accessibilityHint(enabled ? "" : "Turn on the parent setting to make changes")
+    }
+}
+
+/// Read-only fact row (server name, version). It is deliberately not a
+/// focus target; focus should land only on actionable settings rows.
 struct TVSettingsInfoRow: View {
     let title: String
     let value: String
 
     var body: some View {
-        Button {} label: {
-            HStack(spacing: 16) {
-                Text(title)
-                    .font(.system(size: 26))
-                    .lineLimit(1)
-                Spacer(minLength: 16)
-                Text(value)
-                    .font(.system(size: 24))
-                    .opacity(0.68)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.7)
-            }
+        HStack(spacing: 16) {
+            Text(title)
+                .font(.system(size: 26))
+                .lineLimit(1)
+            Spacer(minLength: 16)
+            Text(value)
+                .font(.system(size: 24))
+                .opacity(0.68)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
         }
-        .buttonStyle(TVSettingsPaneRowStyle())
+        .padding(.horizontal, 24)
+        .padding(.vertical, 17)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .foregroundColor(.continuumOnSurface)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(Color.continuumChromeRestingFill)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .strokeBorder(Color.continuumChromeRestingBorder, lineWidth: 1)
+        )
     }
 }
 
@@ -414,13 +453,9 @@ private struct TVSettingsPickerOptionRow: View {
 
     var body: some View {
         HStack(spacing: 16) {
-            Image(systemName: "checkmark")
-                .font(.system(size: 22, weight: .semibold))
-                .opacity(isSelected ? 1 : 0)
-
             VStack(alignment: .leading, spacing: 3) {
                 Text(option.label)
-                    .font(.system(size: 28, weight: .medium))
+                    .font(.system(size: 28, weight: isSelected ? .semibold : .medium))
                     .lineLimit(1)
 
                 if let previewFontName = option.previewFontName {
@@ -432,18 +467,22 @@ private struct TVSettingsPickerOptionRow: View {
             }
 
             Spacer(minLength: 0)
+
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 24, weight: .semibold))
+                .opacity(isSelected ? 1 : 0)
         }
         .foregroundStyle(isFocused ? Color.continuumBackground : .continuumOnSurface)
         .padding(.horizontal, 24)
         .padding(.vertical, 15)
         .background(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(isFocused ? Color.continuumOnSurface : Color.continuumChromeRestingFill)
+                .fill(backgroundFill)
         )
         .overlay(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
                 .strokeBorder(
-                    isFocused ? Color.clear : Color.continuumChromeRestingBorder,
+                    borderColor,
                     lineWidth: 1
                 )
         )
@@ -455,6 +494,18 @@ private struct TVSettingsPickerOptionRow: View {
         .accessibilityAddTraits(.isButton)
         .accessibilityLabel(option.label)
         .accessibilityValue(isSelected ? "Selected" : "")
+    }
+
+    private var backgroundFill: Color {
+        if isFocused { return .continuumOnSurface }
+        if isSelected { return .continuumChromeSelectedFill }
+        return .continuumChromeRestingFill
+    }
+
+    private var borderColor: Color {
+        if isFocused { return .clear }
+        if isSelected { return .continuumChromeSelectedBorder }
+        return .continuumChromeRestingBorder
     }
 }
 

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsView.swift
@@ -24,26 +24,24 @@ struct TVSettingsView: View {
     @Environment(AppRouter.self) private var router
 
     var body: some View {
-        HStack(alignment: .top, spacing: 64) {
-            rail
-                .frame(width: 430)
-                .focusSection()
-                .defaultFocus(
-                    $railFocus,
-                    .category(selectedCategory),
-                    priority: .userInitiated
-                )
-                .onExitCommand(perform: exitSettingsToHome)
+        ZStack {
+            settingsContent
+                .disabled(showSignOutConfirm)
 
-            detailPane
-                .frame(maxWidth: .infinity, alignment: .topLeading)
-                .focusSection()
-                .defaultFocus($detailFocus, .top, priority: .userInitiated)
-                .onExitCommand(perform: returnFocusToRail)
+            if showSignOutConfirm {
+                TVSettingsConfirmationOverlay(
+                    title: "Sign Out",
+                    message: "You will be returned to the login screen.",
+                    confirmTitle: "Sign Out",
+                    cancel: dismissSignOutConfirmation,
+                    confirm: router.signOutAndReset
+                )
+                .transition(.opacity.combined(with: .scale(scale: 0.96)))
+                .zIndex(1)
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .safeAreaPadding(.horizontal, ContinuumTheme.Skyline.safeAreaX)
-        .safeAreaPadding(.top, 64)
+        .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: showSignOutConfirm)
         .defaultFocus($railFocus, .category(selectedCategory))
         .task { await viewModel.load() }
         .onChange(of: railFocus) { _, focus in
@@ -67,14 +65,29 @@ struct TVSettingsView: View {
         .onChange(of: viewModel.editorPreferredMetadataLanguage) { _, _ in
             Task { await viewModel.saveMetadataLanguage() }
         }
-        .alert("Sign Out", isPresented: $showSignOutConfirm) {
-            Button("Sign Out", role: .destructive) {
-                router.signOutAndReset()
-            }
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text("You will be returned to the login screen.")
+    }
+
+    private var settingsContent: some View {
+        HStack(alignment: .top, spacing: 64) {
+            rail
+                .frame(width: 430)
+                .focusSection()
+                .defaultFocus(
+                    $railFocus,
+                    .category(selectedCategory),
+                    priority: .userInitiated
+                )
+                .onExitCommand(perform: exitSettingsToHome)
+
+            detailPane
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+                .focusSection()
+                .defaultFocus($detailFocus, .top, priority: .userInitiated)
+                .onExitCommand(perform: returnFocusToRail)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .safeAreaPadding(.horizontal, ContinuumTheme.Skyline.safeAreaX)
+        .safeAreaPadding(.top, 64)
     }
 
     // MARK: - Left rail
@@ -186,6 +199,14 @@ struct TVSettingsView: View {
     private func returnFocusToRail() {
         detailFocus = nil
         railFocus = .category(selectedCategory)
+    }
+
+    private func dismissSignOutConfirmation() {
+        showSignOutConfirm = false
+        Task { @MainActor in
+            await Task.yield()
+            railFocus = .signOut
+        }
     }
 
     private func exitSettingsToHome() {

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsView.swift
@@ -167,7 +167,9 @@ struct TVSettingsView: View {
                 Spacer(minLength: 0)
             }
         }
-        .buttonStyle(TVSettingsRailRowStyle(isSelected: category == selectedCategory))
+        .buttonStyle(TVSettingsRailRowStyle(
+            isSelected: category == selectedCategory && railFocus != .signOut
+        ))
         .focused($railFocus, equals: .category(category))
     }
 

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsView.swift
@@ -12,15 +12,15 @@ import SwiftUI
 ///
 /// Focus model: one native graph. Each pane is a `.focusSection()`;
 /// vertical movement stays in-pane and Left/Right bridges panes
-/// geometrically. No manual focus mutation (see docs/tvos-focus.md).
+/// geometrically. User-initiated default focus makes each pane's anchor
+/// win during that native resolution; Select/Menu use the same anchors
+/// explicitly (see docs/tvos-focus.md).
 struct TVSettingsView: View {
     @State private var viewModel = TVSettingsViewModel()
     @State private var showSignOutConfirm = false
-    #if DEBUG
-    @State private var debugSettings = TVDebugSettings.shared
-    #endif
     @State private var selectedCategory: TVSettingsCategory = .general
     @FocusState private var railFocus: RailItem?
+    @FocusState private var detailFocus: TVSettingsDetailFocus?
     @Environment(AppRouter.self) private var router
 
     var body: some View {
@@ -28,10 +28,18 @@ struct TVSettingsView: View {
             rail
                 .frame(width: 430)
                 .focusSection()
+                .defaultFocus(
+                    $railFocus,
+                    .category(selectedCategory),
+                    priority: .userInitiated
+                )
+                .onExitCommand(perform: exitSettingsToHome)
 
             detailPane
                 .frame(maxWidth: .infinity, alignment: .topLeading)
                 .focusSection()
+                .defaultFocus($detailFocus, .top, priority: .userInitiated)
+                .onExitCommand(perform: returnFocusToRail)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .safeAreaPadding(.horizontal, ContinuumTheme.Skyline.safeAreaX)
@@ -90,7 +98,7 @@ struct TVSettingsView: View {
 
             signOutRow
 
-            Text("Silo \(Self.appVersion)")
+            Text("Silo \(Self.versionString)")
                 .font(.system(size: 16, weight: .medium, design: .monospaced))
                 .tracking(1)
                 .foregroundColor(.continuumSecondaryText.opacity(0.7))
@@ -133,7 +141,7 @@ struct TVSettingsView: View {
 
     private func categoryRow(_ category: TVSettingsCategory) -> some View {
         Button {
-            selectedCategory = category
+            enterDetailPane(for: category)
         } label: {
             HStack(spacing: 16) {
                 Image(systemName: category.icon)
@@ -168,6 +176,21 @@ struct TVSettingsView: View {
     private func switchProfile() {
         AuthService.shared.profileId = nil
         router.showProfileSelection()
+    }
+
+    private func enterDetailPane(for category: TVSettingsCategory) {
+        selectedCategory = category
+        detailFocus = .top
+    }
+
+    private func returnFocusToRail() {
+        detailFocus = nil
+        railFocus = .category(selectedCategory)
+    }
+
+    private func exitSettingsToHome() {
+        router.popToRoot()
+        router.switchTab(to: .home)
     }
 
     // MARK: - Detail pane
@@ -211,11 +234,11 @@ struct TVSettingsView: View {
     private var paneContent: some View {
         switch selectedCategory {
         case .general:
-            TVGeneralSettingsPane()
+            TVGeneralSettingsPane(detailFocus: $detailFocus)
         case .playback:
-            TVPlaybackSettingsPane(viewModel: viewModel)
+            TVPlaybackSettingsPane(viewModel: viewModel, detailFocus: $detailFocus)
         case .subtitles:
-            TVSubtitleSettingsPane(viewModel: viewModel)
+            TVSubtitleSettingsPane(viewModel: viewModel, detailFocus: $detailFocus)
         case .server:
             serverPane
         }
@@ -252,27 +275,12 @@ struct TVSettingsView: View {
                 }
             }
             .buttonStyle(TVSettingsPaneRowStyle())
+            .focused($detailFocus, equals: .top)
 
             TVSettingsSectionHeader("ABOUT")
 
-            TVSettingsInfoRow(title: "App Version", value: Self.appVersion)
+            TVSettingsInfoRow(title: "App Version", value: Self.versionString)
 
-            #if DEBUG
-            TVSettingsSectionHeader("DEBUGGING")
-
-            TVSettingsToggleRow(
-                title: "Show Focus Targets",
-                isOn: debugSettings.showFocusTargets
-            ) {
-                debugSettings.setShowFocusTargets(!debugSettings.showFocusTargets)
-            }
-
-            TVSettingsFooter(
-                "Overlays the predicted d-pad destination in each direction "
-                    + "from the focused control. Stored on this Apple TV. "
-                    + "Debug builds only."
-            )
-            #endif
         }
     }
 
@@ -284,9 +292,20 @@ struct TVSettingsView: View {
         case signOut
     }
 
-    private static var appVersion: String {
-        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
+    private static var versionString: String {
+        let info = Bundle.main.infoDictionary
+        let version = info?["CFBundleShortVersionString"] as? String ?? "1.0.0"
+        guard let build = info?["CFBundleVersion"] as? String,
+              !build.isEmpty,
+              build != version else {
+            return version
+        }
+        return "\(version) (\(build))"
     }
+}
+
+enum TVSettingsDetailFocus: Hashable {
+    case top
 }
 
 // MARK: - Categories

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsView.swift
@@ -31,10 +31,12 @@ struct TVSettingsView: View {
             if showSignOutConfirm {
                 TVSettingsConfirmationOverlay(
                     title: "Sign Out",
-                    message: "You will be returned to the login screen.",
+                    message: "Choose whether to keep or remove this server from this Apple TV.",
                     confirmTitle: "Sign Out",
+                    additionalDestructiveTitle: "Sign Out & Remove Server",
                     cancel: dismissSignOutConfirmation,
-                    confirm: router.signOutAndReset
+                    confirm: router.signOutAndReset,
+                    additionalDestructiveAction: router.signOutRemoveServerAndReset
                 )
                 .transition(.opacity)
                 .zIndex(1)

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsView.swift
@@ -36,7 +36,7 @@ struct TVSettingsView: View {
                     cancel: dismissSignOutConfirmation,
                     confirm: router.signOutAndReset
                 )
-                .transition(.opacity.combined(with: .scale(scale: 0.96)))
+                .transition(.opacity)
                 .zIndex(1)
             }
         }

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsViewModel.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsViewModel.swift
@@ -45,13 +45,10 @@ final class TVSettingsViewModel {
     var subtitleUsesDeviceAppearanceOverride: Bool = PlayerSettings.shared.subtitleUsesDeviceAppearanceOverride
     var subtitleMatchesSystemAppearance: Bool = PlayerSettings.shared.subtitleMatchesSystemAppearance
 
-    /// What the player will actually render with — the system caption
-    /// style while Match Device Settings is on, otherwise the edited
-    /// appearance. Drives the preview.
+    /// What the player will actually render with: system captions, the
+    /// device override, or the inherited server appearance.
     var effectiveSubtitleAppearance: SubtitleAppearance {
-        subtitleMatchesSystemAppearance
-            ? PlayerSettings.shared.subtitleSystemAppearance
-            : subtitleAppearance
+        PlayerSettings.shared.effectiveSubtitleAppearance
     }
 
     // Server-backed profile prefs editor. Each editor field is either
@@ -223,6 +220,14 @@ final class TVSettingsViewModel {
         await PlayerSettings.shared.setSubtitleDeviceOverrideEnabled(enabled)
         subtitleAppearance = PlayerSettings.shared.subtitleAppearance
         subtitleUsesDeviceAppearanceOverride = PlayerSettings.shared.subtitleUsesDeviceAppearanceOverride
+    }
+
+    @MainActor
+    func resetSubtitleAppearance() async {
+        await PlayerSettings.shared.setSubtitleAppearance(.default)
+        subtitleAppearance = PlayerSettings.shared.subtitleAppearance
+        subtitleUsesDeviceAppearanceOverride = PlayerSettings.shared.subtitleUsesDeviceAppearanceOverride
+        subtitleMatchesSystemAppearance = PlayerSettings.shared.subtitleMatchesSystemAppearance
     }
 
     @MainActor

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSubtitleSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSubtitleSettingsView.swift
@@ -7,7 +7,9 @@ import SwiftUI
 /// appearance block writes a per-device override directly.
 struct TVSubtitleSettingsPane: View {
     @Bindable var viewModel: TVSettingsViewModel
+    let detailFocus: FocusState<TVSettingsDetailFocus?>.Binding
     @State private var activePicker: PickerKind?
+    @State private var showResetConfirmation = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -19,6 +21,14 @@ struct TVSubtitleSettingsPane: View {
         }
         .fullScreenCover(item: $activePicker) { kind in
             pickerSheet(for: kind)
+        }
+        .alert("Reset Custom Appearance?", isPresented: $showResetConfirmation) {
+            Button("Reset", role: .destructive) {
+                Task { await viewModel.resetSubtitleAppearance() }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This restores all custom subtitle appearance options to their defaults.")
         }
     }
 
@@ -32,6 +42,7 @@ struct TVSubtitleSettingsPane: View {
             title: "Language",
             value: TVSettingsOptions.label(for: viewModel.editorSubtitleLanguage, in: TVSettingsOptions.subtitleLanguage)
         ) { activePicker = .language }
+        .focused(detailFocus, equals: .top)
 
         TVSettingsPickerRow(
             title: "Behavior",
@@ -84,61 +95,79 @@ struct TVSubtitleSettingsPane: View {
         }
 
         TVSettingsToggleRow(
-            title: "Custom Appearance",
+            title: "Custom Subtitle Appearance",
             isOn: viewModel.subtitleUsesDeviceAppearanceOverride
         ) {
             let enabled = !viewModel.subtitleUsesDeviceAppearanceOverride
             Task { await viewModel.setSubtitleDeviceOverrideEnabled(enabled) }
         }
 
-        pickerRow("Font Size", options: TVSettingsOptions.subtitleSize,
-                  selection: viewModel.subtitleAppearance.fontSize.rawValue, kind: .fontSize)
-        pickerRow("Font Family", options: TVSettingsOptions.fontFamily,
-                  selection: viewModel.subtitleAppearance.fontFamily.rawValue, kind: .fontFamily)
-        pickerRow("Font Color", options: TVSettingsOptions.fontColor,
-                  selection: viewModel.subtitleAppearance.fontColor.lowercased(), kind: .fontColor)
+        TVSettingsNestedGroup(enabled: viewModel.subtitleUsesDeviceAppearanceOverride) {
+            pickerRow("Font Size", options: TVSettingsOptions.subtitleSize,
+                      selection: viewModel.subtitleAppearance.fontSize.rawValue, kind: .fontSize)
+            pickerRow("Font Family", options: TVSettingsOptions.fontFamily,
+                      selection: viewModel.subtitleAppearance.fontFamily.rawValue, kind: .fontFamily)
+            pickerRow("Font Color", options: TVSettingsOptions.fontColor,
+                      selection: viewModel.subtitleAppearance.fontColor.lowercased(), kind: .fontColor)
 
-        TVSettingsToggleRow(
-            title: "Text Outline",
-            isOn: viewModel.subtitleAppearance.textOutline
-        ) {
-            var next = viewModel.subtitleAppearance
-            next.textOutline.toggle()
-            Task { await viewModel.setSubtitleAppearance(next) }
+            TVSettingsToggleRow(
+                title: "Text Outline",
+                isOn: viewModel.subtitleAppearance.textOutline
+            ) {
+                guard viewModel.subtitleUsesDeviceAppearanceOverride else { return }
+                var next = viewModel.subtitleAppearance
+                next.textOutline.toggle()
+                Task { await viewModel.setSubtitleAppearance(next) }
+            }
+
+            TVSettingsPickerRow(
+                title: "Outline Color",
+                value: viewModel.subtitleAppearance.textOutline
+                    ? TVSettingsOptions.label(
+                        for: viewModel.subtitleAppearance.textOutlineColor.lowercased(),
+                        in: TVSettingsOptions.outlineColor
+                    )
+                    : "—"
+            ) {
+                guard viewModel.subtitleUsesDeviceAppearanceOverride else { return }
+                activePicker = .outlineColor
+            }
+
+            pickerRow("Background Style", options: TVSettingsOptions.backgroundStyle,
+                      selection: viewModel.subtitleAppearance.backgroundStyle.rawValue, kind: .backgroundStyle)
+
+            TVSettingsPickerRow(
+                title: "Background Opacity",
+                value: viewModel.subtitleAppearance.backgroundStyle == .box
+                    ? "\(viewModel.subtitleAppearance.backgroundOpacity)%"
+                    : "—"
+            ) {
+                guard viewModel.subtitleUsesDeviceAppearanceOverride else { return }
+                activePicker = .backgroundOpacity
+            }
+
+            TVSettingsPickerRow(
+                title: "Background Color",
+                value: viewModel.subtitleAppearance.backgroundStyle == .box
+                    ? TVSettingsOptions.label(
+                        for: viewModel.subtitleAppearance.backgroundColor.lowercased(),
+                        in: TVSettingsOptions.backgroundColor
+                    )
+                    : "—"
+            ) {
+                guard viewModel.subtitleUsesDeviceAppearanceOverride else { return }
+                activePicker = .backgroundColor
+            }
+
+            pickerRow("Position", options: TVSettingsOptions.position,
+                      selection: viewModel.subtitleAppearance.position.rawValue, kind: .position)
+
+            Button("Reset Custom Appearance", role: .destructive) {
+                guard viewModel.subtitleUsesDeviceAppearanceOverride else { return }
+                showResetConfirmation = true
+            }
+            .buttonStyle(TVSettingsPaneRowStyle(isDestructive: true))
         }
-
-        TVSettingsPickerRow(
-            title: "Outline Color",
-            value: viewModel.subtitleAppearance.textOutline
-                ? TVSettingsOptions.label(
-                    for: viewModel.subtitleAppearance.textOutlineColor.lowercased(),
-                    in: TVSettingsOptions.outlineColor
-                )
-                : "—"
-        ) { activePicker = .outlineColor }
-
-        pickerRow("Background Style", options: TVSettingsOptions.backgroundStyle,
-                  selection: viewModel.subtitleAppearance.backgroundStyle.rawValue, kind: .backgroundStyle)
-
-        TVSettingsPickerRow(
-            title: "Background Opacity",
-            value: viewModel.subtitleAppearance.backgroundStyle == .box
-                ? "\(viewModel.subtitleAppearance.backgroundOpacity)%"
-                : "—"
-        ) { activePicker = .backgroundOpacity }
-
-        TVSettingsPickerRow(
-            title: "Background Color",
-            value: viewModel.subtitleAppearance.backgroundStyle == .box
-                ? TVSettingsOptions.label(
-                    for: viewModel.subtitleAppearance.backgroundColor.lowercased(),
-                    in: TVSettingsOptions.backgroundColor
-                )
-                : "—"
-        ) { activePicker = .backgroundColor }
-
-        pickerRow("Position", options: TVSettingsOptions.position,
-                  selection: viewModel.subtitleAppearance.position.rawValue, kind: .position)
 
         TVSettingsFooter(appearanceFooterText)
     }
@@ -184,7 +213,10 @@ struct TVSubtitleSettingsPane: View {
         TVSettingsPickerRow(
             title: title,
             value: TVSettingsOptions.label(for: selection, in: options)
-        ) { activePicker = kind }
+        ) {
+            guard viewModel.subtitleUsesDeviceAppearanceOverride else { return }
+            activePicker = kind
+        }
     }
 
     // MARK: - Pickers

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSubtitleSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSubtitleSettingsView.swift
@@ -101,6 +101,7 @@ struct TVSubtitleSettingsPane: View {
             let enabled = !viewModel.subtitleUsesDeviceAppearanceOverride
             Task { await viewModel.setSubtitleDeviceOverrideEnabled(enabled) }
         }
+        .disabled(viewModel.subtitleMatchesSystemAppearance)
 
         TVSettingsNestedGroup(enabled: viewModel.subtitleUsesDeviceAppearanceOverride) {
             pickerRow("Font Size", options: TVSettingsOptions.subtitleSize,

--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -66,7 +66,7 @@ targets:
       base:
         PRODUCT_NAME: Silo
         INFOPLIST_FILE: iosApp/Info.plist
-        MARKETING_VERSION: "0.1.0"
+        MARKETING_VERSION: "1.0.0"
         CURRENT_PROJECT_VERSION: 1
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
@@ -120,7 +120,7 @@ targets:
       base:
         PRODUCT_NAME: SiloTV
         INFOPLIST_FILE: iosApp/tvOS-Info.plist
-        MARKETING_VERSION: "0.1.0"
+        MARKETING_VERSION: "1.0.0"
         CURRENT_PROJECT_VERSION: 1
         ASSETCATALOG_COMPILER_APPICON_NAME: TVAppIcon
         ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
@@ -173,7 +173,7 @@ targets:
       base:
         PRODUCT_NAME: Silo
         INFOPLIST_FILE: macOS-Info.plist
-        MARKETING_VERSION: "0.1.0"
+        MARKETING_VERSION: "1.0.0"
         CURRENT_PROJECT_VERSION: 1
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
@@ -211,7 +211,7 @@ targets:
       base:
         PRODUCT_NAME: SiloTVTopShelf
         INFOPLIST_FILE: TopShelf/Info.plist
-        MARKETING_VERSION: "0.1.0"
+        MARKETING_VERSION: "1.0.0"
         CURRENT_PROJECT_VERSION: 1
         SDKROOT: appletvos
         SUPPORTED_PLATFORMS: "appletvos appletvsimulator"
@@ -236,7 +236,7 @@ targets:
       base:
         PRODUCT_NAME: SiloNotificationService
         INFOPLIST_FILE: NotificationService/Info.plist
-        MARKETING_VERSION: "0.1.0"
+        MARKETING_VERSION: "1.0.0"
         CURRENT_PROJECT_VERSION: 1
         SDKROOT: iphoneos
         SUPPORTED_PLATFORMS: "iphoneos iphonesimulator"
@@ -262,7 +262,7 @@ targets:
       base:
         PRODUCT_NAME: SiloDownloadsActivity
         INFOPLIST_FILE: DownloadsActivity/Info.plist
-        MARKETING_VERSION: "0.1.0"
+        MARKETING_VERSION: "1.0.0"
         CURRENT_PROJECT_VERSION: 1
         TARGETED_DEVICE_FAMILY: "1,2"
         SDKROOT: iphoneos


### PR DESCRIPTION
## Summary

This PR collects the tvOS settings, authentication, server-management, and content-navigation fixes completed during simulator testing.

## Settings navigation and presentation

- Treat the left column as the settings main menu and the right column as its submenu, using the existing native focus graph instead of layering directional overrides on top of it.
- Focus the top submenu item when entering from the main menu.
- Return focus to the related main-menu item when moving left or backing out of a submenu, then route the final Settings exit through the tvOS shell's root-selection state so it always lands on Home.
- Make Right/Left mirror Select/Back within the Settings page without changing remote behavior elsewhere in the app.
- Limit the Server submenu's focusable content to Manage Servers; informational server and version rows remain readable but do not take focus.
- Keep each informational title/value row grouped as one VoiceOver element after removing its button behavior.
- Remove the lingering Server selection indicator when Sign Out has focus and improve the Sign Out row's red-state contrast.
- Derive the displayed app version from the bundle for both the Server submenu and the lower-left Settings version label.

## Custom subtitle appearance

- Rename the Subtitles customization section to Custom Subtitle Appearance and visually indent its dependent controls as sub-items.
- Keep disabled custom-appearance controls focusable for inspection while preventing edits and rendering them in a muted state.
- Preserve the user's custom values when Custom Subtitle Appearance is toggled off so re-enabling restores the prior choices.
- Disable the Custom Subtitle Appearance toggle while Match Device Settings is active, matching the existing iOS behavior.
- Clean up the selection presentation used by subtitle appearance options.
- Add a Reset Custom Appearance action with a confirmation modal and restore the custom values to their defaults only after confirmation.

## Server management and confirmation dialogs

- Restyle Manage Servers to match the wider Settings layout, typography, surfaces, and focus treatment.
- Keep saved server rows focusable; Select is a no-op for the active server and switches to any other saved server.
- Show a dedicated red trash action beside each saved server and confirm removal with the shared tvOS modal.
- Remove long-press server actions and client-side rename support; saved names now remain server-admin-derived.
- Preserve the last valid server-admin name when a pairing/update payload omits the name or supplies an empty value.
- Keep active-server and pairing state consistent when a saved server is removed.
- Treat the active server ID as a routed-view identity boundary so profile, library, Home, focus, and modal state cannot survive a switch to another server with the same auth state.
- Cancel old-server requests and clear process-wide response, prefetch, item-detail, profile-preference, overlay, and feature caches before publishing a new active server or fallback server.
- Clear and rehydrate server-scoped card-overlay preferences on active-server changes, invalidating late responses from the previous server before they can restore stale state.
- Route server removal and sign-out outcomes through the existing auth-navigation helpers so every entry point lands on the same next screen.
- Introduce a reusable tvOS confirmation modal with legible Cancel styling, centered button labels, and full-screen dimming that appears and disappears without the prior border flash.

## Sign-out, sign-in, and profile entry

- Use the shared confirmation modal for Sign Out from Settings, the top profile menu, and profile selection.
- Offer Cancel, Sign Out, and Sign Out & Remove Server; the last option clears the active saved server after signing out.
- Label the full-screen tvOS keyboards Username and Password.
- Move Down from Username to Password instead of the password-visibility control; reach the visibility control only by moving Right from Password.
- Focus Sign In after completing the full-screen username/password entry flow.
- Start PIN entry on keypad 5 and make Back erase entered digits before dismissing the keypad when empty.

## Library, person, and item-detail behavior

- Give empty Library Collections pages a native focus owner so Menu/Back can leave the page instead of trapping the user.
- Hide Movies or Series pills on person pages when the server confirms that media type has no content; failed availability checks leave the pill visible rather than hiding content on a network error.
- Align the episode rail with the season selector on episode detail pages.
- Add long-press episode actions for Mark Watched/Unwatched and Add/Remove Favorites on series, season, and episode detail rails.
- Resolve sibling favorite state with bounded requests, avoid refetching favorites after watched-only changes, and prevent stale refreshes from overwriting a newer favorite toggle.
- Discard a sibling episode's combined cached user-state entry after a favorite change so reopening it cannot briefly restore an outdated favorite value.
- Seed highlighted next-up cards with their resolved favorite state on both series and season pages so their menus correctly offer removal.
- Keep watched/favorite context-menu changes optimistic, then release their local overrides once refreshed server state catches up so cards cannot remain stale.
- Invalidate the known parent series, season list, and episode-list caches after episode watched changes so progress and Next Up cannot fall back to pre-toggle state.
- Restore current-episode focus the first time the user moves into the episode rail on an episode detail page, using native `defaultFocus` rather than directional interception.

## Continue Watching

- Expose Remove from Continue Watching for every item shown in that Home row, including server-provided items without a progress timestamp.
- Fall back to the current timestamp for those dismissals so the server can hide the item until newer playback progress exists.
- Preserve the existing watched/unwatched long-press action and update the visible Home sections/cache after a successful dismissal.

## Validation

- `git diff --check origin/main...HEAD`
- Repeated signed `SiloTV` builds, installs, and launches on Apple TV 4K (2nd generation), tvOS 26.5, including a clean final build after the server-switch review fix.
- Simulator checks throughout implementation for Settings focus handoff, subtitle customization, Manage Servers, confirmation dialogs, sign-in keyboard/focus flow, PIN entry, empty collections, person filters, episode alignment/actions, and Continue Watching menus.
- Codex and CodeRabbit automated review findings assessed, fixed where actionable, and revalidated in the simulator.
