### PR TITLE
fix(settings): make the Audio Language setting reach playback

### DIFF
--- a/iosApp/iosApp/Networking/WireFormatModels.swift
+++ b/iosApp/iosApp/Networking/WireFormatModels.swift
@@ -42,6 +42,7 @@ struct Profile: Codable {
             hasPin: hasPin ?? false,
             isChild: isChild ?? false,
             isPrimary: isPrimary ?? false,
+            language: language,
             subtitleLanguage: subtitleLanguage,
             subtitleMode: subtitleMode,
             showForcedSubtitles: showForcedSubtitles,
@@ -54,6 +55,11 @@ struct Profile: Codable {
 /// caller can patch one or many at a time. Wire format mirrors the
 /// server's `updateProfileRequest`.
 struct UpdateProfileBody: Encodable {
+    /// Preferred spoken/audio language (ISO 639-1; `""` = no preference).
+    /// The server resolves the initial audio track from this field, so it
+    /// is what makes an audio-language choice actually reach playback.
+    /// Encodes as `language`.
+    var language: String?
     var subtitleLanguage: String?
     var subtitleMode: String?
     var showForcedSubtitles: Bool?

--- a/iosApp/iosApp/Screens/Player/PlayerSettings.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerSettings.swift
@@ -39,6 +39,11 @@ enum VideoGravity: String, CaseIterable {
 
 private enum PlayerDeviceSettingKey: String, CaseIterable {
     case preferredQuality = "playback.preferred_quality"
+    /// Legacy device-scoped audio language. The spoken-language choice now
+    /// lives on the profile (`PUT /profiles/{id}` → `language`), which is
+    /// what the server actually reads when it resolves the initial audio
+    /// track. The case is kept so `resetAllDeviceSettings()` still deletes
+    /// rows written by older builds.
     case audioLanguage = "playback.audio_language"
     case autoSkipIntro = "playback.auto_skip_intro"
     case autoSkipCredits = "playback.auto_skip_credits"
@@ -67,10 +72,6 @@ final class PlayerSettings {
 
     var preferredQuality: String {
         didSet { defaults.set(preferredQuality, forKey: Self.cacheKey(Keys.preferredQuality)) }
-    }
-
-    var audioLanguage: String {
-        didSet { defaults.set(audioLanguage, forKey: Self.cacheKey(Keys.audioLanguage)) }
     }
 
     var autoSkipIntro: Bool {
@@ -232,7 +233,6 @@ final class PlayerSettings {
         self.defaults = defaults
         defaults.register(defaults: [
             Keys.preferredQuality: "auto",
-            Keys.audioLanguage: "",
             Keys.autoSkipIntro: false,
             Keys.autoSkipCredits: false,
             Keys.hdrEnabled: true,
@@ -262,7 +262,6 @@ final class PlayerSettings {
         preferredQuality = ApplePlaybackQuality.normalizeStoredId(
             defaults.string(forKey: Self.cacheKey(Keys.preferredQuality))
         )
-        audioLanguage = defaults.string(forKey: Self.cacheKey(Keys.audioLanguage)) ?? ""
         autoSkipIntro = Self.cachedBool(defaults, key: Keys.autoSkipIntro, defaultValue: false)
         autoSkipCredits = Self.cachedBool(defaults, key: Keys.autoSkipCredits, defaultValue: false)
         hdrEnabled = Self.cachedBool(defaults, key: Keys.hdrEnabled, defaultValue: true)
@@ -386,11 +385,6 @@ final class PlayerSettings {
         let normalized = ApplePlaybackQuality.normalizeStoredId(value)
         preferredQuality = normalized
         enqueueDeviceSetting(.preferredQuality, operation: .set(normalized))
-    }
-
-    func setAudioLanguage(_ value: String) {
-        audioLanguage = value
-        enqueueDeviceSetting(.audioLanguage, operation: .set(value))
     }
 
     func setAutoSkipIntro(_ enabled: Bool) {
@@ -554,7 +548,6 @@ final class PlayerSettings {
         preferredQuality = ApplePlaybackQuality.normalizeStoredId(
             effectiveString(for: .preferredQuality, in: effectiveByKey, fallback: "auto")
         )
-        audioLanguage = effectiveString(for: .audioLanguage, in: effectiveByKey, fallback: "")
         autoSkipIntro = effectiveBool(for: .autoSkipIntro, in: effectiveByKey, fallback: false)
         autoSkipCredits = effectiveBool(for: .autoSkipCredits, in: effectiveByKey, fallback: false)
         autoPlayNextEpisode = effectiveBool(for: .autoPlayNext, in: effectiveByKey, fallback: true)
@@ -607,9 +600,6 @@ final class PlayerSettings {
                 defaults.string(forKey: Self.cacheKey(Keys.preferredQuality))
                     ?? defaults.string(forKey: Keys.preferredQuality)
             ),
-            .audioLanguage: defaults.string(forKey: Self.cacheKey(Keys.audioLanguage))
-                ?? defaults.string(forKey: Keys.audioLanguage)
-                ?? "",
             .autoSkipIntro: boolString(
                 Self.cachedBool(defaults, key: Keys.autoSkipIntro, defaultValue: false)
             ),
@@ -650,7 +640,6 @@ final class PlayerSettings {
         preferredQuality = ApplePlaybackQuality.normalizeStoredId(
             defaults.string(forKey: Self.cacheKey(Keys.preferredQuality))
         )
-        audioLanguage = defaults.string(forKey: Self.cacheKey(Keys.audioLanguage)) ?? ""
         autoSkipIntro = Self.cachedBool(defaults, key: Keys.autoSkipIntro, defaultValue: false)
         autoSkipCredits = Self.cachedBool(defaults, key: Keys.autoSkipCredits, defaultValue: false)
         autoPlayNextEpisode = Self.cachedBool(
@@ -876,7 +865,6 @@ final class PlayerSettings {
 
     private enum Keys {
         static let preferredQuality = "preferredQuality"
-        static let audioLanguage = "preferredAudioLanguage"
         static let autoSkipIntro = "skipIntros"
         static let autoSkipCredits = "skipCredits"
         static let hdrEnabled = "player.hdrEnabled"

--- a/iosApp/iosApp/Screens/Profiles/ProfileModels.swift
+++ b/iosApp/iosApp/Screens/Profiles/ProfileModels.swift
@@ -4,7 +4,7 @@ import Foundation
 
 /// Minimal user profile as returned by the server. Carries the
 /// playback-pref fields the player resolver consults at session start
-/// (subtitle language, behavior, forced-subs toggle).
+/// (spoken language, subtitle language, behavior, forced-subs toggle).
 struct UserProfile: Codable, Identifiable, Hashable {
     let id: String
     let name: String
@@ -12,6 +12,11 @@ struct UserProfile: Codable, Identifiable, Hashable {
     let hasPin: Bool
     let isChild: Bool
     let isPrimary: Bool
+    /// Preferred spoken/audio language (ISO 639-1; `""`/nil = no
+    /// preference). The server resolves the initial audio track from
+    /// this field and reports it as `effective_audio_track_index` on the
+    /// watch/detail responses the player starts from.
+    let language: String?
     let subtitleLanguage: String?
     let subtitleMode: String?
     let showForcedSubtitles: Bool?
@@ -26,6 +31,7 @@ struct UserProfile: Codable, Identifiable, Hashable {
         hasPin: Bool,
         isChild: Bool,
         isPrimary: Bool = false,
+        language: String? = nil,
         subtitleLanguage: String? = nil,
         subtitleMode: String? = nil,
         showForcedSubtitles: Bool? = nil,
@@ -37,6 +43,7 @@ struct UserProfile: Codable, Identifiable, Hashable {
         self.hasPin = hasPin
         self.isChild = isChild
         self.isPrimary = isPrimary
+        self.language = language
         self.subtitleLanguage = subtitleLanguage
         self.subtitleMode = subtitleMode
         self.showForcedSubtitles = showForcedSubtitles

--- a/iosApp/iosApp/Screens/Settings/PlaybackSettingsView.swift
+++ b/iosApp/iosApp/Screens/Settings/PlaybackSettingsView.swift
@@ -44,14 +44,15 @@ struct PlaybackSettingsView: View {
             #endif
 
             Picker("Audio Language", selection: Binding(
-                get: { viewModel.preferredAudioLanguage },
+                get: { viewModel.editorAudioLanguage },
                 set: { newValue in
-                    viewModel.preferredAudioLanguage = newValue
-                    Task { await viewModel.setPreferredAudioLanguage(newValue) }
+                    viewModel.editorAudioLanguage = newValue
+                    Task { await viewModel.saveAudioLanguage() }
                 }
             )) {
-                ForEach(audioLanguageOptions, id: \.0) { tag, label in
-                    Text(label).tag(tag)
+                Text("No Preference").tag(PlaybackPrefSentinel.none)
+                ForEach(PlaybackLanguageOption.all) { option in
+                    Text(option.label).tag(option.code)
                 }
             }
             .foregroundStyle(Color.continuumOnSurface)
@@ -103,7 +104,8 @@ struct PlaybackSettingsView: View {
     }
 
     private var streamingFooterText: String {
-        var text = "Turn off Dolby Vision to play Dolby Vision titles as HDR10 instead. Profile 5 titles have no HDR10-compatible layer and always play in Dolby Vision."
+        var text = "Audio Language picks which spoken track starts first; it applies to your profile on every device, not just this one."
+        text += " Turn off Dolby Vision to play Dolby Vision titles as HDR10 instead. Profile 5 titles have no HDR10-compatible layer and always play in Dolby Vision."
         if viewModel.dolbyVisionEnabled {
             text += " The fallback plays Dolby Vision Profile 7 as HDR10 on this device."
         }
@@ -187,20 +189,6 @@ struct PlaybackSettingsView: View {
 
     private var qualityOptions: [(String, String)] {
         ApplePlaybackQuality.settingsOptions.map { ($0.id, $0.labelWithBitrate) }
-    }
-
-    private var audioLanguageOptions: [(String, String)] {
-        [
-            ("", "Default"),
-            ("en", "English"),
-            ("es", "Spanish"),
-            ("fr", "French"),
-            ("de", "German"),
-            ("it", "Italian"),
-            ("pt", "Portuguese"),
-            ("ja", "Japanese"),
-            ("ko", "Korean"),
-        ]
     }
 
     private var nextUpPromptOptions: [(Int, String)] {

--- a/iosApp/iosApp/Screens/Settings/SettingsViewModel.swift
+++ b/iosApp/iosApp/Screens/Settings/SettingsViewModel.swift
@@ -3,10 +3,11 @@ import Foundation
 /// State container for the iOS settings screen.
 ///
 /// Local-only fields (preferred quality, auto-play, skip intros, subtitle
-/// size) live in `UserDefaults`. The subtitle-language / behavior /
-/// forced-subs trio is profile-wide on the server and persisted via
-/// `PUT /profiles/{id}` — same model as the tvOS settings screen, so
-/// edits made on either platform cascade into playback the same way.
+/// size) live in `UserDefaults`. The spoken-language choice and the
+/// subtitle-language / behavior / forced-subs trio are profile-wide on
+/// the server and persisted via `PUT /profiles/{id}` — same model as the
+/// tvOS settings screen, so edits made on either platform cascade into
+/// playback the same way.
 @Observable
 class SettingsViewModel {
     var userInfo: UserInfo?
@@ -27,7 +28,6 @@ class SettingsViewModel {
 
     // Playback preferences (server-backed for this device/profile).
     var preferredQuality: String = PlayerSettings.shared.preferredQuality
-    var preferredAudioLanguage: String = PlayerSettings.shared.audioLanguage
     var autoPlayNext: Bool = PlayerSettings.shared.autoPlayNextEpisode
     var nextUpPromptSeconds: Int = PlayerSettings.shared.nextUpPromptSeconds
     var skipIntros: Bool = PlayerSettings.shared.autoSkipIntro
@@ -52,6 +52,12 @@ class SettingsViewModel {
     // Server-backed profile prefs editor. Each editor field is either
     // a sentinel ("__none__") or a concrete value. We persist directly
     // to the active profile via PUT /profiles/{id}.
+    /// Preferred spoken (audio) language. Profile-wide, not per-device:
+    /// the server resolves the initial audio track from the profile's
+    /// `language` field, so this is the only value that actually reaches
+    /// playback. `PlaybackPrefSentinel.none` maps to the empty string
+    /// ("no preference") on the wire.
+    var editorAudioLanguage: String = PlaybackPrefSentinel.none
     var editorSubtitleLanguage: String = PlaybackPrefSentinel.none
     var editorSubtitleMode: String = SubtitleMode.auto.rawValue
     /// Tri-state stored as "on" / "off". The server treats nil and
@@ -78,7 +84,6 @@ class SettingsViewModel {
     func loadSettings() async {
         await PlayerSettings.shared.refreshFromServer()
         preferredQuality = PlayerSettings.shared.preferredQuality
-        preferredAudioLanguage = PlayerSettings.shared.audioLanguage
         autoPlayNext = PlayerSettings.shared.autoPlayNextEpisode
         nextUpPromptSeconds = PlayerSettings.shared.nextUpPromptSeconds
         skipIntros = PlayerSettings.shared.autoSkipIntro
@@ -114,12 +119,6 @@ class SettingsViewModel {
     func setPreferredQuality(_ value: String) async {
         PlayerSettings.shared.setPreferredQuality(value)
         preferredQuality = PlayerSettings.shared.preferredQuality
-    }
-
-    @MainActor
-    func setPreferredAudioLanguage(_ value: String) async {
-        PlayerSettings.shared.setAudioLanguage(value)
-        preferredAudioLanguage = PlayerSettings.shared.audioLanguage
     }
 
     @MainActor
@@ -168,7 +167,6 @@ class SettingsViewModel {
     func resetPlaybackDeviceSettings() async {
         await PlayerSettings.shared.resetAllDeviceSettings()
         preferredQuality = PlayerSettings.shared.preferredQuality
-        preferredAudioLanguage = PlayerSettings.shared.audioLanguage
         autoPlayNext = PlayerSettings.shared.autoPlayNextEpisode
         nextUpPromptSeconds = PlayerSettings.shared.nextUpPromptSeconds
         skipIntros = PlayerSettings.shared.autoSkipIntro
@@ -210,7 +208,7 @@ class SettingsViewModel {
         prefSaveState = .saving
 
         let body = UpdateProfileBody(
-            subtitleLanguage: outboundSubtitleLanguage(editorSubtitleLanguage),
+            subtitleLanguage: outboundProfileLanguage(editorSubtitleLanguage),
             subtitleMode: editorSubtitleMode,
             showForcedSubtitles: editorShowForcedSubtitles == "on"
         )
@@ -226,6 +224,7 @@ class SettingsViewModel {
                     avatarEmoji: prof.avatarEmoji,
                     hasPin: prof.hasPin,
                     isChild: prof.isChild,
+                    language: prof.language,
                     subtitleLanguage: body.subtitleLanguage,
                     subtitleMode: body.subtitleMode,
                     showForcedSubtitles: body.showForcedSubtitles,
@@ -249,7 +248,7 @@ class SettingsViewModel {
     @MainActor
     func saveMetadataLanguage() async {
         guard activeProfile?.id.isEmpty == false else { return }
-        pendingMetadataLanguageValue = outboundSubtitleLanguage(editorPreferredMetadataLanguage)
+        pendingMetadataLanguageValue = outboundProfileLanguage(editorPreferredMetadataLanguage)
         guard !isSavingMetadataLanguage else { return }
 
         isSavingMetadataLanguage = true
@@ -273,7 +272,7 @@ class SettingsViewModel {
         do {
             try await ContinuumAPI.shared.updateProfile(profileId: profileId, body: body)
             guard activeProfile?.id == profileId,
-                  outboundSubtitleLanguage(editorPreferredMetadataLanguage) == newValue else {
+                  outboundProfileLanguage(editorPreferredMetadataLanguage) == newValue else {
                 return
             }
             prefSaveState = .saved
@@ -284,6 +283,7 @@ class SettingsViewModel {
                     avatarEmoji: prof.avatarEmoji,
                     hasPin: prof.hasPin,
                     isChild: prof.isChild,
+                    language: prof.language,
                     subtitleLanguage: prof.subtitleLanguage,
                     subtitleMode: prof.subtitleMode,
                     showForcedSubtitles: prof.showForcedSubtitles,
@@ -296,7 +296,67 @@ class SettingsViewModel {
             #endif
         } catch {
             guard activeProfile?.id == profileId,
-                  outboundSubtitleLanguage(editorPreferredMetadataLanguage) == newValue else {
+                  outboundProfileLanguage(editorPreferredMetadataLanguage) == newValue else {
+                return
+            }
+            prefSaveState = .failed(
+                (error as? LocalizedError)?.errorDescription
+                    ?? String(describing: error)
+            )
+        }
+    }
+
+    /// Persist the preferred spoken (audio) language as a profile patch.
+    ///
+    /// This is deliberately a profile field rather than a per-device one:
+    /// the server picks the initial audio track from `profile.language`
+    /// and reports the result as `effective_audio_track_index`, which the
+    /// player forwards at session start. A device-scoped value would
+    /// never be read by anything.
+    @MainActor
+    func saveAudioLanguage() async {
+        guard let profileId = activeProfile?.id, !profileId.isEmpty else { return }
+        let newValue = outboundProfileLanguage(editorAudioLanguage)
+        guard newValue != (activeProfile?.language ?? "") else { return }
+
+        prefSaveState = .saving
+
+        do {
+            try await ContinuumAPI.shared.updateProfile(
+                profileId: profileId,
+                body: UpdateProfileBody(language: newValue)
+            )
+            guard activeProfile?.id == profileId,
+                  outboundProfileLanguage(editorAudioLanguage) == newValue else {
+                return
+            }
+            prefSaveState = .saved
+            if let prof = activeProfile {
+                activeProfile = UserProfile(
+                    id: prof.id,
+                    name: prof.name,
+                    avatarEmoji: prof.avatarEmoji,
+                    hasPin: prof.hasPin,
+                    isChild: prof.isChild,
+                    language: newValue,
+                    subtitleLanguage: prof.subtitleLanguage,
+                    subtitleMode: prof.subtitleMode,
+                    showForcedSubtitles: prof.showForcedSubtitles,
+                    preferredMetadataLanguage: prof.preferredMetadataLanguage
+                )
+            }
+            // Detail screens render the server-resolved audio track out of
+            // the cached item payloads, which have no TTL. Drop them so the
+            // new selection shows up without a relaunch. Playback itself
+            // always refetches `/watch`, so this is display consistency
+            // only — it is not what makes the setting take effect.
+            ResponseCache.shared.invalidateAllItemMetadata()
+            #if os(tvOS)
+            ItemDetailCache.shared.clearAll()
+            #endif
+        } catch {
+            guard activeProfile?.id == profileId,
+                  outboundProfileLanguage(editorAudioLanguage) == newValue else {
                 return
             }
             prefSaveState = .failed(
@@ -309,6 +369,9 @@ class SettingsViewModel {
     // MARK: - Editor projection helpers
 
     private func projectActiveProfileIntoEditor() {
+        let audioLang = activeProfile?.language ?? ""
+        editorAudioLanguage = audioLang.isEmpty ? PlaybackPrefSentinel.none : audioLang
+
         let raw = activeProfile?.subtitleLanguage ?? ""
         editorSubtitleLanguage = raw.isEmpty ? PlaybackPrefSentinel.none : raw
 
@@ -322,8 +385,9 @@ class SettingsViewModel {
     }
 
     /// `__none__` sentinel maps to the empty string the server expects
-    /// to mean "no subtitle preference / no subs".
-    private func outboundSubtitleLanguage(_ value: String) -> String {
+    /// to mean "no preference" for any of the profile language fields
+    /// (spoken, subtitle, metadata).
+    private func outboundProfileLanguage(_ value: String) -> String {
         value == PlaybackPrefSentinel.none ? "" : value
     }
 }

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVPlaybackSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVPlaybackSettingsView.swift
@@ -34,7 +34,7 @@ struct TVPlaybackSettingsPane: View {
 
         TVSettingsPickerRow(
             title: "Audio Language",
-            value: TVSettingsOptions.label(for: viewModel.preferredAudioLanguage, in: TVSettingsOptions.audioLanguage)
+            value: TVSettingsOptions.label(for: viewModel.editorAudioLanguage, in: TVSettingsOptions.audioLanguage)
         ) { activePicker = .audioLanguage }
 
         TVSettingsToggleRow(
@@ -70,7 +70,8 @@ struct TVPlaybackSettingsPane: View {
     }
 
     private var streamingFooterText: String {
-        var text = "Turn off Dolby Vision to play Dolby Vision titles as HDR10 instead. Profile 5 titles have no HDR10-compatible layer and always play in Dolby Vision."
+        var text = "Audio Language picks which spoken track starts first; it applies to your profile on every device, not just this Apple TV."
+        text += " Turn off Dolby Vision to play Dolby Vision titles as HDR10 instead. Profile 5 titles have no HDR10-compatible layer and always play in Dolby Vision."
         if viewModel.dolbyVisionEnabled {
             text += " The fallback plays Dolby Vision Profile 7 as HDR10 on this Apple TV."
         }
@@ -157,10 +158,10 @@ struct TVPlaybackSettingsPane: View {
                 title: "Audio Language",
                 options: TVSettingsOptions.audioLanguage,
                 selection: Binding(
-                    get: { viewModel.preferredAudioLanguage },
+                    get: { viewModel.editorAudioLanguage },
                     set: { value in
-                        viewModel.preferredAudioLanguage = value
-                        Task { await viewModel.setPreferredAudioLanguage(value) }
+                        viewModel.editorAudioLanguage = value
+                        Task { await viewModel.saveAudioLanguage() }
                     }
                 )
             )

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsComponents.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsComponents.swift
@@ -17,17 +17,9 @@ enum TVSettingsOptions {
             .init(id: option.id, label: option.labelWithBitrate)
         }
 
-    static let audioLanguage: [TVSettingsOption] = [
-        .init(id: "", label: "Default"),
-        .init(id: "en", label: "English"),
-        .init(id: "es", label: "Spanish"),
-        .init(id: "fr", label: "French"),
-        .init(id: "de", label: "German"),
-        .init(id: "it", label: "Italian"),
-        .init(id: "pt", label: "Portuguese"),
-        .init(id: "ja", label: "Japanese"),
-        .init(id: "ko", label: "Korean"),
-    ]
+    static let audioLanguage: [TVSettingsOption] =
+        [.init(id: PlaybackPrefSentinel.none, label: "No Preference")]
+            + PlaybackLanguageOption.all.map { .init(id: $0.code, label: $0.label) }
 
     static let nextUpPrompt: [TVSettingsOption] = [
         .init(id: "0", label: "At end"),

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsViewModel.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsViewModel.swift
@@ -4,8 +4,9 @@ import Foundation
 /// State container for the tvOS settings screen.
 ///
 /// Local-only fields (preferred quality, auto-play, subtitle size) live
-/// in `UserDefaults`. The subtitle-language / behavior / forced-subs
-/// trio is profile-wide on the server and persisted via
+/// in `UserDefaults`. The spoken-language choice and the
+/// subtitle-language / behavior / forced-subs trio are profile-wide on
+/// the server and persisted via
 /// `PUT /profiles/{id}`. The server cascades profile → library →
 /// per-series at playback time, so a single profile-level edit is
 /// enough to make subs auto-enable everywhere unless the user later
@@ -29,7 +30,6 @@ final class TVSettingsViewModel {
 
     // Playback preferences (server-backed for this device/profile).
     var preferredQuality: String = PlayerSettings.shared.preferredQuality
-    var preferredAudioLanguage: String = PlayerSettings.shared.audioLanguage
     var autoPlayNext: Bool = PlayerSettings.shared.autoPlayNextEpisode
     var nextUpPromptSeconds: Int = PlayerSettings.shared.nextUpPromptSeconds
     var skipIntros: Bool = PlayerSettings.shared.autoSkipIntro
@@ -54,6 +54,12 @@ final class TVSettingsViewModel {
     // Server-backed profile prefs editor. Each editor field is either
     // the `PlaybackPrefSentinel.none` sentinel ("__none__") or a concrete
     // value. We persist directly to the active profile via PUT /profiles/{id}.
+    /// Preferred spoken (audio) language. Profile-wide, not per-device:
+    /// the server resolves the initial audio track from the profile's
+    /// `language` field, so this is the only value that actually reaches
+    /// playback. `PlaybackPrefSentinel.none` maps to the empty string
+    /// ("no preference") on the wire.
+    var editorAudioLanguage: String = PlaybackPrefSentinel.none
     var editorSubtitleLanguage: String = PlaybackPrefSentinel.none
     var editorSubtitleMode: String = SubtitleMode.auto.rawValue
     /// Tri-state stored as "on" / "off". The server treats nil and
@@ -105,7 +111,6 @@ final class TVSettingsViewModel {
     func load() async {
         await PlayerSettings.shared.refreshFromServer()
         preferredQuality = PlayerSettings.shared.preferredQuality
-        preferredAudioLanguage = PlayerSettings.shared.audioLanguage
         autoPlayNext = PlayerSettings.shared.autoPlayNextEpisode
         nextUpPromptSeconds = PlayerSettings.shared.nextUpPromptSeconds
         skipIntros = PlayerSettings.shared.autoSkipIntro
@@ -141,12 +146,6 @@ final class TVSettingsViewModel {
     func setPreferredQuality(_ value: String) async {
         PlayerSettings.shared.setPreferredQuality(value)
         preferredQuality = PlayerSettings.shared.preferredQuality
-    }
-
-    @MainActor
-    func setPreferredAudioLanguage(_ value: String) async {
-        PlayerSettings.shared.setAudioLanguage(value)
-        preferredAudioLanguage = PlayerSettings.shared.audioLanguage
     }
 
     @MainActor
@@ -195,7 +194,6 @@ final class TVSettingsViewModel {
     func resetPlaybackDeviceSettings() async {
         await PlayerSettings.shared.resetAllDeviceSettings()
         preferredQuality = PlayerSettings.shared.preferredQuality
-        preferredAudioLanguage = PlayerSettings.shared.audioLanguage
         autoPlayNext = PlayerSettings.shared.autoPlayNextEpisode
         nextUpPromptSeconds = PlayerSettings.shared.nextUpPromptSeconds
         skipIntros = PlayerSettings.shared.autoSkipIntro
@@ -245,7 +243,7 @@ final class TVSettingsViewModel {
         prefSaveState = .saving
 
         let body = UpdateProfileBody(
-            subtitleLanguage: outboundSubtitleLanguage(editorSubtitleLanguage),
+            subtitleLanguage: outboundProfileLanguage(editorSubtitleLanguage),
             subtitleMode: editorSubtitleMode,
             showForcedSubtitles: editorShowForcedSubtitles == "on"
         )
@@ -263,6 +261,7 @@ final class TVSettingsViewModel {
                     avatarEmoji: prof.avatarEmoji,
                     hasPin: prof.hasPin,
                     isChild: prof.isChild,
+                    language: prof.language,
                     subtitleLanguage: body.subtitleLanguage,
                     subtitleMode: body.subtitleMode,
                     showForcedSubtitles: body.showForcedSubtitles,
@@ -285,7 +284,7 @@ final class TVSettingsViewModel {
     @MainActor
     func saveMetadataLanguage() async {
         guard activeProfile?.id.isEmpty == false else { return }
-        pendingMetadataLanguageValue = outboundSubtitleLanguage(editorPreferredMetadataLanguage)
+        pendingMetadataLanguageValue = outboundProfileLanguage(editorPreferredMetadataLanguage)
         guard !isSavingMetadataLanguage else { return }
 
         isSavingMetadataLanguage = true
@@ -309,7 +308,7 @@ final class TVSettingsViewModel {
         do {
             try await ContinuumAPI.shared.updateProfile(profileId: profileId, body: body)
             guard activeProfile?.id == profileId,
-                  outboundSubtitleLanguage(editorPreferredMetadataLanguage) == newValue else {
+                  outboundProfileLanguage(editorPreferredMetadataLanguage) == newValue else {
                 return
             }
             prefSaveState = .saved
@@ -320,6 +319,7 @@ final class TVSettingsViewModel {
                     avatarEmoji: prof.avatarEmoji,
                     hasPin: prof.hasPin,
                     isChild: prof.isChild,
+                    language: prof.language,
                     subtitleLanguage: prof.subtitleLanguage,
                     subtitleMode: prof.subtitleMode,
                     showForcedSubtitles: prof.showForcedSubtitles,
@@ -332,7 +332,65 @@ final class TVSettingsViewModel {
             #endif
         } catch {
             guard activeProfile?.id == profileId,
-                  outboundSubtitleLanguage(editorPreferredMetadataLanguage) == newValue else {
+                  outboundProfileLanguage(editorPreferredMetadataLanguage) == newValue else {
+                return
+            }
+            prefSaveState = .failed(
+                (error as? LocalizedError)?.errorDescription
+                    ?? String(describing: error)
+            )
+        }
+    }
+
+    /// Persist the preferred spoken (audio) language as a profile patch.
+    ///
+    /// This is deliberately a profile field rather than a per-device one:
+    /// the server picks the initial audio track from `profile.language`
+    /// and reports the result as `effective_audio_track_index`, which the
+    /// player forwards at session start. A device-scoped value would
+    /// never be read by anything.
+    @MainActor
+    func saveAudioLanguage() async {
+        guard let profileId = activeProfile?.id, !profileId.isEmpty else { return }
+        let newValue = outboundProfileLanguage(editorAudioLanguage)
+        guard newValue != (activeProfile?.language ?? "") else { return }
+
+        prefSaveState = .saving
+
+        do {
+            try await ContinuumAPI.shared.updateProfile(
+                profileId: profileId,
+                body: UpdateProfileBody(language: newValue)
+            )
+            guard activeProfile?.id == profileId,
+                  outboundProfileLanguage(editorAudioLanguage) == newValue else {
+                return
+            }
+            prefSaveState = .saved
+            if let prof = activeProfile {
+                activeProfile = UserProfile(
+                    id: prof.id,
+                    name: prof.name,
+                    avatarEmoji: prof.avatarEmoji,
+                    hasPin: prof.hasPin,
+                    isChild: prof.isChild,
+                    language: newValue,
+                    subtitleLanguage: prof.subtitleLanguage,
+                    subtitleMode: prof.subtitleMode,
+                    showForcedSubtitles: prof.showForcedSubtitles,
+                    preferredMetadataLanguage: prof.preferredMetadataLanguage
+                )
+            }
+            // Detail screens render the server-resolved audio track out of
+            // the cached item payloads, which have no TTL. Drop them so the
+            // new selection shows up without a relaunch. Playback itself
+            // always refetches `/watch`, so this is display consistency
+            // only — it is not what makes the setting take effect.
+            ResponseCache.shared.invalidateAllItemMetadata()
+            ItemDetailCache.shared.clearAll()
+        } catch {
+            guard activeProfile?.id == profileId,
+                  outboundProfileLanguage(editorAudioLanguage) == newValue else {
                 return
             }
             prefSaveState = .failed(
@@ -345,6 +403,9 @@ final class TVSettingsViewModel {
     // MARK: - Editor projection helpers
 
     private func projectActiveProfileIntoEditor() {
+        let audioLang = activeProfile?.language ?? ""
+        editorAudioLanguage = audioLang.isEmpty ? PlaybackPrefSentinel.none : audioLang
+
         let raw = activeProfile?.subtitleLanguage ?? ""
         editorSubtitleLanguage = raw.isEmpty ? PlaybackPrefSentinel.none : raw
 
@@ -358,8 +419,9 @@ final class TVSettingsViewModel {
     }
 
     /// `__none__` sentinel maps to the empty string the server expects
-    /// to mean "no subtitle preference / no subs".
-    private func outboundSubtitleLanguage(_ value: String) -> String {
+    /// to mean "no preference" for any of the profile language fields
+    /// (spoken, subtitle, metadata).
+    private func outboundProfileLanguage(_ value: String) -> String {
         value == PlaybackPrefSentinel.none ? "" : value
     }
 }


### PR DESCRIPTION
## Problem

The Audio Language picker writes a value that nothing ever reads. Verified P1 from Silo-Server/silo-server#376.

`PlayerSettings` wrote `playback.audio_language` as a **device** setting, but repository-wide that value was only ever loaded, cached, displayed, and written back inside the settings layer — no detail, session-start, route-planning, or player-selection path consumed it. The server picks the initial audio track from the **profile's** `language` field instead, and `WireFormatModels.asUserProfile` was deliberately dropping that field, while `UpdateProfileBody` had no way to write it.

Net effect: changing a visible setting did nothing.

## Fix

Point the setting at what the server actually reads.

- `Profile.language` now flows through `asUserProfile` into `UserProfile.language`, and `UpdateProfileBody` gained `language` so the client can write it.
- Both settings view models replace the device-backed `preferredAudioLanguage` with a profile editor field plus `saveAudioLanguage()`, which PUTs to `/api/v1/profiles/{id}`, refreshes the local `activeProfile` snapshot, and flushes the item `ResponseCache` (and tvOS `ItemDetailCache`) so an already-visited detail screen stops showing the stale track.
- Both pickers now build from the shared `PlaybackLanguageOption.all` list the subtitle and metadata pickers already use, deleting two duplicated 9-entry lists. This is **required, not cosmetic**: a language set from the web client (zh/ru/ar/hi) would otherwise render as a blank row.
- The now-dead device-scoped `audioLanguage` state is removed from `PlayerSettings`. `PlayerDeviceSettingKey.audioLanguage` is kept so "Reset Playback Overrides" still clears rows written by older builds — leaving a dead write path would have undercut the point of the fix.
- Streaming footers now say the setting is profile-wide.

No server change is needed: `PUT /profiles/{id}` already accepts `language` for self-service, stores it, and returns it. silo-android already reads `activeProfile?.language`.

## Verification

Built on mac-builder in an isolated worktree — **all three schemes, zero errors**:

| Scheme | Target | Result |
|---|---|---|
| `Silo` | iOS Simulator | ✅ SUCCEEDED (52s) |
| `SiloTV` | tvOS Simulator | ✅ SUCCEEDED (36s) |
| `SiloMac` | macOS | ✅ SUCCEEDED (35s) |

All remaining warnings are pre-existing and in untouched files (`SubtitleSession`, `Pairing/*`, `PendingReportStore`, `TVAudiobookDetailView`, `DownloadsManagerComponents`).

The repo's only two executable scripts (`resolve-marketing-version.test.sh`, `resolve-platform.test.sh`) also pass. There is no Swift unit-test target to run.

## Known limits and follow-ups

- **Not device-verified.** Compiles on all three platforms; the actual picker → profile → server → track-selection round trip was not exercised against a live server.
- **Stranded device rows, and this one matters for the contract.** Existing `playback.audio_language` rows in `user_device_settings` from earlier builds are now orphaned. Harmless today, but the settings contract (Silo-Server/silo-server#473) resolves that key `profile_device → profile`, so a stale row would **shadow** the new profile value — and it would be a value the user set months ago and saw no effect from. Needs an explicit migration disposition server-side; deliberately not papered over with a client-side DELETE.
- **Language list is still narrower than the web's** — 12 entries plus the `original` sentinel, versus the full ISO 639-1 list the web writes. Pre-existing gap shared with the subtitle and metadata pickers; this change improves it (9 → 12) without closing it. An unmatched selection displays blank, it does not overwrite the stored value.
- **No write coalescing.** Two picker changes in rapid succession could land out of order. Acceptable given every platform's picker is one-change-per-visit, and consistent with the existing subtitle path.
- **Pre-existing bug, deliberately not fixed:** all four `activeProfile = UserProfile(...)` reconstructions drop `isPrimary`, silently resetting it to `false` after any profile save. Second concern, and anything keying off `isPrimary` would change behavior. Worth its own issue.
- **UI change worth a screenshot:** the picker goes from 9 to 13 rows, and the empty label changes from "Default" to "No Preference" — matching the web and honest now that the value is profile-wide.

Part of Silo-Server/silo-server#376.

## AI-use disclosure

Implemented with AI assistance (Claude Opus 5) under maintainer direction. Builds were run and confirmed independently on mac-builder rather than reported from the implementing agent, which had no Swift toolchain available.
