### PR TITLE
Add mixed library support to iOS and tvOS

### DIFF
--- a/iosApp/Tests/BrowseViewModelTests.swift
+++ b/iosApp/Tests/BrowseViewModelTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import Silo
+
+@MainActor
+final class BrowseViewModelTests: XCTestCase {
+    override func tearDown() {
+        ResponseCache.shared.remove(CacheKey.userLibraries)
+        super.tearDown()
+    }
+
+    func testConfigureUsesInitialMixedLibraryType() async {
+        let viewModel = BrowseViewModel()
+
+        await viewModel.configure(libraryId: 8, libraryType: "mixed")
+
+        XCTAssertEqual(viewModel.mediaType, .mixed)
+    }
+
+    func testConfigureUsesCachedLibraryTypeBeforeItemsLoad() async {
+        ResponseCache.shared.set(
+            LibrariesResponse(libraries: [
+                Library(id: 8, name: "Mixed Media", type: "mixed", sortOrder: nil, posterUrl: nil),
+            ]),
+            for: CacheKey.userLibraries
+        )
+        let viewModel = BrowseViewModel()
+
+        await viewModel.configure(libraryId: 8)
+
+        XCTAssertEqual(viewModel.mediaType, .mixed)
+    }
+}

--- a/iosApp/Tests/CatalogQueryBuilderTests.swift
+++ b/iosApp/Tests/CatalogQueryBuilderTests.swift
@@ -47,6 +47,19 @@ final class CatalogQueryBuilderTests: XCTestCase {
         XCTAssertNil(build(.none, mediaType: .series, includeType: false)["type"])
     }
 
