### PR TITLE
fix(settings): apply audio language from the profile so it affects playback

### DIFF
--- a/iosApp/iosApp/Networking/PlaybackPrefsModels.swift
+++ b/iosApp/iosApp/Networking/PlaybackPrefsModels.swift
@@ -158,7 +158,29 @@ struct PlaybackLanguageOption: Identifiable, Hashable {
 
     static func label(forCode code: String) -> String {
         if code == PlaybackPrefSentinel.originalLanguage { return "Original Language" }
-        return all.first { $0.code == code }?.label ?? code.uppercased()
+        if let known = all.first(where: { $0.code == code })?.label { return known }
+        // A code from outside the twelve still deserves a name rather than a
+        // bare "NL".
+        return Locale.current.localizedString(forLanguageCode: code)?.capitalized
+            ?? code.uppercased()
+    }
+
+    /// The options a picker should show while it holds `code`.
+    ///
+    /// Audio and subtitle language are server-owned profile fields, and the web
+    /// client offers far more languages than the twelve above — as does the
+    /// `original` sentinel, which the server honours at profile scope. A stored
+    /// value outside this list is therefore normal, not corrupt. Without it in
+    /// the list the picker renders an empty selection on iOS and a literal "—"
+    /// on tvOS, and the first tap silently replaces a language this client
+    /// cannot name.
+    static func options(including code: String) -> [PlaybackLanguageOption] {
+        guard !code.isEmpty,
+              code != PlaybackPrefSentinel.none,
+              code != PlaybackPrefSentinel.inherit,
+              !all.contains(where: { $0.code == code })
+        else { return all }
+        return [PlaybackLanguageOption(code: code, label: label(forCode: code))] + all
     }
 }
 

