### PR TITLE
fix(playback): take the media runtime from the v3 plan

### DIFF
--- a/iosApp/Tests/PlaybackProtocolV3Tests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3Tests.swift
@@ -30,6 +30,51 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         XCTAssertEqual(session.playMethod, "direct")
     }
 
+    // The plan describes the effective file the server actually chose, which
+    // need not be the version the client picked, so its runtime wins over the
+    // catalog's.
+    func testPlanRuntimeOverridesTheCatalogVersionDuration() {
+        let session = ApplePlaybackV3PlanAdapter.playbackSession(
+            plan: makePlan(sourceDurationSeconds: 5_400),
+            sessionId: "session-v3",
+            selectedVersion: makeVersion(container: "mp4", videoCodec: "h264", audioCodec: "aac")
+        )
+
+        XCTAssertEqual(session.durationSeconds, 5_400)
+    }
+
+    // Servers predating source.duration_seconds omit it; the catalog value is
+    // the only remaining source and must still be used.
+    func testMissingPlanRuntimeFallsBackToTheCatalogVersionDuration() {
+        let session = ApplePlaybackV3PlanAdapter.playbackSession(
+            plan: makePlan(sourceDurationSeconds: nil),
+            sessionId: "session-v3",
+            selectedVersion: makeVersion(container: "mp4", videoCodec: "h264", audioCodec: "aac")
+        )
+
+        XCTAssertEqual(session.durationSeconds, 120)
+    }
+
+    // A plan without the field at all must decode: every non-Optional property
+    // on the descriptor is a required key, so a non-Optional duration would
+    // fail the whole plan against an older server.
+    func testPlanDecodesWhenTheSourceRuntimeIsAbsent() throws {
+        let json = """
+        {
+          "media_file_id": 42,
+          "container": "mp4",
+          "hdr10_plus": false,
+          "dv_enhancement_layer": "none"
+        }
+        """
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let source = try decoder.decode(PlaybackV3SourceDescriptor.self, from: Data(json.utf8))
+
+        XCTAssertNil(source.durationSeconds)
+        XCTAssertEqual(source.mediaFileId, 42)
+    }
+
     func testCanonicalAttemptKeyMatchesGoAndAndroidFixtures() {
         let hls = makePlan(
             planId: "plan:fixture",
@@ -386,7 +431,8 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         appliedQuirks: [PlaybackV3AppliedQuirk] = [],
         runtimeCorrections: [String] = [],
         playerStart: Double = 4.5,
-        timelineOffset: Double = 0
+        timelineOffset: Double = 0,
+        sourceDurationSeconds: Double? = 5_400
     ) -> PlaybackV3Plan {
         PlaybackV3Plan(
             protocolVersion: 3,
@@ -461,6 +507,7 @@ final class PlaybackProtocolV3Tests: XCTestCase {
             effectiveMediaFileId: 42,
             source: PlaybackV3SourceDescriptor(
                 mediaFileId: 42,
+                durationSeconds: sourceDurationSeconds,
                 container: container,
                 videoCodec: videoCodec,
                 videoProfile: "high",

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3PlanAdapter.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3PlanAdapter.swift
@@ -132,7 +132,11 @@ enum ApplePlaybackV3PlanAdapter {
             isPaused: false,
             streamUrl: plan.stream.url,
             audioTrackIndex: plan.selectedTracks.audio?.index,
-            durationSeconds: selectedVersion.duration,
+            // The plan's runtime is authoritative and describes the effective
+            // file the server actually chose. Fall back to the catalog version
+            // only for servers that predate the field; substituting it when
+            // the server reports an unknown runtime would reintroduce a guess.
+            durationSeconds: plan.source.durationSeconds ?? selectedVersion.duration,
             timelineOffsetSeconds: max(0, plan.timeline.timelineOffsetSeconds),
             subtitleUrls: subtitleUrls,
             playbackInfo: PlaybackInfo(

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/PlaybackProtocolV3Models.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/PlaybackProtocolV3Models.swift
@@ -234,6 +234,17 @@ struct PlaybackV3EffectiveRecipe: Codable, Equatable {
 
 struct PlaybackV3SourceDescriptor: Codable, Equatable {
     let mediaFileId: Int
+    /// Full runtime of the source, or nil when the server does not know it.
+    ///
+    /// Optional so a server predating the field still decodes: every
+    /// non-Optional property here is a required key, and a `keyNotFound`
+    /// would fail the whole plan.
+    ///
+    /// This is the whole file, never `total - sourceStartSeconds` and never
+    /// adjusted by `timelineOffsetSeconds`. Do not substitute the player's
+    /// reported duration: on an HLS copy remux that is the window produced so
+    /// far, not the runtime.
+    let durationSeconds: Double?
     let container: String?
     let videoCodec: String?
     let videoProfile: String?


### PR DESCRIPTION
## Problem

The v3 plan's `source` descriptor was already decoded here, but its runtime was ignored: `ApplePlaybackV3PlanAdapter.playbackSession` took `durationSeconds` from the catalog `FileVersion` the client had selected.

That is the wrong file whenever the server resolves a different effective version — the plan carries both `requested_media_file_id` and `effective_media_file_id` precisely because they can differ — and it is unavailable whenever the catalog value is missing or wrong. The same underlying gap showed up on Android as a 90-minute movie playing back as about a minute.

## What this does

Prefers `plan.source.durationSeconds`, falling back to the catalog version only for servers that predate the field.

`durationSeconds` is declared `Double?`. This matters more than it looks: every non-Optional property on `PlaybackV3SourceDescriptor` is a required key under synthesized `Codable`, so a non-Optional duration would throw `keyNotFound` against an older server and fail the entire plan — turning a missing runtime into dead playback.

## Scope

Client half of Silo-Server/silo-server#482, which adds `source.duration_seconds` to the v3 plan and fixes the scanner rule that let a wrong duration persist. The Android half is Silo-Server/silo-android#104.

**Merge the server PR first.** Without it the field is simply absent and behavior is unchanged from today, so this is safe to merge in either order but provides no benefit until the server ships.

Independent of the `feat/playback-v3-only` work — this branch is cut from `main` and touches neither the legacy fallback path nor the session bridge.

## Verification

```
$ xcodebuild build -scheme Silo -destination "platform=iOS Simulator,..." -configuration Debug
** BUILD SUCCEEDED **

$ xcodebuild test -scheme Silo -only-testing:SiloTests/PlaybackProtocolV3Tests
Test Case '-[SiloTests.PlaybackProtocolV3Tests testMissingPlanRuntimeFallsBackToTheCatalogVersionDuration]' passed (0.000 seconds).
Test Case '-[SiloTests.PlaybackProtocolV3Tests testPlanDecodesWhenTheSourceRuntimeIsAbsent]' passed (0.001 seconds).
Test Case '-[SiloTests.PlaybackProtocolV3Tests testPlanRuntimeOverridesTheCatalogVersionDuration]' passed (0.000 seconds).
	 Executed 12 tests, with 0 failures (0 unexpected) in 0.052 seconds
** TEST SUCCEEDED **
```

Three tests added, per the repo guidance to cover critical shared-logic behavior:
- the plan's runtime overrides the catalog version's (fixture uses 5400 vs the catalog's 120, so the source is unambiguous)
- a missing plan runtime falls back to the catalog value
- a descriptor with no `duration_seconds` key still decodes, guarding the Optional requirement above

## Notes

Not addressed here, and worth separate issues:
- `PlaybackSessionBridge` reports `duration: 0` with `forceOverwrite: true` on stop, and the server clobbers a good stored duration with it.
- AVFoundation still wins the duration race in `PlayerViewModel`: the KVO observer on `AVPlayerItem.duration` re-fires on every playlist refresh and the monotonic-max guard only rejects *smaller* values, so a growing HLS window can still extend a known runtime. The server value seeds it rather than overriding it.
- Six of the eight `PlaybackV3Timeline` fields are decoded and never read; the seek path uses a hardcoded 30-second window instead of `seekWindowStartSeconds`/`seekWindowEndSeconds`/`canSeekAnywhere`.

### AI Disclosure
- Tool(s): Claude Code
- Model(s): claude-opus-5[1m]
- Involvement: fully AI-generated
- Adversarial review: The design was reviewed by three independent agents before implementation. Two findings shaped this client's half. First, the new property must be Optional — review traced Swift's synthesized `Codable` treating every non-Optional property on the descriptor as a required key, so declaring the duration non-Optional would fail the whole plan against any older server; the third test exists to lock that in. Second, a proposed rule to represent duration as genuinely "unknown" in the UI was withdrawn after review found `TVPlayerScrubber` divides by duration with no guard (`0/0` → `NaN`, currently masked only by a `duration > 0` check) and `NowPlayingController` drops the system scrubber when duration is zero. This client keeps treating `0` as unknown internally and only gains a trustworthy first source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Playback sessions now use the source runtime provided by the playback plan when available.
  * Plans without a source runtime continue using the catalog duration as a fallback.
  * Playback plans can now omit the source duration while remaining compatible with decoding.

* **Tests**
  * Added coverage for source-runtime precedence, catalog fallback behavior, and plans missing duration data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->