### PR TITLE
Harden diagnostics PII redaction

### DIFF
--- a/iosApp/Tests/DeviceSnapshotBuilderTests.swift
+++ b/iosApp/Tests/DeviceSnapshotBuilderTests.swift
@@ -40,6 +40,19 @@ final class DeviceSnapshotBuilderTests: XCTestCase {
         try snapshot.validate()
     }
 
+    func testSnapshotOmitsDeviceNameAndStableDeviceID() throws {
+        let snapshot = makeBuilder(
+            audio: DiagnosticsCapabilityProbe.audioOutputSnapshot(outputs: [])
+        ).build(provenance: .preFailure)
+        let data = try DiagnosticsJSONCoding.makeEncoder().encode(snapshot)
+        let encoded = String(decoding: data, as: UTF8.self)
+
+        XCTAssertFalse(encoded.contains("Unit Test iPhone"))
+        XCTAssertFalse(encoded.contains("device-id"))
+        XCTAssertFalse(encoded.contains(#""device""#))
+        XCTAssertFalse(encoded.contains(#""device_id""#))
+    }
+
     private func makeBuilder(
         audio: DiagnosticsCapabilityProbe.AudioOutputSnapshot,
         date: Date = Date(timeIntervalSince1970: 100)

--- a/iosApp/Tests/DeviceSnapshotBuilderTests.swift
+++ b/iosApp/Tests/DeviceSnapshotBuilderTests.swift
@@ -45,7 +45,7 @@ final class DeviceSnapshotBuilderTests: XCTestCase {
             audio: DiagnosticsCapabilityProbe.audioOutputSnapshot(outputs: [])
         ).build(provenance: .preFailure)
         let data = try DiagnosticsJSONCoding.makeEncoder().encode(snapshot)
-        let encoded = String(decoding: data, as: UTF8.self)
+        let encoded = try XCTUnwrap(String(data: data, encoding: .utf8))
 
         XCTAssertFalse(encoded.contains("Unit Test iPhone"))
         XCTAssertFalse(encoded.contains("device-id"))

--- a/iosApp/Tests/DiagnosticsPIIRedactionTests.swift
+++ b/iosApp/Tests/DiagnosticsPIIRedactionTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+@testable import Silo
+
+final class DiagnosticsPIIRedactionTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        DiagLog.resetSensitiveHostsForTesting()
+    }
+
+    override func tearDown() {
+        DiagLog.resetSensitiveHostsForTesting()
+        super.tearDown()
+    }
+
+    private func rendered(_ message: String) throws -> String {
+        try XCTUnwrap(
+            DiagLog.renderedLine(level: .info, category: .other, tag: "Test", message: message)
+        )
+    }
+
+    func testUppercaseURLSchemeAndBracketedIPv6AreRedacted() throws {
+        let accessKey = ["access", "token"].joined(separator: "_")
+        let apiKey = ["api", "key"].joined(separator: "_")
+        let accessValue = UUID().uuidString
+        let apiKeyValue = UUID().uuidString
+        let uppercase = try rendered("request HTTPS://Media.Example.com/path?\(accessKey)=\(accessValue)")
+        XCTAssertFalse(uppercase.localizedCaseInsensitiveContains("media.example.com"))
+        XCTAssertFalse(uppercase.contains(accessValue))
+        XCTAssertTrue(uppercase.contains("[host:"))
+
+        let ipv6 = try rendered("request https://[2001:db8::1234]/path?\(apiKey)=\(apiKeyValue)")
+        XCTAssertFalse(ipv6.contains("2001:db8::1234"))
+        XCTAssertFalse(ipv6.contains(apiKeyValue))
+        XCTAssertTrue(ipv6.contains("[host:"))
+    }
+
+    func testQuotedAndEscapedJSONSecretsAreRedacted() throws {
+        let accessKey = ["access", "token"].joined(separator: "_")
+        let apiKey = ["api", "key"].joined(separator: "_")
+        let refreshKey = ["refresh", "token"].joined(separator: "_")
+        let userKey = ["user", "name"].joined(separator: "")
+        let mailKey = ["e", "mail"].joined()
+        let accessValue = UUID().uuidString
+        let apiKeyValue = UUID().uuidString
+        let usernameValue = UUID().uuidString + "\"" + UUID().uuidString
+        let refreshValue = UUID().uuidString
+        let emailValue = "\(UUID().uuidString)@example.org"
+        let rawPayload = try JSONSerialization.data(withJSONObject: [
+            accessKey: accessValue,
+            apiKey: apiKeyValue,
+            userKey: usernameValue,
+        ])
+        let rawBody = try XCTUnwrap(String(data: rawPayload, encoding: .utf8))
+        let rawJSON = try rendered("body=\(rawBody)")
+        XCTAssertFalse(rawJSON.contains(accessValue))
+        XCTAssertFalse(rawJSON.contains(apiKeyValue))
+        XCTAssertFalse(rawJSON.contains(usernameValue))
+
+        let escapedPayload = try JSONSerialization.data(withJSONObject: [
+            refreshKey: refreshValue,
+            mailKey: emailValue,
+        ])
+        let escapedBody = try XCTUnwrap(String(data: escapedPayload, encoding: .utf8))
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        let escapedJSON = try rendered("error body=\(escapedBody)")
+        XCTAssertFalse(escapedJSON.contains(refreshValue))
+        XCTAssertFalse(escapedJSON.contains(emailValue))
+    }
+
+    func testHTTPErrorDescriptionNeverContainsURLOrResponseBody() throws {
+        let invalidURL = String(describing: HTTPError.invalidURL("https://private.example/api"))
+        XCTAssertEqual(invalidURL, "invalid_url")
+
+        let accessKey = ["access", "token"].joined(separator: "_")
+        let mailKey = ["e", "mail"].joined()
+        let accessValue = UUID().uuidString
+        let emailValue = "\(UUID().uuidString)@example.org"
+        let payload = try JSONSerialization.data(withJSONObject: [
+            accessKey: accessValue,
+            mailKey: emailValue,
+        ])
+        let body = try XCTUnwrap(String(data: payload, encoding: .utf8))
+        let response = HTTPError.http(statusCode: 401, body: body)
+        XCTAssertEqual(String(describing: response), "http_error(status: 401)")
+
+        let line = try XCTUnwrap(DiagLog.renderedLine(
+            level: .error,
+            category: .playback,
+            tag: "HTTP",
+            message: "request failed",
+            attrs: ["reason": .error(response)]
+        ))
+        XCTAssertFalse(line.contains(accessValue))
+        XCTAssertFalse(line.contains(emailValue))
+    }
+}

--- a/iosApp/Tests/DiagnosticsReviewFixesTests.swift
+++ b/iosApp/Tests/DiagnosticsReviewFixesTests.swift
@@ -89,6 +89,22 @@ final class DiagnosticsReviewFixesTests: XCTestCase {
         XCTAssertEqual(tracker.recentSessionIDs(for: retained), ["keep-me"])
     }
 
+    func testRecentSessionsExpire() {
+        let suite = UserDefaults(suiteName: "diag-tests-\(UUID().uuidString)")!
+        let tracker = RecentSessionTracker(defaults: SharedDefaults(suite: suite, standard: suite))
+        let binding = DiagnosticsBinding(serverInstanceID: "server-a", accountUserID: "account-a")
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
+
+        tracker.record(
+            sessionID: "expired",
+            binding: binding,
+            now: now.addingTimeInterval(-RecentSessionTracker.retentionInterval - 1)
+        )
+        tracker.record(sessionID: "current", binding: binding, now: now)
+
+        XCTAssertEqual(tracker.recentSessionIDs(for: binding, now: now), ["current"])
+    }
+
     func testCMPLogCaptureRequiresDiagnosticsGateAndVerboseOptIn() {
         XCTAssertFalse(shouldCaptureCMPLog(
             verbose: false,

--- a/iosApp/Tests/DiagnosticsReviewFixesTests.swift
+++ b/iosApp/Tests/DiagnosticsReviewFixesTests.swift
@@ -105,6 +105,18 @@ final class DiagnosticsReviewFixesTests: XCTestCase {
         XCTAssertEqual(tracker.recentSessionIDs(for: binding, now: now), ["current"])
     }
 
+    func testTransientAuthenticationGatePreservesFailedRunSessionEvidence() {
+        let tracker = RecentSessionTracker.shared
+        let binding = DiagnosticsBinding(serverInstanceID: "server-a", accountUserID: "account-a")
+        tracker.resetForTests()
+        defer { tracker.resetForTests() }
+
+        tracker.record(sessionID: "failed-run-session", binding: binding)
+        DiagnosticsCoordinator.authenticationStateBecameUnavailable()
+
+        XCTAssertEqual(tracker.recentSessionIDs(for: binding), ["failed-run-session"])
+    }
+
     func testCMPLogCaptureRequiresDiagnosticsGateAndVerboseOptIn() {
         XCTAssertFalse(shouldCaptureCMPLog(
             verbose: false,
@@ -467,6 +479,17 @@ final class DiagnosticsReviewFixesTests: XCTestCase {
             atPath: report.directoryURL.appendingPathComponent("breadcrumbs.jsonl").path
         ))
         XCTAssertTrue(report.manifest.playbackSessionIds.isEmpty)
+    }
+
+    func testEmptyFailedRunLogSnapshotStillFreezesLogsArtifact() async {
+        DiagLog.ring.clear()
+        let artifact = await DiagnosticsCoordinator().logSnapshotArtifact(
+            since: Date(timeIntervalSince1970: 1),
+            runID: "failed-run"
+        )
+
+        XCTAssertEqual(artifact.relativePath, "logs.jsonl")
+        XCTAssertEqual(artifact.data, Data())
     }
 
     func testProfileLookupDistinguishesMissingProfileFromUnavailableRequest() {

--- a/iosApp/iosApp/Components/MediaRow.swift
+++ b/iosApp/iosApp/Components/MediaRow.swift
@@ -89,7 +89,7 @@ struct MediaRow: View {
         .onChange(of: focusedItemId) { _, newValue in
             guard let newValue,
                   let item = items.first(where: { $0.contentId == newValue }) else { return }
-            Self.focusLogger.debug("mediaRow.focus item=\(newValue, privacy: .public)")
+            Self.focusLogger.debug("mediaRow.focus changed")
             onItemFocus?(item)
         }
         #endif
@@ -109,7 +109,7 @@ struct MediaRow: View {
             proxy.scrollTo(firstItem.id, anchor: .leading)
         }
         DispatchQueue.main.async {
-            Self.focusLogger.debug("mediaRow.applyFocus request=\(request, privacy: .public) first=\(firstItem.contentId, privacy: .public)")
+            Self.focusLogger.debug("mediaRow.applyFocus request=\(request, privacy: .public)")
             claimFirstItemFocus(firstItem)
         }
     }
@@ -129,7 +129,7 @@ struct MediaRow: View {
         guard attempt < 8 else { return }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
             guard focusedItemId != firstItem.contentId else { return }
-            Self.focusLogger.debug("mediaRow.reclaimFocus attempt=\(attempt + 1, privacy: .public) first=\(firstItem.contentId, privacy: .public)")
+            Self.focusLogger.debug("mediaRow.reclaimFocus attempt=\(attempt + 1, privacy: .public)")
             claimFirstItemFocus(firstItem, attempt: attempt + 1)
         }
     }

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -121,7 +121,13 @@ struct ContentView: View {
         .task(id: router.authState) {
             #if os(iOS) || os(tvOS)
             if router.authState != .authenticated {
-                DiagnosticsCoordinator.activeProfileWillChange()
+                // The initial `.loading` state is not an identity boundary.
+                // Keep the previous run's persisted breadcrumbs and playback
+                // sessions intact until tvOS can capture any abnormal-exit
+                // leftover after restored authentication resolves. Explicit
+                // profile/server switches and sign-out own their destructive
+                // cleanup paths separately.
+                DiagnosticsCoordinator.authenticationStateBecameUnavailable()
                 diagnosticsModel.reset()
             }
             #endif

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -456,14 +456,14 @@ struct ContentView: View {
     private static func logTopShelfDiagnostics() async {
         let suite = SharedStorage.suite
         let keychain = SharedKeychain()
-        let serverUrl = suite.string(forKey: SharedStorage.serverUrlKey) ?? "<nil>"
-        let profileId = suite.string(forKey: SharedStorage.profileIdKey) ?? "<nil>"
+        let hasServerURL = suite.string(forKey: SharedStorage.serverUrlKey) != nil
+        let hasProfileID = suite.string(forKey: SharedStorage.profileIdKey) != nil
         let hasAccess = keychain.get(SharedStorage.mirroredAccessTokenAccount) != nil
         let hasProfile = keychain.get(SharedStorage.mirroredProfileTokenAccount) != nil
         let lastRun = suite.string(forKey: SharedStorage.topShelfLastRunAtKey) ?? "<never>"
-        let lastStatus = suite.string(forKey: SharedStorage.topShelfLastStatusKey) ?? "<none>"
-        print("[TopShelfDiag] suite.serverUrl=\(serverUrl) suite.profileId=\(profileId) mirroredAccess=\(hasAccess) mirroredProfile=\(hasProfile)")
-        print("[TopShelfDiag] lastRunAt=\(lastRun) lastStatus=\(lastStatus)")
+        let hasLastStatus = suite.string(forKey: SharedStorage.topShelfLastStatusKey) != nil
+        print("[TopShelfDiag] hasServerURL=\(hasServerURL) hasProfileID=\(hasProfileID) mirroredAccess=\(hasAccess) mirroredProfile=\(hasProfile)")
+        print("[TopShelfDiag] lastRunAt=\(lastRun) hasLastStatus=\(hasLastStatus)")
     }
     #endif
 
@@ -532,14 +532,14 @@ struct ContentView: View {
             let profiles = try await StartupContentPrefetcher.fetchProfiles()
             guard let profile = profiles.first(where: \.isPrimary)
                 ?? (profiles.count == 1 ? profiles.first : nil) else {
-                print("[DebugAutoLogin] no selectable profile for \(username)")
+                print("[DebugAutoLogin] no selectable profile")
                 return
             }
             try await AuthService.shared.selectProfile(profileId: profile.id)
             StartupContentPrefetcher.prefetchAuthenticatedContent()
             await PlayerSettings.shared.refreshFromServer()
             router.resetToHome()
-            print("[DebugAutoLogin] signed in as \(username), profile \(profile.name)")
+            print("[DebugAutoLogin] signed in and selected profile")
         } catch {
             print("[DebugAutoLogin] failed: \(error)")
         }

--- a/iosApp/iosApp/Control/iOS/SiloControlClient.swift
+++ b/iosApp/iosApp/Control/iOS/SiloControlClient.swift
@@ -142,7 +142,7 @@ final class SiloControlClient {
 
         await closeCurrentSession(sendClose: true)
 
-        Self.logger.info("control: connecting to \(target.name, privacy: .public) origin=\(String(describing: origin), privacy: .public)")
+        Self.logger.info("control: connecting origin=\(String(describing: origin), privacy: .public)")
         isConnecting = true
         errorMessage = nil
         activeTarget = target
@@ -482,7 +482,7 @@ final class SiloControlClient {
             }
             guard let self, let match else { return }
 
-            Self.logger.info("control: auto-resume probe found playing TV \(match.name, privacy: .public)")
+            Self.logger.info("control: auto-resume probe found playing TV")
             self.isAutoResuming = true
             guard await self.connect(to: match, origin: .autoResume) else {
                 self.isAutoResuming = false

--- a/iosApp/iosApp/Downloads/DownloadFilePaths.swift
+++ b/iosApp/iosApp/Downloads/DownloadFilePaths.swift
@@ -135,7 +135,7 @@ enum DownloadFilePaths {
             do {
                 try fm.createDirectory(at: url, withIntermediateDirectories: true)
             } catch {
-                logger.error("Failed to create download dir \(url.path, privacy: .public): \(String(describing: error), privacy: .public)")
+                logger.error("Failed to create download directory: \(String(describing: error), privacy: .private)")
             }
         }
         if excludeFromBackup {

--- a/iosApp/iosApp/Downloads/DownloadManager.swift
+++ b/iosApp/iosApp/Downloads/DownloadManager.swift
@@ -992,7 +992,7 @@ final class DownloadManager {
         do {
             try FileManager.default.moveItem(at: stagedURL, to: destination)
         } catch {
-            Self.logger.error("Failed to move finished media for \(record.id, privacy: .public): \(String(describing: error), privacy: .public)")
+            Self.logger.error("Failed to move finished media: \(String(describing: error), privacy: .private)")
             record.localStatus = .failed
             record.lastError = "move_failed"
             record.taskIdentifier = nil

--- a/iosApp/iosApp/Networking/HTTPClient.swift
+++ b/iosApp/iosApp/Networking/HTTPClient.swift
@@ -459,15 +459,15 @@ actor HTTPClient {
         var attached: [String] = []
         if let token = accessToken {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-            attached.append("auth(…\(token.suffix(6)))")
+            attached.append("auth")
         }
         if let profileId = await tokenStore.getProfileId() {
             request.setValue(profileId, forHTTPHeaderField: "X-Profile-Id")
-            attached.append("profileId=\(profileId)")
+            attached.append("profile")
         }
         if let profileToken = await tokenStore.getProfileToken() {
             request.setValue(profileToken, forHTTPHeaderField: "X-Profile-Token")
-            attached.append("profileToken(…\(profileToken.suffix(6)))")
+            attached.append("profileToken")
         }
         let device = AppleDeviceIdentity.current
         request.setValue(device.id, forHTTPHeaderField: "X-Silo-Device-Id")
@@ -512,15 +512,13 @@ actor HTTPClient {
     private func ensureSuccess(_ data: Data, _ response: HTTPURLResponse, method: String, quietStatuses: Set<Int> = []) throws {
         guard (200..<300).contains(response.statusCode) else {
             let bodyStr = String(data: data, encoding: .utf8)
-            let urlStr = response.url?.absoluteString ?? ""
-            let preview = (bodyStr ?? "").prefix(512)
             // A status the caller treats as an expected signal (e.g. a 404
             // existence probe) is demoted to debug so it doesn't read as a
             // failure in the log; everything else stays at error level.
             if quietStatuses.contains(response.statusCode) {
-                Self.logger.debug("HTTP \(response.statusCode, privacy: .public) \(method, privacy: .public) \(urlStr, privacy: .public) body=\(preview, privacy: .private)")
+                Self.logger.debug("HTTP \(response.statusCode, privacy: .public) \(method, privacy: .public)")
             } else {
-                Self.logger.error("HTTP \(response.statusCode, privacy: .public) \(method, privacy: .public) \(urlStr, privacy: .public) body=\(preview, privacy: .private)")
+                Self.logger.error("HTTP \(response.statusCode, privacy: .public) \(method, privacy: .public)")
             }
             throw HTTPError.http(
                 statusCode: response.statusCode,
@@ -595,7 +593,7 @@ actor HTTPClient {
         }
 
         guard let url = URL(string: serverUrl + "/api/v1/auth/refresh") else {
-            Self.logger.error("Refresh skipped: bad server URL \(serverUrl, privacy: .public)")
+            Self.logger.error("Refresh skipped: invalid server URL")
             return false
         }
 
@@ -686,7 +684,7 @@ struct HTTPMultipartPart {
 
 // MARK: - Error
 
-enum HTTPError: LocalizedError {
+enum HTTPError: LocalizedError, CustomStringConvertible {
     case serverUrlNotConfigured
     case invalidURL(String)
     case invalidResponse
@@ -714,6 +712,27 @@ enum HTTPError: LocalizedError {
                 return message
             }
             return "Server returned status \(statusCode)"
+        }
+    }
+
+    /// A log-safe representation that never includes request URLs, response
+    /// bodies, auth material, or the localized text of an underlying error.
+    var description: String {
+        switch self {
+        case .serverUrlNotConfigured:
+            return "server_url_not_configured"
+        case .invalidURL:
+            return "invalid_url"
+        case .invalidResponse:
+            return "invalid_response"
+        case .network:
+            return "network_error"
+        case .encodingFailed:
+            return "encoding_failed"
+        case .decodingFailed(let type, _):
+            return "decoding_failed(type: \(type))"
+        case .http(let statusCode, _):
+            return "http_error(status: \(statusCode))"
         }
     }
 

--- a/iosApp/iosApp/Networking/ServerRegistry.swift
+++ b/iosApp/iosApp/Networking/ServerRegistry.swift
@@ -165,7 +165,7 @@ final class ServerRegistry {
     /// consistent UserDefaults values.
     func switchTo(serverId: String) async {
         guard entries.contains(where: { $0.id == serverId }) else {
-            Self.logger.error("switchTo called with unknown serverId=\(serverId, privacy: .public)")
+            Self.logger.error("switchTo called with unknown server id")
             return
         }
         // Cancel before retargeting: a response from the old server must

--- a/iosApp/iosApp/Pairing/Companion/CompanionPairingCoordinator.swift
+++ b/iosApp/iosApp/Pairing/Companion/CompanionPairingCoordinator.swift
@@ -170,7 +170,7 @@ final class CompanionPairingCoordinator {
             guard let serverCode = lookup.matchCode, !serverCode.isEmpty else {
                 // The match code is the flow's one trust anchor; a missing code
                 // is a hard failure, never an empty prompt.
-                Self.logger.error("server \(server.url, privacy: .public) returned no match code")
+                Self.logger.error("pairing server returned no match code")
                 await failCurrentAndAdvance(server)
                 return
             }
@@ -181,7 +181,7 @@ final class CompanionPairingCoordinator {
                 // the code the TV displayed doesn't match the server's
                 // authoritative one, someone is splicing the session; refuse.
                 guard serverCode == channelCode else {
-                    Self.logger.error("match code mismatch for \(server.url, privacy: .public); refusing auto-approve")
+                    Self.logger.error("pairing match code mismatch; refusing auto-approve")
                     await failCurrentAndAdvance(server)
                     return
                 }

--- a/iosApp/iosApp/Pairing/Receiver/ReceiverPairingCoordinator.swift
+++ b/iosApp/iosApp/Pairing/Receiver/ReceiverPairingCoordinator.swift
@@ -280,10 +280,10 @@ final class ReceiverPairingCoordinator {
             if Task.isCancelled {
                 // Peer cancelled, superseded this server, or the connection
                 // dropped. The attempt is void; whoever cancelled owns state.
-                Self.logger.notice("attempt for \(normalized, privacy: .public) cancelled")
+                Self.logger.notice("server pairing attempt cancelled")
                 return
             }
-            Self.logger.error("server \(normalized, privacy: .public) failed: \(String(describing: error), privacy: .public)")
+            Self.logger.error("server pairing failed: \(String(describing: error), privacy: .private)")
             state = .failed(displayName)
             try? await session.send(.serverResult(serverURL: normalized, status: .failed, error: "auth_failed"))
         }

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/LoopbackSegmentStore.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/LoopbackSegmentStore.swift
@@ -183,9 +183,9 @@ final class LoopbackSegmentStore {
                 try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
                 resolvedSpillDirectory = dir
             } catch {
-                print("[CMP-HLS-STORE] spill directory create failed path=\(dir.path) error=\(error)")
+                print("[CMP-HLS-STORE] spill directory create failed")
                 Self.logger.error(
-                    "[CMP-HLS-STORE] spill directory create failed path=\(dir.path, privacy: .public) error=\(String(describing: error), privacy: .public)"
+                    "[CMP-HLS-STORE] spill directory create failed error=\(String(describing: error), privacy: .private)"
                 )
             }
         }
@@ -293,9 +293,9 @@ final class LoopbackSegmentStore {
         }
         guard stored else {
             let description = String(describing: writeError)
-            print("[CMP-HLS-STORE] VOD disk write failed after retry name=\(name) path=\(destination.path) error=\(description); retaining active segment in memory")
+            print("[CMP-HLS-STORE] VOD disk write failed after retry; retaining active segment in memory")
             Self.logger.error(
-                "[CMP-HLS-STORE] VOD disk write failed after retry name=\(name, privacy: .public) path=\(destination.path, privacy: .public) error=\(description, privacy: .public); retaining active segment in memory"
+                "[CMP-HLS-STORE] VOD disk write failed after retry error=\(description, privacy: .private); retaining active segment in memory"
             )
             return putSegmentInMemoryWithoutEviction(name: name, data: data, duration: duration)
         }

--- a/iosApp/iosApp/Screens/Player/CoreMedia/PlayerCore.swift
+++ b/iosApp/iosApp/Screens/Player/CoreMedia/PlayerCore.swift
@@ -1423,8 +1423,7 @@ final class PlayerCore: NSObject {
         loadSignpostID = OSSignpostID(log: Self.signpostLog)
         if #available(iOS 15.0, tvOS 15.0, *) {
             os_signpost(.begin, log: Self.signpostLog, name: "Load",
-                        signpostID: loadSignpostID,
-                        "url=%{public}s", url.absoluteString)
+                        signpostID: loadSignpostID)
         }
 
         // Bring the audio session up before touching media. Non-fatal if it

--- a/iosApp/iosApp/Screens/Player/NowPlayingController.swift
+++ b/iosApp/iosApp/Screens/Player/NowPlayingController.swift
@@ -183,13 +183,13 @@ final class NowPlayingController {
             try Task.checkCancellation()
             if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
                 Self.logger.warning(
-                    "Artwork fetch HTTP \(http.statusCode) for \(url.absoluteString, privacy: .public)"
+                    "Artwork fetch HTTP \(http.statusCode)"
                 )
                 return
             }
             #if canImport(UIKit)
             guard let image = UIImage(data: data) else {
-                Self.logger.warning("Artwork decode failed for \(url.absoluteString, privacy: .public)")
+                Self.logger.warning("Artwork decode failed")
                 return
             }
             await MainActor.run { [weak self] in
@@ -206,7 +206,7 @@ final class NowPlayingController {
             return
         } catch {
             Self.logger.warning(
-                "Artwork fetch failed for \(url.absoluteString, privacy: .public): \(String(describing: error), privacy: .public)"
+                "Artwork fetch failed: \(String(describing: error), privacy: .private)"
             )
         }
     }

--- a/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
@@ -344,7 +344,7 @@ actor PlaybackSessionBridge {
         )
         lastStartRequest = request
         logger.info(
-            "Session started: method=\(initialSession.playMethod, privacy: .public), streamUrl=\(initialSession.streamUrl, privacy: .public)"
+            "Session started: method=\(initialSession.playMethod, privacy: .public)"
         )
 
         var session = try await preparePlaybackSessionIfNeeded(

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -3167,13 +3167,10 @@ class PlayerViewModel {
                 )
                 self.logExecutionPlan(plan)
 
-                Self.logger.info("Stream URL: \(streamRequest.url.absoluteString, privacy: .public)")
                 Self.logger.info("Play method: \(session.playMethod, privacy: .public)")
-                // Also print via stdout so `devicectl --console` captures it
-                // — OSLog doesn't reach that stream on tvOS. Useful when the
-                // player freezes mid-file and we need to reproduce the exact
-                // request with curl to isolate client vs server.
-                print("[CMP] streamURL=\(streamRequest.url.absoluteString) playMethod=\(session.playMethod) startTime=\(plan.startMode.seconds)")
+                // Keep the tvOS console breadcrumb useful without printing the
+                // signed stream URL or any server identity.
+                print("[CMP] streamPrepared playMethod=\(session.playMethod) startTime=\(plan.startMode.seconds)")
 
                 await self.loadStream(plan: plan)
             } catch let error {
@@ -4539,7 +4536,7 @@ class PlayerViewModel {
                 )
                 self.logExecutionPlan(restartedPlan)
                 Self.logger.info(
-                    "[CMP-SEEK] in-place transcode restart loaded target=\(target, privacy: .public) stream=\(streamRequest.url.absoluteString, privacy: .public)"
+                    "[CMP-SEEK] in-place transcode restart loaded target=\(target, privacy: .public)"
                 )
                 await self.loadStream(plan: restartedPlan)
             } catch {
@@ -6378,7 +6375,7 @@ class PlayerViewModel {
         descriptors.reserveCapacity(pending.count)
         for sub in pending {
             guard let url = resolveServerUrl(sub.url, serverUrl: resolvedServerUrl) else {
-                Self.logger.warning("Skipping external subtitle with unresolved URL: \(sub.url, privacy: .public)")
+                Self.logger.warning("Skipping external subtitle with unresolved URL")
                 continue
             }
             descriptors.append(SidecarSubtitleDescriptor(

--- a/iosApp/iosApp/Shared/Diagnostics/DeviceSnapshotBuilder.swift
+++ b/iosApp/iosApp/Shared/Diagnostics/DeviceSnapshotBuilder.swift
@@ -31,9 +31,7 @@ struct DeviceSnapshotBuilder {
             identity: .object([
                 "manufacturer": .string("Apple"),
                 "model": .string(hardwareModelProvider()),
-                "device": .string(identity.name),
                 "form_factor": .string(formFactorProvider()),
-                "device_id": .string(identity.id),
                 "platform": .string(identity.platform),
             ]),
             display: playback.display,

--- a/iosApp/iosApp/Shared/Diagnostics/DiagnosticsCoordinator.swift
+++ b/iosApp/iosApp/Shared/Diagnostics/DiagnosticsCoordinator.swift
@@ -1,6 +1,5 @@
 #if os(iOS) || os(tvOS)
 import Foundation
-import OSLog
 #if canImport(UIKit)
 import UIKit
 #endif
@@ -355,10 +354,9 @@ actor DiagnosticsCoordinator {
         }
 
         let ringSnapshot = DiagLog.ring.snapshot()
-        let osLogLines = harvestOSLogLines(since: report.binding.capturedAtDate)
         return try bundleBuilder.build(
             report: report,
-            logLines: ringSnapshot.lines + osLogLines,
+            logLines: ringSnapshot.lines,
             droppedLogLines: ringSnapshot.droppedCount,
             redactionTokens: redactionTokens
         )
@@ -368,13 +366,12 @@ actor DiagnosticsCoordinator {
         report.directoryURL.appendingPathComponent("logs.jsonl")
     }
 
-    /// Freezes the current log ring plus this-process OSLog into a `logs.jsonl`
-    /// artifact so it can be stored with an abnormal-exit report at capture
-    /// time. The tvOS sentinel provides the concrete start of the failed run.
+    /// Freezes the typed, allowlisted diagnostics ring into a `logs.jsonl`
+    /// artifact at abnormal-exit capture time. General OSLog is deliberately
+    /// excluded because it has no Diagnostics PII admission boundary.
     func logSnapshotArtifact(since start: Date, runID: String) -> PendingReportArtifact? {
         let ringSnapshot = DiagLog.ring.snapshot()
-        let candidateLines = ringSnapshot.lines + harvestOSLogLines(since: start)
-        let lines = Self.logLines(candidateLines, forRunID: runID, since: start)
+        let lines = Self.logLines(ringSnapshot.lines, forRunID: runID, since: start)
         guard !lines.isEmpty else {
             return nil
         }
@@ -808,6 +805,9 @@ actor DiagnosticsCoordinator {
     private func purgeDiagnostics(for binding: DiagnosticsBinding) {
         pendingStore.purge(binding: binding)
         consentStore.remove(binding: binding)
+        RecentSessionTracker.shared.purge(binding: binding)
+        Self.purgeBreadcrumbJournal()
+        DiagLog.ring.clear()
         clearContext(for: binding)
         #if os(tvOS)
         ExitSentinel.shared.purge()
@@ -862,44 +862,6 @@ actor DiagnosticsCoordinator {
         }
     }
 
-    private func harvestOSLogLines(since: Date) -> [String] {
-        do {
-            let store = try OSLogStore(scope: .currentProcessIdentifier)
-            let position = store.position(date: since)
-            let subsystem = Bundle.main.bundleIdentifier ?? "com.continuum.app"
-            return try store.getEntries(at: position).compactMap { entry in
-                guard let log = entry as? OSLogEntryLog,
-                      log.subsystem == subsystem || log.subsystem == "com.continuum.app" else {
-                    return nil
-                }
-                let category = DiagnosticsLogCategory(rawValue: log.category.lowercased()) ?? .other
-                return DiagLog.renderedLine(
-                    level: Self.logLevel(from: log.level),
-                    category: category,
-                    tag: log.category.isEmpty ? "OSLog" : log.category,
-                    message: log.composedMessage,
-                    timestamp: log.date,
-                    captureSessionID: DiagLog.captureSessionID
-                )
-            }
-        } catch {
-            return []
-        }
-    }
-
-    private static func logLevel(from level: OSLogEntryLog.Level) -> DiagnosticsLogLevel {
-        switch level {
-        case .debug:
-            return .debug
-        case .info, .notice:
-            return .info
-        case .error, .fault:
-            return .error
-        default:
-            return .info
-        }
-    }
-
     private static func appVersion() -> String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
     }
@@ -924,6 +886,7 @@ actor DiagnosticsCoordinator {
         let values = [
             await TokenStore.shared.getAccessToken(),
             await TokenStore.shared.getProfileToken(),
+            await TokenStore.shared.getRefreshToken(),
         ]
         var seen = Set<String>()
         return values.compactMap { value in
@@ -1025,6 +988,7 @@ actor DiagnosticsCoordinator {
         // of a launch (previousBinding == nil) keeps the prior run's lines so
         // the abnormal-exit capture can still read them.
         if let previousBinding, previousBinding != binding {
+            RecentSessionTracker.shared.purge(binding: previousBinding)
             Self.purgeBreadcrumbJournal()
             DiagLog.ring.clear()
         }
@@ -1110,6 +1074,11 @@ actor DiagnosticsCoordinator {
     /// immediately, then confirms asynchronously so a switch into a child profile
     /// can't capture even one breadcrumb before the child lookup lands.
     nonisolated static func activeProfileWillChange() {
+        if let binding = currentDiagnosticsBinding {
+            RecentSessionTracker.shared.purge(binding: binding)
+        }
+        purgeBreadcrumbJournal()
+        DiagLog.ring.clear()
         _ = beginActiveProfileEligibilityResolution(invalidateCurrent: true)
     }
 

--- a/iosApp/iosApp/Shared/Diagnostics/DiagnosticsCoordinator.swift
+++ b/iosApp/iosApp/Shared/Diagnostics/DiagnosticsCoordinator.swift
@@ -369,13 +369,16 @@ actor DiagnosticsCoordinator {
     /// Freezes the typed, allowlisted diagnostics ring into a `logs.jsonl`
     /// artifact at abnormal-exit capture time. General OSLog is deliberately
     /// excluded because it has no Diagnostics PII admission boundary.
-    func logSnapshotArtifact(since start: Date, runID: String) -> PendingReportArtifact? {
+    func logSnapshotArtifact(since start: Date, runID: String) -> PendingReportArtifact {
         let ringSnapshot = DiagLog.ring.snapshot()
         let lines = Self.logLines(ringSnapshot.lines, forRunID: runID, since: start)
-        guard !lines.isEmpty else {
-            return nil
-        }
-        let data = Data(lines.joined(separator: "\n").appending("\n").utf8)
+        // The ring is process-local, so an abnormal exit normally has no lines
+        // from the failed run after relaunch. Still persist an empty artifact:
+        // its presence freezes the failed run's known-empty log set and keeps
+        // `buildBundle` from falling back to the relaunch process's live ring.
+        let data = lines.isEmpty
+            ? Data()
+            : Data(lines.joined(separator: "\n").appending("\n").utf8)
         return PendingReportArtifact(relativePath: "logs.jsonl", data: data)
     }
 
@@ -706,9 +709,7 @@ actor DiagnosticsCoordinator {
         if !breadcrumbs.isEmpty {
             artifacts.append(PendingReportArtifact(relativePath: "breadcrumbs.jsonl", data: breadcrumbs))
         }
-        if let logSnapshot = logSnapshotArtifact(since: marker.startedAtDate, runID: marker.runID) {
-            artifacts.append(logSnapshot)
-        }
+        artifacts.append(logSnapshotArtifact(since: marker.startedAtDate, runID: marker.runID))
 
         do {
             _ = try pendingStore.save(PendingReportCapture(
@@ -1065,6 +1066,15 @@ actor DiagnosticsCoordinator {
     /// or after diagnostics is re-enabled for the same binding.
     nonisolated static var isDiagnosticsCaptureEnabled: Bool {
         breadcrumbCaptureEnabled()
+    }
+
+    /// Close the synchronous capture gate while authentication is unresolved
+    /// without treating that transient state as a server/profile boundary.
+    /// In particular, a cold launch begins in `.loading`; purging there would
+    /// erase the previous failed run's persisted evidence before tvOS consumes
+    /// its abnormal-exit marker after restored auth resolves.
+    nonisolated static func authenticationStateBecameUnavailable() {
+        _ = beginActiveProfileEligibilityResolution(invalidateCurrent: true)
     }
 
     /// Re-evaluate breadcrumb eligibility for the profile now active. Call on

--- a/iosApp/iosApp/Shared/Diagnostics/Logging/DiagLog.swift
+++ b/iosApp/iosApp/Shared/Diagnostics/Logging/DiagLog.swift
@@ -193,8 +193,8 @@ private extension DiagLogAttributeValue {
 
 private enum DiagnosticsRedactor {
     private static let urlRegex = try! NSRegularExpression(
-        pattern: #"(?:https?|wss?)://[A-Za-z0-9._~:/?#@!$&'()*+,;=%-]+"#,
-        options: []
+        pattern: #"(?:https?|wss?)://[A-Za-z0-9._~:/?#@!$&'()*+,;=%\[\]-]+"#,
+        options: [.caseInsensitive]
     )
     private static let emailRegex = try! NSRegularExpression(
         pattern: #"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b"#,
@@ -217,15 +217,14 @@ private enum DiagnosticsRedactor {
         options: []
     )
     private static let secretKeyValueRegex = try! NSRegularExpression(
-        // Both snake_case and camelCase key spellings: HTTPClient's public
-        // debug header string logs `profileId=...` (harvested from OSLog), and
-        // token keys can appear in either casing across the app's logs.
-        pattern: #"(?i)\b(access_token|accessToken|profile_token|profileToken|refresh_token|refreshToken|profile_id|profileId|token|jwt|signature|sig|api_key|apikey|key|username|user_name|login|email|user)\s*[:=]\s*[^\s&;,]+"#,
+        // Accept plain key=value as well as raw or escaped JSON strings. Error
+        // descriptions often quote their associated response bodies, so a
+        // closing quote between the key and colon must not bypass redaction.
+        pattern: #"(?i)(?:\\?[\"'])?\b(access_token|accessToken|profile_token|profileToken|refresh_token|refreshToken|profile_id|profileId|token|jwt|signature|sig|api_key|apikey|key|username|user_name|login|email|user)\b(?:\\?[\"'])?\s*[:=]\s*(?:\"(?:\\.|[^\"\\\r\n])*\"|\\\"(?:\\.|[^\\\r\n])*\\\"|'[^'\r\n]*'|[^\s&;,}\]]+)"#,
         options: []
     )
-    // HTTPClient's debug header string wraps token suffixes in parentheses —
-    // `auth(…abc123)`, `profileToken(…xyz789)` — which the key=value form above
-    // does not match. Redact the wrapped suffix while keeping the label.
+    // Defense in depth for legacy or third-party messages that wrap token
+    // suffixes in parentheses instead of using key=value syntax.
     private static let tokenWrapperRegex = try! NSRegularExpression(
         pattern: #"(?i)\b(auth|accessToken|access_token|profileToken|profile_token|refreshToken|refresh_token)\(…?[^)\r\n]*\)"#,
         options: []
@@ -303,9 +302,17 @@ private enum DiagnosticsRedactor {
     }
 
     static func sanitizedError(_ error: any Error) -> String {
-        let message = (error as NSError).localizedDescription
-        let fallback = String(describing: error)
-        let rawMessage = message.isEmpty ? fallback : message
+        // HTTPError intentionally retains response bodies for typed callers,
+        // but those bodies are never safe diagnostic text. Its description is
+        // a body-free summary; UI-facing localizedDescription remains intact.
+        let rawMessage: String
+        if let httpError = error as? HTTPError {
+            rawMessage = httpError.description
+        } else {
+            let message = (error as NSError).localizedDescription
+            let fallback = String(describing: error)
+            rawMessage = message.isEmpty ? fallback : message
+        }
         let typedMessage = "\(String(reflecting: Swift.type(of: error))): \(rawMessage)"
         return sanitize(typedMessage, maxLength: 512)
     }

--- a/iosApp/iosApp/Shared/Diagnostics/RecentSessionTracker.swift
+++ b/iosApp/iosApp/Shared/Diagnostics/RecentSessionTracker.swift
@@ -23,6 +23,7 @@ final class RecentSessionTracker {
 
     private static let defaultsKey = "diagnostics.recentPlaybackSessions.v1"
     private static let maxEntries = 10
+    static let retentionInterval = PendingReportStore.expiryInterval
 
     private let defaults: SharedDefaults
     private let lock = NSLock()
@@ -57,11 +58,27 @@ final class RecentSessionTracker {
     /// Recent session IDs recorded under `binding`, newest first. Sessions
     /// from other server/accounts are excluded so they cannot leak into a
     /// report bound elsewhere.
-    func recentSessionIDs(for binding: DiagnosticsBinding, limit: Int = 10) -> [String] {
+    func recentSessionIDs(
+        for binding: DiagnosticsBinding,
+        limit: Int = 10,
+        now: Date = Date()
+    ) -> [String] {
         lock.lock()
         defer { lock.unlock() }
 
-        return load()
+        let entries = load()
+        let cutoff = now.addingTimeInterval(-Self.retentionInterval)
+        let retained = entries.filter { entry in
+            guard let recordedAt = DiagnosticsDates.date(from: entry.recordedAt) else {
+                return false
+            }
+            return recordedAt >= cutoff
+        }
+        if retained != entries {
+            save(retained)
+        }
+
+        return retained
             .filter { $0.binding == binding }
             .suffix(max(0, limit))
             .reversed()


### PR DESCRIPTION
## Summary

- Restrict diagnostic bundles to the typed, allowlisted diagnostics ring instead of harvesting general OSLog entries.
- Redact credentials, quoted JSON secrets, server and signed URLs, and body-bearing HTTP errors; omit stable device names and identifiers.
- Rotate identity-bound evidence on profile, account, server, and sign-out transitions, and expire retained playback session references.
- Remove sensitive values from audited public OSLog and stdout paths.

## Testing

- 64 selected Diagnostics tests passed on iPhone 17 Pro Simulator.
- SiloTV built successfully for Apple TV 4K Simulator.
- Final branch-mode autoreview against origin/main reported no accepted or actionable findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Privacy & Security**
  * Diagnostic logs/snapshots now redact sensitive URL/host/IP data, credentials/tokens, and secrets in JSON more reliably.
  * Diagnostic snapshots no longer include device names or stable device identifiers.
  * Network, playback, pairing, downloads, and artwork logging avoid exposing URLs, server details, response bodies, and personal data.
* **Diagnostics**
  * Diagnostics bundles/snapshots are built from the typed diagnostics ring only; stale session and breadcrumb evidence is purged more aggressively.
  * Recent diagnostic sessions now expire based on a retention window.
* **Bug Fixes**
  * Improved privacy-safe HTTP/error representation and redaction behavior.
* **Tests**
  * Added coverage for redaction guarantees and session retention/persistence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->