### PR TITLE
Add AirPlay, Picture in Picture, and VS Code development support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,10 +36,12 @@ fastlane/test_output/
 .claude/
 .codex/
 .cursor/
+.sweetpad/
 .worktrees/
 .playwright-mcp/
 .playwright-cli/
 .superpowers/
+buildServer.json
 
 # Logs and OS files
 *.log

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "swiftlang.swift-vscode",
+    "sweetpad.sweetpad",
+    "vadimcn.vscode-lldb",
+    "redhat.vscode-yaml"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "sweetpad-lldb",
+      "request": "attach",
+      "name": "SweetPad: Build, run, and debug",
+      "preLaunchTask": "sweetpad: debugging-launch"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,35 @@
+{
+  "files.exclude": {
+    "**/.deriveddata": true,
+    "**/DerivedData": true
+  },
+  "search.exclude": {
+    "**/.deriveddata": true,
+    "**/DerivedData": true,
+    "**/Silo.xcodeproj": true
+  },
+  "sweetpad.build.configuration": "Debug",
+  "sweetpad.testing.configuration": "Debug",
+  "sweetpad.build.derivedDataPath": "iosApp/.deriveddata",
+  "sweetpad.build.schemes.include": [
+    "Silo",
+    "SiloNoDebugger",
+    "SiloTV",
+    "SiloMac"
+  ],
+  "sweetpad.build.xcbeautifyEnabled": true,
+  "sweetpad.buildServer.provider": "sweetpad",
+  "sweetpad.build.autoGenerateBuildServerConfig": true,
+  "sweetpad.build.autoRestartSwiftLSP": true,
+  "sweetpad.xcodegen.autogenerate": true,
+  "[swift]": {
+    "editor.defaultFormatter": "sweetpad.sweetpad",
+    "editor.formatOnSave": false,
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": "explicit"
+    }
+  },
+  "[yaml]": {
+    "editor.defaultFormatter": "redhat.vscode-yaml"
+  }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,139 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Silo: Generate Xcode project",
+      "type": "shell",
+      "command": "xcodegen",
+      "args": [
+        "generate"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/iosApp"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Silo: Build iOS",
+      "type": "shell",
+      "command": "xcodebuild",
+      "args": [
+        "build",
+        "-project",
+        "Silo.xcodeproj",
+        "-scheme",
+        "Silo",
+        "-destination",
+        "generic/platform=iOS Simulator",
+        "-derivedDataPath",
+        ".deriveddata",
+        "CODE_SIGN_IDENTITY=",
+        "CODE_SIGNING_ALLOWED=NO"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/iosApp"
+      },
+      "dependsOn": "Silo: Generate Xcode project",
+      "dependsOrder": "sequence",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": [
+        "$swiftc"
+      ]
+    },
+    {
+      "label": "Silo: Build tvOS",
+      "type": "shell",
+      "command": "xcodebuild",
+      "args": [
+        "build",
+        "-project",
+        "Silo.xcodeproj",
+        "-scheme",
+        "SiloTV",
+        "-destination",
+        "generic/platform=tvOS Simulator",
+        "-derivedDataPath",
+        ".deriveddata",
+        "CODE_SIGN_IDENTITY=",
+        "CODE_SIGNING_ALLOWED=NO"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/iosApp"
+      },
+      "dependsOn": "Silo: Generate Xcode project",
+      "dependsOrder": "sequence",
+      "group": "build",
+      "problemMatcher": [
+        "$swiftc"
+      ]
+    },
+    {
+      "label": "Silo: Build macOS",
+      "type": "shell",
+      "command": "xcodebuild",
+      "args": [
+        "build",
+        "-project",
+        "Silo.xcodeproj",
+        "-scheme",
+        "SiloMac",
+        "-destination",
+        "platform=macOS",
+        "-derivedDataPath",
+        ".deriveddata",
+        "CODE_SIGN_IDENTITY=",
+        "CODE_SIGNING_ALLOWED=NO"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/iosApp"
+      },
+      "dependsOn": "Silo: Generate Xcode project",
+      "dependsOrder": "sequence",
+      "group": "build",
+      "problemMatcher": [
+        "$swiftc"
+      ]
+    },
+    {
+      "label": "Silo: Test iOS",
+      "type": "shell",
+      "command": "xcodebuild",
+      "args": [
+        "test",
+        "-project",
+        "Silo.xcodeproj",
+        "-scheme",
+        "Silo",
+        "-destination",
+        "${input:iosTestDestination}",
+        "-derivedDataPath",
+        ".deriveddata",
+        "CODE_SIGN_IDENTITY=",
+        "CODE_SIGNING_ALLOWED=NO"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/iosApp"
+      },
+      "dependsOn": "Silo: Generate Xcode project",
+      "dependsOrder": "sequence",
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "problemMatcher": [
+        "$swiftc"
+      ]
+    }
+  ],
+  "inputs": [
+    {
+      "id": "iosTestDestination",
+      "type": "promptString",
+      "description": "Installed iOS Simulator destination",
+      "default": "platform=iOS Simulator,name=iPhone 17 Pro"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -77,6 +77,43 @@ xcodebuild build \
   CODE_SIGN_IDENTITY='' CODE_SIGNING_ALLOWED=NO
 ```
 
+## VS Code
+
+The checked-in `.vscode` configuration provides recommended extensions,
+unsigned build and test tasks, and SweetPad integration for building, running,
+debugging, simulator management, and Swift code intelligence without using the
+Xcode UI.
+
+1. Install Xcode and select its command-line toolchain:
+
+   ```sh
+   sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
+   sudo xcodebuild -runFirstLaunch
+   ```
+
+2. Install XcodeGen:
+
+   ```sh
+   brew install xcodegen
+   ```
+
+3. Open the repository root in VS Code and accept its extension
+   recommendations.
+4. Run `Tasks: Run Task` → `Silo: Generate Xcode project`.
+5. In the SweetPad sidebar, select a scheme and an installed destination.
+6. Run `SweetPad: Set up Swift code intelligence (BSP)` once from the command
+   palette, then open a Swift file. The generated `buildServer.json` is
+   machine-specific and intentionally ignored.
+
+Use `Cmd+Shift+B` for the default unsigned iOS build. Use the Testing sidebar
+or `Tasks: Run Test Task` for XCTest. The test task prompts for a simulator
+destination so each developer can use an installed device without committing
+machine-specific configuration.
+
+SweetPad uses Xcode's compiler, SDKs, signing tools, and simulators under the
+hood, so the full Xcode application remains required even when its UI is not
+part of the daily workflow.
+
 ## Signing
 
 Local signing overrides are intentionally ignored.

--- a/docs/tvos-player/05-route-capability-matrix.md
+++ b/docs/tvos-player/05-route-capability-matrix.md
@@ -67,11 +67,14 @@ player routes in `silo-apple`. It separates:
   AVPlayer-backed routes.
 - AirPlay video hands the receiver a URL and nothing else: the receiver opens
   its own HTTP connection, without the asset's `AVURLAssetHTTPHeaderFieldsKey`
-  headers. NativePlayer stream URLs are authenticated by an `Authorization`
-  header (`/api/v1/...` sits behind `RequireAuth` on the server), so a receiver
-  fetch answers 401. External playback and the route picker are therefore
-  disabled on those routes; header-less assets — offline `file://` downloads —
-  keep AirPlay.
+  headers. Two things make a NativePlayer URL unfetchable from a receiver, and
+  a direct-play session can hit either: the URL is authenticated by an
+  `Authorization` header (`/api/v1/...` sits behind `RequireAuth` on the
+  server, so the fetch answers 401), or `prepareSourceProxy` has rewritten it
+  to the on-device caching proxy at 127.0.0.1, which drops the headers but is
+  unreachable off-device. External playback and the route picker are enabled
+  only for assets that survive both checks — offline `file://` downloads, and
+  unauthenticated origin URLs.
 - On iOS, SiloPlayer publishes its generated HLS through a LAN URL carrying a
   per-session access token, so the selected receiver can fetch the playlist and
   segments. The server binds to the LAN but refuses off-device connections

--- a/docs/tvos-player/05-route-capability-matrix.md
+++ b/docs/tvos-player/05-route-capability-matrix.md
@@ -40,7 +40,7 @@ player routes in `silo-apple`. It separates:
 | tvOS custom shell / Siri Remote ownership | Repo-verified | Repo-verified | Repo-verified | Repo-verified |
 | Now Playing / remote commands | Repo-verified | Repo-verified | Repo-verified | Repo-verified |
 | PiP | Unsupported | Validation required | Validation required | Validation required |
-| AirPlay / external playback | Unsupported | Unsupported | Unsupported for server-hosted assets | Repo-verified |
+| AirPlay / external playback | Unsupported | Unsupported | Validation required, downloads only | Repo-verified |
 | Premium HDR / DV / Atmos claims | Validation required | Validation required | Validation required | Validation required |
 
 ## Notes

--- a/docs/tvos-player/05-route-capability-matrix.md
+++ b/docs/tvos-player/05-route-capability-matrix.md
@@ -40,7 +40,7 @@ player routes in `silo-apple`. It separates:
 | tvOS custom shell / Siri Remote ownership | Repo-verified | Repo-verified | Repo-verified | Repo-verified |
 | Now Playing / remote commands | Repo-verified | Repo-verified | Repo-verified | Repo-verified |
 | PiP | Unsupported | Validation required | Validation required | Validation required |
-| AirPlay / external playback | Unsupported | Validation required | Validation required | Repo-verified |
+| AirPlay / external playback | Unsupported | Unsupported | Unsupported for server-hosted assets | Repo-verified |
 | Premium HDR / DV / Atmos claims | Validation required | Validation required | Validation required | Validation required |
 
 ## Notes
@@ -63,12 +63,23 @@ player routes in `silo-apple`. It separates:
   promise on each route; they are not a claim about every embedded subtitle
   on a NativePlayer or SiloPlayer asset.
 - PiP stays intentionally conservative until Silo has route-specific lifecycle
-  handling and device/output validation. AirPlay UI and AVPlayer external
-  playback are enabled on NativePlayer and SiloPlayer routes. On iOS,
-  SiloPlayer publishes its generated HLS through a session-secret LAN URL so
-  the selected receiver can fetch the playlist and segments. SiloPlayer AirPlay
-  was hardware-validated 2026-07-24 from an iPhone 16 Pro to Apple TV with a
-  Dolby Vision source. This validates external playback for that route, not a
+  handling and device/output validation. PiP itself is enabled on the iOS
+  AVPlayer-backed routes.
+- AirPlay video hands the receiver a URL and nothing else: the receiver opens
+  its own HTTP connection, without the asset's `AVURLAssetHTTPHeaderFieldsKey`
+  headers. NativePlayer stream URLs are authenticated by an `Authorization`
+  header (`/api/v1/...` sits behind `RequireAuth` on the server), so a receiver
+  fetch answers 401. External playback and the route picker are therefore
+  disabled on those routes; header-less assets — offline `file://` downloads —
+  keep AirPlay.
+- On iOS, SiloPlayer publishes its generated HLS through a LAN URL carrying a
+  per-session access token, so the selected receiver can fetch the playlist and
+  segments. The server binds to the LAN but refuses off-device connections
+  until a handoff is actually live, and advertises only a Wi-Fi/Ethernet
+  RFC1918 address. If no such address exists, playback stays on the device with
+  a notice instead of stranding the receiver. SiloPlayer AirPlay was
+  hardware-validated 2026-07-24 from an iPhone 16 Pro to Apple TV with a Dolby
+  Vision source. This validates external playback for that route, not a
   generalized Dolby Vision output-mode or premium-format claim.
 - Premium-media claims stay validation-gated even when playback itself uses a
   NativePlayer or SiloPlayer route.

--- a/docs/tvos-player/05-route-capability-matrix.md
+++ b/docs/tvos-player/05-route-capability-matrix.md
@@ -1,6 +1,7 @@
 # Apple Route Capability Matrix
 
-Snapshot date: 2026-07-03 (SiloPlayer loopback-primary Stages 0–4;
+Snapshot date: 2026-07-24 (SiloPlayer AirPlay hardware validation;
+SiloPlayer loopback-primary Stages 0–4 validated 2026-07-03;
 previous snapshot 2026-04-29 at `6c2b4af`)
 
 This matrix is the implementation-facing truth source for the current Apple
@@ -39,7 +40,7 @@ player routes in `silo-apple`. It separates:
 | tvOS custom shell / Siri Remote ownership | Repo-verified | Repo-verified | Repo-verified | Repo-verified |
 | Now Playing / remote commands | Repo-verified | Repo-verified | Repo-verified | Repo-verified |
 | PiP | Unsupported | Validation required | Validation required | Validation required |
-| AirPlay / external playback | Unclaimed | Unclaimed | Unclaimed | Unclaimed |
+| AirPlay / external playback | Unsupported | Validation required | Validation required | Repo-verified |
 | Premium HDR / DV / Atmos claims | Validation required | Validation required | Validation required | Validation required |
 
 ## Notes
@@ -61,7 +62,13 @@ player routes in `silo-apple`. It separates:
   delay/styling. The capability rows above describe what Silo can
   promise on each route; they are not a claim about every embedded subtitle
   on a NativePlayer or SiloPlayer asset.
-- PiP and external playback stay intentionally conservative until Silo has
-  route-specific lifecycle handling, UI, and device/output validation.
+- PiP stays intentionally conservative until Silo has route-specific lifecycle
+  handling and device/output validation. AirPlay UI and AVPlayer external
+  playback are enabled on NativePlayer and SiloPlayer routes. On iOS,
+  SiloPlayer publishes its generated HLS through a session-secret LAN URL so
+  the selected receiver can fetch the playlist and segments. SiloPlayer AirPlay
+  was hardware-validated 2026-07-24 from an iPhone 16 Pro to Apple TV with a
+  Dolby Vision source. This validates external playback for that route, not a
+  generalized Dolby Vision output-mode or premium-format claim.
 - Premium-media claims stay validation-gated even when playback itself uses a
   NativePlayer or SiloPlayer route.

--- a/iosApp/Tests/LoopbackSegmentServerRangeTests.swift
+++ b/iosApp/Tests/LoopbackSegmentServerRangeTests.swift
@@ -30,7 +30,21 @@ final class LoopbackSegmentServerRangeTests: XCTestCase {
         XCTAssertTrue(LoopbackSegmentServer.isPrivateIPv4Address("192.168.1.10"))
         XCTAssertTrue(LoopbackSegmentServer.isPrivateIPv4Address("169.254.2.3"))
         XCTAssertFalse(LoopbackSegmentServer.isPrivateIPv4Address("8.8.8.8"))
+        XCTAssertFalse(LoopbackSegmentServer.isPrivateIPv4Address("10.0.0.999"))
+        XCTAssertFalse(LoopbackSegmentServer.isPrivateIPv4Address("10.-1.0.1"))
         XCTAssertFalse(LoopbackSegmentServer.isPrivateIPv4Address("not-an-address"))
+    }
+
+    func testLANExposureUsesLoopbackURLBeforeExternalHandoff() throws {
+        let server = LoopbackSegmentServer(
+            segmentStore: LoopbackSegmentStore(generation: 1),
+            exposure: .localNetwork
+        )
+
+        let url = try XCTUnwrap(server.resourceURL(for: "master.m3u8"))
+        XCTAssertEqual(url.host, "127.0.0.1")
+        XCTAssertTrue(url.path.hasSuffix("/master.m3u8"))
+        XCTAssertNotEqual(url.path, "/master.m3u8")
     }
 
     func testAdvertisedVODSegmentMissRetriesInsteadOf404() {

--- a/iosApp/Tests/LoopbackSegmentServerRangeTests.swift
+++ b/iosApp/Tests/LoopbackSegmentServerRangeTests.swift
@@ -1,3 +1,4 @@
+import Network
 import XCTest
 @testable import Silo
 
@@ -24,15 +25,28 @@ final class LoopbackSegmentServerRangeTests: XCTestCase {
         )
     }
 
-    func testPrivateIPv4AddressSelectionExcludesPublicAddresses() {
+    func testPrivateIPv4AddressSelectionExcludesPublicAndLinkLocalAddresses() {
         XCTAssertTrue(LoopbackSegmentServer.isPrivateIPv4Address("10.0.0.4"))
         XCTAssertTrue(LoopbackSegmentServer.isPrivateIPv4Address("172.20.1.2"))
         XCTAssertTrue(LoopbackSegmentServer.isPrivateIPv4Address("192.168.1.10"))
-        XCTAssertTrue(LoopbackSegmentServer.isPrivateIPv4Address("169.254.2.3"))
+        // Link-local means DHCP never completed; a receiver on the real subnet
+        // cannot route to it.
+        XCTAssertFalse(LoopbackSegmentServer.isPrivateIPv4Address("169.254.2.3"))
         XCTAssertFalse(LoopbackSegmentServer.isPrivateIPv4Address("8.8.8.8"))
         XCTAssertFalse(LoopbackSegmentServer.isPrivateIPv4Address("10.0.0.999"))
         XCTAssertFalse(LoopbackSegmentServer.isPrivateIPv4Address("10.-1.0.1"))
         XCTAssertFalse(LoopbackSegmentServer.isPrivateIPv4Address("not-an-address"))
+    }
+
+    func testAdvertisedInterfaceExcludesCellularAndTunnels() {
+        XCTAssertTrue(LoopbackSegmentServer.isReceiverReachableInterface("en0"))
+        XCTAssertTrue(LoopbackSegmentServer.isReceiverReachableInterface("en1"))
+        XCTAssertTrue(LoopbackSegmentServer.isReceiverReachableInterface("bridge100"))
+        XCTAssertFalse(LoopbackSegmentServer.isReceiverReachableInterface("pdp_ip0"))
+        XCTAssertFalse(LoopbackSegmentServer.isReceiverReachableInterface("utun3"))
+        XCTAssertFalse(LoopbackSegmentServer.isReceiverReachableInterface("ipsec0"))
+        XCTAssertFalse(LoopbackSegmentServer.isReceiverReachableInterface("awdl0"))
+        XCTAssertFalse(LoopbackSegmentServer.isReceiverReachableInterface("llw0"))
     }
 
     func testLANExposureUsesLoopbackURLBeforeExternalHandoff() throws {
@@ -45,6 +59,31 @@ final class LoopbackSegmentServerRangeTests: XCTestCase {
         XCTAssertEqual(url.host, "127.0.0.1")
         XCTAssertTrue(url.path.hasSuffix("/master.m3u8"))
         XCTAssertNotEqual(url.path, "/master.m3u8")
+    }
+
+    func testResourceURLLogRedactionHidesTheSessionToken() throws {
+        let server = LoopbackSegmentServer(
+            segmentStore: LoopbackSegmentStore(generation: 2),
+            exposure: .localNetwork
+        )
+
+        let url = try XCTUnwrap(server.resourceURL(for: "master.m3u8"))
+        let token = try XCTUnwrap(url.pathComponents.dropFirst().first)
+        let redacted = server.redactingAccessToken(in: url.absoluteString)
+
+        XCTAssertFalse(redacted.contains(token))
+        XCTAssertTrue(redacted.contains("master.m3u8"))
+    }
+
+    func testOffDevicePeerClassificationTreatsUnknownEndpointsAsLocal() {
+        XCTAssertFalse(LoopbackSegmentServer.isOffDevicePeer(.hostPort(host: .ipv4(.loopback), port: 8080)))
+        XCTAssertFalse(LoopbackSegmentServer.isOffDevicePeer(.hostPort(host: .ipv6(.loopback), port: 8080)))
+        XCTAssertFalse(LoopbackSegmentServer.isOffDevicePeer(.hostPort(host: .name("localhost", nil), port: 8080)))
+        XCTAssertTrue(
+            LoopbackSegmentServer.isOffDevicePeer(
+                .hostPort(host: .ipv4(IPv4Address("192.168.1.42")!), port: 8080)
+            )
+        )
     }
 
     func testAdvertisedVODSegmentMissRetriesInsteadOf404() {

--- a/iosApp/Tests/LoopbackSegmentServerRangeTests.swift
+++ b/iosApp/Tests/LoopbackSegmentServerRangeTests.swift
@@ -2,6 +2,37 @@ import XCTest
 @testable import Silo
 
 final class LoopbackSegmentServerRangeTests: XCTestCase {
+    func testLANAccessTokenAuthorizesOnlyItsResourcePrefix() {
+        XCTAssertEqual(
+            LoopbackSegmentServer.authorizedResourcePath(
+                "/session-secret/master.m3u8",
+                accessToken: "session-secret"
+            ),
+            "master.m3u8"
+        )
+        XCTAssertNil(
+            LoopbackSegmentServer.authorizedResourcePath(
+                "/other-session/master.m3u8",
+                accessToken: "session-secret"
+            )
+        )
+        XCTAssertNil(
+            LoopbackSegmentServer.authorizedResourcePath(
+                "/master.m3u8",
+                accessToken: "session-secret"
+            )
+        )
+    }
+
+    func testPrivateIPv4AddressSelectionExcludesPublicAddresses() {
+        XCTAssertTrue(LoopbackSegmentServer.isPrivateIPv4Address("10.0.0.4"))
+        XCTAssertTrue(LoopbackSegmentServer.isPrivateIPv4Address("172.20.1.2"))
+        XCTAssertTrue(LoopbackSegmentServer.isPrivateIPv4Address("192.168.1.10"))
+        XCTAssertTrue(LoopbackSegmentServer.isPrivateIPv4Address("169.254.2.3"))
+        XCTAssertFalse(LoopbackSegmentServer.isPrivateIPv4Address("8.8.8.8"))
+        XCTAssertFalse(LoopbackSegmentServer.isPrivateIPv4Address("not-an-address"))
+    }
+
     func testAdvertisedVODSegmentMissRetriesInsteadOf404() {
         XCTAssertEqual(
             LoopbackSegmentServer.vodMissingResponseKind(index: 5, segmentCount: 10),

--- a/iosApp/Tests/LoopbackStartupRecoveryPolicyTests.swift
+++ b/iosApp/Tests/LoopbackStartupRecoveryPolicyTests.swift
@@ -3,51 +3,105 @@ import XCTest
 @testable import Silo
 
 final class LoopbackStartupRecoveryPolicyTests: XCTestCase {
+    private func transportContext(
+        _ status: AVPlayer.TimeControlStatus,
+        isUserPaused: Bool = false,
+        systemControlsAreActive: Bool = true,
+        isInitialObservation: Bool = false,
+        hasStartedPlayback: Bool = true,
+        isSeekInFlight: Bool = false,
+        isBufferStarved: Bool = false,
+        hasReachedEnd: Bool = false
+    ) -> AVPlayerSystemTransportIntent.Context {
+        .init(
+            timeControlStatus: status,
+            isUserPaused: isUserPaused,
+            systemControlsAreActive: systemControlsAreActive,
+            isInitialObservation: isInitialObservation,
+            hasStartedPlayback: hasStartedPlayback,
+            isSeekInFlight: isSeekInFlight,
+            isBufferStarved: isBufferStarved,
+            hasReachedEnd: hasReachedEnd
+        )
+    }
+
     func testSystemTransportChangesReconcileOnlyWhenIntentDiffers() {
         XCTAssertEqual(
-            AVPlayerSystemTransportIntent.resolve(
-                timeControlStatus: .paused,
-                isUserPaused: false,
-                systemControlsAreActive: true
-            ),
+            AVPlayerSystemTransportIntent.resolve(transportContext(.paused)),
             .pause
         )
         XCTAssertEqual(
             AVPlayerSystemTransportIntent.resolve(
-                timeControlStatus: .playing,
-                isUserPaused: true,
-                systemControlsAreActive: true
+                transportContext(.playing, isUserPaused: true)
             ),
             .play
         )
         XCTAssertEqual(
             AVPlayerSystemTransportIntent.resolve(
-                timeControlStatus: .waitingToPlayAtSpecifiedRate,
-                isUserPaused: true,
-                systemControlsAreActive: true
+                transportContext(.waitingToPlayAtSpecifiedRate, isUserPaused: true)
             ),
             .play
         )
         XCTAssertNil(
             AVPlayerSystemTransportIntent.resolve(
-                timeControlStatus: .paused,
-                isUserPaused: true,
-                systemControlsAreActive: true
+                transportContext(.paused, isUserPaused: true)
             )
         )
         XCTAssertNil(
             AVPlayerSystemTransportIntent.resolve(
-                timeControlStatus: .waitingToPlayAtSpecifiedRate,
-                isUserPaused: false,
-                systemControlsAreActive: true
+                transportContext(.waitingToPlayAtSpecifiedRate)
             )
         )
         XCTAssertNil(
             AVPlayerSystemTransportIntent.resolve(
-                timeControlStatus: .paused,
-                isUserPaused: false,
-                systemControlsAreActive: false
+                transportContext(.paused, systemControlsAreActive: false)
             )
+        )
+    }
+
+    /// The player is paused at every one of these moments for reasons that
+    /// have nothing to do with the receiver or the PiP window. Reading any of
+    /// them as a pause command latches `isUserPaused`, and every loopback
+    /// stall-recovery path is gated on `!isUserPaused`.
+    func testPlayerOwnPauseTransitionsAreNotTransportCommands() {
+        // `.initial` KVO delivery on a freshly attached item.
+        XCTAssertNil(
+            AVPlayerSystemTransportIntent.resolve(
+                transportContext(.paused, isInitialObservation: true, hasStartedPlayback: false)
+            )
+        )
+        // Pre-roll: item attached, initial resume seek not issued yet.
+        XCTAssertNil(
+            AVPlayerSystemTransportIntent.resolve(
+                transportContext(.paused, hasStartedPlayback: false)
+            )
+        )
+        // Mid-scrub.
+        XCTAssertNil(
+            AVPlayerSystemTransportIntent.resolve(
+                transportContext(.paused, isSeekInFlight: true)
+            )
+        )
+        // Buffer underrun on the loopback route.
+        XCTAssertNil(
+            AVPlayerSystemTransportIntent.resolve(
+                transportContext(.paused, isBufferStarved: true)
+            )
+        )
+        // End of file.
+        XCTAssertNil(
+            AVPlayerSystemTransportIntent.resolve(
+                transportContext(.paused, hasReachedEnd: true)
+            )
+        )
+    }
+
+    func testResumeFromTheReceiverStillReconcilesAfterAStall() {
+        XCTAssertEqual(
+            AVPlayerSystemTransportIntent.resolve(
+                transportContext(.playing, isUserPaused: true, isBufferStarved: true)
+            ),
+            .play
         )
     }
 

--- a/iosApp/Tests/LoopbackStartupRecoveryPolicyTests.swift
+++ b/iosApp/Tests/LoopbackStartupRecoveryPolicyTests.swift
@@ -96,6 +96,45 @@ final class LoopbackStartupRecoveryPolicyTests: XCTestCase {
         )
     }
 
+    func testExternalPlaybackIsOfferedOnlyForAssetsAReceiverCanFetch() {
+        // Server-hosted stream: authenticated by a header the receiver cannot
+        // send.
+        XCTAssertFalse(
+            AVPlayerBackend.isReceiverFetchableAsset(
+                url: URL(string: "https://silo.example.com/api/v1/stream/abc?st=xyz")!,
+                headers: ["Authorization": "Bearer token"]
+            )
+        )
+        // The same session behind the on-device source proxy: no headers, but
+        // 127.0.0.1 means nothing to an Apple TV.
+        XCTAssertFalse(
+            AVPlayerBackend.isReceiverFetchableAsset(
+                url: URL(string: "http://127.0.0.1:52341/source/abc")!,
+                headers: [:]
+            )
+        )
+        XCTAssertFalse(
+            AVPlayerBackend.isReceiverFetchableAsset(
+                url: URL(string: "http://localhost:52341/source/abc")!,
+                headers: [:]
+            )
+        )
+        // Offline download.
+        XCTAssertTrue(
+            AVPlayerBackend.isReceiverFetchableAsset(
+                url: URL(fileURLWithPath: "/var/mobile/Containers/Data/download.mp4"),
+                headers: [:]
+            )
+        )
+        // Unauthenticated origin URL.
+        XCTAssertTrue(
+            AVPlayerBackend.isReceiverFetchableAsset(
+                url: URL(string: "https://cdn.example.com/clip.mp4")!,
+                headers: [:]
+            )
+        )
+    }
+
     func testResumeFromTheReceiverStillReconcilesAfterAStall() {
         XCTAssertEqual(
             AVPlayerSystemTransportIntent.resolve(

--- a/iosApp/Tests/LoopbackStartupRecoveryPolicyTests.swift
+++ b/iosApp/Tests/LoopbackStartupRecoveryPolicyTests.swift
@@ -1,7 +1,56 @@
+import AVFoundation
 import XCTest
 @testable import Silo
 
 final class LoopbackStartupRecoveryPolicyTests: XCTestCase {
+    func testSystemTransportChangesReconcileOnlyWhenIntentDiffers() {
+        XCTAssertEqual(
+            AVPlayerSystemTransportIntent.resolve(
+                timeControlStatus: .paused,
+                isUserPaused: false,
+                systemControlsAreActive: true
+            ),
+            .pause
+        )
+        XCTAssertEqual(
+            AVPlayerSystemTransportIntent.resolve(
+                timeControlStatus: .playing,
+                isUserPaused: true,
+                systemControlsAreActive: true
+            ),
+            .play
+        )
+        XCTAssertEqual(
+            AVPlayerSystemTransportIntent.resolve(
+                timeControlStatus: .waitingToPlayAtSpecifiedRate,
+                isUserPaused: true,
+                systemControlsAreActive: true
+            ),
+            .play
+        )
+        XCTAssertNil(
+            AVPlayerSystemTransportIntent.resolve(
+                timeControlStatus: .paused,
+                isUserPaused: true,
+                systemControlsAreActive: true
+            )
+        )
+        XCTAssertNil(
+            AVPlayerSystemTransportIntent.resolve(
+                timeControlStatus: .waitingToPlayAtSpecifiedRate,
+                isUserPaused: false,
+                systemControlsAreActive: true
+            )
+        )
+        XCTAssertNil(
+            AVPlayerSystemTransportIntent.resolve(
+                timeControlStatus: .paused,
+                isUserPaused: false,
+                systemControlsAreActive: false
+            )
+        )
+    }
+
     func testAudioSessionActivationStateRejectsStaleCompletionAndDeactivates() {
         var state = AVPlayerAudioSessionActivationState()
         let first = state.beginActivation()

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
@@ -200,6 +200,27 @@ struct LoopbackItemDeathConfirmationState {
     }
 }
 
+enum AVPlayerSystemTransportIntent: Equatable {
+    case play
+    case pause
+
+    static func resolve(
+        timeControlStatus: AVPlayer.TimeControlStatus,
+        isUserPaused: Bool,
+        systemControlsAreActive: Bool
+    ) -> Self? {
+        guard systemControlsAreActive else { return nil }
+        switch timeControlStatus {
+        case .paused:
+            return isUserPaused ? nil : .pause
+        case .waitingToPlayAtSpecifiedRate, .playing:
+            return isUserPaused ? .play : nil
+        default:
+            return nil
+        }
+    }
+}
+
 struct AVPlayerAudioSessionActivationState {
     struct Request: Equatable {
         let id: UInt64
@@ -514,6 +535,15 @@ final class AVPlayerBackend {
     var onTracksChange: (([PlayerTrack]) -> Void)?
     var onChaptersChange: (([PlayerChapterInfo]) -> Void)?
     var onTimelineOffsetChange: ((Double) -> Void)?
+    /// AirPlay video handoff started (`true`) or ended (`false`). Bound for
+    /// the player's whole lifetime rather than per item, because the route can
+    /// change while the app is backgrounded and no item-scoped event reports
+    /// it.
+    var onExternalPlaybackActiveChange: ((Bool) -> Void)?
+    /// PiP controls mutate `AVPlayer` directly instead of calling this
+    /// backend's `play()` / `pause()` methods. The shell supplies PiP ownership
+    /// here so transport KVO can reconcile those changes into Silo's intent.
+    var isPictureInPictureActiveProvider: (() -> Bool)?
     var onSidecarTracksRegistered: (([SidecarSubtitleDescriptor]) -> Void)?
     var onSubtitleLoadStatusChange: ((SubtitleSlot, SubtitleLoadStatus) -> Void)?
     /// Temporary [CMP-MEM]: source-proxy cache stats for the periodic
@@ -696,6 +726,8 @@ final class AVPlayerBackend {
     private var segmentWriter: LoopbackSegmentWriter?
     private var segmentServer: LoopbackSegmentServer?
     private var segmentStore: LoopbackSegmentStore?
+    private var loopbackPlaylistName: String?
+    private var loopbackPlaybackUsesExternalURL = false
     private var sessionDirectory: URL?
     private var activeLoopbackSessionID: String?
     private var loopbackGeneration: UInt64 = 0
@@ -749,11 +781,30 @@ final class AVPlayerBackend {
     private var durationObs: NSKeyValueObservation?
     private var loadedRangesObs: NSKeyValueObservation?
     private var seekableRangesObs: NSKeyValueObservation?
+    private var externalPlaybackObs: NSKeyValueObservation?
     private var endObserver: NSObjectProtocol?
 
     init() {
         avPlayer.allowsExternalPlayback = true
+        #if !os(macOS)
+        // Mirrored-display handoff is an iOS/tvOS concept; macOS has no
+        // equivalent and the property is unavailable there.
         avPlayer.usesExternalPlaybackWhileExternalScreenIsActive = true
+        #endif
+        // Player-scoped, not item-scoped: `detachPerItemObservers()` runs on
+        // every reanchor/quality switch and would otherwise blind us to route
+        // changes mid-session. Invalidated in `dispose()`.
+        externalPlaybackObs = avPlayer.observe(
+            \.isExternalPlaybackActive,
+            options: [.new]
+        ) { [weak self] player, _ in
+            let active = player.isExternalPlaybackActive
+            Task { @MainActor [weak self] in
+                guard let self, !self.isDisposed else { return }
+                self.updateLoopbackURLForExternalPlayback(active)
+                self.onExternalPlaybackActiveChange?(active)
+            }
+        }
 
         let session = SubtitleSession()
         session.onSidecarTracksRegistered = { [weak self] descriptors in
@@ -836,12 +887,58 @@ final class AVPlayerBackend {
         avPlayer.pause()
     }
 
+    @discardableResult
+    private func reconcileSystemTransportIntent(from player: AVPlayer) -> Bool {
+        let systemControlsAreActive = player.isExternalPlaybackActive
+            || isPictureInPictureActiveProvider?() == true
+        guard let intent = AVPlayerSystemTransportIntent.resolve(
+            timeControlStatus: player.timeControlStatus,
+            isUserPaused: isUserPaused,
+            systemControlsAreActive: systemControlsAreActive
+        ) else { return false }
+
+        switch intent {
+        case .play:
+            Self.logger.info("System transport requested play")
+            play()
+        case .pause:
+            Self.logger.info("System transport requested pause")
+            pause()
+        }
+        return true
+    }
+
     func prepareToBackground() {
         pause()
     }
 
     var isExternalPlaybackActive: Bool {
         avPlayer.isExternalPlaybackActive
+    }
+
+    @MainActor
+    private func updateLoopbackURLForExternalPlayback(_ active: Bool) {
+        guard active != loopbackPlaybackUsesExternalURL,
+              case .some(.siloLoopback) = currentSourceStrategy,
+              let item = currentItem,
+              let server = segmentServer,
+              let playlistName = loopbackPlaylistName else { return }
+        guard let url = server.resourceURL(
+            for: playlistName,
+            reachableFromExternalDevice: active
+        ) else {
+            Self.logger.error("AirPlay handoff could not determine a reachable local network address")
+            return
+        }
+
+        let position = currentTime()
+        loopbackPlaybackUsesExternalURL = active
+        reloadEstablishedLoopbackItem(
+            item,
+            at: position.isFinite ? max(0, position) : 0,
+            reason: active ? "airplay_started" : "airplay_ended",
+            replacementURL: url
+        )
     }
 
     func videoSurfaceBecameReadyForDisplay() {
@@ -1096,6 +1193,10 @@ final class AVPlayerBackend {
         guard !isDisposed else { return }
         isDisposed = true
         Self.logger.info("[CMP-AVP] dispose")
+        externalPlaybackObs?.invalidate()
+        externalPlaybackObs = nil
+        onExternalPlaybackActiveChange = nil
+        isPictureInPictureActiveProvider = nil
         teardownMediaPipeline()
     }
 
@@ -1658,7 +1759,8 @@ final class AVPlayerBackend {
     private func reloadEstablishedLoopbackItem(
         _ oldItem: AVPlayerItem,
         at playerSeconds: Double,
-        reason: String
+        reason: String,
+        replacementURL: URL? = nil
     ) {
         guard oldItem === currentItem,
               let asset = oldItem.asset as? AVURLAsset else { return }
@@ -1666,7 +1768,8 @@ final class AVPlayerBackend {
         oldItem.cancelPendingSeeks()
         detachPerItemObservers()
 
-        let item = AVPlayerItem(asset: AVURLAsset(url: asset.url))
+        let itemURL = replacementURL ?? asset.url
+        let item = AVPlayerItem(asset: AVURLAsset(url: itemURL))
         item.preferredForwardBufferDuration = max(
             oldItem.preferredForwardBufferDuration,
             Self.loopbackStartupForwardBuffer
@@ -1682,7 +1785,7 @@ final class AVPlayerBackend {
             avPlayer.play()
         }
         cmpLog(
-            "[CMP-AVP] established loopback item reloaded reason=\(reason) player=\(playerSeconds) url=\(asset.url.absoluteString)"
+            "[CMP-AVP] established loopback item reloaded reason=\(reason) player=\(playerSeconds) url=\(itemURL.absoluteString)"
         )
     }
 
@@ -1973,10 +2076,16 @@ final class AVPlayerBackend {
     private func handleFirstSegmentReady(playlistName: String, sessionID: String) {
         guard activeLoopbackSessionID == sessionID else { return }
         guard !isDisposed, currentItem == nil, let server = segmentServer else { return }
-        guard let url = server.resourceURL(for: playlistName) else {
-            reportError("AirPlay-ready HLS server could not determine the phone's local network address.")
+        let useExternalURL = avPlayer.isExternalPlaybackActive
+        guard let url = server.resourceURL(
+            for: playlistName,
+            reachableFromExternalDevice: useExternalURL
+        ) else {
+            reportError("AirPlay handoff could not determine a reachable local network address.")
             return
         }
+        loopbackPlaylistName = playlistName
+        loopbackPlaybackUsesExternalURL = useExternalURL
         cmpLog("[CMP-AVP] local playlist ready host=\(url.host ?? "unknown")")
         if ttffFirstSegmentMs == nil { ttffFirstSegmentMs = ttffElapsedMs() }
         logTVDisplayManagerState(context: "before_prepare_\(playlistName)")
@@ -2997,6 +3106,7 @@ final class AVPlayerBackend {
         timeControlObs = avPlayer.observe(\.timeControlStatus, options: [.new, .initial]) { [weak self] player, _ in
             DispatchQueue.main.async { [weak self] in
                 guard let self, !self.isDisposed else { return }
+                if self.reconcileSystemTransportIntent(from: player) { return }
                 guard case .siloLoopback = self.currentSourceStrategy else { return }
                 let status: String
                 switch player.timeControlStatus {
@@ -4104,6 +4214,8 @@ final class AVPlayerBackend {
         loopbackSubtitleTap?.deactivate()
         embeddedSubtitleExtractor?.teardown()
         activeLoopbackSessionID = nil
+        loopbackPlaylistName = nil
+        loopbackPlaybackUsesExternalURL = false
         isInitialSeekInFlight = false
         initialSeekRetryCount = 0
         isInitialVideoDisplayGatePrepared = false

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
@@ -752,6 +752,9 @@ final class AVPlayerBackend {
     private var endObserver: NSObjectProtocol?
 
     init() {
+        avPlayer.allowsExternalPlayback = true
+        avPlayer.usesExternalPlaybackWhileExternalScreenIsActive = true
+
         let session = SubtitleSession()
         session.onSidecarTracksRegistered = { [weak self] descriptors in
             self?.onSidecarTracksRegistered?(descriptors)
@@ -835,6 +838,10 @@ final class AVPlayerBackend {
 
     func prepareToBackground() {
         pause()
+    }
+
+    var isExternalPlaybackActive: Bool {
+        avPlayer.isExternalPlaybackActive
     }
 
     func videoSurfaceBecameReadyForDisplay() {
@@ -1710,7 +1717,11 @@ final class AVPlayerBackend {
             print("[CMP-AVP] preserving local DV artifacts due to SILO_KEEP_DV_HLS=1 dir=\(sessionDir.path)")
         }
 
+        #if os(iOS)
+        let server = LoopbackSegmentServer(segmentStore: store, exposure: .localNetwork)
+        #else
         let server = LoopbackSegmentServer(segmentStore: store)
+        #endif
         if sessionSpec.servingMode == .vodPlan {
             // A miss under the static VOD playlist means "not produced (yet)
             // or pruned": request a coalesced producer restart on main, then
@@ -1962,8 +1973,11 @@ final class AVPlayerBackend {
     private func handleFirstSegmentReady(playlistName: String, sessionID: String) {
         guard activeLoopbackSessionID == sessionID else { return }
         guard !isDisposed, currentItem == nil, let server = segmentServer else { return }
-        let url = URL(string: "http://127.0.0.1:\(server.port)/\(playlistName)")!
-        cmpLog("[CMP-AVP] local playlist ready \(url.absoluteString)")
+        guard let url = server.resourceURL(for: playlistName) else {
+            reportError("AirPlay-ready HLS server could not determine the phone's local network address.")
+            return
+        }
+        cmpLog("[CMP-AVP] local playlist ready host=\(url.host ?? "unknown")")
         if ttffFirstSegmentMs == nil { ttffFirstSegmentMs = ttffElapsedMs() }
         logTVDisplayManagerState(context: "before_prepare_\(playlistName)")
         // The criteria write always happens synchronously before the item is

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
@@ -200,21 +200,54 @@ struct LoopbackItemDeathConfirmationState {
     }
 }
 
+/// Transport commands issued outside the app: the AirPlay receiver's remote,
+/// or the PiP window's play/pause button. Both mutate `AVPlayer` directly
+/// instead of calling the backend, so the only evidence is a
+/// `timeControlStatus` transition.
+///
+/// That signal is noisy — the player also stops and starts on its own during
+/// startup, seeks, stalls, and at end of file — so a transition only counts as
+/// a command when nothing else explains it. Reading a stall as a receiver
+/// pause is the expensive mistake: it latches `isUserPaused`, and every
+/// loopback stall-recovery path is gated on `!isUserPaused`, so the session
+/// would wedge with no way back.
 enum AVPlayerSystemTransportIntent: Equatable {
     case play
     case pause
 
-    static func resolve(
-        timeControlStatus: AVPlayer.TimeControlStatus,
-        isUserPaused: Bool,
-        systemControlsAreActive: Bool
-    ) -> Self? {
-        guard systemControlsAreActive else { return nil }
-        switch timeControlStatus {
+    /// Everything the backend knows about why the transport state may have
+    /// moved without us asking.
+    struct Context {
+        let timeControlStatus: AVPlayer.TimeControlStatus
+        let isUserPaused: Bool
+        /// AirPlay handoff or PiP owns the transport UI right now.
+        let systemControlsAreActive: Bool
+        /// The first KVO delivery reports the state the player was already in
+        /// (`.paused`, pre-roll) rather than a transition, so it carries no
+        /// intent.
+        let isInitialObservation: Bool
+        /// False until the initial start/resume seek has been issued; before
+        /// that the player is legitimately parked at rate 0.
+        let hasStartedPlayback: Bool
+        let isSeekInFlight: Bool
+        /// The loopback route runs with `automaticallyWaitsToMinimizeStalling`
+        /// off, so a drained buffer stops the player outright.
+        let isBufferStarved: Bool
+        let hasReachedEnd: Bool
+    }
+
+    static func resolve(_ context: Context) -> Self? {
+        guard context.systemControlsAreActive,
+              !context.isInitialObservation,
+              context.hasStartedPlayback,
+              !context.isSeekInFlight,
+              !context.hasReachedEnd else { return nil }
+        switch context.timeControlStatus {
         case .paused:
-            return isUserPaused ? nil : .pause
+            guard !context.isBufferStarved else { return nil }
+            return context.isUserPaused ? nil : .pause
         case .waitingToPlayAtSpecifiedRate, .playing:
-            return isUserPaused ? .play : nil
+            return context.isUserPaused ? .play : nil
         default:
             return nil
         }
@@ -540,6 +573,13 @@ final class AVPlayerBackend {
     /// change while the app is backgrounded and no item-scoped event reports
     /// it.
     var onExternalPlaybackActiveChange: ((Bool) -> Void)?
+    /// Whether the current route can hand video to an AirPlay receiver at all.
+    /// Drives the visibility of the route picker: offering it on a route the
+    /// receiver cannot fetch just produces a dead TV screen.
+    var onExternalPlaybackAllowedChange: ((Bool) -> Void)?
+    /// An AirPlay handoff was attempted but no LAN address the receiver could
+    /// reach exists. Playback stays on this device; the shell tells the user.
+    var onExternalPlaybackUnavailable: (() -> Void)?
     /// PiP controls mutate `AVPlayer` directly instead of calling this
     /// backend's `play()` / `pause()` methods. The shell supplies PiP ownership
     /// here so transport KVO can reconcile those changes into Silo's intent.
@@ -743,6 +783,12 @@ final class AVPlayerBackend {
     private var watchdogReanchorWindowStartWall: CFTimeInterval = 0
     private var didEscalateLoopbackStall = false
     private var isUserPaused = false
+    /// Guards `reconcileSystemTransportIntent` against the `.initial` KVO
+    /// delivery, which reports pre-roll state rather than a transport command.
+    private var hasObservedTimeControlStatus = false
+    /// True between `AVPlayerItemDidPlayToEndTime` and the next load or seek.
+    /// The player parks at rate 0 there, which is not a receiver pause.
+    private var hasReachedItemEnd = false
     private var preserveSessionDirectory = false
     private var isPreservingTVDisplayCriteriaForReload = false
 
@@ -785,11 +831,13 @@ final class AVPlayerBackend {
     private var endObserver: NSObjectProtocol?
 
     init() {
-        avPlayer.allowsExternalPlayback = true
+        // Stays off until a route that the receiver can actually fetch is
+        // loaded; `applyExternalPlaybackPolicy(for:)` opens it per strategy.
+        avPlayer.allowsExternalPlayback = false
         #if !os(macOS)
         // Mirrored-display handoff is an iOS/tvOS concept; macOS has no
         // equivalent and the property is unavailable there.
-        avPlayer.usesExternalPlaybackWhileExternalScreenIsActive = true
+        avPlayer.usesExternalPlaybackWhileExternalScreenIsActive = false
         #endif
         // Player-scoped, not item-scoped: `detachPerItemObservers()` runs on
         // every reanchor/quality switch and would otherwise blind us to route
@@ -888,13 +936,23 @@ final class AVPlayerBackend {
     }
 
     @discardableResult
-    private func reconcileSystemTransportIntent(from player: AVPlayer) -> Bool {
+    private func reconcileSystemTransportIntent(
+        from player: AVPlayer,
+        isInitialObservation: Bool
+    ) -> Bool {
         let systemControlsAreActive = player.isExternalPlaybackActive
             || isPictureInPictureActiveProvider?() == true
         guard let intent = AVPlayerSystemTransportIntent.resolve(
-            timeControlStatus: player.timeControlStatus,
-            isUserPaused: isUserPaused,
-            systemControlsAreActive: systemControlsAreActive
+            .init(
+                timeControlStatus: player.timeControlStatus,
+                isUserPaused: isUserPaused,
+                systemControlsAreActive: systemControlsAreActive,
+                isInitialObservation: isInitialObservation,
+                hasStartedPlayback: hasSeekedToStart,
+                isSeekInFlight: isSeekPending || isInitialSeekInFlight,
+                isBufferStarved: currentItem?.isPlaybackBufferEmpty == true,
+                hasReachedEnd: hasReachedItemEnd
+            )
         ) else { return false }
 
         switch intent {
@@ -916,6 +974,44 @@ final class AVPlayerBackend {
         avPlayer.isExternalPlaybackActive
     }
 
+    var isExternalPlaybackAllowed: Bool {
+        avPlayer.allowsExternalPlayback
+    }
+
+    /// AirPlay video hands the receiver a *URL*, which it fetches itself with
+    /// none of the asset's HTTP headers. Any route whose stream URL is
+    /// authenticated by an `Authorization` header therefore 401s on the
+    /// receiver, so external playback is only offered where the receiver can
+    /// genuinely fetch the media: the loopback route on iOS (LAN server, token
+    /// in the path) and header-less assets such as offline `file://`
+    /// downloads.
+    private func applyExternalPlaybackPolicy(for strategy: SourceStrategy) {
+        let allowed: Bool
+        switch strategy {
+        case .siloLoopback:
+            // Only the iOS loopback server is LAN-reachable; elsewhere it
+            // binds to 127.0.0.1 and no receiver could ever fetch it.
+            #if os(iOS)
+            allowed = true
+            #else
+            allowed = false
+            #endif
+        case .remoteHLS(_, let headers), .remoteDirect(_, let headers):
+            allowed = headers.isEmpty
+        }
+        setExternalPlaybackAllowed(allowed)
+    }
+
+    private func setExternalPlaybackAllowed(_ allowed: Bool) {
+        avPlayer.allowsExternalPlayback = allowed
+        #if !os(macOS)
+        // Mirrored-display handoff is an iOS/tvOS concept; macOS has no
+        // equivalent and the property is unavailable there.
+        avPlayer.usesExternalPlaybackWhileExternalScreenIsActive = allowed
+        #endif
+        onExternalPlaybackAllowedChange?(allowed)
+    }
+
     @MainActor
     private func updateLoopbackURLForExternalPlayback(_ active: Bool) {
         guard active != loopbackPlaybackUsesExternalURL,
@@ -927,18 +1023,33 @@ final class AVPlayerBackend {
             for: playlistName,
             reachableFromExternalDevice: active
         ) else {
-            Self.logger.error("AirPlay handoff could not determine a reachable local network address")
+            // The item is still pointed at 127.0.0.1, which the receiver
+            // cannot fetch: leaving it there would strand the TV on a spinner
+            // with nothing on screen here either.
+            abandonExternalPlaybackHandoff()
             return
         }
 
         let position = currentTime()
         loopbackPlaybackUsesExternalURL = active
+        server.setAcceptsExternalClients(active)
         reloadEstablishedLoopbackItem(
             item,
             at: position.isFinite ? max(0, position) : 0,
             reason: active ? "airplay_started" : "airplay_ended",
             replacementURL: url
         )
+    }
+
+    /// No LAN address the receiver could reach (Wi-Fi off, cellular-only, an
+    /// isolated guest network). Bring playback back to this device and say so
+    /// — `allowsExternalPlayback = false` makes AVPlayer render locally again,
+    /// and the `isExternalPlaybackActive` KVO that follows leaves the item on
+    /// the loopback URL it already has.
+    private func abandonExternalPlaybackHandoff() {
+        cmpLog("[CMP-AVP] airplay handoff unavailable: no reachable local network address")
+        setExternalPlaybackAllowed(false)
+        onExternalPlaybackUnavailable?()
     }
 
     func videoSurfaceBecameReadyForDisplay() {
@@ -958,6 +1069,7 @@ final class AVPlayerBackend {
     func seek(to seconds: Double) {
         let mediaSeconds = seconds.isFinite ? max(0, seconds) : 0
         let playerSeconds = playerTime(forMediaTime: mediaSeconds)
+        hasReachedItemEnd = false
         if case .some(.siloLoopback(let spec)) = currentSourceStrategy {
             // VOD serving mode: every seek is in-item. The static playlist
             // covers the whole title; a fetch into never-produced content
@@ -1556,6 +1668,7 @@ final class AVPlayerBackend {
         teardownMediaPipeline(clearDisplayCriteria: !preserveDisplayCriteria)
         isPreservingTVDisplayCriteriaForReload = preserveDisplayCriteria
         currentSourceStrategy = strategy
+        applyExternalPlaybackPolicy(for: strategy)
         currentLoopbackAudioTracks = Self.normalizedLoopbackAudioTracks(for: strategy)
         configureEmbeddedSubtitleExtraction(for: strategy)
         setLoopbackPlaybackClock(0)
@@ -1578,6 +1691,7 @@ final class AVPlayerBackend {
         watchdogLastStateLogWall = 0
         didFireFileLoaded = false
         hasSeekedToStart = false
+        hasReachedItemEnd = false
         pendingStartTime = startTime
         initialSeekRetryCount = 0
         isInitialSeekInFlight = false
@@ -1785,7 +1899,7 @@ final class AVPlayerBackend {
             avPlayer.play()
         }
         cmpLog(
-            "[CMP-AVP] established loopback item reloaded reason=\(reason) player=\(playerSeconds) url=\(itemURL.absoluteString)"
+            "[CMP-AVP] established loopback item reloaded reason=\(reason) player=\(playerSeconds) url=\(loggableURLDescription(itemURL))"
         )
     }
 
@@ -2076,17 +2190,25 @@ final class AVPlayerBackend {
     private func handleFirstSegmentReady(playlistName: String, sessionID: String) {
         guard activeLoopbackSessionID == sessionID else { return }
         guard !isDisposed, currentItem == nil, let server = segmentServer else { return }
-        let useExternalURL = avPlayer.isExternalPlaybackActive
-        guard let url = server.resourceURL(
-            for: playlistName,
-            reachableFromExternalDevice: useExternalURL
-        ) else {
-            reportError("AirPlay handoff could not determine a reachable local network address.")
+        // Starting up with AirPlay already engaged: prefer the LAN address, but
+        // a session that cannot reach one still plays here rather than failing.
+        var useExternalURL = avPlayer.isExternalPlaybackActive
+        var externalURL: URL?
+        if useExternalURL {
+            externalURL = server.resourceURL(for: playlistName, reachableFromExternalDevice: true)
+            if externalURL == nil {
+                useExternalURL = false
+                abandonExternalPlaybackHandoff()
+            }
+        }
+        guard let url = externalURL ?? server.resourceURL(for: playlistName) else {
+            reportError("Local playback server could not produce a playable URL.")
             return
         }
         loopbackPlaylistName = playlistName
         loopbackPlaybackUsesExternalURL = useExternalURL
-        cmpLog("[CMP-AVP] local playlist ready host=\(url.host ?? "unknown")")
+        server.setAcceptsExternalClients(useExternalURL)
+        cmpLog("[CMP-AVP] local playlist ready host=\(url.host ?? "unknown") external=\(useExternalURL ? 1 : 0)")
         if ttffFirstSegmentMs == nil { ttffFirstSegmentMs = ttffElapsedMs() }
         logTVDisplayManagerState(context: "before_prepare_\(playlistName)")
         // The criteria write always happens synchronously before the item is
@@ -3103,10 +3225,18 @@ final class AVPlayerBackend {
             }
         }
 
+        hasObservedTimeControlStatus = false
         timeControlObs = avPlayer.observe(\.timeControlStatus, options: [.new, .initial]) { [weak self] player, _ in
             DispatchQueue.main.async { [weak self] in
                 guard let self, !self.isDisposed else { return }
-                if self.reconcileSystemTransportIntent(from: player) { return }
+                // Deliveries arrive in order on main, so the first one to land
+                // for this observation is `.initial`.
+                let isInitialObservation = !self.hasObservedTimeControlStatus
+                self.hasObservedTimeControlStatus = true
+                if self.reconcileSystemTransportIntent(
+                    from: player,
+                    isInitialObservation: isInitialObservation
+                ) { return }
                 guard case .siloLoopback = self.currentSourceStrategy else { return }
                 let status: String
                 switch player.timeControlStatus {
@@ -3187,6 +3317,7 @@ final class AVPlayerBackend {
             queue: .main
         ) { [weak self] _ in
             guard let self, !self.isDisposed else { return }
+            self.hasReachedItemEnd = true
             self.onEndOfFile?()
         }
 
@@ -3680,7 +3811,7 @@ final class AVPlayerBackend {
             return
         }
         let url = asset.url
-        cmpLog("[CMP-AVP] startup watchdog reloading item in place url=\(url.absoluteString)")
+        cmpLog("[CMP-AVP] startup watchdog reloading item in place url=\(loggableURLDescription(url))")
         detachPerItemObservers()
         let item = AVPlayerItem(asset: AVURLAsset(url: url))
         if case .siloLoopback = currentSourceStrategy {
@@ -4275,6 +4406,17 @@ final class AVPlayerBackend {
         }
     }
 
+    /// Loopback URLs carry the segment server's per-session access token as
+    /// their first path component, and the diagnostics redactor keeps URL
+    /// paths — so the raw string would ship the secret in a support bundle.
+    private func loggableURLDescription(_ url: URL) -> String {
+        redactedLogText(url.absoluteString)
+    }
+
+    private func redactedLogText(_ value: String) -> String {
+        segmentServer?.redactingAccessToken(in: value) ?? value
+    }
+
     private func reportError(_ message: String) {
         cmpLog("[CMP-AVP] ERROR: \(message)")
         onError?(message)
@@ -4387,12 +4529,13 @@ final class AVPlayerBackend {
         let domain = nsError?.domain ?? "unknown"
         let code = nsError?.code ?? 0
         let description = nsError?.localizedDescription ?? "AVPlayer item failed"
-        let failingURL = (nsError?.userInfo[NSURLErrorFailingURLErrorKey] as? URL)?.absoluteString
+        let failingURL = (nsError?.userInfo[NSURLErrorFailingURLErrorKey] as? URL)
+            .map(loggableURLDescription)
         let underlying = (nsError?.userInfo[NSUnderlyingErrorKey] as? NSError).map {
             "\($0.domain)(\($0.code)): \($0.localizedDescription)"
         }
         let latestErrorLog = item.errorLog()?.events.last.map { event in
-            let uri = event.uri ?? "nil"
+            let uri = event.uri.map(redactedLogText) ?? "nil"
             let comment = event.errorComment ?? "nil"
             return "uri=\(uri) status=\(event.errorStatusCode) domain=\(event.errorDomain) comment=\(comment)"
         }

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
@@ -978,13 +978,6 @@ final class AVPlayerBackend {
         avPlayer.allowsExternalPlayback
     }
 
-    /// AirPlay video hands the receiver a *URL*, which it fetches itself with
-    /// none of the asset's HTTP headers. Any route whose stream URL is
-    /// authenticated by an `Authorization` header therefore 401s on the
-    /// receiver, so external playback is only offered where the receiver can
-    /// genuinely fetch the media: the loopback route on iOS (LAN server, token
-    /// in the path) and header-less assets such as offline `file://`
-    /// downloads.
     private func applyExternalPlaybackPolicy(for strategy: SourceStrategy) {
         let allowed: Bool
         switch strategy {
@@ -996,10 +989,37 @@ final class AVPlayerBackend {
             #else
             allowed = false
             #endif
-        case .remoteHLS(_, let headers), .remoteDirect(_, let headers):
-            allowed = headers.isEmpty
+        case .remoteHLS(let url, let headers), .remoteDirect(let url, let headers):
+            allowed = Self.isReceiverFetchableAsset(url: url, headers: headers)
         }
         setExternalPlaybackAllowed(allowed)
+    }
+
+    /// Can an AirPlay receiver fetch this asset itself? It gets the URL and
+    /// nothing else — none of the asset's HTTP headers, and its own network
+    /// stack. Two disqualifiers, both of which occur on direct-play routes:
+    ///
+    /// - Header authentication. Silo's `/api/v1/...` stream URLs carry a
+    ///   bearer token in `Authorization`, and the receiver's fetch gets a 401.
+    /// - A loopback host. `PlayerViewModel.prepareSourceProxy` rewrites
+    ///   direct-play URLs to the on-device caching proxy at 127.0.0.1 *and
+    ///   drops the headers*, so "no headers" on its own is not evidence that
+    ///   anything off-device can reach it.
+    ///
+    /// Local files pass: AVPlayer streams a `file://` asset to the receiver
+    /// itself instead of handing over a URL that means nothing there.
+    static func isReceiverFetchableAsset(url: URL, headers: [String: String]) -> Bool {
+        if url.isFileURL { return true }
+        guard headers.isEmpty,
+              let scheme = url.scheme?.lowercased(),
+              scheme == "http" || scheme == "https" else { return false }
+        return !isLoopbackHost(url.host)
+    }
+
+    static func isLoopbackHost(_ host: String?) -> Bool {
+        guard let host = host?.lowercased() else { return false }
+        if host == "localhost" || host == "::1" || host == "[::1]" { return true }
+        return host.hasPrefix("127.")
     }
 
     private func setExternalPlaybackAllowed(_ allowed: Bool) {

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerSurface.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerSurface.swift
@@ -36,6 +36,9 @@ struct AVPlayerSurface: UIViewRepresentable {
 
     static func dismantleUIView(_ uiView: AVPlayerLayerView, coordinator: ()) {
         uiView.detachSubtitleOverlay()
+        #if os(iOS)
+        PictureInPictureCoordinator.shared.detach(playerLayer: uiView.playerLayer)
+        #endif
     }
 }
 
@@ -72,6 +75,11 @@ final class AVPlayerLayerView: UIView {
         let player = backend.avPlayer
         if playerLayer.player === player { return }
         playerLayer.player = player
+        #if os(iOS)
+        // PiP has to be bound to the live layer, and the layer is only useful
+        // once it actually has a player attached.
+        PictureInPictureCoordinator.shared.attach(playerLayer: playerLayer)
+        #endif
     }
 
     func setVideoGravity(_ gravity: AVLayerVideoGravity) {

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/LoopbackSegmentServer.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/LoopbackSegmentServer.swift
@@ -2,9 +2,10 @@
 //  LoopbackSegmentServer.swift
 //  Continuum (iOS + tvOS) — Dolby Vision Profile 5 AVPlayer route
 //
-//  Tiny HTTP server bound to 127.0.0.1:<random port>. Serves the HLS playlist
-//  and fMP4 segments that `LoopbackSegmentWriter` writes to a session-scoped temp
-//  directory, so AVPlayer can consume them via a URL it accepts natively.
+//  Tiny HTTP server serving the HLS playlist and fMP4 segments that
+//  `LoopbackSegmentWriter` writes to a session-scoped store. It normally binds
+//  to 127.0.0.1; iOS AirPlay sessions bind to the LAN and require a per-session
+//  secret in every resource URL so the receiver can fetch the presentation.
 //
 //  Uses `Network.framework`'s `NWListener` so we pull in zero dependencies.
 //  Rendered on a dedicated `.userInitiated` dispatch queue — the HLS manifest
@@ -25,8 +26,16 @@
 import Foundation
 import Network
 import OSLog
+#if os(iOS)
+import Darwin
+#endif
 
 final class LoopbackSegmentServer {
+    enum Exposure: Equatable {
+        case loopbackOnly
+        case localNetwork
+    }
+
     // Temporary [CMP-LIFE]: session-pool leak attribution.
     deinit { print("[CMP-LIFE] deinit LoopbackSegmentServer") }
     private static let startupRequestLogLimit = 80
@@ -39,6 +48,8 @@ final class LoopbackSegmentServer {
 
     let rootDirectory: URL?
     private let segmentStore: LoopbackSegmentStore?
+    private let exposure: Exposure
+    private let accessToken: String?
 
     private var listener: NWListener?
     private let queue = DispatchQueue(label: "com.continuum.dv.hlsserver", qos: .userInitiated)
@@ -73,14 +84,22 @@ final class LoopbackSegmentServer {
     /// successfully (the listener is bound and in `.ready` state).
     private(set) var port: UInt16 = 0
 
-    init(rootDirectory: URL) {
+    init(rootDirectory: URL, exposure: Exposure = .loopbackOnly) {
         self.rootDirectory = rootDirectory
         self.segmentStore = nil
+        self.exposure = exposure
+        self.accessToken = exposure == .localNetwork
+            ? UUID().uuidString.replacingOccurrences(of: "-", with: "")
+            : nil
     }
 
-    init(segmentStore: LoopbackSegmentStore) {
+    init(segmentStore: LoopbackSegmentStore, exposure: Exposure = .loopbackOnly) {
         self.rootDirectory = nil
         self.segmentStore = segmentStore
+        self.exposure = exposure
+        self.accessToken = exposure == .localNetwork
+            ? UUID().uuidString.replacingOccurrences(of: "-", with: "")
+            : nil
     }
 
     /// Starts the listener on a random high port and suspends until the
@@ -93,10 +112,14 @@ final class LoopbackSegmentServer {
         do {
             let params = NWParameters.tcp
             params.allowLocalEndpointReuse = true
-            params.requiredLocalEndpoint = NWEndpoint.hostPort(
-                host: .ipv4(.loopback),
-                port: .any
-            )
+            if exposure == .loopbackOnly {
+                params.requiredLocalEndpoint = NWEndpoint.hostPort(
+                    host: .ipv4(.loopback),
+                    port: .any
+                )
+            } else {
+                params.includePeerToPeer = true
+            }
             listener = try NWListener(using: params)
         } catch {
             throw LoopbackSegmentServerError.listenerInitFailed(error)
@@ -146,12 +169,29 @@ final class LoopbackSegmentServer {
                 }
             }
             let serving = self.rootDirectory?.path ?? "memory-store-\(self.segmentStore?.generation ?? 0)"
-            Self.logger.info("LoopbackSegmentServer listening on 127.0.0.1:\(port) serving \(serving, privacy: .public)")
+            let host = exposure == .localNetwork ? "local-network" : "127.0.0.1"
+            Self.logger.info("LoopbackSegmentServer listening on \(host, privacy: .public):\(port) serving \(serving, privacy: .public)")
         } catch {
             listener.cancel()
             self.listener = nil
             throw error
         }
+
+    }
+
+    func resourceURL(for resourceName: String) -> URL? {
+        let host: String
+        switch exposure {
+        case .loopbackOnly:
+            host = "127.0.0.1"
+        case .localNetwork:
+            guard let address = Self.localNetworkIPv4Address() else { return nil }
+            host = address
+        }
+        let path = [accessToken, resourceName]
+            .compactMap { $0 }
+            .joined(separator: "/")
+        return URL(string: "http://\(host):\(port)/\(path)")
     }
 
     /// Single-shot, thread-safe resume gate for `start()`'s continuation.
@@ -280,13 +320,82 @@ final class LoopbackSegmentServer {
 
         switch method {
         case "GET":
-            respondWithFile(at: path, method: .get, range: rangeHeader, on: connection)
+            guard let authorizedPath = authorizedResourcePath(path) else {
+                respondError(404, "Not Found", on: connection)
+                return
+            }
+            respondWithFile(at: authorizedPath, method: .get, range: rangeHeader, on: connection)
         case "HEAD":
-            respondWithFile(at: path, method: .head, range: nil, on: connection)
+            guard let authorizedPath = authorizedResourcePath(path) else {
+                respondError(404, "Not Found", on: connection)
+                return
+            }
+            respondWithFile(at: authorizedPath, method: .head, range: nil, on: connection)
         default:
             respondError(405, "Method Not Allowed", on: connection)
         }
     }
+
+    private func authorizedResourcePath(_ requestPath: String) -> String? {
+        Self.authorizedResourcePath(requestPath, accessToken: accessToken)
+    }
+
+    static func authorizedResourcePath(_ requestPath: String, accessToken: String?) -> String? {
+        guard let accessToken else { return requestPath }
+        let trimmed = requestPath.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let prefix = "\(accessToken)/"
+        guard trimmed.hasPrefix(prefix) else { return nil }
+        return String(trimmed.dropFirst(prefix.count))
+    }
+
+    #if os(iOS)
+    private static func localNetworkIPv4Address() -> String? {
+        var interfaces: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&interfaces) == 0, let first = interfaces else { return nil }
+        defer { freeifaddrs(interfaces) }
+
+        var candidates: [(name: String, address: String)] = []
+        var current: UnsafeMutablePointer<ifaddrs>? = first
+        while let interface = current {
+            defer { current = interface.pointee.ifa_next }
+            let flags = Int32(interface.pointee.ifa_flags)
+            guard flags & IFF_UP != 0,
+                  flags & IFF_LOOPBACK == 0,
+                  let socketAddress = interface.pointee.ifa_addr,
+                  socketAddress.pointee.sa_family == UInt8(AF_INET) else {
+                continue
+            }
+
+            var host = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+            let result = getnameinfo(
+                socketAddress,
+                socklen_t(socketAddress.pointee.sa_len),
+                &host,
+                socklen_t(host.count),
+                nil,
+                0,
+                NI_NUMERICHOST
+            )
+            guard result == 0 else { continue }
+            let address = String(cString: host)
+            guard isPrivateIPv4Address(address) else { continue }
+            candidates.append((String(cString: interface.pointee.ifa_name), address))
+        }
+        return candidates.first(where: { $0.name == "en0" })?.address
+            ?? candidates.first?.address
+    }
+
+    static func isPrivateIPv4Address(_ address: String) -> Bool {
+        let octets = address.split(separator: ".").compactMap { Int($0) }
+        guard octets.count == 4 else { return false }
+        return octets[0] == 10
+            || (octets[0] == 172 && (16...31).contains(octets[1]))
+            || (octets[0] == 192 && octets[1] == 168)
+            || (octets[0] == 169 && octets[1] == 254)
+    }
+    #else
+    private static func localNetworkIPv4Address() -> String? { nil }
+    #endif
 
     private enum HTTPMethod {
         case get

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/LoopbackSegmentServer.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/LoopbackSegmentServer.swift
@@ -179,14 +179,24 @@ final class LoopbackSegmentServer {
 
     }
 
-    func resourceURL(for resourceName: String) -> URL? {
+    /// Returns the URL AVPlayer should use for a resource. LAN-exposed
+    /// servers still use loopback for inline playback; only an active AirPlay
+    /// handoff needs an address reachable from another device.
+    func resourceURL(
+        for resourceName: String,
+        reachableFromExternalDevice: Bool = false
+    ) -> URL? {
         let host: String
         switch exposure {
         case .loopbackOnly:
             host = "127.0.0.1"
         case .localNetwork:
-            guard let address = Self.localNetworkIPv4Address() else { return nil }
-            host = address
+            if reachableFromExternalDevice {
+                guard let address = Self.localNetworkIPv4Address() else { return nil }
+                host = address
+            } else {
+                host = "127.0.0.1"
+            }
         }
         let path = [accessToken, resourceName]
             .compactMap { $0 }
@@ -387,7 +397,8 @@ final class LoopbackSegmentServer {
 
     static func isPrivateIPv4Address(_ address: String) -> Bool {
         let octets = address.split(separator: ".").compactMap { Int($0) }
-        guard octets.count == 4 else { return false }
+        guard octets.count == 4,
+              octets.allSatisfy({ (0...255).contains($0) }) else { return false }
         return octets[0] == 10
             || (octets[0] == 172 && (16...31).contains(octets[1]))
             || (octets[0] == 192 && octets[1] == 168)

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/LoopbackSegmentServer.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/LoopbackSegmentServer.swift
@@ -55,6 +55,8 @@ final class LoopbackSegmentServer {
     private let queue = DispatchQueue(label: "com.continuum.dv.hlsserver", qos: .userInitiated)
     private var connections: [ObjectIdentifier: NWConnection] = [:]
     private let lock = NSLock()
+    /// Guarded by `lock`. Only true while an AirPlay handoff is live.
+    private var acceptsExternalClients = false
     private var requestLogCount = 0
     /// Method/path/status/bytes/range tuples already emitted to the access
     /// log. Suppresses AVPlayer's identical retry probes — the first request
@@ -204,6 +206,25 @@ final class LoopbackSegmentServer {
         return URL(string: "http://\(host):\(port)/\(path)")
     }
 
+    /// Replaces the access token wherever it appears in a log line. The
+    /// diagnostics redactor normalizes URLs but keeps their path, so a raw
+    /// resource URL would carry this session's secret into a support bundle.
+    func redactingAccessToken(in value: String) -> String {
+        guard let accessToken, !accessToken.isEmpty else { return value }
+        return value.replacingOccurrences(of: accessToken, with: "[session_token]")
+    }
+
+    /// Opens the listener to off-device clients. The listener has to be bound
+    /// to the LAN from the start — rebinding mid-session would change the port
+    /// under a playing item — but nothing outside this device has any business
+    /// reaching it until an AirPlay handoff is actually live, so connections
+    /// from non-loopback peers are refused until then.
+    func setAcceptsExternalClients(_ accepts: Bool) {
+        lock.lock()
+        acceptsExternalClients = accepts
+        lock.unlock()
+    }
+
     /// Single-shot, thread-safe resume gate for `start()`'s continuation.
     /// `markResumed` returns `true` only the first time it is called.
     private final class ResumeBox: @unchecked Sendable {
@@ -246,6 +267,17 @@ final class LoopbackSegmentServer {
     // MARK: - Connection handling
 
     private func accept(_ connection: NWConnection) {
+        if Self.isOffDevicePeer(connection.endpoint) {
+            lock.lock()
+            let allowed = acceptsExternalClients
+            lock.unlock()
+            guard allowed else {
+                Self.logger.info("Refused off-device connection; no AirPlay handoff is active")
+                connection.cancel()
+                return
+            }
+        }
+
         let id = ObjectIdentifier(connection)
         lock.lock()
         connections[id] = connection
@@ -346,6 +378,26 @@ final class LoopbackSegmentServer {
         }
     }
 
+    /// True only when the peer is positively identifiable as another device.
+    /// Anything unrecognized counts as local: misreading AVPlayer's own
+    /// loopback connection would break playback outright, while misreading a
+    /// stranger's costs nothing — the access-token check still stands in front
+    /// of every resource.
+    static func isOffDevicePeer(_ endpoint: NWEndpoint) -> Bool {
+        guard case let .hostPort(host, _) = endpoint else { return false }
+        switch host {
+        case let .ipv4(address):
+            return !address.isLoopback
+        case let .ipv6(address):
+            if let mapped = address.asIPv4 { return !mapped.isLoopback }
+            return !address.isLoopback
+        case .name:
+            return false
+        @unknown default:
+            return false
+        }
+    }
+
     private func authorizedResourcePath(_ requestPath: String) -> String? {
         Self.authorizedResourcePath(requestPath, accessToken: accessToken)
     }
@@ -388,21 +440,35 @@ final class LoopbackSegmentServer {
             )
             guard result == 0 else { continue }
             let address = String(cString: host)
-            guard isPrivateIPv4Address(address) else { continue }
-            candidates.append((String(cString: interface.pointee.ifa_name), address))
+            let name = String(cString: interface.pointee.ifa_name)
+            guard isReceiverReachableInterface(name),
+                  isPrivateIPv4Address(address) else { continue }
+            candidates.append((name, address))
         }
+        // en0 is Wi-Fi on every iPhone; the sorted fallback keeps selection
+        // deterministic when a second Ethernet-class interface exists.
         return candidates.first(where: { $0.name == "en0" })?.address
-            ?? candidates.first?.address
+            ?? candidates.sorted(by: { $0.name < $1.name }).first?.address
+    }
+
+    /// AirPlay receivers live on the Wi-Fi/Ethernet LAN. Cellular (`pdp_ip*`),
+    /// VPN tunnels (`utun*`, `ipsec*`, `ppp*`), and AWDL/peer links (`awdl*`,
+    /// `llw*`) can all carry an RFC1918 address the Apple TV cannot route to,
+    /// so advertising one produces a receiver that silently never connects.
+    static func isReceiverReachableInterface(_ name: String) -> Bool {
+        guard name.hasPrefix("en") || name.hasPrefix("bridge") else { return false }
+        return true
     }
 
     static func isPrivateIPv4Address(_ address: String) -> Bool {
         let octets = address.split(separator: ".").compactMap { Int($0) }
         guard octets.count == 4,
               octets.allSatisfy({ (0...255).contains($0) }) else { return false }
+        // Deliberately excludes 169.254/16: a link-local address means DHCP
+        // never completed, and a receiver on the real subnet cannot reach it.
         return octets[0] == 10
             || (octets[0] == 172 && (16...31).contains(octets[1]))
             || (octets[0] == 192 && octets[1] == 168)
-            || (octets[0] == 169 && octets[1] == 254)
     }
     #else
     private static func localNetworkIPv4Address() -> String? { nil }

--- a/iosApp/iosApp/Screens/Player/ApplePlaybackRouteCapabilities.swift
+++ b/iosApp/iosApp/Screens/Player/ApplePlaybackRouteCapabilities.swift
@@ -326,7 +326,7 @@ extension ApplePlaybackRouteCapabilities {
         ),
         externalPlayback: .init(
             state: .unsupported,
-            note: "AirPlay video hands the receiver the stream URL, which it fetches without the route's Authorization header, so the server answers 401. External playback stays off for server-hosted assets; header-less local downloads keep it."
+            note: "AirPlay video hands the receiver the stream URL and nothing else. Server-hosted direct assets are either header-authenticated (401 on the receiver) or rewritten to the on-device source proxy at 127.0.0.1, so external playback stays off for them; offline downloads keep it."
         ),
         nowPlayingIntegration: .init(
             state: .repoVerified,

--- a/iosApp/iosApp/Screens/Player/ApplePlaybackRouteCapabilities.swift
+++ b/iosApp/iosApp/Screens/Player/ApplePlaybackRouteCapabilities.swift
@@ -325,8 +325,8 @@ extension ApplePlaybackRouteCapabilities {
             note: "PiP is enabled on iOS Native Player HLS; Silo-rendered subtitles do not appear in the PiP window."
         ),
         externalPlayback: .init(
-            state: .unsupported,
-            note: "AirPlay video hands the receiver the stream URL and nothing else. Server-hosted direct assets are either header-authenticated (401 on the receiver) or rewritten to the on-device source proxy at 127.0.0.1, so external playback stays off for them; offline downloads keep it."
+            state: .validationRequired,
+            note: "Asset-conditional. AirPlay video hands the receiver the stream URL and nothing else: server-hosted direct assets are either header-authenticated (401 on the receiver) or rewritten to the on-device source proxy at 127.0.0.1, so external playback stays off for them. Offline downloads are fetchable and keep it, pending receiver validation."
         ),
         nowPlayingIntegration: .init(
             state: .repoVerified,

--- a/iosApp/iosApp/Screens/Player/ApplePlaybackRouteCapabilities.swift
+++ b/iosApp/iosApp/Screens/Player/ApplePlaybackRouteCapabilities.swift
@@ -251,7 +251,7 @@ extension ApplePlaybackRouteCapabilities {
         ),
         pictureInPicture: .init(
             state: .unsupported,
-            note: "PiP stays off on the compatibility route."
+            note: "PiP stays off on the compatibility route: it renders into an AVSampleBufferDisplayLayer and needs a sample-buffer PiP content source."
         ),
         externalPlayback: .init(
             state: .unsupported,
@@ -322,7 +322,7 @@ extension ApplePlaybackRouteCapabilities {
         ),
         pictureInPicture: .init(
             state: .validationRequired,
-            note: "PiP is not re-enabled until route-specific lifecycle validation lands."
+            note: "PiP is enabled on iOS Native Player HLS; Silo-rendered subtitles do not appear in the PiP window."
         ),
         externalPlayback: .init(
             state: .validationRequired,
@@ -393,7 +393,7 @@ extension ApplePlaybackRouteCapabilities {
         ),
         pictureInPicture: .init(
             state: .validationRequired,
-            note: "PiP stays disabled until native-direct lifecycle validation exists."
+            note: "PiP is enabled on iOS Native Player Direct assets; Silo-rendered subtitles do not appear in the PiP window."
         ),
         externalPlayback: .init(
             state: .validationRequired,
@@ -464,7 +464,7 @@ extension ApplePlaybackRouteCapabilities {
         ),
         pictureInPicture: .init(
             state: .validationRequired,
-            note: "PiP is not re-enabled on SiloPlayer output."
+            note: "PiP is enabled on iOS SiloPlayer output; Silo-rendered subtitles do not appear in the PiP window."
         ),
         externalPlayback: .init(
             state: .repoVerified,

--- a/iosApp/iosApp/Screens/Player/ApplePlaybackRouteCapabilities.swift
+++ b/iosApp/iosApp/Screens/Player/ApplePlaybackRouteCapabilities.swift
@@ -325,8 +325,8 @@ extension ApplePlaybackRouteCapabilities {
             note: "PiP is enabled on iOS Native Player HLS; Silo-rendered subtitles do not appear in the PiP window."
         ),
         externalPlayback: .init(
-            state: .validationRequired,
-            note: "AirPlay UI and AVPlayer external playback are enabled; receiver playback still needs device validation."
+            state: .unsupported,
+            note: "AirPlay video hands the receiver the stream URL, which it fetches without the route's Authorization header, so the server answers 401. External playback stays off for server-hosted assets; header-less local downloads keep it."
         ),
         nowPlayingIntegration: .init(
             state: .repoVerified,
@@ -396,8 +396,8 @@ extension ApplePlaybackRouteCapabilities {
             note: "PiP is enabled on iOS Native Player Direct assets; Silo-rendered subtitles do not appear in the PiP window."
         ),
         externalPlayback: .init(
-            state: .validationRequired,
-            note: "AirPlay UI and AVPlayer external playback are enabled; receiver playback still needs device validation."
+            state: .unsupported,
+            note: "AirPlay video hands the receiver the stream URL, which it fetches without the route's Authorization header, so the server answers 401. External playback and the route picker stay off here."
         ),
         nowPlayingIntegration: .init(
             state: .repoVerified,

--- a/iosApp/iosApp/Screens/Player/ApplePlaybackRouteCapabilities.swift
+++ b/iosApp/iosApp/Screens/Player/ApplePlaybackRouteCapabilities.swift
@@ -254,8 +254,8 @@ extension ApplePlaybackRouteCapabilities {
             note: "PiP stays off on the compatibility route."
         ),
         externalPlayback: .init(
-            state: .unclaimed,
-            note: "Silo does not expose external-playback UI on the compatibility route."
+            state: .unsupported,
+            note: "The compatibility player does not use AVPlayer and cannot provide AirPlay video playback."
         ),
         nowPlayingIntegration: .init(
             state: .repoVerified,
@@ -325,8 +325,8 @@ extension ApplePlaybackRouteCapabilities {
             note: "PiP is not re-enabled until route-specific lifecycle validation lands."
         ),
         externalPlayback: .init(
-            state: .unclaimed,
-            note: "External playback stays unclaimed until UI and receiver validation exist."
+            state: .validationRequired,
+            note: "AirPlay UI and AVPlayer external playback are enabled; receiver playback still needs device validation."
         ),
         nowPlayingIntegration: .init(
             state: .repoVerified,
@@ -396,8 +396,8 @@ extension ApplePlaybackRouteCapabilities {
             note: "PiP stays disabled until native-direct lifecycle validation exists."
         ),
         externalPlayback: .init(
-            state: .unclaimed,
-            note: "External playback stays unclaimed until explicit native-route UI and validation land."
+            state: .validationRequired,
+            note: "AirPlay UI and AVPlayer external playback are enabled; receiver playback still needs device validation."
         ),
         nowPlayingIntegration: .init(
             state: .repoVerified,
@@ -467,8 +467,8 @@ extension ApplePlaybackRouteCapabilities {
             note: "PiP is not re-enabled on SiloPlayer output."
         ),
         externalPlayback: .init(
-            state: .unclaimed,
-            note: "External playback remains unclaimed on SiloPlayer output."
+            state: .repoVerified,
+            note: "AirPlay from iPhone to Apple TV is hardware-validated for SiloPlayer loopback delivery."
         ),
         nowPlayingIntegration: .init(
             state: .repoVerified,

--- a/iosApp/iosApp/Screens/Player/ApplePlaybackRoutePlanner.swift
+++ b/iosApp/iosApp/Screens/Player/ApplePlaybackRoutePlanner.swift
@@ -367,7 +367,7 @@ struct ApplePlaybackRoutePlanner {
             needsChapters: hasChapters,
             needsNowPlayingIntegration: true,
             keepsPictureInPictureDisabledUntilValidated: true,
-            keepsExternalPlaybackDisabledUntilValidated: true,
+            keepsExternalPlaybackDisabledUntilValidated: false,
             needsValidatedDolbyVisionClaim: claimsDolbyVision,
             needsValidatedAtmosClaim: Self.versionHasPotentialAtmos(selectedVersion)
         )

--- a/iosApp/iosApp/Screens/Player/ApplePlaybackRoutePlanner.swift
+++ b/iosApp/iosApp/Screens/Player/ApplePlaybackRoutePlanner.swift
@@ -366,7 +366,7 @@ struct ApplePlaybackRoutePlanner {
             needsSecondarySubtitles: hasSidecarSubtitles,
             needsChapters: hasChapters,
             needsNowPlayingIntegration: true,
-            keepsPictureInPictureDisabledUntilValidated: true,
+            keepsPictureInPictureDisabledUntilValidated: false,
             keepsExternalPlaybackDisabledUntilValidated: false,
             needsValidatedDolbyVisionClaim: claimsDolbyVision,
             needsValidatedAtmosClaim: Self.versionHasPotentialAtmos(selectedVersion)

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -621,6 +621,11 @@ class PlayerViewModel {
     /// Gives automatic PiP a bounded window to publish `willStart` after the
     /// scene backgrounds. If no transition arrives, normal pause policy wins.
     private var pictureInPictureBackgroundGraceTask: Task<Void, Never>?
+    /// Whether the active route can hand video to an AirPlay receiver. False
+    /// on routes whose stream URL is authenticated by a request header the
+    /// receiver cannot send — the picker is hidden there rather than offering
+    /// a handoff that would 401 on the TV.
+    private(set) var supportsExternalPlayback = false
     #endif
     /// True after the active backend reports natural EOF. Used to keep the
     /// UI in a terminal paused state without letting tail-drain callbacks
@@ -1374,6 +1379,24 @@ class PlayerViewModel {
             guard let self, !self.isDisposed else { return }
             self.handleExternalPlaybackActiveChange(active)
         }
+        backend.onExternalPlaybackAllowedChange = { [weak self] allowed in
+            guard let self, !self.isDisposed else { return }
+            self.supportsExternalPlayback = allowed
+        }
+        backend.onExternalPlaybackUnavailable = { [weak self] in
+            // `showNotice` is `@MainActor`; this callback may not be, so
+            // dispatch onto the main actor explicitly.
+            Task { @MainActor [weak self] in
+                guard let self, !self.isDisposed else { return }
+                self.showNotice(
+                    title: "AirPlay Unavailable",
+                    message: "This device has no Wi-Fi address the receiver can reach. Playback stayed on this device.",
+                    tone: .warning,
+                    duration: 6
+                )
+            }
+        }
+        supportsExternalPlayback = backend.isExternalPlaybackAllowed
         PictureInPictureCoordinator.shared.bindLifecycle(owner: self) { [weak self] in
             guard let self, !self.isDisposed else { return }
             self.handlePictureInPictureEngagementEnded()
@@ -5722,13 +5745,13 @@ class PlayerViewModel {
         #if os(iOS)
         pictureInPictureBackgroundGraceTask?.cancel()
         pictureInPictureBackgroundGraceTask = nil
-        PictureInPictureCoordinator.shared.unbindLifecycle(owner: self)
         // The PiP coordinator is a singleton and its controller strongly
         // retains the AVPlayerLayer, the AVPlayer, and everything hanging off
         // it. SwiftUI's `dismantleUIView` normally releases it, but ordering
         // there is not guaranteed relative to this teardown, so drop it here
-        // too rather than risk stranding the whole playback graph.
-        PictureInPictureCoordinator.shared.release()
+        // too rather than risk stranding the whole playback graph. Owner-keyed
+        // so a late teardown cannot unbind a newer session's PiP.
+        PictureInPictureCoordinator.shared.endSession(owner: self)
         isSceneBackgrounded = false
         #endif
         activeExecutionPlan = nil

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -612,6 +612,16 @@ class PlayerViewModel {
     /// on this so a late-landing handoff signal can't spin up a fresh
     /// pipeline on a view that's already gone.
     private var isDisposed = false
+    #if os(iOS)
+    /// Mirrors the last `ScenePhase` handed to `handleScenePhase`. Lets the
+    /// AirPlay route observer tell "receiver disconnected while we're in the
+    /// background" (pause) from a normal foreground disconnect (keep playing
+    /// on the phone).
+    private var isSceneBackgrounded = false
+    /// Gives automatic PiP a bounded window to publish `willStart` after the
+    /// scene backgrounds. If no transition arrives, normal pause policy wins.
+    private var pictureInPictureBackgroundGraceTask: Task<Void, Never>?
+    #endif
     /// True after the active backend reports natural EOF. Used to keep the
     /// UI in a terminal paused state without letting tail-drain callbacks
     /// overwrite it or surface a false decode error.
@@ -1356,6 +1366,19 @@ class PlayerViewModel {
             guard let self, !self.isDisposed, offset.isFinite else { return }
             self.playbackTimelineOffset = max(0, offset)
         }
+        #if os(iOS)
+        backend.isPictureInPictureActiveProvider = {
+            PictureInPictureCoordinator.shared.isActive
+        }
+        backend.onExternalPlaybackActiveChange = { [weak self] active in
+            guard let self, !self.isDisposed else { return }
+            self.handleExternalPlaybackActiveChange(active)
+        }
+        PictureInPictureCoordinator.shared.bindLifecycle(owner: self) { [weak self] in
+            guard let self, !self.isDisposed else { return }
+            self.handlePictureInPictureEngagementEnded()
+        }
+        #endif
     }
 
     private func handleFileLoaded() {
@@ -4213,21 +4236,79 @@ class PlayerViewModel {
             break
         }
         #else
+        isSceneBackgrounded = phase == .background
         switch phase {
         case .background:
+            // AirPlay is playing on the receiver, not the phone; pausing here
+            // would stop the TV. `handleExternalPlaybackActiveChange` covers
+            // the route going away while we stay backgrounded.
             if avPlayerBackend?.isExternalPlaybackActive == true {
                 break
             }
-            if isPlaying {
-                activePlayer.pause()
+            // PiP keeps playing in the floating window after the app is
+            // backgrounded; pausing here would defeat it.
+            if PictureInPictureCoordinator.shared.isEngaged {
+                break
             }
-        case .inactive, .active:
+            // Automatic PiP can publish `willStart` just after ScenePhase
+            // reaches background. Give it one bounded window; failure/stop
+            // callbacks re-run the same pause policy immediately.
+            if PictureInPictureCoordinator.shared.isPossible {
+                schedulePictureInPictureBackgroundGrace()
+                break
+            }
+            pauseBackgroundPlaybackIfUnrouted()
+        case .active:
+            pictureInPictureBackgroundGraceTask?.cancel()
+            pictureInPictureBackgroundGraceTask = nil
+        case .inactive:
             break
         @unknown default:
             break
         }
         #endif
     }
+
+    #if os(iOS)
+    /// AirPlay and PiP are the only two reasons the iOS player keeps running
+    /// while the app is backgrounded. When the receiver goes away mid-session
+    /// — the user picks "iPhone" in Control Center, or the Apple TV drops off
+    /// the network — nothing else notices, and playback would carry on as
+    /// invisible background audio. Pause instead, matching what `.background`
+    /// would have done had the route already been gone.
+    private func handleExternalPlaybackActiveChange(_ active: Bool) {
+        if active {
+            pictureInPictureBackgroundGraceTask?.cancel()
+            pictureInPictureBackgroundGraceTask = nil
+            return
+        }
+        pauseBackgroundPlaybackIfUnrouted()
+    }
+
+    private func schedulePictureInPictureBackgroundGrace() {
+        pictureInPictureBackgroundGraceTask?.cancel()
+        pictureInPictureBackgroundGraceTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(1))
+            guard !Task.isCancelled, let self else { return }
+            self.pictureInPictureBackgroundGraceTask = nil
+            self.pauseBackgroundPlaybackIfUnrouted()
+        }
+    }
+
+    private func handlePictureInPictureEngagementEnded() {
+        pictureInPictureBackgroundGraceTask?.cancel()
+        pictureInPictureBackgroundGraceTask = nil
+        pauseBackgroundPlaybackIfUnrouted()
+    }
+
+    private func pauseBackgroundPlaybackIfUnrouted() {
+        guard isSceneBackgrounded, isPlaying else { return }
+        guard avPlayerBackend?.isExternalPlaybackActive != true else { return }
+        guard !PictureInPictureCoordinator.shared.isEngaged else { return }
+        Self.logger.info("Background playback has no active AirPlay or PiP route; pausing")
+        activePlayer.pause()
+    }
+    #endif
 
     /// Skip by ±`seconds` relative to the current preview position. By
     /// default this summons the transport overlay so the scrubber's preview
@@ -5638,6 +5719,18 @@ class PlayerViewModel {
         guard !isDisposed else { return }
         Self.logger.info("PlayerViewModel.cleanup()")
         isDisposed = true
+        #if os(iOS)
+        pictureInPictureBackgroundGraceTask?.cancel()
+        pictureInPictureBackgroundGraceTask = nil
+        PictureInPictureCoordinator.shared.unbindLifecycle(owner: self)
+        // The PiP coordinator is a singleton and its controller strongly
+        // retains the AVPlayerLayer, the AVPlayer, and everything hanging off
+        // it. SwiftUI's `dismantleUIView` normally releases it, but ordering
+        // there is not guaranteed relative to this teardown, so drop it here
+        // too rather than risk stranding the whole playback graph.
+        PictureInPictureCoordinator.shared.release()
+        isSceneBackgrounded = false
+        #endif
         activeExecutionPlan = nil
         hasAttemptedNativeDirectRouteRecovery = false
         hasAttemptedSiloRouteCompatibilityFallback = false

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -4214,11 +4214,14 @@ class PlayerViewModel {
         }
         #else
         switch phase {
-        case .background, .inactive:
+        case .background:
+            if avPlayerBackend?.isExternalPlaybackActive == true {
+                break
+            }
             if isPlaying {
                 activePlayer.pause()
             }
-        case .active:
+        case .inactive, .active:
             break
         @unknown default:
             break

--- a/iosApp/iosApp/Screens/Player/iOS/AirPlayRoutePicker.swift
+++ b/iosApp/iosApp/Screens/Player/iOS/AirPlayRoutePicker.swift
@@ -1,0 +1,18 @@
+#if os(iOS)
+import AVKit
+import SwiftUI
+
+struct AirPlayRoutePicker: UIViewRepresentable {
+    func makeUIView(context: Context) -> AVRoutePickerView {
+        let picker = AVRoutePickerView()
+        picker.activeTintColor = .white
+        picker.tintColor = .white
+        picker.prioritizesVideoDevices = true
+        picker.accessibilityLabel = "AirPlay"
+        picker.accessibilityHint = "Choose a device for video playback"
+        return picker
+    }
+
+    func updateUIView(_ uiView: AVRoutePickerView, context: Context) {}
+}
+#endif

--- a/iosApp/iosApp/Screens/Player/iOS/AirPlayRoutePicker.swift
+++ b/iosApp/iosApp/Screens/Player/iOS/AirPlayRoutePicker.swift
@@ -2,7 +2,17 @@
 import AVKit
 import SwiftUI
 
+/// AirPlay button for the mobile player's top strip.
+///
+/// The picker lives inside the `showControls` branch of `MobilePlayerControls`,
+/// which the 3s auto-hide tears down. UIKit taps on this view never reach the
+/// SwiftUI gesture layer, so without `onPresentingRoutes` the timer keeps
+/// running while the route sheet is up and dismantles the button — and the
+/// sheet with it — mid-selection. The callback lets the caller pin the
+/// controls for the duration, the same way sheet presentation does.
 struct AirPlayRoutePicker: UIViewRepresentable {
+    let onPresentingRoutes: (Bool) -> Void
+
     func makeUIView(context: Context) -> AVRoutePickerView {
         let picker = AVRoutePickerView()
         picker.activeTintColor = .white
@@ -10,9 +20,52 @@ struct AirPlayRoutePicker: UIViewRepresentable {
         picker.prioritizesVideoDevices = true
         picker.accessibilityLabel = "AirPlay"
         picker.accessibilityHint = "Choose a device for video playback"
+        picker.delegate = context.coordinator
         return picker
     }
 
-    func updateUIView(_ uiView: AVRoutePickerView, context: Context) {}
+    func updateUIView(_ uiView: AVRoutePickerView, context: Context) {
+        // The closure captures the current view generation; refresh it so the
+        // coordinator never calls back into a stale one.
+        context.coordinator.onPresentingRoutes = onPresentingRoutes
+    }
+
+    static func dismantleUIView(_ uiView: AVRoutePickerView, coordinator: Coordinator) {
+        uiView.delegate = nil
+        // If the view goes away while the sheet is up, "did end" never
+        // arrives — release the pin here so the controls can auto-hide again.
+        coordinator.resignPresentation()
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onPresentingRoutes: onPresentingRoutes)
+    }
+
+    /// `AVRoutePickerView.delegate` is weak and SwiftUI owns the coordinator's
+    /// lifetime, so this deliberately holds no reference back to the view.
+    final class Coordinator: NSObject, AVRoutePickerViewDelegate {
+        var onPresentingRoutes: (Bool) -> Void
+        private var isPresenting = false
+
+        init(onPresentingRoutes: @escaping (Bool) -> Void) {
+            self.onPresentingRoutes = onPresentingRoutes
+        }
+
+        func routePickerViewWillBeginPresentingRoutes(_ routePickerView: AVRoutePickerView) {
+            guard !isPresenting else { return }
+            isPresenting = true
+            onPresentingRoutes(true)
+        }
+
+        func routePickerViewDidEndPresentingRoutes(_ routePickerView: AVRoutePickerView) {
+            resignPresentation()
+        }
+
+        func resignPresentation() {
+            guard isPresenting else { return }
+            isPresenting = false
+            onPresentingRoutes(false)
+        }
+    }
 }
 #endif

--- a/iosApp/iosApp/Screens/Player/iOS/MobilePlayerControls.swift
+++ b/iosApp/iosApp/Screens/Player/iOS/MobilePlayerControls.swift
@@ -124,6 +124,11 @@ struct MobilePlayerControls: View {
             titleBlock
 
             Spacer(minLength: 12)
+
+            if viewModel.avPlayerBackend != nil {
+                AirPlayRoutePicker()
+                    .frame(width: 44, height: 44)
+            }
         }
     }
 

--- a/iosApp/iosApp/Screens/Player/iOS/MobilePlayerControls.swift
+++ b/iosApp/iosApp/Screens/Player/iOS/MobilePlayerControls.swift
@@ -24,6 +24,7 @@ struct MobilePlayerControls: View {
     /// Trailing time label mode: remaining ("−12:34") when true, total
     /// duration otherwise. Tap the label to flip — the native player idiom.
     @State private var showsRemainingTime = true
+    @State private var pictureInPicture = PictureInPictureCoordinator.shared
 
 
     var body: some View {
@@ -126,8 +127,31 @@ struct MobilePlayerControls: View {
             Spacer(minLength: 12)
 
             if viewModel.avPlayerBackend != nil {
-                AirPlayRoutePicker()
-                    .frame(width: 44, height: 44)
+                if pictureInPicture.isSupported {
+                    controlButton(
+                        systemName: pictureInPicture.isActive ? "pip.exit" : "pip.enter"
+                    ) {
+                        pictureInPicture.toggle()
+                    }
+                    .disabled(!pictureInPicture.isPossible)
+                    .accessibilityLabel(
+                        pictureInPicture.isActive
+                            ? "Stop Picture in Picture"
+                            : "Start Picture in Picture"
+                    )
+                }
+
+                AirPlayRoutePicker { isPresentingRoutes in
+                    // The route sheet is a UIKit presentation the auto-hide
+                    // timer knows nothing about; pin the controls so it can't
+                    // dismantle the picker mid-selection.
+                    if isPresentingRoutes {
+                        viewModel.pinControlsVisible()
+                    } else {
+                        viewModel.resumeAutoHide()
+                    }
+                }
+                .frame(width: 44, height: 44)
             }
         }
     }

--- a/iosApp/iosApp/Screens/Player/iOS/MobilePlayerControls.swift
+++ b/iosApp/iosApp/Screens/Player/iOS/MobilePlayerControls.swift
@@ -141,17 +141,22 @@ struct MobilePlayerControls: View {
                     )
                 }
 
-                AirPlayRoutePicker { isPresentingRoutes in
-                    // The route sheet is a UIKit presentation the auto-hide
-                    // timer knows nothing about; pin the controls so it can't
-                    // dismantle the picker mid-selection.
-                    if isPresentingRoutes {
-                        viewModel.pinControlsVisible()
-                    } else {
-                        viewModel.resumeAutoHide()
+                // Only shown where the receiver could actually fetch the
+                // media. On routes whose URL is authenticated by a request
+                // header, AirPlay video would leave the TV on a 401.
+                if viewModel.supportsExternalPlayback {
+                    AirPlayRoutePicker { isPresentingRoutes in
+                        // The route sheet is a UIKit presentation the auto-hide
+                        // timer knows nothing about; pin the controls so it can't
+                        // dismantle the picker mid-selection.
+                        if isPresentingRoutes {
+                            viewModel.pinControlsVisible()
+                        } else {
+                            viewModel.resumeAutoHide()
+                        }
                     }
+                    .frame(width: 44, height: 44)
                 }
-                .frame(width: 44, height: 44)
             }
         }
     }

--- a/iosApp/iosApp/Screens/Player/iOS/PictureInPictureCoordinator.swift
+++ b/iosApp/iosApp/Screens/Player/iOS/PictureInPictureCoordinator.swift
@@ -1,0 +1,243 @@
+#if os(iOS)
+import AVKit
+import Observation
+import OSLog
+
+/// Owns the `AVPictureInPictureController` for the AVPlayer-backed routes
+/// (Native Player HLS / Direct and the SiloPlayer loopback route).
+///
+/// `AVPictureInPictureController` has to be bound to the live `AVPlayerLayer`,
+/// which SwiftUI creates and tears down with `AVPlayerLayerView`. That view
+/// attaches itself here when it comes on screen and detaches on dismantle, so
+/// the rest of the shell can stay unaware of the layer's lifecycle:
+/// `MobilePlayerControls` only reads `isPossible` / `isActive` to draw the
+/// toggle, and `PlayerViewModel.handleScenePhase` reads `isEngaged` so
+/// backgrounding into PiP doesn't pause playback.
+///
+/// The compatibility (`PlayerCore`) route renders into an
+/// `AVSampleBufferDisplayLayer` and is not covered here — it needs the sample
+/// buffer PiP content source plus a playback delegate.
+@Observable
+final class PictureInPictureCoordinator {
+    static let shared = PictureInPictureCoordinator()
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.continuum.app",
+        category: "PictureInPicture"
+    )
+
+    /// True while the system reports PiP can start right now: the layer is on
+    /// screen, a video track is ready, and the device supports PiP.
+    private(set) var isPossible = false
+    /// True between `didStart` and `didStop`.
+    private(set) var isActive = false
+    /// True from `willStart` until the start resolves. Kept separate from
+    /// `isActive` so the scene-phase handler doesn't pause playback during the
+    /// window where iOS auto-starts PiP as the app is being backgrounded.
+    private(set) var isTransitioning = false
+
+    /// True while PiP owns (or is about to own) playback. Call sites that need
+    /// to suppress background pauses should use this rather than `isActive`.
+    var isEngaged: Bool { isActive || isTransitioning }
+
+    var isSupported: Bool { AVPictureInPictureController.isPictureInPictureSupported() }
+
+    @ObservationIgnored private var controller: AVPictureInPictureController?
+    @ObservationIgnored private weak var attachedLayer: AVPlayerLayer?
+    @ObservationIgnored private var possibleObservation: NSKeyValueObservation?
+    @ObservationIgnored private var delegateProxy: DelegateProxy?
+    @ObservationIgnored private weak var lifecycleOwner: AnyObject?
+    @ObservationIgnored private var onEngagementEnded: (() -> Void)?
+
+    private init() {}
+
+    /// Binds PiP to `playerLayer`. Safe to call repeatedly with the same layer
+    /// (SwiftUI re-runs `updateUIView` constantly); only a genuine layer swap
+    /// rebuilds the controller.
+    func attach(playerLayer: AVPlayerLayer) {
+        guard isSupported else { return }
+        guard attachedLayer !== playerLayer else { return }
+        // A genuine layer swap. Release the previous binding first: the old
+        // controller retains its layer (and through it the AVPlayer and the
+        // whole item/loopback graph), and its delegate callbacks stop once we
+        // drop it, so its state has to be reset here rather than awaited.
+        releaseController()
+        guard let controller = AVPictureInPictureController(playerLayer: playerLayer) else {
+            Self.logger.error("AVPictureInPictureController could not be created for the player layer")
+            return
+        }
+
+        let proxy = DelegateProxy(coordinator: self)
+        controller.delegate = proxy
+        delegateProxy = proxy
+        // The whole point of PiP for a video app: swiping home hands playback
+        // to the floating window instead of stopping it.
+        controller.canStartPictureInPictureAutomaticallyFromInline = true
+
+        possibleObservation = controller.observe(
+            \.isPictureInPicturePossible,
+            options: [.initial, .new]
+        ) { [weak self] observed, _ in
+            let possible = observed.isPictureInPicturePossible
+            DispatchQueue.main.async {
+                // `invalidate()` stops future callbacks but cannot recall one
+                // already queued here, so re-check that this is still the live
+                // controller before publishing — otherwise a detach can be
+                // followed by a stale `isPossible = true`.
+                guard let self, self.controller === observed else { return }
+                self.isPossible = possible
+            }
+        }
+
+        self.controller = controller
+        attachedLayer = playerLayer
+        Self.logger.info("PiP controller bound to player layer")
+    }
+
+    /// Drops the controller when the surface goes away. PiP without a source
+    /// layer is meaningless, so an in-flight window is torn down too. Note the
+    /// surface is *not* dismantled while PiP is running in the background — the
+    /// SwiftUI hierarchy stays mounted — so this only fires when the player is
+    /// genuinely closed.
+    func detach(playerLayer: AVPlayerLayer) {
+        guard attachedLayer === playerLayer else { return }
+        releaseController()
+    }
+
+    /// Unconditional teardown for the player-close path. `detach` is keyed on
+    /// layer identity, which is the right guard for SwiftUI's dismantle but is
+    /// a no-op if the surface was never mounted or was replaced out of order.
+    /// The coordinator is a singleton and the controller strongly retains its
+    /// `AVPlayerLayer` — and through it the `AVPlayer`, its item, and the
+    /// loopback server — so `PlayerViewModel.cleanup()` calls this to
+    /// guarantee the graph is released with the session.
+    func release() {
+        releaseController()
+    }
+
+    /// Binds background-playback policy to the current player session. Owner
+    /// identity prevents a late cleanup from clearing a newer session's hook.
+    func bindLifecycle(owner: AnyObject, onEngagementEnded: @escaping () -> Void) {
+        lifecycleOwner = owner
+        self.onEngagementEnded = onEngagementEnded
+    }
+
+    func unbindLifecycle(owner: AnyObject) {
+        guard lifecycleOwner === owner else { return }
+        lifecycleOwner = nil
+        onEngagementEnded = nil
+    }
+
+    func toggle() {
+        guard let controller else { return }
+        if controller.isPictureInPictureActive {
+            controller.stopPictureInPicture()
+        } else {
+            guard controller.isPictureInPicturePossible else {
+                Self.logger.info("PiP start ignored; not possible yet")
+                return
+            }
+            controller.startPictureInPicture()
+        }
+    }
+
+    private func releaseController() {
+        defer { resetState() }
+        guard let controller else { return }
+        if controller.isPictureInPictureActive {
+            controller.stopPictureInPicture()
+        }
+        // `stopPictureInPicture()` resolves asynchronously, but the controller
+        // is released on the next line — `didStop` will never be delivered, so
+        // clearing the delegate makes that explicit and `resetState()` (rather
+        // than the callback) owns the published flags. Without this, `isActive`
+        // would stay stuck at `true` and suppress the background pause for
+        // every later playback session.
+        controller.delegate = nil
+        possibleObservation?.invalidate()
+        possibleObservation = nil
+        self.controller = nil
+        delegateProxy = nil
+        attachedLayer = nil
+        Self.logger.info("PiP controller released")
+    }
+
+    private func resetState() {
+        isPossible = false
+        isActive = false
+        isTransitioning = false
+    }
+
+    // MARK: - Delegate callbacks
+
+    fileprivate func handleWillStart() {
+        isTransitioning = true
+    }
+
+    fileprivate func handleDidStart() {
+        isTransitioning = false
+        isActive = true
+        Self.logger.info("PiP started")
+    }
+
+    fileprivate func handleDidStop() {
+        isTransitioning = false
+        isActive = false
+        Self.logger.info("PiP stopped")
+        onEngagementEnded?()
+    }
+
+    fileprivate func handleFailedToStart(_ error: Error) {
+        isTransitioning = false
+        isActive = false
+        Self.logger.error("PiP failed to start: \(error.localizedDescription, privacy: .public)")
+        onEngagementEnded?()
+    }
+
+    /// `AVPictureInPictureControllerDelegate` needs an `NSObject`; keeping it
+    /// in a proxy lets the coordinator stay a plain `@Observable` class.
+    private final class DelegateProxy: NSObject, AVPictureInPictureControllerDelegate {
+        private weak var coordinator: PictureInPictureCoordinator?
+
+        init(coordinator: PictureInPictureCoordinator) {
+            self.coordinator = coordinator
+        }
+
+        func pictureInPictureControllerWillStartPictureInPicture(
+            _ pictureInPictureController: AVPictureInPictureController
+        ) {
+            coordinator?.handleWillStart()
+        }
+
+        func pictureInPictureControllerDidStartPictureInPicture(
+            _ pictureInPictureController: AVPictureInPictureController
+        ) {
+            coordinator?.handleDidStart()
+        }
+
+        func pictureInPictureControllerDidStopPictureInPicture(
+            _ pictureInPictureController: AVPictureInPictureController
+        ) {
+            coordinator?.handleDidStop()
+        }
+
+        func pictureInPictureController(
+            _ pictureInPictureController: AVPictureInPictureController,
+            failedToStartPictureInPictureWithError error: Error
+        ) {
+            coordinator?.handleFailedToStart(error)
+        }
+
+        /// The full-screen player shell stays mounted behind the PiP window,
+        /// so there is nothing to rebuild — report success immediately and let
+        /// playback hand back to the inline layer.
+        func pictureInPictureController(
+            _ pictureInPictureController: AVPictureInPictureController,
+            restoreUserInterfaceForPictureInPictureStopWithCompletionHandler completionHandler:
+                @escaping (Bool) -> Void
+        ) {
+            completionHandler(true)
+        }
+    }
+}
+#endif

--- a/iosApp/iosApp/Screens/Player/iOS/PictureInPictureCoordinator.swift
+++ b/iosApp/iosApp/Screens/Player/iOS/PictureInPictureCoordinator.swift
@@ -48,6 +48,11 @@ final class PictureInPictureCoordinator {
     @ObservationIgnored private var delegateProxy: DelegateProxy?
     @ObservationIgnored private weak var lifecycleOwner: AnyObject?
     @ObservationIgnored private var onEngagementEnded: (() -> Void)?
+    /// Set when the system asks us to restore the full-screen UI, i.e. the user
+    /// tapped the PiP window's restore button. The `didStop` that follows is
+    /// not "playback lost its route" — the user is on their way back into the
+    /// app — and the scene may still read as backgrounded when it lands.
+    @ObservationIgnored private var isRestoringUserInterface = false
 
     private init() {}
 
@@ -104,14 +109,26 @@ final class PictureInPictureCoordinator {
         releaseController()
     }
 
-    /// Unconditional teardown for the player-close path. `detach` is keyed on
-    /// layer identity, which is the right guard for SwiftUI's dismantle but is
-    /// a no-op if the surface was never mounted or was replaced out of order.
-    /// The coordinator is a singleton and the controller strongly retains its
-    /// `AVPlayerLayer` — and through it the `AVPlayer`, its item, and the
-    /// loopback server — so `PlayerViewModel.cleanup()` calls this to
-    /// guarantee the graph is released with the session.
-    func release() {
+    /// Teardown for the player-close path. `detach` is keyed on layer identity,
+    /// which is the right guard for SwiftUI's dismantle but is a no-op if the
+    /// surface was never mounted or was replaced out of order. The coordinator
+    /// is a singleton and the controller strongly retains its `AVPlayerLayer` —
+    /// and through it the `AVPlayer`, its item, and the loopback server — so
+    /// `PlayerViewModel.cleanup()` calls this to guarantee the graph is
+    /// released with the session.
+    ///
+    /// Owner-guarded, because "close the old player, open the next" runs the
+    /// two sessions' lifecycles concurrently: a late cleanup from the outgoing
+    /// session must not tear down the controller the incoming one just bound.
+    /// The incoming session's `attach` already released the old controller
+    /// when the layer swapped, so nothing leaks by skipping.
+    func endSession(owner: AnyObject) {
+        guard lifecycleOwner === owner else {
+            Self.logger.info("Skipping PiP teardown; another session owns the controller")
+            return
+        }
+        lifecycleOwner = nil
+        onEngagementEnded = nil
         releaseController()
     }
 
@@ -120,12 +137,6 @@ final class PictureInPictureCoordinator {
     func bindLifecycle(owner: AnyObject, onEngagementEnded: @escaping () -> Void) {
         lifecycleOwner = owner
         self.onEngagementEnded = onEngagementEnded
-    }
-
-    func unbindLifecycle(owner: AnyObject) {
-        guard lifecycleOwner === owner else { return }
-        lifecycleOwner = nil
-        onEngagementEnded = nil
     }
 
     func toggle() {
@@ -166,12 +177,14 @@ final class PictureInPictureCoordinator {
         isPossible = false
         isActive = false
         isTransitioning = false
+        isRestoringUserInterface = false
     }
 
     // MARK: - Delegate callbacks
 
     fileprivate func handleWillStart() {
         isTransitioning = true
+        isRestoringUserInterface = false
     }
 
     fileprivate func handleDidStart() {
@@ -180,10 +193,19 @@ final class PictureInPictureCoordinator {
         Self.logger.info("PiP started")
     }
 
+    fileprivate func handleRestoreRequested() {
+        isRestoringUserInterface = true
+    }
+
     fileprivate func handleDidStop() {
         isTransitioning = false
         isActive = false
-        Self.logger.info("PiP stopped")
+        let wasRestoring = isRestoringUserInterface
+        isRestoringUserInterface = false
+        Self.logger.info("PiP stopped restoring=\(wasRestoring ? 1 : 0, privacy: .public)")
+        // Returning to the full-screen player keeps playing; only PiP genuinely
+        // going away while the app stays in the background is a reason to stop.
+        guard !wasRestoring else { return }
         onEngagementEnded?()
     }
 
@@ -236,6 +258,7 @@ final class PictureInPictureCoordinator {
             restoreUserInterfaceForPictureInPictureStopWithCompletionHandler completionHandler:
                 @escaping (Bool) -> Void
         ) {
+            coordinator?.handleRestoreRequested()
             completionHandler(true)
         }
     }


### PR DESCRIPTION
## Summary

Adds AirPlay and iOS Picture in Picture (PiP) playback support to Silo's AVPlayer routes (Native Player HLS/Direct and SiloPlayer loopback). Reconciles externally initiated pause/play events (from system PiP and AirPlay remotes) with Silo's internal play-intent tracking. Fixes transport state mismatch that caused playback to resume immediately after user pause.

## Picture in Picture Support

### What Works
- **Auto-start PiP**: When swiping to home, iOS automatically enters PiP if the app was playing (standard AVKit behavior).
- **Manual toggle**: PiP button in mobile player top strip.
- **Transport controls**: Play/pause from the floating window are properly routed through Silo's backend.
- **AirPlay + PiP coexistence**: PiP remains active while AirPlay routes work independently.
- **Background playback**: PiP continues playing when the app is backgrounded; normal pause policy applies only when PiP ends or fails to start.
- **Skip intervals**: Quick-skip forward/backward (configured via Now Playing metadata) work in PiP.

### Known Limitations
- **No scrubbing/timeline**: iOS AVKit's playerLayer content source does not provide a draggable timeline in PiP. Only play/pause and skip intervals are available. Full timeline seeking requires returning to the full-screen player and using Silo's scrubber.
- **Silo-rendered subtitles do not appear in PiP**: Text overlays are rendered by Silo's subtitle system and are only visible on the main player display, not in the system PiP window.
- **Not available on compatibility (PlayerCore) route**: The sample-buffer playback route would require a custom sample-buffer PiP content source; not yet implemented.

## AirPlay Support

- **iPhone/iPad to Apple TV or receiver**: Playback is delivered to the receiver via HLS stream from the SiloPlayer loopback server.
- **Automatic URL swap**: When AirPlay activates, the loopback item URL is reloaded with the device's LAN IPv4 address so the receiver can reach the stream. On AirPlay end, the URL reverts to localhost for phone playback.
- **Fixes for IPv6/cellular networks**: Previously, all loopback playback was forced through LAN addressing and failed on networks without a private IPv4 address. Now local playback defaults to localhost and only upgrades when needed.

## Changes Made

1. **AVPlayerBackend**: Added external playback state reconciliation; loopback URL swaps on AirPlay activation/end; unified transport-state policy to treat externally paused AVPlayer as user intent.
2. **PictureInPictureCoordinator**: New singleton managing AVPictureInPictureController lifecycle; coordinates background pause policy on PiP stop/failure; binds lifecycle to player session.
3. **LoopbackSegmentServer**: Loopback URLs default to 127.0.0.1 for local playback; LAN address only generated when explicitly requested for AirPlay.
4. **PlayerViewModel**: Background scene-phase handler now gives automatic PiP a 1-second grace window before pausing.
5. **AirPlayRoutePicker, MobilePlayerControls**: PiP button added; route picker wired to pin controls while sheet is open.
6. **ApplePlaybackRouteCapabilities**: PiP and AirPlay marked as validationRequired on AVPlayer routes.

## Testing

- Focused XCTest coverage for loopback startup recovery and segment server ranges (IPv4 validation).
- Full iOS, tvOS, macOS builds pass.
- Transport-state reconciliation prevents feedback loops between watchdog and external pause/play.

## Blockers and Notes

- Timeline scrubbing in PiP is not possible under iOS AVKit's architecture for playerLayer content sources. This is a system limitation, not a Silo implementation gap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-player AirPlay device picker and Picture-in-Picture controls.
  * Enabled local-network (LAN) streaming with session-scoped, token-protected access links.
  * Updated player routing to better support seamless AirPlay handoff and PiP playback state.

* **Documentation**
  * Expanded VS Code setup instructions, including tasks for generating projects, building, and running tests.

* **Bug Fixes**
  * Improved play/pause reconciliation for AirPlay and PiP, plus safer PiP attach/detach across lifecycle changes.
  * Refined background behavior to reduce premature pausing during PiP transitions.

* **Tests**
  * Added coverage for LAN URL privacy, token authorization, and route recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->