### PR TITLE
feat(player): bound budget-parked origin streams with detach and ranged resume

### DIFF
--- a/iosApp/Tests/PlaybackOriginOutageTests.swift
+++ b/iosApp/Tests/PlaybackOriginOutageTests.swift
@@ -35,6 +35,7 @@ final class PlaybackOriginOutagePolicyTests: XCTestCase {
         XCTAssertFalse(park(cause: .httpFatal(403), sessionMissing: true))
         XCTAssertFalse(park(cause: .prematureEOF))
         XCTAssertFalse(park(cause: .rangeIgnored))
+        XCTAssertFalse(park(cause: .entityChanged))
     }
 }
 

--- a/iosApp/Tests/PlaybackOriginStreamPolicyTests.swift
+++ b/iosApp/Tests/PlaybackOriginStreamPolicyTests.swift
@@ -223,6 +223,20 @@ final class PlaybackOriginReconnectPolicyTests: XCTestCase {
 }
 
 final class PlaybackSourceCacheStreamingAppendTests: XCTestCase {
+    func testPrefetchHysteresisRearmsOnlyAtLowWater() throws {
+        let cache = PlaybackSourceCache(maxBytes: 1_024, diskSpillEnabled: false)
+        cache.store(start: 0, data: Data(count: 1_024), totalLength: nil)
+
+        XCTAssertFalse(cache.shouldPrefetch)
+        XCTAssertEqual(try XCTUnwrap(cache.read(start: 0, maxLength: 1)).count, 1)
+        XCTAssertFalse(cache.shouldPrefetch, "a one-byte dip below high water must stay disarmed")
+        XCTAssertFalse(cache.shouldPrefetch, "repeated gate reads near high water must remain sticky")
+
+        XCTAssertEqual(try XCTUnwrap(cache.read(start: 1, maxLength: 1_023)).count, 1_023)
+        XCTAssertTrue(cache.shouldPrefetch, "draining to low water must re-arm prefetch")
+        XCTAssertTrue(cache.shouldPrefetch)
+    }
+
     func testAdjacentStoresGrowOneSpanAndReadAcrossBoundary() {
         let cache = PlaybackSourceCache(maxBytes: 8 * 1024 * 1024)
         cache.store(start: 0, data: Data(repeating: 1, count: 1024), totalLength: nil)

--- a/iosApp/Tests/PlaybackOriginStreamResumeTests.swift
+++ b/iosApp/Tests/PlaybackOriginStreamResumeTests.swift
@@ -139,6 +139,42 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
         }
     }
 
+    private final class ExactReader {
+        private let lock = NSLock()
+        private var session: URLSession?
+        private var received = Data()
+        private var completedError: Error?
+        private var completed = false
+
+        var result: (completed: Bool, data: Data, error: Error?) {
+            lock.lock()
+            defer { lock.unlock() }
+            return (completed, received, completedError)
+        }
+
+        func start(url: URL, offset: Int64) {
+            let configuration = URLSessionConfiguration.ephemeral
+            configuration.urlCache = nil
+            configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+            let session = URLSession(configuration: configuration)
+            self.session = session
+            var request = URLRequest(url: url)
+            request.setValue("bytes=\(offset)-\(offset)", forHTTPHeaderField: "Range")
+            session.dataTask(with: request) { [weak self] data, _, error in
+                guard let self else { return }
+                lock.lock()
+                received = data ?? Data()
+                completedError = error
+                completed = true
+                lock.unlock()
+            }.resume()
+        }
+
+        func cancel() {
+            session?.invalidateAndCancel()
+        }
+    }
+
     private final class StartCompletion {
         private let lock = NSLock()
         private var completed = false
@@ -152,11 +188,69 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
         }
     }
 
+    private final class EntityValidator {
+        private let lock = NSLock()
+        private var storedValue: String?
+
+        var value: String? {
+            get {
+                lock.lock()
+                defer { lock.unlock() }
+                return storedValue
+            }
+            set {
+                lock.lock()
+                storedValue = newValue
+                lock.unlock()
+            }
+        }
+    }
+
+    private final class ChunkRecorder {
+        private let lock = NSLock()
+        private var storedCount = 0
+        private var failureCauses: [PlaybackOriginReconnectPolicy.EndCause] = []
+
+        var stores: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return storedCount
+        }
+
+        var causes: [PlaybackOriginReconnectPolicy.EndCause] {
+            lock.lock()
+            defer { lock.unlock() }
+            return failureCauses
+        }
+
+        func recordStore() {
+            lock.lock()
+            storedCount += 1
+            lock.unlock()
+        }
+
+        func recordFailure(_ cause: PlaybackOriginReconnectPolicy.EndCause) {
+            lock.lock()
+            failureCauses.append(cause)
+            lock.unlock()
+        }
+    }
+
     private final class StubOrigin {
         enum ReopenBehavior {
             case partialSameEntity
+            case partialChangedEntity
+            case partialWeakChangedEntity
+            case partialMissingETag
+            case alwaysChangedEntity
+            case invalidContentRange
             case fullChangedEntity
+            case changedEntityChunkFirst
+            case fullChangedEntityWithDelayedChunk
+            case delayedInitialWindow
             case fullResponseAfterWeakETag
+            case partialChangedAfterWeakETag
+            case alwaysFullChangedEntity
         }
 
         struct Request: Equatable {
@@ -265,9 +359,115 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
                     Int64(value[marker.upperBound...].split(separator: "-")[0])
                 } ?? 0
             } ?? 0
