### PR TITLE
fix(diagnostics): fall back to chunked upload when a proxy rejects the send

### DIFF
--- a/iosApp/Tests/DiagnosticsChunkedUploadTests.swift
+++ b/iosApp/Tests/DiagnosticsChunkedUploadTests.swift
@@ -164,6 +164,65 @@ final class DiagnosticsChunkedUploadTests: XCTestCase {
         XCTAssertFalse(state.completed)
         XCTAssertTrue(state.aborted, "a failed upload must best-effort abort its session")
     }
+
+    func testUploadChunkedFailsFastOnNonPositiveChunkBytes() async throws {
+        // A zero/negative advertised chunk size must fail fast, not degrade
+        // to 1-byte chunks (millions of PUTs for a real bundle).
+        ChunkedUploadStubProtocol.reset(chunkBytes: 0, failChunkIndex: nil)
+        let api = await makeStubbedAPI()
+
+        do {
+            _ = try await api.uploadChunked(
+                manifestData: Data(#"{"schema_version":1}"#.utf8),
+                bundleData: Data("0123456789".utf8)
+            )
+            XCTFail("uploadChunked should reject chunk_bytes = 0")
+        } catch let error as DiagnosticsUploadError {
+            guard case .underlying = error else {
+                return XCTFail("expected underlying for invalid chunk_bytes, got \(error)")
+            }
+        }
+
+        let state = ChunkedUploadStubProtocol.state()
+        XCTAssertTrue(state.chunkIndexes.isEmpty, "no chunk PUTs may be issued")
+        XCTAssertFalse(state.completed)
+        XCTAssertTrue(state.aborted, "the opened session should still be reclaimed")
+    }
+
+    func testUploadChunkedStopsWithoutAbortWhenDestinationChanges() async throws {
+        // Simulate a server/profile switch after the first chunk: the check
+        // fires before every post-init request, the remaining bundle bytes
+        // must not be sent, and no abort may be issued (it would target the
+        // newly active destination).
+        ChunkedUploadStubProtocol.reset(chunkBytes: 4, failChunkIndex: nil)
+        let api = await makeStubbedAPI()
+
+        let checkCount = ChunkCheckCounter()
+        do {
+            _ = try await api.uploadChunked(
+                manifestData: Data(#"{"schema_version":1}"#.utf8),
+                bundleData: Data("0123456789".utf8),
+                destinationUnchanged: { await checkCount.next() <= 1 }
+            )
+            XCTFail("uploadChunked should stop on a destination change")
+        } catch let error as DiagnosticsUploadError {
+            XCTAssertEqual(error, .retryable("destination_changed"))
+        }
+
+        let state = ChunkedUploadStubProtocol.state()
+        XCTAssertEqual(state.chunkIndexes, [0], "upload must stop after the destination changed")
+        XCTAssertFalse(state.completed)
+        XCTAssertFalse(state.aborted, "abort would target the new destination and must be skipped")
+    }
+}
+
+/// Serializes destination-check counting across the async upload loop.
+private actor ChunkCheckCounter {
+    private var count = 0
+    func next() -> Int {
+        count += 1
+        return count
+    }
 }
 
 /// In-process stub for the chunked upload endpoints. State is static because
@@ -200,11 +259,11 @@ final class ChunkedUploadStubProtocol: URLProtocol {
         lock.unlock()
     }
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override static func canInit(with request: URLRequest) -> Bool {
         request.url?.host == "chunk-test.invalid"
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
         request
     }
 

--- a/iosApp/Tests/DiagnosticsChunkedUploadTests.swift
+++ b/iosApp/Tests/DiagnosticsChunkedUploadTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import Silo
+
+final class DiagnosticsChunkedUploadTests: XCTestCase {
+    // MARK: - Bare-413 classification (the proxy body-cap bug)
+
+    func testBare413MapsToRequestBlockedByProxy() {
+        // An intermediary's 413 carries no Silo JSON envelope (nginx returns
+        // an HTML error page) and must be distinguished from Silo's own
+        // `too_large` verdict so the client can fall back to chunking.
+        let proxyError = HTTPError.http(
+            statusCode: 413,
+            body: "<html><head><title>413 Request Entity Too Large</title></head></html>"
+        )
+        XCTAssertEqual(DiagnosticsAPI.mapUploadError(proxyError), .requestBlockedByProxy)
+    }
+
+    func testSilo413StillMapsToTooLarge() {
+        let siloError = HTTPError.http(
+            statusCode: 413,
+            body: #"{"error":"too_large","message":"Diagnostics upload is too large"}"#
+        )
+        XCTAssertEqual(DiagnosticsAPI.mapUploadError(siloError), .tooLarge)
+    }
+
+    func testBodylessProxy413StillMapsToRequestBlockedByProxy() {
+        XCTAssertEqual(
+            DiagnosticsAPI.mapUploadError(HTTPError.http(statusCode: 413, body: nil)),
+            .requestBlockedByProxy
+        )
+    }
+
+    func testOther4xxWithoutCodeStaysUnderlying() {
+        if case .underlying = DiagnosticsAPI.mapUploadError(HTTPError.http(statusCode: 404, body: nil)) {
+        } else {
+            XCTFail("bare 404 should stay non-retryable underlying")
+        }
+    }
+
+    // MARK: - Status decoding with and without upload_chunk_bytes
+
+    func testStatusDecodesUploadChunkBytes() throws {
+        let status = try HTTPClient.makeJSONDecoder().decode(DiagnosticsStatusResponse.self, from: Data("""
+        {
+          "status": "available",
+          "server_instance_id": "srv_123",
+          "accepted_schema_versions": [1],
+          "max_bundle_bytes": 10485760,
+          "max_manifest_bytes": 65536,
+          "retention_days": 30,
+          "consent_notice_version": 1,
+          "upload_chunk_bytes": 786432
+        }
+        """.utf8))
+        XCTAssertEqual(status.uploadChunkBytes, 786_432)
+        XCTAssertTrue(status.supportsChunkedUpload)
+    }
+
+    func testStatusFromOlderServerWithoutChunkFieldDecodes() throws {
+        // Older servers omit upload_chunk_bytes entirely; decoding must not
+        // fail and chunking must read as unsupported.
+        let status = try HTTPClient.makeJSONDecoder().decode(DiagnosticsStatusResponse.self, from: Data("""
+        {
+          "status": "available",
+          "server_instance_id": "srv_123",
+          "accepted_schema_versions": [1],
+          "max_bundle_bytes": 10485760,
+          "max_manifest_bytes": 65536,
+          "retention_days": 30,
+          "consent_notice_version": 1
+        }
+        """.utf8))
+        XCTAssertNil(status.uploadChunkBytes)
+        XCTAssertFalse(status.supportsChunkedUpload)
+    }
+
+    func testChunkedSessionResponseDecodes() throws {
+        let session = try HTTPClient.makeJSONDecoder().decode(DiagnosticsChunkedUploadSession.self, from: Data("""
+        {
+          "upload_id": "0123456789abcdef",
+          "chunk_bytes": 786432,
+          "total_chunks": 3,
+          "expires_at": "2026-07-27T12:00:00Z"
+        }
+        """.utf8))
+        XCTAssertEqual(session.uploadId, "0123456789abcdef")
+        XCTAssertEqual(session.chunkBytes, 786_432)
+        XCTAssertEqual(session.totalChunks, 3)
+    }
+}

--- a/iosApp/Tests/DiagnosticsChunkedUploadTests.swift
+++ b/iosApp/Tests/DiagnosticsChunkedUploadTests.swift
@@ -15,6 +15,17 @@ final class DiagnosticsChunkedUploadTests: XCTestCase {
         XCTAssertEqual(DiagnosticsAPI.mapUploadError(proxyError), .requestBlockedByProxy)
     }
 
+    func testJSON413FromNonSiloProxyStillMapsToRequestBlockedByProxy() {
+        // Some proxies emit JSON error envelopes. Any 413 whose code is not
+        // Silo's own `too_large` still came from an intermediary and must
+        // trigger the chunked fallback rather than mapping to `.underlying`.
+        let jsonProxyError = HTTPError.http(
+            statusCode: 413,
+            body: #"{"error":"request_too_large","message":"body exceeds limit"}"#
+        )
+        XCTAssertEqual(DiagnosticsAPI.mapUploadError(jsonProxyError), .requestBlockedByProxy)
+    }
+
     func testSilo413StillMapsToTooLarge() {
         let siloError = HTTPError.http(
             statusCode: 413,
@@ -86,5 +97,185 @@ final class DiagnosticsChunkedUploadTests: XCTestCase {
         XCTAssertEqual(session.uploadId, "0123456789abcdef")
         XCTAssertEqual(session.chunkBytes, 786_432)
         XCTAssertEqual(session.totalChunks, 3)
+    }
+
+    // MARK: - uploadChunked orchestration (URLProtocol-backed)
+
+    /// Stands up a DiagnosticsAPI whose HTTPClient talks to
+    /// ChunkedUploadStubProtocol, with a TokenStore isolated to this test.
+    private func makeStubbedAPI() async -> DiagnosticsAPI {
+        let suiteName = "diag-chunk-tests-\(UUID().uuidString)"
+        let suite = UserDefaults(suiteName: suiteName)!
+        addTeardownBlock {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+        }
+        let tokenStore = TokenStore(
+            keychain: SharedKeychain(service: "DiagnosticsChunkedUploadTests.\(UUID().uuidString)", accessGroup: nil),
+            defaults: SharedDefaults(suite: suite, standard: suite)
+        )
+        await tokenStore.setServerUrl("http://chunk-test.invalid")
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [ChunkedUploadStubProtocol.self]
+        let http = HTTPClient(session: URLSession(configuration: config), tokenStore: tokenStore)
+        return DiagnosticsAPI(http: http)
+    }
+
+    func testUploadChunkedSplitsSequentiallyAndCompletes() async throws {
+        ChunkedUploadStubProtocol.reset(chunkBytes: 4, failChunkIndex: nil)
+        let api = await makeStubbedAPI()
+
+        let bundle = Data("0123456789".utf8) // 10 bytes → chunks of 4/4/2
+        let manifest = Data(#"{"schema_version":1}"#.utf8)
+        let response = try await api.uploadChunked(manifestData: manifest, bundleData: bundle)
+
+        XCTAssertEqual(response.shortID, "SILO-TEST12345678")
+        let state = ChunkedUploadStubProtocol.state()
+        XCTAssertEqual(state.chunkBodies.count, 3)
+        XCTAssertEqual(state.chunkBodies.map(\.count), [4, 4, 2])
+        XCTAssertEqual(Data(state.chunkBodies.joined()), bundle, "reassembled chunks must equal the bundle")
+        XCTAssertEqual(state.chunkIndexes, [0, 1, 2], "chunks must arrive in order")
+        XCTAssertTrue(state.completed)
+        XCTAssertFalse(state.aborted)
+        // Init must embed the manifest bytes verbatim.
+        XCTAssertNotNil(state.initBody)
+        if let initBody = state.initBody {
+            XCTAssertNotNil(initBody.range(of: manifest))
+        }
+    }
+
+    func testUploadChunkedAbortsSessionWhenAChunkFails() async throws {
+        ChunkedUploadStubProtocol.reset(chunkBytes: 4, failChunkIndex: 1)
+        let api = await makeStubbedAPI()
+
+        do {
+            _ = try await api.uploadChunked(
+                manifestData: Data(#"{"schema_version":1}"#.utf8),
+                bundleData: Data("0123456789".utf8)
+            )
+            XCTFail("uploadChunked should rethrow the failed chunk")
+        } catch let error as DiagnosticsUploadError {
+            guard case .retryable = error else {
+                return XCTFail("expected retryable for a 500 chunk, got \(error)")
+            }
+        }
+
+        let state = ChunkedUploadStubProtocol.state()
+        XCTAssertFalse(state.completed)
+        XCTAssertTrue(state.aborted, "a failed upload must best-effort abort its session")
+    }
+}
+
+/// In-process stub for the chunked upload endpoints. State is static because
+/// URLSession instantiates the protocol itself; `reset` scopes it per test.
+final class ChunkedUploadStubProtocol: URLProtocol {
+    struct State {
+        var chunkBytes = 4
+        var failChunkIndex: Int?
+        var initBody: Data?
+        var chunkIndexes: [Int] = []
+        var chunkBodies: [Data] = []
+        var completed = false
+        var aborted = false
+    }
+
+    private static let lock = NSLock()
+    private static var current = State()
+
+    static func reset(chunkBytes: Int, failChunkIndex: Int?) {
+        lock.lock()
+        current = State(chunkBytes: chunkBytes, failChunkIndex: failChunkIndex)
+        lock.unlock()
+    }
+
+    static func state() -> State {
+        lock.lock()
+        defer { lock.unlock() }
+        return current
+    }
+
+    private static func mutate(_ apply: (inout State) -> Void) {
+        lock.lock()
+        apply(&current)
+        lock.unlock()
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.host == "chunk-test.invalid"
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        let path = request.url?.path ?? ""
+        let method = request.httpMethod ?? ""
+        let body = Self.requestBody(of: request)
+
+        switch (method, path) {
+        case ("POST", "/api/v1/diagnostics/reports/uploads"):
+            Self.mutate { $0.initBody = body }
+            let chunkBytes = Self.state().chunkBytes
+            respond(status: 201, json: #"{"upload_id":"stub-session","chunk_bytes":\#(chunkBytes),"total_chunks":3,"expires_at":"2026-01-01T00:00:00Z"}"#)
+        case ("PUT", let chunkPath) where chunkPath.contains("/uploads/stub-session/chunks/"):
+            let index = Int(chunkPath.split(separator: "/").last ?? "") ?? -1
+            if Self.state().failChunkIndex == index {
+                respond(status: 500, json: #"{"error":"internal_error","message":"stub chunk failure"}"#)
+                return
+            }
+            Self.mutate {
+                $0.chunkIndexes.append(index)
+                $0.chunkBodies.append(body ?? Data())
+            }
+            respond(status: 200, json: #"{"received_chunks":\#(index + 1),"total_chunks":3}"#)
+        case ("POST", "/api/v1/diagnostics/reports/uploads/stub-session/complete"):
+            Self.mutate { $0.completed = true }
+            respond(status: 201, json: #"{"report_id":"11111111-1111-1111-1111-111111111111","short_id":"SILO-TEST12345678"}"#)
+        case ("DELETE", "/api/v1/diagnostics/reports/uploads/stub-session"):
+            Self.mutate { $0.aborted = true }
+            respond(status: 204, json: "")
+        default:
+            respond(status: 404, json: #"{"error":"not_found"}"#)
+        }
+    }
+
+    override func stopLoading() {}
+
+    /// URLSession surfaces outgoing bodies to URLProtocol as a stream, not
+    /// `httpBody`; drain it.
+    private static func requestBody(of request: URLRequest) -> Data? {
+        if let body = request.httpBody {
+            return body
+        }
+        guard let stream = request.httpBodyStream else {
+            return nil
+        }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let bufferSize = 64 * 1024
+        var buffer = [UInt8](repeating: 0, count: bufferSize)
+        while stream.hasBytesAvailable {
+            let read = stream.read(&buffer, maxLength: bufferSize)
+            guard read > 0 else { break }
+            data.append(buffer, count: read)
+        }
+        return data
+    }
+
+    private func respond(status: Int, json: String) {
+        guard let url = request.url, let client else { return }
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: status,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        if !json.isEmpty {
+            client.urlProtocol(self, didLoad: Data(json.utf8))
+        }
+        client.urlProtocolDidFinishLoading(self)
     }
 }

--- a/iosApp/iosApp/Networking/DiagnosticsAPI.swift
+++ b/iosApp/iosApp/Networking/DiagnosticsAPI.swift
@@ -15,9 +15,17 @@ struct DiagnosticsStatusResponse: Codable, Equatable {
     let maxManifestBytes: Int
     let retentionDays: Int
     let consentNoticeVersion: Int
+    /// Chunk payload size for the chunked upload fallback. Absent (nil) on
+    /// servers that predate chunked uploads; those can only take the
+    /// single-shot multipart upload.
+    let uploadChunkBytes: Int?
 
     var serverInstanceID: String {
         serverInstanceId
+    }
+
+    var supportsChunkedUpload: Bool {
+        (uploadChunkBytes ?? 0) > 0
     }
 }
 
@@ -45,8 +53,20 @@ enum DiagnosticsUploadError: Error, Equatable {
     case staleConsent
     case archiveMismatch
     case invalidBundle
+    /// An intermediary (reverse proxy/CDN) rejected the request body as too
+    /// large before it reached Silo — a 413 with no Silo error envelope.
+    /// Distinct from `.tooLarge` (Silo's own bundle-size verdict): the server
+    /// may still accept the same bundle through the chunked upload fallback,
+    /// whose requests stay under typical proxy body caps.
+    case requestBlockedByProxy
     case retryable(String)
     case underlying(String)
+}
+
+struct DiagnosticsChunkedUploadSession: Codable, Equatable {
+    let uploadId: String
+    let chunkBytes: Int
+    let totalChunks: Int
 }
 
 actor DiagnosticsAPI {
@@ -89,7 +109,71 @@ actor DiagnosticsAPI {
         }
     }
 
-    private static func mapUploadError(_ error: HTTPError) -> DiagnosticsUploadError {
+    // MARK: - Chunked upload fallback
+
+    /// Uploads via the chunked endpoints: init → sequential chunk PUTs →
+    /// complete. Used when the single-shot upload is rejected by an
+    /// intermediary body-size cap (`.requestBlockedByProxy`); every request
+    /// here stays under the server-advertised `upload_chunk_bytes` (768 KiB),
+    /// which clears nginx's default 1 MiB `client_max_body_size`.
+    ///
+    /// On failure after init, the session is aborted best-effort so the
+    /// server can reclaim its spool immediately instead of waiting out the
+    /// session TTL.
+    func uploadChunked(manifestData: Data, bundleData: Data) async throws -> DiagnosticsUploadResponse {
+        let session: DiagnosticsChunkedUploadSession
+        do {
+            // The manifest bytes are embedded verbatim into the init JSON
+            // rather than re-encoded: the server compares the received
+            // manifest against the archive's embedded manifest.json, and any
+            // re-serialization here could reorder keys and break equality.
+            var initBody = Data(#"{"bundle_bytes":\#(bundleData.count),"manifest":"#.utf8)
+            initBody.append(manifestData)
+            initBody.append(Data("}".utf8))
+            session = try await http.postRaw(
+                "/api/v1/diagnostics/reports/uploads",
+                body: initBody,
+                contentType: "application/json"
+            )
+        } catch let error as HTTPError {
+            throw Self.mapUploadError(error)
+        } catch {
+            throw DiagnosticsUploadError.underlying(String(describing: error))
+        }
+
+        do {
+            let chunkBytes = max(session.chunkBytes, 1)
+            var index = 0
+            var offset = 0
+            while offset < bundleData.count {
+                let end = min(offset + chunkBytes, bundleData.count)
+                let _: EmptyDiagnosticsResponse = try await http.putRaw(
+                    "/api/v1/diagnostics/reports/uploads/\(session.uploadId)/chunks/\(index)",
+                    body: bundleData.subdata(in: offset..<end),
+                    contentType: "application/octet-stream"
+                )
+                offset = end
+                index += 1
+            }
+            return try await http.postRaw(
+                "/api/v1/diagnostics/reports/uploads/\(session.uploadId)/complete",
+                body: Data(),
+                contentType: "application/json",
+                timeout: .extended
+            )
+        } catch {
+            // Free the server-side spool now rather than at TTL expiry. Errors
+            // are swallowed: the abort is a courtesy and must not mask the
+            // upload error the caller acts on.
+            try? await http.delete("/api/v1/diagnostics/reports/uploads/\(session.uploadId)")
+            if let httpError = error as? HTTPError {
+                throw Self.mapUploadError(httpError)
+            }
+            throw DiagnosticsUploadError.underlying(String(describing: error))
+        }
+    }
+
+    static func mapUploadError(_ error: HTTPError) -> DiagnosticsUploadError {
         switch error.serverErrorCode {
         case "disabled":
             return .disabled
@@ -117,6 +201,14 @@ actor DiagnosticsAPI {
             }
             return .underlying(code)
         case nil:
+            // A 413 with no Silo error envelope means a proxy in front of the
+            // server refused the request body before Silo ever saw it (Silo's
+            // own too-large answer always carries the `too_large` code).
+            // Surfaced distinctly so the coordinator can fall back to the
+            // chunked upload instead of retrying a request that can never fit.
+            if error.statusCode == 413 {
+                return .requestBlockedByProxy
+            }
             if error.statusCode.map({ $0 >= 500 || $0 == 429 }) == true {
                 return .retryable("http_\(error.statusCode ?? 0)")
             }
@@ -124,4 +216,8 @@ actor DiagnosticsAPI {
         }
     }
 }
+
+/// Some chunk endpoints reply with small JSON state the client doesn't need;
+/// decode into this to accept any object without depending on its shape.
+private struct EmptyDiagnosticsResponse: Decodable {}
 #endif

--- a/iosApp/iosApp/Networking/DiagnosticsAPI.swift
+++ b/iosApp/iosApp/Networking/DiagnosticsAPI.swift
@@ -117,10 +117,23 @@ actor DiagnosticsAPI {
     /// here stays under the server-advertised `upload_chunk_bytes` (768 KiB),
     /// which clears nginx's default 1 MiB `client_max_body_size`.
     ///
+    /// `destinationUnchanged` re-validates the upload's destination identity
+    /// before every request after init. HTTPClient resolves the active server
+    /// URL and auth per request, so a server/profile switch mid-sequence
+    /// would otherwise send the remaining chunk bodies to whatever
+    /// destination became active. When the check fails the upload stops with
+    /// a retryable error and no abort is attempted — the DELETE would target
+    /// the *new* destination; the original server's session TTL reclaims the
+    /// spool.
+    ///
     /// On failure after init, the session is aborted best-effort so the
     /// server can reclaim its spool immediately instead of waiting out the
     /// session TTL.
-    func uploadChunked(manifestData: Data, bundleData: Data) async throws -> DiagnosticsUploadResponse {
+    func uploadChunked(
+        manifestData: Data,
+        bundleData: Data,
+        destinationUnchanged: (() async -> Bool)? = nil
+    ) async throws -> DiagnosticsUploadResponse {
         let session: DiagnosticsChunkedUploadSession
         do {
             // The manifest bytes are embedded verbatim into the init JSON
@@ -141,6 +154,13 @@ actor DiagnosticsAPI {
             throw DiagnosticsUploadError.underlying(String(describing: error))
         }
 
+        func ensureDestinationUnchanged() async throws {
+            guard let destinationUnchanged else { return }
+            guard await destinationUnchanged() else {
+                throw DiagnosticsUploadError.retryable("destination_changed")
+            }
+        }
+
         do {
             // Fail fast on a nonsensical chunk size rather than degrade: a
             // zero/negative value coerced to something tiny would turn one
@@ -152,6 +172,7 @@ actor DiagnosticsAPI {
             var index = 0
             var offset = 0
             while offset < bundleData.count {
+                try await ensureDestinationUnchanged()
                 let end = min(offset + chunkBytes, bundleData.count)
                 let _: EmptyDiagnosticsResponse = try await http.putRaw(
                     "/api/v1/diagnostics/reports/uploads/\(session.uploadId)/chunks/\(index)",
@@ -161,12 +182,17 @@ actor DiagnosticsAPI {
                 offset = end
                 index += 1
             }
+            try await ensureDestinationUnchanged()
             return try await http.postRaw(
                 "/api/v1/diagnostics/reports/uploads/\(session.uploadId)/complete",
                 body: Data(),
                 contentType: "application/json",
                 timeout: .extended
             )
+        } catch DiagnosticsUploadError.retryable(let code) where code == "destination_changed" {
+            // Deliberately no abort: HTTPClient now points at a different
+            // server/account, so the DELETE would go to the wrong place.
+            throw DiagnosticsUploadError.retryable(code)
         } catch {
             // Free the server-side spool now rather than at TTL expiry. Errors
             // are swallowed: the abort is a courtesy and must not mask the

--- a/iosApp/iosApp/Networking/DiagnosticsAPI.swift
+++ b/iosApp/iosApp/Networking/DiagnosticsAPI.swift
@@ -142,7 +142,13 @@ actor DiagnosticsAPI {
         }
 
         do {
-            let chunkBytes = max(session.chunkBytes, 1)
+            // Fail fast on a nonsensical chunk size rather than degrade: a
+            // zero/negative value coerced to something tiny would turn one
+            // bundle into millions of sequential PUTs.
+            guard session.chunkBytes > 0 else {
+                throw DiagnosticsUploadError.underlying("invalid chunk_bytes \(session.chunkBytes)")
+            }
+            let chunkBytes = session.chunkBytes
             var index = 0
             var offset = 0
             while offset < bundleData.count {
@@ -168,6 +174,9 @@ actor DiagnosticsAPI {
             try? await http.delete("/api/v1/diagnostics/reports/uploads/\(session.uploadId)")
             if let httpError = error as? HTTPError {
                 throw Self.mapUploadError(httpError)
+            }
+            if let uploadError = error as? DiagnosticsUploadError {
+                throw uploadError
             }
             throw DiagnosticsUploadError.underlying(String(describing: error))
         }
@@ -196,6 +205,13 @@ actor DiagnosticsAPI {
         case "invalid_bundle":
             return .invalidBundle
         case let code?:
+            // A 413 whose error code is not Silo's own `too_large` (handled
+            // above) came from an intermediary — some proxies emit JSON error
+            // envelopes rather than nginx's default HTML page. Same fallback
+            // as the envelope-less case below.
+            if error.statusCode == 413 {
+                return .requestBlockedByProxy
+            }
             if error.statusCode.map({ $0 >= 500 || $0 == 429 }) == true {
                 return .retryable(code)
             }

--- a/iosApp/iosApp/Networking/HTTPClient.swift
+++ b/iosApp/iosApp/Networking/HTTPClient.swift
@@ -318,19 +318,41 @@ actor HTTPClient {
         quietStatuses: Set<Int> = [],
         timeout: HTTPTimeout = .standard
     ) async throws -> Data {
+        try await performWithAuthRetry(
+            method: method,
+            path: path,
+            quietStatuses: quietStatuses,
+            timeout: timeout
+        ) { serverUrl in
+            try self.buildRequest(
+                serverUrl: serverUrl,
+                method: method,
+                path: path,
+                query: query,
+                body: body
+            )
+        }
+    }
+
+    /// Shared server-URL/auth/401-refresh/success skeleton for every request
+    /// shape. `makeRequest` builds a fresh, unauthenticated request per
+    /// attempt; auth headers are attached here so the retry after a token
+    /// refresh carries the new token while keeping the caller's body and
+    /// Content-Type intact.
+    private func performWithAuthRetry(
+        method: String,
+        path: String,
+        quietStatuses: Set<Int> = [],
+        timeout: HTTPTimeout,
+        makeRequest: (String) throws -> URLRequest
+    ) async throws -> Data {
         let serverUrl = await tokenStore.getServerUrl()
         guard !serverUrl.isEmpty else {
             throw HTTPError.serverUrlNotConfigured
         }
 
         let tokenBeforeRequest = await tokenStore.getAccessToken()
-        var request = try buildRequest(
-            serverUrl: serverUrl,
-            method: method,
-            path: path,
-            query: query,
-            body: body
-        )
+        var request = try makeRequest(serverUrl)
         await attachAuthHeaders(&request, accessToken: tokenBeforeRequest)
 
         let (data, response) = try await perform(request: request, timeout: timeout)
@@ -340,13 +362,7 @@ actor HTTPClient {
             if refreshed {
                 // Rebuild the request so headers reflect the new access token.
                 let refreshedToken = await tokenStore.getAccessToken()
-                var retry = try buildRequest(
-                    serverUrl: serverUrl,
-                    method: method,
-                    path: path,
-                    query: query,
-                    body: body
-                )
+                var retry = try makeRequest(serverUrl)
                 await attachAuthHeaders(&retry, accessToken: refreshedToken)
                 let (retryData, retryResponse) = try await perform(request: retry, timeout: timeout)
                 try ensureSuccess(retryData, retryResponse, method: method, quietStatuses: quietStatuses)
@@ -390,47 +406,18 @@ actor HTTPClient {
         contentType: String,
         timeout: HTTPTimeout
     ) async throws -> Data {
-        let serverUrl = await tokenStore.getServerUrl()
-        guard !serverUrl.isEmpty else {
-            throw HTTPError.serverUrlNotConfigured
+        try await performWithAuthRetry(method: method, path: path, timeout: timeout) { serverUrl in
+            var request = try self.buildRequest(
+                serverUrl: serverUrl,
+                method: method,
+                path: path,
+                query: [:],
+                body: Optional<String>.none
+            )
+            request.setValue(contentType, forHTTPHeaderField: "Content-Type")
+            request.httpBody = body
+            return request
         }
-
-        let authStateBeforeRequest = await tokenStore.getAccessToken()
-        var request = try buildRequest(
-            serverUrl: serverUrl,
-            method: method,
-            path: path,
-            query: [:],
-            body: Optional<String>.none
-        )
-        request.setValue(contentType, forHTTPHeaderField: "Content-Type")
-        request.httpBody = body
-        await attachAuthHeaders(&request, accessToken: authStateBeforeRequest)
-
-        let (data, response) = try await perform(request: request, timeout: timeout)
-
-        if response.statusCode == 401, shouldAttemptRefresh(path: path) {
-            let refreshed = await refreshTokens(tokenAtRequestTime: authStateBeforeRequest)
-            if refreshed {
-                let refreshedAuthState = await tokenStore.getAccessToken()
-                var retry = try buildRequest(
-                    serverUrl: serverUrl,
-                    method: method,
-                    path: path,
-                    query: [:],
-                    body: Optional<String>.none
-                )
-                retry.setValue(contentType, forHTTPHeaderField: "Content-Type")
-                retry.httpBody = body
-                await attachAuthHeaders(&retry, accessToken: refreshedAuthState)
-                let (retryData, retryResponse) = try await perform(request: retry, timeout: timeout)
-                try ensureSuccess(retryData, retryResponse, method: method)
-                return retryData
-            }
-        }
-
-        try ensureSuccess(data, response, method: method)
-        return data
     }
 
     // MARK: - Request building

--- a/iosApp/iosApp/Networking/HTTPClient.swift
+++ b/iosApp/iosApp/Networking/HTTPClient.swift
@@ -136,16 +136,37 @@ actor HTTPClient {
         parts: [HTTPMultipartPart],
         timeout: HTTPTimeout = .extended
     ) async throws -> T {
-        let data = try await sendMultipartRaw(method: "POST", path: path, parts: parts, timeout: timeout)
-        if data.isEmpty, let empty = EmptyResponse.empty as? T {
-            return empty
-        }
-        do {
-            return try decoder.decode(T.self, from: data)
-        } catch {
-            Self.logDecodingFailure(type: String(describing: T.self), path: path, error: error, data: data)
-            throw HTTPError.decodingFailed(type: String(describing: T.self), underlying: error)
-        }
+        let boundary = "SiloDiagnostics-\(UUID().uuidString)"
+        return try await sendRawBody(
+            method: "POST",
+            path: path,
+            body: Self.multipartBody(parts: parts, boundary: boundary),
+            contentType: "multipart/form-data; boundary=\(boundary)",
+            timeout: timeout
+        )
+    }
+
+    /// POST a pre-encoded body verbatim. Exists for callers whose payload
+    /// cannot go through `JSONEncoder` — e.g. diagnostics chunked-upload init,
+    /// which embeds an already-serialized manifest byte-for-byte (re-encoding
+    /// could reorder keys and break the server's manifest equality check).
+    func postRaw<T: Decodable>(
+        _ path: String,
+        body: Data,
+        contentType: String,
+        timeout: HTTPTimeout = .standard
+    ) async throws -> T {
+        try await sendRawBody(method: "POST", path: path, body: body, contentType: contentType, timeout: timeout)
+    }
+
+    /// PUT a raw binary body (e.g. one diagnostics bundle chunk).
+    func putRaw<T: Decodable>(
+        _ path: String,
+        body: Data,
+        contentType: String,
+        timeout: HTTPTimeout = .extended
+    ) async throws -> T {
+        try await sendRawBody(method: "PUT", path: path, body: body, contentType: contentType, timeout: timeout)
     }
 
     func put<T: Decodable>(
@@ -337,11 +358,37 @@ actor HTTPClient {
         return data
     }
 
-    private func sendMultipartRaw(
+    private func sendRawBody<T: Decodable>(
         method: String,
         path: String,
-        parts: [HTTPMultipartPart],
-        timeout: HTTPTimeout = .extended
+        body: Data,
+        contentType: String,
+        timeout: HTTPTimeout
+    ) async throws -> T {
+        let data = try await sendRawBodyData(
+            method: method,
+            path: path,
+            body: body,
+            contentType: contentType,
+            timeout: timeout
+        )
+        if data.isEmpty, let empty = EmptyResponse.empty as? T {
+            return empty
+        }
+        do {
+            return try decoder.decode(T.self, from: data)
+        } catch {
+            Self.logDecodingFailure(type: String(describing: T.self), path: path, error: error, data: data)
+            throw HTTPError.decodingFailed(type: String(describing: T.self), underlying: error)
+        }
+    }
+
+    private func sendRawBodyData(
+        method: String,
+        path: String,
+        body: Data,
+        contentType: String,
+        timeout: HTTPTimeout
     ) async throws -> Data {
         let serverUrl = await tokenStore.getServerUrl()
         guard !serverUrl.isEmpty else {
@@ -349,8 +396,6 @@ actor HTTPClient {
         }
 
         let authStateBeforeRequest = await tokenStore.getAccessToken()
-        let boundary = "SiloDiagnostics-\(UUID().uuidString)"
-        let body = Self.multipartBody(parts: parts, boundary: boundary)
         var request = try buildRequest(
             serverUrl: serverUrl,
             method: method,
@@ -358,7 +403,7 @@ actor HTTPClient {
             query: [:],
             body: Optional<String>.none
         )
-        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        request.setValue(contentType, forHTTPHeaderField: "Content-Type")
         request.httpBody = body
         await attachAuthHeaders(&request, accessToken: authStateBeforeRequest)
 
@@ -375,7 +420,7 @@ actor HTTPClient {
                     query: [:],
                     body: Optional<String>.none
                 )
-                retry.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+                retry.setValue(contentType, forHTTPHeaderField: "Content-Type")
                 retry.httpBody = body
                 await attachAuthHeaders(&retry, accessToken: refreshedAuthState)
                 let (retryData, retryResponse) = try await perform(request: retry, timeout: timeout)

--- a/iosApp/iosApp/Shared/Diagnostics/DiagnosticsCoordinator.swift
+++ b/iosApp/iosApp/Shared/Diagnostics/DiagnosticsCoordinator.swift
@@ -541,10 +541,25 @@ actor DiagnosticsCoordinator {
         guard cachedStatus?.status.supportsChunkedUpload == true else {
             throw DiagnosticsUploadError.unsupportedSchema
         }
+        // Pin the destination identity for the whole multi-request sequence.
+        // HTTPClient resolves the active server URL and auth per request, so
+        // without this a server/account/profile switch between chunk PUTs
+        // would send the remaining bundle bytes to the newly active
+        // destination. Same stable identity as the single-shot pre-POST check:
+        // server registry id + profile, token presence only (a transparent
+        // token refresh mid-upload must not abort the sequence).
+        let destinationServerRegistryID = ServerRegistry.shared.activeServerId
+        let destinationProfileID = await TokenStore.shared.getProfileId()
         do {
             return try await api.uploadChunked(
                 manifestData: bundle.manifestData,
-                bundleData: bundle.bundleData
+                bundleData: bundle.bundleData,
+                destinationUnchanged: {
+                    guard await Self.currentAccessTokenFingerprint() != nil else { return false }
+                    guard ServerRegistry.shared.activeServerId == destinationServerRegistryID else { return false }
+                    let activeProfileID = await TokenStore.shared.getProfileId()
+                    return activeProfileID == destinationProfileID
+                }
             )
         } catch DiagnosticsUploadError.requestBlockedByProxy {
             // Even individual chunk-sized requests are blocked: the proxy cap

--- a/iosApp/iosApp/Shared/Diagnostics/DiagnosticsCoordinator.swift
+++ b/iosApp/iosApp/Shared/Diagnostics/DiagnosticsCoordinator.swift
@@ -503,16 +503,54 @@ actor DiagnosticsCoordinator {
                   ) else {
                 return .keptRetryable
             }
-            let response = try await api.upload(
-                manifestData: bundle.manifestData,
-                bundleData: bundle.bundleData
-            )
+            let response: DiagnosticsUploadResponse
+            do {
+                response = try await api.upload(
+                    manifestData: bundle.manifestData,
+                    bundleData: bundle.bundleData
+                )
+            } catch DiagnosticsUploadError.requestBlockedByProxy {
+                // A proxy in front of the server capped the request body below
+                // the bundle size (nginx defaults to 1 MiB; bundles may be
+                // 10 MiB). Retrying the same request can never succeed, so
+                // fall back to the chunked upload, whose per-request size
+                // stays under such caps.
+                response = try await uploadChunkedFallback(report: report, bundle: bundle)
+            }
             pendingStore.delete(report)
             return .uploaded(response)
         } catch let error as DiagnosticsUploadError {
             return handleUploadError(error, report: report)
         } catch {
             return .keptRetryable
+        }
+    }
+
+    /// Chunked-upload fallback for a single-shot upload the fronting proxy
+    /// refused. Throws `DiagnosticsUploadError` for the caller's shared
+    /// error mapping.
+    private func uploadChunkedFallback(
+        report: PendingReport,
+        bundle: DiagnosticsBundleBuildResult
+    ) async throws -> DiagnosticsUploadResponse {
+        // Chunking needs server support (upload_chunk_bytes in status). An
+        // older server behind a capping proxy can't take this bundle by any
+        // route until it updates — the same terminal state as an unsupported
+        // schema, so reuse that classification (kept, visible, manually
+        // retryable after the deployment is fixed; never auto-retried).
+        guard cachedStatus?.status.supportsChunkedUpload == true else {
+            throw DiagnosticsUploadError.unsupportedSchema
+        }
+        do {
+            return try await api.uploadChunked(
+                manifestData: bundle.manifestData,
+                bundleData: bundle.bundleData
+            )
+        } catch DiagnosticsUploadError.requestBlockedByProxy {
+            // Even individual chunk-sized requests are blocked: the proxy cap
+            // is below the chunk size. No retry of this fixed payload can
+            // succeed — the same permanence as a server-side size rejection.
+            throw DiagnosticsUploadError.tooLarge
         }
     }
 
@@ -858,6 +896,11 @@ actor DiagnosticsCoordinator {
             // forever. Mark it a permanent local failure instead.
             pendingStore.markTooLarge(report)
             return .keptTooLarge
+        case .requestBlockedByProxy:
+            // Normally consumed by the chunked-upload fallback before reaching
+            // here; if it does surface (fallback path itself unavailable),
+            // the report is kept — a proxy config fix makes it sendable again.
+            return .keptRetryable
         case .disabled, .storageUnavailable, .quotaExceeded, .busy, .retryable, .underlying:
             return .keptRetryable
         }


### PR DESCRIPTION
## Problem

"Failed to send" on tvOS diagnostics. Root cause (replicated in the tvOS simulator against a proxy mirroring production): the edge in front of the server caps request bodies at nginx's default `client_max_body_size` of **1 MiB**, while `/diagnostics/status` advertises bundles up to 10 MiB. The proxy answers the single-shot multipart POST with its own HTML 413 before Silo ever sees it. The client mapped that bare 413 to a generic retryable error — so it kept re-sending a request that could never fit, and every send failed.

## Change

- **Classify the proxy 413.** `DiagnosticsAPI.mapUploadError` now maps a 413 *without* Silo's JSON error envelope to a new `requestBlockedByProxy` case. Silo's own `too_large` (always enveloped) keeps its existing permanent-failure handling.
- **Chunked upload fallback.** On `requestBlockedByProxy`, the coordinator retries through the server's new chunked endpoints (server PR: Silo-Server/silo-server#494): `POST /diagnostics/reports/uploads` (manifest + size) → sequential `PUT …/chunks/{i}` of ≤768 KiB → `POST …/complete`, which returns the same 201 payload. Every request stays under typical proxy caps. Failed sessions are aborted best-effort so the server reclaims spool space immediately.
- **Downgrade paths stay sane.** Server without chunk support (`upload_chunk_bytes` absent from status) → report is kept as needs-server-update, not retried in a loop. Proxy cap below even chunk size → report marked too large (permanent). Both remain visible and manually sendable from settings after the deployment is fixed.
- **HTTPClient:** the multipart sender is generalized into raw-body `postRaw`/`putRaw` that reuse the existing auth-header + single-flight 401-refresh path. Init embeds the already-serialized manifest verbatim — the server compares it byte-for-byte against the archive's embedded `manifest.json`, so re-encoding could break equality.
- `DiagnosticsStatusResponse` gains optional `uploadChunkBytes` (older servers omit it; decoding unaffected).

## Verification

- New `DiagnosticsChunkedUploadTests`: bare-413 vs enveloped-413 classification, status decode with/without `upload_chunk_bytes`, session response decode. Full diagnostics test suites pass on the iOS simulator.
- tvOS and macOS both build (`SiloTV` tvOS-sim, `SiloMac` macOS, `CODE_SIGNING_ALLOWED=NO`).
- **End-to-end in the tvOS simulator** against a local silo-server behind an OpenResty proxy whose body cap rejects the single-shot upload: pressing Send on the crash-report prompt now produces `POST /reports → 413`, then `init → chunk PUT → complete → 201` per report; all pending reports cleared and were accepted server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Diagnostics uploads can automatically switch to chunked transfers when the server supports them.
  * When large uploads are blocked by proxies, uploads now use a chunked-upload fallback and classify failures appropriately for fixed payload size.
  * Added raw binary request APIs for non-multipart payloads.

* **Bug Fixes**
  * Refined upload error classification (including proxy-blocked 413 handling) and standardized response decoding.
  * Best-effort chunked upload session abort is attempted when a chunked upload fails.

* **Reliability**
  * Multipart handling now uses a shared raw-body decoding/error pipeline with consistent auth retry behavior.

* **Tests**
  * Added URLProtocol-backed chunked upload orchestration coverage and expanded upload/error mapping tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->