### PR TITLE
Keep tvOS subtitles within the title-safe area

### DIFF
--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleOverlayView.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleOverlayView.swift
@@ -192,7 +192,7 @@ final class SubtitleOverlayView: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
         withoutImplicitLayerAnimation {
-            contentsLayer.frame = contentsFrameOverride ?? bounds
+            contentsLayer.frame = resolvedContentsFrame
             bitmapCueHost.frame = bounds
         }
         pushFrameGeometry()
@@ -226,11 +226,40 @@ final class SubtitleOverlayView: UIView {
             } else {
                 contentsFrameOverride = nil
             }
-            contentsLayer.frame = contentsFrameOverride ?? bounds
+            contentsLayer.frame = resolvedContentsFrame
             // CALayer.contents takes `Any?` — pass `image` directly to avoid
             // the ARC/CFType dance of an explicit `as CGImage`.
             contentsLayer.contents = image
         }
+    }
+
+    /// tvOS can crop the outer portion of the full-screen render surface for
+    /// overscan. The Bottom preset intentionally uses the letterbox bar, but
+    /// its final composited image still has to remain inside the title-safe
+    /// region. Translate the already-rendered image as one unit so multi-line
+    /// cues preserve their spacing and alignment.
+    private var resolvedContentsFrame: CGRect {
+        guard var frame = contentsFrameOverride else { return bounds }
+        #if os(tvOS)
+        let safeFrame = bounds.inset(by: safeAreaInsets)
+        guard !safeFrame.isEmpty else { return frame }
+
+        if frame.width <= safeFrame.width {
+            if frame.minX < safeFrame.minX {
+                frame.origin.x += safeFrame.minX - frame.minX
+            } else if frame.maxX > safeFrame.maxX {
+                frame.origin.x -= frame.maxX - safeFrame.maxX
+            }
+        }
+        if frame.height <= safeFrame.height {
+            if frame.minY < safeFrame.minY {
+                frame.origin.y += safeFrame.minY - frame.minY
+            } else if frame.maxY > safeFrame.maxY {
+                frame.origin.y -= frame.maxY - safeFrame.maxY
+            }
+        }
+        #endif
+        return frame
     }
 
     /// Replace the bitmap cue layers with the given placements. Frames


### PR DESCRIPTION
## Summary

- keep libass-composited subtitle images inside the tvOS title-safe area
- translate the complete rendered image as one unit so multi-line cue spacing and alignment remain intact
- leave iOS and macOS subtitle placement unchanged

## Root cause

The subtitle renderer correctly produced every forced-English cue, but the tvOS overlay placed some final composited image frames below the display's safe area. The television cropped those pixels, which made the second speaker's line disappear and then made the rapid dialogue near the end of the scene appear to stop entirely.

This change resolves the final layer frame against `safeAreaInsets` on tvOS. It shifts a bounded image back inside the safe frame without resizing or restyling the authored subtitle output.

## Validation

- `git diff --check origin/main...HEAD`
- reproduced the missing forced subtitles on a physical Apple TV before the fix
- replayed the same forced-English track and confirmed the previously missing rapid dialogue before “I get paid in cash. Up front.” remained visible after the fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subtitle positioning on tvOS by keeping subtitle overlays within the title-safe area.
  * Prevented subtitles from extending beyond screen-safe boundaries while preserving existing subtitle rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->