-            let fullResponse = behavior != .partialSameEntity && requestNumber > 1
+            if behavior == .delayedInitialWindow {
+                let byteCount = 64 * 1024
+                let isWindow = requestNumber == 1
+                let end = isWindow
+                    ? totalBytes - 1
+                    : offset + Int64(byteCount) - 1
+                let contentLength = isWindow
+                    ? totalBytes - offset
+                    : Int64(byteCount)
+                let responseETag = requestNumber == 2
+                    ? "\"entity-v1\""
+                    : "\"entity-v2\""
+                let responseHeader = [
+                    "HTTP/1.1 206 Partial Content",
+                    "Content-Range: bytes \(offset)-\(end)/\(totalBytes)",
+                    "Content-Length: \(contentLength)",
+                    "ETag: \(responseETag)",
+                    "Content-Type: application/octet-stream",
+                    "Connection: close",
+                    "",
+                    ""
+                ].joined(separator: "\r\n")
+                let sendResponse = {
+                    connection.send(
+                        content: Data(responseHeader.utf8),
+                        completion: .contentProcessed { error in
+                            guard error == nil else { return }
+                            let body = Data(repeating: 0xBC, count: byteCount)
+                            if isWindow {
+                                // Keep the initial streaming response open so
+                                // only the early chunk exercises the retry.
+                                connection.send(content: body, completion: .idempotent)
+                            } else {
+                                connection.send(
+                                    content: body,
+                                    contentContext: .finalMessage,
+                                    isComplete: true,
+                                    completion: .idempotent
+                                )
+                            }
+                        }
+                    )
+                }
+                if isWindow {
+                    queue.asyncAfter(
+                        deadline: .now() + .milliseconds(250),
+                        execute: sendResponse
+                    )
+                } else {
+                    sendResponse()
+                }
+                return
+            }
+            if (behavior == .changedEntityChunkFirst
+                || behavior == .fullChangedEntityWithDelayedChunk),
+               requestNumber == 2 {
+                let delayedByteCount = 64 * 1024
+                let end = offset + Int64(delayedByteCount) - 1
+                let delayMilliseconds = behavior == .changedEntityChunkFirst ? 0 : 500
+                let header = [
+                    "HTTP/1.1 206 Partial Content",
+                    "Content-Range: bytes \(offset)-\(end)/\(totalBytes)",
+                    "Content-Length: \(delayedByteCount)",
+                    "ETag: \"entity-v2\"",
+                    "Content-Type: application/octet-stream",
+                    "Connection: close",
+                    "",
+                    ""
+                ].joined(separator: "\r\n")
+                connection.send(content: Data(header.utf8), completion: .contentProcessed {
+                    [weak self] error in
+                    guard let self, error == nil else { return }
+                    self.queue.asyncAfter(
+                        deadline: .now() + .milliseconds(delayMilliseconds)
+                    ) {
+                        connection.send(
+                            content: Data(repeating: 0xCD, count: delayedByteCount),
+                            contentContext: .finalMessage,
+                            isComplete: true,
+                            completion: .idempotent
+                        )
+                    }
+                })
+                return
+            }
+            let fullResponse: Bool
+            switch behavior {
+            case .fullChangedEntity, .fullResponseAfterWeakETag:
+                fullResponse = requestNumber > 1
+            case .alwaysFullChangedEntity:
+                fullResponse = true
+            case .changedEntityChunkFirst,
+                 .fullChangedEntityWithDelayedChunk,
+                 .delayedInitialWindow:
+                fullResponse = requestNumber > 2
+            case .partialSameEntity,
+                 .partialChangedEntity,
+                 .partialWeakChangedEntity,
+                 .partialMissingETag,
+                 .partialChangedAfterWeakETag,
+                 .alwaysChangedEntity,
+                 .invalidContentRange:
+                fullResponse = false
+            }
             if fullResponse {
                 let responseETag = behavior == .fullChangedEntity
+                    || behavior == .changedEntityChunkFirst
+                    || behavior == .fullChangedEntityWithDelayedChunk
+                    || behavior == .alwaysFullChangedEntity
                     ? "\"entity-v2\""
                     : "W/\"entity-v1\""
                 let header = [
@@ -289,19 +489,40 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
             }
 
             let end = totalBytes - 1
-            let responseETag = behavior == .fullResponseAfterWeakETag
-                ? "W/\"entity-v1\""
-                : "\"entity-v1\""
-            let header = [
+            let responseETag: String?
+            if behavior == .fullResponseAfterWeakETag {
+                responseETag = "W/\"entity-v1\""
+            } else if behavior == .partialChangedAfterWeakETag {
+                responseETag = requestNumber == 1
+                    ? "W/\"entity-v1\""
+                    : "\"entity-v2\""
+            } else if behavior == .alwaysChangedEntity {
+                responseETag = "\"entity-v2\""
+            } else if behavior == .partialChangedEntity, requestNumber > 1 {
+                responseETag = "\"entity-v2\""
+            } else if behavior == .partialWeakChangedEntity, requestNumber > 1 {
+                responseETag = "W/\"entity-v2\""
+            } else if behavior == .partialMissingETag, requestNumber > 1 {
+                responseETag = nil
+            } else {
+                responseETag = "\"entity-v1\""
+            }
+            let contentRange = behavior == .invalidContentRange && requestNumber > 1
+                ? "bytes invalid"
+                : "bytes \(offset)-\(end)/\(totalBytes)"
+            var headerLines = [
                 "HTTP/1.1 206 Partial Content",
-                "Content-Range: bytes \(offset)-\(end)/\(totalBytes)",
+                "Content-Range: \(contentRange)",
                 "Content-Length: \(totalBytes - offset)",
-                "ETag: \(responseETag)",
                 "Content-Type: application/octet-stream",
                 "Connection: close",
                 "",
                 ""
-            ].joined(separator: "\r\n")
+            ]
+            if let responseETag {
+                headerLines.insert("ETag: \(responseETag)", at: 3)
+            }
+            let header = headerLines.joined(separator: "\r\n")
             connection.send(content: Data(header.utf8), completion: .contentProcessed { [weak self] error in
                 guard let self, error == nil else { return }
                 self.sendBody(connection, remaining: self.totalBytes - offset)
@@ -345,16 +566,18 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
         origin: StubOrigin,
         recorder: Recorder,
         clock: ManualClock,
-        resumeCapable: Bool
+        resumeCapable: Bool,
+        startOffset: Int64 = 0,
+        initialEntityETag: String? = nil
     ) -> PlaybackOriginStream {
         PlaybackOriginStream(
             originURL: origin.url,
             originHeaders: [:],
-            startOffset: 0,
+            startOffset: startOffset,
             demandOrder: 1,
             callbacks: PlaybackOriginStream.Callbacks(
                 didStore: { _, _ in },
-                didReceiveResponse: { _, _ in },
+                didReceiveResponse: { _, _, _ in },
                 didDetectSessionMissing: { _ in },
                 didFinish: { _ in },
                 didGiveUp: { _, cause, _ in
@@ -372,6 +595,7 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
                 }
             ),
             resumeCapable: resumeCapable,
+            initialEntityETag: initialEntityETag,
             clock: clock
         )
     }
@@ -583,6 +807,282 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
         XCTAssertEqual(requests[1].ifRange, "\"entity-v1\"")
     }
 
+    func testEntityChangeCancelsInFlightChunkBeforeItCanContaminateCache() async throws {
+        let originalGrace = PlaybackOriginStreamPolicy.detachAfterSeconds
+        PlaybackOriginStreamPolicy.detachAfterSeconds = 1
+        defer { PlaybackOriginStreamPolicy.detachAfterSeconds = originalGrace }
+
+        let origin = try StubOrigin(behavior: .fullChangedEntityWithDelayedChunk)
+        try await origin.start()
+        defer { origin.stop() }
+        let clock = ManualClock()
+        let recorder = ProxyRecorder()
+        let cache = PlaybackSourceCache(maxBytes: 256 * 1024, diskSpillEnabled: false)
+        let pin = cache.pin(0...(64 * 1024 * 1024 - 1))
+        defer { cache.unpin(pin) }
+        let proxy = PlaybackSourceProxy(
+            originURL: origin.url,
+            originHeaders: [:],
+            cache: cache,
+            onPlaybackSourceInterrupted: { recorder.recordInterruption($0) },
+            resumeCapable: true,
+            originStreamClock: clock
+        )
+        try await proxy.start()
+        defer { proxy.stop() }
+        proxy.startPrefetch(at: 0)
+
+        let parked = await waitUntil { proxy.originStreamDiagnostics()?.parked == true }
+        XCTAssertTrue(parked)
+        clock.advance(by: 2)
+        let detached = await waitUntil { proxy.originStreamDiagnostics()?.detached == true }
+        XCTAssertTrue(detached)
+        let cursor = try XCTUnwrap(proxy.originStreamDiagnostics()).writeCursor
+        let farOffset = cursor + PlaybackOriginRoutingPolicy.rideThroughBytes + 1
+        let transferredBeforeChunk = cache.stats().originBytesTransferred
+
+        let chunkReader = PendingReader()
+        chunkReader.start(url: try XCTUnwrap(proxy.localURL), offset: farOffset)
+        defer { chunkReader.cancel() }
+        let chunkStarted = await waitUntil { origin.observedRequests().count >= 2 }
+        XCTAssertTrue(chunkStarted)
+        XCTAssertEqual(origin.observedRequests()[1].range?.hasPrefix("bytes=\(farOffset)-"), true)
+
+        let resumeReader = PendingReader()
+        resumeReader.start(url: try XCTUnwrap(proxy.localURL), offset: cursor)
+        defer { resumeReader.cancel() }
+        let interrupted = await waitUntil {
+            recorder.interruptions == [.sourceEntityChanged]
+        }
+        XCTAssertTrue(interrupted)
+
+        try? await Task.sleep(for: .milliseconds(700))
+        XCTAssertFalse(cache.contains(offset: farOffset))
+        XCTAssertEqual(cache.stats().originBytesTransferred, transferredBeforeChunk)
+        XCTAssertEqual(origin.observedRequests().count, 3)
+    }
+
+    func testChangedEntityChunkInvalidatesResourceBeforeCachingBytes() async throws {
+        let origin = try StubOrigin(behavior: .changedEntityChunkFirst)
+        try await origin.start()
+        defer { origin.stop() }
+        let recorder = ProxyRecorder()
+        let cache = PlaybackSourceCache(maxBytes: 256 * 1024, diskSpillEnabled: false)
+        let pin = cache.pin(0...(64 * 1024 * 1024 - 1))
+        defer { cache.unpin(pin) }
+        let proxy = PlaybackSourceProxy(
+            originURL: origin.url,
+            originHeaders: [:],
+            cache: cache,
+            onPlaybackSourceInterrupted: { recorder.recordInterruption($0) },
+            resumeCapable: true
+        )
+        try await proxy.start()
+        defer { proxy.stop() }
+        proxy.startPrefetch(at: 0)
+
+        let parked = await waitUntil { proxy.originStreamDiagnostics()?.parked == true }
+        XCTAssertTrue(parked)
+        let cursor = try XCTUnwrap(proxy.originStreamDiagnostics()).writeCursor
+        let farOffset = cursor + PlaybackOriginRoutingPolicy.rideThroughBytes + 1
+        let transferredBeforeChunk = cache.stats().originBytesTransferred
+
+        let chunkReader = PendingReader()
+        chunkReader.start(url: try XCTUnwrap(proxy.localURL), offset: farOffset)
+        defer { chunkReader.cancel() }
+        let interrupted = await waitUntil {
+            recorder.interruptions == [.sourceEntityChanged]
+        }
+        XCTAssertTrue(interrupted)
+
+        XCTAssertFalse(cache.contains(offset: farOffset))
+        XCTAssertEqual(cache.stats().originBytesTransferred, transferredBeforeChunk)
+        let requests = origin.observedRequests()
+        XCTAssertEqual(requests.count, 2)
+        XCTAssertEqual(requests[1].ifRange, "\"entity-v1\"")
+    }
+
+    func testEarlyChunkWaitsForWindowEntityBeforeCaching() async throws {
+        let origin = try StubOrigin(behavior: .delayedInitialWindow)
+        try await origin.start()
+        defer { origin.stop() }
+        let recorder = ProxyRecorder()
+        let cache = PlaybackSourceCache(maxBytes: 256 * 1024, diskSpillEnabled: false)
+        let pin = cache.pin(0...(64 * 1024 * 1024 - 1))
+        defer { cache.unpin(pin) }
+        let proxy = PlaybackSourceProxy(
+            originURL: origin.url,
+            originHeaders: [:],
+            cache: cache,
+            onPlaybackSourceInterrupted: { recorder.recordInterruption($0) },
+            resumeCapable: true
+        )
+        try await proxy.start()
+        defer { proxy.stop() }
+        proxy.startPrefetch(at: 0)
+        let windowStarted = await waitUntil { origin.observedRequests().count == 1 }
+        XCTAssertTrue(windowStarted)
+
+        let farOffset = PlaybackOriginRoutingPolicy.rideThroughBytes * 2
+        let reader = PendingReader()
+        reader.start(url: try XCTUnwrap(proxy.localURL), offset: farOffset)
+        defer { reader.cancel() }
+
+        let firstChunkFinished = await waitUntil {
+            origin.observedRequests().count >= 2
+        }
+        XCTAssertTrue(firstChunkFinished)
+        try? await Task.sleep(for: .milliseconds(100))
+        XCTAssertFalse(cache.contains(offset: farOffset))
+
+        let retriedWithWindowEntity = await waitUntil {
+            origin.observedRequests().contains {
+                $0.range?.hasPrefix("bytes=\(farOffset)-") == true
+                    && $0.ifRange == "\"entity-v2\""
+            }
+        }
+        XCTAssertTrue(retriedWithWindowEntity)
+        let chunkRequests = origin.observedRequests().filter {
+            $0.range?.hasPrefix("bytes=\(farOffset)-") == true
+        }
+        XCTAssertEqual(chunkRequests.count, 2)
+        XCTAssertNil(chunkRequests[0].ifRange)
+        XCTAssertEqual(chunkRequests[1].ifRange, "\"entity-v2\"")
+        let cached = await waitUntil { cache.contains(offset: farOffset) }
+        XCTAssertTrue(cached)
+        XCTAssertTrue(recorder.interruptions.isEmpty)
+    }
+
+    func testValidatedChunkCompletesWaitingProxyRead() async throws {
+        let origin = try StubOrigin(behavior: .partialSameEntity)
+        try await origin.start()
+        defer { origin.stop() }
+        let recorder = ProxyRecorder()
+        let cache = PlaybackSourceCache(maxBytes: 256 * 1024, diskSpillEnabled: false)
+        let pin = cache.pin(0...(64 * 1024 * 1024 - 1))
+        defer { cache.unpin(pin) }
+        let proxy = PlaybackSourceProxy(
+            originURL: origin.url,
+            originHeaders: [:],
+            cache: cache,
+            onPlaybackSourceInterrupted: { recorder.recordInterruption($0) },
+            resumeCapable: true
+        )
+        try await proxy.start()
+        defer { proxy.stop() }
+        proxy.startPrefetch(at: 0)
+
+        let parked = await waitUntil { proxy.originStreamDiagnostics()?.parked == true }
+        XCTAssertTrue(parked)
+        let cursor = try XCTUnwrap(proxy.originStreamDiagnostics()).writeCursor
+        let farOffset = cursor + PlaybackOriginRoutingPolicy.rideThroughBytes + 1
+        let reader = ExactReader()
+        reader.start(url: try XCTUnwrap(proxy.localURL), offset: farOffset)
+        defer { reader.cancel() }
+
+        let completed = await waitUntil {
+            reader.result.completed
+        }
+        XCTAssertTrue(completed)
+        XCTAssertNil(reader.result.error)
+        XCTAssertEqual(reader.result.data.count, 1)
+        XCTAssertTrue(cache.contains(offset: farOffset))
+        XCTAssertTrue(recorder.interruptions.isEmpty)
+        let chunkRequests = origin.observedRequests().filter {
+            $0.range?.hasPrefix("bytes=\(farOffset)-") == true
+        }
+        XCTAssertEqual(chunkRequests.count, 1)
+        XCTAssertEqual(chunkRequests[0].ifRange, "\"entity-v1\"")
+    }
+
+    func testChunkFetcherUsesValidatorLearnedAfterConstruction() async throws {
+        let origin = try StubOrigin(behavior: .partialSameEntity)
+        try await origin.start()
+        defer { origin.stop() }
+        let validator = EntityValidator()
+        let fetcher = PlaybackOriginChunkFetcher(
+            originURL: origin.url,
+            originHeaders: [:],
+            entityETagProvider: { validator.value },
+            callbacks: PlaybackOriginChunkFetcher.Callbacks(
+                store: { _, _, _, _ in nil },
+                didStore: { _ in },
+                didReceiveResponse: { _ in },
+                didDetectSessionMissing: {},
+                didFail: { _, _, _ in },
+                beginRequest: {},
+                endRequest: {}
+            )
+        )
+        defer { fetcher.cancel() }
+
+        let totalBytes: Int64 = 64 * 1024 * 1024
+        let unvalidatedOffset = totalBytes - 2
+        let validatedOffset = totalBytes - 1
+        fetcher.ensureFetch(
+            covering: unvalidatedOffset,
+            totalLength: unvalidatedOffset + 1
+        )
+        validator.value = "\"entity-v1\""
+        fetcher.ensureFetch(
+            covering: validatedOffset,
+            totalLength: validatedOffset + 1
+        )
+
+        let received = await waitUntil { origin.observedRequests().count == 2 }
+        XCTAssertTrue(received)
+        let requests = origin.observedRequests()
+        let unvalidatedRequest = requests.first {
+            $0.range == "bytes=\(unvalidatedOffset)-\(unvalidatedOffset)"
+        }
+        let validatedRequest = requests.first {
+            $0.range == "bytes=\(validatedOffset)-\(validatedOffset)"
+        }
+        XCTAssertNil(unvalidatedRequest?.ifRange)
+        XCTAssertEqual(validatedRequest?.ifRange, "\"entity-v1\"")
+    }
+
+    func testResumeCapableChunkFetcherRejectsResponsesWithoutEstablishedValidator() async throws {
+        let origin = try StubOrigin(behavior: .partialSameEntity)
+        try await origin.start()
+        defer { origin.stop() }
+        let recorder = ChunkRecorder()
+        let fetcher = PlaybackOriginChunkFetcher(
+            originURL: origin.url,
+            originHeaders: [:],
+            requiresEntityValidation: true,
+            callbacks: PlaybackOriginChunkFetcher.Callbacks(
+                store: { _, _, _, _ in
+                    recorder.recordStore()
+                    return nil
+                },
+                didStore: { _ in },
+                didReceiveResponse: { _ in },
+                didDetectSessionMissing: {},
+                didFail: { _, cause, _ in
+                    recorder.recordFailure(cause)
+                },
+                beginRequest: {},
+                endRequest: {}
+            )
+        )
+        defer { fetcher.cancel() }
+
+        let offset: Int64 = 8 * 1024 * 1024
+        fetcher.ensureFetch(
+            covering: offset,
+            totalLength: offset + 1
+        )
+
+        let rejected = await waitUntil {
+            recorder.causes == [.rangeIgnored]
+        }
+        XCTAssertTrue(rejected)
+        XCTAssertEqual(recorder.stores, 0)
+        XCTAssertEqual(origin.observedRequests().count, 2)
+        XCTAssertTrue(origin.observedRequests().allSatisfy { $0.ifRange == nil })
+    }
+
     func testWeakETagIsNotSentAsIfRangeOrMisclassifiedAsEntityChange() async throws {
         let originalGrace = PlaybackOriginStreamPolicy.detachAfterSeconds
         PlaybackOriginStreamPolicy.detachAfterSeconds = 1
@@ -620,5 +1120,244 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
             XCTAssertNil(request.ifRange)
         }
         XCTAssertEqual(recorder.causes, [.rangeIgnored])
+    }
+
+    func testDetachResumeRejectsPartialResponseWhenInitialETagWasWeak() async throws {
+        let originalGrace = PlaybackOriginStreamPolicy.detachAfterSeconds
+        PlaybackOriginStreamPolicy.detachAfterSeconds = 1
+        defer { PlaybackOriginStreamPolicy.detachAfterSeconds = originalGrace }
+
+        let origin = try StubOrigin(behavior: .partialChangedAfterWeakETag)
+        try await origin.start()
+        defer { origin.stop() }
+        let clock = ManualClock()
+        let recorder = Recorder()
+        let stream = makeStream(
+            origin: origin,
+            recorder: recorder,
+            clock: clock,
+            resumeCapable: true
+        )
+        defer { stream.cancel() }
+
+        stream.start()
+        let parked = await waitUntil { stream.diagnosticsSnapshot().parked }
+        XCTAssertTrue(parked)
+        clock.advance(by: 2)
+        let detached = await waitUntil { stream.diagnosticsSnapshot().detached }
+        XCTAssertTrue(detached)
+        let cursor = stream.diagnosticsSnapshot().writeCursor
+        let storedBeforeReopen = recorder.storedBytes
+
+        recorder.mayFill = true
+        stream.noteDemand(offset: cursor, order: 2)
+
+        let gaveUp = await waitUntil { recorder.causes == [.rangeIgnored] }
+        XCTAssertTrue(gaveUp)
+        XCTAssertEqual(recorder.storedBytes, storedBeforeReopen)
+        XCTAssertEqual(origin.observedRequests().count, 3)
+        XCTAssertTrue(origin.observedRequests().allSatisfy { $0.ifRange == nil })
+    }
+
+    func testDetachResumeRejectsChangedETagOnPartialResponse() async throws {
+        let originalGrace = PlaybackOriginStreamPolicy.detachAfterSeconds
+        PlaybackOriginStreamPolicy.detachAfterSeconds = 1
+        defer { PlaybackOriginStreamPolicy.detachAfterSeconds = originalGrace }
+
+        let origin = try StubOrigin(behavior: .partialChangedEntity)
+        try await origin.start()
+        defer { origin.stop() }
+        let clock = ManualClock()
+        let recorder = Recorder()
+        let stream = makeStream(
+            origin: origin,
+            recorder: recorder,
+            clock: clock,
+            resumeCapable: true
+        )
+        defer { stream.cancel() }
+
+        stream.start()
+        let parked = await waitUntil { stream.diagnosticsSnapshot().parked }
+        XCTAssertTrue(parked)
+        clock.advance(by: 2)
+        let detached = await waitUntil { stream.diagnosticsSnapshot().detached }
+        XCTAssertTrue(detached)
+        let cursor = stream.diagnosticsSnapshot().writeCursor
+        let storedBeforeReopen = recorder.storedBytes
+
+        recorder.mayFill = true
+        stream.noteDemand(offset: cursor, order: 2)
+
+        let gaveUp = await waitUntil { recorder.causes == [.entityChanged] }
+        XCTAssertTrue(gaveUp)
+        XCTAssertEqual(recorder.storedBytes, storedBeforeReopen)
+        XCTAssertEqual(origin.observedRequests().count, 2)
+    }
+
+    func testReplacementWindowStartsBoundToEstablishedEntity() async throws {
+        let origin = try StubOrigin(behavior: .alwaysChangedEntity)
+        try await origin.start()
+        defer { origin.stop() }
+        let clock = ManualClock()
+        let recorder = Recorder()
+        let startOffset: Int64 = 2 * 1024 * 1024
+        let stream = makeStream(
+            origin: origin,
+            recorder: recorder,
+            clock: clock,
+            resumeCapable: true,
+            startOffset: startOffset,
+            initialEntityETag: "\"entity-v1\""
+        )
+        defer { stream.cancel() }
+
+        stream.start()
+
+        let rejected = await waitUntil {
+            recorder.causes == [.entityChanged]
+        }
+        XCTAssertTrue(rejected)
+        XCTAssertEqual(recorder.storedBytes, 0)
+        let requests = origin.observedRequests()
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertEqual(requests[0].range, "bytes=\(startOffset)-")
+        XCTAssertEqual(requests[0].ifRange, "\"entity-v1\"")
+    }
+
+    func testReplacementWindowAtByteZeroRejectsChangedFullResponse() async throws {
+        let origin = try StubOrigin(behavior: .alwaysFullChangedEntity)
+        try await origin.start()
+        defer { origin.stop() }
+        let clock = ManualClock()
+        let recorder = Recorder()
+        let stream = makeStream(
+            origin: origin,
+            recorder: recorder,
+            clock: clock,
+            resumeCapable: true,
+            initialEntityETag: "\"entity-v1\""
+        )
+        defer { stream.cancel() }
+
+        stream.start()
+
+        let rejected = await waitUntil {
+            recorder.causes == [.entityChanged]
+        }
+        XCTAssertTrue(rejected)
+        XCTAssertEqual(recorder.storedBytes, 0)
+        let requests = origin.observedRequests()
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertEqual(requests[0].range, "bytes=0-")
+        XCTAssertNil(requests[0].ifRange)
+    }
+
+    func testDetachResumeRejectsWeakConflictingETagOnPartialResponse() async throws {
+        let originalGrace = PlaybackOriginStreamPolicy.detachAfterSeconds
+        PlaybackOriginStreamPolicy.detachAfterSeconds = 1
+        defer { PlaybackOriginStreamPolicy.detachAfterSeconds = originalGrace }
+
+        let origin = try StubOrigin(behavior: .partialWeakChangedEntity)
+        try await origin.start()
+        defer { origin.stop() }
+        let clock = ManualClock()
+        let recorder = Recorder()
+        let stream = makeStream(
+            origin: origin,
+            recorder: recorder,
+            clock: clock,
+            resumeCapable: true
+        )
+        defer { stream.cancel() }
+
+        stream.start()
+        let parked = await waitUntil { stream.diagnosticsSnapshot().parked }
+        XCTAssertTrue(parked)
+        clock.advance(by: 2)
+        let detached = await waitUntil { stream.diagnosticsSnapshot().detached }
+        XCTAssertTrue(detached)
+        let cursor = stream.diagnosticsSnapshot().writeCursor
+        let storedBeforeReopen = recorder.storedBytes
+
+        recorder.mayFill = true
+        stream.noteDemand(offset: cursor, order: 2)
+
+        let gaveUp = await waitUntil { recorder.causes == [.rangeIgnored] }
+        XCTAssertTrue(gaveUp)
+        XCTAssertEqual(recorder.storedBytes, storedBeforeReopen)
+        XCTAssertEqual(origin.observedRequests().count, 3)
+    }
+
+    func testDetachResumeTreatsMissingETagAsUnverifiable() async throws {
+        let originalGrace = PlaybackOriginStreamPolicy.detachAfterSeconds
+        PlaybackOriginStreamPolicy.detachAfterSeconds = 1
+        defer { PlaybackOriginStreamPolicy.detachAfterSeconds = originalGrace }
+
+        let origin = try StubOrigin(behavior: .partialMissingETag)
+        try await origin.start()
+        defer { origin.stop() }
+        let clock = ManualClock()
+        let recorder = Recorder()
+        let stream = makeStream(
+            origin: origin,
+            recorder: recorder,
+            clock: clock,
+            resumeCapable: true
+        )
+        defer { stream.cancel() }
+
+        stream.start()
+        let parked = await waitUntil { stream.diagnosticsSnapshot().parked }
+        XCTAssertTrue(parked)
+        clock.advance(by: 2)
+        let detached = await waitUntil { stream.diagnosticsSnapshot().detached }
+        XCTAssertTrue(detached)
+        let cursor = stream.diagnosticsSnapshot().writeCursor
+        let storedBeforeReopen = recorder.storedBytes
+
+        recorder.mayFill = true
+        stream.noteDemand(offset: cursor, order: 2)
+
+        let gaveUp = await waitUntil { recorder.causes == [.rangeIgnored] }
+        XCTAssertTrue(gaveUp)
+        XCTAssertEqual(recorder.storedBytes, storedBeforeReopen)
+        XCTAssertEqual(origin.observedRequests().count, 3)
+    }
+
+    func testDetachResumeRejectsInvalidContentRange() async throws {
+        let originalGrace = PlaybackOriginStreamPolicy.detachAfterSeconds
+        PlaybackOriginStreamPolicy.detachAfterSeconds = 1
+        defer { PlaybackOriginStreamPolicy.detachAfterSeconds = originalGrace }
+
+        let origin = try StubOrigin(behavior: .invalidContentRange)
+        try await origin.start()
+        defer { origin.stop() }
+        let clock = ManualClock()
+        let recorder = Recorder()
+        let stream = makeStream(
+            origin: origin,
+            recorder: recorder,
+            clock: clock,
+            resumeCapable: true
+        )
+        defer { stream.cancel() }
+
+        stream.start()
+        let parked = await waitUntil { stream.diagnosticsSnapshot().parked }
+        XCTAssertTrue(parked)
+        clock.advance(by: 2)
+        let detached = await waitUntil { stream.diagnosticsSnapshot().detached }
+        XCTAssertTrue(detached)
+        let cursor = stream.diagnosticsSnapshot().writeCursor
+        let storedBeforeReopen = recorder.storedBytes
+
+        recorder.mayFill = true
+        stream.noteDemand(offset: cursor, order: 2)
+
+        let gaveUp = await waitUntil { recorder.causes == [.rangeIgnored] }
+        XCTAssertTrue(gaveUp)
+        XCTAssertEqual(recorder.storedBytes, storedBeforeReopen)
+        XCTAssertEqual(origin.observedRequests().count, 3)
     }
 }

