### PR TITLE
fix(playback): honor source color range fallback

### DIFF
--- a/iosApp/Tests/DetailVersionSelectionTests.swift
+++ b/iosApp/Tests/DetailVersionSelectionTests.swift
@@ -85,6 +85,12 @@ final class DetailVersionSelectionTests: XCTestCase {
         XCTAssertNil(ApplePlaybackRoutePlanner.unambiguousColorRange(for: version))
     }
 
+    func testSourceColorRangeIsNotAppliedToTranscodedOutput() {
+        XCTAssertTrue(PlaybackDeliveryStrategy.direct.preservesSourceVideoMetadata)
+        XCTAssertTrue(PlaybackDeliveryStrategy.remux.preservesSourceVideoMetadata)
+        XCTAssertFalse(PlaybackDeliveryStrategy.transcode.preservesSourceVideoMetadata)
+    }
+
     private func decodedVersions(_ json: String) -> [FileVersion] {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase

--- a/iosApp/Tests/DetailVersionSelectionTests.swift
+++ b/iosApp/Tests/DetailVersionSelectionTests.swift
@@ -50,7 +50,7 @@ final class DetailVersionSelectionTests: XCTestCase {
             "codec_audio": "eac3",
             "hdr": true,
             "video_tracks": [
-              { "dolby_vision": "Profile 8.1" }
+              { "dolby_vision": "Profile 8.1", "color_range": "tv" }
             ]
           }
         ]
@@ -64,6 +64,25 @@ final class DetailVersionSelectionTests: XCTestCase {
             DetailPlaybackFormatting.versionPrimaryText(version),
             "2160p · HEVC · DV · EAC3"
         )