+    func testMixedLibraryTypeScope() {
+        XCTAssertNil(build(.none, mediaType: .mixed, includeType: true)["type"],
+                     "mixed browses merged — no library-derived scope")
+
+        // The user-chosen Type facet always scopes, even when includeType is
+        // false (the iOS path), and wins over the library-derived scope.
+        var s = CatalogFilterState(); s.mediaScope = "series"
+        XCTAssertEqual(build(s, mediaType: .mixed, includeType: false)["type"], "series")
+        XCTAssertEqual(build(s, mediaType: .mixed, includeType: true)["type"], "series")
+        XCTAssertNil(build(s, mediaType: .mixed)["groups[0][match]"],
+                     "media scope is a query param, not a rule group")
+    }
+
     func testMultiGenreBecomesOneAnyGroup() {
         var s = CatalogFilterState(); s.genres = ["Drama", "Action"]
         let q = build(s)

--- a/iosApp/Tests/CatalogQueryBuilderTests.swift
+++ b/iosApp/Tests/CatalogQueryBuilderTests.swift
@@ -51,13 +51,33 @@ final class CatalogQueryBuilderTests: XCTestCase {
         XCTAssertNil(build(.none, mediaType: .mixed, includeType: true)["type"],
                      "mixed browses merged — no library-derived scope")
 
-        // The user-chosen Type facet always scopes, even when includeType is
-        // false (the iOS path), and wins over the library-derived scope.
+        // The user-chosen Type facet is a grouped filter, even when includeType
+        // is false (the iOS path), and wins over the library-derived scope.
         var s = CatalogFilterState(); s.mediaScope = "series"
-        XCTAssertEqual(build(s, mediaType: .mixed, includeType: false)["type"], "series")
-        XCTAssertEqual(build(s, mediaType: .mixed, includeType: true)["type"], "series")
-        XCTAssertNil(build(s, mediaType: .mixed)["groups[0][match]"],
-                     "media scope is a query param, not a rule group")
+        let q = build(s, mediaType: .mixed, includeType: false)
+        XCTAssertNil(q["type"], "Type facet must not become unconditional media_scope")
+        XCTAssertEqual(q["groups[0][match]"], "all")
+        XCTAssertEqual(q["groups[0][rules][0][field]"], "type")
+        XCTAssertEqual(q["groups[0][rules][0][op]"], "is")
+        XCTAssertEqual(q["groups[0][rules][0][value]"], "series")
+
+        let includeTypeQuery = build(s, mediaType: .mixed, includeType: true)
+        XCTAssertNil(includeTypeQuery["type"], "mixed library Type facet stays matchable")
+    }
+
+    func testMixedTypeFacetParticipatesInMatchAny() {
+        var s = CatalogFilterState()
+        s.matchAll = false
+        s.mediaScope = "movie"
+        s.genres = ["Drama"]
+
+        let q = build(s, mediaType: .mixed)
+        XCTAssertEqual(q["match"], "any")
+        XCTAssertNil(q["type"])
+        XCTAssertEqual(q["groups[0][rules][0][field]"], "type")
+        XCTAssertEqual(q["groups[0][rules][0][value]"], "movie")
+        XCTAssertEqual(q["groups[1][rules][0][field]"], "genre")
+        XCTAssertEqual(q["groups[1][rules][0][value]"], "Drama")
     }
 
     func testMultiGenreBecomesOneAnyGroup() {

--- a/iosApp/Tests/LibraryVisibilityTests.swift
+++ b/iosApp/Tests/LibraryVisibilityTests.swift
@@ -12,7 +12,8 @@ final class LibraryVisibilityTests: XCTestCase {
           { "id": 4, "name": "Music", "type": "music" },
           { "id": 5, "name": "Ebooks", "type": "ebooks" },
           { "id": 6, "name": "Comics", "type": "comics" },
-          { "id": 7, "name": "Podcasts", "type": "podcasts" }
+          { "id": 7, "name": "Podcasts", "type": "podcasts" },
+          { "id": 8, "name": "Mixed Media", "type": "mixed" }
         ]
         """
         let decoder = JSONDecoder()
@@ -20,7 +21,7 @@ final class LibraryVisibilityTests: XCTestCase {
 
         let response = try! decoder.decode(LibrariesResponse.self, from: Data(json.utf8))
 
-        XCTAssertEqual(response.libraries.map(\.id), [1, 2, 3])
+        XCTAssertEqual(response.libraries.map(\.id), [1, 2, 3, 8])
     }
 
     func testLibraryVisibilityUsesExplicitAudiobookLibraryTypesOnly() {

--- a/iosApp/iosApp/Networking/Models.swift
+++ b/iosApp/iosApp/Networking/Models.swift
@@ -271,8 +271,14 @@ enum SiloMediaType {
         }
     }
 
+    /// A "mixed" library holds movies and series in one folder; each item
+    /// still carries its own concrete `type`, so it browses as one library.
+    static func isMixedLibrary(_ type: String) -> Bool {
+        normalized(type) == "mixed"
+    }
+
     static func isSupportedLibrary(_ type: String) -> Bool {
-        isMovieLibrary(type) || isSeries(type) || isAudiobookLibrary(type)
+        isMovieLibrary(type) || isSeries(type) || isAudiobookLibrary(type) || isMixedLibrary(type)
     }
 
     /// Section items are kept only when their type maps to a library type
@@ -1139,6 +1145,7 @@ struct Library: Codable, Identifiable, Hashable {
     var isMovieLibrary: Bool { SiloMediaType.isMovieLibrary(type) }
     var isAudiobookLibrary: Bool { SiloMediaType.isAudiobookLibrary(type) }
     var isSeriesLibrary: Bool { SiloMediaType.isSeries(type) }
+    var isMixedLibrary: Bool { SiloMediaType.isMixedLibrary(type) }
     var isSupportedLibrary: Bool { SiloMediaType.isSupportedLibrary(type) }
 }
 

--- a/iosApp/iosApp/Screens/Browse/BrowseView.swift
+++ b/iosApp/iosApp/Screens/Browse/BrowseView.swift
@@ -5,6 +5,7 @@ struct BrowseView: View {
     let libraryId: Int?
     var title: String? = "Browse"
     var showsSearchShortcut = true
+    var libraryType: String? = nil
 
     @State private var viewModel = BrowseViewModel()
     @State private var showFilters = false
@@ -47,8 +48,8 @@ struct BrowseView: View {
         .sheet(isPresented: $showFilters) {
             FilterView(viewModel: viewModel)
         }
-        .task {
-            viewModel.configure(libraryId: libraryId)
+        .task(id: BrowseConfigurationID(libraryId: libraryId, libraryType: libraryType)) {
+            guard await viewModel.configure(libraryId: libraryId, libraryType: libraryType) else { return }
             await viewModel.loadItems(reset: true)
             await viewModel.loadFacetsIfNeeded()
         }
@@ -243,6 +244,11 @@ struct BrowseView: View {
     }
 }
 
+private struct BrowseConfigurationID: Hashable {
+    let libraryId: Int?
+    let libraryType: String?
+}
+
 enum LibraryPageTab: String, CaseIterable, Identifiable {
     case recommended
     case library
@@ -300,16 +306,25 @@ struct LibraryPageTabSelector: View {
 struct LibraryDetailView: View {
     let libraryId: Int
     let initialTitle: String?
+    let initialLibraryType: String?
     let showsNavigationTitle: Bool
 
     @State private var selectedTab: LibraryPageTab = .recommended
     @State private var title: String
+    @State private var libraryType: String?
 
-    init(libraryId: Int, initialTitle: String?, showsNavigationTitle: Bool = true) {
+    init(
+        libraryId: Int,
+        initialTitle: String?,
+        initialLibraryType: String? = nil,
+        showsNavigationTitle: Bool = true
+    ) {
         self.libraryId = libraryId
         self.initialTitle = initialTitle
+        self.initialLibraryType = initialLibraryType
         self.showsNavigationTitle = showsNavigationTitle
         _title = State(initialValue: initialTitle ?? "Library")
+        _libraryType = State(initialValue: initialLibraryType)
     }
 
     var body: some View {
@@ -326,7 +341,7 @@ struct LibraryDetailView: View {
         }
         .continuumBackground()
         .task {
-            await loadLibraryTitleIfNeeded()
+            await loadLibraryMetadataIfNeeded()
         }
     }
 
@@ -336,19 +351,22 @@ struct LibraryDetailView: View {
         case .recommended:
             LibraryRecommendedView(libraryId: libraryId)
         case .library:
-            BrowseView(libraryId: libraryId, title: nil, showsSearchShortcut: false)
+            BrowseView(libraryId: libraryId, title: nil, showsSearchShortcut: false, libraryType: libraryType)
         case .collections:
             LibraryCollectionsView(libraryId: libraryId)
         }
     }
 
-    private func loadLibraryTitleIfNeeded() async {
-        guard initialTitle == nil else { return }
+    private func loadLibraryMetadataIfNeeded() async {
+        guard initialTitle == nil || libraryType == nil else { return }
 
         do {
             let response = try await StartupContentPrefetcher.fetchUserLibraries()
             if let matchedLibrary = response.libraries.first(where: { $0.id == libraryId }) {
-                title = matchedLibrary.name
+                if initialTitle == nil {
+                    title = matchedLibrary.name
+                }
+                libraryType = matchedLibrary.type
             }
         } catch {
             // Fall back to the generic title if library metadata is unavailable.

--- a/iosApp/iosApp/Screens/Browse/BrowseViewModel.swift
+++ b/iosApp/iosApp/Screens/Browse/BrowseViewModel.swift
@@ -12,8 +12,7 @@ class BrowseViewModel {
     /// The committed filter + sort state. The filter sheet edits a draft and
     /// commits it via `apply`.
     private(set) var filterState = CatalogFilterState()
-    /// Media family of this library — picks the sort/facet vocabulary. Best
-    /// effort until the first page lands, then refined from the items.
+    /// Media family of this library — picks the sort/facet vocabulary.
     private(set) var mediaType: BrowseMediaType = .movie
     /// Live facet vocabulary for the filter sheet, loaded lazily.
     private(set) var facets: CatalogFacets?
@@ -21,28 +20,36 @@ class BrowseViewModel {
     private var currentPage = 0
     private let pageSize = 60
     private var libraryId: Int?
+    private var hasConfigured = false
+    private var configurationGeneration = 0
     /// Bumped on every reset; a returning fetch from an older generation
     /// discards its results instead of appending stale data.
     private var generation = 0
 
-    func configure(libraryId: Int?) {
+    @discardableResult
+    func configure(libraryId: Int?, libraryType: String? = nil) async -> Bool {
+        configurationGeneration += 1
+        let myConfiguration = configurationGeneration
+        let libraryChanged = !hasConfigured || self.libraryId != libraryId
+        let resolvedMediaType = await resolveMediaType(libraryId: libraryId, libraryType: libraryType)
+        guard myConfiguration == configurationGeneration, !Task.isCancelled else { return false }
+
         self.libraryId = libraryId
-        // Resolve the media family from the cached library list when we can —
-        // a mixed library must be known up front (it can't be refined from
-        // items, whose concrete types are movie/series).
-        if let libraryId,
-           let cached: LibrariesResponse = ResponseCache.shared.get(CacheKey.userLibraries),
-           let library = cached.libraries.first(where: { $0.id == libraryId }) {
-            mediaType = BrowseMediaType.from(libraryType: library.type)
+        hasConfigured = true
+        mediaType = resolvedMediaType
+
+        if libraryChanged {
+            generation += 1
+            currentPage = 0
+            hasMore = true
+            items = []
+            filterState = BrowsePrefsStore.shared.savedState(libraryId: libraryId) ?? .none
         }
-        // Restore persisted sort/filters for this library + profile (no-op
-        // when the user turned "Preserve" off).
-        if let saved = BrowsePrefsStore.shared.savedState(libraryId: libraryId) {
-            filterState = saved
-        }
+
         facets = FacetLoader.shared.cachedFacets(libraryId: libraryId)
         // Hydrate the page-1 snapshot the next reset will write back into.
         hydratePage1FromCache()
+        return true
     }
 
     // MARK: - Load Items
@@ -204,6 +211,26 @@ class BrowseViewModel {
         guard completedGeneration == generation else { return }
         isLoading = false
         isRefreshing = false
+    }
+
+    private func resolveMediaType(libraryId: Int?, libraryType: String?) async -> BrowseMediaType {
+        if let libraryType {
+            return BrowseMediaType.from(libraryType: libraryType)
+        }
+
+        guard let libraryId else { return .movie }
+
+        if let cached: LibrariesResponse = ResponseCache.shared.get(CacheKey.userLibraries),
+           let library = cached.libraries.first(where: { $0.id == libraryId }) {
+            return BrowseMediaType.from(libraryType: library.type)
+        }
+
+        if let response = try? await StartupContentPrefetcher.fetchUserLibraries(),
+           let library = response.libraries.first(where: { $0.id == libraryId }) {
+            return BrowseMediaType.from(libraryType: library.type)
+        }
+
+        return .movie
     }
 
     /// Refine the media family from the first loaded item so the sort/facet

--- a/iosApp/iosApp/Screens/Browse/BrowseViewModel.swift
+++ b/iosApp/iosApp/Screens/Browse/BrowseViewModel.swift
@@ -27,6 +27,14 @@ class BrowseViewModel {
 
     func configure(libraryId: Int?) {
         self.libraryId = libraryId
+        // Resolve the media family from the cached library list when we can —
+        // a mixed library must be known up front (it can't be refined from
+        // items, whose concrete types are movie/series).
+        if let libraryId,
+           let cached: LibrariesResponse = ResponseCache.shared.get(CacheKey.userLibraries),
+           let library = cached.libraries.first(where: { $0.id == libraryId }) {
+            mediaType = BrowseMediaType.from(libraryType: library.type)
+        }
         // Restore persisted sort/filters for this library + profile (no-op
         // when the user turned "Preserve" off).
         if let saved = BrowsePrefsStore.shared.savedState(libraryId: libraryId) {
@@ -202,7 +210,9 @@ class BrowseViewModel {
     /// vocabulary matches the library (audiobook vs video) without ever
     /// sending a `type` scope that could filter the page empty.
     private func refineMediaType(from response: CatalogResponse) {
-        guard let first = response.items.first else { return }
+        // A mixed library was resolved from the library list in `configure`;
+        // refining from a (movie or series) item would hide the Type facet.
+        guard mediaType != .mixed, let first = response.items.first else { return }
         mediaType = BrowseMediaType.from(libraryType: first.type)
     }
 }

--- a/iosApp/iosApp/Screens/Browse/Filtering/CatalogFacets.swift
+++ b/iosApp/iosApp/Screens/Browse/Filtering/CatalogFacets.swift
@@ -52,7 +52,7 @@ struct CatalogFacets {
         case .author: return authors
         case .narrator: return narrators
         case .seriesName: return series
-        case .decade, .dynamicRange, .watchStatus: return []
+        case .itemType, .decade, .dynamicRange, .watchStatus: return []
         }
     }
 
@@ -63,6 +63,8 @@ struct CatalogFacets {
     /// server vocab otherwise. `watchStatus` is hidden without a profile.
     func optionPairs(for facet: CatalogFacet, hasProfile: Bool) -> [(value: String, label: String)] {
         switch facet {
+        case .itemType:
+            return [("movie", "Movies"), ("series", "Series")]
         case .decade:
             return Self.decadeLadder.map { (String($0), "\($0)s") }
         case .dynamicRange:

--- a/iosApp/iosApp/Screens/Browse/Filtering/CatalogFilterState.swift
+++ b/iosApp/iosApp/Screens/Browse/Filtering/CatalogFilterState.swift
@@ -25,6 +25,9 @@ enum WatchStatusFilter: String, Codable, CaseIterable, Hashable {
 /// `queryFieldDefs`); `decade`, `dynamicRange`, and `watchStatus` are
 /// client-side groupings that lower to one or more server rules.
 enum CatalogFacet: String, CaseIterable, Codable, Hashable {
+    /// Movie-vs-series scope, offered only in mixed libraries. Lowers to the
+    /// catalog `type` (media_scope) param rather than a rule group.
+    case itemType = "item_type"
     case genre
     case decade
     case watchStatus
@@ -44,6 +47,7 @@ enum CatalogFacet: String, CaseIterable, Codable, Hashable {
 
     var title: String {
         switch self {
+        case .itemType: return "Type"
         case .genre: return "Genre"
         case .decade: return "Decade"
         case .watchStatus: return "Watch Status"
@@ -75,7 +79,7 @@ enum CatalogFacet: String, CaseIterable, Codable, Hashable {
     /// server-provided value list (decade, dynamic range, watch status).
     var hasFixedVocabulary: Bool {
         switch self {
-        case .decade, .dynamicRange, .watchStatus: return true
+        case .itemType, .decade, .dynamicRange, .watchStatus: return true
         default: return false
         }
     }
@@ -86,6 +90,10 @@ enum CatalogFacet: String, CaseIterable, Codable, Hashable {
         switch mediaType {
         case .movie, .series:
             return [.genre, .decade, .watchStatus, .contentRating, .resolution,
+                    .dynamicRange, .studio, .network, .country,
+                    .audioLanguage, .subtitleLanguage, .originalLanguage]
+        case .mixed:
+            return [.itemType, .genre, .decade, .watchStatus, .contentRating, .resolution,
                     .dynamicRange, .studio, .network, .country,
                     .audioLanguage, .subtitleLanguage, .originalLanguage]
         case .audiobook:
@@ -117,6 +125,9 @@ struct CatalogFilterState: Equatable, Codable, Hashable {
     /// OR'd.
     var matchAll: Bool = true
 
+    /// Movie-vs-series scope for mixed libraries ("movie" / "series");
+    /// `nil` = both. Single-select; lowers to the catalog `type` param.
+    var mediaScope: String? = nil
     var genres: Set<String> = []
     var contentRatings: Set<String> = []
     var studios: Set<String> = []
@@ -154,6 +165,7 @@ struct CatalogFilterState: Equatable, Codable, Hashable {
                     resolutions, audioLanguages, subtitleLanguages,
                     originalLanguages, authors, narrators, seriesNames]
         where !set.isEmpty { n += 1 }
+        if mediaScope != nil { n += 1 }
         if !decades.isEmpty { n += 1 }
         if hdr || dolbyVision { n += 1 }
         if watchStatus != nil { n += 1 }
@@ -174,6 +186,7 @@ struct CatalogFilterState: Equatable, Codable, Hashable {
 
     func selectedValues(_ facet: CatalogFacet) -> Set<String> {
         switch facet {
+        case .itemType: return mediaScope.map { [$0] } ?? []
         case .genre: return genres
         case .contentRating: return contentRatings
         case .studio: return studios
@@ -205,6 +218,8 @@ struct CatalogFilterState: Equatable, Codable, Hashable {
     /// (toggling the active value clears it); everything else is multi-select.
     mutating func toggle(_ facet: CatalogFacet, value: String) {
         switch facet {
+        case .itemType:
+            mediaScope = (mediaScope == value) ? nil : value
         case .genre: Self.toggle(&genres, value)
         case .contentRating: Self.toggle(&contentRatings, value)
         case .studio: Self.toggle(&studios, value)
@@ -233,6 +248,7 @@ struct CatalogFilterState: Equatable, Codable, Hashable {
     /// Clear a whole facet dimension.
     mutating func clear(_ facet: CatalogFacet) {
         switch facet {
+        case .itemType: mediaScope = nil
         case .genre: genres.removeAll()
         case .contentRating: contentRatings.removeAll()
         case .studio: studios.removeAll()
@@ -272,7 +288,7 @@ struct CatalogFilterState: Equatable, Codable, Hashable {
     /// Active selections as removable chips, in facet display order.
     func activeChips() -> [CatalogFilterChip] {
         var chips: [CatalogFilterChip] = []
-        let ordered: [CatalogFacet] = [.genre, .decade, .watchStatus, .contentRating,
+        let ordered: [CatalogFacet] = [.itemType, .genre, .decade, .watchStatus, .contentRating,
                                        .resolution, .dynamicRange, .studio, .network,
                                        .country, .audioLanguage, .subtitleLanguage,
                                        .originalLanguage, .author, .narrator, .seriesName]
@@ -287,6 +303,8 @@ struct CatalogFilterState: Equatable, Codable, Hashable {
 
     static func chipLabel(facet: CatalogFacet, value: String) -> String {
         switch facet {
+        case .itemType:
+            return value == "series" ? "Series" : "Movies"
         case .decade:
             return Int(value).map { "\($0)s" } ?? value
         case .dynamicRange:
@@ -314,6 +332,7 @@ struct CatalogFilterState: Equatable, Codable, Hashable {
             "m=\(matchAll ? "all" : "any")",
         ]
         if let p = namePrefix { parts.append("p=\(encode(p))") }
+        if let sc = mediaScope { parts.append("sc=\(encode(sc))") }
         if !genres.isEmpty { parts.append("g=\(join(genres))") }
         if !contentRatings.isEmpty { parts.append("cr=\(join(contentRatings))") }
         if !studios.isEmpty { parts.append("st=\(join(studios))") }

--- a/iosApp/iosApp/Screens/Browse/Filtering/CatalogFilterState.swift
+++ b/iosApp/iosApp/Screens/Browse/Filtering/CatalogFilterState.swift
@@ -25,8 +25,8 @@ enum WatchStatusFilter: String, Codable, CaseIterable, Hashable {
 /// `queryFieldDefs`); `decade`, `dynamicRange`, and `watchStatus` are
 /// client-side groupings that lower to one or more server rules.
 enum CatalogFacet: String, CaseIterable, Codable, Hashable {
-    /// Movie-vs-series scope, offered only in mixed libraries. Lowers to the
-    /// catalog `type` (media_scope) param rather than a rule group.
+    /// Movie-vs-series scope, offered only in mixed libraries. Lowers to a
+    /// catalog `type` rule so it participates in Match All / Match Any.
     case itemType = "item_type"
     case genre
     case decade
@@ -126,7 +126,7 @@ struct CatalogFilterState: Equatable, Codable, Hashable {
     var matchAll: Bool = true
 
     /// Movie-vs-series scope for mixed libraries ("movie" / "series");
-    /// `nil` = both. Single-select; lowers to the catalog `type` param.
+    /// `nil` = both. Single-select; lowers to a catalog `type` rule.
     var mediaScope: String? = nil
     var genres: Set<String> = []
     var contentRatings: Set<String> = []

--- a/iosApp/iosApp/Screens/Browse/Filtering/CatalogQueryBuilder.swift
+++ b/iosApp/iosApp/Screens/Browse/Filtering/CatalogQueryBuilder.swift
@@ -33,7 +33,14 @@ enum CatalogQueryBuilder {
             "match": state.matchAll ? "all" : "any",
         ]
         if let libraryId { q["library_id"] = String(libraryId) }
-        if includeType, let type = mediaType.catalogTypeParam { q["type"] = type }
+        // A user-chosen Type facet (mixed libraries) always scopes the query;
+        // it is valid by construction, unlike the library-derived scope that
+        // `includeType` guards.
+        if let scope = state.mediaScope {
+            q["type"] = scope
+        } else if includeType, let type = mediaType.catalogTypeParam {
+            q["type"] = type
+        }
         if let prefix = state.namePrefix { q["name_prefix"] = prefix }
         if let snapshot { q["snapshot_at"] = snapshot }
         if !includeTotal { q["include_total"] = "false" }

--- a/iosApp/iosApp/Screens/Browse/Filtering/CatalogQueryBuilder.swift
+++ b/iosApp/iosApp/Screens/Browse/Filtering/CatalogQueryBuilder.swift
@@ -33,12 +33,9 @@ enum CatalogQueryBuilder {
             "match": state.matchAll ? "all" : "any",
         ]
         if let libraryId { q["library_id"] = String(libraryId) }
-        // A user-chosen Type facet (mixed libraries) always scopes the query;
-        // it is valid by construction, unlike the library-derived scope that
-        // `includeType` guards.
-        if let scope = state.mediaScope {
-            q["type"] = scope
-        } else if includeType, let type = mediaType.catalogTypeParam {
+        if state.mediaScope == nil,
+           includeType,
+           let type = mediaType.catalogTypeParam {
             q["type"] = type
         }
         if let prefix = state.namePrefix { q["name_prefix"] = prefix }
@@ -46,6 +43,12 @@ enum CatalogQueryBuilder {
         if !includeTotal { q["include_total"] = "false" }
 
         var groups = GroupAccumulator()
+        // A user-chosen Type facet (mixed libraries) is a filter facet, not an
+        // unconditional media_scope. Keep it inside the grouped filter logic so
+        // top-level Match All / Match Any applies consistently across facets.
+        if let scope = state.mediaScope {
+            groups.add(field: "type", op: "is", value: scope)
+        }
         // Array columns accept `contains`; scalar columns accept `is`.
         groups.add(field: "genre", op: "contains", values: state.genres)
         groups.add(field: "studio", op: "is", values: state.studios)
@@ -88,6 +91,10 @@ private struct GroupAccumulator {
 
     mutating func addBool(field: String, value: Bool) {
         groups.append((match: "all", rules: [Rule(field: field, op: "is", values: [value ? "true" : "false"])]))
+    }
+
+    mutating func add(field: String, op: String, value: String) {
+        groups.append((match: "all", rules: [Rule(field: field, op: op, values: [value])]))
     }
 
     mutating func addDynamicRange(hdr: Bool, dolbyVision: Bool) {

--- a/iosApp/iosApp/Screens/Browse/Filtering/CatalogSortKey.swift
+++ b/iosApp/iosApp/Screens/Browse/Filtering/CatalogSortKey.swift
@@ -30,7 +30,7 @@ enum BrowseMediaType: String, Codable, Hashable {
     /// `library_id` already scopes the query, matching the existing browse
     /// paths which never send `type` for audiobook/music libraries. Mixed
     /// libraries omit it too so movies and series come back merged; the
-    /// Type facet supplies a scope when the user narrows.
+    /// Type facet supplies a grouped rule when the user narrows.
     var catalogTypeParam: String? {
         switch self {
         case .movie: return "movie"

--- a/iosApp/iosApp/Screens/Browse/Filtering/CatalogSortKey.swift
+++ b/iosApp/iosApp/Screens/Browse/Filtering/CatalogSortKey.swift
@@ -15,8 +15,12 @@ enum BrowseMediaType: String, Codable, Hashable {
     case movie
     case series
     case audiobook
+    /// Movies + series in one library. Browses merged; the user narrows via
+    /// the Type facet (`CatalogFacet.itemType`), not navigation.
+    case mixed
 
     static func from(libraryType: String) -> BrowseMediaType {
+        if SiloMediaType.isMixedLibrary(libraryType) { return .mixed }
         if SiloMediaType.isAudiobook(libraryType) { return .audiobook }
         if SiloMediaType.isSeries(libraryType) { return .series }
         return .movie
@@ -24,12 +28,14 @@ enum BrowseMediaType: String, Codable, Hashable {
 
     /// The catalog `type` (media_scope) param. Audiobooks omit it — the
     /// `library_id` already scopes the query, matching the existing browse
-    /// paths which never send `type` for audiobook/music libraries.
+    /// paths which never send `type` for audiobook/music libraries. Mixed
+    /// libraries omit it too so movies and series come back merged; the
+    /// Type facet supplies a scope when the user narrows.
     var catalogTypeParam: String? {
         switch self {
         case .movie: return "movie"
         case .series: return "series"
-        case .audiobook: return nil
+        case .audiobook, .mixed: return nil
         }
     }
 }
@@ -97,7 +103,7 @@ enum CatalogSortKey: String, CaseIterable, Codable, Hashable {
         switch mediaType {
         case .audiobook:
             return [.title, .author, .narrator, .series, .addedAt, .runtime]
-        case .movie, .series:
+        case .movie, .series, .mixed:
             return [.title, .addedAt, .year, .ratingImdb, .runtime, .resolution]
         }
     }

--- a/iosApp/iosApp/Screens/Browse/LibrariesTabView.swift
+++ b/iosApp/iosApp/Screens/Browse/LibrariesTabView.swift
@@ -85,7 +85,7 @@ struct LibrariesTabView: View {
         case .recommended:
             LibraryRecommendedView(libraryId: activeLibrary.id)
         case .library:
-            BrowseView(libraryId: activeLibrary.id, title: nil, showsSearchShortcut: false)
+            BrowseView(libraryId: activeLibrary.id, title: nil, showsSearchShortcut: false, libraryType: activeLibrary.type)
         case .collections:
             LibraryCollectionsView(libraryId: activeLibrary.id)
         }

--- a/iosApp/iosApp/Screens/Browse/LibrariesTabView.swift
+++ b/iosApp/iosApp/Screens/Browse/LibrariesTabView.swift
@@ -252,6 +252,7 @@ private struct LibrarySelectorButton: View {
 
     private var typeLabel: String {
         if library.isAudiobookLibrary { return "Audiobooks" }
+        if library.isMixedLibrary { return "Movies & Series" }
         if library.isSeriesLibrary { return "Series" }
         if library.type == "movies" { return "Movies" }
         if library.type == "music" { return "Music" }
@@ -366,6 +367,7 @@ private struct LibraryPickerRow: View {
 
     private var iconName: String {
         if library.isAudiobookLibrary { return "book.closed.fill" }
+        if library.isMixedLibrary { return "square.stack.3d.up.fill" }
         if library.isSeriesLibrary { return "tv.fill" }
         if library.type == "movies" { return "film.fill" }
         if library.type == "music" { return "music.note" }
@@ -374,6 +376,7 @@ private struct LibraryPickerRow: View {
 
     private var typeLabel: String {
         if library.isAudiobookLibrary { return "Audiobooks library" }
+        if library.isMixedLibrary { return "Movies & Series library" }
         if library.isSeriesLibrary { return "TV library" }
         if library.type == "movies" { return "Movies library" }
         if library.type == "music" { return "Music library" }

--- a/iosApp/iosApp/tvOS/Navigation/TVCascadeSelector.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVCascadeSelector.swift
@@ -225,9 +225,12 @@ struct TVCascadeSelector: View {
     private func libraryRow(_ library: Library) -> some View {
         let isFocused = focus == .library(library.id)
         let isCurrent = library.id == currentScopeId
+        // Mixed libraries appear under both video tabs; a distinct layers
+        // glyph signals "Movies & Series" so the dual listing doesn't read
+        // as two different libraries.
         let label = TVCascadeLibraryRowLabel(
             title: library.name,
-            systemImage: type.systemImage,
+            systemImage: library.isMixedLibrary ? "square.stack.3d.up" : type.systemImage,
             trailingGlyph: isCurrent ? "checkmark" : "chevron.right",
             isFocused: isFocused
         )

--- a/iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift
@@ -65,11 +65,13 @@ enum TVLibraryTabType: String, CaseIterable, Hashable {
         }
     }
 
-    /// Whether a server library belongs under this tab.
+    /// Whether a server library belongs under this tab. A mixed library
+    /// (movies + series in one folder) belongs to both video tabs — it stays
+    /// one browsable library, reachable from either dropdown.
     func matches(_ library: Library) -> Bool {
         switch self {
-        case .movies: return library.type == "movies"
-        case .series: return library.isSeriesLibrary
+        case .movies: return library.type == "movies" || library.isMixedLibrary
+        case .series: return library.isSeriesLibrary || library.isMixedLibrary
         case .music: return library.type == "music"
         case .audiobooks: return library.isAudiobookLibrary
         }


### PR DESCRIPTION
## Summary

A server library of type `mixed` (movies + series in one folder) was silently dropped at decode (`isSupportedLibrary` filtering in `LibrariesResponse`) and never reached any UI. This PR surfaces it as a **single browsable library** — deliberately not split into per-type views:

- **tvOS**: the mixed library appears as a row in **both** the Movies and Series cascade dropdowns, marked with a layers glyph so the dual listing reads as one library, not two. Selecting it gives the normal Recommended / Collections / Browse sections over the full merged catalog.
- **iOS**: the library appears in the Libraries picker labeled "Movies & Series" and browses the same merged grid.
- **Narrowing is filtering, not navigation**: a new **Type** facet (Movies / Series, single-select) is offered first in the filter panel/sheet, only for mixed libraries. Movies and series already share identical sort and facet vocabularies, so the merged grid needs no other filter changes.

## Implementation

- `SiloMediaType.isMixedLibrary` joins `isSupportedLibrary`; `Library.isMixedLibrary` convenience.
- `BrowseMediaType.mixed`: no library-derived `type` scope (items come back merged), movie/series sort + facet vocabulary.
- `CatalogFacet.itemType` + `CatalogFilterState.mediaScope`: single-select, lowers to the catalog `type` media-scope param rather than a rule group. It is user-chosen and valid by construction, so `CatalogQueryBuilder` emits it even on the iOS `includeType: false` path and it wins over the library-derived scope. Wired through chips, active-count badge, cache key, and per-library persistence.
- `TVLibraryTabType.matches()`: movies and series tabs both accept mixed; cascade rows swap in the layers glyph for mixed libraries.
- iOS `BrowseViewModel` resolves the media family from the cached user-libraries list in `configure` — a mixed library cannot be refined from its first item (whose concrete type is movie or series), so refine now guards `.mixed`.
- Downstream (detail, playback, Top Shelf, home rows) needed no changes: everything already routes on per-item `type`.

## Testing

- `LibraryVisibilityTests` locks in mixed as a supported library type.
- `CatalogQueryBuilderTests.testMixedLibraryTypeScope` covers the media-scope wire format (merged by default, facet always scopes, no rule group).
- Silo (iOS), SiloTV, and SiloMac all build green; focused test suites pass.
- Validated live on the tvOS simulator against the dev server's mixed "Sports" library (677 items): dropdown placement in both tabs, merged grid (series interleaved with movies), and a Type=Series server round-trip narrowing the grid.

## Out of scope (cross-repo follow-ups)

- silo-server: mixed libraries fall to the generic section defaults — no movie/series-scoped rows, so the Recommended pill is thinner than for dedicated libraries.
- silo-android: Android TV orphans mixed libraries entirely (`TvLibraryTabType.matches` has no mixed case); phone shows them generically with no Type scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for mixed “Movies & Series” libraries across browsing, library selection, and TV navigation.
  * Introduced a new “Type” (movie/series) facet for mixed libraries.
* **Bug Fixes**
  * Improved mixed-library filtering behavior by correctly scoping the Type facet within the active match logic.
  * Preserved filter state and selected type scope when reloading and using cached results.
  * Updated Movies/Series tab matching to include mixed libraries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->