--- a/iosApp/iosApp/Networking/WireFormatModels.swift
+++ b/iosApp/iosApp/Networking/WireFormatModels.swift
@@ -42,6 +42,7 @@ struct Profile: Codable {
             hasPin: hasPin ?? false,
             isChild: isChild ?? false,
             isPrimary: isPrimary ?? false,
+            language: language,
             subtitleLanguage: subtitleLanguage,
             subtitleMode: subtitleMode,
             showForcedSubtitles: showForcedSubtitles,
@@ -54,6 +55,11 @@ struct Profile: Codable {
 /// caller can patch one or many at a time. Wire format mirrors the
 /// server's `updateProfileRequest`.
 struct UpdateProfileBody: Encodable {
+    /// Preferred spoken/audio language (ISO 639-1; `""` = no preference).
+    /// The server resolves the initial audio track from this field, so it
+    /// is what makes an audio-language choice actually reach playback.
+    /// Encodes as `language`.
+    var language: String?
     var subtitleLanguage: String?
     var subtitleMode: String?
     var showForcedSubtitles: Bool?

--- a/iosApp/iosApp/Screens/Player/PlayerSettings.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerSettings.swift
@@ -39,6 +39,11 @@ enum VideoGravity: String, CaseIterable {
 
 private enum PlayerDeviceSettingKey: String, CaseIterable {
     case preferredQuality = "playback.preferred_quality"
+    /// Legacy device-scoped audio language. The spoken-language choice now
+    /// lives on the profile (`PUT /profiles/{id}` → `language`), which is
+    /// what the server actually reads when it resolves the initial audio
+    /// track. The case is kept so `resetAllDeviceSettings()` still deletes
+    /// rows written by older builds.
     case audioLanguage = "playback.audio_language"
     case autoSkipIntro = "playback.auto_skip_intro"
     case autoSkipCredits = "playback.auto_skip_credits"
@@ -67,10 +72,6 @@ final class PlayerSettings {
 
     var preferredQuality: String {
         didSet { defaults.set(preferredQuality, forKey: Self.cacheKey(Keys.preferredQuality)) }
-    }
-
-    var audioLanguage: String {
-        didSet { defaults.set(audioLanguage, forKey: Self.cacheKey(Keys.audioLanguage)) }
     }
 
     var autoSkipIntro: Bool {
@@ -232,7 +233,6 @@ final class PlayerSettings {
         self.defaults = defaults
         defaults.register(defaults: [
             Keys.preferredQuality: "auto",
-            Keys.audioLanguage: "",
             Keys.autoSkipIntro: false,
             Keys.autoSkipCredits: false,
             Keys.hdrEnabled: true,
@@ -262,7 +262,6 @@ final class PlayerSettings {
         preferredQuality = ApplePlaybackQuality.normalizeStoredId(
             defaults.string(forKey: Self.cacheKey(Keys.preferredQuality))
         )
-        audioLanguage = defaults.string(forKey: Self.cacheKey(Keys.audioLanguage)) ?? ""
         autoSkipIntro = Self.cachedBool(defaults, key: Keys.autoSkipIntro, defaultValue: false)
         autoSkipCredits = Self.cachedBool(defaults, key: Keys.autoSkipCredits, defaultValue: false)
         hdrEnabled = Self.cachedBool(defaults, key: Keys.hdrEnabled, defaultValue: true)
@@ -386,11 +385,6 @@ final class PlayerSettings {
         let normalized = ApplePlaybackQuality.normalizeStoredId(value)
         preferredQuality = normalized
         enqueueDeviceSetting(.preferredQuality, operation: .set(normalized))
-    }
-
-    func setAudioLanguage(_ value: String) {
-        audioLanguage = value
-        enqueueDeviceSetting(.audioLanguage, operation: .set(value))
     }
 
     func setAutoSkipIntro(_ enabled: Bool) {
@@ -554,7 +548,6 @@ final class PlayerSettings {
         preferredQuality = ApplePlaybackQuality.normalizeStoredId(
             effectiveString(for: .preferredQuality, in: effectiveByKey, fallback: "auto")
         )
-        audioLanguage = effectiveString(for: .audioLanguage, in: effectiveByKey, fallback: "")
         autoSkipIntro = effectiveBool(for: .autoSkipIntro, in: effectiveByKey, fallback: false)
         autoSkipCredits = effectiveBool(for: .autoSkipCredits, in: effectiveByKey, fallback: false)
         autoPlayNextEpisode = effectiveBool(for: .autoPlayNext, in: effectiveByKey, fallback: true)
@@ -607,9 +600,6 @@ final class PlayerSettings {
                 defaults.string(forKey: Self.cacheKey(Keys.preferredQuality))
                     ?? defaults.string(forKey: Keys.preferredQuality)
             ),
-            .audioLanguage: defaults.string(forKey: Self.cacheKey(Keys.audioLanguage))
-                ?? defaults.string(forKey: Keys.audioLanguage)
-                ?? "",
             .autoSkipIntro: boolString(
                 Self.cachedBool(defaults, key: Keys.autoSkipIntro, defaultValue: false)
             ),
@@ -650,7 +640,6 @@ final class PlayerSettings {
         preferredQuality = ApplePlaybackQuality.normalizeStoredId(
             defaults.string(forKey: Self.cacheKey(Keys.preferredQuality))
         )
-        audioLanguage = defaults.string(forKey: Self.cacheKey(Keys.audioLanguage)) ?? ""
         autoSkipIntro = Self.cachedBool(defaults, key: Keys.autoSkipIntro, defaultValue: false)
         autoSkipCredits = Self.cachedBool(defaults, key: Keys.autoSkipCredits, defaultValue: false)
         autoPlayNextEpisode = Self.cachedBool(
@@ -876,7 +865,6 @@ final class PlayerSettings {
 
     private enum Keys {
         static let preferredQuality = "preferredQuality"
-        static let audioLanguage = "preferredAudioLanguage"
         static let autoSkipIntro = "skipIntros"
         static let autoSkipCredits = "skipCredits"
         static let hdrEnabled = "player.hdrEnabled"

--- a/iosApp/iosApp/Screens/Profiles/ProfileModels.swift
+++ b/iosApp/iosApp/Screens/Profiles/ProfileModels.swift
@@ -49,6 +49,39 @@ struct UserProfile: Codable, Identifiable, Hashable {
         self.showForcedSubtitles = showForcedSubtitles
         self.preferredMetadataLanguage = preferredMetadataLanguage
     }
+
+    /// Returns a copy with the named fields replaced and everything else
+    /// carried over.
+    ///
+    /// Use this instead of re-invoking the initializer by hand. Every
+    /// hand-written reconstruction dropped `isPrimary` — Swift fills an
+    /// omitted defaulted parameter without a word, so the household parent
+    /// quietly demoted themselves on every profile-preference save — and the
+    /// same trap catches the next field anyone adds. Nothing can be forgotten
+    /// here, because omitting a parameter means "keep it".
+    ///
+    /// The double optionals distinguish "not supplied" from "set to nil".
+    func with(
+        language: String?? = nil,
+        subtitleLanguage: String?? = nil,
+        subtitleMode: String?? = nil,
+        showForcedSubtitles: Bool?? = nil,
+        preferredMetadataLanguage: String?? = nil
+    ) -> UserProfile {
+        UserProfile(
+            id: id,
+            name: name,
+            avatarEmoji: avatarEmoji,
+            hasPin: hasPin,
+            isChild: isChild,
+            isPrimary: isPrimary,
+            language: language ?? self.language,
+            subtitleLanguage: subtitleLanguage ?? self.subtitleLanguage,
+            subtitleMode: subtitleMode ?? self.subtitleMode,
+            showForcedSubtitles: showForcedSubtitles ?? self.showForcedSubtitles,
+            preferredMetadataLanguage: preferredMetadataLanguage ?? self.preferredMetadataLanguage
+        )
+    }
 }
 
 /// Request body for selecting a profile.

--- a/iosApp/iosApp/Screens/Profiles/ProfileModels.swift
+++ b/iosApp/iosApp/Screens/Profiles/ProfileModels.swift
@@ -4,7 +4,7 @@ import Foundation
 
 /// Minimal user profile as returned by the server. Carries the
 /// playback-pref fields the player resolver consults at session start
-/// (subtitle language, behavior, forced-subs toggle).
+/// (spoken language, subtitle language, behavior, forced-subs toggle).
 struct UserProfile: Codable, Identifiable, Hashable {
     let id: String
     let name: String
@@ -12,6 +12,11 @@ struct UserProfile: Codable, Identifiable, Hashable {
     let hasPin: Bool
     let isChild: Bool
     let isPrimary: Bool
+    /// Preferred spoken/audio language (ISO 639-1; `""`/nil = no
+    /// preference). The server resolves the initial audio track from
+    /// this field and reports it as `effective_audio_track_index` on the
+    /// watch/detail responses the player starts from.
+    let language: String?
     let subtitleLanguage: String?
     let subtitleMode: String?
     let showForcedSubtitles: Bool?
@@ -26,6 +31,7 @@ struct UserProfile: Codable, Identifiable, Hashable {
         hasPin: Bool,
         isChild: Bool,
         isPrimary: Bool = false,
+        language: String? = nil,
         subtitleLanguage: String? = nil,
         subtitleMode: String? = nil,
         showForcedSubtitles: Bool? = nil,
@@ -37,6 +43,7 @@ struct UserProfile: Codable, Identifiable, Hashable {
         self.hasPin = hasPin
         self.isChild = isChild
         self.isPrimary = isPrimary
+        self.language = language
         self.subtitleLanguage = subtitleLanguage
         self.subtitleMode = subtitleMode
         self.showForcedSubtitles = showForcedSubtitles

--- a/iosApp/iosApp/Screens/Settings/PlaybackSettingsView.swift
+++ b/iosApp/iosApp/Screens/Settings/PlaybackSettingsView.swift
@@ -51,7 +51,7 @@ struct PlaybackSettingsView: View {
                 }
             )) {
                 Text("No Preference").tag(PlaybackPrefSentinel.none)
-                ForEach(PlaybackLanguageOption.all) { option in
+                ForEach(PlaybackLanguageOption.options(including: viewModel.editorAudioLanguage)) { option in
                     Text(option.label).tag(option.code)
                 }
             }
@@ -97,8 +97,16 @@ struct PlaybackSettingsView: View {
             Text("Streaming")
                 .foregroundStyle(Color.continuumSecondaryText)
         } footer: {
-            Text(streamingFooterText)
-                .foregroundStyle(Color.continuumSecondaryText)
+            VStack(alignment: .leading, spacing: 6) {
+                Text(streamingFooterText)
+                // Audio Language saves to the server from this section, so its
+                // result has to be visible here rather than only on the
+                // Subtitles screen.
+                if let state = viewModel.prefSaveState {
+                    PrefSaveStateLabel(state: state)
+                }
+            }
+            .foregroundStyle(Color.continuumSecondaryText)
         }
         .listRowBackground(Color.continuumSurfaceElevated)
     }
@@ -179,7 +187,10 @@ struct PlaybackSettingsView: View {
                 Task { await viewModel.resetPlaybackDeviceSettings() }
             }
         } footer: {
-            Text("Resets playback choices for this device and profile back to the server fallback.")
+            // Deliberately scoped to "this device": the reset clears the
+            // device-scoped rows, and Audio Language is a profile field that it
+            // does not touch. The previous wording promised the profile too.
+            Text("Resets this device's playback choices back to the server fallback. Audio Language applies to your whole profile and is not affected.")
                 .foregroundStyle(Color.continuumSecondaryText)
         }
         .listRowBackground(Color.continuumSurfaceElevated)

--- a/iosApp/iosApp/Screens/Settings/PlaybackSettingsView.swift
+++ b/iosApp/iosApp/Screens/Settings/PlaybackSettingsView.swift
@@ -44,14 +44,15 @@ struct PlaybackSettingsView: View {
             #endif
 
             Picker("Audio Language", selection: Binding(
-                get: { viewModel.preferredAudioLanguage },
+                get: { viewModel.editorAudioLanguage },
                 set: { newValue in
-                    viewModel.preferredAudioLanguage = newValue
-                    Task { await viewModel.setPreferredAudioLanguage(newValue) }
+                    viewModel.editorAudioLanguage = newValue
+                    Task { await viewModel.saveAudioLanguage() }
                 }
             )) {
-                ForEach(audioLanguageOptions, id: \.0) { tag, label in
-                    Text(label).tag(tag)
+                Text("No Preference").tag(PlaybackPrefSentinel.none)
+                ForEach(PlaybackLanguageOption.all) { option in
+                    Text(option.label).tag(option.code)
                 }
             }
             .foregroundStyle(Color.continuumOnSurface)
@@ -103,7 +104,8 @@ struct PlaybackSettingsView: View {
     }
 
     private var streamingFooterText: String {
-        var text = "Turn off Dolby Vision to play Dolby Vision titles as HDR10 instead. Profile 5 titles have no HDR10-compatible layer and always play in Dolby Vision."
+        var text = "Audio Language picks which spoken track starts first; it applies to your profile on every device, not just this one."
+        text += " Turn off Dolby Vision to play Dolby Vision titles as HDR10 instead. Profile 5 titles have no HDR10-compatible layer and always play in Dolby Vision."
         if viewModel.dolbyVisionEnabled {
             text += " The fallback plays Dolby Vision Profile 7 as HDR10 on this device."
         }
@@ -187,20 +189,6 @@ struct PlaybackSettingsView: View {
 
     private var qualityOptions: [(String, String)] {
         ApplePlaybackQuality.settingsOptions.map { ($0.id, $0.labelWithBitrate) }
-    }
-
-    private var audioLanguageOptions: [(String, String)] {
-        [
-            ("", "Default"),
-            ("en", "English"),
-            ("es", "Spanish"),
-            ("fr", "French"),
-            ("de", "German"),
-            ("it", "Italian"),
-            ("pt", "Portuguese"),
-            ("ja", "Japanese"),
-            ("ko", "Korean"),
-        ]
     }
 
     private var nextUpPromptOptions: [(Int, String)] {

--- a/iosApp/iosApp/Screens/Settings/PlaybackSettingsView.swift
+++ b/iosApp/iosApp/Screens/Settings/PlaybackSettingsView.swift
@@ -101,8 +101,9 @@ struct PlaybackSettingsView: View {
                 Text(streamingFooterText)
                 // Audio Language saves to the server from this section, so its
                 // result has to be visible here rather than only on the
-                // Subtitles screen.
-                if let state = viewModel.prefSaveState {
+                // Subtitles screen. Scoped to the audio write specifically: a
+                // subtitle or metadata failure belongs under its own row.
+                if let state = viewModel.audioSaveState {
                     PrefSaveStateLabel(state: state)
                 }
             }

--- a/iosApp/iosApp/Screens/Settings/PrefSaveStateLabel.swift
+++ b/iosApp/iosApp/Screens/Settings/PrefSaveStateLabel.swift
@@ -9,6 +9,10 @@ import SwiftUI
 /// a flaky connection, or the 403 a PIN-gated primary profile gets — left the
 /// picker showing the value the server had just rejected, with no indication
 /// anything had gone wrong, and surfaced the error on a different screen.
+///
+/// Each view model holds one of these per profile-backed write (audio,
+/// subtitle, metadata) rather than one shared field, so a result always
+/// renders under the row that produced it.
 protocol PrefSaveStateRepresentable {
     var saveStateMessage: String { get }
     var saveStateIsError: Bool { get }

--- a/iosApp/iosApp/Screens/Settings/PrefSaveStateLabel.swift
+++ b/iosApp/iosApp/Screens/Settings/PrefSaveStateLabel.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+/// A settings save state that can be shown to the user.
+///
+/// iOS and tvOS each carry their own `PrefSaveState` enum on their own view
+/// model, so this protocol is what lets one view render both. That matters
+/// because the alternative is what shipped: the message existed only on the
+/// Subtitles screens, so a failed audio-language save on the Playback screen —
+/// a flaky connection, or the 403 a PIN-gated primary profile gets — left the
+/// picker showing the value the server had just rejected, with no indication
+/// anything had gone wrong, and surfaced the error on a different screen.
+protocol PrefSaveStateRepresentable {
+    var saveStateMessage: String { get }
+    var saveStateIsError: Bool { get }
+}
+
+extension SettingsViewModel.PrefSaveState: PrefSaveStateRepresentable {
+    var saveStateMessage: String {
+        switch self {
+        case .saving: return "Saving…"
+        case .saved: return "Saved"
+        case .failed(let message): return "Couldn't save: \(message)"
+        }
+    }
+
+    var saveStateIsError: Bool {
+        if case .failed = self { return true }
+        return false
+    }
+}
+
+/// The transient "Saving… / Saved / Couldn't save" line shown under a
+/// server-backed settings section on iOS and macOS.
+struct PrefSaveStateLabel<SaveState: PrefSaveStateRepresentable>: View {
+    let state: SaveState
+
+    var body: some View {
+        Text(state.saveStateMessage)
+            .foregroundStyle(state.saveStateIsError ? Color.continuumError : Color.continuumSecondaryText)
+    }
+}
+
+#if os(tvOS)
+extension TVSettingsViewModel.PrefSaveState: PrefSaveStateRepresentable {
+    var saveStateMessage: String {
+        switch self {
+        case .saving: return "Saving…"
+        case .saved: return "Saved"
+        case .failed(let message): return "Couldn't save: \(message)"
+        }
+    }
+
+    var saveStateIsError: Bool {
+        if case .failed = self { return true }
+        return false
+    }
+}
+
+/// tvOS variant, sized for the ten-foot UI. Extracted from
+/// `TVSubtitleSettingsView` so the Playback pane, which also saves profile
+/// fields, reports its result the same way instead of silently.
+struct TVPrefSaveFooter<SaveState: PrefSaveStateRepresentable>: View {
+    let state: SaveState?
+
+    var body: some View {
+        if let state {
+            if state.saveStateIsError {
+                Text(state.saveStateMessage)
+                    .font(.system(size: 19))
+                    .foregroundStyle(.red)
+                    .padding(.horizontal, 24)
+                    .padding(.top, 4)
+            } else {
+                TVSettingsFooter(state.saveStateMessage)
+            }
+        }
+    }
+}
+#endif

--- a/iosApp/iosApp/Screens/Settings/SettingsViewModel.swift
+++ b/iosApp/iosApp/Screens/Settings/SettingsViewModel.swift
@@ -3,10 +3,11 @@ import Foundation
 /// State container for the iOS settings screen.
 ///
 /// Local-only fields (preferred quality, auto-play, skip intros, subtitle
-/// size) live in `UserDefaults`. The subtitle-language / behavior /
-/// forced-subs trio is profile-wide on the server and persisted via
-/// `PUT /profiles/{id}` — same model as the tvOS settings screen, so
-/// edits made on either platform cascade into playback the same way.
+/// size) live in `UserDefaults`. The spoken-language choice and the
+/// subtitle-language / behavior / forced-subs trio are profile-wide on
+/// the server and persisted via `PUT /profiles/{id}` — same model as the
+/// tvOS settings screen, so edits made on either platform cascade into
+/// playback the same way.
 @Observable
 class SettingsViewModel {
     var userInfo: UserInfo?
@@ -27,7 +28,6 @@ class SettingsViewModel {
 
     // Playback preferences (server-backed for this device/profile).
     var preferredQuality: String = PlayerSettings.shared.preferredQuality
-    var preferredAudioLanguage: String = PlayerSettings.shared.audioLanguage
     var autoPlayNext: Bool = PlayerSettings.shared.autoPlayNextEpisode
     var nextUpPromptSeconds: Int = PlayerSettings.shared.nextUpPromptSeconds
     var skipIntros: Bool = PlayerSettings.shared.autoSkipIntro
@@ -52,6 +52,12 @@ class SettingsViewModel {
     // Server-backed profile prefs editor. Each editor field is either
     // a sentinel ("__none__") or a concrete value. We persist directly
     // to the active profile via PUT /profiles/{id}.
+    /// Preferred spoken (audio) language. Profile-wide, not per-device:
+    /// the server resolves the initial audio track from the profile's
+    /// `language` field, so this is the only value that actually reaches
+    /// playback. `PlaybackPrefSentinel.none` maps to the empty string
+    /// ("no preference") on the wire.
+    var editorAudioLanguage: String = PlaybackPrefSentinel.none
     var editorSubtitleLanguage: String = PlaybackPrefSentinel.none
     var editorSubtitleMode: String = SubtitleMode.auto.rawValue
     /// Tri-state stored as "on" / "off". The server treats nil and
@@ -78,7 +84,6 @@ class SettingsViewModel {
     func loadSettings() async {
         await PlayerSettings.shared.refreshFromServer()
         preferredQuality = PlayerSettings.shared.preferredQuality
-        preferredAudioLanguage = PlayerSettings.shared.audioLanguage
         autoPlayNext = PlayerSettings.shared.autoPlayNextEpisode
         nextUpPromptSeconds = PlayerSettings.shared.nextUpPromptSeconds
         skipIntros = PlayerSettings.shared.autoSkipIntro
@@ -114,12 +119,6 @@ class SettingsViewModel {
     func setPreferredQuality(_ value: String) async {
         PlayerSettings.shared.setPreferredQuality(value)
         preferredQuality = PlayerSettings.shared.preferredQuality
-    }
-
-    @MainActor
-    func setPreferredAudioLanguage(_ value: String) async {
-        PlayerSettings.shared.setAudioLanguage(value)
-        preferredAudioLanguage = PlayerSettings.shared.audioLanguage
     }
 
     @MainActor
@@ -168,7 +167,6 @@ class SettingsViewModel {
     func resetPlaybackDeviceSettings() async {
         await PlayerSettings.shared.resetAllDeviceSettings()
         preferredQuality = PlayerSettings.shared.preferredQuality
-        preferredAudioLanguage = PlayerSettings.shared.audioLanguage
         autoPlayNext = PlayerSettings.shared.autoPlayNextEpisode
         nextUpPromptSeconds = PlayerSettings.shared.nextUpPromptSeconds
         skipIntros = PlayerSettings.shared.autoSkipIntro
@@ -210,7 +208,7 @@ class SettingsViewModel {
         prefSaveState = .saving
 
         let body = UpdateProfileBody(
-            subtitleLanguage: outboundSubtitleLanguage(editorSubtitleLanguage),
+            subtitleLanguage: outboundProfileLanguage(editorSubtitleLanguage),
             subtitleMode: editorSubtitleMode,
             showForcedSubtitles: editorShowForcedSubtitles == "on"
         )
@@ -226,6 +224,7 @@ class SettingsViewModel {
                     avatarEmoji: prof.avatarEmoji,
                     hasPin: prof.hasPin,
                     isChild: prof.isChild,
+                    language: prof.language,
                     subtitleLanguage: body.subtitleLanguage,
                     subtitleMode: body.subtitleMode,
                     showForcedSubtitles: body.showForcedSubtitles,
@@ -249,7 +248,7 @@ class SettingsViewModel {
     @MainActor
     func saveMetadataLanguage() async {
         guard activeProfile?.id.isEmpty == false else { return }
-        pendingMetadataLanguageValue = outboundSubtitleLanguage(editorPreferredMetadataLanguage)
+        pendingMetadataLanguageValue = outboundProfileLanguage(editorPreferredMetadataLanguage)
         guard !isSavingMetadataLanguage else { return }
 
         isSavingMetadataLanguage = true
@@ -273,7 +272,7 @@ class SettingsViewModel {
         do {
             try await ContinuumAPI.shared.updateProfile(profileId: profileId, body: body)
             guard activeProfile?.id == profileId,
-                  outboundSubtitleLanguage(editorPreferredMetadataLanguage) == newValue else {
+                  outboundProfileLanguage(editorPreferredMetadataLanguage) == newValue else {
                 return
             }
             prefSaveState = .saved
@@ -284,6 +283,7 @@ class SettingsViewModel {
                     avatarEmoji: prof.avatarEmoji,
                     hasPin: prof.hasPin,
                     isChild: prof.isChild,
+                    language: prof.language,
                     subtitleLanguage: prof.subtitleLanguage,
                     subtitleMode: prof.subtitleMode,
                     showForcedSubtitles: prof.showForcedSubtitles,
@@ -296,7 +296,67 @@ class SettingsViewModel {
             #endif
         } catch {
             guard activeProfile?.id == profileId,
-                  outboundSubtitleLanguage(editorPreferredMetadataLanguage) == newValue else {
+                  outboundProfileLanguage(editorPreferredMetadataLanguage) == newValue else {
+                return
+            }
+            prefSaveState = .failed(
+                (error as? LocalizedError)?.errorDescription
+                    ?? String(describing: error)
+            )
+        }
+    }
+
+    /// Persist the preferred spoken (audio) language as a profile patch.
+    ///
+    /// This is deliberately a profile field rather than a per-device one:
+    /// the server picks the initial audio track from `profile.language`
+    /// and reports the result as `effective_audio_track_index`, which the
+    /// player forwards at session start. A device-scoped value would
+    /// never be read by anything.
+    @MainActor
+    func saveAudioLanguage() async {
+        guard let profileId = activeProfile?.id, !profileId.isEmpty else { return }
+        let newValue = outboundProfileLanguage(editorAudioLanguage)
+        guard newValue != (activeProfile?.language ?? "") else { return }
+
+        prefSaveState = .saving
+
+        do {
+            try await ContinuumAPI.shared.updateProfile(
+                profileId: profileId,
+                body: UpdateProfileBody(language: newValue)
+            )
+            guard activeProfile?.id == profileId,
+                  outboundProfileLanguage(editorAudioLanguage) == newValue else {
+                return
+            }
+            prefSaveState = .saved
+            if let prof = activeProfile {
+                activeProfile = UserProfile(
+                    id: prof.id,
+                    name: prof.name,
+                    avatarEmoji: prof.avatarEmoji,
+                    hasPin: prof.hasPin,
+                    isChild: prof.isChild,
+                    language: newValue,
+                    subtitleLanguage: prof.subtitleLanguage,
+                    subtitleMode: prof.subtitleMode,
+                    showForcedSubtitles: prof.showForcedSubtitles,
+                    preferredMetadataLanguage: prof.preferredMetadataLanguage
+                )
+            }
+            // Detail screens render the server-resolved audio track out of
+            // the cached item payloads, which have no TTL. Drop them so the
+            // new selection shows up without a relaunch. Playback itself
+            // always refetches `/watch`, so this is display consistency
+            // only — it is not what makes the setting take effect.
+            ResponseCache.shared.invalidateAllItemMetadata()
+            #if os(tvOS)
+            ItemDetailCache.shared.clearAll()
+            #endif
+        } catch {
+            guard activeProfile?.id == profileId,
+                  outboundProfileLanguage(editorAudioLanguage) == newValue else {
                 return
             }
             prefSaveState = .failed(
@@ -309,6 +369,9 @@ class SettingsViewModel {
     // MARK: - Editor projection helpers
 
     private func projectActiveProfileIntoEditor() {
+        let audioLang = activeProfile?.language ?? ""
+        editorAudioLanguage = audioLang.isEmpty ? PlaybackPrefSentinel.none : audioLang
+
         let raw = activeProfile?.subtitleLanguage ?? ""
         editorSubtitleLanguage = raw.isEmpty ? PlaybackPrefSentinel.none : raw
 
@@ -322,8 +385,9 @@ class SettingsViewModel {
     }
 
     /// `__none__` sentinel maps to the empty string the server expects
-    /// to mean "no subtitle preference / no subs".
-    private func outboundSubtitleLanguage(_ value: String) -> String {
+    /// to mean "no preference" for any of the profile language fields
+    /// (spoken, subtitle, metadata).
+    private func outboundProfileLanguage(_ value: String) -> String {
         value == PlaybackPrefSentinel.none ? "" : value
     }
 }

--- a/iosApp/iosApp/Screens/Settings/SettingsViewModel.swift
+++ b/iosApp/iosApp/Screens/Settings/SettingsViewModel.swift
@@ -69,9 +69,15 @@ class SettingsViewModel {
     /// Gated on `AICapabilities.shared.metadataEnabled` at the row.
     var editorPreferredMetadataLanguage: String = PlaybackPrefSentinel.none
 
-    /// Surfaces the most recent server save state. The subtitle screen
-    /// shows a transient message when this is non-nil.
-    var prefSaveState: PrefSaveState?
+    /// Save state for the three profile-backed writes, kept apart by which
+    /// row produced them. A single shared field misattributes results: the
+    /// Playback screen renders the audio one and the Subtitles screen renders
+    /// the other two, and nothing clears the field between screens, so a
+    /// failed subtitle save would otherwise appear under Audio Language and
+    /// an audio result would sit pinned under the Subtitles footer.
+    var audioSaveState: PrefSaveState?
+    var subtitleSaveState: PrefSaveState?
+    var metadataSaveState: PrefSaveState?
     private var isSavingMetadataLanguage = false
     private var pendingMetadataLanguageValue: String?
     private var isSavingAudioLanguage = false
@@ -207,7 +213,7 @@ class SettingsViewModel {
     func saveProfilePrefs() async {
         guard let profileId = activeProfile?.id, !profileId.isEmpty else { return }
 
-        prefSaveState = .saving
+        subtitleSaveState = .saving
 
         let body = UpdateProfileBody(
             subtitleLanguage: outboundProfileLanguage(editorSubtitleLanguage),
@@ -216,14 +222,14 @@ class SettingsViewModel {
         )
         do {
             try await ContinuumAPI.shared.updateProfile(profileId: profileId, body: body)
-            prefSaveState = .saved
+            subtitleSaveState = .saved
             // Keep the detail-page track-ordering preference in sync.
             ProfilePrefsStore.shared.setPreferredSubtitleLanguage(body.subtitleLanguage)
             if let prof = activeProfile {
                 activeProfile = prof.with(subtitleLanguage: body.subtitleLanguage, subtitleMode: body.subtitleMode, showForcedSubtitles: body.showForcedSubtitles)
             }
         } catch {
-            prefSaveState = .failed(
+            subtitleSaveState = .failed(
                 (error as? LocalizedError)?.errorDescription
                     ?? String(describing: error)
             )
@@ -257,29 +263,30 @@ class SettingsViewModel {
         let oldValue = activeProfile?.preferredMetadataLanguage ?? ""
         guard newValue != oldValue else { return }
 
-        prefSaveState = .saving
+        metadataSaveState = .saving
 
         let body = UpdateProfileBody(preferredMetadataLanguage: newValue)
         do {
             try await ContinuumAPI.shared.updateProfile(profileId: profileId, body: body)
-            guard activeProfile?.id == profileId,
-                  outboundProfileLanguage(editorPreferredMetadataLanguage) == newValue else {
-                return
-            }
-            prefSaveState = .saved
+            guard activeProfile?.id == profileId else { return }
+            // Record the write before deciding whether to report, so a queued
+            // follow-up compares against the value the server now holds.
             if let prof = activeProfile {
                 activeProfile = prof.with(preferredMetadataLanguage: newValue)
             }
+            // Reported unconditionally: the write landed, and a still-queued
+            // value will overwrite this message when it lands in turn. Gating
+            // on "no newer value pending" strands the footer on "Saving…"
+            // whenever the user re-picks the value already being written,
+            // because the queued pass then no-ops on the equality guard above.
+            metadataSaveState = .saved
             ResponseCache.shared.invalidateAllItemMetadata()
             #if os(tvOS)
             ItemDetailCache.shared.clearAll()
             #endif
         } catch {
-            guard activeProfile?.id == profileId,
-                  outboundProfileLanguage(editorPreferredMetadataLanguage) == newValue else {
-                return
-            }
-            prefSaveState = .failed(
+            guard activeProfile?.id == profileId else { return }
+            metadataSaveState = .failed(
                 (error as? LocalizedError)?.errorDescription
                     ?? String(describing: error)
             )
@@ -304,7 +311,7 @@ class SettingsViewModel {
         // leaving the server holding the first value while the picker shows the
         // second.
         guard activeProfile?.id.isEmpty == false else {
-            prefSaveState = .failed("No active profile to save to.")
+            audioSaveState = .failed("No active profile to save to.")
             return
         }
         pendingAudioLanguageValue = outboundProfileLanguage(editorAudioLanguage)
@@ -324,25 +331,29 @@ class SettingsViewModel {
         guard let profileId = activeProfile?.id, !profileId.isEmpty else { return }
         guard newValue != (activeProfile?.language ?? "") else { return }
 
-        prefSaveState = .saving
+        audioSaveState = .saving
 
         do {
             try await ContinuumAPI.shared.updateProfile(
                 profileId: profileId,
                 body: UpdateProfileBody(language: newValue)
             )
+            guard activeProfile?.id == profileId else { return }
             // The write landed. Record it even if the user has since moved on
             // to another value: the queue above will save that one next, and
             // leaving `activeProfile` stale would make the follow-up save
             // compare against the wrong baseline and skip itself.
-            if let prof = activeProfile, prof.id == profileId {
+            if let prof = activeProfile {
                 activeProfile = prof.with(language: newValue)
             }
-            guard activeProfile?.id == profileId,
-                  pendingAudioLanguageValue == nil else {
-                return
-            }
-            prefSaveState = .saved
+            // Reported unconditionally rather than only when nothing is queued.
+            // Suppressing it stranded the footer on "Saving…" forever when the
+            // user re-selected the value already in flight: the queued pass then
+            // matches `activeProfile.language` and returns at the guard above,
+            // so nothing ever reached `.saved` — and the caches never flushed,
+            // leaving detail screens on the old track. A queued value that
+            // differs will overwrite this message when it lands.
+            audioSaveState = .saved
             // Detail screens render the server-resolved audio track out of
             // the cached item payloads, which have no TTL. Drop them so the
             // new selection shows up without a relaunch. Playback itself
@@ -357,7 +368,7 @@ class SettingsViewModel {
             // Reported even when a newer value is already queued: the user needs
             // to know this save failed, and the queued one will overwrite the
             // message if it succeeds.
-            prefSaveState = .failed(
+            audioSaveState = .failed(
                 (error as? LocalizedError)?.errorDescription
                     ?? String(describing: error)
             )

--- a/iosApp/iosApp/Screens/Settings/SettingsViewModel.swift
+++ b/iosApp/iosApp/Screens/Settings/SettingsViewModel.swift
@@ -75,6 +75,12 @@ class SettingsViewModel {
     /// the other two, and nothing clears the field between screens, so a
     /// failed subtitle save would otherwise appear under Audio Language and
     /// an audio result would sit pinned under the Subtitles footer.
+    ///
+    /// `nil` means "nothing to report" and hides the row's footer line. A
+    /// save that finishes against a profile the user has since switched away
+    /// from resets to `nil` rather than returning early, which would leave
+    /// the footer reading "Saving…" for a write that is no longer this
+    /// screen's to report.
     var audioSaveState: PrefSaveState?
     var subtitleSaveState: PrefSaveState?
     var metadataSaveState: PrefSaveState?
@@ -268,7 +274,18 @@ class SettingsViewModel {
         let body = UpdateProfileBody(preferredMetadataLanguage: newValue)
         do {
             try await ContinuumAPI.shared.updateProfile(profileId: profileId, body: body)
-            guard activeProfile?.id == profileId else { return }
+            // The write landed, so the cached payloads are stale no matter
+            // which profile is active now. Flushed before the guard below:
+            // both caches are pure drops that refetch on demand, and a
+            // profile switch is if anything a stronger reason to drop them.
+            ResponseCache.shared.invalidateAllItemMetadata()
+            #if os(tvOS)
+            ItemDetailCache.shared.clearAll()
+            #endif
+            guard activeProfile?.id == profileId else {
+                metadataSaveState = nil
+                return
+            }
             // Record the write before deciding whether to report, so a queued
             // follow-up compares against the value the server now holds.
             if let prof = activeProfile {
@@ -280,12 +297,11 @@ class SettingsViewModel {
             // whenever the user re-picks the value already being written,
             // because the queued pass then no-ops on the equality guard above.
             metadataSaveState = .saved
-            ResponseCache.shared.invalidateAllItemMetadata()
-            #if os(tvOS)
-            ItemDetailCache.shared.clearAll()
-            #endif
         } catch {
-            guard activeProfile?.id == profileId else { return }
+            guard activeProfile?.id == profileId else {
+                metadataSaveState = nil
+                return
+            }
             metadataSaveState = .failed(
                 (error as? LocalizedError)?.errorDescription
                     ?? String(describing: error)
@@ -338,7 +354,21 @@ class SettingsViewModel {
                 profileId: profileId,
                 body: UpdateProfileBody(language: newValue)
             )
-            guard activeProfile?.id == profileId else { return }
+            // Detail screens render the server-resolved audio track out of
+            // the cached item payloads, which have no TTL. Drop them so the
+            // new selection shows up without a relaunch. Playback itself
+            // always refetches `/watch`, so this is display consistency
+            // only — it is not what makes the setting take effect. Flushed
+            // before the guard below for the same reason as the metadata
+            // save: the write landed either way.
+            ResponseCache.shared.invalidateAllItemMetadata()
+            #if os(tvOS)
+            ItemDetailCache.shared.clearAll()
+            #endif
+            guard activeProfile?.id == profileId else {
+                audioSaveState = nil
+                return
+            }
             // The write landed. Record it even if the user has since moved on
             // to another value: the queue above will save that one next, and
             // leaving `activeProfile` stale would make the follow-up save
@@ -354,17 +384,11 @@ class SettingsViewModel {
             // leaving detail screens on the old track. A queued value that
             // differs will overwrite this message when it lands.
             audioSaveState = .saved
-            // Detail screens render the server-resolved audio track out of
-            // the cached item payloads, which have no TTL. Drop them so the
-            // new selection shows up without a relaunch. Playback itself
-            // always refetches `/watch`, so this is display consistency
-            // only — it is not what makes the setting take effect.
-            ResponseCache.shared.invalidateAllItemMetadata()
-            #if os(tvOS)
-            ItemDetailCache.shared.clearAll()
-            #endif
         } catch {
-            guard activeProfile?.id == profileId else { return }
+            guard activeProfile?.id == profileId else {
+                audioSaveState = nil
+                return
+            }
             // Reported even when a newer value is already queued: the user needs
             // to know this save failed, and the queued one will overwrite the
             // message if it succeeds.

--- a/iosApp/iosApp/Screens/Settings/SettingsViewModel.swift
+++ b/iosApp/iosApp/Screens/Settings/SettingsViewModel.swift
@@ -74,6 +74,8 @@ class SettingsViewModel {
     var prefSaveState: PrefSaveState?
     private var isSavingMetadataLanguage = false
     private var pendingMetadataLanguageValue: String?
+    private var isSavingAudioLanguage = false
+    private var pendingAudioLanguageValue: String?
 
     enum PrefSaveState: Equatable {
         case saving
@@ -218,18 +220,7 @@ class SettingsViewModel {
             // Keep the detail-page track-ordering preference in sync.
             ProfilePrefsStore.shared.setPreferredSubtitleLanguage(body.subtitleLanguage)
             if let prof = activeProfile {
-                activeProfile = UserProfile(
-                    id: prof.id,
-                    name: prof.name,
-                    avatarEmoji: prof.avatarEmoji,
-                    hasPin: prof.hasPin,
-                    isChild: prof.isChild,
-                    language: prof.language,
-                    subtitleLanguage: body.subtitleLanguage,
-                    subtitleMode: body.subtitleMode,
-                    showForcedSubtitles: body.showForcedSubtitles,
-                    preferredMetadataLanguage: prof.preferredMetadataLanguage
-                )
+                activeProfile = prof.with(subtitleLanguage: body.subtitleLanguage, subtitleMode: body.subtitleMode, showForcedSubtitles: body.showForcedSubtitles)
             }
         } catch {
             prefSaveState = .failed(
@@ -277,18 +268,7 @@ class SettingsViewModel {
             }
             prefSaveState = .saved
             if let prof = activeProfile {
-                activeProfile = UserProfile(
-                    id: prof.id,
-                    name: prof.name,
-                    avatarEmoji: prof.avatarEmoji,
-                    hasPin: prof.hasPin,
-                    isChild: prof.isChild,
-                    language: prof.language,
-                    subtitleLanguage: prof.subtitleLanguage,
-                    subtitleMode: prof.subtitleMode,
-                    showForcedSubtitles: prof.showForcedSubtitles,
-                    preferredMetadataLanguage: newValue
-                )
+                activeProfile = prof.with(preferredMetadataLanguage: newValue)
             }
             ResponseCache.shared.invalidateAllItemMetadata()
             #if os(tvOS)
@@ -315,8 +295,33 @@ class SettingsViewModel {
     /// never be read by anything.
     @MainActor
     func saveAudioLanguage() async {
+        // The picker fires this on every change, so two quick selections race
+        // across the `await` below. Serialize them the way
+        // `saveMetadataLanguage` does: record the latest value, let the
+        // in-flight save drain it, and never put two PUTs for the same field on
+        // the wire at once. Without this the second task reads a stale
+        // `activeProfile.language`, decides nothing changed, and returns —
+        // leaving the server holding the first value while the picker shows the
+        // second.
+        guard activeProfile?.id.isEmpty == false else {
+            prefSaveState = .failed("No active profile to save to.")
+            return
+        }
+        pendingAudioLanguageValue = outboundProfileLanguage(editorAudioLanguage)
+        guard !isSavingAudioLanguage else { return }
+
+        isSavingAudioLanguage = true
+        defer { isSavingAudioLanguage = false }
+
+        while let newValue = pendingAudioLanguageValue {
+            pendingAudioLanguageValue = nil
+            await saveAudioLanguageValue(newValue)
+        }
+    }
+
+    @MainActor
+    private func saveAudioLanguageValue(_ newValue: String) async {
         guard let profileId = activeProfile?.id, !profileId.isEmpty else { return }
-        let newValue = outboundProfileLanguage(editorAudioLanguage)
         guard newValue != (activeProfile?.language ?? "") else { return }
 
         prefSaveState = .saving
@@ -326,25 +331,18 @@ class SettingsViewModel {
                 profileId: profileId,
                 body: UpdateProfileBody(language: newValue)
             )
+            // The write landed. Record it even if the user has since moved on
+            // to another value: the queue above will save that one next, and
+            // leaving `activeProfile` stale would make the follow-up save
+            // compare against the wrong baseline and skip itself.
+            if let prof = activeProfile, prof.id == profileId {
+                activeProfile = prof.with(language: newValue)
+            }
             guard activeProfile?.id == profileId,
-                  outboundProfileLanguage(editorAudioLanguage) == newValue else {
+                  pendingAudioLanguageValue == nil else {
                 return
             }
             prefSaveState = .saved
-            if let prof = activeProfile {
-                activeProfile = UserProfile(
-                    id: prof.id,
-                    name: prof.name,
-                    avatarEmoji: prof.avatarEmoji,
-                    hasPin: prof.hasPin,
-                    isChild: prof.isChild,
-                    language: newValue,
-                    subtitleLanguage: prof.subtitleLanguage,
-                    subtitleMode: prof.subtitleMode,
-                    showForcedSubtitles: prof.showForcedSubtitles,
-                    preferredMetadataLanguage: prof.preferredMetadataLanguage
-                )
-            }
             // Detail screens render the server-resolved audio track out of
             // the cached item payloads, which have no TTL. Drop them so the
             // new selection shows up without a relaunch. Playback itself
@@ -355,10 +353,10 @@ class SettingsViewModel {
             ItemDetailCache.shared.clearAll()
             #endif
         } catch {
-            guard activeProfile?.id == profileId,
-                  outboundProfileLanguage(editorAudioLanguage) == newValue else {
-                return
-            }
+            guard activeProfile?.id == profileId else { return }
+            // Reported even when a newer value is already queued: the user needs
+            // to know this save failed, and the queued one will overwrite the
+            // message if it succeeds.
             prefSaveState = .failed(
                 (error as? LocalizedError)?.errorDescription
                     ?? String(describing: error)

--- a/iosApp/iosApp/Screens/Settings/SubtitleSettingsView.swift
+++ b/iosApp/iosApp/Screens/Settings/SubtitleSettingsView.swift
@@ -60,8 +60,15 @@ struct SubtitleSettingsView: View {
             Text("Metadata")
                 .foregroundStyle(Color.continuumSecondaryText)
         } footer: {
-            Text("Translates descriptions and taglines into your preferred language when available. Titles are never translated.")
-                .foregroundStyle(Color.continuumSecondaryText)
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Translates descriptions and taglines into your preferred language when available. Titles are never translated.")
+                // Metadata Language is its own profile write, so it reports
+                // here instead of under the subtitle trio's footer.
+                if let state = viewModel.metadataSaveState {
+                    PrefSaveStateLabel(state: state)
+                }
+            }
+            .foregroundStyle(Color.continuumSecondaryText)
         }
         .listRowBackground(Color.continuumSurfaceElevated)
     }
@@ -111,7 +118,7 @@ struct SubtitleSettingsView: View {
         } footer: {
             VStack(alignment: .leading, spacing: 6) {
                 Text("Used to pick a matching track when one is available. Forced subtitles cover foreign-language dialogue even when subtitles are off or set to auto.")
-                if let state = viewModel.prefSaveState {
+                if let state = viewModel.subtitleSaveState {
                     PrefSaveStateLabel(state: state)
                 }
             }

--- a/iosApp/iosApp/Screens/Settings/SubtitleSettingsView.swift
+++ b/iosApp/iosApp/Screens/Settings/SubtitleSettingsView.swift
@@ -46,7 +46,7 @@ struct SubtitleSettingsView: View {
         Section {
             Picker("Metadata Language", selection: $viewModel.editorPreferredMetadataLanguage) {
                 Text("Library Default").tag(PlaybackPrefSentinel.none)
-                ForEach(PlaybackLanguageOption.all) { option in
+                ForEach(PlaybackLanguageOption.options(including: viewModel.editorPreferredMetadataLanguage)) { option in
                     Text(option.label).tag(option.code)
                 }
             }
@@ -73,7 +73,7 @@ struct SubtitleSettingsView: View {
         Section {
             Picker("Language", selection: $viewModel.editorSubtitleLanguage) {
                 Text("None").tag(PlaybackPrefSentinel.none)
-                ForEach(PlaybackLanguageOption.all) { option in
+                ForEach(PlaybackLanguageOption.options(including: viewModel.editorSubtitleLanguage)) { option in
                     Text(option.label).tag(option.code)
                 }
             }
@@ -112,7 +112,7 @@ struct SubtitleSettingsView: View {
             VStack(alignment: .leading, spacing: 6) {
                 Text("Used to pick a matching track when one is available. Forced subtitles cover foreign-language dialogue even when subtitles are off or set to auto.")
                 if let state = viewModel.prefSaveState {
-                    saveStateView(state)
+                    PrefSaveStateLabel(state: state)
                 }
             }
             .foregroundStyle(Color.continuumSecondaryText)
@@ -348,18 +348,6 @@ struct SubtitleSettingsView: View {
         )
     }
 
-    @ViewBuilder
-    private func saveStateView(_ state: SettingsViewModel.PrefSaveState) -> some View {
-        switch state {
-        case .saving:
-            Text("Saving…")
-        case .saved:
-            Text("Saved")
-        case .failed(let message):
-            Text("Couldn't save: \(message)")
-                .foregroundStyle(Color.continuumError)
-        }
-    }
 }
 
 // MARK: - Color choice row

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVPlaybackSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVPlaybackSettingsView.swift
@@ -34,7 +34,7 @@ struct TVPlaybackSettingsPane: View {
 
         TVSettingsPickerRow(
             title: "Audio Language",
-            value: TVSettingsOptions.label(for: viewModel.preferredAudioLanguage, in: TVSettingsOptions.audioLanguage)
+            value: TVSettingsOptions.label(for: viewModel.editorAudioLanguage, in: TVSettingsOptions.audioLanguage)
         ) { activePicker = .audioLanguage }
 
         TVSettingsToggleRow(
@@ -70,7 +70,8 @@ struct TVPlaybackSettingsPane: View {
     }
 
     private var streamingFooterText: String {
-        var text = "Turn off Dolby Vision to play Dolby Vision titles as HDR10 instead. Profile 5 titles have no HDR10-compatible layer and always play in Dolby Vision."
+        var text = "Audio Language picks which spoken track starts first; it applies to your profile on every device, not just this Apple TV."
+        text += " Turn off Dolby Vision to play Dolby Vision titles as HDR10 instead. Profile 5 titles have no HDR10-compatible layer and always play in Dolby Vision."
         if viewModel.dolbyVisionEnabled {
             text += " The fallback plays Dolby Vision Profile 7 as HDR10 on this Apple TV."
         }
@@ -157,10 +158,10 @@ struct TVPlaybackSettingsPane: View {
                 title: "Audio Language",
                 options: TVSettingsOptions.audioLanguage,
                 selection: Binding(
-                    get: { viewModel.preferredAudioLanguage },
+                    get: { viewModel.editorAudioLanguage },
                     set: { value in
-                        viewModel.preferredAudioLanguage = value
-                        Task { await viewModel.setPreferredAudioLanguage(value) }
+                        viewModel.editorAudioLanguage = value
+                        Task { await viewModel.saveAudioLanguage() }
                     }
                 )
             )

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVPlaybackSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVPlaybackSettingsView.swift
@@ -68,8 +68,10 @@ struct TVPlaybackSettingsPane: View {
 
         TVSettingsFooter(streamingFooterText)
         // Audio Language writes to the server from this pane, so the result has
-        // to show here rather than only on the Subtitles pane.
-        TVPrefSaveFooter(state: viewModel.prefSaveState)
+        // to show here rather than only on the Subtitles pane. Scoped to the
+        // audio write specifically: the rail switches panes on focus alone, so
+        // a shared field would show a subtitle failure under this footer.
+        TVPrefSaveFooter(state: viewModel.audioSaveState)
     }
 
     private var streamingFooterText: String {

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVPlaybackSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVPlaybackSettingsView.swift
@@ -34,7 +34,7 @@ struct TVPlaybackSettingsPane: View {
 
         TVSettingsPickerRow(
             title: "Audio Language",
-            value: TVSettingsOptions.label(for: viewModel.editorAudioLanguage, in: TVSettingsOptions.audioLanguage)
+            value: TVSettingsOptions.label(for: viewModel.editorAudioLanguage, in: TVSettingsOptions.audioLanguage(including: viewModel.editorAudioLanguage))
         ) { activePicker = .audioLanguage }
 
         TVSettingsToggleRow(
@@ -67,6 +67,9 @@ struct TVPlaybackSettingsPane: View {
         }
 
         TVSettingsFooter(streamingFooterText)
+        // Audio Language writes to the server from this pane, so the result has
+        // to show here rather than only on the Subtitles pane.
+        TVPrefSaveFooter(state: viewModel.prefSaveState)
     }
 
     private var streamingFooterText: String {
@@ -133,7 +136,9 @@ struct TVPlaybackSettingsPane: View {
         }
         .buttonStyle(TVSettingsPaneRowStyle(isDestructive: true))
 
-        TVSettingsFooter("Resets playback choices for this Apple TV and profile back to the server fallback.")
+        // Scoped to this device on purpose: the reset clears device-scoped
+        // rows, and Audio Language is a profile field it does not touch.
+        TVSettingsFooter("Resets this Apple TV's playback choices back to the server fallback. Audio Language applies to your whole profile and is not affected.")
     }
 
     // MARK: - Pickers
@@ -156,7 +161,7 @@ struct TVPlaybackSettingsPane: View {
         case .audioLanguage:
             TVSettingsPickerSheet(
                 title: "Audio Language",
-                options: TVSettingsOptions.audioLanguage,
+                options: TVSettingsOptions.audioLanguage(including: viewModel.editorAudioLanguage),
                 selection: Binding(
                     get: { viewModel.editorAudioLanguage },
                     set: { value in

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsComponents.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsComponents.swift
@@ -17,17 +17,9 @@ enum TVSettingsOptions {
             .init(id: option.id, label: option.labelWithBitrate)
         }
 
-    static let audioLanguage: [TVSettingsOption] = [
-        .init(id: "", label: "Default"),
-        .init(id: "en", label: "English"),
-        .init(id: "es", label: "Spanish"),
-        .init(id: "fr", label: "French"),
-        .init(id: "de", label: "German"),
-        .init(id: "it", label: "Italian"),
-        .init(id: "pt", label: "Portuguese"),
-        .init(id: "ja", label: "Japanese"),
-        .init(id: "ko", label: "Korean"),
-    ]
+    static let audioLanguage: [TVSettingsOption] =
+        [.init(id: PlaybackPrefSentinel.none, label: "No Preference")]
+            + PlaybackLanguageOption.all.map { .init(id: $0.code, label: $0.label) }
 
     static let nextUpPrompt: [TVSettingsOption] = [
         .init(id: "0", label: "At end"),

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsComponents.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsComponents.swift
@@ -17,9 +17,17 @@ enum TVSettingsOptions {
             .init(id: option.id, label: option.labelWithBitrate)
         }
 
-    static let audioLanguage: [TVSettingsOption] =
+    /// Audio-language options for a row currently holding `code`.
+    ///
+    /// A function rather than a stored list because the value is a server-owned
+    /// profile field: the web client can set it to a language outside the
+    /// twelve below, and a row that cannot represent its own value renders a
+    /// literal "—" and is overwritten by the first selection the user makes.
+    static func audioLanguage(including code: String) -> [TVSettingsOption] {
         [.init(id: PlaybackPrefSentinel.none, label: "No Preference")]
-            + PlaybackLanguageOption.all.map { .init(id: $0.code, label: $0.label) }
+            + PlaybackLanguageOption.options(including: code)
+                .map { .init(id: $0.code, label: $0.label) }
+    }
 
     static let nextUpPrompt: [TVSettingsOption] = [
         .init(id: "0", label: "At end"),
@@ -29,13 +37,17 @@ enum TVSettingsOptions {
         .init(id: "120", label: "2 minutes before end"),
     ]
 
-    static let subtitleLanguage: [TVSettingsOption] =
+    static func subtitleLanguage(including code: String) -> [TVSettingsOption] {
         [.init(id: PlaybackPrefSentinel.none, label: "None")]
-            + PlaybackLanguageOption.all.map { .init(id: $0.code, label: $0.label) }
+            + PlaybackLanguageOption.options(including: code)
+                .map { .init(id: $0.code, label: $0.label) }
+    }
 
-    static let metadataLanguage: [TVSettingsOption] =
+    static func metadataLanguage(including code: String) -> [TVSettingsOption] {
         [.init(id: PlaybackPrefSentinel.none, label: "Library Default")]
-            + PlaybackLanguageOption.all.map { .init(id: $0.code, label: $0.label) }
+            + PlaybackLanguageOption.options(including: code)
+                .map { .init(id: $0.code, label: $0.label) }
+    }
 
     static let subtitleMode: [TVSettingsOption] =
         SubtitleMode.allCases.map { .init(id: $0.rawValue, label: $0.displayLabel) }

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsViewModel.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsViewModel.swift
@@ -4,8 +4,9 @@ import Foundation
 /// State container for the tvOS settings screen.
 ///
 /// Local-only fields (preferred quality, auto-play, subtitle size) live
-/// in `UserDefaults`. The subtitle-language / behavior / forced-subs
-/// trio is profile-wide on the server and persisted via
+/// in `UserDefaults`. The spoken-language choice and the
+/// subtitle-language / behavior / forced-subs trio are profile-wide on
+/// the server and persisted via
 /// `PUT /profiles/{id}`. The server cascades profile → library →
 /// per-series at playback time, so a single profile-level edit is
 /// enough to make subs auto-enable everywhere unless the user later
@@ -29,7 +30,6 @@ final class TVSettingsViewModel {
 
     // Playback preferences (server-backed for this device/profile).
     var preferredQuality: String = PlayerSettings.shared.preferredQuality
-    var preferredAudioLanguage: String = PlayerSettings.shared.audioLanguage
     var autoPlayNext: Bool = PlayerSettings.shared.autoPlayNextEpisode
     var nextUpPromptSeconds: Int = PlayerSettings.shared.nextUpPromptSeconds
     var skipIntros: Bool = PlayerSettings.shared.autoSkipIntro
@@ -54,6 +54,12 @@ final class TVSettingsViewModel {
     // Server-backed profile prefs editor. Each editor field is either
     // the `PlaybackPrefSentinel.none` sentinel ("__none__") or a concrete
     // value. We persist directly to the active profile via PUT /profiles/{id}.
+    /// Preferred spoken (audio) language. Profile-wide, not per-device:
+    /// the server resolves the initial audio track from the profile's
+    /// `language` field, so this is the only value that actually reaches
+    /// playback. `PlaybackPrefSentinel.none` maps to the empty string
+    /// ("no preference") on the wire.
+    var editorAudioLanguage: String = PlaybackPrefSentinel.none
     var editorSubtitleLanguage: String = PlaybackPrefSentinel.none
     var editorSubtitleMode: String = SubtitleMode.auto.rawValue
     /// Tri-state stored as "on" / "off". The server treats nil and
@@ -105,7 +111,6 @@ final class TVSettingsViewModel {
     func load() async {
         await PlayerSettings.shared.refreshFromServer()
         preferredQuality = PlayerSettings.shared.preferredQuality
-        preferredAudioLanguage = PlayerSettings.shared.audioLanguage
         autoPlayNext = PlayerSettings.shared.autoPlayNextEpisode
         nextUpPromptSeconds = PlayerSettings.shared.nextUpPromptSeconds
         skipIntros = PlayerSettings.shared.autoSkipIntro
@@ -141,12 +146,6 @@ final class TVSettingsViewModel {
     func setPreferredQuality(_ value: String) async {
         PlayerSettings.shared.setPreferredQuality(value)
         preferredQuality = PlayerSettings.shared.preferredQuality
-    }
-
-    @MainActor
-    func setPreferredAudioLanguage(_ value: String) async {
-        PlayerSettings.shared.setAudioLanguage(value)
-        preferredAudioLanguage = PlayerSettings.shared.audioLanguage
     }
 
     @MainActor
@@ -195,7 +194,6 @@ final class TVSettingsViewModel {
     func resetPlaybackDeviceSettings() async {
         await PlayerSettings.shared.resetAllDeviceSettings()
         preferredQuality = PlayerSettings.shared.preferredQuality
-        preferredAudioLanguage = PlayerSettings.shared.audioLanguage
         autoPlayNext = PlayerSettings.shared.autoPlayNextEpisode
         nextUpPromptSeconds = PlayerSettings.shared.nextUpPromptSeconds
         skipIntros = PlayerSettings.shared.autoSkipIntro
@@ -245,7 +243,7 @@ final class TVSettingsViewModel {
         prefSaveState = .saving
 
         let body = UpdateProfileBody(
-            subtitleLanguage: outboundSubtitleLanguage(editorSubtitleLanguage),
+            subtitleLanguage: outboundProfileLanguage(editorSubtitleLanguage),
             subtitleMode: editorSubtitleMode,
             showForcedSubtitles: editorShowForcedSubtitles == "on"
         )
@@ -263,6 +261,7 @@ final class TVSettingsViewModel {
                     avatarEmoji: prof.avatarEmoji,
                     hasPin: prof.hasPin,
                     isChild: prof.isChild,
+                    language: prof.language,
                     subtitleLanguage: body.subtitleLanguage,
                     subtitleMode: body.subtitleMode,
                     showForcedSubtitles: body.showForcedSubtitles,
@@ -285,7 +284,7 @@ final class TVSettingsViewModel {
     @MainActor
     func saveMetadataLanguage() async {
         guard activeProfile?.id.isEmpty == false else { return }
-        pendingMetadataLanguageValue = outboundSubtitleLanguage(editorPreferredMetadataLanguage)
+        pendingMetadataLanguageValue = outboundProfileLanguage(editorPreferredMetadataLanguage)
         guard !isSavingMetadataLanguage else { return }
 
         isSavingMetadataLanguage = true
@@ -309,7 +308,7 @@ final class TVSettingsViewModel {
         do {
             try await ContinuumAPI.shared.updateProfile(profileId: profileId, body: body)
             guard activeProfile?.id == profileId,
-                  outboundSubtitleLanguage(editorPreferredMetadataLanguage) == newValue else {
+                  outboundProfileLanguage(editorPreferredMetadataLanguage) == newValue else {
                 return
             }
             prefSaveState = .saved
@@ -320,6 +319,7 @@ final class TVSettingsViewModel {
                     avatarEmoji: prof.avatarEmoji,
                     hasPin: prof.hasPin,
                     isChild: prof.isChild,
+                    language: prof.language,
                     subtitleLanguage: prof.subtitleLanguage,
                     subtitleMode: prof.subtitleMode,
                     showForcedSubtitles: prof.showForcedSubtitles,
@@ -332,7 +332,65 @@ final class TVSettingsViewModel {
             #endif
         } catch {
             guard activeProfile?.id == profileId,
-                  outboundSubtitleLanguage(editorPreferredMetadataLanguage) == newValue else {
+                  outboundProfileLanguage(editorPreferredMetadataLanguage) == newValue else {
+                return
+            }
+            prefSaveState = .failed(
+                (error as? LocalizedError)?.errorDescription
+                    ?? String(describing: error)
+            )
+        }
+    }
+
+    /// Persist the preferred spoken (audio) language as a profile patch.
+    ///
+    /// This is deliberately a profile field rather than a per-device one:
+    /// the server picks the initial audio track from `profile.language`
+    /// and reports the result as `effective_audio_track_index`, which the
+    /// player forwards at session start. A device-scoped value would
+    /// never be read by anything.
+    @MainActor
+    func saveAudioLanguage() async {
+        guard let profileId = activeProfile?.id, !profileId.isEmpty else { return }
+        let newValue = outboundProfileLanguage(editorAudioLanguage)
+        guard newValue != (activeProfile?.language ?? "") else { return }
+
+        prefSaveState = .saving
+
+        do {
+            try await ContinuumAPI.shared.updateProfile(
+                profileId: profileId,
+                body: UpdateProfileBody(language: newValue)
+            )
+            guard activeProfile?.id == profileId,
+                  outboundProfileLanguage(editorAudioLanguage) == newValue else {
+                return
+            }
+            prefSaveState = .saved
+            if let prof = activeProfile {
+                activeProfile = UserProfile(
+                    id: prof.id,
+                    name: prof.name,
+                    avatarEmoji: prof.avatarEmoji,
+                    hasPin: prof.hasPin,
+                    isChild: prof.isChild,
+                    language: newValue,
+                    subtitleLanguage: prof.subtitleLanguage,
+                    subtitleMode: prof.subtitleMode,
+                    showForcedSubtitles: prof.showForcedSubtitles,
+                    preferredMetadataLanguage: prof.preferredMetadataLanguage
+                )
+            }
+            // Detail screens render the server-resolved audio track out of
+            // the cached item payloads, which have no TTL. Drop them so the
+            // new selection shows up without a relaunch. Playback itself
+            // always refetches `/watch`, so this is display consistency
+            // only — it is not what makes the setting take effect.
+            ResponseCache.shared.invalidateAllItemMetadata()
+            ItemDetailCache.shared.clearAll()
+        } catch {
+            guard activeProfile?.id == profileId,
+                  outboundProfileLanguage(editorAudioLanguage) == newValue else {
                 return
             }
             prefSaveState = .failed(
@@ -345,6 +403,9 @@ final class TVSettingsViewModel {
     // MARK: - Editor projection helpers
 
     private func projectActiveProfileIntoEditor() {
+        let audioLang = activeProfile?.language ?? ""
+        editorAudioLanguage = audioLang.isEmpty ? PlaybackPrefSentinel.none : audioLang
+
         let raw = activeProfile?.subtitleLanguage ?? ""
         editorSubtitleLanguage = raw.isEmpty ? PlaybackPrefSentinel.none : raw
 
@@ -358,8 +419,9 @@ final class TVSettingsViewModel {
     }
 
     /// `__none__` sentinel maps to the empty string the server expects
-    /// to mean "no subtitle preference / no subs".
-    private func outboundSubtitleLanguage(_ value: String) -> String {
+    /// to mean "no preference" for any of the profile language fields
+    /// (spoken, subtitle, metadata).
+    private func outboundProfileLanguage(_ value: String) -> String {
         value == PlaybackPrefSentinel.none ? "" : value
     }
 }

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsViewModel.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsViewModel.swift
@@ -76,6 +76,12 @@ final class TVSettingsViewModel {
     /// worse here than on iOS: the rail switches panes live on focus, with no
     /// navigation, so a failed subtitle save would show under Audio Language
     /// the instant focus moved to Playback.
+    ///
+    /// `nil` means "nothing to report" and hides the row's footer line. A
+    /// save that finishes against a profile the user has since switched away
+    /// from resets to `nil` rather than returning early, which would leave
+    /// the footer reading "Saving…" for a write that is no longer this
+    /// screen's to report.
     var audioSaveState: PrefSaveState?
     var subtitleSaveState: PrefSaveState?
     var metadataSaveState: PrefSaveState?
@@ -303,7 +309,16 @@ final class TVSettingsViewModel {
         let body = UpdateProfileBody(preferredMetadataLanguage: newValue)
         do {
             try await ContinuumAPI.shared.updateProfile(profileId: profileId, body: body)
-            guard activeProfile?.id == profileId else { return }
+            // The write landed, so the cached payloads are stale no matter
+            // which profile is active now. Flushed before the guard below:
+            // both caches are pure drops that refetch on demand, and a
+            // profile switch is if anything a stronger reason to drop them.
+            ResponseCache.shared.invalidateAllItemMetadata()
+            ItemDetailCache.shared.clearAll()
+            guard activeProfile?.id == profileId else {
+                metadataSaveState = nil
+                return
+            }
             // Record the write before deciding whether to report, so a queued
             // follow-up compares against the value the server now holds.
             if let prof = activeProfile {
@@ -315,10 +330,11 @@ final class TVSettingsViewModel {
             // whenever the user re-picks the value already being written,
             // because the queued pass then no-ops on the equality guard above.
             metadataSaveState = .saved
-            ResponseCache.shared.invalidateAllItemMetadata()
-            ItemDetailCache.shared.clearAll()
         } catch {
-            guard activeProfile?.id == profileId else { return }
+            guard activeProfile?.id == profileId else {
+                metadataSaveState = nil
+                return
+            }
             metadataSaveState = .failed(
                 (error as? LocalizedError)?.errorDescription
                     ?? String(describing: error)
@@ -367,7 +383,19 @@ final class TVSettingsViewModel {
                 profileId: profileId,
                 body: UpdateProfileBody(language: newValue)
             )
-            guard activeProfile?.id == profileId else { return }
+            // Detail screens render the server-resolved audio track out of
+            // the cached item payloads, which have no TTL. Drop them so the
+            // new selection shows up without a relaunch. Playback itself
+            // always refetches `/watch`, so this is display consistency
+            // only — it is not what makes the setting take effect. Flushed
+            // before the guard below for the same reason as the metadata
+            // save: the write landed either way.
+            ResponseCache.shared.invalidateAllItemMetadata()
+            ItemDetailCache.shared.clearAll()
+            guard activeProfile?.id == profileId else {
+                audioSaveState = nil
+                return
+            }
             // The write landed. Record it even if the user has since moved on
             // to another value: the queue above will save that one next, and
             // leaving `activeProfile` stale would make the follow-up save
@@ -383,15 +411,11 @@ final class TVSettingsViewModel {
             // leaving detail screens on the old track. A queued value that
             // differs will overwrite this message when it lands.
             audioSaveState = .saved
-            // Detail screens render the server-resolved audio track out of
-            // the cached item payloads, which have no TTL. Drop them so the
-            // new selection shows up without a relaunch. Playback itself
-            // always refetches `/watch`, so this is display consistency
-            // only — it is not what makes the setting take effect.
-            ResponseCache.shared.invalidateAllItemMetadata()
-            ItemDetailCache.shared.clearAll()
         } catch {
-            guard activeProfile?.id == profileId else { return }
+            guard activeProfile?.id == profileId else {
+                audioSaveState = nil
+                return
+            }
             // Reported even when a newer value is already queued: the user needs
             // to know this save failed, and the queued one will overwrite the
             // message if it succeeds.

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsViewModel.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsViewModel.swift
@@ -76,6 +76,8 @@ final class TVSettingsViewModel {
     var prefSaveState: PrefSaveState?
     private var isSavingMetadataLanguage = false
     private var pendingMetadataLanguageValue: String?
+    private var isSavingAudioLanguage = false
+    private var pendingAudioLanguageValue: String?
 
     enum PrefSaveState: Equatable {
         case saving
@@ -255,18 +257,7 @@ final class TVSettingsViewModel {
             // Refresh the local profile snapshot so a re-load reflects
             // what we just wrote.
             if let prof = activeProfile {
-                activeProfile = UserProfile(
-                    id: prof.id,
-                    name: prof.name,
-                    avatarEmoji: prof.avatarEmoji,
-                    hasPin: prof.hasPin,
-                    isChild: prof.isChild,
-                    language: prof.language,
-                    subtitleLanguage: body.subtitleLanguage,
-                    subtitleMode: body.subtitleMode,
-                    showForcedSubtitles: body.showForcedSubtitles,
-                    preferredMetadataLanguage: prof.preferredMetadataLanguage
-                )
+                activeProfile = prof.with(subtitleLanguage: body.subtitleLanguage, subtitleMode: body.subtitleMode, showForcedSubtitles: body.showForcedSubtitles)
             }
         } catch {
             prefSaveState = .failed(
@@ -313,18 +304,7 @@ final class TVSettingsViewModel {
             }
             prefSaveState = .saved
             if let prof = activeProfile {
-                activeProfile = UserProfile(
-                    id: prof.id,
-                    name: prof.name,
-                    avatarEmoji: prof.avatarEmoji,
-                    hasPin: prof.hasPin,
-                    isChild: prof.isChild,
-                    language: prof.language,
-                    subtitleLanguage: prof.subtitleLanguage,
-                    subtitleMode: prof.subtitleMode,
-                    showForcedSubtitles: prof.showForcedSubtitles,
-                    preferredMetadataLanguage: newValue
-                )
+                activeProfile = prof.with(preferredMetadataLanguage: newValue)
             }
             ResponseCache.shared.invalidateAllItemMetadata()
             #if os(tvOS)
@@ -351,8 +331,29 @@ final class TVSettingsViewModel {
     /// never be read by anything.
     @MainActor
     func saveAudioLanguage() async {
+        // Serialized the same way as saveMetadataLanguage: the picker fires on
+        // every change, so two quick selections would otherwise race across the
+        // await and leave the server holding the first value while the row
+        // shows the second.
+        guard activeProfile?.id.isEmpty == false else {
+            prefSaveState = .failed("No active profile to save to.")
+            return
+        }
+        pendingAudioLanguageValue = outboundProfileLanguage(editorAudioLanguage)
+        guard !isSavingAudioLanguage else { return }
+
+        isSavingAudioLanguage = true
+        defer { isSavingAudioLanguage = false }
+
+        while let newValue = pendingAudioLanguageValue {
+            pendingAudioLanguageValue = nil
+            await saveAudioLanguageValue(newValue)
+        }
+    }
+
+    @MainActor
+    private func saveAudioLanguageValue(_ newValue: String) async {
         guard let profileId = activeProfile?.id, !profileId.isEmpty else { return }
-        let newValue = outboundProfileLanguage(editorAudioLanguage)
         guard newValue != (activeProfile?.language ?? "") else { return }
 
         prefSaveState = .saving
@@ -362,25 +363,14 @@ final class TVSettingsViewModel {
                 profileId: profileId,
                 body: UpdateProfileBody(language: newValue)
             )
+            if let prof = activeProfile, prof.id == profileId {
+                activeProfile = prof.with(language: newValue)
+            }
             guard activeProfile?.id == profileId,
-                  outboundProfileLanguage(editorAudioLanguage) == newValue else {
+                  pendingAudioLanguageValue == nil else {
                 return
             }
             prefSaveState = .saved
-            if let prof = activeProfile {
-                activeProfile = UserProfile(
-                    id: prof.id,
-                    name: prof.name,
-                    avatarEmoji: prof.avatarEmoji,
-                    hasPin: prof.hasPin,
-                    isChild: prof.isChild,
-                    language: newValue,
-                    subtitleLanguage: prof.subtitleLanguage,
-                    subtitleMode: prof.subtitleMode,
-                    showForcedSubtitles: prof.showForcedSubtitles,
-                    preferredMetadataLanguage: prof.preferredMetadataLanguage
-                )
-            }
             // Detail screens render the server-resolved audio track out of
             // the cached item payloads, which have no TTL. Drop them so the
             // new selection shows up without a relaunch. Playback itself
@@ -389,8 +379,7 @@ final class TVSettingsViewModel {
             ResponseCache.shared.invalidateAllItemMetadata()
             ItemDetailCache.shared.clearAll()
         } catch {
-            guard activeProfile?.id == profileId,
-                  outboundProfileLanguage(editorAudioLanguage) == newValue else {
+            guard activeProfile?.id == profileId else {
                 return
             }
             prefSaveState = .failed(

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsViewModel.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsViewModel.swift
@@ -71,9 +71,14 @@ final class TVSettingsViewModel {
     /// Gated on `AICapabilities.shared.metadataEnabled` at the row.
     var editorPreferredMetadataLanguage: String = PlaybackPrefSentinel.none
 
-    /// Surfaces the most recent server save state. Settings UI shows a
-    /// transient message when prefSaveState != nil.
-    var prefSaveState: PrefSaveState?
+    /// Save state for the three profile-backed writes, kept apart by which
+    /// row produced them. A single shared field misattributes results, and
+    /// worse here than on iOS: the rail switches panes live on focus, with no
+    /// navigation, so a failed subtitle save would show under Audio Language
+    /// the instant focus moved to Playback.
+    var audioSaveState: PrefSaveState?
+    var subtitleSaveState: PrefSaveState?
+    var metadataSaveState: PrefSaveState?
     private var isSavingMetadataLanguage = false
     private var pendingMetadataLanguageValue: String?
     private var isSavingAudioLanguage = false
@@ -242,7 +247,7 @@ final class TVSettingsViewModel {
     func saveProfilePrefs() async {
         guard let profileId = activeProfile?.id, !profileId.isEmpty else { return }
 
-        prefSaveState = .saving
+        subtitleSaveState = .saving
 
         let body = UpdateProfileBody(
             subtitleLanguage: outboundProfileLanguage(editorSubtitleLanguage),
@@ -251,7 +256,7 @@ final class TVSettingsViewModel {
         )
         do {
             try await ContinuumAPI.shared.updateProfile(profileId: profileId, body: body)
-            prefSaveState = .saved
+            subtitleSaveState = .saved
             // Keep the detail-page track-ordering preference in sync.
             ProfilePrefsStore.shared.setPreferredSubtitleLanguage(body.subtitleLanguage)
             // Refresh the local profile snapshot so a re-load reflects
@@ -260,7 +265,7 @@ final class TVSettingsViewModel {
                 activeProfile = prof.with(subtitleLanguage: body.subtitleLanguage, subtitleMode: body.subtitleMode, showForcedSubtitles: body.showForcedSubtitles)
             }
         } catch {
-            prefSaveState = .failed(
+            subtitleSaveState = .failed(
                 (error as? LocalizedError)?.errorDescription
                     ?? String(describing: error)
             )
@@ -293,29 +298,28 @@ final class TVSettingsViewModel {
         let oldValue = activeProfile?.preferredMetadataLanguage ?? ""
         guard newValue != oldValue else { return }
 
-        prefSaveState = .saving
+        metadataSaveState = .saving
 
         let body = UpdateProfileBody(preferredMetadataLanguage: newValue)
         do {
             try await ContinuumAPI.shared.updateProfile(profileId: profileId, body: body)
-            guard activeProfile?.id == profileId,
-                  outboundProfileLanguage(editorPreferredMetadataLanguage) == newValue else {
-                return
-            }
-            prefSaveState = .saved
+            guard activeProfile?.id == profileId else { return }
+            // Record the write before deciding whether to report, so a queued
+            // follow-up compares against the value the server now holds.
             if let prof = activeProfile {
                 activeProfile = prof.with(preferredMetadataLanguage: newValue)
             }
+            // Reported unconditionally: the write landed, and a still-queued
+            // value will overwrite this message when it lands in turn. Gating
+            // on "no newer value pending" strands the footer on "Saving…"
+            // whenever the user re-picks the value already being written,
+            // because the queued pass then no-ops on the equality guard above.
+            metadataSaveState = .saved
             ResponseCache.shared.invalidateAllItemMetadata()
-            #if os(tvOS)
             ItemDetailCache.shared.clearAll()
-            #endif
         } catch {
-            guard activeProfile?.id == profileId,
-                  outboundProfileLanguage(editorPreferredMetadataLanguage) == newValue else {
-                return
-            }
-            prefSaveState = .failed(
+            guard activeProfile?.id == profileId else { return }
+            metadataSaveState = .failed(
                 (error as? LocalizedError)?.errorDescription
                     ?? String(describing: error)
             )
@@ -336,7 +340,7 @@ final class TVSettingsViewModel {
         // await and leave the server holding the first value while the row
         // shows the second.
         guard activeProfile?.id.isEmpty == false else {
-            prefSaveState = .failed("No active profile to save to.")
+            audioSaveState = .failed("No active profile to save to.")
             return
         }
         pendingAudioLanguageValue = outboundProfileLanguage(editorAudioLanguage)
@@ -356,21 +360,29 @@ final class TVSettingsViewModel {
         guard let profileId = activeProfile?.id, !profileId.isEmpty else { return }
         guard newValue != (activeProfile?.language ?? "") else { return }
 
-        prefSaveState = .saving
+        audioSaveState = .saving
 
         do {
             try await ContinuumAPI.shared.updateProfile(
                 profileId: profileId,
                 body: UpdateProfileBody(language: newValue)
             )
-            if let prof = activeProfile, prof.id == profileId {
+            guard activeProfile?.id == profileId else { return }
+            // The write landed. Record it even if the user has since moved on
+            // to another value: the queue above will save that one next, and
+            // leaving `activeProfile` stale would make the follow-up save
+            // compare against the wrong baseline and skip itself.
+            if let prof = activeProfile {
                 activeProfile = prof.with(language: newValue)
             }
-            guard activeProfile?.id == profileId,
-                  pendingAudioLanguageValue == nil else {
-                return
-            }
-            prefSaveState = .saved
+            // Reported unconditionally rather than only when nothing is queued.
+            // Suppressing it stranded the footer on "Saving…" forever when the
+            // user re-selected the value already in flight: the queued pass then
+            // matches `activeProfile.language` and returns at the guard above,
+            // so nothing ever reached `.saved` — and the caches never flushed,
+            // leaving detail screens on the old track. A queued value that
+            // differs will overwrite this message when it lands.
+            audioSaveState = .saved
             // Detail screens render the server-resolved audio track out of
             // the cached item payloads, which have no TTL. Drop them so the
             // new selection shows up without a relaunch. Playback itself
@@ -379,10 +391,11 @@ final class TVSettingsViewModel {
             ResponseCache.shared.invalidateAllItemMetadata()
             ItemDetailCache.shared.clearAll()
         } catch {
-            guard activeProfile?.id == profileId else {
-                return
-            }
-            prefSaveState = .failed(
+            guard activeProfile?.id == profileId else { return }
+            // Reported even when a newer value is already queued: the user needs
+            // to know this save failed, and the queued one will overwrite the
+            // message if it succeeds.
+            audioSaveState = .failed(
                 (error as? LocalizedError)?.errorDescription
                     ?? String(describing: error)
             )

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSubtitleSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSubtitleSettingsView.swift
@@ -40,7 +40,7 @@ struct TVSubtitleSettingsPane: View {
 
         TVSettingsPickerRow(
             title: "Language",
-            value: TVSettingsOptions.label(for: viewModel.editorSubtitleLanguage, in: TVSettingsOptions.subtitleLanguage)
+            value: TVSettingsOptions.label(for: viewModel.editorSubtitleLanguage, in: TVSettingsOptions.subtitleLanguage(including: viewModel.editorSubtitleLanguage))
         ) { activePicker = .language }
         .focused(detailFocus, equals: .top)
 
@@ -58,7 +58,7 @@ struct TVSubtitleSettingsPane: View {
         }
 
         TVSettingsFooter("Used to pick a matching track when one is available. Forced subtitles cover foreign-language dialogue even when subtitles are off or set to auto.")
-        prefSaveFooter
+        TVPrefSaveFooter(state: viewModel.prefSaveState)
     }
 
     @ViewBuilder
@@ -67,7 +67,7 @@ struct TVSubtitleSettingsPane: View {
 
         TVSettingsPickerRow(
             title: "Metadata Language",
-            value: TVSettingsOptions.label(for: viewModel.editorPreferredMetadataLanguage, in: TVSettingsOptions.metadataLanguage)
+            value: TVSettingsOptions.label(for: viewModel.editorPreferredMetadataLanguage, in: TVSettingsOptions.metadataLanguage(including: viewModel.editorPreferredMetadataLanguage))
         ) { activePicker = .metadataLanguage }
 
         TVSettingsFooter("Translates descriptions and taglines into your preferred language when available. Titles are never translated.")
@@ -185,23 +185,6 @@ struct TVSubtitleSettingsPane: View {
         return source + " Subtitles with their own built-in styling keep their original appearance; image-based subtitles keep their authored fonts and colors but follow the size, position, and background settings."
     }
 
-    @ViewBuilder
-    private var prefSaveFooter: some View {
-        if let state = viewModel.prefSaveState {
-            switch state {
-            case .saving:
-                TVSettingsFooter("Saving…")
-            case .saved:
-                TVSettingsFooter("Saved")
-            case .failed(let err):
-                Text("Couldn't save: \(err)")
-                    .font(.system(size: 19))
-                    .foregroundStyle(.red)
-                    .padding(.horizontal, 24)
-                    .padding(.top, 4)
-            }
-        }
-    }
 
     // MARK: - Rows
 
@@ -228,7 +211,7 @@ struct TVSubtitleSettingsPane: View {
         case .language:
             TVSettingsPickerSheet(
                 title: "Language",
-                options: TVSettingsOptions.subtitleLanguage,
+                options: TVSettingsOptions.subtitleLanguage(including: viewModel.editorSubtitleLanguage),
                 selection: $viewModel.editorSubtitleLanguage
             )
         case .mode:
@@ -240,7 +223,7 @@ struct TVSubtitleSettingsPane: View {
         case .metadataLanguage:
             TVSettingsPickerSheet(
                 title: "Metadata Language",
-                options: TVSettingsOptions.metadataLanguage,
+                options: TVSettingsOptions.metadataLanguage(including: viewModel.editorPreferredMetadataLanguage),
                 selection: $viewModel.editorPreferredMetadataLanguage
             )
         case .fontSize:

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSubtitleSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSubtitleSettingsView.swift
@@ -58,7 +58,7 @@ struct TVSubtitleSettingsPane: View {
         }
 
         TVSettingsFooter("Used to pick a matching track when one is available. Forced subtitles cover foreign-language dialogue even when subtitles are off or set to auto.")
-        TVPrefSaveFooter(state: viewModel.prefSaveState)
+        TVPrefSaveFooter(state: viewModel.subtitleSaveState)
     }
 
     @ViewBuilder
@@ -71,6 +71,9 @@ struct TVSubtitleSettingsPane: View {
         ) { activePicker = .metadataLanguage }
 
         TVSettingsFooter("Translates descriptions and taglines into your preferred language when available. Titles are never translated.")
+        // Metadata Language is its own profile write, so it reports here
+        // instead of under the subtitle trio's footer.
+        TVPrefSaveFooter(state: viewModel.metadataSaveState)
     }
 
     @ViewBuilder


### PR DESCRIPTION
The Audio Language picker in Settings did nothing. Verified P1 from Silo-Server/silo-server#376.

It wrote `playback.audio_language` as a **device** setting, but nothing anywhere read that value back — repository-wide it was only loaded, cached, displayed, and written inside the settings layer. No detail, session-start, route-planning, or player-selection path touched it. The server picks the initial audio track from the **profile's** `language` field, which `WireFormatModels.asUserProfile` was explicitly dropping and `UpdateProfileBody` had no way to write.

## What changed

**Carry the profile language through the wire layer**
- `WireFormatModels.swift` — `Profile.language` now flows into `UserProfile.language` instead of being discarded
- `ProfileModels.swift` — `UpdateProfileBody` gains `language` so the client can write it

**Point the setting at the profile**
- `SettingsViewModel.swift`, `TVSettingsViewModel.swift` — the device-backed `preferredAudioLanguage` is replaced by a profile editor field plus `saveAudioLanguage()`, which PUTs to `/api/v1/profiles/{id}`, refreshes the local `activeProfile` snapshot, and flushes the item `ResponseCache` (and tvOS `ItemDetailCache`) so an already-visited detail screen stops showing the stale track

**Remove the dead write path**
- `PlayerSettings.swift` — the device-scoped `audioLanguage` property, setter, registered default, init read, and snapshot entries are gone. `PlayerDeviceSettingKey.audioLanguage` is kept so "Reset Playback Overrides" still clears rows written by older builds

**Fix the picker contents**
- `PlaybackSettingsView.swift`, `TVPlaybackSettingsView.swift`, `TVSettingsComponents.swift` — both pickers build from the shared `PlaybackLanguageOption.all` list the subtitle and metadata pickers already use, deleting two duplicated 9-entry lists. **Required, not cosmetic**: a language set from the web client (zh/ru/ar/hi) rendered as a blank row before. Footers now say the setting is profile-wide.

No server change needed — `PUT /profiles/{id}` already accepts `language` for self-service, stores it, and returns it. silo-android already reads `activeProfile?.language`.

## Review pass — four defects in the new picker

All four end with the server and the UI disagreeing and nothing telling the user.

**No write coalescing.** `saveAudioLanguage` had none, unlike `saveMetadataLanguage` twenty lines above it, which has an explicit queue for exactly this. The picker fires on every change, so two quick selections raced across the `await`: the second task read an `activeProfile.language` the first had not written back yet, concluded nothing had changed, and returned. The server kept the first value, the picker showed the second, and `prefSaveState` stayed on `.saving` forever. Both platforms now drain a pending value the way the metadata save does, and record the write before the early return so a follow-up save compares against the right baseline.

**Failures were invisible.** Neither Playback screen rendered `prefSaveState` — the only readers were the Subtitles screens — so a failed save showed nothing and its message surfaced on a *different* screen. A PIN-gated primary profile gets a 403 here and saw nothing at all. The save-state view is extracted so both platforms' Playback panes report their own result, replacing two near-identical private copies.

**A nil `activeProfile` swallowed edits** before `prefSaveState` was ever set, so an offline settings visit silently discarded every selection. It now reports.

**The language list was narrower than the field it writes.** Listed below as an accepted limit, with the note that an unmatched selection "does not overwrite the stored value" — that turned out not to hold. tvOS rendered a literal `—`, iOS rendered blank, and the first tap *did* replace the stored language. Rather than duplicating the web's ~37-entry table, the pickers now include whatever the field currently holds — including the `original` sentinel the server honours at profile scope — and name unknown codes via `Locale` instead of shouting the raw code back.

**`isPrimary`, also listed below as deliberately left alone**, is fixed. Six sites (three iOS, three tvOS — two of them added by this PR) reconstructed `UserProfile` by hand and dropped it, because Swift fills an omitted defaulted parameter silently, so the household parent demoted themselves on every preference save. Replaced with a `with(...)` copy helper: omitting a parameter now means "keep it", so the next field added cannot be dropped.

Both reset footers claimed to reset "this device and profile"; the reset clears device rows and does not touch the profile's audio language. Reworded to match what it does.

## Second review pass — two defects introduced by the first one

Both were found on this branch by a follow-up review and are fixed in `a5d1c1b`. Each was present on both platforms.

**The coalescing fix could skip the completion path for a write that landed.** Guarding `.saved` on `pendingAudioLanguageValue == nil` looked like "don't report a stale result", but it misfires when the queued value *equals* the one being written — A → B → B before the first PUT returns. At completion B is still queued, so the success path returns before `.saved` and before flushing the caches; the drained pass then matches the freshly-recorded `activeProfile.language` and returns at its own equality guard. Nothing ever reports: the footer reads "Saving…" indefinitely, and cached detail screens keep the old track — the exact symptom the coalescing was added to eliminate. The write is now recorded first and reported unconditionally, since a genuinely newer value overwrites the message when it lands. `saveMetadataLanguage` had the same shape through its editor-value comparison and got the same treatment.

**One untagged save state served three different writes.** `prefSaveState` was written by the subtitle, metadata, and audio paths and never cleared. That was survivable while only the Subtitles screen read it; making Playback render it too turned it into cross-screen misattribution — a failed subtitle save shows "Couldn't save: …" under Audio Language, and an audio result sits pinned under the Subtitles footer on next visit. Worse on tvOS, where the rail switches panes on focus alone with no navigation to stale it out. Split into `audioSaveState` / `subtitleSaveState` / `metadataSaveState`, each rendered under the row that produces it. Metadata Language gains its own footer line as a result; it had been borrowing the subtitle trio's.

Two other bot findings were checked and not acted on: extracting the duplicated save machinery is a maintainability nitpick whose duplication predates this PR, and refreshing live tvOS detail models rather than only clearing `ItemDetailCache` is a real but pre-existing display-consistency limit that `saveMetadataLanguage` already shares — not a regression from this branch, and out of scope here.

## Verification

Built and tested on mac-builder (macOS 26.5.1, Xcode 26.4) from an isolated
checkout at this branch's exact source state. Re-run after `a5d1c1b`.

```
$ xcodebuild -scheme Silo   -destination 'generic/platform=iOS Simulator'   build   ** BUILD SUCCEEDED **
$ xcodebuild -scheme SiloTV -destination 'generic/platform=tvOS Simulator'  build   ** BUILD SUCCEEDED **
$ xcodebuild -scheme SiloMac -destination 'platform=macOS'                  build   ** BUILD SUCCEEDED **

$ xcodebuild -scheme Silo -destination 'platform=iOS Simulator,id=…' test
     Executed 761 tests, with 0 failures (0 unexpected) in 30.035 seconds
** TEST SUCCEEDED **
```

## Known limits and follow-ups

- **Not device-verified.** Compiles everywhere; the picker → profile → server → track-selection round trip was not exercised against a live server.
- **Stranded device rows — this one matters for the contract.** Existing `playback.audio_language` rows in `user_device_settings` from earlier builds are now orphaned. Harmless today, but the settings contract resolves that key `profile_device → profile`, so a stale row would **shadow** the new profile value — and it would be a value the user set months ago and demonstrably saw no effect from. Needs an explicit server-side migration disposition; deliberately not papered over with a client-side DELETE.
- ~~**Language list is still narrower than the web's.**~~ **Fixed in the review commit.** The claim that an unmatched selection "does not overwrite the stored value" was wrong — tvOS showed `—`, iOS showed blank, and the first tap replaced it. Pickers now carry the current value plus the twelve.
- ~~**No write coalescing.**~~ **Fixed in the review commit** — the divergence was worse than "land out of order": the second save skipped itself and `prefSaveState` stranded on `.saving`. The coalescing itself then needed a second fix (`a5d1c1b`): its completion guard could strand the same footer when the queued value equalled the in-flight one.
- ~~**Save results were reported through one shared, untagged field.**~~ **Fixed in `a5d1c1b`** — split per write, so the Playback screen rendering it no longer misattributes subtitle and metadata results.
- ~~**Pre-existing bug, deliberately left alone:** `isPrimary` dropped on reconstruction.~~ **Fixed in the review commit** at all six sites (there were six, not four) via a `with(...)` copy helper. Still latent in effect — nothing reads `activeProfile.isPrimary` today — but the trap is gone.
- **UI change worth a screenshot:** picker goes 9 → 13 rows, and the empty label changes from "Default" to "No Preference" — matching the web, and honest now that the value is profile-wide.
- **Live tvOS detail models aren't refreshed, only their cache is cleared.** `ItemDetailCache.clearAll()` drops cache references but does not refresh a resident `TVItemDetailView`'s `@State` model, so a detail screen visited earlier in the session can keep showing the old track until it reloads. Pre-existing — `saveMetadataLanguage` has had exactly this treatment — and display-only, since playback refetches `/watch`. Fixing it properly needs a refresh broadcast covering both writes, which is a separate change.

Part of Silo-Server/silo-server#376. Server-side contract: Silo-Server/silo-server#479. Supersedes #103, closed when its branch was renamed.

### AI Disclosure

- **Tool(s):** Claude Code
- **Model(s):** `claude-opus-5[1m]`
- **Involvement:** AI-assisted, under maintainer direction
- **Adversarial review:** Reviewed by a parallel multi-agent pass plus an independent adversarial pass using Codex. Both independently found the missing save serialization. The parallel pass additionally found the invisible failure state, the nil-profile swallow, that the language-list limitation was worse than this PR's own body claimed, and that `isPrimary` was dropped at six sites rather than four. Reviewers also confirmed by inspection that `UpdateProfileBody`'s optional fields cannot wipe siblings — `encodeIfPresent` omits them and the server patches per-field — so that concern was checked and dropped rather than "fixed". A second review pass over the review commit itself found the two defects fixed in `a5d1c1b`; both had been introduced by the first pass's fixes, which is the argument for reviewing review commits.

Builds and tests were run on mac-builder and the real output is quoted above, rather than reported from the implementing agent, which has no Swift toolchain. One self-inflicted bug was caught before building: both new view structs used `State` as a generic parameter name, shadowing SwiftUI's `@State`; renamed to `SaveState`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added profile-wide audio language preferences across iOS and tvOS.
  * Audio language changes now save through the profile and display saving, success, or error status.
  * Language pickers now retain and display custom or previously selected language codes.
  * Updated settings explanations clarify that audio language is profile-wide and unaffected by device resets.

* **Bug Fixes**
  * Improved localized labels for unknown language codes.
  * Ensured subtitle and metadata language selections remain available in picker lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
