### PR TITLE
Refine tvOS player remote and timeline interactions

### DIFF
--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -162,6 +162,11 @@ struct PlayerView: View {
                             showsTimelinePreview: isTimelinePreviewVisible,
                             timeDisplayMode: timelineTimeDisplayMode,
                             timelineSelectionRequest: timelineSelectionRequest,
+                            onToggleTimeDisplayMode: {
+                                withAnimation(.easeOut(duration: ContinuumTheme.fastDuration)) {
+                                    timelineTimeDisplayMode.toggle()
+                                }
+                            },
                             onDismiss: { dismissPlayer() }
                         )
                     }
@@ -272,6 +277,8 @@ struct PlayerView: View {
         .onChange(of: viewModel.showControls) { _, visible in
             if visible {
                 hideTimelinePreview()
+            } else {
+                timelineTimeDisplayMode = .elapsedRemaining
             }
         }
         #endif

--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -35,6 +35,11 @@ struct PlayerView: View {
     #endif
     #if os(tvOS)
     @State private var remoteIdentityNotice: RemotePlaybackIdentityManager.ActiveIdentity?
+    @State private var isTimelinePreviewVisible = false
+    @State private var timelineTimeDisplayMode: TVPlayerTimeDisplayMode = .elapsedRemaining
+    @State private var timelineSelectionRequest: UUID?
+    @State private var timelinePreviewHideTask: Task<Void, Never>?
+    @State private var timelinePreviewContactCanToggle = false
     #endif
 
     init(
@@ -90,7 +95,8 @@ struct PlayerView: View {
                     //
                     // Two modes:
                     //   • Not in seek mode: Tap Left/Right = quick skip,
-                    //     Tap Up/Down = open player menus, Tap Select = summon overlay,
+                    //     Tap Up/Down = open player menus, Tap Select = pause and
+                    //     enter the focused timeline,
                     //     Hold Left/Right = enter seek mode.
                     //   • In seek mode: Tap Left/Right = adjust rate along
                     //     the signed ladder, Tap Select = commit + exit,
@@ -125,9 +131,23 @@ struct PlayerView: View {
                                 case .up, .down: break
                                 }
                             },
+                            onTouchSurfaceContactBegan: {
+                                handleTimelinePreviewContactBegan()
+                            },
+                            onTouchSurfaceContactEnded: {
+                                handleTimelinePreviewContactEnded()
+                            },
+                            onTouchSurfaceContactCancelled: {
+                                handleTimelinePreviewContactCancelled()
+                            },
                             onSelect: {
                                 if viewModel.isHoldSeeking {
                                     viewModel.commitHoldSeek()
+                                } else if viewModel.isPlaying {
+                                    timelinePreviewContactCanToggle = false
+                                    hideTimelinePreview(immediately: true)
+                                    viewModel.pauseForTimelineSelection()
+                                    timelineSelectionRequest = UUID()
                                 } else {
                                     viewModel.revealControls()
                                 }
@@ -137,7 +157,13 @@ struct PlayerView: View {
                     }
 
                     if !viewModel.isLoading && !viewModel.isHoldSeeking {
-                        TVPlayerControls(viewModel: viewModel, onDismiss: { dismissPlayer() })
+                        TVPlayerControls(
+                            viewModel: viewModel,
+                            showsTimelinePreview: isTimelinePreviewVisible,
+                            timeDisplayMode: timelineTimeDisplayMode,
+                            timelineSelectionRequest: timelineSelectionRequest,
+                            onDismiss: { dismissPlayer() }
+                        )
                     }
 
                     // Speed-indicator chip shown only while a seek session is
@@ -242,6 +268,13 @@ struct PlayerView: View {
             didNotifyPlaybackStarted = true
             onPlaybackStarted?()
         }
+        #if os(tvOS)
+        .onChange(of: viewModel.showControls) { _, visible in
+            if visible {
+                hideTimelinePreview()
+            }
+        }
+        #endif
         .onChange(of: viewModel.remoteDismissToken) { _, newValue in
             guard newValue != nil else { return }
             dismissPlayer()
@@ -278,6 +311,10 @@ struct PlayerView: View {
         }
         #endif
         .onDisappear {
+            #if os(tvOS)
+            timelinePreviewHideTask?.cancel()
+            timelinePreviewHideTask = nil
+            #endif
             viewModel.cleanup()
             #if os(tvOS)
             TVControlReceiver.shared.unregisterPlayer(viewModel)
@@ -311,6 +348,68 @@ struct PlayerView: View {
         viewModel.cleanup()
         dismiss()
     }
+
+    #if os(tvOS)
+    private func handleTimelinePreviewContactBegan() {
+        guard viewModel.isPlaying,
+              !viewModel.showControls,
+              !viewModel.isHUDPresented,
+              !viewModel.isHoldSeeking else { return }
+
+        timelinePreviewHideTask?.cancel()
+        timelinePreviewHideTask = nil
+        timelinePreviewContactCanToggle = isTimelinePreviewVisible
+        withAnimation(.easeOut(duration: ContinuumTheme.fastDuration)) {
+            if !isTimelinePreviewVisible {
+                isTimelinePreviewVisible = true
+            }
+        }
+    }
+
+    private func handleTimelinePreviewContactEnded() {
+        guard isTimelinePreviewVisible else { return }
+        if timelinePreviewContactCanToggle {
+            withAnimation(.easeOut(duration: ContinuumTheme.fastDuration)) {
+                timelineTimeDisplayMode.toggle()
+            }
+        }
+        timelinePreviewContactCanToggle = false
+        scheduleTimelinePreviewHide()
+    }
+
+    private func handleTimelinePreviewContactCancelled() {
+        timelinePreviewContactCanToggle = false
+        scheduleTimelinePreviewHide()
+    }
+
+    private func scheduleTimelinePreviewHide() {
+        guard isTimelinePreviewVisible else { return }
+        timelinePreviewHideTask?.cancel()
+        timelinePreviewHideTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(3))
+            guard !Task.isCancelled else { return }
+            hideTimelinePreview()
+        }
+    }
+
+    private func hideTimelinePreview(immediately: Bool = false) {
+        timelinePreviewHideTask?.cancel()
+        timelinePreviewHideTask = nil
+        timelinePreviewContactCanToggle = false
+        guard isTimelinePreviewVisible else { return }
+        if immediately {
+            isTimelinePreviewVisible = false
+        } else {
+            withAnimation(.easeOut(duration: ContinuumTheme.fastDuration)) {
+                isTimelinePreviewVisible = false
+            }
+            // A dismissed quick preview always starts fresh in duration mode
+            // on the next light touch. The immediate Select-to-HUD handoff
+            // intentionally preserves the current display mode instead.
+            timelineTimeDisplayMode = .elapsedRemaining
+        }
+    }
+    #endif
 
     /// Video surface. tvOS uses focus-driven transport; on iOS the touch
     /// gestures (tap-to-toggle, pinch, double-tap skip, …) live in

--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -76,7 +76,11 @@ struct PlayerView: View {
                 if viewModel.showNextUpScreen {
                     PlayerNextUpScreen(
                         viewModel: viewModel,
-                        onBack: { dismissPlayer() },
+                        onBack: {
+                            if !viewModel.keepWatchingCurrentEpisode() {
+                                dismissPlayer()
+                            }
+                        },
                         miniPlayer: { playerSurface(ignoresSafeArea: false) }
                     )
                     .transition(.opacity)
@@ -245,7 +249,9 @@ struct PlayerView: View {
         // it; this fallback keeps the user from getting stuck.
         .onExitCommand {
             if viewModel.showNextUpScreen {
-                dismissPlayer()
+                if !viewModel.keepWatchingCurrentEpisode() {
+                    dismissPlayer()
+                }
             } else if viewModel.isHoldSeeking {
                 viewModel.cancelHoldSeek()
             } else if viewModel.isBackgroundSuspended {
@@ -756,7 +762,9 @@ private struct PlayerNextUpScreen<MiniPlayer: View>: View {
     private func actionRow(hasNextEpisode: Bool) -> some View {
         #if os(tvOS)
         VStack(alignment: .leading, spacing: 18) {
-            HStack(spacing: 24) {
+            // Reserve enough room for the primary pill's focused scale and
+            // outer focus outline so the countdown never overlaps it.
+            HStack(spacing: 56) {
                 if hasNextEpisode {
                     Button(action: { viewModel.playNextEpisodeNow() }) {
                         HStack(spacing: 18) {

--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -99,7 +99,8 @@ struct PlayerView: View {
                     //
                     // Two modes:
                     //   • Not in seek mode: Tap Left/Right = quick skip,
-                    //     Tap Up/Down = open player menus, Tap Select = pause and
+                    //     Tap Down = open the player menu, Tap Up = reveal the
+                    //     full transport HUD, Tap Select = pause and
                     //     enter the focused timeline,
                     //     Hold Left/Right = enter seek mode.
                     //   • In seek mode: Tap Left/Right = adjust rate along
@@ -121,7 +122,7 @@ struct PlayerView: View {
                                     case .left:  viewModel.skipBackward()
                                     case .right: viewModel.skipForward()
                                     case .down:  viewModel.openSettingsHUD()
-                                    case .up:    viewModel.openPlaybackHUD()
+                                    case .up:    viewModel.revealControls()
                                     }
                                 }
                             },

--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -136,6 +136,9 @@ struct PlayerView: View {
                                 case .up, .down: break
                                 }
                             },
+                            onDirectionalPressBegan: {
+                                timelinePreviewContactCanToggle = false
+                            },
                             onTouchSurfaceContactBegan: {
                                 handleTimelinePreviewContactBegan()
                             },

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -4671,16 +4671,30 @@ class PlayerViewModel {
         scrubPreviewTime = max(0, min(fraction, 1)) * duration
     }
 
-    func endScrub(resumePlayback: Bool = false) {
+    func endScrub(resumePlayback: Bool = false, shouldSeek: Bool = true) {
         guard !isBackgroundSuspended else { return }
         guard !hasReachedEndOfFile else { return }
         guard isScrubbing else { return }
         skipDebounceTask?.cancel()
         skipDebounceTask = nil
-        Self.logger.info(
-            "[CMP-SEEK] scrub ended target=\(self.scrubPreviewTime, privacy: .public) current=\(self.currentTime, privacy: .public)"
-        )
-        let reloadsPlaybackPipeline = commitSeek(to: scrubPreviewTime, source: "scrub")
+        let reloadsPlaybackPipeline: Bool
+        if shouldSeek {
+            Self.logger.info(
+                "[CMP-SEEK] scrub ended target=\(self.scrubPreviewTime, privacy: .public) current=\(self.currentTime, privacy: .public)"
+            )
+            reloadsPlaybackPipeline = commitSeek(to: scrubPreviewTime, source: "scrub")
+        } else {
+            // Select entered and exited timeline mode without moving the
+            // playhead. Keep the backend parked at its exact paused position
+            // instead of issuing a redundant seek that can snap to a nearby
+            // keyframe and briefly rebuffer.
+            isScrubbing = false
+            scrubPreviewTime = currentTime
+            reloadsPlaybackPipeline = false
+            Self.logger.info(
+                "[CMP-SEEK] scrub ended without movement; resuming without seek at current=\(self.currentTime, privacy: .public)"
+            )
+        }
         if resumePlayback, !reloadsPlaybackPipeline {
             activePlayer.play()
         }

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -3861,6 +3861,20 @@ class PlayerViewModel {
         scheduleHideControls()
     }
 
+    #if os(tvOS)
+    /// Native-player Select behavior for timeline entry: pause immediately
+    /// and keep the full transport mounted. When controls were hidden,
+    /// `TVPlayerControls` consumes a separate request token to focus and
+    /// activate its timeline scrubber.
+    func pauseForTimelineSelection() {
+        guard !isBackgroundSuspended, !isLoading, !hasReachedEndOfFile else { return }
+        if isPlaying {
+            activePlayer.pause()
+        }
+        pinControlsVisible()
+    }
+    #endif
+
     func switchQuality(_ qualityId: String) {
         guard !isBackgroundSuspended else { return }
         guard let plan = activeExecutionPlan else { return }
@@ -4181,12 +4195,13 @@ class PlayerViewModel {
     /// prior optimistic target) — the midpoint between that and the new
     /// target still correctly rejects drainage from either the current or
     /// the prior seek.
-    private func commitSeek(to target: Double, source: String = "unspecified") {
+    @discardableResult
+    private func commitSeek(to target: Double, source: String = "unspecified") -> Bool {
         Self.logger.info(
             "[CMP-SEEK] commit requested source=\(source, privacy: .public) target=\(target, privacy: .public) current=\(self.currentTime, privacy: .public) preview=\(self.scrubPreviewTime, privacy: .public) isScrubbing=\(self.isScrubbing, privacy: .public) route=\(self.activeRouteKind.label, privacy: .public) offset=\(self.playbackTimelineOffset, privacy: .public)"
         )
         if reloadServerBackedHLSForSeek(to: target) {
-            return
+            return true
         }
 
         hasReachedEndOfFile = false
@@ -4212,6 +4227,7 @@ class PlayerViewModel {
             self.seekTargetTime = nil
             self.seekFilterTimeoutTask = nil
         }
+        return false
     }
 
     private func reloadServerBackedHLSForSeek(to target: Double) -> Bool {
@@ -4655,7 +4671,7 @@ class PlayerViewModel {
         scrubPreviewTime = max(0, min(fraction, 1)) * duration
     }
 
-    func endScrub() {
+    func endScrub(resumePlayback: Bool = false) {
         guard !isBackgroundSuspended else { return }
         guard !hasReachedEndOfFile else { return }
         guard isScrubbing else { return }
@@ -4664,7 +4680,10 @@ class PlayerViewModel {
         Self.logger.info(
             "[CMP-SEEK] scrub ended target=\(self.scrubPreviewTime, privacy: .public) current=\(self.currentTime, privacy: .public)"
         )
-        commitSeek(to: scrubPreviewTime, source: "scrub")
+        let reloadsPlaybackPipeline = commitSeek(to: scrubPreviewTime, source: "scrub")
+        if resumePlayback, !reloadsPlaybackPipeline {
+            activePlayer.play()
+        }
         scheduleHideControls()
     }
 

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -422,6 +422,11 @@ class PlayerViewModel {
     var nextUpCountdownSeconds: Int?
     var nextUpCountdownTotalSeconds: Int = 10
     var nextUpScreenVideoEnded = false
+    private enum NextUpPresentationSource {
+        case automatic
+        case hud
+    }
+    private var nextUpPresentationSource: NextUpPresentationSource = .automatic
     private var serverProvidedChapters: [PlayerChapterInfo] = []
 
     /// Secondary metadata surfaced to the player overlay. Populated from
@@ -967,6 +972,7 @@ class PlayerViewModel {
     private static let serverOutageRecoveryMaxDelay: TimeInterval = 8
     private static let serverOutageRecoveryTimeout: TimeInterval = 90
     private static let nextUpCountdownDefaultSeconds = 10
+    private static let nextUpHUDCountdownThresholdSeconds: Double = 100
     private static let introAutoSkipCountdownDefaultSeconds = 5
     static var nextUpCountdownTotal: Int { nextUpCountdownDefaultSeconds }
     private static let nearEndPlaybackErrorThresholdSeconds: Double = 8
@@ -1659,7 +1665,7 @@ class PlayerViewModel {
             return
         }
         guard !nextUpPromptDismissed else { return }
-        beginNextUpPostroll(videoEnded: false)
+        beginNextUpPostroll(videoEnded: false, source: .automatic)
     }
 
     private func shouldShowNextUpBeforeEnd(at movieTime: Double) -> Bool {
@@ -1673,11 +1679,18 @@ class PlayerViewModel {
 
     func showNextUpNow() {
         guard canShowNextUpScreen else { return }
-        beginNextUpPostroll(videoEnded: false)
+        beginNextUpPostroll(videoEnded: false, source: .hud)
     }
 
-    private func beginNextUpPostroll(videoEnded: Bool) {
+    private func beginNextUpPostroll(
+        videoEnded: Bool,
+        source: NextUpPresentationSource = .automatic
+    ) {
+        let wasAlreadyShowing = showNextUpScreen
         let wasShowingBeforeEnd = showNextUpScreen && !nextUpScreenVideoEnded
+        if !wasAlreadyShowing {
+            nextUpPresentationSource = source
+        }
         showNextUpScreen = true
         nextUpScreenVideoEnded = videoEnded
         showControls = false
@@ -1740,7 +1753,15 @@ class PlayerViewModel {
         }
 
         let remaining = max(0, duration - movieTime)
-        nextUpCountdownTotalSeconds = max(1, settings.nextUpPromptSeconds)
+        if nextUpPresentationSource == .hud,
+           remaining >= Self.nextUpHUDCountdownThresholdSeconds {
+            nextUpCountdownSeconds = nil
+            nextUpCountdownTotalSeconds = Int(Self.nextUpHUDCountdownThresholdSeconds)
+            return
+        }
+        nextUpCountdownTotalSeconds = nextUpPresentationSource == .hud
+            ? Int(Self.nextUpHUDCountdownThresholdSeconds)
+            : max(1, settings.nextUpPromptSeconds)
         nextUpCountdownSeconds = max(0, Int(ceil(remaining)))
         if remaining <= 0.35 {
             playNextEpisodeNow()
@@ -1767,12 +1788,38 @@ class PlayerViewModel {
         cancelNextUpCountdown()
     }
 
-    func keepWatchingCurrentEpisode() {
+    @discardableResult
+    func keepWatchingCurrentEpisode() -> Bool {
+        // An autoplay load failure may restore the postroll after disposing
+        // the old playback pipeline. There is no current episode to resume in
+        // that state, so let the shell fall back to closing the player.
+        guard !activePlayer.isNone else { return false }
+
+        let shouldResumeAfterEnd = nextUpScreenVideoEnded || hasReachedEndOfFile
         nextUpAutoplayCancelled = true
         nextUpPromptDismissed = true
         showNextUpScreen = false
         nextUpScreenVideoEnded = false
         cancelNextUpCountdown()
+
+        if shouldResumeAfterEnd,
+           duration.isFinite,
+           duration > 0,
+           !activePlayer.isNone {
+            // Returning from the terminal postroll needs a real playable
+            // position; resuming at exact EOF would immediately present the
+            // postroll again. Replay a short tail of the current episode.
+            hasReachedEndOfFile = false
+            let target = max(0, duration - 10)
+            let reloadsPlaybackPipeline = commitSeek(to: target, source: "nextUpBack")
+            if !reloadsPlaybackPipeline {
+                activePlayer.play()
+            }
+        } else if !isPlaying {
+            activePlayer.play()
+        }
+        scheduleHideControls()
+        return true
     }
 
     func setNextUpAutoPlayEnabled(_ enabled: Bool) {
@@ -2823,6 +2870,7 @@ class PlayerViewModel {
         nextUpCountdownSeconds = nil
         nextUpCountdownTotalSeconds = Self.nextUpCountdownDefaultSeconds
         nextUpScreenVideoEnded = false
+        nextUpPresentationSource = .automatic
         nextUpAutoplayCancelled = false
         nextUpPromptDismissed = false
         audioTracks = []

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPlayerControls.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPlayerControls.swift
@@ -1,6 +1,15 @@
 #if os(tvOS)
 import SwiftUI
 
+enum TVPlayerTimeDisplayMode: Equatable {
+    case elapsedRemaining
+    case currentAndFinish
+
+    mutating func toggle() {
+        self = self == .elapsedRemaining ? .currentAndFinish : .elapsedRemaining
+    }
+}
+
 /// tvOS player overlay. Post-redesign the idle state is VidHub-minimal:
 /// no hero strip, thin scrubber, icon-only transport row along the bottom.
 /// When the user opens the options panel, the idle overlay steps aside and
@@ -10,6 +19,9 @@ import SwiftUI
 /// depending on what's on screen.
 struct TVPlayerControls: View {
     let viewModel: PlayerViewModel
+    let showsTimelinePreview: Bool
+    let timeDisplayMode: TVPlayerTimeDisplayMode
+    let timelineSelectionRequest: UUID?
     let onDismiss: () -> Void
 
     @Environment(\.scenePhase) private var scenePhase
@@ -55,6 +67,10 @@ struct TVPlayerControls: View {
 
     var body: some View {
         ZStack {
+            if showsTimelinePreview && !viewModel.showControls && !isHUDPresented {
+                timelinePreviewOverlay
+                    .transition(.opacity)
+            }
             // Idle overlay and HUD are mutually exclusive. Stacking both
             // confused the focus engine (scrubber clicks bleeding into
             // hidden transport buttons) and added visual noise from the
@@ -115,6 +131,10 @@ struct TVPlayerControls: View {
             applyHUDEntryPoint(entryPoint)
             viewModel.consumeTVHUDEntryRequest()
         }
+        .onChange(of: timelineSelectionRequest) { _, request in
+            guard request != nil else { return }
+            enterTimelineSelection()
+        }
         // Re-arm the auto-hide whenever focus moves between transport controls,
         // so navigating the overlay doesn't let the fixed 5s timer hide it (and
         // the user's focus) out from under them mid-interaction.
@@ -161,6 +181,55 @@ struct TVPlayerControls: View {
     }
 
     // MARK: - Idle overlay
+
+    private var timelinePreviewOverlay: some View {
+        ZStack(alignment: .bottom) {
+            bottomGradient.ignoresSafeArea()
+            VStack(spacing: 10) {
+                passiveTimelineBar
+                timeRow
+            }
+            .padding(.horizontal, 80)
+            .padding(.bottom, 48)
+        }
+        .allowsHitTesting(false)
+    }
+
+    private var passiveTimelineBar: some View {
+        GeometryReader { geo in
+            let width = geo.size.width
+            ZStack(alignment: .leading) {
+                Capsule(style: .continuous)
+                    .fill(Color.white.opacity(0.24))
+                    .frame(height: 7)
+
+                let bufferedAhead = max(0, bufferedFraction - progressFraction)
+                if bufferedAhead > 0 {
+                    Capsule(style: .continuous)
+                        .fill(Color.white.opacity(0.28))
+                        .frame(width: width * bufferedAhead, height: 7)
+                        .offset(x: width * progressFraction)
+                }
+
+                Capsule(style: .continuous)
+                    .fill(Color.white)
+                    .frame(width: width * progressFraction, height: 7)
+            }
+            .frame(height: 20, alignment: .center)
+        }
+        .frame(height: 20)
+    }
+
+    private var progressFraction: Double {
+        guard viewModel.duration > 0 else { return 0 }
+        return min(max(scrubberDisplayTime / viewModel.duration, 0), 1)
+    }
+
+    private var bufferedFraction: Double {
+        guard viewModel.duration > 0 else { return 0 }
+        let end = viewModel.currentTime + viewModel.bufferedAheadSeconds
+        return min(max(end / viewModel.duration, 0), 1)
+    }
 
     @ViewBuilder
     private var idleOverlay: some View {
@@ -416,20 +485,34 @@ struct TVPlayerControls: View {
             : viewModel.metadata.primaryTitle
     }
 
+    @ViewBuilder
     private var timeRow: some View {
-        HStack {
-            Text(formatTime(scrubberDisplayTime))
-                .font(.system(size: 28, weight: .semibold, design: .rounded))
-                .foregroundStyle(.white)
-                .monospacedDigit()
-            Spacer()
-            if viewModel.duration > 0 {
-                Text("−\(formatTime(remainingTime))")
-                    .font(.system(size: 28, weight: .semibold, design: .rounded))
-                    .foregroundStyle(.white)
-                    .monospacedDigit()
+        if timeDisplayMode == .currentAndFinish {
+            TimelineView(.periodic(from: .now, by: 1)) { context in
+                HStack {
+                    clockText(formatClockTime(context.date))
+                    Spacer()
+                    if viewModel.duration > 0 {
+                        clockText(formatClockTime(estimatedFinishDate(from: context.date)))
+                    }
+                }
+            }
+        } else {
+            HStack {
+                clockText(formatTime(scrubberDisplayTime))
+                Spacer()
+                if viewModel.duration > 0 {
+                    clockText("−\(formatTime(remainingTime))")
+                }
             }
         }
+    }
+
+    private func clockText(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 28, weight: .semibold, design: .rounded))
+            .foregroundStyle(.white)
+            .monospacedDigit()
     }
 
     private var scrubberDisplayTime: Double {
@@ -440,7 +523,35 @@ struct TVPlayerControls: View {
         max(0, viewModel.duration - scrubberDisplayTime)
     }
 
+    private func estimatedFinishDate(from now: Date) -> Date {
+        let speed = max(viewModel.settings.playbackSpeed, 0.1)
+        return now.addingTimeInterval(remainingTime / speed)
+    }
+
+    private func formatClockTime(_ date: Date) -> String {
+        date.formatted(date: .omitted, time: .shortened)
+    }
+
     // MARK: - HUD open/close
+
+    private func enterTimelineSelection() {
+        cancelPendingScrub = false
+        focusedHUDTab = nil
+        focusedTransportButton = nil
+        focusedIntroAction = nil
+        viewModel.pinControlsVisible()
+
+        guard viewModel.duration > 0 else {
+            isTimelineScrubbing = false
+            isScrubberFocused = true
+            return
+        }
+
+        let fraction = min(max(viewModel.currentTime / viewModel.duration, 0), 1)
+        viewModel.beginScrub(fraction: fraction)
+        isTimelineScrubbing = true
+        isScrubberFocused = true
+    }
 
     /// Open the Infuse-style HUD. Side-effects land in this order so focus
     /// transitions cleanly:

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPlayerControls.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPlayerControls.swift
@@ -41,6 +41,10 @@ struct TVPlayerControls: View {
     /// puck). Held here so the transport cluster can leave the focus graph
     /// while the scrub is modal.
     @State private var isTimelineScrubbing: Bool = false
+    /// Tracks whether the current explicit timeline session interrupted
+    /// active playback. Exiting a timeline opened from an already-paused
+    /// HUD must leave playback paused, while Select from playing resumes.
+    @State private var resumePlaybackAfterTimelineSelection = false
     /// True while the scrubber owns focus. The transport row leaves the
     /// focus graph for that duration so a Down press has no native target:
     /// the engine otherwise moves focus geometrically — to whichever button
@@ -160,6 +164,9 @@ struct TVPlayerControls: View {
         .onChange(of: timelineSelectionRequest) { _, request in
             guard request != nil else { return }
             fullHUDContactCanToggle = false
+            // PlayerView only issues this request from its playing Select
+            // path, immediately after pausing the backend.
+            resumePlaybackAfterTimelineSelection = true
             enterTimelineSelection()
         }
         .onChange(of: viewModel.showControls) { _, _ in
@@ -459,6 +466,7 @@ struct TVPlayerControls: View {
                     }
                 },
                 isTimelineScrubbing: $isTimelineScrubbing,
+                resumePlaybackAfterTimelineSelection: $resumePlaybackAfterTimelineSelection,
                 cancelOnBlur: cancelPendingScrub
             )
             timeRow
@@ -576,6 +584,7 @@ struct TVPlayerControls: View {
 
         guard viewModel.duration > 0 else {
             isTimelineScrubbing = false
+            resumePlaybackAfterTimelineSelection = false
             isScrubberFocused = true
             return
         }

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPlayerControls.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPlayerControls.swift
@@ -100,7 +100,10 @@ struct TVPlayerControls: View {
         }
         .background {
             TVTouchSurfaceContactGestureView(
-                isActive: viewModel.showControls && !isHUDPresented && !isTimelineScrubbing,
+                // Keep the raw contact observer active in both normal HUD
+                // and timeline-selection states. Its simultaneous-recognition
+                // delegate lets an actual pan continue to own scrubbing.
+                isActive: viewModel.showControls && !isHUDPresented,
                 onContactBegan: {
                     fullHUDContactCanToggle = true
                 },
@@ -430,7 +433,6 @@ struct TVPlayerControls: View {
             TVPlayerScrubber(
                 viewModel: viewModel,
                 isFocused: $isScrubberFocused,
-                onToggleTimeDisplayMode: onToggleTimeDisplayMode,
                 onSelectInteraction: {
                     fullHUDContactCanToggle = false
                 },

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPlayerControls.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPlayerControls.swift
@@ -100,7 +100,7 @@ struct TVPlayerControls: View {
         }
         .background {
             TVTouchSurfaceContactGestureView(
-                isActive: viewModel.showControls && !isHUDPresented,
+                isActive: viewModel.showControls && !isHUDPresented && !isTimelineScrubbing,
                 onContactBegan: {
                     fullHUDContactCanToggle = true
                 },
@@ -430,6 +430,7 @@ struct TVPlayerControls: View {
             TVPlayerScrubber(
                 viewModel: viewModel,
                 isFocused: $isScrubberFocused,
+                onToggleTimeDisplayMode: onToggleTimeDisplayMode,
                 onSelectInteraction: {
                     fullHUDContactCanToggle = false
                 },

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPlayerControls.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPlayerControls.swift
@@ -118,6 +118,9 @@ struct TVPlayerControls: View {
                 },
                 onContactCancelled: {
                     fullHUDContactCanToggle = false
+                },
+                onDirectionalPressBegan: {
+                    fullHUDContactCanToggle = false
                 }
             )
             .frame(width: 1, height: 1)

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPlayerControls.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPlayerControls.swift
@@ -22,6 +22,7 @@ struct TVPlayerControls: View {
     let showsTimelinePreview: Bool
     let timeDisplayMode: TVPlayerTimeDisplayMode
     let timelineSelectionRequest: UUID?
+    let onToggleTimeDisplayMode: () -> Void
     let onDismiss: () -> Void
 
     @Environment(\.scenePhase) private var scenePhase
@@ -50,6 +51,10 @@ struct TVPlayerControls: View {
     /// any other reason (intro skip, HUD) so direction moves into the row
     /// keep working from elsewhere.
     @State private var trapsTransportFocus = false
+    /// A touch-surface contact can toggle the full HUD's clock labels only
+    /// if it ends as a light touch. Select and drag interactions clear this
+    /// candidate so their existing transport behavior remains exclusive.
+    @State private var fullHUDContactCanToggle = false
 
     // Focus states. SwiftUI's focus engine only holds focus on one
     // focusable at a time, so selecting one of these implicitly clears the
@@ -93,6 +98,23 @@ struct TVPlayerControls: View {
                 .transition(.opacity)
             }
         }
+        .background {
+            TVTouchSurfaceContactGestureView(
+                isActive: viewModel.showControls && !isHUDPresented,
+                onContactBegan: {
+                    fullHUDContactCanToggle = true
+                },
+                onContactEnded: {
+                    guard fullHUDContactCanToggle else { return }
+                    fullHUDContactCanToggle = false
+                    onToggleTimeDisplayMode()
+                },
+                onContactCancelled: {
+                    fullHUDContactCanToggle = false
+                }
+            )
+            .frame(width: 1, height: 1)
+        }
         .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: isHUDPresented)
         // Menu / exit handling intentionally lives at the `PlayerView` level
         // rather than here. That higher handler reads `viewModel.isHUDPresented`
@@ -100,6 +122,7 @@ struct TVPlayerControls: View {
         // the HUD's tab pill — adding a handler here would consume Menu while
         // the HUD is closed and break the "dismiss controls first" path.
         .onChange(of: isHUDPresented) { _, presented in
+            fullHUDContactCanToggle = false
             if !presented {
                 cancelPendingScrub = false
                 focusedHUDTab = nil
@@ -133,7 +156,11 @@ struct TVPlayerControls: View {
         }
         .onChange(of: timelineSelectionRequest) { _, request in
             guard request != nil else { return }
+            fullHUDContactCanToggle = false
             enterTimelineSelection()
+        }
+        .onChange(of: viewModel.showControls) { _, _ in
+            fullHUDContactCanToggle = false
         }
         // Re-arm the auto-hide whenever focus moves between transport controls,
         // so navigating the overlay doesn't let the fixed 5s timer hide it (and
@@ -403,6 +430,9 @@ struct TVPlayerControls: View {
             TVPlayerScrubber(
                 viewModel: viewModel,
                 isFocused: $isScrubberFocused,
+                onSelectInteraction: {
+                    fullHUDContactCanToggle = false
+                },
                 onMoveToTransport: {
                     // This fires only because the trap kept the transport row
                     // out of the focus graph (no native Down target). Restore

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPlayerScrubber.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPlayerScrubber.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct TVPlayerScrubber: View {
     let viewModel: PlayerViewModel
     @FocusState.Binding var isFocused: Bool
+    let onSelectInteraction: () -> Void
     let onMoveToTransport: () -> Void
     let onExitWhenIdle: () -> Void
 
@@ -373,6 +374,7 @@ struct TVPlayerScrubber: View {
     /// Select on an in-flight scrub commits the preview immediately instead
     /// of waiting for the debounce to fire.
     private func commitScrub() {
+        onSelectInteraction()
         if isTimelineScrubbing || viewModel.isScrubbing {
             let resumesPlayback = isTimelineScrubbing
             stopTimelineAutoSeek()

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPlayerScrubber.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPlayerScrubber.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct TVPlayerScrubber: View {
     let viewModel: PlayerViewModel
     @FocusState.Binding var isFocused: Bool
+    let onToggleTimeDisplayMode: () -> Void
     let onSelectInteraction: () -> Void
     let onMoveToTransport: () -> Void
     let onExitWhenIdle: () -> Void
@@ -118,6 +119,7 @@ struct TVPlayerScrubber: View {
                     // command.
                     TVPanCaptureView(
                         isActive: isFocused && isTimelineScrubbing && !isTimelineAutoSeeking,
+                        onSurfaceTap: onToggleTimeDisplayMode,
                         onPanBegan: {
                             isPanScrubbing = true
                             panEngaged = false

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPlayerScrubber.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPlayerScrubber.swift
@@ -12,7 +12,6 @@ import SwiftUI
 struct TVPlayerScrubber: View {
     let viewModel: PlayerViewModel
     @FocusState.Binding var isFocused: Bool
-    let onToggleTimeDisplayMode: () -> Void
     let onSelectInteraction: () -> Void
     let onMoveToTransport: () -> Void
     let onExitWhenIdle: () -> Void
@@ -119,7 +118,6 @@ struct TVPlayerScrubber: View {
                     // command.
                     TVPanCaptureView(
                         isActive: isFocused && isTimelineScrubbing && !isTimelineAutoSeeking,
-                        onSurfaceTap: onToggleTimeDisplayMode,
                         onPanBegan: {
                             isPanScrubbing = true
                             panEngaged = false

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPlayerScrubber.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPlayerScrubber.swift
@@ -374,11 +374,13 @@ struct TVPlayerScrubber: View {
     /// of waiting for the debounce to fire.
     private func commitScrub() {
         if isTimelineScrubbing || viewModel.isScrubbing {
+            let resumesPlayback = isTimelineScrubbing
             stopTimelineAutoSeek()
             isTimelineScrubbing = false
-            viewModel.endScrub()
+            viewModel.endScrub(resumePlayback: resumesPlayback)
         } else {
             guard viewModel.duration > 0 else { return }
+            viewModel.pauseForTimelineSelection()
             let fraction = viewModel.currentTime / viewModel.duration
             viewModel.beginScrub(fraction: fraction)
             isTimelineScrubbing = true

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPlayerScrubber.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPlayerScrubber.swift
@@ -49,6 +49,9 @@ struct TVPlayerScrubber: View {
     @State private var isPanScrubbing = false
     @State private var panEngaged = false
     @State private var panAccumulated: CGFloat = 0
+    /// Distinguishes entering/exiting timeline mode from a real seek. A
+    /// Select-only round trip should resume the paused pipeline in place.
+    @State private var hasTimelineSelectionMoved = false
 
     // Visual metrics pulled out as compile-time constants so layout doesn't
     // re-evaluate them each pass. Chapter ticks rely on `trackHeight` so the
@@ -142,6 +145,11 @@ struct TVPlayerScrubber: View {
                     } else {
                         viewModel.endScrub()
                     }
+                }
+            }
+            .onChange(of: isTimelineScrubbing) { _, scrubbing in
+                if scrubbing {
+                    hasTimelineSelectionMoved = false
                 }
             }
             .onMoveCommand(perform: handleMove)
@@ -377,9 +385,10 @@ struct TVPlayerScrubber: View {
         onSelectInteraction()
         if isTimelineScrubbing || viewModel.isScrubbing {
             let resumesPlayback = isTimelineScrubbing
+            let shouldSeek = !isTimelineScrubbing || hasTimelineSelectionMoved
             stopTimelineAutoSeek()
             isTimelineScrubbing = false
-            viewModel.endScrub(resumePlayback: resumesPlayback)
+            viewModel.endScrub(resumePlayback: resumesPlayback, shouldSeek: shouldSeek)
         } else {
             guard viewModel.duration > 0 else { return }
             viewModel.pauseForTimelineSelection()
@@ -402,6 +411,9 @@ struct TVPlayerScrubber: View {
         let base = viewModel.isScrubbing ? viewModel.scrubPreviewTime : viewModel.currentTime
         let deltaSeconds = Double(deltaX / Self.panPointsForFullTimeline) * viewModel.duration
         let target = min(max(base + deltaSeconds, 0), viewModel.duration)
+        if target != base {
+            hasTimelineSelectionMoved = true
+        }
         viewModel.updateScrub(fraction: target / viewModel.duration)
     }
 
@@ -441,6 +453,9 @@ struct TVPlayerScrubber: View {
     private func stepTimeline(by delta: Double) {
         let base = viewModel.isScrubbing ? viewModel.scrubPreviewTime : viewModel.currentTime
         let target = min(max(base + delta, 0), viewModel.duration)
+        if target != base {
+            hasTimelineSelectionMoved = true
+        }
         viewModel.updateScrub(fraction: target / viewModel.duration)
     }
 

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPlayerScrubber.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPlayerScrubber.swift
@@ -22,6 +22,11 @@ struct TVPlayerScrubber: View {
     /// natively, before `onMoveCommand` ever fires.
     @Binding var isTimelineScrubbing: Bool
 
+    /// Whether this explicit timeline session paused active playback and
+    /// should therefore resume it when committed. Kept by the shell so an
+    /// externally-requested session can carry its pre-pause state in.
+    @Binding var resumePlaybackAfterTimelineSelection: Bool
+
     /// When true, blurring the scrubber cancels the in-progress scrub rather
     /// than committing it. The shell flips this on before opening a sheet so
     /// the focus-lost path doesn't turn into an accidental seek.
@@ -139,6 +144,7 @@ struct TVPlayerScrubber: View {
                     if isTimelineScrubbing {
                         stopTimelineAutoSeek()
                         isTimelineScrubbing = false
+                        resumePlaybackAfterTimelineSelection = false
                         viewModel.cancelScrub()
                     } else if cancelOnBlur {
                         viewModel.cancelScrub()
@@ -336,6 +342,7 @@ struct TVPlayerScrubber: View {
     private func beginTimelineHoldIfNeeded() {
         guard !isTimelineScrubbing else { return }
         guard viewModel.duration > 0 else { return }
+        resumePlaybackAfterTimelineSelection = viewModel.isPlaying
         let base = viewModel.isScrubbing ? viewModel.scrubPreviewTime : viewModel.currentTime
         viewModel.beginScrub(fraction: min(max(base / viewModel.duration, 0), 1))
         isTimelineScrubbing = true
@@ -376,6 +383,7 @@ struct TVPlayerScrubber: View {
         guard isTimelineScrubbing || viewModel.isScrubbing else { return }
         stopTimelineAutoSeek()
         isTimelineScrubbing = false
+        resumePlaybackAfterTimelineSelection = false
         viewModel.cancelScrub()
     }
 
@@ -384,13 +392,15 @@ struct TVPlayerScrubber: View {
     private func commitScrub() {
         onSelectInteraction()
         if isTimelineScrubbing || viewModel.isScrubbing {
-            let resumesPlayback = isTimelineScrubbing
+            let resumesPlayback = isTimelineScrubbing && resumePlaybackAfterTimelineSelection
             let shouldSeek = !isTimelineScrubbing || hasTimelineSelectionMoved
             stopTimelineAutoSeek()
             isTimelineScrubbing = false
+            resumePlaybackAfterTimelineSelection = false
             viewModel.endScrub(resumePlayback: resumesPlayback, shouldSeek: shouldSeek)
         } else {
             guard viewModel.duration > 0 else { return }
+            resumePlaybackAfterTimelineSelection = viewModel.isPlaying
             viewModel.pauseForTimelineSelection()
             let fraction = viewModel.currentTime / viewModel.duration
             viewModel.beginScrub(fraction: fraction)

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPressCaptureView.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPressCaptureView.swift
@@ -27,6 +27,11 @@ struct TVPressCaptureView: UIViewRepresentable {
     var onArrowHoldRepeat: (ArrowDirection) -> Void = { _ in }
     /// Release after a hold.
     var onArrowHoldEnd: (ArrowDirection) -> Void = { _ in }
+    /// Finger contact with the Siri Remote touch surface, without requiring
+    /// the clickpad/Select button to be pressed.
+    var onTouchSurfaceContactBegan: () -> Void = {}
+    var onTouchSurfaceContactEnded: () -> Void = {}
+    var onTouchSurfaceContactCancelled: () -> Void = {}
     /// Select (center button) press. Menu is intentionally not intercepted
     /// so SwiftUI's `.onExitCommand` chain continues to own it.
     var onSelect: () -> Void = {}
@@ -47,6 +52,9 @@ struct TVPressCaptureView: UIViewRepresentable {
         view.onArrowHoldBegin = onArrowHoldBegin
         view.onArrowHoldRepeat = onArrowHoldRepeat
         view.onArrowHoldEnd = onArrowHoldEnd
+        view.onTouchSurfaceContactBegan = onTouchSurfaceContactBegan
+        view.onTouchSurfaceContactEnded = onTouchSurfaceContactEnded
+        view.onTouchSurfaceContactCancelled = onTouchSurfaceContactCancelled
         view.onSelect = onSelect
     }
 }
@@ -344,6 +352,9 @@ final class PressCaptureUIView: UIView {
     var onArrowHoldBegin: (TVPressCaptureView.ArrowDirection) -> Void = { _ in }
     var onArrowHoldRepeat: (TVPressCaptureView.ArrowDirection) -> Void = { _ in }
     var onArrowHoldEnd: (TVPressCaptureView.ArrowDirection) -> Void = { _ in }
+    var onTouchSurfaceContactBegan: () -> Void = {}
+    var onTouchSurfaceContactEnded: () -> Void = {}
+    var onTouchSurfaceContactCancelled: () -> Void = {}
     var onSelect: () -> Void = {}
 
     /// Threshold between "tap" and "hold". 300 ms is snappy enough that a
@@ -362,8 +373,29 @@ final class PressCaptureUIView: UIView {
     /// simultaneous presses (rare on the Siri Remote, but possible on a
     /// Bluetooth keyboard) track independently.
     private var pending: [UIPress.PressType: Pending] = [:]
+    private var activeIndirectTouchIDs: Set<ObjectIdentifier> = []
 
     override var canBecomeFocused: Bool { true }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        let indirectTouches = touches.filter { $0.type == .indirect }
+        let wasInactive = activeIndirectTouchIDs.isEmpty
+        activeIndirectTouchIDs.formUnion(indirectTouches.map(ObjectIdentifier.init))
+        if wasInactive, !activeIndirectTouchIDs.isEmpty {
+            onTouchSurfaceContactBegan()
+        }
+        super.touchesBegan(touches, with: event)
+    }
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        finishIndirectTouches(touches, cancelled: false)
+        super.touchesEnded(touches, with: event)
+    }
+
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
+        finishIndirectTouches(touches, cancelled: true)
+        super.touchesCancelled(touches, with: event)
+    }
 
     override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
         var handled = false
@@ -442,6 +474,21 @@ final class PressCaptureUIView: UIView {
             onArrowHoldEnd(entry.direction)
         } else {
             onArrowTap(entry.direction)
+        }
+    }
+
+    private func finishIndirectTouches(_ touches: Set<UITouch>, cancelled: Bool) {
+        let endedIDs = touches
+            .filter { $0.type == .indirect }
+            .map(ObjectIdentifier.init)
+        guard !endedIDs.isEmpty else { return }
+        activeIndirectTouchIDs.subtract(endedIDs)
+        if activeIndirectTouchIDs.isEmpty {
+            if cancelled {
+                onTouchSurfaceContactCancelled()
+            } else {
+                onTouchSurfaceContactEnded()
+            }
         }
     }
 

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPressCaptureView.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPressCaptureView.swift
@@ -30,6 +30,7 @@ struct TVPressCaptureView: UIViewRepresentable {
     var onArrowHoldEnd: (ArrowDirection) -> Void = { _ in }
     /// Finger contact with the Siri Remote touch surface, without requiring
     /// the clickpad/Select button to be pressed.
+    var onDirectionalPressBegan: () -> Void = {}
     var onTouchSurfaceContactBegan: () -> Void = {}
     var onTouchSurfaceContactEnded: () -> Void = {}
     var onTouchSurfaceContactCancelled: () -> Void = {}
@@ -53,6 +54,7 @@ struct TVPressCaptureView: UIViewRepresentable {
         view.onArrowHoldBegin = onArrowHoldBegin
         view.onArrowHoldRepeat = onArrowHoldRepeat
         view.onArrowHoldEnd = onArrowHoldEnd
+        view.onDirectionalPressBegan = onDirectionalPressBegan
         view.onTouchSurfaceContactBegan = onTouchSurfaceContactBegan
         view.onTouchSurfaceContactEnded = onTouchSurfaceContactEnded
         view.onTouchSurfaceContactCancelled = onTouchSurfaceContactCancelled
@@ -99,6 +101,7 @@ struct TVTouchSurfaceContactGestureView: UIViewRepresentable {
     var onContactBegan: () -> Void = {}
     var onContactEnded: () -> Void = {}
     var onContactCancelled: () -> Void = {}
+    var onDirectionalPressBegan: () -> Void = {}
 
     func makeUIView(context: Context) -> TouchSurfaceContactGestureUIView {
         let view = TouchSurfaceContactGestureUIView()
@@ -115,6 +118,7 @@ struct TVTouchSurfaceContactGestureView: UIViewRepresentable {
         view.onContactBegan = onContactBegan
         view.onContactEnded = onContactEnded
         view.onContactCancelled = onContactCancelled
+        view.onDirectionalPressBegan = onDirectionalPressBegan
     }
 }
 
@@ -123,9 +127,11 @@ final class TouchSurfaceContactGestureUIView: UIView, UIGestureRecognizerDelegat
     var onContactBegan: () -> Void = {}
     var onContactEnded: () -> Void = {}
     var onContactCancelled: () -> Void = {}
+    var onDirectionalPressBegan: () -> Void = {}
 
     private weak var attachedWindow: UIWindow?
     private var contactRecognizer: TouchSurfaceContactGestureRecognizer?
+    private var directionalPressRecognizers: [UIGestureRecognizer] = []
     private var isTrackingContact = false
 
     override func didMoveToWindow() {
@@ -154,6 +160,19 @@ final class TouchSurfaceContactGestureUIView: UIView, UIGestureRecognizerDelegat
         contact.delegate = self
         window.addGestureRecognizer(contact)
         contactRecognizer = contact
+
+        for pressType in [UIPress.PressType.leftArrow, .rightArrow, .upArrow, .downArrow] {
+            let press = NonPreventingDirectionalPressGestureRecognizer(
+                target: self,
+                action: #selector(handleDirectionalPress(_:))
+            )
+            press.allowedPressTypes = [NSNumber(value: pressType.rawValue)]
+            press.minimumPressDuration = 0
+            press.cancelsTouchesInView = false
+            press.delegate = self
+            window.addGestureRecognizer(press)
+            directionalPressRecognizers.append(press)
+        }
     }
 
     private func detachRecognizer() {
@@ -164,8 +183,19 @@ final class TouchSurfaceContactGestureUIView: UIView, UIGestureRecognizerDelegat
         if let attachedWindow, let contactRecognizer {
             attachedWindow.removeGestureRecognizer(contactRecognizer)
         }
+        if let attachedWindow {
+            for recognizer in directionalPressRecognizers {
+                attachedWindow.removeGestureRecognizer(recognizer)
+            }
+        }
+        directionalPressRecognizers.removeAll()
         contactRecognizer = nil
         attachedWindow = nil
+    }
+
+    @objc private func handleDirectionalPress(_ recognizer: UILongPressGestureRecognizer) {
+        guard isActive, recognizer.state == .began else { return }
+        onDirectionalPressBegan()
     }
 
     @objc private func handleContact(_ recognizer: TouchSurfaceContactGestureRecognizer) {
@@ -276,6 +306,19 @@ final class TouchSurfaceContactGestureRecognizer: UIGestureRecognizer {
             activeTouchIDs.remove(id)
             initialLocations.removeValue(forKey: id)
         }
+    }
+}
+
+/// Observes a directional click at press-down without participating in
+/// gesture arbitration. The full HUD uses it only to disqualify the current
+/// light-touch contact from toggling the clock labels on release.
+final class NonPreventingDirectionalPressGestureRecognizer: UILongPressGestureRecognizer {
+    override func canPrevent(_ preventedGestureRecognizer: UIGestureRecognizer) -> Bool {
+        false
+    }
+
+    override func canBePrevented(by preventingGestureRecognizer: UIGestureRecognizer) -> Bool {
+        false
     }
 }
 
@@ -543,6 +586,7 @@ final class PressCaptureUIView: UIView {
     var onArrowHoldBegin: (TVPressCaptureView.ArrowDirection) -> Void = { _ in }
     var onArrowHoldRepeat: (TVPressCaptureView.ArrowDirection) -> Void = { _ in }
     var onArrowHoldEnd: (TVPressCaptureView.ArrowDirection) -> Void = { _ in }
+    var onDirectionalPressBegan: () -> Void = {}
     var onTouchSurfaceContactBegan: () -> Void = {}
     var onTouchSurfaceContactEnded: () -> Void = {}
     var onTouchSurfaceContactCancelled: () -> Void = {}
@@ -594,6 +638,7 @@ final class PressCaptureUIView: UIView {
             if let direction = Self.arrowDirection(from: press.type),
                capturedDirections.contains(direction) {
                 handled = true
+                onDirectionalPressBegan()
                 startArrow(type: press.type, direction: direction)
             } else if press.type == .select {
                 handled = true

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPressCaptureView.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPressCaptureView.swift
@@ -89,6 +89,114 @@ struct TVDirectionalPressGestureView: UIViewRepresentable {
     }
 }
 
+/// Window-level light-touch bridge for the Siri Remote surface. It observes
+/// indirect contact without claiming SwiftUI focus or cancelling the
+/// scrubber's own Select and pan gestures. Moving beyond UIKit's normal
+/// long-press tolerance cancels the contact, so swipes do not toggle labels.
+struct TVTouchSurfaceContactGestureView: UIViewRepresentable {
+    var isActive: Bool
+    var onContactBegan: () -> Void = {}
+    var onContactEnded: () -> Void = {}
+    var onContactCancelled: () -> Void = {}
+
+    func makeUIView(context: Context) -> TouchSurfaceContactGestureUIView {
+        let view = TouchSurfaceContactGestureUIView()
+        apply(to: view)
+        return view
+    }
+
+    func updateUIView(_ uiView: TouchSurfaceContactGestureUIView, context: Context) {
+        apply(to: uiView)
+    }
+
+    private func apply(to view: TouchSurfaceContactGestureUIView) {
+        view.isActive = isActive
+        view.onContactBegan = onContactBegan
+        view.onContactEnded = onContactEnded
+        view.onContactCancelled = onContactCancelled
+    }
+}
+
+final class TouchSurfaceContactGestureUIView: UIView, UIGestureRecognizerDelegate {
+    var isActive: Bool = false
+    var onContactBegan: () -> Void = {}
+    var onContactEnded: () -> Void = {}
+    var onContactCancelled: () -> Void = {}
+
+    private weak var attachedWindow: UIWindow?
+    private var contactRecognizer: UILongPressGestureRecognizer?
+    private var isTrackingContact = false
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        if window == nil {
+            detachRecognizer()
+        } else {
+            attachRecognizerIfNeeded()
+        }
+    }
+
+    deinit {
+        detachRecognizer()
+    }
+
+    private func attachRecognizerIfNeeded() {
+        guard let window, attachedWindow !== window else { return }
+        detachRecognizer()
+        attachedWindow = window
+
+        let contact = UILongPressGestureRecognizer(target: self, action: #selector(handleContact(_:)))
+        contact.minimumPressDuration = 0
+        contact.allowedTouchTypes = [NSNumber(value: UITouch.TouchType.indirect.rawValue)]
+        contact.cancelsTouchesInView = false
+        contact.delegate = self
+        window.addGestureRecognizer(contact)
+        contactRecognizer = contact
+    }
+
+    private func detachRecognizer() {
+        if isTrackingContact {
+            isTrackingContact = false
+            onContactCancelled()
+        }
+        if let attachedWindow, let contactRecognizer {
+            attachedWindow.removeGestureRecognizer(contactRecognizer)
+        }
+        contactRecognizer = nil
+        attachedWindow = nil
+    }
+
+    @objc private func handleContact(_ recognizer: UILongPressGestureRecognizer) {
+        switch recognizer.state {
+        case .began:
+            guard isActive else { return }
+            isTrackingContact = true
+            onContactBegan()
+        case .ended:
+            guard isTrackingContact else { return }
+            isTrackingContact = false
+            onContactEnded()
+        case .cancelled, .failed:
+            guard isTrackingContact else { return }
+            isTrackingContact = false
+            onContactCancelled()
+        default:
+            break
+        }
+    }
+
+    override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        isActive
+    }
+
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        true
+    }
+}
+
 /// Window-level trackpad pan bridge. SwiftUI on tvOS only surfaces the Siri
 /// Remote touch surface as discrete `.onMoveCommand` steps, so continuous
 /// drag-the-playhead scrubbing needs a `UIPanGestureRecognizer` reading the

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPressCaptureView.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPressCaptureView.swift
@@ -1,6 +1,7 @@
 #if os(tvOS)
 import SwiftUI
 import UIKit
+import UIKit.UIGestureRecognizerSubclass
 
 /// Bridges the Siri Remote's press lifecycle into SwiftUI. `.onMoveCommand`
 /// only exposes single press events with no way to distinguish a held
@@ -89,10 +90,10 @@ struct TVDirectionalPressGestureView: UIViewRepresentable {
     }
 }
 
-/// Window-level light-touch bridge for the Siri Remote surface. It observes
-/// indirect contact without claiming SwiftUI focus or cancelling the
-/// scrubber's own Select and pan gestures. Moving beyond UIKit's normal
-/// long-press tolerance cancels the contact, so swipes do not toggle labels.
+/// Window-level light-touch bridge for the Siri Remote surface. This uses a
+/// custom recognizer so full-HUD contact follows the same raw indirect-touch
+/// lifecycle as `PressCaptureUIView`, rather than approximating contact with
+/// tap or long-press semantics that tvOS may arbitrate away.
 struct TVTouchSurfaceContactGestureView: UIViewRepresentable {
     var isActive: Bool
     var onContactBegan: () -> Void = {}
@@ -124,7 +125,7 @@ final class TouchSurfaceContactGestureUIView: UIView, UIGestureRecognizerDelegat
     var onContactCancelled: () -> Void = {}
 
     private weak var attachedWindow: UIWindow?
-    private var contactRecognizer: UILongPressGestureRecognizer?
+    private var contactRecognizer: TouchSurfaceContactGestureRecognizer?
     private var isTrackingContact = false
 
     override func didMoveToWindow() {
@@ -145,10 +146,11 @@ final class TouchSurfaceContactGestureUIView: UIView, UIGestureRecognizerDelegat
         detachRecognizer()
         attachedWindow = window
 
-        let contact = UILongPressGestureRecognizer(target: self, action: #selector(handleContact(_:)))
-        contact.minimumPressDuration = 0
+        let contact = TouchSurfaceContactGestureRecognizer(target: self, action: #selector(handleContact(_:)))
         contact.allowedTouchTypes = [NSNumber(value: UITouch.TouchType.indirect.rawValue)]
         contact.cancelsTouchesInView = false
+        contact.delaysTouchesBegan = false
+        contact.delaysTouchesEnded = false
         contact.delegate = self
         window.addGestureRecognizer(contact)
         contactRecognizer = contact
@@ -166,7 +168,7 @@ final class TouchSurfaceContactGestureUIView: UIView, UIGestureRecognizerDelegat
         attachedWindow = nil
     }
 
-    @objc private func handleContact(_ recognizer: UILongPressGestureRecognizer) {
+    @objc private func handleContact(_ recognizer: TouchSurfaceContactGestureRecognizer) {
         switch recognizer.state {
         case .began:
             guard isActive else { return }
@@ -197,6 +199,86 @@ final class TouchSurfaceContactGestureUIView: UIView, UIGestureRecognizerDelegat
     }
 }
 
+/// Continuous raw-contact recognizer for the Siri Remote touch surface. It
+/// recognizes immediately on indirect touch-down, ends on lift, and cancels
+/// once movement becomes an intentional swipe. It never prevents or can be
+/// prevented by the scrubber's pan/focus recognizers, so observing a tap has
+/// no effect on existing remote behavior.
+final class TouchSurfaceContactGestureRecognizer: UIGestureRecognizer {
+    private static let movementTolerance: CGFloat = 12
+
+    private var initialLocations: [ObjectIdentifier: CGPoint] = [:]
+    private var activeTouchIDs: Set<ObjectIdentifier> = []
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
+        let indirectTouches = touches.filter { $0.type == .indirect }
+        guard !indirectTouches.isEmpty else { return }
+
+        let wasInactive = activeTouchIDs.isEmpty
+        for touch in indirectTouches {
+            let id = ObjectIdentifier(touch)
+            activeTouchIDs.insert(id)
+            initialLocations[id] = touch.location(in: view)
+        }
+
+        if wasInactive {
+            state = .began
+        }
+    }
+
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
+        guard state == .began || state == .changed else { return }
+
+        for touch in touches where touch.type == .indirect {
+            let id = ObjectIdentifier(touch)
+            guard let origin = initialLocations[id] else { continue }
+            let location = touch.location(in: view)
+            if hypot(location.x - origin.x, location.y - origin.y) > Self.movementTolerance {
+                state = .cancelled
+                return
+            }
+        }
+
+        state = .changed
+    }
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent) {
+        remove(touches)
+        if activeTouchIDs.isEmpty, state == .began || state == .changed {
+            state = .ended
+        }
+    }
+
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent) {
+        remove(touches)
+        if state == .began || state == .changed {
+            state = .cancelled
+        }
+    }
+
+    override func reset() {
+        initialLocations.removeAll()
+        activeTouchIDs.removeAll()
+        super.reset()
+    }
+
+    override func canPrevent(_ preventedGestureRecognizer: UIGestureRecognizer) -> Bool {
+        false
+    }
+
+    override func canBePrevented(by preventingGestureRecognizer: UIGestureRecognizer) -> Bool {
+        false
+    }
+
+    private func remove(_ touches: Set<UITouch>) {
+        for touch in touches where touch.type == .indirect {
+            let id = ObjectIdentifier(touch)
+            activeTouchIDs.remove(id)
+            initialLocations.removeValue(forKey: id)
+        }
+    }
+}
+
 /// Window-level trackpad pan bridge. SwiftUI on tvOS only surfaces the Siri
 /// Remote touch surface as discrete `.onMoveCommand` steps, so continuous
 /// drag-the-playhead scrubbing needs a `UIPanGestureRecognizer` reading the
@@ -205,8 +287,6 @@ final class TouchSurfaceContactGestureUIView: UIView, UIGestureRecognizerDelegat
 /// pan translation streams through the callbacks.
 struct TVPanCaptureView: UIViewRepresentable {
     var isActive: Bool
-    /// A stationary indirect touch while timeline selection is active.
-    var onSurfaceTap: () -> Void = {}
     var onPanBegan: () -> Void = {}
     /// Incremental horizontal translation (points) since the last change.
     var onPanChanged: (CGFloat) -> Void = { _ in }
@@ -224,7 +304,6 @@ struct TVPanCaptureView: UIViewRepresentable {
 
     private func apply(to view: PanCaptureUIView) {
         view.isActive = isActive
-        view.onSurfaceTap = onSurfaceTap
         view.onPanBegan = onPanBegan
         view.onPanChanged = onPanChanged
         view.onPanEnded = onPanEnded
@@ -233,14 +312,12 @@ struct TVPanCaptureView: UIViewRepresentable {
 
 final class PanCaptureUIView: UIView, UIGestureRecognizerDelegate {
     var isActive: Bool = false
-    var onSurfaceTap: () -> Void = {}
     var onPanBegan: () -> Void = {}
     var onPanChanged: (CGFloat) -> Void = { _ in }
     var onPanEnded: () -> Void = {}
 
     private weak var attachedWindow: UIWindow?
     private var panRecognizer: UIPanGestureRecognizer?
-    private var tapRecognizer: UITapGestureRecognizer?
     private var lastTranslationX: CGFloat = 0
 
     override func didMoveToWindow() {
@@ -265,36 +342,18 @@ final class PanCaptureUIView: UIView, UIGestureRecognizerDelegate {
 
         let pan = UIPanGestureRecognizer(target: self, action: #selector(handlePan(_:)))
         pan.allowedTouchTypes = [NSNumber(value: UITouch.TouchType.indirect.rawValue)]
+        pan.cancelsTouchesInView = false
         pan.delegate = self
         window.addGestureRecognizer(pan)
         panRecognizer = pan
-
-        let tap = UITapGestureRecognizer(target: self, action: #selector(handleSurfaceTap(_:)))
-        tap.allowedTouchTypes = [NSNumber(value: UITouch.TouchType.indirect.rawValue)]
-        tap.cancelsTouchesInView = false
-        tap.delegate = self
-        // A stationary contact toggles the clocks only after the pan has
-        // failed. Any real movement therefore remains exclusively a scrub.
-        tap.require(toFail: pan)
-        window.addGestureRecognizer(tap)
-        tapRecognizer = tap
     }
 
     private func detachRecognizer() {
         if let attachedWindow, let panRecognizer {
             attachedWindow.removeGestureRecognizer(panRecognizer)
         }
-        if let attachedWindow, let tapRecognizer {
-            attachedWindow.removeGestureRecognizer(tapRecognizer)
-        }
         panRecognizer = nil
-        tapRecognizer = nil
         attachedWindow = nil
-    }
-
-    @objc private func handleSurfaceTap(_ recognizer: UITapGestureRecognizer) {
-        guard isActive, recognizer.state == .ended else { return }
-        onSurfaceTap()
     }
 
     @objc private func handlePan(_ recognizer: UIPanGestureRecognizer) {

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPressCaptureView.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPressCaptureView.swift
@@ -205,6 +205,8 @@ final class TouchSurfaceContactGestureUIView: UIView, UIGestureRecognizerDelegat
 /// pan translation streams through the callbacks.
 struct TVPanCaptureView: UIViewRepresentable {
     var isActive: Bool
+    /// A stationary indirect touch while timeline selection is active.
+    var onSurfaceTap: () -> Void = {}
     var onPanBegan: () -> Void = {}
     /// Incremental horizontal translation (points) since the last change.
     var onPanChanged: (CGFloat) -> Void = { _ in }
@@ -222,6 +224,7 @@ struct TVPanCaptureView: UIViewRepresentable {
 
     private func apply(to view: PanCaptureUIView) {
         view.isActive = isActive
+        view.onSurfaceTap = onSurfaceTap
         view.onPanBegan = onPanBegan
         view.onPanChanged = onPanChanged
         view.onPanEnded = onPanEnded
@@ -230,12 +233,14 @@ struct TVPanCaptureView: UIViewRepresentable {
 
 final class PanCaptureUIView: UIView, UIGestureRecognizerDelegate {
     var isActive: Bool = false
+    var onSurfaceTap: () -> Void = {}
     var onPanBegan: () -> Void = {}
     var onPanChanged: (CGFloat) -> Void = { _ in }
     var onPanEnded: () -> Void = {}
 
     private weak var attachedWindow: UIWindow?
     private var panRecognizer: UIPanGestureRecognizer?
+    private var tapRecognizer: UITapGestureRecognizer?
     private var lastTranslationX: CGFloat = 0
 
     override func didMoveToWindow() {
@@ -263,14 +268,33 @@ final class PanCaptureUIView: UIView, UIGestureRecognizerDelegate {
         pan.delegate = self
         window.addGestureRecognizer(pan)
         panRecognizer = pan
+
+        let tap = UITapGestureRecognizer(target: self, action: #selector(handleSurfaceTap(_:)))
+        tap.allowedTouchTypes = [NSNumber(value: UITouch.TouchType.indirect.rawValue)]
+        tap.cancelsTouchesInView = false
+        tap.delegate = self
+        // A stationary contact toggles the clocks only after the pan has
+        // failed. Any real movement therefore remains exclusively a scrub.
+        tap.require(toFail: pan)
+        window.addGestureRecognizer(tap)
+        tapRecognizer = tap
     }
 
     private func detachRecognizer() {
         if let attachedWindow, let panRecognizer {
             attachedWindow.removeGestureRecognizer(panRecognizer)
         }
+        if let attachedWindow, let tapRecognizer {
+            attachedWindow.removeGestureRecognizer(tapRecognizer)
+        }
         panRecognizer = nil
+        tapRecognizer = nil
         attachedWindow = nil
+    }
+
+    @objc private func handleSurfaceTap(_ recognizer: UITapGestureRecognizer) {
+        guard isActive, recognizer.state == .ended else { return }
+        onSurfaceTap()
     }
 
     @objc private func handlePan(_ recognizer: UIPanGestureRecognizer) {


### PR DESCRIPTION
## What changed

- add a passive Siri Remote timeline preview while playback controls are hidden
- toggle duration labels and current/finish clock labels from light touch contact
- make Select pause and enter timeline selection, then resume immediately on commit
- avoid a redundant seek when timeline selection is committed without moving
- keep preview, full transport HUD, and options HUD presentation mutually exclusive
- map Up to the full transport HUD while preserving Down for the options menu
- make Back from the Up Next postroll resume the current episode
- suppress HUD-opened Up Next countdowns until fewer than 100 seconds remain
- move the countdown ring clear of the focused Play Now button

## Why

The tvOS player previously mixed preview and full-HUD states, treated Select inconsistently, and used gesture approximations that could lose light Siri Remote contact under tvOS gesture arbitration. The Up Next postroll also exited the player on Back and exposed long countdowns when opened early from the HUD.

## Implementation notes

The full-HUD touch observer now uses a non-preventing custom UIKit gesture recognizer that receives the same raw indirect-touch lifecycle as the working hidden-player capture. It cancels after intentional movement so timeline pans remain exclusive.

A no-movement timeline selection resumes the paused pipeline directly instead of issuing a seek, preventing rebuffering and timestamp drift.

## Validation

- `git diff --check`
- SiloTV tvOS Simulator compile with `CODE_SIGNING_ALLOWED=NO`
- build succeeded with only the two existing traditional-headermap warnings

Physical Siri Remote validation is still the authoritative check for indirect touch contact and should be included in review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a tvOS timeline preview while navigating playback, including progress, buffering, and selectable time displays.
  * Added Siri Remote touch-surface interactions for toggling time display modes and entering timeline selection.
  * Improved timeline scrubbing with clearer selection behavior and playback resumption options.

* **Bug Fixes**
  * Refined Next Up dismissal and “keep watching” behavior to resume playback more reliably.
  * Improved controls and preview visibility as the player HUD appears or disappears.
  * Adjusted Next Up button spacing to prevent countdown overlap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->