+        XCTAssertEqual(version.videoTracks?.first?.colorRange, "tv")
+        XCTAssertEqual(ApplePlaybackRoutePlanner.unambiguousColorRange(for: version), "tv")
+    }
+
+    func testColorRangeFallbackRequiresAnUnambiguousVideoTrack() throws {
+        let version = try XCTUnwrap(decodedVersions("""
+        [
+          {
+            "file_id": 22,
+            "file_path": "/media/multi-angle.mkv",
+            "video_tracks": [
+              { "index": 0, "color_range": "tv" },
+              { "index": 1, "color_range": "pc" }
+            ]
+          }
+        ]
+        """).first)
+
+        XCTAssertNil(ApplePlaybackRoutePlanner.unambiguousColorRange(for: version))
     }
 
     private func decodedVersions(_ json: String) -> [FileVersion] {

--- a/iosApp/Tests/HDRDisplayCriteriaPolicyTests.swift
+++ b/iosApp/Tests/HDRDisplayCriteriaPolicyTests.swift
@@ -138,7 +138,7 @@ final class HDRDisplayCriteriaPolicyTests: XCTestCase {
                 VideoTrack(
                     index: 0, codec: "hevc", width: 3840, height: 2160,
                     frameRate: "23.976", bitrate: nil, profile: nil,
-                    level: nil, bitDepth: nil, colorSpace: nil,
+                    level: nil, bitDepth: nil, colorRange: nil, colorSpace: nil,
                     colorPrimaries: nil, colorTransfer: colorTransfer,
                     videoRange: videoRange, dolbyVision: nil, title: nil,
                     language: nil

--- a/iosApp/Tests/SoftwareVideoOutputFormatTests.swift
+++ b/iosApp/Tests/SoftwareVideoOutputFormatTests.swift
@@ -39,4 +39,16 @@ final class SoftwareVideoOutputFormatTests: XCTestCase {
             kCVPixelFormatType_420YpCbCr10BiPlanarFullRange
         )
     }
+
+    func testLocalColorRangeOverridesServerFallback() {
+        XCTAssertTrue(VideoColorMetadata.isFullRange(AVCOL_RANGE_JPEG, fallbackName: "tv"))
+        XCTAssertFalse(VideoColorMetadata.isFullRange(AVCOL_RANGE_MPEG, fallbackName: "pc"))
+    }
+
+    func testServerColorRangeFillsOnlyUnspecifiedLocalMetadata() {
+        XCTAssertTrue(VideoColorMetadata.isFullRange(AVCOL_RANGE_UNSPECIFIED, fallbackName: "pc"))
+        XCTAssertFalse(VideoColorMetadata.isFullRange(AVCOL_RANGE_UNSPECIFIED, fallbackName: "tv"))
+        XCTAssertFalse(VideoColorMetadata.isFullRange(AVCOL_RANGE_UNSPECIFIED, fallbackName: "unknown"))
+        XCTAssertFalse(VideoColorMetadata.isFullRange(AVCOL_RANGE_UNSPECIFIED, fallbackName: nil))
+    }
 }

--- a/iosApp/Tests/SoftwareVideoOutputFormatTests.swift
+++ b/iosApp/Tests/SoftwareVideoOutputFormatTests.swift
@@ -43,6 +43,7 @@ final class SoftwareVideoOutputFormatTests: XCTestCase {
     func testLocalColorRangeOverridesServerFallback() {
         XCTAssertTrue(VideoColorMetadata.isFullRange(AVCOL_RANGE_JPEG, fallbackName: "tv"))
         XCTAssertFalse(VideoColorMetadata.isFullRange(AVCOL_RANGE_MPEG, fallbackName: "pc"))
+        XCTAssertFalse(VideoColorMetadata.isFullRange(AVCOL_RANGE_NB, fallbackName: "pc"))
     }
 
     func testServerColorRangeFillsOnlyUnspecifiedLocalMetadata() {

--- a/iosApp/iosApp/Networking/Models.swift
+++ b/iosApp/iosApp/Networking/Models.swift
@@ -814,6 +814,7 @@ struct VideoTrack: Codable, Identifiable, Hashable {
     let profile: String?
     let level: Int?
     let bitDepth: Int?
+    let colorRange: String?
     let colorSpace: String?
     let colorPrimaries: String?
     let colorTransfer: String?

--- a/iosApp/iosApp/Screens/Player/ApplePlaybackRoutePlanner.swift
+++ b/iosApp/iosApp/Screens/Player/ApplePlaybackRoutePlanner.swift
@@ -477,6 +477,11 @@ extension ApplePlaybackRoutePlanner {
     static func hevcLoopbackVideoRange(for version: FileVersion) -> String {
         videoRange(for: .passthroughHEVC, source: version)
     }
+
+    static func unambiguousColorRange(for version: FileVersion) -> String? {
+        guard let tracks = version.videoTracks, tracks.count == 1 else { return nil }
+        return tracks[0].colorRange
+    }
 }
 
 private extension ApplePlaybackRoutePlanner {
@@ -719,7 +724,8 @@ private extension ApplePlaybackRoutePlanner {
             videoCodec: normalizedVideoCodec(version.codecVideo ?? session.playbackInfo?.videoCodec),
             audioCodec: normalizedAudioCodec(version.codecAudio ?? session.playbackInfo?.audioCodec),
             subtitleCodecs: embeddedSubtitleCodecs(for: version),
-            dolbyVisionProfile: dolbyVisionProfile(for: version)
+            dolbyVisionProfile: dolbyVisionProfile(for: version),
+            colorRange: unambiguousColorRange(for: version)
         )
     }
 

--- a/iosApp/iosApp/Screens/Player/CoreMedia/PlayerCore.swift
+++ b/iosApp/iosApp/Screens/Player/CoreMedia/PlayerCore.swift
@@ -537,6 +537,8 @@ final class PlayerCore: NSObject {
 
     private var refreshRate: Float = 24.0
     private var dynamicRange: SpikeDynamicRange = .sdr
+    private var sourceColorRangeHint: String?
+    private var resolvedVideoColorRange: String?
     /// Parsed Dolby Vision config record from the stream's `AV_PKT_DATA_DOVI_CONF`
     /// side data. `nil` when the source is not DV. Set during
     /// `buildVideoFormatDescription`.
@@ -1382,7 +1384,12 @@ final class PlayerCore: NSObject {
         return true
     }
 
-    func load(url: URL, headers: [String: String], startTime: Double) {
+    func load(
+        url: URL,
+        headers: [String: String],
+        startTime: Double,
+        colorRangeHint: String? = nil
+    ) {
         guard !isDisposed else { return }
 
         // Stash the load args so the rejection signal (fired from deep inside
@@ -1391,6 +1398,8 @@ final class PlayerCore: NSObject {
         lastLoadURL = url
         lastLoadHeaders = headers
         lastLoadStartTime = startTime
+        sourceColorRangeHint = VideoColorMetadata.normalizedColorRangeName(colorRangeHint)
+        resolvedVideoColorRange = nil
         pendingRejection = nil
         ttffLoadAnchor = CFAbsoluteTimeGetCurrent()
 
@@ -3509,6 +3518,8 @@ final class PlayerCore: NSObject {
               let codecparPtr = stream.pointee.codecpar
         else { return false }
         let codecpar = codecparPtr.pointee
+        resolvedVideoColorRange = VideoColorMetadata.colorRangeName(codecpar.color_range)
+            ?? sourceColorRangeHint
         videoDecodeOutputDimensions = nil
         useUntimedCompressedVideoSamples = false
 
@@ -3693,7 +3704,10 @@ final class PlayerCore: NSObject {
         // work because their BL is HDR10/SDR/HLG-compatible and VT decodes the
         // BL with 'hvc1' while the dvcC atom + RPU-carrying NALs pass through
         // for the display to apply DV dynamic metadata.
-        let fullRange = codecpar.color_range == AVCOL_RANGE_JPEG
+        let fullRange = VideoColorMetadata.isFullRange(
+            codecpar.color_range,
+            fallbackName: resolvedVideoColorRange
+        )
         // Pick a CVPixelBuffer format that matches the advertised fullRange.
         // Mismatches (e.g. `FullRangeVideo=true` + video-range pixel format)
         // leave VT with no registered decoder → unimpErr (-4). This is what
@@ -4529,7 +4543,10 @@ final class PlayerCore: NSObject {
         height: Int
     ) -> CVPixelBuffer? {
         let outputFormat = VideoColorMetadata.highBitDepthOutputPixelFormat(
-            fullRange: frame.pointee.color_range == AVCOL_RANGE_JPEG)
+            fullRange: VideoColorMetadata.isFullRange(
+                frame.pointee.color_range,
+                fallbackName: resolvedVideoColorRange
+            ))
         let attrs: CFDictionary = [
             kCVPixelBufferIOSurfacePropertiesKey: [:],
             kCVPixelBufferMetalCompatibilityKey: true,
@@ -4630,7 +4647,10 @@ final class PlayerCore: NSObject {
             return nil
         }
 
-        let pixelFormat = frame.pointee.color_range == AVCOL_RANGE_JPEG
+        let pixelFormat = VideoColorMetadata.isFullRange(
+            frame.pointee.color_range,
+            fallbackName: resolvedVideoColorRange
+        )
             ? kCVPixelFormatType_420YpCbCr8PlanarFullRange
             : kCVPixelFormatType_420YpCbCr8Planar
         let attrs: CFDictionary = [

--- a/iosApp/iosApp/Screens/Player/CoreMedia/VideoColorMetadata.swift
+++ b/iosApp/iosApp/Screens/Player/CoreMedia/VideoColorMetadata.swift
@@ -29,11 +29,13 @@ enum VideoColorMetadata {
     }
 
     /// Resolve FFmpeg's stream/frame value first and consult server metadata
-    /// only when libav reports AVCOL_RANGE_UNSPECIFIED (or another unknown
-    /// value). Explicit local signaling always wins over the API fallback.
+    /// only when libav reports AVCOL_RANGE_UNSPECIFIED. Explicit local
+    /// signaling always wins over the API fallback.
     static func isFullRange(_ range: AVColorRange, fallbackName: String?) -> Bool {
-        let resolved = colorRangeName(range) ?? normalizedColorRangeName(fallbackName)
-        return resolved == "pc"
+        if range == AVCOL_RANGE_UNSPECIFIED {
+            return normalizedColorRangeName(fallbackName) == "pc"
+        }
+        return colorRangeName(range) == "pc"
     }
 
     static func pickPixelFormat(

--- a/iosApp/iosApp/Screens/Player/CoreMedia/VideoColorMetadata.swift
+++ b/iosApp/iosApp/Screens/Player/CoreMedia/VideoColorMetadata.swift
@@ -12,6 +12,30 @@ import VideoToolbox
 /// colorimetry-string mapping can be reused by the CMSampleBuffer builders
 /// without going through PlayerCore static dispatch.
 enum VideoColorMetadata {
+    static func normalizedColorRangeName(_ value: String?) -> String? {
+        let normalized = value?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        switch normalized {
+        case "tv", "pc": return normalized
+        default: return nil
+        }
+    }
+
+    static func colorRangeName(_ range: AVColorRange) -> String? {
+        switch range {
+        case AVCOL_RANGE_MPEG: return "tv"
+        case AVCOL_RANGE_JPEG: return "pc"
+        default: return nil
+        }
+    }
+
+    /// Resolve FFmpeg's stream/frame value first and consult server metadata
+    /// only when libav reports AVCOL_RANGE_UNSPECIFIED (or another unknown
+    /// value). Explicit local signaling always wins over the API fallback.
+    static func isFullRange(_ range: AVColorRange, fallbackName: String?) -> Bool {
+        let resolved = colorRangeName(range) ?? normalizedColorRangeName(fallbackName)
+        return resolved == "pc"
+    }
+
     static func pickPixelFormat(
         dynamicRange: SpikeDynamicRange,
         fullRange: Bool

--- a/iosApp/iosApp/Screens/Player/PlaybackEngine.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackEngine.swift
@@ -93,7 +93,8 @@ final class CompatibilityPlayerEngine: PlaybackEngine {
         core.load(
             url: plan.streamRequest.url,
             headers: plan.streamRequest.headers,
-            startTime: plan.startMode.seconds
+            startTime: plan.startMode.seconds,
+            colorRangeHint: plan.sourceMetadata.colorRange
         )
     }
 

--- a/iosApp/iosApp/Screens/Player/PlaybackEngine.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackEngine.swift
@@ -94,7 +94,9 @@ final class CompatibilityPlayerEngine: PlaybackEngine {
             url: plan.streamRequest.url,
             headers: plan.streamRequest.headers,
             startTime: plan.startMode.seconds,
-            colorRangeHint: plan.sourceMetadata.colorRange
+            colorRangeHint: plan.delivery.preservesSourceVideoMetadata
+                ? plan.sourceMetadata.colorRange
+                : nil
         )
     }
 

--- a/iosApp/iosApp/Screens/Player/PlaybackExecutionPlan.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackExecutionPlan.swift
@@ -295,13 +295,15 @@ struct PlaybackSourceMetadata: Equatable {
     let audioCodec: String?
     let subtitleCodecs: [String]
     let dolbyVisionProfile: Int?
+    let colorRange: String?
 
     static let unknown = PlaybackSourceMetadata(
         container: nil,
         videoCodec: nil,
         audioCodec: nil,
         subtitleCodecs: [],
-        dolbyVisionProfile: nil
+        dolbyVisionProfile: nil,
+        colorRange: nil
     )
 }
 

--- a/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
@@ -152,6 +152,15 @@ enum PlaybackDeliveryStrategy {
             return "transcode"
         }
     }
+
+    var preservesSourceVideoMetadata: Bool {
+        switch self {
+        case .direct, .remux:
+            return true
+        case .transcode:
+            return false
+        }
+    }
 }
 
 /// Manages the lifecycle of a playback session with the Continuum API.


### PR DESCRIPTION
## Summary

- decode the additive `color_range` video-track field from the native server API
- pass an unambiguous range hint into PlayerCore
- map FFmpeg `tv` to limited range and `pc` to full range only when local libav stream/frame metadata is unspecified
- skip the fallback for multi-video-track files because the current plan does not identify a selected video stream

## Why

Silo preserves the source bytes, but files whose local decoder metadata is unspecified can still need the server-probed FFmpeg range to configure the output pixel format correctly. Explicit local FFmpeg signaling remains authoritative.

## Testing

- `xcodebuild test -project Silo.xcodeproj -scheme Silo -destination "platform=iOS Simulator,name=iPhone 17 Pro" -derivedDataPath /Volumes/NVMe/Xcode/DerivedData/native-color-range-apple CODE_SIGNING_ALLOWED=NO -only-testing:SiloTests/SoftwareVideoOutputFormatTests -only-testing:SiloTests/DetailVersionSelectionTests` (30 tests passed)
- autoreview clean

## Coordination

Depends on Silo-Server/silo-server#447.

Part of Silo-Server/silo-server#446

## AI use

Implemented with OpenAI Codex. The generated patch was reviewed, focused tests were run, and review findings were addressed before publication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video color-range detection during playback by honoring explicit color-range metadata when available and using a safer fallback when it isn’t.
  * Refined full-range handling and pixel format selection for both compressed and software-decoded video paths (standard and high bit depth).
  * Ensured codec-provided color range continues to take priority over fallback metadata.
* **Tests**
  * Added/expanded test coverage for metadata precedence, full-range selection, and unambiguous-vs-ambiguous multi-track behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->