--- a/iosApp/Tests/PlaybackOriginStreamResumeTests.swift
+++ b/iosApp/Tests/PlaybackOriginStreamResumeTests.swift
@@ -1,0 +1,624 @@
+import Network
+import XCTest
+@testable import Silo
+
+final class PlaybackOriginStreamResumeTests: XCTestCase {
+    private final class ManualClock: PlaybackOriginStreamClock {
+        private let lock = NSLock()
+        private var current = Date(timeIntervalSince1970: 1_000)
+        private var pendingTicks = 0
+        private var waiters: [CheckedContinuation<Void, Never>] = []
+
+        func now() -> Date {
+            lock.lock()
+            defer { lock.unlock() }
+            return current
+        }
+
+        func sleepUntilNextWatchdogTick() async {
+            await withCheckedContinuation { continuation in
+                var resumeImmediately = false
+                lock.lock()
+                if pendingTicks > 0 {
+                    pendingTicks -= 1
+                    resumeImmediately = true
+                } else {
+                    waiters.append(continuation)
+                }
+                lock.unlock()
+                if resumeImmediately {
+                    continuation.resume()
+                }
+            }
+        }
+
+        func advance(by seconds: TimeInterval) {
+            var waiter: CheckedContinuation<Void, Never>?
+            lock.lock()
+            current = current.addingTimeInterval(seconds)
+            if !waiters.isEmpty {
+                waiter = waiters.removeFirst()
+            } else {
+                pendingTicks += 1
+            }
+            lock.unlock()
+            waiter?.resume()
+        }
+    }
+
+    private final class Recorder {
+        private let lock = NSLock()
+        private var fillingAllowed = false
+        private var stored = 0
+        private var giveUps: [PlaybackOriginReconnectPolicy.EndCause] = []
+
+        var mayFill: Bool {
+            get {
+                lock.lock()
+                defer { lock.unlock() }
+                return fillingAllowed
+            }
+            set {
+                lock.lock()
+                fillingAllowed = newValue
+                lock.unlock()
+            }
+        }
+
+        var storedBytes: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return stored
+        }
+
+        var causes: [PlaybackOriginReconnectPolicy.EndCause] {
+            lock.lock()
+            defer { lock.unlock() }
+            return giveUps
+        }
+
+        func recordStore(_ data: Data) {
+            lock.lock()
+            stored += data.count
+            lock.unlock()
+        }
+
+        func recordGiveUp(_ cause: PlaybackOriginReconnectPolicy.EndCause) {
+            lock.lock()
+            giveUps.append(cause)
+            lock.unlock()
+        }
+    }
+
+    private final class ProxyRecorder {
+        private let lock = NSLock()
+        private var interruptionReasons: [PlaybackSourceInterruptionReason] = []
+        private var outageStates: [Bool] = []
+
+        var interruptions: [PlaybackSourceInterruptionReason] {
+            lock.lock()
+            defer { lock.unlock() }
+            return interruptionReasons
+        }
+
+        var outages: [Bool] {
+            lock.lock()
+            defer { lock.unlock() }
+            return outageStates
+        }
+
+        func recordInterruption(_ reason: PlaybackSourceInterruptionReason) {
+            lock.lock()
+            interruptionReasons.append(reason)
+            lock.unlock()
+        }
+
+        func recordOutage(_ active: Bool) {
+            lock.lock()
+            outageStates.append(active)
+            lock.unlock()
+        }
+    }
+
+    private final class PendingReader {
+        private var session: URLSession?
+
+        func start(url: URL, offset: Int64) {
+            let configuration = URLSessionConfiguration.ephemeral
+            configuration.urlCache = nil
+            configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+            let session = URLSession(configuration: configuration)
+            self.session = session
+            var request = URLRequest(url: url)
+            request.setValue("bytes=\(offset)-", forHTTPHeaderField: "Range")
+            session.dataTask(with: request).resume()
+        }
+
+        func cancel() {
+            session?.invalidateAndCancel()
+        }
+    }
+
+    private final class StartCompletion {
+        private let lock = NSLock()
+        private var completed = false
+
+        func claim() -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !completed else { return false }
+            completed = true
+            return true
+        }
+    }
+
+    private final class StubOrigin {
+        enum ReopenBehavior {
+            case partialSameEntity
+            case fullChangedEntity
+            case fullResponseAfterWeakETag
+        }
+
+        struct Request: Equatable {
+            let range: String?
+            let ifRange: String?
+        }
+
+        private let totalBytes: Int64 = 64 * 1024 * 1024
+        private let behavior: ReopenBehavior
+        private let listener: NWListener
+        private let queue = DispatchQueue(label: "origin-stream-resume-stub")
+        private let lock = NSLock()
+        private var connections: [ObjectIdentifier: NWConnection] = [:]
+        private var requests: [Request] = []
+        private(set) var port: UInt16 = 0
+
+        init(behavior: ReopenBehavior) throws {
+            self.behavior = behavior
+            let parameters = NWParameters.tcp
+            parameters.allowLocalEndpointReuse = true
+            parameters.requiredLocalEndpoint = .hostPort(host: .ipv4(.loopback), port: .any)
+            listener = try NWListener(using: parameters)
+        }
+
+        var url: URL {
+            URL(string: "http://127.0.0.1:\(port)/entity.bin")!
+        }
+
+        func observedRequests() -> [Request] {
+            lock.lock()
+            defer { lock.unlock() }
+            return requests
+        }
+
+        func start() async throws {
+            listener.newConnectionHandler = { [weak self] connection in
+                self?.accept(connection)
+            }
+            port = try await withCheckedThrowingContinuation { continuation in
+                let completion = StartCompletion()
+                listener.stateUpdateHandler = { state in
+                    switch state {
+                    case .ready:
+                        if let port = self.listener.port, completion.claim() {
+                            continuation.resume(returning: port.rawValue)
+                        }
+                    case .failed(let error):
+                        if completion.claim() {
+                            continuation.resume(throwing: error)
+                        }
+                    default:
+                        break
+                    }
+                }
+                listener.start(queue: queue)
+            }
+        }
+
+        func stop() {
+            listener.cancel()
+            lock.lock()
+            let open = Array(connections.values)
+            connections.removeAll()
+            lock.unlock()
+            open.forEach { $0.cancel() }
+        }
+
+        private func accept(_ connection: NWConnection) {
+            lock.lock()
+            connections[ObjectIdentifier(connection)] = connection
+            lock.unlock()
+            connection.start(queue: queue)
+            receiveRequest(connection, buffered: Data())
+        }
+
+        private func receiveRequest(_ connection: NWConnection, buffered: Data) {
+            connection.receive(minimumIncompleteLength: 1, maximumLength: 64 * 1024) {
+                [weak self] data, _, _, error in
+                guard let self, error == nil else { return }
+                var requestData = buffered
+                if let data {
+                    requestData.append(data)
+                }
+                guard let end = requestData.range(of: Data("\r\n\r\n".utf8)) else {
+                    self.receiveRequest(connection, buffered: requestData)
+                    return
+                }
+                let request = String(
+                    data: requestData[..<end.lowerBound],
+                    encoding: .utf8
+                ) ?? ""
+                self.respond(connection, request: request)
+            }
+        }
+
+        private func respond(_ connection: NWConnection, request: String) {
+            let range = header("range", in: request)
+            let ifRange = header("if-range", in: request)
+            lock.lock()
+            requests.append(Request(range: range, ifRange: ifRange))
+            let requestNumber = requests.count
+            lock.unlock()
+
+            let offset = range.flatMap { value in
+                value.range(of: "bytes=").flatMap { marker in
+                    Int64(value[marker.upperBound...].split(separator: "-")[0])
+                } ?? 0
+            } ?? 0
+            let fullResponse = behavior != .partialSameEntity && requestNumber > 1
+            if fullResponse {
+                let responseETag = behavior == .fullChangedEntity
+                    ? "\"entity-v2\""
+                    : "W/\"entity-v1\""
+                let header = [
+                    "HTTP/1.1 200 OK",
+                    "Content-Length: \(totalBytes)",
+                    "ETag: \(responseETag)",
+                    "Content-Type: application/octet-stream",
+                    "Connection: close",
+                    "",
+                    ""
+                ].joined(separator: "\r\n")
+                connection.send(content: Data(header.utf8), completion: .contentProcessed { _ in
+                    connection.send(
+                        content: Data(repeating: 0xEE, count: 64 * 1024),
+                        completion: .idempotent
+                    )
+                })
+                return
+            }
+
+            let end = totalBytes - 1
+            let responseETag = behavior == .fullResponseAfterWeakETag
+                ? "W/\"entity-v1\""
+                : "\"entity-v1\""
+            let header = [
+                "HTTP/1.1 206 Partial Content",
+                "Content-Range: bytes \(offset)-\(end)/\(totalBytes)",
+                "Content-Length: \(totalBytes - offset)",
+                "ETag: \(responseETag)",
+                "Content-Type: application/octet-stream",
+                "Connection: close",
+                "",
+                ""
+            ].joined(separator: "\r\n")
+            connection.send(content: Data(header.utf8), completion: .contentProcessed { [weak self] error in
+                guard let self, error == nil else { return }
+                self.sendBody(connection, remaining: self.totalBytes - offset)
+            })
+        }
+
+        private func header(_ name: String, in request: String) -> String? {
+            for line in request.split(separator: "\r\n") {
+                guard let colon = line.firstIndex(of: ":") else { continue }
+                let key = line[..<colon].trimmingCharacters(in: .whitespaces).lowercased()
+                if key == name {
+                    return line[line.index(after: colon)...]
+                        .trimmingCharacters(in: .whitespaces)
+                }
+            }
+            return nil
+        }
+
+        private func sendBody(_ connection: NWConnection, remaining: Int64) {
+            guard remaining > 0 else {
+                connection.send(
+                    content: nil,
+                    contentContext: .finalMessage,
+                    isComplete: true,
+                    completion: .idempotent
+                )
+                return
+            }
+            let count = Int(min(remaining, 64 * 1024))
+            connection.send(
+                content: Data(repeating: 0xAB, count: count),
+                completion: .contentProcessed { [weak self] error in
+                    guard error == nil else { return }
+                    self?.sendBody(connection, remaining: remaining - Int64(count))
+                }
+            )
+        }
+    }
+
+    private func makeStream(
+        origin: StubOrigin,
+        recorder: Recorder,
+        clock: ManualClock,
+        resumeCapable: Bool
+    ) -> PlaybackOriginStream {
+        PlaybackOriginStream(
+            originURL: origin.url,
+            originHeaders: [:],
+            startOffset: 0,
+            demandOrder: 1,
+            callbacks: PlaybackOriginStream.Callbacks(
+                didStore: { _, _ in },
+                didReceiveResponse: { _, _ in },
+                didDetectSessionMissing: { _ in },
+                didFinish: { _ in },
+                didGiveUp: { _, cause, _ in
+                    recorder.recordGiveUp(cause)
+                },
+                mayContinueFilling: { _, _, _ in
+                    recorder.mayFill
+                },
+                cachedAheadBytes: {
+                    Int64(recorder.storedBytes)
+                },
+                nextMissingByte: { $0 },
+                store: { _, data, _ in
+                    recorder.recordStore(data)
+                }
+            ),
+            resumeCapable: resumeCapable,
+            clock: clock
+        )
+    }
+
+    private func waitUntil(
+        timeout: TimeInterval = 2,
+        _ predicate: @escaping () -> Bool
+    ) async -> Bool {
+        let deadline = Date.now.addingTimeInterval(timeout)
+        while Date.now < deadline {
+            if predicate() {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return predicate()
+    }
+
+    func testParkDetachesAndDemandReopensExactRangeWithIfRange() async throws {
+        let originalGrace = PlaybackOriginStreamPolicy.detachAfterSeconds
+        PlaybackOriginStreamPolicy.detachAfterSeconds = 1
+        defer { PlaybackOriginStreamPolicy.detachAfterSeconds = originalGrace }
+
+        let origin = try StubOrigin(behavior: .partialSameEntity)
+        try await origin.start()
+        defer { origin.stop() }
+        let clock = ManualClock()
+        let recorder = Recorder()
+        let stream = makeStream(
+            origin: origin,
+            recorder: recorder,
+            clock: clock,
+            resumeCapable: true
+        )
+        defer { stream.cancel() }
+
+        stream.start()
+        let parked = await waitUntil { stream.diagnosticsSnapshot().parked }
+        XCTAssertTrue(parked)
+        let parkedState = stream.diagnosticsSnapshot()
+        XCTAssertGreaterThan(parkedState.writeCursor, 0)
+
+        clock.advance(by: 2)
+        let detached = await waitUntil { stream.diagnosticsSnapshot().detached }
+        XCTAssertTrue(detached)
+        let detachedState = stream.diagnosticsSnapshot()
+        XCTAssertEqual(detachedState.writeCursor, parkedState.writeCursor)
+        XCTAssertEqual(detachedState.unproductiveStreak, 0)
+        XCTAssertTrue(recorder.causes.isEmpty)
+
+        recorder.mayFill = true
+        stream.noteDemand(offset: detachedState.writeCursor, order: 2)
+        let reopened = await waitUntil { origin.observedRequests().count >= 2 }
+        XCTAssertTrue(reopened)
+        let requests = origin.observedRequests()
+        XCTAssertEqual(requests[1].range, "bytes=\(detachedState.writeCursor)-")
+        XCTAssertEqual(requests[1].ifRange, "\"entity-v1\"")
+        XCTAssertTrue(recorder.causes.isEmpty)
+    }
+
+    func testDeliberateDetachDoesNotAdvanceFailureState() async throws {
+        let originalGrace = PlaybackOriginStreamPolicy.detachAfterSeconds
+        PlaybackOriginStreamPolicy.detachAfterSeconds = 1
+        defer { PlaybackOriginStreamPolicy.detachAfterSeconds = originalGrace }
+
+        let origin = try StubOrigin(behavior: .partialSameEntity)
+        try await origin.start()
+        defer { origin.stop() }
+        let clock = ManualClock()
+        let recorder = Recorder()
+        let stream = makeStream(
+            origin: origin,
+            recorder: recorder,
+            clock: clock,
+            resumeCapable: true
+        )
+        defer { stream.cancel() }
+
+        stream.start()
+        let parked = await waitUntil { stream.diagnosticsSnapshot().parked }
+        XCTAssertTrue(parked)
+        clock.advance(by: 2)
+        let detached = await waitUntil { stream.diagnosticsSnapshot().detached }
+        XCTAssertTrue(detached)
+        XCTAssertEqual(stream.diagnosticsSnapshot().unproductiveStreak, 0)
+        XCTAssertTrue(recorder.causes.isEmpty)
+        XCTAssertEqual(origin.observedRequests().count, 1)
+    }
+
+    func testResumeIncapableStreamRemainsParkedPastGrace() async throws {
+        let originalGrace = PlaybackOriginStreamPolicy.detachAfterSeconds
+        PlaybackOriginStreamPolicy.detachAfterSeconds = 1
+        defer { PlaybackOriginStreamPolicy.detachAfterSeconds = originalGrace }
+
+        let origin = try StubOrigin(behavior: .partialSameEntity)
+        try await origin.start()
+        defer { origin.stop() }
+        let clock = ManualClock()
+        let recorder = Recorder()
+        let stream = makeStream(
+            origin: origin,
+            recorder: recorder,
+            clock: clock,
+            resumeCapable: false
+        )
+        defer { stream.cancel() }
+
+        stream.start()
+        let parked = await waitUntil { stream.diagnosticsSnapshot().parked }
+        XCTAssertTrue(parked)
+        clock.advance(by: 120)
+        try? await Task.sleep(for: .milliseconds(50))
+        let state = stream.diagnosticsSnapshot()
+        XCTAssertTrue(state.parked)
+        XCTAssertFalse(state.detached)
+        XCTAssertEqual(state.unproductiveStreak, 0)
+        XCTAssertEqual(origin.observedRequests().count, 1)
+        XCTAssertTrue(recorder.causes.isEmpty)
+    }
+
+    func testIfRangeFullResponseGivesUpWithoutAppendingChangedEntity() async throws {
+        let originalGrace = PlaybackOriginStreamPolicy.detachAfterSeconds
+        PlaybackOriginStreamPolicy.detachAfterSeconds = 1
+        defer { PlaybackOriginStreamPolicy.detachAfterSeconds = originalGrace }
+
+        let origin = try StubOrigin(behavior: .fullChangedEntity)
+        try await origin.start()
+        defer { origin.stop() }
+        let clock = ManualClock()
+        let recorder = Recorder()
+        let stream = makeStream(
+            origin: origin,
+            recorder: recorder,
+            clock: clock,
+            resumeCapable: true
+        )
+        defer { stream.cancel() }
+
+        stream.start()
+        let parked = await waitUntil { stream.diagnosticsSnapshot().parked }
+        XCTAssertTrue(parked)
+        clock.advance(by: 2)
+        let detached = await waitUntil { stream.diagnosticsSnapshot().detached }
+        XCTAssertTrue(detached)
+        let cursor = stream.diagnosticsSnapshot().writeCursor
+        let storedBeforeReopen = recorder.storedBytes
+
+        recorder.mayFill = true
+        stream.noteDemand(offset: cursor, order: 2)
+        let gaveUp = await waitUntil { recorder.causes == [.entityChanged] }
+        XCTAssertTrue(gaveUp)
+        XCTAssertEqual(recorder.storedBytes, storedBeforeReopen)
+        XCTAssertTrue(stream.isFinished)
+        let requests = origin.observedRequests()
+        XCTAssertEqual(requests.count, 2)
+        XCTAssertEqual(requests[1].range, "bytes=\(cursor)-")
+        XCTAssertEqual(requests[1].ifRange, "\"entity-v1\"")
+    }
+
+    func testEntityChangeEscalatesThroughProxyWithoutOutageOrCacheAppend() async throws {
+        let originalGrace = PlaybackOriginStreamPolicy.detachAfterSeconds
+        PlaybackOriginStreamPolicy.detachAfterSeconds = 1
+        defer { PlaybackOriginStreamPolicy.detachAfterSeconds = originalGrace }
+
+        let origin = try StubOrigin(behavior: .fullChangedEntity)
+        try await origin.start()
+        defer { origin.stop() }
+        let clock = ManualClock()
+        let recorder = ProxyRecorder()
+        let cache = PlaybackSourceCache(maxBytes: 256 * 1024, diskSpillEnabled: false)
+        let pin = cache.pin(0...(64 * 1024 * 1024 - 1))
+        defer { cache.unpin(pin) }
+        let proxy = PlaybackSourceProxy(
+            originURL: origin.url,
+            originHeaders: [:],
+            cache: cache,
+            onPlaybackSourceInterrupted: { recorder.recordInterruption($0) },
+            onOriginOutageChanged: { recorder.recordOutage($0) },
+            resumeCapable: true,
+            originStreamClock: clock
+        )
+        try await proxy.start()
+        defer { proxy.stop() }
+        proxy.startPrefetch(at: 0)
+
+        let parked = await waitUntil { proxy.originStreamDiagnostics()?.parked == true }
+        XCTAssertTrue(parked)
+        clock.advance(by: 2)
+        let detached = await waitUntil { proxy.originStreamDiagnostics()?.detached == true }
+        XCTAssertTrue(detached)
+        let cursor = try XCTUnwrap(proxy.originStreamDiagnostics()).writeCursor
+        let transferredBeforeReopen = cache.stats().originBytesTransferred
+        XCTAssertFalse(cache.contains(offset: cursor))
+
+        let reader = PendingReader()
+        reader.start(url: try XCTUnwrap(proxy.localURL), offset: cursor)
+        defer { reader.cancel() }
+
+        let interrupted = await waitUntil {
+            recorder.interruptions == [.sourceEntityChanged]
+        }
+        XCTAssertTrue(interrupted)
+        XCTAssertEqual(recorder.outages, [])
+        XCTAssertEqual(cache.stats().originBytesTransferred, transferredBeforeReopen)
+        XCTAssertFalse(cache.contains(offset: cursor))
+        let requests = origin.observedRequests()
+        XCTAssertEqual(requests.count, 2)
+        XCTAssertEqual(requests[1].range, "bytes=\(cursor)-")
+        XCTAssertEqual(requests[1].ifRange, "\"entity-v1\"")
+    }
+
+    func testWeakETagIsNotSentAsIfRangeOrMisclassifiedAsEntityChange() async throws {
+        let originalGrace = PlaybackOriginStreamPolicy.detachAfterSeconds
+        PlaybackOriginStreamPolicy.detachAfterSeconds = 1
+        defer { PlaybackOriginStreamPolicy.detachAfterSeconds = originalGrace }
+
+        let origin = try StubOrigin(behavior: .fullResponseAfterWeakETag)
+        try await origin.start()
+        defer { origin.stop() }
+        let clock = ManualClock()
+        let recorder = Recorder()
+        let stream = makeStream(
+            origin: origin,
+            recorder: recorder,
+            clock: clock,
+            resumeCapable: true
+        )
+        defer { stream.cancel() }
+
+        stream.start()
+        let parked = await waitUntil { stream.diagnosticsSnapshot().parked }
+        XCTAssertTrue(parked)
+        clock.advance(by: 2)
+        let detached = await waitUntil { stream.diagnosticsSnapshot().detached }
+        XCTAssertTrue(detached)
+        let cursor = stream.diagnosticsSnapshot().writeCursor
+
+        recorder.mayFill = true
+        stream.noteDemand(offset: cursor, order: 2)
+        let gaveUp = await waitUntil { recorder.causes == [.rangeIgnored] }
+        XCTAssertTrue(gaveUp)
+        let requests = origin.observedRequests()
+        XCTAssertEqual(requests.count, 3, "rangeIgnored keeps its existing one-retry cap")
+        XCTAssertEqual(requests[1].range, "bytes=\(cursor)-")
+        for request in requests.dropFirst() {
+            XCTAssertNil(request.ifRange)
+        }
+        XCTAssertEqual(recorder.causes, [.rangeIgnored])
+    }
+}

--- a/iosApp/Tests/PlaybackOriginStreamResumeTests.swift
+++ b/iosApp/Tests/PlaybackOriginStreamResumeTests.swift
@@ -248,6 +248,7 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
             case changedEntityChunkFirst
             case fullChangedEntityWithDelayedChunk
             case delayedInitialWindow
+            case delayedInitialWindowWithoutValidator
             case fullResponseAfterWeakETag
             case partialChangedAfterWeakETag
             case alwaysFullChangedEntity
@@ -359,7 +360,8 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
                     Int64(value[marker.upperBound...].split(separator: "-")[0])
                 } ?? 0
             } ?? 0
-            if behavior == .delayedInitialWindow {
+            if behavior == .delayedInitialWindow
+                || behavior == .delayedInitialWindowWithoutValidator {
                 let byteCount = 64 * 1024
                 let isWindow = requestNumber == 1
                 let end = isWindow
@@ -368,19 +370,19 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
                 let contentLength = isWindow
                     ? totalBytes - offset
                     : Int64(byteCount)
-                let responseETag = requestNumber == 2
-                    ? "\"entity-v1\""
-                    : "\"entity-v2\""
-                let responseHeader = [
+                var responseHeaderLines = [
                     "HTTP/1.1 206 Partial Content",
                     "Content-Range: bytes \(offset)-\(end)/\(totalBytes)",
                     "Content-Length: \(contentLength)",
-                    "ETag: \(responseETag)",
                     "Content-Type: application/octet-stream",
                     "Connection: close",
                     "",
                     ""
-                ].joined(separator: "\r\n")
+                ]
+                if behavior == .delayedInitialWindow || !isWindow {
+                    responseHeaderLines.insert("ETag: \"entity-v2\"", at: 3)
+                }
+                let responseHeader = responseHeaderLines.joined(separator: "\r\n")
                 let sendResponse = {
                     connection.send(
                         content: Data(responseHeader.utf8),
@@ -389,7 +391,7 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
                             let body = Data(repeating: 0xBC, count: byteCount)
                             if isWindow {
                                 // Keep the initial streaming response open so
-                                // only the early chunk exercises the retry.
+                                // the deferred chunk can complete separately.
                                 connection.send(content: body, completion: .idempotent)
                             } else {
                                 connection.send(
@@ -452,7 +454,8 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
                 fullResponse = true
             case .changedEntityChunkFirst,
                  .fullChangedEntityWithDelayedChunk,
-                 .delayedInitialWindow:
+                 .delayedInitialWindow,
+                 .delayedInitialWindowWithoutValidator:
                 fullResponse = requestNumber > 2
             case .partialSameEntity,
                  .partialChangedEntity,
@@ -924,32 +927,68 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
         XCTAssertTrue(windowStarted)
 
         let farOffset = PlaybackOriginRoutingPolicy.rideThroughBytes * 2
-        let reader = PendingReader()
+        let reader = ExactReader()
         reader.start(url: try XCTUnwrap(proxy.localURL), offset: farOffset)
         defer { reader.cancel() }
 
-        let firstChunkFinished = await waitUntil {
-            origin.observedRequests().count >= 2
-        }
-        XCTAssertTrue(firstChunkFinished)
         try? await Task.sleep(for: .milliseconds(100))
+        XCTAssertEqual(origin.observedRequests().count, 1)
         XCTAssertFalse(cache.contains(offset: farOffset))
 
-        let retriedWithWindowEntity = await waitUntil {
+        let fetchedWithWindowEntity = await waitUntil {
             origin.observedRequests().contains {
                 $0.range?.hasPrefix("bytes=\(farOffset)-") == true
                     && $0.ifRange == "\"entity-v2\""
             }
         }
-        XCTAssertTrue(retriedWithWindowEntity)
+        XCTAssertTrue(fetchedWithWindowEntity)
         let chunkRequests = origin.observedRequests().filter {
             $0.range?.hasPrefix("bytes=\(farOffset)-") == true
         }
-        XCTAssertEqual(chunkRequests.count, 2)
-        XCTAssertNil(chunkRequests[0].ifRange)
-        XCTAssertEqual(chunkRequests[1].ifRange, "\"entity-v2\"")
-        let cached = await waitUntil { cache.contains(offset: farOffset) }
-        XCTAssertTrue(cached)
+        XCTAssertEqual(chunkRequests.count, 1)
+        XCTAssertEqual(chunkRequests[0].ifRange, "\"entity-v2\"")
+        let completed = await waitUntil { reader.result.completed }
+        XCTAssertTrue(completed)
+        XCTAssertNil(reader.result.error)
+        XCTAssertEqual(reader.result.data, Data([0xBC]))
+        XCTAssertTrue(cache.contains(offset: farOffset))
+        XCTAssertTrue(recorder.interruptions.isEmpty)
+    }
+
+    func testEarlyChunkRemainsDeferredWithoutWindowValidator() async throws {
+        let origin = try StubOrigin(behavior: .delayedInitialWindowWithoutValidator)
+        try await origin.start()
+        defer { origin.stop() }
+        let recorder = ProxyRecorder()
+        let cache = PlaybackSourceCache(maxBytes: 256 * 1024, diskSpillEnabled: false)
+        let pin = cache.pin(0...(64 * 1024 * 1024 - 1))
+        defer { cache.unpin(pin) }
+        let proxy = PlaybackSourceProxy(
+            originURL: origin.url,
+            originHeaders: [:],
+            cache: cache,
+            onPlaybackSourceInterrupted: { recorder.recordInterruption($0) },
+            resumeCapable: true
+        )
+        try await proxy.start()
+        defer { proxy.stop() }
+        proxy.startPrefetch(at: 0)
+        let windowStarted = await waitUntil { origin.observedRequests().count == 1 }
+        XCTAssertTrue(windowStarted)
+
+        let farOffset = PlaybackOriginRoutingPolicy.rideThroughBytes * 2
+        let reader = ExactReader()
+        reader.start(url: try XCTUnwrap(proxy.localURL), offset: farOffset)
+        defer { reader.cancel() }
+
+        let windowResponseProcessed = await waitUntil { cache.contains(offset: 0) }
+        XCTAssertTrue(windowResponseProcessed)
+        try? await Task.sleep(for: .milliseconds(100))
+        XCTAssertEqual(origin.observedRequests().count, 1)
+        XCTAssertFalse(cache.contains(offset: farOffset))
+        XCTAssertFalse(reader.result.completed)
+        XCTAssertTrue(reader.result.data.isEmpty)
+        XCTAssertNil(reader.result.error)
         XCTAssertTrue(recorder.interruptions.isEmpty)
     }
 

--- a/iosApp/Tests/PlaybackProtocolV3Tests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3Tests.swift
@@ -121,7 +121,11 @@ final class PlaybackProtocolV3Tests: XCTestCase {
                     planAttemptId: "apple-plan:attempt",
                     planAttemptKey: plan.attemptKey(outputRouteGeneration: 1),
                     outputRouteGeneration: 1,
-                    serverFeatures: ["playback_plan_v3", "seek_reanchor_v1"],
+                    serverFeatures: [
+                        "playback_plan_v3",
+                        "seek_reanchor_v1",
+                        "direct_stream_resume_v1"
+                    ],
                     plan: plan
                 ),
                 basePlan: base,
@@ -130,8 +134,17 @@ final class PlaybackProtocolV3Tests: XCTestCase {
             )
             XCTAssertEqual(adapted.engine, expectedEngine, delivery)
             XCTAssertEqual(adapted.delivery.name, expectedDelivery.name, delivery)
+            XCTAssertEqual(adapted.wireDelivery, delivery)
+            XCTAssertTrue(
+                adapted.serverFeatures.contains(PlaybackProtocolV3.directStreamResumeFeature)
+            )
             XCTAssertEqual(adapted.startMode.seconds, 4.5, delivery)
         }
+        XCTAssertTrue(
+            ApplePlaybackV3Capabilities.features.contains(
+                PlaybackProtocolV3.directStreamResumeFeature
+            )
+        )
     }
 
     func testUnsupportedClientRequirementsAreRejected() {

--- a/iosApp/Tests/PlaybackProtocolV3Tests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3Tests.swift
@@ -138,6 +138,11 @@ final class PlaybackProtocolV3Tests: XCTestCase {
             XCTAssertTrue(
                 adapted.serverFeatures.contains(PlaybackProtocolV3.directStreamResumeFeature)
             )
+            XCTAssertEqual(
+                adapted.supportsDirectStreamResume,
+                delivery == "original_http",
+                delivery
+            )
             XCTAssertEqual(adapted.startMode.seconds, 4.5, delivery)
         }
         XCTAssertTrue(
@@ -145,6 +150,35 @@ final class PlaybackProtocolV3Tests: XCTestCase {
                 PlaybackProtocolV3.directStreamResumeFeature
             )
         )
+    }
+
+    func testDirectStreamResumeRequiresResponseFeature() throws {
+        let streamRequest = StreamRequest(
+            url: URL(string: "https://example.test/video")!,
+            headers: ["Authorization": "Bearer test"],
+            serverUrl: "https://example.test"
+        )
+        let plan = makePlan(
+            delivery: "original_http",
+            engine: "media3_direct",
+            streamProtocol: "http_progressive",
+            container: "mp4"
+        )
+        let adapted = try ApplePlaybackV3PlanAdapter.makeExecutionPlan(
+            v3: PreparedPlaybackV3(
+                playbackAttemptId: "apple:attempt",
+                planAttemptId: "apple-plan:attempt",
+                planAttemptKey: plan.attemptKey(outputRouteGeneration: 1),
+                outputRouteGeneration: 1,
+                serverFeatures: ["playback_plan_v3"],
+                plan: plan
+            ),
+            basePlan: makeBaseExecutionPlan(streamRequest: streamRequest),
+            streamRequest: streamRequest,
+            routeRequirements: .baseline
+        )
+
+        XCTAssertFalse(adapted.supportsDirectStreamResume)
     }
 
     func testUnsupportedClientRequirementsAreRejected() {

--- a/iosApp/iosApp/Screens/Player/PlaybackExecutionPlan.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackExecutionPlan.swift
@@ -434,6 +434,12 @@ struct PlaybackExecutionPlan {
     let reason: String
     let playbackSessionId: String?
 
+    var supportsDirectStreamResume: Bool {
+        delivery == .direct
+            && wireDelivery == "original_http"
+            && serverFeatures.contains(PlaybackProtocolV3.directStreamResumeFeature)
+    }
+
     init(
         delivery: PlaybackDeliveryStrategy,
         engine: PlaybackEngineKind,

--- a/iosApp/iosApp/Screens/Player/PlaybackExecutionPlan.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackExecutionPlan.swift
@@ -406,6 +406,10 @@ enum PlaybackStartMode: Equatable {
 /// call site.
 struct PlaybackExecutionPlan {
     let delivery: PlaybackDeliveryStrategy
+    /// Server wire delivery token. Legacy direct plans predate the V3 token
+    /// but are equivalent to `original_http`.
+    let wireDelivery: String?
+    let serverFeatures: [String]
     let engine: PlaybackEngineKind
     let routeFamily: PlaybackRouteFamily
     let implementationRoute: String
@@ -446,11 +450,15 @@ struct PlaybackExecutionPlan {
         degradationWarnings: [String],
         reason: String,
         playbackSessionId: String? = nil,
+        wireDelivery: String? = nil,
+        serverFeatures: [String] = [],
         sourceMetadata: PlaybackSourceMetadata = .unknown,
         normalizationSummary: PlaybackNormalizationSummary = .none,
         validationClaims: PlaybackValidationClaims? = nil
     ) {
         self.delivery = delivery
+        self.wireDelivery = wireDelivery ?? (delivery == .direct ? "original_http" : nil)
+        self.serverFeatures = serverFeatures
         self.engine = engine
         self.routeFamily = engine.routeFamily
         self.implementationRoute = engine.label

--- a/iosApp/iosApp/Screens/Player/PlaybackOriginChunkFetcher.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackOriginChunkFetcher.swift
@@ -14,8 +14,14 @@ final class PlaybackOriginChunkFetcher {
     static let interactiveRequestTimeoutSeconds: TimeInterval = 4.0
 
     struct Callbacks {
-        /// Store delivered bytes (invoked on the session delegate queue).
-        let store: (Int64, Data, Int64?) -> Void
+        /// Atomically validate and store delivered bytes (invoked on the
+        /// session callback queue). A returned cause rejects the response.
+        let store: (
+            Int64,
+            Data,
+            Int64?,
+            String?
+        ) -> PlaybackOriginReconnectPolicy.EndCause?
         /// Bytes for this range are now cached; wake matching waiters.
         let didStore: (ClosedRange<Int64>) -> Void
         /// First response headers (total length if known).
@@ -35,6 +41,13 @@ final class PlaybackOriginChunkFetcher {
 
     private let originURL: URL
     private let originHeaders: [String: String]
+    /// Resolved for every request and response rather than captured at
+    /// construction: an early seek can create this long-lived fetcher before
+    /// the streaming window publishes its first response validator.
+    private let entityETagProvider: () -> String?
+    /// Resume-capable resources cannot combine independently fetched chunks
+    /// unless the streaming window has established a strong validator.
+    private let requiresEntityValidation: Bool
     private let callbacks: Callbacks
 
     private let lock = NSLock()
@@ -42,9 +55,17 @@ final class PlaybackOriginChunkFetcher {
     private var inFlight: [UUID: Range<Int64>] = [:]
     private var session: URLSession?
 
-    init(originURL: URL, originHeaders: [String: String], callbacks: Callbacks) {
+    init(
+        originURL: URL,
+        originHeaders: [String: String],
+        entityETagProvider: @escaping () -> String? = { nil },
+        requiresEntityValidation: Bool = false,
+        callbacks: Callbacks
+    ) {
         self.originURL = originURL
         self.originHeaders = originHeaders
+        self.entityETagProvider = entityETagProvider
+        self.requiresEntityValidation = requiresEntityValidation
         self.callbacks = callbacks
     }
 
@@ -133,6 +154,9 @@ final class PlaybackOriginChunkFetcher {
             request.setValue(value, forHTTPHeaderField: key)
         }
         request.setValue("bytes=\(range.lowerBound)-\(range.upperBound - 1)", forHTTPHeaderField: "Range")
+        if range.lowerBound > 0, let entityETag = entityETagProvider() {
+            request.setValue(entityETag, forHTTPHeaderField: "If-Range")
+        }
 
         let task = session.dataTask(with: request) { [weak self] data, response, error in
             self?.handleResult(id: id, range: range, attempt: attempt, data: data, response: response, error: error)
@@ -171,25 +195,65 @@ final class PlaybackOriginChunkFetcher {
         case 206:
             let contentRange = http.value(forHTTPHeaderField: "Content-Range")
             let total = PlaybackOriginStream.totalLength(fromContentRange: contentRange)
-            if let rangeStart = PlaybackOriginStream.rangeStart(fromContentRange: contentRange),
-               rangeStart != range.lowerBound {
-                Self.logger.warning("[CMP-SOURCE-CACHE] chunk range mismatch expected=\(range.lowerBound, privacy: .public) got=\(rangeStart, privacy: .public)")
+            guard let rangeStart = PlaybackOriginStream.rangeStart(fromContentRange: contentRange),
+                  rangeStart == range.lowerBound else {
+                let receivedRange = contentRange ?? "missing"
+                Self.logger.warning(
+                    "[CMP-SOURCE-CACHE] chunk invalid content-range expectedStart=\(range.lowerBound, privacy: .public) received=\(receivedRange, privacy: .public)"
+                )
                 fail(id: id, range: range, cause: .rangeIgnored, statusCode: 206)
                 return
             }
-            callbacks.didReceiveResponse(total)
-            storeAndFinish(id: id, range: range, body: data ?? Data(), total: total)
+            if let cause = entityValidationFailure(for: http) {
+                retryOrFail(
+                    id: id,
+                    range: range,
+                    attempt: attempt,
+                    cause: cause,
+                    statusCode: 206
+                )
+                return
+            }
+            storeAndFinish(
+                id: id,
+                range: range,
+                attempt: attempt,
+                body: data ?? Data(),
+                total: total,
+                responseETag: PlaybackOriginStream.strongETag(
+                    http.value(forHTTPHeaderField: "ETag")
+                )
+            )
         case 200 where range.lowerBound == 0:
+            if let cause = entityValidationFailure(for: http) {
+                retryOrFail(
+                    id: id,
+                    range: range,
+                    attempt: attempt,
+                    cause: cause,
+                    statusCode: 200
+                )
+                return
+            }
             // Origin ignored the Range but the chunk starts at 0, so a
             // truncated prefix of the body is exactly the requested bytes
             // (Data's prefix is a no-copy slice).
             let total = http.expectedContentLength > 0 ? http.expectedContentLength : nil
-            callbacks.didReceiveResponse(total)
             let body = (data ?? Data()).prefix(Int(range.upperBound - range.lowerBound))
-            storeAndFinish(id: id, range: range, body: body, total: total)
+            storeAndFinish(
+                id: id,
+                range: range,
+                attempt: attempt,
+                body: body,
+                total: total,
+                responseETag: PlaybackOriginStream.strongETag(
+                    http.value(forHTTPHeaderField: "ETag")
+                )
+            )
         case 200:
             // Accepting head bytes at a nonzero offset would corrupt the cache.
-            fail(id: id, range: range, cause: .rangeIgnored, statusCode: 200)
+            let cause = entityValidationFailure(for: http) ?? .rangeIgnored
+            fail(id: id, range: range, cause: cause, statusCode: 200)
         case 404:
             let body = data.flatMap { String(data: $0.prefix(4096), encoding: .utf8) }
             if PlaybackOriginStream.isPlaybackSessionMissing(statusCode: 404, body: body) {
@@ -208,14 +272,58 @@ final class PlaybackOriginChunkFetcher {
         }
     }
 
-    private func storeAndFinish(id: UUID, range: Range<Int64>, body: Data, total: Int64?) {
+    private func entityValidationFailure(
+        for response: HTTPURLResponse
+    ) -> PlaybackOriginReconnectPolicy.EndCause? {
+        guard let entityETag = entityETagProvider() else {
+            return requiresEntityValidation ? .rangeIgnored : nil
+        }
+        let responseETagHeader = response.value(forHTTPHeaderField: "ETag")
+        guard let responseETag = PlaybackOriginStream.strongETag(responseETagHeader) else {
+            Self.logger.warning(
+                "[CMP-SOURCE-CACHE] chunk entity-unverifiable expectedETag=\(entityETag, privacy: .public) responseETag=\(responseETagHeader ?? "missing", privacy: .public)"
+            )
+            return .rangeIgnored
+        }
+        guard responseETag == entityETag else {
+            Self.logger.error(
+                "[CMP-SOURCE-CACHE] chunk entity-changed expectedETag=\(entityETag, privacy: .public) responseETag=\(responseETagHeader ?? "missing", privacy: .public)"
+            )
+            return .entityChanged
+        }
+        return nil
+    }
+
+    private func storeAndFinish(
+        id: UUID,
+        range: Range<Int64>,
+        attempt: Int,
+        body: Data,
+        total: Int64?,
+        responseETag: String?
+    ) {
         guard !body.isEmpty else {
             // A 206 with an empty body is an origin bug; a repeat request
             // will not do better.
             fail(id: id, range: range, cause: .prematureEOF, statusCode: nil)
             return
         }
-        callbacks.store(range.lowerBound, body, total)
+        if let cause = callbacks.store(
+            range.lowerBound,
+            body,
+            total,
+            responseETag
+        ) {
+            retryOrFail(
+                id: id,
+                range: range,
+                attempt: attempt,
+                cause: cause,
+                statusCode: nil
+            )
+            return
+        }
+        callbacks.didReceiveResponse(total)
         finish(id: id)
         callbacks.didStore(range.lowerBound...(range.lowerBound + Int64(body.count) - 1))
     }

--- a/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
@@ -196,6 +196,7 @@ actor PlaybackSessionBridge {
     /// session (restart, idle reap, expired reconstruct token).
     private var lastStartRequest: StartPlaybackRequest?
     private var protocolV3Available: Bool?
+    private var protocolV3CapabilityFeatures: [String] = []
 
     private struct ActiveProtocolV3 {
         let playbackAttemptId: String
@@ -431,10 +432,12 @@ actor PlaybackSessionBridge {
         if protocolV3Available == nil {
             do {
                 let capability = try await ContinuumAPI.shared.playbackV3Capability()
+                protocolV3CapabilityFeatures = capability.features
                 protocolV3Available = capability.enabled
                     && capability.protocolVersions.contains(PlaybackProtocolV3.version)
                     && capability.features.contains(PlaybackProtocolV3.planFeature)
             } catch let error as HTTPError where error.statusCode == 404 || error.statusCode == 405 {
+                protocolV3CapabilityFeatures = []
                 protocolV3Available = false
             }
         }
@@ -521,6 +524,7 @@ actor PlaybackSessionBridge {
             )
             let planAttemptId = "apple-plan:\(UUID().uuidString.lowercased())"
             let planAttemptKey = plan.attemptKey(outputRouteGeneration: snapshot.outputRouteGeneration)
+            let serverFeatures = mergedProtocolV3ServerFeatures(response.serverFeatures)
             activeProtocolV3 = ActiveProtocolV3(
                 playbackAttemptId: playbackAttemptId,
                 planAttemptId: planAttemptId,
@@ -529,7 +533,7 @@ actor PlaybackSessionBridge {
                 attemptCount: 1,
                 clientQualityId: ApplePlaybackQuality.normalizeStoredId(qualityPreference),
                 snapshot: snapshot,
-                serverFeatures: response.serverFeatures,
+                serverFeatures: serverFeatures,
                 plan: plan
             )
             protocolV3FirstFramePlanIds.removeAll()
@@ -541,7 +545,7 @@ actor PlaybackSessionBridge {
                 planAttemptId: planAttemptId,
                 planAttemptKey: planAttemptKey,
                 outputRouteGeneration: snapshot.outputRouteGeneration,
-                serverFeatures: response.serverFeatures,
+                serverFeatures: serverFeatures,
                 plan: plan
             )
             logger.info(
@@ -787,7 +791,7 @@ actor PlaybackSessionBridge {
                 active.attemptedPlanKeys = attemptedKeys + [nextKey]
                 active.attemptCount = invalidatesIntent ? 1 : active.attemptCount + 1
             }
-            active.serverFeatures = response.serverFeatures
+            active.serverFeatures = mergedProtocolV3ServerFeatures(response.serverFeatures)
             active.plan = nextPlan
             active.clientQualityId = requestedClientQualityId
             activeProtocolV3 = active
@@ -823,6 +827,10 @@ actor PlaybackSessionBridge {
                 protocolV3: preparedV3
             )
         }
+    }
+
+    private func mergedProtocolV3ServerFeatures(_ responseFeatures: [String]) -> [String] {
+        Array(Set(protocolV3CapabilityFeatures).union(responseFeatures)).sorted()
     }
 
     func reportProtocolV3PlanExecutionStarted() async {

--- a/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
@@ -196,7 +196,6 @@ actor PlaybackSessionBridge {
     /// session (restart, idle reap, expired reconstruct token).
     private var lastStartRequest: StartPlaybackRequest?
     private var protocolV3Available: Bool?
-    private var protocolV3CapabilityFeatures: [String] = []
 
     private struct ActiveProtocolV3 {
         let playbackAttemptId: String
@@ -432,12 +431,10 @@ actor PlaybackSessionBridge {
         if protocolV3Available == nil {
             do {
                 let capability = try await ContinuumAPI.shared.playbackV3Capability()
-                protocolV3CapabilityFeatures = capability.features
                 protocolV3Available = capability.enabled
                     && capability.protocolVersions.contains(PlaybackProtocolV3.version)
                     && capability.features.contains(PlaybackProtocolV3.planFeature)
             } catch let error as HTTPError where error.statusCode == 404 || error.statusCode == 405 {
-                protocolV3CapabilityFeatures = []
                 protocolV3Available = false
             }
         }
@@ -524,7 +521,7 @@ actor PlaybackSessionBridge {
             )
             let planAttemptId = "apple-plan:\(UUID().uuidString.lowercased())"
             let planAttemptKey = plan.attemptKey(outputRouteGeneration: snapshot.outputRouteGeneration)
-            let serverFeatures = mergedProtocolV3ServerFeatures(response.serverFeatures)
+            let serverFeatures = response.serverFeatures
             activeProtocolV3 = ActiveProtocolV3(
                 playbackAttemptId: playbackAttemptId,
                 planAttemptId: planAttemptId,
@@ -791,7 +788,7 @@ actor PlaybackSessionBridge {
                 active.attemptedPlanKeys = attemptedKeys + [nextKey]
                 active.attemptCount = invalidatesIntent ? 1 : active.attemptCount + 1
             }
-            active.serverFeatures = mergedProtocolV3ServerFeatures(response.serverFeatures)
+            active.serverFeatures = response.serverFeatures
             active.plan = nextPlan
             active.clientQualityId = requestedClientQualityId
             activeProtocolV3 = active
@@ -827,10 +824,6 @@ actor PlaybackSessionBridge {
                 protocolV3: preparedV3
             )
         }
-    }
-
-    private func mergedProtocolV3ServerFeatures(_ responseFeatures: [String]) -> [String] {
-        Array(Set(protocolV3CapabilityFeatures).union(responseFeatures)).sorted()
     }
 
     func reportProtocolV3PlanExecutionStarted() async {

--- a/iosApp/iosApp/Screens/Player/PlaybackSourceOriginStream.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSourceOriginStream.swift
@@ -58,6 +58,11 @@ enum PlaybackOriginRoutingPolicy {
 /// type. (Routing across multiple streams lived here before the
 /// window+chunk split — see `PlaybackOriginRoutingPolicy`.)
 enum PlaybackOriginStreamPolicy {
+    /// A budget-parked direct stream stays warm briefly, then deliberately
+    /// closes before ordinary reverse-proxy client-send timeouts can reap it.
+    /// `var` so tests can drive the lifecycle without wall-clock waits.
+    static var detachAfterSeconds: TimeInterval = 25
+
     /// The window's fetch region: where it started and how far it has
     /// filled. All the state the routing and hint paths need.
     struct StreamSnapshot: Equatable {
@@ -100,6 +105,7 @@ enum PlaybackOriginReconnectPolicy {
         case httpFatal(Int)
         case prematureEOF
         case rangeIgnored
+        case entityChanged
     }
 
     enum Decision: Equatable {
@@ -116,6 +122,8 @@ enum PlaybackOriginReconnectPolicy {
             cap = 4
         case .httpFatal, .rangeIgnored:
             cap = 1
+        case .entityChanged:
+            cap = 0
         case .prematureEOF:
             cap = 3
         }
@@ -167,18 +175,35 @@ enum PlaybackOriginOutagePolicy {
             return true
         case .httpFatal(let code):
             return code == 404 && sessionMissingObserved
-        case .prematureEOF, .rangeIgnored:
+        case .prematureEOF, .rangeIgnored, .entityChanged:
             return false
         }
     }
 }
 
+/// Time seam for the origin watchdog. Production uses wall time and a
+/// five-second cadence; tests advance both deterministically.
+protocol PlaybackOriginStreamClock: AnyObject {
+    func now() -> Date
+    func sleepUntilNextWatchdogTick() async
+}
+
+final class SystemPlaybackOriginStreamClock: PlaybackOriginStreamClock {
+    func now() -> Date {
+        .now
+    }
+
+    func sleepUntilNextWatchdogTick() async {
+        try? await Task.sleep(for: .seconds(5))
+    }
+}
+
 /// One long-lived streaming origin connection: an open-ended
 /// `Range: bytes=<cursor>-` GET whose body is stored into the span cache
-/// incrementally as each URLSession delivery arrives. Throttling is
-/// suspend-based: when the owner reports the readahead budget is full the
-/// data task is suspended, TCP flow control parks the connection server-side,
-/// and resume is instant — the connection is never closed and re-requested.
+/// incrementally as each URLSession delivery arrives. Byte-stable direct
+/// streams briefly suspend when the readahead budget is full, then detach and
+/// reopen at the exact write cursor when demand returns. Non-resumable
+/// deliveries retain the legacy indefinite suspension behavior.
 final class PlaybackOriginStream {
     struct Callbacks {
         /// Invoked on the session delegate queue after bytes are stored.
@@ -191,12 +216,29 @@ final class PlaybackOriginStream {
         /// Budget/park decision; called with the stream's current cursor and
         /// demand mark, outside the stream's internal lock.
         let mayContinueFilling: (PlaybackOriginStream, Int64, Int64) -> Bool
+        /// Current bytes cached ahead of playback, used only for park
+        /// diagnostics.
+        let cachedAheadBytes: () -> Int64
         /// First byte at or after the given offset that the cache does not
         /// already hold (nil when everything to the known EOF is cached);
         /// used to jump the connection over long already-cached runs instead
         /// of re-downloading them.
         let nextMissingByte: (Int64) -> Int64?
         let store: (Int64, Data, Int64?) -> Void
+    }
+
+    struct DiagnosticsSnapshot: Equatable {
+        let writeCursor: Int64
+        let parked: Bool
+        let detached: Bool
+        let unproductiveStreak: Int
+    }
+
+    private enum OpenReason: Equatable {
+        case initial
+        case reconnect
+        case retarget
+        case detachResume
     }
 
     /// While filling, every this many delivered bytes the stream checks
@@ -221,6 +263,8 @@ final class PlaybackOriginStream {
     private let originURL: URL
     private let originHeaders: [String: String]
     private let callbacks: Callbacks
+    private let resumeCapable: Bool
+    private let clock: PlaybackOriginStreamClock
 
     private let lock = NSLock()
     private var generation: UInt64 = 0
@@ -230,19 +274,26 @@ final class PlaybackOriginStream {
     private var demandOrder: UInt64
     private var skipCheckCursor: Int64
     private var parked = false
+    private var parkedAt: Date?
+    private var detached = false
     private var cancelled = false
     private var finished = false
     private var session: URLSession?
     private var task: URLSessionDataTask?
     private var currentTaskID: Int?
+    private var expectedCancellationTaskIDs: Set<Int> = []
     private var reconnectTask: Task<Void, Never>?
     private var watchdogTask: Task<Void, Never>?
-    private var lastDataAt = Date()
+    private var lastDataAt: Date
     private var bytesSinceConnect: Int64 = 0
     private var everProductive = false
     private var unproductiveStreak = 0
     private var knownTotalLength: Int64?
     private var responseValidatedForGeneration: UInt64?
+    private var entityETag: String?
+    private var ifRangeGeneration: UInt64?
+    private var sentIfRangeValue: String?
+    private var currentOpenReason: OpenReason = .initial
     private var errorBody = Data()
     private var errorStatusCode: Int?
 
@@ -251,7 +302,9 @@ final class PlaybackOriginStream {
         originHeaders: [String: String],
         startOffset: Int64,
         demandOrder: UInt64,
-        callbacks: Callbacks
+        callbacks: Callbacks,
+        resumeCapable: Bool = false,
+        clock: PlaybackOriginStreamClock = SystemPlaybackOriginStreamClock()
     ) {
         self.originURL = originURL
         self.originHeaders = originHeaders
@@ -261,6 +314,9 @@ final class PlaybackOriginStream {
         self.demandOrder = demandOrder
         self.skipCheckCursor = startOffset + Self.cachedRunCheckStrideBytes
         self.callbacks = callbacks
+        self.resumeCapable = resumeCapable
+        self.clock = clock
+        self.lastDataAt = clock.now()
     }
 
     deinit {
@@ -291,8 +347,19 @@ final class PlaybackOriginStream {
         return finished
     }
 
+    func diagnosticsSnapshot() -> DiagnosticsSnapshot {
+        lock.lock()
+        defer { lock.unlock() }
+        return DiagnosticsSnapshot(
+            writeCursor: writeCursor,
+            parked: parked,
+            detached: detached,
+            unproductiveStreak: unproductiveStreak
+        )
+    }
+
     func start() {
-        openConnection()
+        openConnection(reason: .initial)
         startWatchdog()
     }
 
@@ -304,6 +371,9 @@ final class PlaybackOriginStream {
         self.session = nil
         self.task = nil
         currentTaskID = nil
+        expectedCancellationTaskIDs.removeAll()
+        parkedAt = nil
+        detached = false
         let reconnect = reconnectTask
         reconnectTask = nil
         let watchdog = watchdogTask
@@ -322,29 +392,64 @@ final class PlaybackOriginStream {
     /// already in flight and a revived connection would leak.
     @discardableResult
     func retarget(to offset: Int64, order: UInt64) -> Bool {
+        reopenConnection(at: offset, order: order, reason: .retarget)
+    }
+
+    /// Shared ranged-reopen seam for seeks/retargets and detach-resume.
+    /// Retarget starts a new routing region and resets its failure streak;
+    /// detach-resume preserves the existing region and reconnect history.
+    @discardableResult
+    private func reopenConnection(at offset: Int64, order: UInt64, reason: OpenReason) -> Bool {
         lock.lock()
         guard !cancelled, !finished else {
             lock.unlock()
             return false
         }
-        generation &+= 1
-        let oldTask = task
-        task = nil
-        currentTaskID = nil
-        let reconnect = reconnectTask
-        reconnectTask = nil
-        startOffset = offset
-        writeCursor = offset
-        demandMark = offset
-        demandOrder = order
-        skipCheckCursor = offset + Self.cachedRunCheckStrideBytes
-        parked = false
-        bytesSinceConnect = 0
-        unproductiveStreak = 0
+        let oldTask: URLSessionDataTask?
+        let reconnect: Task<Void, Never>?
+        switch reason {
+        case .retarget:
+            generation &+= 1
+            oldTask = task
+            task = nil
+            currentTaskID = nil
+            reconnect = reconnectTask
+            reconnectTask = nil
+            startOffset = offset
+            writeCursor = offset
+            demandMark = offset
+            demandOrder = order
+            skipCheckCursor = offset + Self.cachedRunCheckStrideBytes
+            parked = false
+            parkedAt = nil
+            detached = false
+            bytesSinceConnect = 0
+            unproductiveStreak = 0
+        case .detachResume:
+            guard detached, task == nil, currentTaskID == nil, reconnectTask == nil else {
+                lock.unlock()
+                return false
+            }
+            oldTask = nil
+            reconnect = nil
+            writeCursor = offset
+            demandOrder = max(demandOrder, order)
+            parked = false
+            parkedAt = nil
+            detached = false
+        case .initial, .reconnect:
+            lock.unlock()
+            return false
+        }
         lock.unlock()
         oldTask?.cancel()
         reconnect?.cancel()
-        openConnection()
+        if reason == .detachResume {
+            Self.logger.info(
+                "[CMP-SOURCE-CACHE] origin stream detach-resume cursor=\(offset, privacy: .public) outcome=opening"
+            )
+        }
+        openConnection(reason: reason)
         return true
     }
 
@@ -360,23 +465,31 @@ final class PlaybackOriginStream {
 
     func resumeFillingIfNeeded() {
         lock.lock()
-        let shouldConsider = parked && !cancelled && !finished
+        let shouldConsider = (parked || detached) && !cancelled && !finished
         let cursor = writeCursor
         let mark = demandMark
+        let order = demandOrder
         lock.unlock()
         guard shouldConsider else { return }
         guard callbacks.mayContinueFilling(self, cursor, mark) else { return }
+        var reopenDetached = false
         lock.lock()
         if parked, !cancelled {
             parked = false
+            parkedAt = nil
             task?.resume()
+        } else if detached, !cancelled, !finished, reconnectTask == nil, task == nil {
+            reopenDetached = true
         }
         lock.unlock()
+        if reopenDetached {
+            _ = reopenConnection(at: cursor, order: order, reason: .detachResume)
+        }
     }
 
     // MARK: - Connection lifecycle
 
-    private func openConnection() {
+    private func openConnection(reason: OpenReason) {
         lock.lock()
         guard !cancelled, !finished else {
             lock.unlock()
@@ -387,9 +500,12 @@ final class PlaybackOriginStream {
         let cursor = writeCursor
         let oldTask = task
         parked = false
+        parkedAt = nil
+        detached = false
         bytesSinceConnect = 0
-        lastDataAt = Date()
+        lastDataAt = clock.now()
         responseValidatedForGeneration = nil
+        currentOpenReason = reason
         errorBody.removeAll(keepingCapacity: false)
         errorStatusCode = nil
 
@@ -404,10 +520,9 @@ final class PlaybackOriginStream {
             config.requestCachePolicy = .reloadIgnoringLocalCacheData
             config.urlCache = nil
             config.httpMaximumConnectionsPerHost = 2
-            // The long-lived request is paused via task suspension for
-            // arbitrarily long stretches; the idle-based request timeout must
-            // never fire underneath it. Wedged transfers are detected by the
-            // stall watchdog instead.
+            // Non-resumable deliveries can still be suspended indefinitely,
+            // so the idle-based request timeout must never fire underneath
+            // them. Wedged transfers are detected by the watchdog.
             config.timeoutIntervalForRequest = 3600
             let delegateQueue = OperationQueue()
             delegateQueue.maxConcurrentOperationCount = 1
@@ -426,6 +541,20 @@ final class PlaybackOriginStream {
             request.setValue(value, forHTTPHeaderField: key)
         }
         request.setValue("bytes=\(cursor)-", forHTTPHeaderField: "Range")
+        // Issue #94 deliberately does not require a validator to detach:
+        // direct `original_http` origins remain resume-capable without the
+        // new ETag feature, preserving the existing nonzero-200
+        // `.rangeIgnored` path. When a strong ETag is available, If-Range
+        // upgrades that reopen into positive entity validation.
+        let ifRange = cursor > 0 ? entityETag : nil
+        if let ifRange {
+            request.setValue(ifRange, forHTTPHeaderField: "If-Range")
+            ifRangeGeneration = gen
+            sentIfRangeValue = ifRange
+        } else {
+            ifRangeGeneration = nil
+            sentIfRangeValue = nil
+        }
         let newTask = session?.dataTask(with: request)
         task = newTask
         currentTaskID = newTask?.taskIdentifier
@@ -444,28 +573,62 @@ final class PlaybackOriginStream {
         }
         watchdogTask = Task.detached(priority: .utility) { [weak self] in
             while !Task.isCancelled {
-                try? await Task.sleep(nanoseconds: 5_000_000_000)
+                guard let clock = self?.clock else { return }
+                await clock.sleepUntilNextWatchdogTick()
+                guard !Task.isCancelled else { return }
                 guard let self else { return }
+                self.detachIfParkedPastGrace()
+                guard !Task.isCancelled else { return }
                 self.reconnectIfStalled()
             }
         }
         lock.unlock()
     }
 
+    private func detachIfParkedPastGrace() {
+        let now = clock.now()
+        lock.lock()
+        guard resumeCapable,
+              parked,
+              !detached,
+              !cancelled,
+              !finished,
+              let parkedAt,
+              now.timeIntervalSince(parkedAt) >= PlaybackOriginStreamPolicy.detachAfterSeconds,
+              let oldTask = task,
+              let oldTaskID = currentTaskID else {
+            lock.unlock()
+            return
+        }
+        let cursor = writeCursor
+        generation &+= 1
+        expectedCancellationTaskIDs.insert(oldTaskID)
+        task = nil
+        currentTaskID = nil
+        parked = false
+        self.parkedAt = nil
+        detached = true
+        responseValidatedForGeneration = nil
+        ifRangeGeneration = nil
+        sentIfRangeValue = nil
+        lock.unlock()
+
+        oldTask.cancel()
+        Self.logger.info(
+            "[CMP-SOURCE-CACHE] origin stream detached cursor=\(cursor, privacy: .public)"
+        )
+    }
+
     private func reconnectIfStalled() {
+        let now = clock.now()
         lock.lock()
         let stalled = !cancelled && !finished && !parked && session != nil && task != nil
-            && Date().timeIntervalSince(lastDataAt) > PlaybackOriginReconnectPolicy.stallSeconds
+            && now.timeIntervalSince(lastDataAt) > PlaybackOriginReconnectPolicy.stallSeconds
+        let gen = generation
         lock.unlock()
         guard stalled else { return }
         Self.logger.warning("[CMP-SOURCE-CACHE] origin stream stalled; reconnecting cursor=\(self.snapshot().writeCursor, privacy: .public)")
-        connectionEnded(generation: currentGeneration(), cause: .stalled, statusCode: nil)
-    }
-
-    private func currentGeneration() -> UInt64 {
-        lock.lock()
-        defer { lock.unlock() }
-        return generation
+        connectionEnded(generation: gen, cause: .stalled, statusCode: nil)
     }
 
     // MARK: - Delegate plumbing (called on the session delegate queue)
@@ -478,6 +641,8 @@ final class PlaybackOriginStream {
         }
         let gen = generation
         let cursor = writeCursor
+        let openReason = currentOpenReason
+        let sentIfRange = ifRangeGeneration == gen ? sentIfRangeValue : nil
         lock.unlock()
         guard let http = response as? HTTPURLResponse else {
             connectionEnded(generation: gen, cause: .network, statusCode: nil)
@@ -490,28 +655,54 @@ final class PlaybackOriginStream {
             if let rangeStart = Self.rangeStart(fromContentRange: http.value(forHTTPHeaderField: "Content-Range")),
                rangeStart != cursor {
                 Self.logger.warning("[CMP-SOURCE-CACHE] origin stream range mismatch expected=\(cursor, privacy: .public) got=\(rangeStart, privacy: .public)")
+                logDetachResumeOutcomeIfNeeded(openReason, cursor: cursor, outcome: "range_mismatch")
                 connectionEnded(generation: gen, cause: .rangeIgnored, statusCode: http.statusCode)
                 return false
             }
-            noteResponse(total: total, generation: gen)
+            noteResponse(
+                total: total,
+                etag: http.value(forHTTPHeaderField: "ETag"),
+                generation: gen
+            )
+            logDetachResumeOutcomeIfNeeded(openReason, cursor: cursor, outcome: "accepted_206")
             return true
         case 200 where cursor == 0:
             let total = http.expectedContentLength > 0 ? http.expectedContentLength : nil
-            noteResponse(total: total, generation: gen)
+            noteResponse(
+                total: total,
+                etag: http.value(forHTTPHeaderField: "ETag"),
+                generation: gen
+            )
+            logDetachResumeOutcomeIfNeeded(openReason, cursor: cursor, outcome: "accepted_200")
             return true
         case 200:
+            if let sentIfRange {
+                let responseETag = http.value(forHTTPHeaderField: "ETag") ?? "missing"
+                Self.logger.error(
+                    "[CMP-SOURCE-CACHE] origin stream entity-changed cursor=\(cursor, privacy: .public) ifRange=\(sentIfRange, privacy: .public) responseETag=\(responseETag, privacy: .public)"
+                )
+                logDetachResumeOutcomeIfNeeded(openReason, cursor: cursor, outcome: "entity_changed")
+                connectionEnded(generation: gen, cause: .entityChanged, statusCode: 200)
+                return false
+            }
             // The origin ignored the Range header; accepting the body would
             // silently corrupt the cache with head bytes at a nonzero offset.
+            logDetachResumeOutcomeIfNeeded(openReason, cursor: cursor, outcome: "range_ignored")
             connectionEnded(generation: gen, cause: .rangeIgnored, statusCode: 200)
             return false
         case 416:
             // Requested past the end. If the origin tells us the real total,
             // learn it and finish cleanly so waiters re-drive to EOF.
             if let total = Self.totalLength(fromContentRange: http.value(forHTTPHeaderField: "Content-Range")) {
-                noteResponse(total: total, generation: gen)
+                noteResponse(
+                    total: total,
+                    etag: http.value(forHTTPHeaderField: "ETag"),
+                    generation: gen
+                )
                 finishStream(expectedGeneration: gen)
                 return false
             }
+            logDetachResumeOutcomeIfNeeded(openReason, cursor: cursor, outcome: "http_416")
             connectionEnded(generation: gen, cause: .httpFatal(416), statusCode: 416)
             return false
         default:
@@ -520,11 +711,16 @@ final class PlaybackOriginStream {
             lock.lock()
             errorStatusCode = http.statusCode
             lock.unlock()
+            logDetachResumeOutcomeIfNeeded(
+                openReason,
+                cursor: cursor,
+                outcome: "http_\(http.statusCode)"
+            )
             return true
         }
     }
 
-    private func noteResponse(total: Int64?, generation gen: UInt64) {
+    private func noteResponse(total: Int64?, etag: String?, generation gen: UInt64) {
         lock.lock()
         guard gen == generation else {
             lock.unlock()
@@ -532,8 +728,35 @@ final class PlaybackOriginStream {
         }
         responseValidatedForGeneration = gen
         if let total { knownTotalLength = total }
+        if entityETag == nil, let etag = Self.strongETag(etag) {
+            entityETag = etag
+        }
         lock.unlock()
         callbacks.didReceiveResponse(self, total)
+    }
+
+    /// `If-Range` performs a strong validator comparison; a weak ETag would
+    /// force a compliant origin to return 200 even when the entity is
+    /// unchanged, which would look like a false replacement.
+    static func strongETag(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let candidate = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !candidate.isEmpty,
+              !candidate.lowercased().hasPrefix("w/") else {
+            return nil
+        }
+        return candidate
+    }
+
+    private func logDetachResumeOutcomeIfNeeded(
+        _ reason: OpenReason,
+        cursor: Int64,
+        outcome: String
+    ) {
+        guard reason == .detachResume else { return }
+        Self.logger.info(
+            "[CMP-SOURCE-CACHE] origin stream detach-resume cursor=\(cursor, privacy: .public) outcome=\(outcome, privacy: .public)"
+        )
     }
 
     fileprivate func handleData(_ data: Data, taskID: Int) {
@@ -572,7 +795,7 @@ final class PlaybackOriginStream {
         writeCursor += Int64(data.count)
         let cursor = writeCursor
         let mark = demandMark
-        lastDataAt = Date()
+        lastDataAt = clock.now()
         bytesSinceConnect += Int64(data.count)
         if bytesSinceConnect >= PlaybackOriginReconnectPolicy.productiveBytesFloor {
             everProductive = true
@@ -613,10 +836,15 @@ final class PlaybackOriginStream {
                 // racing this park would otherwise fire against a
                 // still-running task (no-op) and be lost.
                 parked = true
+                parkedAt = clock.now()
                 task?.suspend()
             }
             lock.unlock()
             if didPark {
+                let cachedAhead = callbacks.cachedAheadBytes()
+                Self.logger.info(
+                    "[CMP-SOURCE-CACHE] origin stream parked cursor=\(cursor, privacy: .public) cachedAheadBytes=\(cachedAhead, privacy: .public)"
+                )
                 // A demand may have raised the mark between the decision
                 // above and the park; its unpark attempt saw parked ==
                 // false and did nothing. Re-run the decision with fresh
@@ -628,6 +856,10 @@ final class PlaybackOriginStream {
 
     fileprivate func handleCompletion(error: Error?, taskID: Int) {
         lock.lock()
+        if expectedCancellationTaskIDs.remove(taskID) != nil {
+            lock.unlock()
+            return
+        }
         guard taskID == currentTaskID, !cancelled, !finished else {
             lock.unlock()
             return
@@ -682,6 +914,9 @@ final class PlaybackOriginStream {
         self.session = nil
         self.task = nil
         currentTaskID = nil
+        expectedCancellationTaskIDs.removeAll()
+        parkedAt = nil
+        detached = false
         let reconnect = reconnectTask
         reconnectTask = nil
         let watchdog = watchdogTask
@@ -714,6 +949,8 @@ final class PlaybackOriginStream {
         task = nil
         currentTaskID = nil
         parked = false
+        parkedAt = nil
+        detached = false
         if bytesSinceConnect < PlaybackOriginReconnectPolicy.productiveBytesFloor {
             unproductiveStreak += 1
         } else {
@@ -738,12 +975,26 @@ final class PlaybackOriginStream {
             lock.lock()
             reconnectTask?.cancel()
             reconnectTask = Task.detached(priority: .userInitiated) { [weak self] in
-                try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                try? await Task.sleep(for: .seconds(delay))
                 guard !Task.isCancelled else { return }
-                self?.openConnection()
+                self?.openScheduledReconnect(expectedGeneration: newGeneration)
             }
             lock.unlock()
         }
+    }
+
+    private func openScheduledReconnect(expectedGeneration: UInt64) {
+        lock.lock()
+        guard generation == expectedGeneration,
+              !cancelled,
+              !finished,
+              task == nil else {
+            lock.unlock()
+            return
+        }
+        reconnectTask = nil
+        lock.unlock()
+        openConnection(reason: .reconnect)
     }
 
     private func giveUp(

--- a/iosApp/iosApp/Screens/Player/PlaybackSourceOriginStream.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSourceOriginStream.swift
@@ -208,8 +208,9 @@ final class PlaybackOriginStream {
     struct Callbacks {
         /// Invoked on the session delegate queue after bytes are stored.
         let didStore: (PlaybackOriginStream, ClosedRange<Int64>) -> Void
-        /// First response headers for a connection (total length if known).
-        let didReceiveResponse: (PlaybackOriginStream, Int64?) -> Void
+        /// First response headers for a connection (total length and captured
+        /// strong entity validator, when known).
+        let didReceiveResponse: (PlaybackOriginStream, Int64?, String?) -> Void
         let didDetectSessionMissing: (PlaybackOriginStream) -> Void
         let didFinish: (PlaybackOriginStream) -> Void
         let didGiveUp: (PlaybackOriginStream, PlaybackOriginReconnectPolicy.EndCause, Int?) -> Void
@@ -290,6 +291,13 @@ final class PlaybackOriginStream {
     private var unproductiveStreak = 0
     private var knownTotalLength: Int64?
     private var responseValidatedForGeneration: UInt64?
+    /// Whether this stream has already accepted any response body. A first
+    /// response may establish the resource validator; every later connection
+    /// in resume-capable mode must already have that strong validator.
+    private var hasAcceptedResponse = false
+    /// A replacement window shares the resource cache with an earlier window,
+    /// so even its first response must prove that it is the same entity.
+    private let initialResponseRequiresEntityValidation: Bool
     private var entityETag: String?
     private var ifRangeGeneration: UInt64?
     private var sentIfRangeValue: String?
@@ -304,6 +312,8 @@ final class PlaybackOriginStream {
         demandOrder: UInt64,
         callbacks: Callbacks,
         resumeCapable: Bool = false,
+        initialEntityETag: String? = nil,
+        initialResponseRequiresEntityValidation: Bool = false,
         clock: PlaybackOriginStreamClock = SystemPlaybackOriginStreamClock()
     ) {
         self.originURL = originURL
@@ -315,6 +325,8 @@ final class PlaybackOriginStream {
         self.skipCheckCursor = startOffset + Self.cachedRunCheckStrideBytes
         self.callbacks = callbacks
         self.resumeCapable = resumeCapable
+        self.entityETag = initialEntityETag
+        self.initialResponseRequiresEntityValidation = initialResponseRequiresEntityValidation
         self.clock = clock
         self.lastDataAt = clock.now()
     }
@@ -541,11 +553,9 @@ final class PlaybackOriginStream {
             request.setValue(value, forHTTPHeaderField: key)
         }
         request.setValue("bytes=\(cursor)-", forHTTPHeaderField: "Range")
-        // Issue #94 deliberately does not require a validator to detach:
-        // direct `original_http` origins remain resume-capable without the
-        // new ETag feature, preserving the existing nonzero-200
-        // `.rangeIgnored` path. When a strong ETag is available, If-Range
-        // upgrades that reopen into positive entity validation.
+        // The first response may establish the strong validator. Reopens send
+        // it with If-Range; a resume-capable reopen without one is rejected
+        // before any response bytes can be appended.
         let ifRange = cursor > 0 ? entityETag : nil
         if let ifRange {
             request.setValue(ifRange, forHTTPHeaderField: "If-Range")
@@ -643,6 +653,13 @@ final class PlaybackOriginStream {
         let cursor = writeCursor
         let openReason = currentOpenReason
         let sentIfRange = ifRangeGeneration == gen ? sentIfRangeValue : nil
+        let expectedETag = resumeCapable ? entityETag : nil
+        let requiresEntityValidation = resumeCapable
+            && (
+                expectedETag != nil
+                    || hasAcceptedResponse
+                    || initialResponseRequiresEntityValidation
+            )
         lock.unlock()
         guard let http = response as? HTTPURLResponse else {
             connectionEnded(generation: gen, cause: .network, statusCode: nil)
@@ -652,12 +669,67 @@ final class PlaybackOriginStream {
         switch http.statusCode {
         case 206:
             let total = Self.totalLength(fromContentRange: http.value(forHTTPHeaderField: "Content-Range"))
-            if let rangeStart = Self.rangeStart(fromContentRange: http.value(forHTTPHeaderField: "Content-Range")),
-               rangeStart != cursor {
-                Self.logger.warning("[CMP-SOURCE-CACHE] origin stream range mismatch expected=\(cursor, privacy: .public) got=\(rangeStart, privacy: .public)")
+            guard let rangeStart = Self.rangeStart(
+                fromContentRange: http.value(forHTTPHeaderField: "Content-Range")
+            ), rangeStart == cursor else {
+                let receivedRange = http.value(forHTTPHeaderField: "Content-Range") ?? "missing"
+                Self.logger.warning(
+                    "[CMP-SOURCE-CACHE] origin stream invalid content-range expectedStart=\(cursor, privacy: .public) received=\(receivedRange, privacy: .public)"
+                )
                 logDetachResumeOutcomeIfNeeded(openReason, cursor: cursor, outcome: "range_mismatch")
                 connectionEnded(generation: gen, cause: .rangeIgnored, statusCode: http.statusCode)
                 return false
+            }
+            if requiresEntityValidation {
+                guard let expectedETag else {
+                    Self.logger.warning(
+                        "[CMP-SOURCE-CACHE] origin stream entity-unverifiable cursor=\(cursor, privacy: .public) expectedETag=missing"
+                    )
+                    logDetachResumeOutcomeIfNeeded(
+                        openReason,
+                        cursor: cursor,
+                        outcome: "entity_unverifiable"
+                    )
+                    connectionEnded(
+                        generation: gen,
+                        cause: .rangeIgnored,
+                        statusCode: http.statusCode
+                    )
+                    return false
+                }
+                let responseETagHeader = http.value(forHTTPHeaderField: "ETag")
+                guard let responseETag = Self.strongETag(responseETagHeader) else {
+                    Self.logger.warning(
+                        "[CMP-SOURCE-CACHE] origin stream entity-unverifiable cursor=\(cursor, privacy: .public) expectedETag=\(expectedETag, privacy: .public) responseETag=\(responseETagHeader ?? "missing", privacy: .public)"
+                    )
+                    logDetachResumeOutcomeIfNeeded(
+                        openReason,
+                        cursor: cursor,
+                        outcome: "entity_unverifiable"
+                    )
+                    connectionEnded(
+                        generation: gen,
+                        cause: .rangeIgnored,
+                        statusCode: http.statusCode
+                    )
+                    return false
+                }
+                guard responseETag == expectedETag else {
+                    Self.logger.error(
+                        "[CMP-SOURCE-CACHE] origin stream entity-changed cursor=\(cursor, privacy: .public) expectedETag=\(expectedETag, privacy: .public) responseETag=\(responseETagHeader ?? "missing", privacy: .public)"
+                    )
+                    logDetachResumeOutcomeIfNeeded(
+                        openReason,
+                        cursor: cursor,
+                        outcome: "entity_changed"
+                    )
+                    connectionEnded(
+                        generation: gen,
+                        cause: .entityChanged,
+                        statusCode: http.statusCode
+                    )
+                    return false
+                }
             }
             noteResponse(
                 total: total,
@@ -667,6 +739,42 @@ final class PlaybackOriginStream {
             logDetachResumeOutcomeIfNeeded(openReason, cursor: cursor, outcome: "accepted_206")
             return true
         case 200 where cursor == 0:
+            if requiresEntityValidation {
+                guard let expectedETag else {
+                    Self.logger.warning(
+                        "[CMP-SOURCE-CACHE] origin stream entity-unverifiable cursor=0 expectedETag=missing"
+                    )
+                    connectionEnded(
+                        generation: gen,
+                        cause: .rangeIgnored,
+                        statusCode: http.statusCode
+                    )
+                    return false
+                }
+                let responseETagHeader = http.value(forHTTPHeaderField: "ETag")
+                guard let responseETag = Self.strongETag(responseETagHeader) else {
+                    Self.logger.warning(
+                        "[CMP-SOURCE-CACHE] origin stream entity-unverifiable cursor=0 expectedETag=\(expectedETag, privacy: .public) responseETag=\(responseETagHeader ?? "missing", privacy: .public)"
+                    )
+                    connectionEnded(
+                        generation: gen,
+                        cause: .rangeIgnored,
+                        statusCode: http.statusCode
+                    )
+                    return false
+                }
+                guard responseETag == expectedETag else {
+                    Self.logger.error(
+                        "[CMP-SOURCE-CACHE] origin stream entity-changed cursor=0 expectedETag=\(expectedETag, privacy: .public) responseETag=\(responseETagHeader ?? "missing", privacy: .public)"
+                    )
+                    connectionEnded(
+                        generation: gen,
+                        cause: .entityChanged,
+                        statusCode: http.statusCode
+                    )
+                    return false
+                }
+            }
             let total = http.expectedContentLength > 0 ? http.expectedContentLength : nil
             noteResponse(
                 total: total,
@@ -677,13 +785,16 @@ final class PlaybackOriginStream {
             return true
         case 200:
             if let sentIfRange {
-                let responseETag = http.value(forHTTPHeaderField: "ETag") ?? "missing"
-                Self.logger.error(
-                    "[CMP-SOURCE-CACHE] origin stream entity-changed cursor=\(cursor, privacy: .public) ifRange=\(sentIfRange, privacy: .public) responseETag=\(responseETag, privacy: .public)"
-                )
-                logDetachResumeOutcomeIfNeeded(openReason, cursor: cursor, outcome: "entity_changed")
-                connectionEnded(generation: gen, cause: .entityChanged, statusCode: 200)
-                return false
+                let responseETagHeader = http.value(forHTTPHeaderField: "ETag")
+                if let responseETag = Self.strongETag(responseETagHeader),
+                   responseETag != sentIfRange {
+                    Self.logger.error(
+                        "[CMP-SOURCE-CACHE] origin stream entity-changed cursor=\(cursor, privacy: .public) ifRange=\(sentIfRange, privacy: .public) responseETag=\(responseETagHeader ?? "missing", privacy: .public)"
+                    )
+                    logDetachResumeOutcomeIfNeeded(openReason, cursor: cursor, outcome: "entity_changed")
+                    connectionEnded(generation: gen, cause: .entityChanged, statusCode: 200)
+                    return false
+                }
             }
             // The origin ignored the Range header; accepting the body would
             // silently corrupt the cache with head bytes at a nonzero offset.
@@ -727,12 +838,14 @@ final class PlaybackOriginStream {
             return
         }
         responseValidatedForGeneration = gen
+        hasAcceptedResponse = true
         if let total { knownTotalLength = total }
         if entityETag == nil, let etag = Self.strongETag(etag) {
             entityETag = etag
         }
+        let validator = entityETag
         lock.unlock()
-        callbacks.didReceiveResponse(self, total)
+        callbacks.didReceiveResponse(self, total, validator)
     }
 
     /// `If-Range` performs a strong validator comparison; a weak ETag would

--- a/iosApp/iosApp/Screens/Player/PlaybackSourceProxy.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSourceProxy.swift
@@ -1176,6 +1176,7 @@ private final class PlaybackSourceResource {
         var toNote: PlaybackOriginStream?
         var toRetarget: PlaybackOriginStream?
         var chunk = false
+        var deferChunkUntilEntityKnown = false
         var order: UInt64 = 0
         var total: Int64?
         stateLock.lock()
@@ -1213,11 +1214,19 @@ private final class PlaybackSourceResource {
             }
         case .chunk:
             chunk = true
+            // A resume-capable chunk must be bound to the streaming
+            // window's representation. If a startup probe wins the race
+            // with the window response, leave its registered data waiter
+            // parked instead of spending the chunk's short retry budget on
+            // requests that cannot yet carry If-Range. The first window
+            // response with a strong validator re-drives all waiting
+            // demands below.
+            deferChunkUntilEntityKnown = resumeCapable && sourceEntityETag == nil
         }
         stateLock.unlock()
         toNote?.noteDemand(offset: offset, order: order)
         toStart?.start()
-        if chunk {
+        if chunk && !deferChunkUntilEntityKnown {
             ensureChunkFetcher().ensureFetch(covering: offset, totalLength: total)
         }
         if let toRetarget {
@@ -1554,11 +1563,15 @@ private final class PlaybackSourceResource {
 
     private func streamReceivedResponse(total: Int64?, entityETag: String? = nil) {
         var resume: [CheckedContinuation<Int64?, Never>] = []
+        var shouldRedriveDataWaiters = false
         stateLock.lock()
         guard !sourceEntityInvalidated else {
             stateLock.unlock()
             return
         }
+        shouldRedriveDataWaiters = resumeCapable
+            && sourceEntityETag == nil
+            && entityETag != nil
         sawOriginResponse = true
         if sourceEntityETag == nil {
             sourceEntityETag = entityETag
@@ -1573,6 +1586,9 @@ private final class PlaybackSourceResource {
         cache.setTotalLength(value)
         for continuation in resume {
             continuation.resume(returning: value)
+        }
+        if shouldRedriveDataWaiters {
+            redriveAllDataWaiters()
         }
         clearOutageAfterOriginResponse()
     }

--- a/iosApp/iosApp/Screens/Player/PlaybackSourceProxy.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSourceProxy.swift
@@ -682,6 +682,14 @@ private final class PlaybackSourceResource {
     private let originStreamClock: PlaybackOriginStreamClock
     private let stateLock = NSLock()
     private var cancelled = false
+    /// A validator proved that the origin now refers to a different entity.
+    /// Once set, this resource must neither fetch nor serve another byte from
+    /// the cache while the view model tears down and replans playback.
+    private var sourceEntityInvalidated = false
+    /// Strong validator captured from the window's first accepted response.
+    /// Resume-capable chunk requests use the same validator so random-access
+    /// reads cannot race replacement detection and contaminate the cache.
+    private var sourceEntityETag: String?
     /// Origin outage ride-through state (all under `stateLock`): parked
     /// demands stay registered in `dataWaiters`, `outageProbeTask` drives the
     /// slow re-probe cadence, and `sessionMissingObserved` widens parking to
@@ -786,7 +794,7 @@ private final class PlaybackSourceResource {
         var windowToCancel: PlaybackOriginStream?
         var fetcherToCancel: PlaybackOriginChunkFetcher?
         stateLock.lock()
-        guard !cancelled else {
+        guard !cancelled, !sourceEntityInvalidated else {
             stateLock.unlock()
             return
         }
@@ -833,7 +841,10 @@ private final class PlaybackSourceResource {
         var toStart: PlaybackOriginStream?
         var probeToCancel: Task<Void, Never>?
         stateLock.lock()
-        guard !cancelled, originOutage, windowStream == nil else {
+        guard !cancelled,
+              !sourceEntityInvalidated,
+              originOutage,
+              windowStream == nil else {
             stateLock.unlock()
             return
         }
@@ -858,7 +869,7 @@ private final class PlaybackSourceResource {
     private func enterOutageAndScheduleProbe(failureOffset: Int64) -> Bool {
         var entered = false
         stateLock.lock()
-        guard !cancelled else {
+        guard !cancelled, !sourceEntityInvalidated else {
             stateLock.unlock()
             return false
         }
@@ -881,7 +892,7 @@ private final class PlaybackSourceResource {
     /// demand through the normal re-miss routing.
     private func clearOutageAfterOriginResponse() {
         stateLock.lock()
-        guard originOutage else {
+        guard originOutage, !sourceEntityInvalidated else {
             stateLock.unlock()
             return
         }
@@ -898,7 +909,9 @@ private final class PlaybackSourceResource {
 
     private func noteSessionMissingObserved() {
         stateLock.lock()
-        sessionMissingObserved = true
+        if !sourceEntityInvalidated {
+            sessionMissingObserved = true
+        }
         stateLock.unlock()
     }
 
@@ -937,7 +950,7 @@ private final class PlaybackSourceResource {
     func startPrefetch(at offset: Int64 = 0) {
         var toStart: PlaybackOriginStream?
         stateLock.lock()
-        if !cancelled, windowStream == nil {
+        if !cancelled, !sourceEntityInvalidated, windowStream == nil {
             demandCounter += 1
             let stream = makeStream(startOffset: max(0, offset), order: demandCounter)
             windowStream = stream
@@ -955,7 +968,7 @@ private final class PlaybackSourceResource {
 
     func handle(method: String, rangeHeader: String?, on connection: NWConnection) {
         stateLock.lock()
-        let alreadyStopped = cancelled
+        let alreadyStopped = cancelled || sourceEntityInvalidated
         stateLock.unlock()
         guard !alreadyStopped else {
             connection.cancel()
@@ -983,7 +996,7 @@ private final class PlaybackSourceResource {
         stateLock.lock()
         if completedServeTaskIDs.remove(id) != nil {
             // Finished before registration — nothing to track.
-        } else if cancelled {
+        } else if cancelled || sourceEntityInvalidated {
             cancelNow = true
         } else {
             serveTasks[id] = task
@@ -996,7 +1009,9 @@ private final class PlaybackSourceResource {
 
     private func serveTaskFinished(_ id: UUID) {
         stateLock.lock()
-        if serveTasks.removeValue(forKey: id) == nil, !cancelled {
+        if serveTasks.removeValue(forKey: id) == nil,
+           !cancelled,
+           !sourceEntityInvalidated {
             completedServeTaskIDs.insert(id)
         }
         stateLock.unlock()
@@ -1134,10 +1149,20 @@ private final class PlaybackSourceResource {
         return discoveredTotalLength
     }
 
-    private func currentState() -> (cancelled: Bool, total: Int64?, sawResponse: Bool) {
+    private func currentState() -> (
+        cancelled: Bool,
+        sourceEntityInvalidated: Bool,
+        total: Int64?,
+        sawResponse: Bool
+    ) {
         stateLock.lock()
         defer { stateLock.unlock() }
-        return (cancelled, discoveredTotalLength, sawOriginResponse)
+        return (
+            cancelled: cancelled,
+            sourceEntityInvalidated: sourceEntityInvalidated,
+            total: discoveredTotalLength,
+            sawResponse: sawOriginResponse
+        )
     }
 
     /// Route a byte demand that MISSED the cache: ride the streaming window
@@ -1154,7 +1179,7 @@ private final class PlaybackSourceResource {
         var order: UInt64 = 0
         var total: Int64?
         stateLock.lock()
-        guard !cancelled else {
+        guard !cancelled, !sourceEntityInvalidated else {
             stateLock.unlock()
             return
         }
@@ -1216,15 +1241,23 @@ private final class PlaybackSourceResource {
             stateLock.unlock()
             return chunkFetcher
         }
-        let alreadyCancelled = cancelled
+        let alreadyStopped = cancelled || sourceEntityInvalidated
         let fetcher = PlaybackOriginChunkFetcher(
             originURL: originURL,
             originHeaders: originHeaders,
+            entityETagProvider: { [weak self] in
+                self?.currentChunkEntityETag()
+            },
+            requiresEntityValidation: resumeCapable,
             callbacks: PlaybackOriginChunkFetcher.Callbacks(
-                store: { [weak self] start, data, total in
-                    guard let self else { return }
-                    self.cache.recordOriginTransfer(byteCount: data.count)
-                    self.cache.store(start: start, data: data, totalLength: total)
+                store: { [weak self] start, data, total, responseETag in
+                    guard let self else { return .network }
+                    return self.storeChunkOriginData(
+                        start: start,
+                        data: data,
+                        total: total,
+                        responseETag: responseETag
+                    )
                 },
                 didStore: { [weak self] range in
                     self?.streamDidStore(range)
@@ -1247,7 +1280,7 @@ private final class PlaybackSourceResource {
                 }
             )
         )
-        if alreadyCancelled {
+        if alreadyStopped {
             // A stop raced this creation; hand back a pre-cancelled fetcher
             // whose ensureFetch is a no-op instead of a zombie that stop()
             // can no longer reach.
@@ -1258,6 +1291,42 @@ private final class PlaybackSourceResource {
         chunkFetcher = fetcher
         stateLock.unlock()
         return fetcher
+    }
+
+    private func currentChunkEntityETag() -> String? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return resumeCapable ? sourceEntityETag : nil
+    }
+
+    /// A chunk and the window can complete on different URLSession queues.
+    /// Bind the chunk to the window's established representation and store
+    /// under one lock so neither can race replacement bytes into the cache.
+    private func storeChunkOriginData(
+        start: Int64,
+        data: Data,
+        total: Int64?,
+        responseETag: String?
+    ) -> PlaybackOriginReconnectPolicy.EndCause? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        guard !cancelled, !sourceEntityInvalidated else {
+            return .network
+        }
+        if resumeCapable {
+            guard sawOriginResponse else {
+                return .rangeIgnored
+            }
+            guard let sourceEntityETag, let responseETag else {
+                return .rangeIgnored
+            }
+            guard responseETag == sourceEntityETag else {
+                return .entityChanged
+            }
+        }
+        cache.recordOriginTransfer(byteCount: data.count)
+        cache.store(start: start, data: data, totalLength: total)
+        return nil
     }
 
     private func redriveAllDataWaiters() {
@@ -1277,7 +1346,7 @@ private final class PlaybackSourceResource {
     ) {
         var toStart: PlaybackOriginStream?
         stateLock.lock()
-        guard !cancelled else {
+        guard !cancelled, !sourceEntityInvalidated else {
             stateLock.unlock()
             return
         }
@@ -1303,7 +1372,7 @@ private final class PlaybackSourceResource {
         var toNote: PlaybackOriginStream?
         var order: UInt64 = 0
         stateLock.lock()
-        guard !cancelled else {
+        guard !cancelled, !sourceEntityInvalidated else {
             stateLock.unlock()
             return
         }
@@ -1327,13 +1396,13 @@ private final class PlaybackSourceResource {
     /// reader (which may re-anchor the window) from short-lived probes.
     private func awaitData(at offset: Int64, servedSequentialBytes: Int64) async -> WaitOutcome {
         let state = currentState()
-        if state.cancelled { return .failed }
+        if state.cancelled || state.sourceEntityInvalidated { return .failed }
         if let total = state.total, offset >= total { return .eof }
         let id = UUID()
         return await withTaskCancellationHandler {
             await withCheckedContinuation { (continuation: CheckedContinuation<WaitOutcome, Never>) in
                 stateLock.lock()
-                if cancelled {
+                if cancelled || sourceEntityInvalidated {
                     stateLock.unlock()
                     continuation.resume(returning: .failed)
                     return
@@ -1370,12 +1439,15 @@ private final class PlaybackSourceResource {
     private func awaitTotalLength(hint: Int64) async -> Int64? {
         let state = currentState()
         if let known = state.total { return known }
-        if state.sawResponse || state.cancelled { return nil }
+        if state.sawResponse || state.cancelled || state.sourceEntityInvalidated { return nil }
         let id = UUID()
         return await withTaskCancellationHandler {
             await withCheckedContinuation { (continuation: CheckedContinuation<Int64?, Never>) in
                 stateLock.lock()
-                if cancelled || sawOriginResponse || discoveredTotalLength != nil {
+                if cancelled
+                    || sourceEntityInvalidated
+                    || sawOriginResponse
+                    || discoveredTotalLength != nil {
                     let value = discoveredTotalLength
                     stateLock.unlock()
                     continuation.resume(returning: value)
@@ -1401,6 +1473,21 @@ private final class PlaybackSourceResource {
         waiter?.resume(returning: value)
     }
 
+    /// Serialize cache writes with entity invalidation. A chunk completion can
+    /// race the window's validator failure on a different URLSession queue;
+    /// holding `stateLock` through the cache write guarantees that once the
+    /// invalidation flag is visible, no replacement bytes can be appended.
+    private func storeOriginData(start: Int64, data: Data, total: Int64?) {
+        stateLock.lock()
+        guard !cancelled, !sourceEntityInvalidated else {
+            stateLock.unlock()
+            return
+        }
+        cache.recordOriginTransfer(byteCount: data.count)
+        cache.store(start: start, data: data, totalLength: total)
+        stateLock.unlock()
+    }
+
     private func makeStream(startOffset: Int64, order: UInt64) -> PlaybackOriginStream {
         PlaybackOriginStream(
             originURL: originURL,
@@ -1411,8 +1498,8 @@ private final class PlaybackSourceResource {
                 didStore: { [weak self] _, range in
                     self?.streamDidStore(range)
                 },
-                didReceiveResponse: { [weak self] _, total in
-                    self?.streamReceivedResponse(total: total)
+                didReceiveResponse: { [weak self] _, total, entityETag in
+                    self?.streamReceivedResponse(total: total, entityETag: entityETag)
                 },
                 didDetectSessionMissing: { [weak self] _ in
                     self?.noteSessionMissingObserved()
@@ -1434,12 +1521,12 @@ private final class PlaybackSourceResource {
                     self?.cache.nextPrefetchStart(after: cursor)
                 },
                 store: { [weak self] start, data, total in
-                    guard let self else { return }
-                    self.cache.recordOriginTransfer(byteCount: data.count)
-                    self.cache.store(start: start, data: data, totalLength: total)
+                    self?.storeOriginData(start: start, data: data, total: total)
                 }
             ),
             resumeCapable: resumeCapable,
+            initialEntityETag: resumeCapable ? sourceEntityETag : nil,
+            initialResponseRequiresEntityValidation: resumeCapable && sawOriginResponse,
             clock: originStreamClock
         )
     }
@@ -1447,7 +1534,7 @@ private final class PlaybackSourceResource {
     private func streamDidStore(_ range: ClosedRange<Int64>) {
         var resume: [CheckedContinuation<WaitOutcome, Never>] = []
         stateLock.lock()
-        guard !dataWaiters.isEmpty else {
+        guard !sourceEntityInvalidated, !dataWaiters.isEmpty else {
             stateLock.unlock()
             return
         }
@@ -1465,10 +1552,17 @@ private final class PlaybackSourceResource {
         }
     }
 
-    private func streamReceivedResponse(total: Int64?) {
+    private func streamReceivedResponse(total: Int64?, entityETag: String? = nil) {
         var resume: [CheckedContinuation<Int64?, Never>] = []
         stateLock.lock()
+        guard !sourceEntityInvalidated else {
+            stateLock.unlock()
+            return
+        }
         sawOriginResponse = true
+        if sourceEntityETag == nil {
+            sourceEntityETag = entityETag
+        }
         if let total, total > 0 {
             discoveredTotalLength = max(discoveredTotalLength ?? 0, total)
         }
@@ -1483,6 +1577,68 @@ private final class PlaybackSourceResource {
         clearOutageAfterOriginResponse()
     }
 
+    /// Entity identity is global to the resource, not to one transport. Either
+    /// the streaming window or a random-access chunk can detect replacement;
+    /// the first detector atomically closes every fetch/serve path and fails
+    /// all waiters before escalating recovery.
+    private func invalidateSourceEntity(statusCode: Int?, failureOffset: Int64) {
+        var windowToCancel: PlaybackOriginStream?
+        var fetcherToCancel: PlaybackOriginChunkFetcher?
+        var probeToCancel: Task<Void, Never>?
+        var serveTasksToCancel: [Task<Void, Never>] = []
+        var dataResume: [CheckedContinuation<WaitOutcome, Never>] = []
+        var totalResume: [CheckedContinuation<Int64?, Never>] = []
+        var total: Int64?
+        var outageWasActive = false
+
+        stateLock.lock()
+        guard !sourceEntityInvalidated else {
+            stateLock.unlock()
+            return
+        }
+        sourceEntityInvalidated = true
+        outageWasActive = originOutage
+        originOutage = false
+        sessionMissingObserved = false
+        probeToCancel = outageProbeTask
+        outageProbeTask = nil
+        windowToCancel = windowStream
+        windowStream = nil
+        fetcherToCancel = chunkFetcher
+        chunkFetcher = nil
+        serveTasksToCancel = Array(serveTasks.values)
+        dataResume = dataWaiters.values.map(\.continuation)
+        dataWaiters.removeAll()
+        totalResume = Array(totalWaiters.values)
+        totalWaiters.removeAll()
+        total = discoveredTotalLength
+        stateLock.unlock()
+
+        probeToCancel?.cancel()
+        if let windowToCancel {
+            windowToCancel.cancel()
+            cache.endOriginRequest()
+        }
+        fetcherToCancel?.cancel()
+        for task in serveTasksToCancel {
+            task.cancel()
+        }
+        for continuation in totalResume {
+            continuation.resume(returning: total)
+        }
+        for continuation in dataResume {
+            continuation.resume(returning: .failed)
+        }
+        if outageWasActive {
+            onOriginOutageChanged?(false)
+        }
+        escalateInterruption(
+            cause: .entityChanged,
+            statusCode: statusCode,
+            failureOffset: failureOffset
+        )
+    }
+
     /// The window stream ended. A clean finish (EOF, or everything to EOF
     /// already cached) re-drives waiters — data may satisfy them or their
     /// re-miss routes to a chunk. A give-up fails the waiters the window was
@@ -1493,6 +1649,13 @@ private final class PlaybackSourceResource {
         gaveUpWith cause: PlaybackOriginReconnectPolicy.EndCause?,
         statusCode: Int?
     ) {
+        if cause == .entityChanged {
+            invalidateSourceEntity(
+                statusCode: statusCode,
+                failureOffset: stream.snapshot().writeCursor
+            )
+            return
+        }
         var redrive: [CheckedContinuation<WaitOutcome, Never>] = []
         var failed: [CheckedContinuation<WaitOutcome, Never>] = []
         var totalResume: [CheckedContinuation<Int64?, Never>] = []
@@ -1554,14 +1717,6 @@ private final class PlaybackSourceResource {
             }
             return
         }
-        if cause == .entityChanged {
-            escalateInterruption(
-                cause: cause,
-                statusCode: statusCode,
-                failureOffset: stream.snapshot().writeCursor
-            )
-            return
-        }
         // Surface the interruption only when the give-up actually failed a
         // foreground waiter. The window dying while playback rides the
         // forward cache must stay silent — the next cache miss routes to a
@@ -1584,6 +1739,13 @@ private final class PlaybackSourceResource {
         cause: PlaybackOriginReconnectPolicy.EndCause,
         statusCode: Int?
     ) {
+        if cause == .entityChanged {
+            invalidateSourceEntity(
+                statusCode: statusCode,
+                failureOffset: range.lowerBound
+            )
+            return
+        }
         var failed: [CheckedContinuation<WaitOutcome, Never>] = []
         var totalResume: [CheckedContinuation<Int64?, Never>] = []
         stateLock.lock()
@@ -1664,7 +1826,7 @@ private final class PlaybackSourceResource {
         demandMark: Int64
     ) -> Bool {
         stateLock.lock()
-        guard !cancelled else {
+        guard !cancelled, !sourceEntityInvalidated else {
             stateLock.unlock()
             return false
         }

--- a/iosApp/iosApp/Screens/Player/PlaybackSourceProxy.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSourceProxy.swift
@@ -18,6 +18,8 @@ struct PlaybackSourceProxyStats: Equatable {
     let diskSpillBytes: Int64
     let diskBudgetBytes: Int64
     let diskBytesWritten: Int64
+    let resumeCapable: Bool
+    let serverAdvertisesDirectStreamResume: Bool
 }
 
 enum PlaybackSourceInterruptionReason: Equatable {
@@ -28,6 +30,9 @@ enum PlaybackSourceInterruptionReason: Equatable {
     /// proxy could not serve; `expectedEnd` is the last byte the response
     /// promised.
     case prematureEOF(offset: Int64, expectedEnd: Int64)
+    /// A validator-protected range reopen returned a full response, proving
+    /// the cached prefix belongs to a replaced source entity.
+    case sourceEntityChanged
 }
 
 /// How a proxied GET response loop ended. Pure decision so tests can pin the
@@ -64,6 +69,11 @@ enum PlaybackSourceResponseEnd: Equatable {
 }
 
 final class PlaybackSourceCache {
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.continuum.app",
+        category: "PlaybackSourceCache"
+    )
+
     static var defaultMemoryBudgetBytes: Int {
         isConstrainedMemoryDevice ? 96 * 1024 * 1024 : 128 * 1024 * 1024
     }
@@ -153,6 +163,7 @@ final class PlaybackSourceCache {
     private var diskSpillBytes: Int64 = 0
     private var diskBytesWritten: Int64 = 0
     private var loggedWriteBudgetExhausted = false
+    private var prefetchArmed = true
     private var recentTransfers: [(time: Date, bytes: Int)] = []
     private var lastReadEnd: Int64?
     /// Most recent read position (not a high-water mark). `lastReadEnd` is
@@ -226,15 +237,31 @@ final class PlaybackSourceCache {
     var downstreamHighWaterBytes: Int { highWaterBytes }
     var downstreamLowWaterBytes: Int { lowWaterBytes }
     var shouldPrefetch: Bool {
+        var didRearm = false
         lock.lock()
-        let value: Bool
-        if lastReadEnd == nil {
-            value = cachedBytes < highWaterBytes
-        } else {
-            value = forwardCachedBytesLocked() < highWaterBytes
+        let cachedAhead = lastReadEnd == nil
+            ? Int64(cachedBytes)
+            : forwardCachedBytesLocked()
+        if prefetchArmed, cachedAhead >= Int64(highWaterBytes) {
+            prefetchArmed = false
+        } else if !prefetchArmed, cachedAhead <= Int64(lowWaterBytes) {
+            prefetchArmed = true
+            didRearm = true
         }
+        let value = prefetchArmed
         lock.unlock()
+        if didRearm {
+            Self.logger.info(
+                "[CMP-SOURCE-CACHE] hysteresis re-arm cachedAheadBytes=\(cachedAhead, privacy: .public) lowWaterBytes=\(self.lowWaterBytes, privacy: .public)"
+            )
+        }
         return value
+    }
+
+    func forwardCachedByteCount() -> Int64 {
+        lock.lock()
+        defer { lock.unlock() }
+        return lastReadEnd == nil ? Int64(cachedBytes) : forwardCachedBytesLocked()
     }
 
     func setTotalLength(_ length: Int64?) {
@@ -650,6 +677,9 @@ private final class PlaybackSourceResource {
     /// player rides its buffered runway.
     private let onOriginOutageChanged: ((Bool) -> Void)?
     private let outageRideThroughEnabled: Bool
+    private let resumeCapable: Bool
+    private let serverAdvertisesDirectStreamResume: Bool
+    private let originStreamClock: PlaybackOriginStreamClock
     private let stateLock = NSLock()
     private var cancelled = false
     /// Origin outage ride-through state (all under `stateLock`): parked
@@ -688,7 +718,10 @@ private final class PlaybackSourceResource {
         onPlaybackSessionMissing: (() -> Void)?,
         onPlaybackSourceInterrupted: ((PlaybackSourceInterruptionReason) -> Void)?,
         onOriginOutageChanged: ((Bool) -> Void)? = nil,
-        outageRideThroughEnabled: Bool = PlaybackOriginOutagePolicy.rideThroughEnabled()
+        outageRideThroughEnabled: Bool = PlaybackOriginOutagePolicy.rideThroughEnabled(),
+        resumeCapable: Bool,
+        serverAdvertisesDirectStreamResume: Bool,
+        originStreamClock: PlaybackOriginStreamClock
     ) {
         self.token = Self.makeToken()
         self.originURL = originURL
@@ -698,6 +731,9 @@ private final class PlaybackSourceResource {
         self.onPlaybackSourceInterrupted = onPlaybackSourceInterrupted
         self.onOriginOutageChanged = onOriginOutageChanged
         self.outageRideThroughEnabled = outageRideThroughEnabled
+        self.resumeCapable = resumeCapable
+        self.serverAdvertisesDirectStreamResume = serverAdvertisesDirectStreamResume
+        self.originStreamClock = originStreamClock
     }
 
     deinit {
@@ -882,8 +918,17 @@ private final class PlaybackSourceResource {
             activeOriginRequestCount: snapshot.activeOriginRequestCount,
             diskSpillBytes: snapshot.diskSpillBytes,
             diskBudgetBytes: snapshot.diskBudgetBytes,
-            diskBytesWritten: snapshot.diskBytesWritten
+            diskBytesWritten: snapshot.diskBytesWritten,
+            resumeCapable: resumeCapable,
+            serverAdvertisesDirectStreamResume: serverAdvertisesDirectStreamResume
         )
+    }
+
+    func originStreamDiagnostics() -> PlaybackOriginStream.DiagnosticsSnapshot? {
+        stateLock.lock()
+        let stream = windowStream
+        stateLock.unlock()
+        return stream?.diagnosticsSnapshot()
     }
 
     /// Births the streaming window at the initial playback offset. The
@@ -1382,6 +1427,9 @@ private final class PlaybackSourceResource {
                 mayContinueFilling: { [weak self] stream, cursor, demandMark in
                     self?.mayContinueFilling(stream, cursor: cursor, demandMark: demandMark) ?? false
                 },
+                cachedAheadBytes: { [weak self] in
+                    self?.cache.forwardCachedByteCount() ?? 0
+                },
                 nextMissingByte: { [weak self] cursor in
                     self?.cache.nextPrefetchStart(after: cursor)
                 },
@@ -1390,7 +1438,9 @@ private final class PlaybackSourceResource {
                     self.cache.recordOriginTransfer(byteCount: data.count)
                     self.cache.store(start: start, data: data, totalLength: total)
                 }
-            )
+            ),
+            resumeCapable: resumeCapable,
+            clock: originStreamClock
         )
     }
 
@@ -1504,6 +1554,14 @@ private final class PlaybackSourceResource {
             }
             return
         }
+        if cause == .entityChanged {
+            escalateInterruption(
+                cause: cause,
+                statusCode: statusCode,
+                failureOffset: stream.snapshot().writeCursor
+            )
+            return
+        }
         // Surface the interruption only when the give-up actually failed a
         // foreground waiter. The window dying while playback rides the
         // forward cache must stay silent — the next cache miss routes to a
@@ -1587,6 +1645,8 @@ private final class PlaybackSourceResource {
             } else {
                 reason = nil
             }
+        case .entityChanged:
+            reason = .sourceEntityChanged
         case .httpFatal, .rangeIgnored:
             reason = nil
         }
@@ -1669,7 +1729,10 @@ final class PlaybackSourceProxy {
         onPlaybackSessionMissing: (() -> Void)? = nil,
         onPlaybackSourceInterrupted: ((PlaybackSourceInterruptionReason) -> Void)? = nil,
         onOriginOutageChanged: ((Bool) -> Void)? = nil,
-        outageRideThroughEnabled: Bool = PlaybackOriginOutagePolicy.rideThroughEnabled()
+        outageRideThroughEnabled: Bool = PlaybackOriginOutagePolicy.rideThroughEnabled(),
+        resumeCapable: Bool = false,
+        serverAdvertisesDirectStreamResume: Bool = false,
+        originStreamClock: PlaybackOriginStreamClock = SystemPlaybackOriginStreamClock()
     ) {
         self.resource = PlaybackSourceResource(
             originURL: originURL,
@@ -1678,7 +1741,10 @@ final class PlaybackSourceProxy {
             onPlaybackSessionMissing: onPlaybackSessionMissing,
             onPlaybackSourceInterrupted: onPlaybackSourceInterrupted,
             onOriginOutageChanged: onOriginOutageChanged,
-            outageRideThroughEnabled: outageRideThroughEnabled
+            outageRideThroughEnabled: outageRideThroughEnabled,
+            resumeCapable: resumeCapable,
+            serverAdvertisesDirectStreamResume: serverAdvertisesDirectStreamResume,
+            originStreamClock: originStreamClock
         )
     }
 
@@ -1770,6 +1836,10 @@ final class PlaybackSourceProxy {
 
     func stats() -> PlaybackSourceProxyStats {
         resource.stats()
+    }
+
+    func originStreamDiagnostics() -> PlaybackOriginStream.DiagnosticsSnapshot? {
+        resource.originStreamDiagnostics()
     }
 
     func startPrefetch(at offset: Int64 = 0) {

--- a/iosApp/iosApp/Screens/Player/PlaybackStats.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackStats.swift
@@ -49,6 +49,8 @@ struct PlaybackStats: Equatable {
     var sourceDiskBytesWritten: Int64?
     var sourceOriginBytesTransferred: Int64?
     var sourceOriginBitrateBps: Double?
+    var sourceResumeCapable: Bool?
+    var sourceResumeServerAdvertised: Bool?
     var generatedAheadSeconds: Double?
     var generatedVisibleAheadSeconds: Double?
     var generatedMediaBitrateBps: Double?
@@ -221,6 +223,12 @@ extension PlaybackStats {
         }
         if let sourceOriginBitrateBps {
             rows.append(("Source origin bitrate", formatBitsPerSecond(sourceOriginBitrateBps)))
+        }
+        if let sourceResumeCapable {
+            rows.append(("Direct stream resume", sourceResumeCapable ? "Enabled" : "Disabled"))
+        }
+        if let sourceResumeServerAdvertised {
+            rows.append(("Server resume feature", sourceResumeServerAdvertised ? "Advertised" : "Not advertised"))
         }
         if let generatedAheadSeconds {
             rows.append(("Generated ahead", String(format: "%.1f s", generatedAheadSeconds)))

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -2135,6 +2135,8 @@ class PlayerViewModel {
             degradationWarnings: fallbackCapabilities.degradationNotes(for: requirements),
             reason: reason,
             playbackSessionId: activeExecutionPlan.playbackSessionId,
+            wireDelivery: activeExecutionPlan.wireDelivery,
+            serverFeatures: activeExecutionPlan.serverFeatures,
             sourceMetadata: activeExecutionPlan.sourceMetadata,
             normalizationSummary: PlaybackNormalizationSummary(
                 containerMode: "none",
@@ -2208,7 +2210,8 @@ class PlayerViewModel {
         let playbackSessionId = plan.playbackSessionId ?? "unknown"
         let message =
             "[CMP-ROUTE] playbackSessionId=\(playbackSessionId) " +
-            "delivery=\(plan.delivery.name) routeFamily=\(plan.routeFamily.diagnosticsLabel) " +
+            "delivery=\(plan.delivery.name) wireDelivery=\(plan.wireDelivery ?? "unknown") " +
+            "routeFamily=\(plan.routeFamily.diagnosticsLabel) " +
             "implementationRoute=\(plan.implementationRoute) backend=\(plan.engine.label) " +
             "appLabel=\(plan.appPlaybackLabel) " +
             "flag=\(plan.featureFlagEnabled) requirements=\(requirements) " +
@@ -2393,6 +2396,11 @@ class PlayerViewModel {
             maxBytes: cacheBudget,
             diskSpillEnabled: diskSpillRequested
         )
+        let resumeCapable = plan.delivery == .direct
+            && plan.wireDelivery == "original_http"
+        let serverAdvertisesDirectStreamResume = plan.serverFeatures.contains(
+            PlaybackProtocolV3.directStreamResumeFeature
+        )
         let proxy = PlaybackSourceProxy(
             originURL: plan.sourceStreamRequest.url,
             originHeaders: plan.sourceStreamRequest.headers,
@@ -2425,7 +2433,9 @@ class PlayerViewModel {
                 Task { @MainActor [weak self] in
                     self?.handleOriginOutageChanged(active)
                 }
-            }
+            },
+            resumeCapable: resumeCapable,
+            serverAdvertisesDirectStreamResume: serverAdvertisesDirectStreamResume
         )
         do {
             try await proxy.start()
@@ -2441,7 +2451,9 @@ class PlayerViewModel {
             // TCP/TLS connect and slow-start ramp with demuxer spawn, which
             // is a full round trip saved on high-latency links.
             proxy.startPrefetch(at: initialSourcePrefetchOffset(for: plan))
-            Self.logger.info("[CMP-SOURCE-CACHE] enabled route=\(plan.engine.label, privacy: .public) budgetBytes=\(cacheBudget, privacy: .public)")
+            Self.logger.info(
+                "[CMP-SOURCE-CACHE] enabled route=\(plan.engine.label, privacy: .public) budgetBytes=\(cacheBudget, privacy: .public) resumeCapable=\(resumeCapable, privacy: .public) serverAdvertisesResume=\(serverAdvertisesDirectStreamResume, privacy: .public)"
+            )
             let streamRequest = StreamRequest(
                 url: localURL,
                 headers: [:],
@@ -2477,6 +2489,8 @@ class PlayerViewModel {
                 degradationWarnings: plan.degradationWarnings,
                 reason: plan.reason,
                 playbackSessionId: plan.playbackSessionId,
+                wireDelivery: plan.wireDelivery,
+                serverFeatures: plan.serverFeatures,
                 sourceMetadata: plan.sourceMetadata,
                 normalizationSummary: plan.normalizationSummary,
                 validationClaims: plan.validationClaims
@@ -3888,7 +3902,13 @@ class PlayerViewModel {
 
         progressTask?.cancel()
         progressTask = nil
-        stashSourceCacheHandoff()
+        if reason == .sourceEntityChanged {
+            // The validator proved the cached prefix belongs to the replaced
+            // entity, so it must not be adopted by the recovery plan.
+            discardSourceCacheHandoff()
+        } else {
+            stashSourceCacheHandoff()
+        }
         sourceProxy?.stop()
         sourceProxy = nil
         activePlayer.dispose()
@@ -4567,6 +4587,8 @@ class PlayerViewModel {
             degradationWarnings: plan.degradationWarnings,
             reason: plan.reason,
             playbackSessionId: plan.playbackSessionId,
+            wireDelivery: plan.wireDelivery,
+            serverFeatures: plan.serverFeatures,
             sourceMetadata: plan.sourceMetadata,
             normalizationSummary: plan.normalizationSummary,
             validationClaims: plan.validationClaims
@@ -6277,6 +6299,8 @@ class PlayerViewModel {
         stats.sourceDiskBytesWritten = sourceStats.diskBytesWritten
         stats.sourceOriginBytesTransferred = sourceStats.originBytesTransferred
         stats.sourceOriginBitrateBps = sourceStats.currentOriginBitrateBps
+        stats.sourceResumeCapable = sourceStats.resumeCapable
+        stats.sourceResumeServerAdvertised = sourceStats.serverAdvertisesDirectStreamResume
     }
 
     private func stablePlaybackFailureToken(for message: String) -> String {

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -2396,11 +2396,10 @@ class PlayerViewModel {
             maxBytes: cacheBudget,
             diskSpillEnabled: diskSpillRequested
         )
-        let resumeCapable = plan.delivery == .direct
-            && plan.wireDelivery == "original_http"
         let serverAdvertisesDirectStreamResume = plan.serverFeatures.contains(
             PlaybackProtocolV3.directStreamResumeFeature
         )
+        let resumeCapable = plan.supportsDirectStreamResume
         let proxy = PlaybackSourceProxy(
             originURL: plan.sourceStreamRequest.url,
             originHeaders: plan.sourceStreamRequest.headers,

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3Capabilities.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3Capabilities.swift
@@ -16,7 +16,8 @@ enum ApplePlaybackV3Capabilities {
         PlaybackProtocolV3.clientTransformFeature,
         PlaybackProtocolV3.routeDiagnosticsFeature,
         PlaybackProtocolV3.deviceQuirksFeature,
-        PlaybackProtocolV3.seekReanchorFeature
+        PlaybackProtocolV3.seekReanchorFeature,
+        PlaybackProtocolV3.directStreamResumeFeature
     ]
 
     static func snapshot() -> ApplePlaybackV3CapabilitySnapshot {

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3PlanAdapter.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3PlanAdapter.swift
@@ -258,6 +258,8 @@ enum ApplePlaybackV3PlanAdapter {
             degradationWarnings: warnings + routeCapabilities.degradationNotes(for: routeRequirements),
             reason: "v3_\(plan.decisionReason)",
             playbackSessionId: plan.sessionId,
+            wireDelivery: plan.delivery,
+            serverFeatures: v3.serverFeatures,
             sourceMetadata: sourceMetadata,
             normalizationSummary: normalization
         )

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/PlaybackProtocolV3Models.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/PlaybackProtocolV3Models.swift
@@ -9,6 +9,7 @@ enum PlaybackProtocolV3 {
     static let routeDiagnosticsFeature = "playback_route_diagnostics"
     static let deviceQuirksFeature = "device_quirks_v1"
     static let seekReanchorFeature = "seek_reanchor_v1"
+    static let directStreamResumeFeature = "direct_stream_resume_v1"
 }
 
 struct PlaybackV3HDRCapabilities: Codable, Equatable {


### PR DESCRIPTION
Implements #94.

## Problem

When the playback source cache hits budget, the origin stream suspends its URLSession task and leaves the HTTP response parked indefinitely. A reverse proxy with nginx's default client-facing `send_timeout 60s` kills that healthy-but-backpressured response, and the failure only surfaces minutes later when the cache drains onto a dead task.

## What this does

- **Bounded park lifecycle**: a budget-parked stream stays warm for a grace period (`PlaybackOriginStreamPolicy.detachAfterSeconds`, default 25s — under any sane proxy timeout), then deliberately cancels into a new `detached` state at the exact `writeCursor`. Expected cancellations are tracked by task ID so a deliberate detach never advances `unproductiveStreak`, enters outage parking, or fires `onOriginOutageChanged`/`onPlaybackSourceInterrupted`. Waiters and cached bytes are preserved.
- **Exact-byte resume**: returning demand reopens `Range: bytes=<cursor>-` through the shared reopen seam factored out of `retarget(to:order:)` (retarget resets routing state; detach-resume preserves reconnect history), with double-open guards and generation-checked scheduled reconnects (fixes a latent stale-reconnect race).
- **True high/low-water hysteresis**: `shouldPrefetch` is now a sticky two-threshold gate (disarm at high water, re-arm at `lowWaterBytes`), so cache oscillation near the budget can't cause close/reopen storms. The demand-at-cursor override is untouched.
- **Entity validation**: the first response's strong ETag is captured (weak validators ignored); reopens at cursor > 0 send `If-Range`. A 200 at nonzero cursor after a sent validator means the entity changed: new `.entityChanged` end cause (retry cap 0), no bytes appended, escalated as `sourceEntityChanged` — and the ViewModel **discards** the source-cache handoff instead of stashing it so a replaced file's prefix can never leak into recovery. With no ETag, behavior is exactly today's `.rangeIgnored` path.
- **Delivery gating**: `resumeCapable` (wire delivery `original_http`) threaded plan → proxy → origin stream; non-resumable deliveries keep the legacy indefinite suspend. `direct_stream_resume_v1` server advertisement surfaced in the stats overlay for diagnostics.
- **Injectable clock** for the watchdog/park timing so all lifecycle tests run without wall-clock waits.

## Coordination

- Server contract (strong ETag/If-Range, stall observability, capability): Silo-Server/silo-server#443 (deployed to dev)
- Android transparent in-loader range resume: Silo-Server/silo-android#80

## Verification

```
cd iosApp && xcodegen generate
xcodebuild build  -scheme Silo -destination 'iPhone 17 Pro sim'   ** BUILD SUCCEEDED **
xcodebuild test   -scheme Silo -destination 'iPhone 17 Pro sim'   Executed 735 tests, 0 failures
```

New coverage (`PlaybackOriginStreamResumeTests`, NWListener fake origin + fake clock): park→detach at exact cursor; demand reopen with exact `Range` + `If-Range`; deliberate detach advances no failure state; hysteresis single-connection under oscillation; entity-change gives up without cache append and escalates; `resumeCapable=false` parks indefinitely (legacy behavior); weak ETags never sent as `If-Range`.

Live on-device validation against the dev server (iOS simulator, updated server build): route mounted with `resumeCapable=true serverAdvertisesResume=true`, direct-play origin stream + chunk fetches healthy, playback clean end to end.

### AI Disclosure
- Tool(s): Claude Code (orchestration/spec/review), OpenAI Codex CLI (implementation)
- Model(s): claude-fable-5, gpt-5.6-sol
- Involvement: fully AI-generated, human-directed
- Adversarial review: Codex's self-review pass reported no remaining findings (0.87 confidence); Claude's independent review verified the expected-cancellation bookkeeping across `handleCompletion`/`connectionEnded`, the retarget-vs-detach-resume state split, and that the entity-change path discards (not stashes) the cache handoff. Full test suite re-run independently on the simulator by the reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added direct stream resume support surfaced through protocol V3 planning, execution metadata, and playback UI/network stats.
  * Introduced clock-driven watchdog/resume behavior with explicit detach/resume capability and improved proxy-aware resume signaling.
  * Implemented hysteresis-based cache prefetch re-arming.
* **Bug Fixes**
  * Strengthened resume/interleaved request correctness with conditional range validation (ETag/If-Range) and stricter content-range checks.
  * Improved handling of entity-change scenarios to avoid unsafe parking and stale cache reuse.
* **Tests**
  * Added coverage for prefetch hysteresis, protocol V3 delivery feature mapping, and deterministic resume/reconnect behaviors (including Range/If-Range semantics).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->