### PR TITLE
Keep Apple hero metadata editorial

### DIFF
--- a/docs/superpowers/plans/2026-07-29-apple-hero-editorial-metadata.md
+++ b/docs/superpowers/plans/2026-07-29-apple-hero-editorial-metadata.md
@@ -1,0 +1,1121 @@
+# Apple Hero Editorial Metadata Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove hard-coded technical quality metadata and duplicate cast copy from Apple-client hero surfaces while preserving editorial metadata, artwork enrichment, playback/version selectors, dedicated cast rails, and the current iOS Home experience.
+
+**Architecture:** Keep the existing platform split: `PhoneHeroMetadata` remains the non-tvOS detail formatter, `TVMarqueeContent`/`TVMarqueeEnrichment` remain the shared tvOS Home and library Browse marquee payloads, and `TVHeroMetadata` remains the tvOS detail formatter. Narrow those formatters and hero interfaces instead of changing API models or server contracts; retain the marquee detail fetch because episode backdrops depend on its enriched artwork even after cast text is removed.
+
+**Tech Stack:** Swift 5, SwiftUI, XCTest, XcodeGen, `xcodebuild`, iOS 26, tvOS 26, macOS 26.
+
+## Global Constraints
+
+- Preserve the iOS/macOS Home no-hero layout and all current `HomeFeedRow`, `HomePosterCard`, and `HomeStillCard` behavior.
+- Remove hard-coded resolution, HDR/Dolby Vision, audio-layout, and CC tokens from iOS/macOS detail hero facts.
+- On the shared tvOS Home and library Browse marquee, preserve editorial facts and content-rating badges while removing resolution, HDR/Dolby Vision, audio badges, and cast-name enrichment.
+- Preserve tvOS episode marquee detail enrichment for air date and higher-quality series backdrop artwork; air date may remain.
+- Remove hard-coded technical facts and the right-side `Starring …` overlay from tvOS movie, episode, series, and season detail heroes.
+- Preserve iOS/macOS and tvOS version/audio/subtitle selectors and their technical labels.
+- Preserve dedicated phone and tvOS cast sections and person navigation.
+- Preserve configurable overlay systems on iOS detail artwork and tvOS cards; this change targets hard-coded hero facts/marquee badges, not administrator-configured overlays.
+- Make no server, API contract, networking-model, or playback-protocol changes.
+- Do not change `iosApp/project.yml`; its source globs already include the focused iOS test file, and the repository has no tvOS unit-test target.
+- Use the local Xcode toolchain first. Consult `.claude/skills/mac-builder/SKILL.md` only if `xcode-select`, `xcodebuild`, or the required simulator runtimes prove unavailable locally.
+- Use iOS and tvOS simulators for visual smoke testing only; do not install on or launch physical devices.
+- Keep this work isolated on `feat/apple-hero-editorial-metadata` and submit it as its own pull request.
+
+---
+
+## File Map
+
+**Create**
+
+- `iosApp/Tests/HeroEditorialMetadataTests.swift` — focused regression tests proving rich file metadata cannot leak into non-tvOS detail hero facts.
+
+**Modify**
+
+- `iosApp/iosApp/Screens/Detail/Phone/PhoneHeroMetadata.swift` — return editorial facts only and remove the hard-coded quality-token builder.
+- `iosApp/iosApp/Screens/Detail/Phone/PhoneDetailHero.swift` — remove the now-unreachable `.chip` rendering branch while retaining text and rating fact rendering.
+- `iosApp/iosApp/Screens/Detail/MovieDetailContent.swift` — call the version-independent editorial facts interface.
+- `iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift` — retain content rating/editorial metadata and episode artwork enrichment, but remove technical badge creation and cast names.
+- `iosApp/iosApp/tvOS/Screens/Detail/TVDetailHero.swift` — remove the starring input/overlay and all hard-coded quality-token production/rendering.
+- `iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift` — adopt the simplified hero and facts interfaces.
+- `iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift` — stop supplying duplicate starring copy.
+- `iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift` — stop supplying duplicate starring copy.
+
+**Explicitly leave unchanged**
+
+- `iosApp/iosApp/Screens/Home/HomeView.swift`
+- `iosApp/iosApp/Screens/Home/Feed/HomeFeedKit.swift`
+- `iosApp/iosApp/Screens/Home/Feed/HomeFeedRow.swift`
+- `iosApp/iosApp/Components/MediaRow.swift`
+- `iosApp/iosApp/Screens/Detail/Phone/PhoneCastRail.swift`
+- `iosApp/iosApp/tvOS/Screens/Detail/TVDetailCastRail.swift`
+- `iosApp/iosApp/Screens/Detail/Phone/PhonePlaybackSelectorRow.swift`
+- `iosApp/iosApp/tvOS/Screens/Detail/TVPlaybackSelectorRow.swift`
+- `iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift`
+- `iosApp/iosApp/Screens/Detail/DetailVersionSelection.swift`
+- `iosApp/iosApp/Networking/Models.swift`
+- `iosApp/iosApp/Networking/ContinuumAPI.swift`
+- `iosApp/project.yml`
+
+## Local Execution Preflight
+
+- [ ] **Step 1: Confirm the branch, base, and clean starting state**
+
+Run:
+
+```bash
+git status --short --branch
+git rev-parse HEAD
+git merge-base HEAD upstream/main
+```
+
+Expected: branch `feat/apple-hero-editorial-metadata`, `HEAD` and merge-base `b9bdfb08d62807736614dcfa87bebf495b065d7b`, with no unplanned source changes. The plan file may be present as the only documentation change before implementation begins.
+
+- [ ] **Step 2: Prove the local Apple toolchain is available before considering the remote builder**
+
+Run:
+
+```bash
+xcode-select -p
+xcodebuild -version
+command -v xcodegen
+xcrun simctl list devices available
+```
+
+Expected: a local Xcode developer directory, Xcode version output, an `xcodegen` executable, and available iOS 26/tvOS 26 simulators including `iPhone 17 Pro` and `Apple TV 4K (3rd generation)`. If any command is unavailable, stop this local workflow, read `.claude/skills/mac-builder/SKILL.md`, and follow its sync-and-verify procedure before running the same logical build/test gates remotely.
+
+- [ ] **Step 3: Generate the project from the checked-in specification**
+
+Run:
+
+```bash
+cd iosApp
+xcodegen generate
+cd ..
+```
+
+Expected: `Silo.xcodeproj` is generated successfully. Do not hand-edit the generated project.
+
+- [ ] **Step 4: Commit the approved implementation plan before source work**
+
+The repository ignores `docs/*`, so force-add this one approved plan explicitly:
+
+```bash
+git add -f docs/superpowers/plans/2026-07-29-apple-hero-editorial-metadata.md
+git commit -m "docs: plan Apple hero editorial metadata"
+```
+
+Expected: the plan is the only file in this documentation commit. Do not force-add any other ignored documentation.
+
+### Task 1: Make iOS/macOS Detail Hero Facts Editorial-Only
+
+**Files:**
+
+- Create: `iosApp/Tests/HeroEditorialMetadataTests.swift`
+- Modify: `iosApp/iosApp/Screens/Detail/Phone/PhoneHeroMetadata.swift:3-224`
+- Modify: `iosApp/iosApp/Screens/Detail/Phone/PhoneDetailHero.swift:334-385`
+- Modify: `iosApp/iosApp/Screens/Detail/MovieDetailContent.swift:66-78`
+
+**Interfaces:**
+
+- Consumes: `ItemDetail`, `PhoneHeroFactToken`, and `DetailDateFormatting` from the existing app target.
+- Produces: `PhoneHeroMetadata.movieFactsLine(from detail: ItemDetail) -> [PhoneHeroFactToken]` and the unchanged `PhoneHeroMetadata.seriesFactsLine(from detail: ItemDetail) -> [PhoneHeroFactToken]`, both guaranteed to return editorial tokens only.
+- Produces: `PhoneHeroFactToken` with `.text(String)` and `.rating(String)` cases; `.chip(String)` is removed because no hard-coded phone hero quality token remains.
+
+- [ ] **Step 1: Add failing regression tests for movie and series facts**
+
+Create `iosApp/Tests/HeroEditorialMetadataTests.swift` with:
+
+```swift
+import Foundation
+import XCTest
+@testable import Silo
+
+final class HeroEditorialMetadataTests: XCTestCase {
+    func testMovieFactsExcludeTechnicalFileMetadata() throws {
+        let detail = try decodeDetail(
+            """
+            {
+              "content_id": "movie-1",
+              "type": "movie",
+              "title": "Editorial Movie",
+              "year": 2026,
+              "runtime": 125,
+              "rating_imdb": 8.4,
+              "versions": [
+                {
+                  "file_id": 10,
+                  "resolution": "2160p",
+                  "hdr": true,
+                  "video_tracks": [
+                    { "index": 0, "dolby_vision": "Profile 8.1" }
+                  ],
+                  "audio_tracks": [
+                    { "index": 1, "layout": "7.1 Atmos", "default": true }
+                  ],
+                  "subtitle_tracks": [
+                    { "index": 2, "codec": "srt", "language": "eng" }
+                  ]
+                }
+              ]
+            }
+            """
+        )
+
+        XCTAssertEqual(
+            PhoneHeroMetadata.movieFactsLine(from: detail),
+            [.text("2026"), .text("2h 5m"), .text("★ 8.4")]
+        )
+    }
+
+    func testSeriesFactsExcludeTechnicalFileMetadata() throws {
+        let detail = try decodeDetail(
+            """
+            {
+              "content_id": "series-1",
+              "type": "series",
+              "title": "Editorial Series",
+              "year": 2024,
+              "season_count": 3,
+              "rating_imdb": 9.1,
+              "versions": [
+                {
+                  "file_id": 20,
+                  "resolution": "1080p",
+                  "hdr": true,
+                  "audio_tracks": [
+                    { "index": 1, "layout": "5.1", "default": true }
+                  ],
+                  "subtitle_tracks": [
+                    { "index": 2, "codec": "srt", "language": "eng" }
+                  ]
+                }
+              ]
+            }
+            """
+        )
+
+        XCTAssertEqual(
+            PhoneHeroMetadata.seriesFactsLine(from: detail),
+            [.text("2024"), .text("3 Seasons"), .text("★ 9.1")]
+        )
+    }
+
+    private func decodeDetail(_ json: String) throws -> ItemDetail {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(ItemDetail.self, from: Data(json.utf8))
+    }
+}
+```
+
+- [ ] **Step 2: Regenerate the project so the new test source enters `SiloTests`**
+
+Run:
+
+```bash
+cd iosApp
+xcodegen generate
+cd ..
+```
+
+Expected: generation succeeds without editing `iosApp/project.yml`.
+
+- [ ] **Step 3: Run the focused tests and verify the red state**
+
+Run:
+
+```bash
+xcodebuild test \
+  -project iosApp/Silo.xcodeproj \
+  -scheme Silo \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -only-testing:SiloTests/HeroEditorialMetadataTests \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: both tests execute and fail because the current arrays contain `.chip` entries such as `4K`, `DOLBY VISION`, `ATMOS`, `5.1`, or `CC`.
+
+- [ ] **Step 4: Narrow the phone fact token and metadata interfaces**
+
+In `PhoneHeroMetadata.swift`, replace the token declaration and facts builders with:
+
+```swift
+/// A token in the hero's editorial facts row. `.text` items get a
+/// middle-dot separator; `.rating` retains the supported rating treatment.
+enum PhoneHeroFactToken: Hashable {
+    case text(String)
+    case rating(String)
+}
+
+enum PhoneHeroMetadata {
+    // Existing source-row, eyebrow, title-splitting, and helper code stays.
+
+    static func movieFactsLine(from detail: ItemDetail) -> [PhoneHeroFactToken] {
+        var tokens: [PhoneHeroFactToken] = []
+        if detail.type == "episode",
+           let airDate = DetailDateFormatting.abbreviatedDate(detail.airDate) {
+            tokens.append(.text(airDate))
+        } else if let year = detail.year, year > 0 {
+            tokens.append(.text(String(year)))
+        }
+        if let runtime = detail.runtime, runtime > 0 {
+            tokens.append(.text(formatRuntime(runtime)))
+        }
+        if let imdb = detail.ratingImdb {
+            tokens.append(.text(String(format: "★ %.1f", imdb)))
+        }
+        return tokens
+    }
+
+    static func seriesFactsLine(from detail: ItemDetail) -> [PhoneHeroFactToken] {
+        var tokens: [PhoneHeroFactToken] = []
+        if let year = detail.year, year > 0 {
+            tokens.append(.text(String(year)))
+        }
+        if let count = detail.seasonCount, count > 0 {
+            tokens.append(.text("\(count) Season\(count == 1 ? "" : "s")"))
+        }
+        if let imdb = detail.ratingImdb {
+            tokens.append(.text(String(format: "★ %.1f", imdb)))
+        }
+        return tokens
+    }
+}
+```
+
+Delete these private helpers from `PhoneHeroMetadata` because they have no remaining caller:
+
+```swift
+qualityTokens(from:version:)
+preferredVersion(from:)
+resolutionLabel(_:)
+dolbyVisionLabel(version:)
+primaryAudioLabel(version:)
+hasSubtitles(version:)
+```
+
+Retain `formatRuntime(_:)`, `typeLabel(detail:)`, episode-number formatting, source tokens, content rating, eyebrow logic, and title splitting unchanged.
+
+- [ ] **Step 5: Remove the unreachable phone chip renderer**
+
+In `PhoneDetailHero.swift`, keep the `.text` and `.rating` branches in `FlowingFactsRow.factsItem(_:)` and delete only:
+
+```swift
+case .chip(let value):
+    Text(value)
+        .font(.system(size: 10, weight: .heavy))
+        .tracking(0.8)
+        .foregroundColor(.continuumOnSurface)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .overlay(
+            RoundedRectangle(cornerRadius: 3)
+                .stroke(Color.continuumOnSurface.opacity(0.45), lineWidth: 1)
+        )
+```
+
+Update the nearby `FlowingFactsRow` comment so it describes wrapping editorial facts rather than a quality-badge row.
+
+- [ ] **Step 6: Stop coupling movie hero facts to the selected file version**
+
+In `MovieDetailContent.hero`, replace:
+
+```swift
+factsLine: PhoneHeroMetadata.movieFactsLine(from: detail, version: effectiveVersion),
+```
+
+with:
+
+```swift
+factsLine: PhoneHeroMetadata.movieFactsLine(from: detail),
+```
+
+Do not change `effectiveVersion`, `PhonePlaybackSelectorRow`, downloads, or playback launch selection; those still consume the chosen file version.
+
+- [ ] **Step 7: Run the focused tests and verify the green state**
+
+Run:
+
+```bash
+xcodebuild test \
+  -project iosApp/Silo.xcodeproj \
+  -scheme Silo \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -only-testing:SiloTests/HeroEditorialMetadataTests \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: `HeroEditorialMetadataTests` passes both tests.
+
+- [ ] **Step 8: Prove the retained playback formatter still exposes technical information**
+
+Run:
+
+```bash
+xcodebuild test \
+  -project iosApp/Silo.xcodeproj \
+  -scheme Silo \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -only-testing:SiloTests/DetailVersionSelectionTests/testVersionSelectorUsesRichPrePlaySummary \
+  -only-testing:SiloTests/DetailVersionSelectionTests/testVersionSelectorUsesDVForDolbyVisionMetadata \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: both existing selector-formatting tests pass, proving technical metadata was removed from hero facts rather than from playback selection.
+
+- [ ] **Step 9: Commit the independently tested phone/macOS formatter change**
+
+Run:
+
+```bash
+git add \
+  iosApp/Tests/HeroEditorialMetadataTests.swift \
+  iosApp/iosApp/Screens/Detail/Phone/PhoneHeroMetadata.swift \
+  iosApp/iosApp/Screens/Detail/Phone/PhoneDetailHero.swift \
+  iosApp/iosApp/Screens/Detail/MovieDetailContent.swift
+git commit -m "refactor(detail): keep phone hero facts editorial"
+```
+
+Expected: one commit containing only the focused tests and non-tvOS detail metadata/interface changes.
+
+### Task 2: Make the Shared tvOS Home/Browse Marquee Editorial-Only
+
+**Files:**
+
+- Modify: `iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift:7-228`
+- Verify unchanged: `iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift`
+- Verify unchanged: `iosApp/iosApp/Components/MediaRow.swift`
+
+**Interfaces:**
+
+- Consumes: `SectionItem.contentRating`, editorial `SectionItem` fields, and `ItemDetail.airDate`, `backdropUrl`, and `backdropThumbhash`.
+- Produces: unchanged `TVMarqueeContent.badges: [String]`, now containing only the editorial content-rating badge.
+- Produces: unchanged `TVMarqueeEnrichment.detailLine: String?`, now containing only formatted air date, plus unchanged enriched backdrop fields.
+- Preserves: `TVFocusMarqueeModel.loadEnrichment(for:)`, `backdropURL`, and `backdropThumbhash`, which are required to upgrade episode stills to detail-level series artwork.
+
+There is no tvOS test bundle in `project.yml`, and `TVFocusMarquee.swift` is compiled out of the iOS-hosted `SiloTests` target. Keep this task narrowly covered by source-level acceptance checks, a tvOS compile gate, and the simulator smoke task below rather than adding a new test target.
+
+- [ ] **Step 1: Record the current failing source-level acceptance state**
+
+Run:
+
+```bash
+rg -n \
+  'Self\.badges\(from: item\.overlaySummary\)|summary\.(resolution|hdr|audio)|detail\.cast|map\(\\\.name\)' \
+  iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
+```
+
+Expected: matches in `TVMarqueeContent.init(item:rowTitle:)`, `badges(from:)`, and `TVMarqueeEnrichment.init(detail:)`. These are the technical badge and cast-enrichment paths to remove.
+
+- [ ] **Step 2: Build marquee badges from content rating only**
+
+In `TVMarqueeContent.init(item:rowTitle:)`, replace:
+
+```swift
+var badges = Self.badges(from: item.overlaySummary)
+if let contentRating = Self.nonEmpty(item.contentRating) {
+    badges.append(contentRating.uppercased())
+}
+```
+
+with:
+
+```swift
+let badges = Self.nonEmpty(item.contentRating).map {
+    [$0.uppercased()]
+} ?? []
+```
+
+Delete `badges(from:)` and `prettyResolution(_:)`. Retain `episodeToken`, time-left, length, runtime, and non-empty formatting.
+
+Update `TVMarqueeContent.badges` documentation to say:
+
+```swift
+/// Editorial badge chips, currently the uppercased content rating.
+let badges: [String]
+```
+
+Do not remove `SectionItem.overlaySummary` from the networking model or card overlay extraction; other surfaces still use it.
+
+- [ ] **Step 3: Remove cast names while retaining air date and episode artwork enrichment**
+
+Replace `TVMarqueeEnrichment.init(detail:)` with:
+
+```swift
+init(detail: ItemDetail) {
+    backdropUrl = detail.backdropUrl
+    backdropThumbhash = detail.backdropThumbhash
+    detailLine = Self.airDateText(detail.airDate).map { "Aired \($0)" }
+}
+```
+
+Update the type and property comments to describe air-date/artwork enrichment, not air-date/cast enrichment. Keep `airDateText(_:)` unchanged.
+
+Do not change this existing model behavior:
+
+```swift
+private func loadEnrichment(for candidate: TVMarqueeContent) {
+    enrichTask?.cancel()
+    guard let contentId = candidate.contentId else {
+        enrichment = nil
+        return
+    }
+    if let cached = enrichmentCache[contentId] {
+        enrichment = cached
+        sampleTintIfNeeded(for: backdropURL)
+        return
+    }
+
+    enrichment = nil
+    enrichTask = Task { [weak self] in
+        guard let detail = try? await ContinuumAPI.shared.itemDetail(contentId: contentId) else { return }
+        guard !Task.isCancelled, let self else { return }
+        let enrichment = TVMarqueeEnrichment(detail: detail)
+        self.enrichmentCache[contentId] = enrichment
+        if self.content?.contentId == contentId {
+            self.enrichment = enrichment
+            self.sampleTintIfNeeded(for: self.backdropURL)
+        }
+    }
+}
+```
+
+That fetch and cache remain necessary because `backdropURL` prefers `enrichment.backdropUrl` for episode content.
+
+- [ ] **Step 4: Update view/accessibility comments without changing layout**
+
+In `TVFocusMarquee` and `TVMarqueeBlock`, update references from “air date + top-billed cast” to “air date” and retain:
+
+```swift
+enrichment?.detailLine
+```
+
+in both the visible `detailLine` and `accessibilityDescription`. This preserves air-date accessibility and the stable one-line layout reservation while ensuring cast names are absent.
+
+- [ ] **Step 5: Verify technical badge and cast paths are gone while episode enrichment remains**
+
+Run:
+
+```bash
+! rg -n \
+  'summary\.(resolution|hdr|audio)|detail\.cast|map\(\\\.name\)|prettyResolution|private static func badges' \
+  iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
+
+rg -n \
+  'contentRating|backdropUrl = detail\.backdropUrl|backdropThumbhash = detail\.backdropThumbhash|loadEnrichment|enrichment\?\.backdropUrl|airDateText' \
+  iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
+```
+
+Expected: the negative search succeeds with no matches; the positive search shows content rating, air-date formatting, detail loading/caching, and enriched episode backdrop selection.
+
+- [ ] **Step 6: Compile the tvOS app after the marquee change**
+
+Run:
+
+```bash
+xcodebuild build \
+  -project iosApp/Silo.xcodeproj \
+  -scheme SiloTV \
+  -destination 'generic/platform=tvOS Simulator' \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: `BUILD SUCCEEDED`.
+
+- [ ] **Step 7: Commit the independently compiled shared-marquee change**
+
+Run:
+
+```bash
+git add iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
+git commit -m "refactor(tvos): keep marquee metadata editorial"
+```
+
+Expected: one commit touching only the shared tvOS marquee implementation. Both Home and library Browse inherit the same policy because both intentionally use `TVSkylineSectionFeed`.
+
+### Task 3: Simplify the tvOS Detail Hero and Remove Duplicate Starring Copy
+
+**Files:**
+
+- Modify: `iosApp/iosApp/tvOS/Screens/Detail/TVDetailHero.swift:5-625`
+- Modify: `iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift:63-75`
+- Modify: `iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift:110-122`
+- Modify: `iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift:74-86`
+- Verify unchanged: `iosApp/iosApp/tvOS/Screens/Detail/TVDetailCastRail.swift`
+- Verify unchanged: `iosApp/iosApp/tvOS/Screens/Detail/TVPlaybackSelectorRow.swift`
+
+**Interfaces:**
+
+- Produces: `TVDetailHero` without a `starringText` initializer argument.
+- Produces: `TVHeroMetadata.movieFactsLine(from detail: ItemDetail) -> [TVHeroFactToken]`, no longer coupled to `FileVersion`.
+- Preserves: `TVHeroMetadata.seriesFactsLine(from:)`, now editorial-only.
+- Produces: `TVHeroFactToken` with `.text(String)` and `.rating(String)` cases; `.chip(String)` is removed.
+- Preserves: all `TVDetailCastRail` and `TVPlaybackSelectorRow` call sites below and within the hero.
+
+As in Task 2, these types are tvOS-only and have no test host. Use a source-level red/green acceptance check, compile gate, and simulator smoke verification.
+
+- [ ] **Step 1: Record the current failing source-level acceptance state**
+
+Run:
+
+```bash
+rg -n \
+  'starringText|starringOverlay|qualityTokens|case chip|case \.chip|movieFactsLine\(from: detail, version:' \
+  iosApp/iosApp/tvOS/Screens/Detail/TVDetailHero.swift \
+  iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift \
+  iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift \
+  iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
+```
+
+Expected: matches for the right-side starring API/rendering, technical token builder/renderer, and the selected-version facts call.
+
+- [ ] **Step 2: Remove the starring input and overlay from `TVDetailHero`**
+
+Delete:
+
+```swift
+let starringText: String?
+```
+
+Delete this modifier from `body`:
+
+```swift
+.overlay(alignment: .trailing) { starringOverlay }
+```
+
+Delete the complete `starringOverlay` computed property:
+
+```swift
+@ViewBuilder
+private var starringOverlay: some View {
+    if let starringText, !starringText.isEmpty {
+        Text(starringText)
+            .font(.system(size: 24, weight: .regular))
+            .foregroundColor(Color.white.opacity(0.8))
+            .multilineTextAlignment(.trailing)
+            .lineLimit(2)
+            .frame(maxWidth: 460, alignment: .trailing)
+            .shadow(color: .black.opacity(0.55), radius: 6, y: 2)
+            .padding(.trailing, ContinuumTheme.safePadding)
+            .padding(.bottom, heroHeight * 0.45)
+    }
+}
+```
+
+Update the top-level hero comment so it describes only the left editorial stack and below-fold rail preview.
+
+- [ ] **Step 3: Make tvOS detail fact tokens editorial-only**
+
+Replace the fact token declaration with:
+
+```swift
+/// A token in the combined editorial facts row. `.text` items get
+/// separators; `.rating` retains the supported rating treatment.
+enum TVHeroFactToken: Hashable {
+    case text(String)
+    case rating(String)
+}
+```
+
+Delete only the `.chip` branch from `factsItem(_:)`; retain the `.text` and `.rating` view treatments.
+
+Replace the two facts builders with:
+
+```swift
+static func movieFactsLine(from detail: ItemDetail) -> [TVHeroFactToken] {
+    var tokens: [TVHeroFactToken] = []
+    if detail.type == "episode",
+       let airDate = DetailDateFormatting.abbreviatedDate(detail.airDate) {
+        tokens.append(.text(airDate))
+    } else if let year = detail.year, year > 0 {
+        tokens.append(.text(String(year)))
+    }
+    if let runtime = detail.runtime, runtime > 0 {
+        tokens.append(.text(formatRuntime(runtime)))
+    }
+    if let imdb = detail.ratingImdb {
+        tokens.append(.text(String(format: "★ %.1f", imdb)))
+    }
+    return tokens
+}
+
+static func seriesFactsLine(from detail: ItemDetail) -> [TVHeroFactToken] {
+    var tokens: [TVHeroFactToken] = []
+    if let year = detail.year, year > 0 {
+        tokens.append(.text(String(year)))
+    }
+    if let count = detail.seasonCount, count > 0 {
+        tokens.append(.text("\(count) Season\(count == 1 ? "" : "s")"))
+    }
+    if let imdb = detail.ratingImdb {
+        tokens.append(.text(String(format: "★ %.1f", imdb)))
+    }
+    return tokens
+}
+```
+
+Delete:
+
+```swift
+starringText(from:)
+qualityTokens(from:version:)
+preferredVersion(from:)
+resolutionLabel(_:)
+dolbyVisionLabel(version:)
+primaryAudioLabel(version:)
+hasSubtitles(version:)
+```
+
+Retain source tokens, content-rating chip, episode numbering, eyebrow, type labels, and runtime formatting.
+
+- [ ] **Step 4: Update all three tvOS detail call sites**
+
+In `TVMovieDetailView`, use:
+
+```swift
+factsLine: TVHeroMetadata.movieFactsLine(from: detail),
+actions: { actionColumn },
+belowSynopsis: belowSynopsis
+```
+
+and remove:
+
+```swift
+starringText: TVHeroMetadata.starringText(from: detail),
+```
+
+In `TVSeriesDetailView`, retain:
+
+```swift
+factsLine: TVHeroMetadata.seriesFactsLine(from: detail),
+actions: { actionColumn },
+belowSynopsis: belowSynopsis
+```
+
+and remove its `starringText` argument.
+
+In `TVSeasonDetailView`, retain:
+
+```swift
+factsLine: [],
+actions: { actionColumn },
+belowSynopsis: belowSynopsis
+```
+
+and remove its `starringText` argument.
+
+Do not remove `currentVersion` from `TVMovieDetailView`; it remains the input to `TVPlaybackSelectorRow`.
+
+- [ ] **Step 5: Verify the removed paths are absent and retained cast/selector surfaces still exist**
+
+Run:
+
+```bash
+! rg -n \
+  'starringText|starringOverlay|qualityTokens|case chip|case \.chip|movieFactsLine\(from: detail, version:' \
+  iosApp/iosApp/tvOS/Screens/Detail/TVDetailHero.swift \
+  iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift \
+  iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift \
+  iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
+
+rg -n \
+  'TVDetailCastRail|TVPlaybackSelectorRow' \
+  iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift \
+  iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift \
+  iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
+```
+
+Expected: no removed-path matches; cast rail calls remain on movie/episode, series, and season pages, and playback selectors remain on each playable detail path.
+
+- [ ] **Step 6: Compile the tvOS app after the detail interface change**
+
+Run:
+
+```bash
+xcodebuild build \
+  -project iosApp/Silo.xcodeproj \
+  -scheme SiloTV \
+  -destination 'generic/platform=tvOS Simulator' \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: `BUILD SUCCEEDED`, proving every `TVDetailHero` initializer was updated consistently.
+
+- [ ] **Step 7: Commit the independently compiled tvOS detail change**
+
+Run:
+
+```bash
+git add \
+  iosApp/iosApp/tvOS/Screens/Detail/TVDetailHero.swift \
+  iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift \
+  iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift \
+  iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
+git commit -m "refactor(tvos): simplify detail hero metadata"
+```
+
+Expected: one commit limited to tvOS detail hero metadata/interfaces.
+
+### Task 4: Run Cross-Platform Automated Verification
+
+**Files:**
+
+- Verify unchanged paths listed in the File Map.
+- Test: all files under `iosApp/Tests/` through the `SiloTests` bundle.
+
+**Interfaces:**
+
+- Consumes: the three implementation commits from Tasks 1-3.
+- Produces: evidence that iOS, tvOS, and macOS compile unsigned and that the full iOS test bundle remains green.
+
+- [ ] **Step 1: Regenerate from `project.yml` once more**
+
+Run:
+
+```bash
+cd iosApp
+xcodegen generate
+cd ..
+```
+
+Expected: generation succeeds with no `project.yml` change.
+
+- [ ] **Step 2: Run the complete iOS unit-test bundle**
+
+Run:
+
+```bash
+xcodebuild test \
+  -project iosApp/Silo.xcodeproj \
+  -scheme Silo \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: `TEST SUCCEEDED`, including `HeroEditorialMetadataTests` and existing playback selector tests.
+
+- [ ] **Step 3: Run the unsigned iOS build**
+
+Run:
+
+```bash
+xcodebuild build \
+  -project iosApp/Silo.xcodeproj \
+  -scheme Silo \
+  -destination 'generic/platform=iOS Simulator' \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: `BUILD SUCCEEDED`.
+
+- [ ] **Step 4: Run the unsigned tvOS build**
+
+Run:
+
+```bash
+xcodebuild build \
+  -project iosApp/Silo.xcodeproj \
+  -scheme SiloTV \
+  -destination 'generic/platform=tvOS Simulator' \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: `BUILD SUCCEEDED`.
+
+- [ ] **Step 5: Run the unsigned macOS build**
+
+Run:
+
+```bash
+xcodebuild build \
+  -project iosApp/Silo.xcodeproj \
+  -scheme SiloMac \
+  -destination 'platform=macOS' \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: `BUILD SUCCEEDED`. This gate is required because the phone metadata and hero files are guarded by `#if !os(tvOS)` and therefore also compile into `SiloMac`.
+
+- [ ] **Step 6: Prove protected source areas did not change**
+
+Run:
+
+```bash
+git diff --exit-code b9bdfb0 -- \
+  iosApp/iosApp/Screens/Home/HomeView.swift \
+  iosApp/iosApp/Screens/Home/Feed/HomeFeedKit.swift \
+  iosApp/iosApp/Screens/Home/Feed/HomeFeedRow.swift \
+  iosApp/iosApp/Components/MediaRow.swift \
+  iosApp/iosApp/Screens/Detail/Phone/PhoneCastRail.swift \
+  iosApp/iosApp/tvOS/Screens/Detail/TVDetailCastRail.swift \
+  iosApp/iosApp/Screens/Detail/Phone/PhonePlaybackSelectorRow.swift \
+  iosApp/iosApp/tvOS/Screens/Detail/TVPlaybackSelectorRow.swift \
+  iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift \
+  iosApp/iosApp/Screens/Detail/DetailVersionSelection.swift \
+  iosApp/iosApp/Networking/Models.swift \
+  iosApp/iosApp/Networking/ContinuumAPI.swift \
+  iosApp/project.yml
+```
+
+Expected: no diff. This is the explicit guard for iOS no-hero Home/cards, configurable card overlays, cast rails, selectors, models/API, and project structure.
+
+- [ ] **Step 7: Check whitespace and repository state**
+
+Run:
+
+```bash
+git diff --check upstream/main...HEAD
+git status --short
+git log --oneline --decorate upstream/main..HEAD
+```
+
+Expected: no whitespace errors, no uncommitted implementation changes, and the three focused implementation commits plus the plan documentation change in the branch history.
+
+### Task 5: Perform iOS and tvOS Simulator Visual Smoke Tests
+
+**Files:**
+
+- No source changes.
+- Capture evidence outside the repository under `/tmp`.
+
+**Interfaces:**
+
+- Consumes: locally built simulator apps and an existing signed-in or cached Silo profile/library.
+- Produces: visual confirmation of metadata composition, retained navigation/actions, and episode backdrop enrichment without touching a physical device.
+
+- [ ] **Step 1: Build and launch iOS in an isolated simulator derived-data directory**
+
+Run:
+
+```bash
+xcrun simctl shutdown all
+xcrun simctl boot 'iPhone 17 Pro'
+open -a Simulator
+
+xcodebuild build \
+  -project iosApp/Silo.xcodeproj \
+  -scheme Silo \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -derivedDataPath /tmp/silo-apple-hero-editorial-ios \
+  CODE_SIGNING_ALLOWED=NO
+
+xcrun simctl install booted \
+  /tmp/silo-apple-hero-editorial-ios/Build/Products/Debug-iphonesimulator/Silo.app
+xcrun simctl launch booted org.siloserver.silo
+```
+
+Expected: the iOS app launches in the iPhone simulator. No physical-device command is used.
+
+- [ ] **Step 2: Inspect iOS Home and representative detail pages**
+
+Using the simulator UI, verify all of the following:
+
+- Home starts directly with section rows beneath the floating header; no hero appears.
+- Existing poster, still, progress, watched, downloaded, S/E, square-audiobook, caption, and selective row-differentiating badge treatments are unchanged.
+- A movie detail hero shows editorial facts such as year, runtime, and IMDb score but no `4K`, `HD`, `HDR`, `DOLBY VISION`, `ATMOS`, `7.1`, `5.1`, or `CC` hard-coded fact chip.
+- An episode detail hero may show air date/runtime/rating but no technical fact chip.
+- A series detail hero shows year/season count/rating but no technical fact chip.
+- Version, Audio, and Subtitles selector rows still display their rich technical values and remain interactive when multiple choices exist.
+- The below-fold Cast & Crew section still appears and person cards still navigate.
+- Configurable artwork overlays, when enabled in overlay settings, remain independent of the removed hard-coded facts.
+
+- [ ] **Step 3: Capture an iOS simulator screenshot outside the repository**
+
+Run:
+
+```bash
+xcrun simctl io booted screenshot /tmp/apple-hero-editorial-ios.png
+```
+
+Expected: `/tmp/apple-hero-editorial-ios.png` contains the currently inspected iOS screen and no repository file is created.
+
+- [ ] **Step 4: Build and launch tvOS in an isolated simulator derived-data directory**
+
+Run:
+
+```bash
+xcrun simctl shutdown all
+xcrun simctl boot 'Apple TV 4K (3rd generation)'
+open -a Simulator
+
+xcodebuild build \
+  -project iosApp/Silo.xcodeproj \
+  -scheme SiloTV \
+  -destination 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation)' \
+  -derivedDataPath /tmp/silo-apple-hero-editorial-tvos \
+  CODE_SIGNING_ALLOWED=NO
+
+xcrun simctl install booted \
+  /tmp/silo-apple-hero-editorial-tvos/Build/Products/Debug-appletvsimulator/SiloTV.app
+xcrun simctl launch booted org.siloserver.silo
+```
+
+Expected: the tvOS app launches in the Apple TV simulator. No physical Apple TV is addressed.
+
+- [ ] **Step 5: Inspect shared Home/Library marquee behavior**
+
+Using the simulator remote/keyboard navigation, verify:
+
+- Home marquee retains title/logo, synopsis, content-rating badge, year/genre/runtime/IMDb facts, episode S/E/title/runtime/time-left facts, backdrop, and focus-driven crossfade.
+- No marquee emits resolution, HDR/Dolby Vision, or audio badges.
+- No marquee enrichment line emits actor names.
+- An episode with an air date may still show `Aired …`.
+- After an episode rests in focus, the backdrop can still upgrade from section artwork to the detail-level series backdrop; the enrichment fetch must not have been removed.
+- A library Browse landing exhibits the same metadata policy because it shares `TVSkylineSectionFeed` and `TVFocusMarquee`.
+- Configurable poster/thumbnail card overlays remain unchanged.
+
+- [ ] **Step 6: Inspect tvOS detail behavior**
+
+Verify representative movie/episode, series, and season detail pages:
+
+- The hero facts remain editorial and contain no resolution, HDR/Dolby Vision, audio-layout, or CC token.
+- No right-side `Starring …` overlay appears.
+- The below-fold Cast & Crew rail remains present and focusable.
+- Version, Audio, and Subtitles selectors retain technical values and focus behavior.
+- Season/episode rails, details facts, synopsis expansion, action buttons, and person navigation remain intact.
+
+- [ ] **Step 7: Capture a tvOS simulator screenshot outside the repository**
+
+Run:
+
+```bash
+xcrun simctl io booted screenshot /tmp/apple-hero-editorial-tvos.png
+```
+
+Expected: `/tmp/apple-hero-editorial-tvos.png` contains the inspected tvOS screen and no repository file is created.
+
+- [ ] **Step 8: Confirm visual smoke testing did not dirty the worktree**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: no simulator-generated repository changes.
+
+### Task 6: Independent Review and Separate Pull Request
+
+**Files:**
+
+- Review the complete `upstream/main...HEAD` diff.
+- No new production files unless a concrete review finding requires returning to Tasks 1-3.
+
+**Interfaces:**
+
+- Consumes: green automated verification, simulator smoke evidence, and the complete commit range.
+- Produces: an independent review verdict and one dedicated GitHub pull request for this feature branch.
+
+- [ ] **Step 1: Prepare the exact review range and acceptance brief**
+
+Run:
+
+```bash
+git fetch upstream
+git log --oneline upstream/main..HEAD
+git diff --stat upstream/main...HEAD
+git diff --check upstream/main...HEAD
+```
+
+Expected: a small diff limited to the plan, one focused test file, phone/macOS hero metadata, shared tvOS marquee metadata, and tvOS detail hero interfaces.
+
+- [ ] **Step 2: Request an independent code review**
+
+Invoke `superpowers:requesting-code-review` with:
+
+```text
+Base: upstream/main
+Head: HEAD
+Review the Apple hero editorial metadata change for:
+1. iOS Home and editorial cards remain untouched.
+2. iOS/macOS detail facts exclude hard-coded resolution, HDR/DV, audio-layout, and CC tokens.
+3. tvOS Home and library Browse marquee preserve editorial facts/content rating and remove technical badges/cast names.
+4. tvOS episode enrichment still fetches/caches detail artwork and may show air date.
+5. tvOS detail removes technical facts and the right-side Starring overlay.
+6. Dedicated cast rails, person navigation, configurable overlays, and playback/version selectors remain intact.
+7. No server/API/model/project.yml changes.
+8. Tests and all three unsigned platform builds support the claims.
+```
+
+Expected: an independent reviewer reports either no findings or concrete findings with file/line references and severity.
+
+- [ ] **Step 3: Resolve review findings through the relevant test/build gate**
+
+If the reviewer reports a finding, return to the task owning that file:
+
+- Phone facts/interface finding: add or tighten an assertion in `HeroEditorialMetadataTests`, run the focused red/green command from Task 1, then commit with `fix(detail): address editorial metadata review`.
+- Shared marquee finding: run the Task 2 negative/positive source checks and tvOS build after the correction, then commit with `fix(tvos): address marquee metadata review`.
+- tvOS detail finding: run the Task 3 source checks and tvOS build after the correction, then commit with `fix(tvos): address detail hero review`.
+- Preservation/build finding: rerun the protected-path diff and the affected full platform build from Task 4 before committing with `fix(apple): preserve hero metadata boundaries`.
+
+After any correction, repeat Step 2 against the new `HEAD`. Proceed only when the independent review has no unresolved findings.
+
+- [ ] **Step 4: Run the final verification-before-completion gate**
+
+Invoke `superpowers:verification-before-completion`, then rerun:
+
+```bash
+xcodebuild test \
+  -project iosApp/Silo.xcodeproj \
+  -scheme Silo \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  CODE_SIGNING_ALLOWED=NO
+
+xcodebuild build \
+  -project iosApp/Silo.xcodeproj \
+  -scheme Silo \
+  -destination 'generic/platform=iOS Simulator' \
+  CODE_SIGNING_ALLOWED=NO
+
+xcodebuild build \
+  -project iosApp/Silo.xcodeproj \
+  -scheme SiloTV \
+  -destination 'generic/platform=tvOS Simulator' \
+  CODE_SIGNING_ALLOWED=NO
+
+xcodebuild build \
+  -project iosApp/Silo.xcodeproj \
+  -scheme SiloMac \
+  -destination 'platform=macOS' \
+  CODE_SIGNING_ALLOWED=NO
+
+git diff --check upstream/main...HEAD
+git status --short
+```
+
+Expected: full iOS tests pass, all three unsigned builds succeed, no whitespace errors exist, and the worktree is clean.
+
+- [ ] **Step 5: Push only the dedicated feature branch**
+
+Run:
+
+```bash
+git push -u origin feat/apple-hero-editorial-metadata
+```
+
+Expected: the isolated branch is published without merging or pushing unrelated branches.
+
+- [ ] **Step 6: Open the separate pull request**
+
+Run:
+
+```bash
+gh pr create \
+  --base main \
+  --head feat/apple-hero-editorial-metadata \
+  --title 'Keep Apple hero metadata editorial' \
+  --body $'## Summary\n- remove hard-coded technical quality tokens from iOS/macOS and tvOS detail hero facts\n- keep tvOS Home and library Browse marquee editorial while removing technical badges and cast-name enrichment\n- preserve episode backdrop enrichment, content ratings, cast rails, configurable overlays, and playback selectors\n\n## Verification\n- full SiloTests on iPhone 17 Pro simulator\n- unsigned iOS simulator build\n- unsigned tvOS simulator build\n- unsigned macOS build\n- iOS and tvOS simulator visual smoke\n- independent code review with no unresolved findings'
+```
+
+Expected: one new pull request from `feat/apple-hero-editorial-metadata` to `main`, containing only this plan and implementation.
+
+## Plan Self-Review
+
+- Spec coverage: Tasks 1-3 cover every requested platform surface; Task 4 explicitly guards iOS Home/cards, selectors, cast rails, API/models, and `project.yml`; Task 5 covers simulator-only visual behavior; Task 6 covers independent review and the separate PR.
+- Testability: non-tvOS pure metadata receives focused XCTest red/green coverage; tvOS-only types use explicit source acceptance checks, compile gates, and simulator verification because the repository has no tvOS test target.
+- Placeholder scan: the plan contains no unresolved marker, deferred implementation instruction, unnamed test, or undefined interface.
+- Type consistency: both simplified `movieFactsLine` functions take only `ItemDetail`; both token enums remove `.chip`; every affected call site is listed; marquee enrichment retains its existing property names and model API.
+- Boundary consistency: `OverlaySummary`, configurable `OverlayData`, `currentVersion`, playback selectors, cast rails, and episode artwork enrichment remain deliberately intact.

--- a/docs/superpowers/specs/2026-07-29-apple-hero-editorial-metadata-design.md
+++ b/docs/superpowers/specs/2026-07-29-apple-hero-editorial-metadata-design.md
@@ -1,0 +1,195 @@
+# Apple Hero Editorial Metadata Design
+
+**Date:** 2026-07-29
+**Status:** Approved
+**Repository:** `silo-apple`
+**Clients:** iOS, tvOS, and macOS
+
+## Goal
+
+Make Apple-client heroes describe the title rather than the selected file.
+Preserve the intentionally hero-free iOS Home design, remove hard-coded
+technical tokens from detail heroes, simplify the tvOS marquee, and keep cast
+in dedicated cast sections.
+
+## Product contract
+
+Movie and series browse heroes use this priority:
+
+1. Year
+2. Runtime
+3. IMDb rating
+4. One or two genres
+5. Content rating
+
+Episode browse heroes use:
+
+1. Season and episode identity
+2. Runtime
+3. Content rating when useful
+
+Detail heroes use:
+
+- Movies and episodes: year or air date, runtime, IMDb rating, one or two
+  genres, and content rating
+- Series: year, season count, IMDb rating, one or two genres, and content
+  rating
+
+Hard-coded technical metadata does not appear in Home marquees or detail
+facts:
+
+- Resolution or 4K
+- HDR or Dolby Vision
+- Audio codec, layout, or Atmos
+- Subtitle or CC availability
+
+Cast names do not appear as hero overlays. Cast remains available in the
+dedicated cast rails.
+
+## Scope decisions
+
+- iOS Home remains hero-free and its current feed cards remain unchanged.
+- The non-tvOS detail implementation is shared by iOS and macOS, so both adopt
+  the editorial-only detail facts.
+- The tvOS focus marquee is shared by Home and library Browse; both adopt the
+  same editorial policy.
+- Configurable/admin-controlled card or artwork overlays are separate from the
+  hard-coded hero facts and remain unchanged.
+- Playback/version selectors and technical detail formatters remain unchanged.
+- No networking model, API, or server change is required.
+
+## Architecture
+
+### iOS Home
+
+`HomeView` continues to render feed rows without a hero. `HomeFeedRow`,
+`HomeFeedKit`, and their selective row/card badge policy are not redesigned.
+The recent card treatment intentionally uses technical badges only where they
+differentiate items in a row; this design does not remove that configurable
+card-level information.
+
+### iOS and macOS detail
+
+`PhoneHeroMetadata` remains the pure metadata builder for the shared non-tvOS
+detail surface. Its movie/episode facts retain air date or year, runtime, and
+valid IMDb rating. Series facts retain year, season count, and valid IMDb
+rating.
+
+The builder stops appending resolution, HDR/Dolby Vision, audio, and CC
+tokens. Its selected-version argument is removed if it has no remaining
+editorial purpose. `MovieDetailContent` is updated accordingly.
+
+Content rating and genres remain in their current source/facts locations, with
+blank values omitted. Existing configurable backdrop overlays supplied by
+`OverlayData.from(detail)` remain available because they are user/admin
+presentation choices rather than hard-coded facts.
+
+Generic `.chip` rendering may remain if another caller needs it. Hero-only
+quality resolution helpers and selected-version coupling are removed.
+
+### tvOS Home and library Browse marquee
+
+`TVMarqueeContent` keeps title/logo, synopsis, artwork, year, runtime,
+IMDb rating, episode identity/title, progress-derived time remaining, and
+content rating.
+
+It stops deriving resolution, HDR/Dolby Vision, and audio badges from
+`OverlaySummary`. Content rating remains a classification badge. Movie and
+series editorial metadata is ordered year, runtime, IMDb, then up to two
+genres. Episode metadata keeps season/episode identity, episode title,
+runtime, and time remaining without adding duplicate series genres.
+
+`TVMarqueeEnrichment` retains air-date formatting and detail-level backdrop
+data. It stops appending cast names. The enrichment fetch and model lifecycle
+remain because episodes depend on the enriched series backdrop and thumbhash;
+removing cast must not regress episode artwork quality.
+
+The poster/thumbnail overlay system used by tvOS rows remains unchanged.
+
+### tvOS detail
+
+`TVHeroMetadata.movieFactsLine` and `seriesFactsLine` stop appending technical
+quality tokens. Selected-version parameters are removed when no editorial
+facts depend on them.
+
+`TVDetailHero` removes the right-aligned `starringText` input and
+`starringOverlay`. Movie, series, and season detail call sites stop supplying
+starring text. `TVHeroMetadata.starringText` and hero-only quality helpers are
+deleted.
+
+Dedicated movie, series, and season cast rails remain. `TVPlaybackSelectorRow`,
+`PhonePlaybackSelectorRow`, `DetailPlaybackFormatting`,
+`DetailVersionSelection`, and playback screens remain unchanged.
+
+## Validation and fallback rules
+
+- Runtime values must be positive; unavailable runtime is omitted.
+- IMDb ratings must be finite, greater than zero, and no greater than ten.
+- Genres and content ratings are trimmed; blank values are omitted; genres
+  are first-seen deduplicated and capped according to the surface.
+- No `Unknown`, zero, blank chip, or empty separator is rendered.
+- Metadata overflow continues using each native surface's existing truncation
+  behavior.
+- No additional detail fetch is introduced.
+- No focus, navigation, playback, artwork, caching, or session semantics
+  change.
+
+## Expected files
+
+iOS/macOS detail:
+
+- `iosApp/iosApp/Screens/Detail/Phone/PhoneHeroMetadata.swift`
+- `iosApp/iosApp/Screens/Detail/MovieDetailContent.swift`
+- A focused metadata regression test under `iosApp/Tests/`
+
+tvOS marquee:
+
+- `iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift`
+
+tvOS detail:
+
+- `iosApp/iosApp/tvOS/Screens/Detail/TVDetailHero.swift`
+- `iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift`
+- `iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift`
+- `iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift`
+
+`iosApp/project.yml` is not expected to change because the test target already
+includes `Tests/**`.
+
+## Test design
+
+The iOS-hosted metadata tests use rich `ItemDetail` and `FileVersion` fixtures
+to prove:
+
+- Movie, episode, and series facts retain their editorial order
+- Resolution, HDR/Dolby Vision, audio, and CC are absent
+- Content rating and genre normalization remains correct
+- Invalid ratings and runtimes are omitted
+- Playback/version formatting still exposes technical information outside the
+  hero
+
+tvOS-only metadata helpers currently compile only into the tvOS target, and
+the repository has no tvOS unit-test target. Adding a new target is
+disproportionate to this presentation change. tvOS verification therefore
+uses:
+
+- iOS-hosted tests for any platform-neutral formatter extracted during
+  implementation
+- Unsigned tvOS compilation
+- Simulator visual checks for Home, library Browse, movie detail, episode
+  detail, series detail, and season detail
+- Explicit confirmation that enriched episode backdrops still load
+
+Final verification includes iOS tests, unsigned iOS/tvOS/macOS builds, and
+visual smoke checks on one phone-size surface and one TV-size surface. No
+physical-device installation is part of this work.
+
+## Non-goals
+
+- Adding an iOS Home hero
+- Removing configurable card/backdrop overlays
+- Removing technical information from selectors, playback, or file details
+- Removing dedicated cast sections
+- Server, API, schema, or networking changes
+- Adding a tvOS unit-test target solely for this cleanup
+- Changing focus, navigation, artwork caching, or playback behavior

--- a/iosApp/Tests/HeroEditorialMetadataTests.swift
+++ b/iosApp/Tests/HeroEditorialMetadataTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import XCTest
+@testable import Silo
+
+final class HeroEditorialMetadataTests: XCTestCase {
+    func testMovieFactsExcludeTechnicalFileMetadata() throws {
+        let detail = try decodeDetail(
+            """
+            {
+              "content_id": "movie-1",
+              "type": "movie",
+              "title": "Editorial Movie",
+              "year": 2026,
+              "runtime": 125,
+              "rating_imdb": 8.4,
+              "versions": [
+                {
+                  "file_id": 10,
+                  "resolution": "2160p",
+                  "hdr": true,
+                  "video_tracks": [
+                    { "index": 0, "dolby_vision": "Profile 8.1" }
+                  ],
+                  "audio_tracks": [
+                    { "index": 1, "layout": "7.1 Atmos", "default": true }
+                  ],
+                  "subtitle_tracks": [
+                    { "index": 2, "codec": "srt", "language": "eng" }
+                  ]
+                }
+              ]
+            }
+            """
+        )
+
+        XCTAssertEqual(
+            PhoneHeroMetadata.movieFactsLine(from: detail),
+            [.text("2026"), .text("2h 5m"), .text("★ 8.4")]
+        )
+    }
+
+    func testSeriesFactsExcludeTechnicalFileMetadata() throws {
+        let detail = try decodeDetail(
+            """
+            {
+              "content_id": "series-1",
+              "type": "series",
+              "title": "Editorial Series",
+              "year": 2024,
+              "season_count": 3,
+              "rating_imdb": 9.1,
+              "versions": [
+                {
+                  "file_id": 20,
+                  "resolution": "1080p",
+                  "hdr": true,
+                  "audio_tracks": [
+                    { "index": 1, "layout": "5.1", "default": true }
+                  ],
+                  "subtitle_tracks": [
+                    { "index": 2, "codec": "srt", "language": "eng" }
+                  ]
+                }
+              ]
+            }
+            """
+        )
+
+        XCTAssertEqual(
+            PhoneHeroMetadata.seriesFactsLine(from: detail),
+            [.text("2024"), .text("3 Seasons"), .text("★ 9.1")]
+        )
+    }
+
+    private func decodeDetail(_ json: String) throws -> ItemDetail {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(ItemDetail.self, from: Data(json.utf8))
+    }
+}

--- a/iosApp/Tests/HeroEditorialMetadataTests.swift
+++ b/iosApp/Tests/HeroEditorialMetadataTests.swift
@@ -12,11 +12,15 @@ final class HeroEditorialMetadataTests: XCTestCase {
               "title": "Editorial Movie",
               "year": 2026,
               "runtime": 125,
+              "content_rating": "  R  ",
+              "genres": [" Drama ", "drama", "", "Unknown", " Sci-Fi ", "Comedy"],
               "rating_imdb": 8.4,
               "versions": [
                 {
                   "file_id": 10,
                   "resolution": "2160p",
+                  "codec_video": "hevc",
+                  "codec_audio": "truehd",
                   "hdr": true,
                   "video_tracks": [
                     { "index": 0, "dolby_vision": "Profile 8.1" }
@@ -37,6 +41,14 @@ final class HeroEditorialMetadataTests: XCTestCase {
             PhoneHeroMetadata.movieFactsLine(from: detail),
             [.text("2026"), .text("2h 5m"), .text("★ 8.4")]
         )
+        XCTAssertEqual(PhoneHeroMetadata.movieSourceTokens(from: detail), ["Movie", "Drama", "Sci-Fi"])
+        XCTAssertEqual(PhoneHeroMetadata.contentRatingChip(from: detail), "R")
+
+        let version = try XCTUnwrap(detail.versions?.first)
+        XCTAssertEqual(
+            DetailPlaybackFormatting.versionShortLabel(version),
+            "2160p · HEVC · DV · TrueHD"
+        )
     }
 
     func testSeriesFactsExcludeTechnicalFileMetadata() throws {
@@ -48,6 +60,8 @@ final class HeroEditorialMetadataTests: XCTestCase {
               "title": "Editorial Series",
               "year": 2024,
               "season_count": 3,
+              "genres": [" Drama ", "DRAMA", "Unknown", " Mystery "],
+              "content_rating": " Unknown ",
               "rating_imdb": 9.1,
               "versions": [
                 {
@@ -69,6 +83,112 @@ final class HeroEditorialMetadataTests: XCTestCase {
         XCTAssertEqual(
             PhoneHeroMetadata.seriesFactsLine(from: detail),
             [.text("2024"), .text("3 Seasons"), .text("★ 9.1")]
+        )
+        XCTAssertEqual(PhoneHeroMetadata.seriesSourceTokens(from: detail), ["TV Show", "Drama", "Mystery"])
+        XCTAssertNil(PhoneHeroMetadata.contentRatingChip(from: detail))
+    }
+
+    func testEpisodeFactsRetainEditorialOrderAndNormalizedIdentity() throws {
+        let detail = try decodeDetail(
+            """
+            {
+              "content_id": "episode-1",
+              "type": "episode",
+              "title": "The Episode",
+              "series_title": "  The Series  ",
+              "season_number": 2,
+              "episode_number": 7,
+              "air_date": "2026-07-29T12:00:00Z",
+              "runtime": 47,
+              "rating_imdb": 7.5,
+              "genres": [" Drama ", "drama", " Mystery "]
+            }
+            """
+        )
+
+        XCTAssertEqual(
+            PhoneHeroMetadata.movieSourceTokens(from: detail),
+            ["Season 2 · Episode 7", "Drama"]
+        )
+        XCTAssertEqual(PhoneHeroMetadata.eyebrow(from: detail), "The Series")
+        let facts = PhoneHeroMetadata.movieFactsLine(from: detail)
+        guard let firstFact = facts.first, case let .text(airDate) = firstFact else {
+            return XCTFail("Expected the air date to be the first episode fact")
+        }
+        XCTAssertFalse(airDate.isEmpty)
+        XCTAssertEqual(Array(facts.dropFirst()), [.text("47 min"), .text("★ 7.5")])
+    }
+
+    func testInvalidIMDbRatingsAndRuntimesAreOmitted() throws {
+        let zeroDetail = try decodeDetail(
+            """
+            {
+              "content_id": "movie-zero",
+              "type": "movie",
+              "title": "Zero",
+              "year": 2026,
+              "runtime": 0,
+              "rating_imdb": 0
+            }
+            """
+        )
+        let highDetail = try decodeDetail(
+            """
+            {
+              "content_id": "movie-high",
+              "type": "movie",
+              "title": "High",
+              "runtime": -5,
+              "rating_imdb": 10.1
+            }
+            """
+        )
+
+        XCTAssertEqual(PhoneHeroMetadata.movieFactsLine(from: zeroDetail), [.text("2026")])
+        XCTAssertEqual(PhoneHeroMetadata.movieFactsLine(from: highDetail), [])
+        XCTAssertNil(HeroEditorialMetadata.imdbRatingText(-1))
+        XCTAssertNil(HeroEditorialMetadata.imdbRatingText(.nan))
+        XCTAssertNil(HeroEditorialMetadata.imdbRatingText(.infinity))
+        XCTAssertEqual(HeroEditorialMetadata.imdbRatingText(10), "10.0")
+    }
+
+    func testSharedNormalizationTrimsDeduplicatesFiltersAndCapsGenres() {
+        XCTAssertEqual(
+            HeroEditorialMetadata.normalizedGenres(
+                [" Drama ", "drama", "", " Unknown ", "\nSci-Fi\t", "Comedy"],
+                limit: 2
+            ),
+            ["Drama", "Sci-Fi"]
+        )
+        XCTAssertEqual(HeroEditorialMetadata.normalizedGenres(["Drama"], limit: 0), [])
+        XCTAssertNil(HeroEditorialMetadata.normalizedValue(" \n "))
+        XCTAssertNil(HeroEditorialMetadata.normalizedValue(" unknown "))
+        XCTAssertEqual(HeroEditorialMetadata.normalizedValue(" TV-MA "), "TV-MA")
+    }
+
+    func testBrowseMetadataUsesEditorialPriorityAndTwoNormalizedGenres() {
+        XCTAssertEqual(
+            HeroEditorialMetadata.browseMetadataParts(
+                year: 2026,
+                runtime: "2h 5m",
+                imdbRating: 8.4,
+                genres: [" Drama ", "drama", "Sci-Fi", "Comedy"]
+            ),
+            ["2026", "2h 5m", "8.4", "Drama", "Sci-Fi"]
+        )
+    }
+
+    func testEpisodeIdentityRejectsInvalidNumbersAndHandlesSpecials() {
+        XCTAssertEqual(
+            HeroEditorialMetadata.episodeIdentity(season: 0, episode: 5, style: .detail),
+            "Specials · Episode 5"
+        )
+        XCTAssertEqual(
+            HeroEditorialMetadata.episodeIdentity(season: 2, episode: 7, style: .compact),
+            "S2 E7"
+        )
+        XCTAssertNil(
+            HeroEditorialMetadata.episodeIdentity(season: -1, episode: 0, style: .detail)
         )
     }
 

--- a/iosApp/iosApp/Screens/Detail/HeroEditorialMetadata.swift
+++ b/iosApp/iosApp/Screens/Detail/HeroEditorialMetadata.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// Shared validation and normalization for editorial hero metadata.
+enum HeroEditorialMetadata {
+    enum EpisodeIdentityStyle {
+        case detail
+        case compact
+    }
+
+    static func normalizedValue(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty,
+              value.caseInsensitiveCompare("Unknown") != .orderedSame else {
+            return nil
+        }
+        return value
+    }
+
+    static func normalizedGenres(_ genres: [String]?, limit: Int) -> [String] {
+        guard limit > 0 else { return [] }
+
+        var seen: Set<String> = []
+        var result: [String] = []
+        for rawGenre in genres ?? [] {
+            guard let genre = normalizedValue(rawGenre) else { continue }
+            let key = genre.lowercased()
+            guard seen.insert(key).inserted else { continue }
+            result.append(genre)
+            if result.count == limit { break }
+        }
+        return result
+    }
+
+    static func imdbRatingText(_ rating: Double?) -> String? {
+        guard let rating, rating.isFinite, rating > 0, rating <= 10 else {
+            return nil
+        }
+        return rating.formatted(.number.precision(.fractionLength(1)))
+    }
+
+    static func browseMetadataParts(
+        year: Int?,
+        runtime: String?,
+        imdbRating: Double?,
+        genres: [String]?,
+        genreLimit: Int = 2
+    ) -> [String] {
+        var parts: [String] = []
+        if let year, year > 0 {
+            parts.append(String(year))
+        }
+        if let runtime = normalizedValue(runtime) {
+            parts.append(runtime)
+        }
+        if let rating = imdbRatingText(imdbRating) {
+            parts.append(rating)
+        }
+        parts.append(contentsOf: normalizedGenres(genres, limit: genreLimit))
+        return parts
+    }
+
+    static func episodeIdentity(
+        season: Int?,
+        episode: Int?,
+        style: EpisodeIdentityStyle
+    ) -> String? {
+        let seasonPart: String?
+        if let season, season >= 0 {
+            switch style {
+            case .detail:
+                seasonPart = season == 0 ? "Specials" : "Season \(season)"
+            case .compact:
+                seasonPart = season == 0 ? "Specials" : "S\(season)"
+            }
+        } else {
+            seasonPart = nil
+        }
+
+        let episodePart = episode.flatMap { value -> String? in
+            guard value > 0 else { return nil }
+            switch style {
+            case .detail: return "Episode \(value)"
+            case .compact: return "E\(value)"
+            }
+        }
+
+        let separator: String
+        switch style {
+        case .detail: separator = " · "
+        case .compact: separator = " "
+        }
+        return [seasonPart, episodePart]
+            .compactMap { $0 }
+            .joined(separator: separator)
+            .nilIfEmpty
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
+}

--- a/iosApp/iosApp/Screens/Detail/MovieDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/MovieDetailContent.swift
@@ -97,7 +97,7 @@ struct MovieDetailContent<BelowOverview: View>: View {
             sourceTokens: PhoneHeroMetadata.movieSourceTokens(from: detail),
             ratingChip: PhoneHeroMetadata.contentRatingChip(from: detail),
             overview: detail.overview,
-            factsLine: PhoneHeroMetadata.movieFactsLine(from: detail, version: effectiveVersion),
+            factsLine: PhoneHeroMetadata.movieFactsLine(from: detail),
             overlayData: OverlayData.from(detail),
             actions: { actionStack },
             belowOverview: belowOverview

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneDetailHero.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneDetailHero.swift
@@ -510,8 +510,8 @@ private struct PhoneHeroEyebrow: View {
 
 /// Centered facts row that line-wraps when the tokens exceed the
 /// container width. SwiftUI's plain HStack truncates instead of
-/// wrapping, so we lean on `Layout` to flow the chips like Apple's
-/// quality-badge row beneath the overview.
+/// wrapping, so we lean on `Layout` to flow the editorial facts
+/// beneath the overview.
 private struct FlowingFactsRow: View {
     let tokens: [PhoneHeroFactToken]
     let alignment: HorizontalAlignment
@@ -547,24 +547,13 @@ private struct FlowingFactsRow: View {
                     .font(.system(size: 13, weight: .medium))
                     .foregroundColor(.continuumOnSurface.opacity(0.78))
             }
-        case .chip(let value):
-            Text(value)
-                .font(.system(size: 10, weight: .heavy))
-                .tracking(0.8)
-                .foregroundColor(.continuumOnSurface)
-                .padding(.horizontal, 6)
-                .padding(.vertical, 2)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 3)
-                        .stroke(Color.continuumOnSurface.opacity(0.45), lineWidth: 1)
-                )
         }
     }
 }
 
 /// Minimal flow layout that wraps subviews onto new lines when the
 /// proposed width can't fit them. Uses each subview's intrinsic
-/// width — no shrinking — so every chip stays at its natural size.
+/// width — no shrinking — so every fact stays at its natural size.
 private struct PhoneFactsFlowLayout: Layout {
     var spacing: CGFloat
     var lineSpacing: CGFloat

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneHeroMetadata.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneHeroMetadata.swift
@@ -17,26 +17,26 @@ enum PhoneHeroMetadata {
     // MARK: - Source row
 
     static func movieSourceTokens(from detail: ItemDetail) -> [String] {
-        if detail.type == "episode" {
+        if detail.type.lowercased() == "episode" {
             var tokens: [String] = []
-            if let label = episodeNumberLabel(from: detail) { tokens.append(label) }
-            if let genres = detail.genres, !genres.isEmpty {
-                tokens.append(contentsOf: genres.prefix(1))
+            if let label = HeroEditorialMetadata.episodeIdentity(
+                season: detail.seasonNumber,
+                episode: detail.episodeNumber,
+                style: .detail
+            ) {
+                tokens.append(label)
             }
+            tokens.append(contentsOf: HeroEditorialMetadata.normalizedGenres(detail.genres, limit: 1))
             return tokens
         }
         var tokens: [String] = [typeLabel(detail: detail)]
-        if let genres = detail.genres, !genres.isEmpty {
-            tokens.append(contentsOf: genres.prefix(2))
-        }
+        tokens.append(contentsOf: HeroEditorialMetadata.normalizedGenres(detail.genres, limit: 2))
         return tokens
     }
 
     static func seriesSourceTokens(from detail: ItemDetail) -> [String] {
         var tokens: [String] = ["TV Show"]
-        if let genres = detail.genres, !genres.isEmpty {
-            tokens.append(contentsOf: genres.prefix(2))
-        }
+        tokens.append(contentsOf: HeroEditorialMetadata.normalizedGenres(detail.genres, limit: 2))
         return tokens
     }
 
@@ -44,24 +44,19 @@ enum PhoneHeroMetadata {
         var tokens: [String] = []
         let count = detail.episodeCount ?? episodeCount
         if count > 0 { tokens.append("\(count) Episode\(count == 1 ? "" : "s")") }
-        if let genres = detail.genres, !genres.isEmpty {
-            tokens.append(contentsOf: genres.prefix(2))
-        }
+        tokens.append(contentsOf: HeroEditorialMetadata.normalizedGenres(detail.genres, limit: 2))
         return tokens
     }
 
     static func contentRatingChip(from detail: ItemDetail) -> String? {
-        guard let rating = detail.contentRating?
-            .trimmingCharacters(in: .whitespaces), !rating.isEmpty
-        else { return nil }
-        return rating
+        HeroEditorialMetadata.normalizedValue(detail.contentRating)
     }
 
     // MARK: - Facts row
 
     static func movieFactsLine(from detail: ItemDetail) -> [PhoneHeroFactToken] {
         var tokens: [PhoneHeroFactToken] = []
-        if detail.type == "episode",
+        if detail.type.lowercased() == "episode",
            let airDate = DetailDateFormatting.abbreviatedDate(detail.airDate) {
             tokens.append(.text(airDate))
         } else if let year = detail.year, year > 0 {
@@ -70,8 +65,8 @@ enum PhoneHeroMetadata {
         if let runtime = detail.runtime, runtime > 0 {
             tokens.append(.text(formatRuntime(runtime)))
         }
-        if let imdb = detail.ratingImdb {
-            tokens.append(.text(String(format: "★ %.1f", imdb)))
+        if let imdb = HeroEditorialMetadata.imdbRatingText(detail.ratingImdb) {
+            tokens.append(.text("★ \(imdb)"))
         }
         return tokens
     }
@@ -82,8 +77,8 @@ enum PhoneHeroMetadata {
         if let count = detail.seasonCount, count > 0 {
             tokens.append(.text("\(count) Season\(count == 1 ? "" : "s")"))
         }
-        if let imdb = detail.ratingImdb {
-            tokens.append(.text(String(format: "★ %.1f", imdb)))
+        if let imdb = HeroEditorialMetadata.imdbRatingText(detail.ratingImdb) {
+            tokens.append(.text("★ \(imdb)"))
         }
         return tokens
     }
@@ -91,15 +86,13 @@ enum PhoneHeroMetadata {
     // MARK: - Eyebrow
 
     static func eyebrow(from detail: ItemDetail) -> String? {
-        if detail.type == "episode" {
-            if let seriesTitle = detail.seriesTitle?
-                .trimmingCharacters(in: .whitespaces), !seriesTitle.isEmpty {
+        if detail.type.lowercased() == "episode" {
+            if let seriesTitle = HeroEditorialMetadata.normalizedValue(detail.seriesTitle) {
                 return seriesTitle
             }
         }
-        if let status = detail.status?
-            .trimmingCharacters(in: .whitespaces), !status.isEmpty,
-           detail.type == "series" {
+        if let status = HeroEditorialMetadata.normalizedValue(detail.status),
+           detail.type.lowercased() == "series" {
             switch status.lowercased() {
             case "continuing", "returning series", "returning":
                 return "Continuing Series"
@@ -133,23 +126,6 @@ enum PhoneHeroMetadata {
     }
 
     // MARK: - Helpers
-
-    private static func episodeNumberLabel(from detail: ItemDetail) -> String? {
-        let seasonPart: String?
-        if let season = detail.seasonNumber {
-            seasonPart = season == 0 ? "Specials" : "Season \(season)"
-        } else {
-            seasonPart = nil
-        }
-        let episodePart = detail.episodeNumber.flatMap { n in n > 0 ? "Episode \(n)" : nil }
-
-        switch (seasonPart, episodePart) {
-        case let (.some(s), .some(e)): return "\(s) \u{00B7} \(e)"
-        case let (.some(s), .none):    return s
-        case let (.none, .some(e)):    return e
-        case (.none, .none):           return nil
-        }
-    }
 
     private static func typeLabel(detail: ItemDetail) -> String {
         switch detail.type.lowercased() {

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneHeroMetadata.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneHeroMetadata.swift
@@ -1,13 +1,11 @@
 #if !os(tvOS)
 import Foundation
 
-/// A token in the hero's facts row. `.text` items get a middle-dot
-/// separator between them; `.rating` renders a green check + maturity
-/// label; `.chip` renders an outlined uppercase pill (4K / HDR / ATMOS / CC).
+/// A token in the hero's editorial facts row. `.text` items get a
+/// middle-dot separator; `.rating` retains the supported rating treatment.
 enum PhoneHeroFactToken: Hashable {
     case text(String)
     case rating(String)
-    case chip(String)
 }
 
 /// Builds the eyebrow / source / facts / starring strings shown by the
@@ -61,7 +59,7 @@ enum PhoneHeroMetadata {
 
     // MARK: - Facts row
 
-    static func movieFactsLine(from detail: ItemDetail, version selectedVersion: FileVersion? = nil) -> [PhoneHeroFactToken] {
+    static func movieFactsLine(from detail: ItemDetail) -> [PhoneHeroFactToken] {
         var tokens: [PhoneHeroFactToken] = []
         if detail.type == "episode",
            let airDate = DetailDateFormatting.abbreviatedDate(detail.airDate) {
@@ -75,7 +73,6 @@ enum PhoneHeroMetadata {
         if let imdb = detail.ratingImdb {
             tokens.append(.text(String(format: "★ %.1f", imdb)))
         }
-        tokens.append(contentsOf: qualityTokens(from: detail, version: selectedVersion))
         return tokens
     }
 
@@ -88,7 +85,6 @@ enum PhoneHeroMetadata {
         if let imdb = detail.ratingImdb {
             tokens.append(.text(String(format: "★ %.1f", imdb)))
         }
-        tokens.append(contentsOf: qualityTokens(from: detail))
         return tokens
     }
 
@@ -163,69 +159,6 @@ enum PhoneHeroMetadata {
         case "season": return "Season"
         default: return detail.type.capitalized
         }
-    }
-
-    private static func qualityTokens(from detail: ItemDetail, version selectedVersion: FileVersion? = nil) -> [PhoneHeroFactToken] {
-        guard let version = selectedVersion ?? preferredVersion(from: detail) else { return [] }
-        var tokens: [PhoneHeroFactToken] = []
-        if let res = resolutionLabel(version.resolution) { tokens.append(.chip(res)) }
-        if version.hdr == true {
-            tokens.append(.chip(dolbyVisionLabel(version: version) ?? "HDR"))
-        }
-        if let audio = primaryAudioLabel(version: version) { tokens.append(.chip(audio)) }
-        if hasSubtitles(version: version) { tokens.append(.chip("CC")) }
-        return tokens
-    }
-
-    private static func preferredVersion(from detail: ItemDetail) -> FileVersion? {
-        guard let versions = detail.versions, !versions.isEmpty else { return nil }
-        if let lastId = detail.userData?.lastFileId,
-           let lastVersion = versions.first(where: { $0.fileId == lastId }) {
-            return lastVersion
-        }
-        return versions.first
-    }
-
-    private static func resolutionLabel(_ raw: String?) -> String? {
-        guard let raw = raw?.lowercased() else { return nil }
-        if raw.contains("2160") || raw.contains("4k") { return "4K" }
-        if raw.contains("1080") { return "HD" }
-        if raw.contains("720") { return "HD" }
-        if raw.contains("480") { return "SD" }
-        return nil
-    }
-
-    private static func dolbyVisionLabel(version: FileVersion) -> String? {
-        let videoTracks = version.videoTracks ?? []
-        if videoTracks.contains(where: { ($0.dolbyVision ?? "").isEmpty == false }) {
-            return "DOLBY VISION"
-        }
-        return nil
-    }
-
-    private static func primaryAudioLabel(version: FileVersion) -> String? {
-        let tracks = version.audioTracks ?? []
-        let defaultTrack = tracks.first(where: { $0.isDefault == true }) ?? tracks.first
-        guard let track = defaultTrack else { return nil }
-
-        if let layout = track.channelLayout?.lowercased() {
-            if layout.contains("atmos") { return "ATMOS" }
-            if layout.contains("7.1") { return "7.1" }
-            if layout.contains("5.1") { return "5.1" }
-            if layout.contains("stereo") || layout == "2.0" { return nil }
-        }
-        if let channels = track.channels {
-            switch channels {
-            case 8: return "7.1"
-            case 6: return "5.1"
-            default: return nil
-            }
-        }
-        return nil
-    }
-
-    private static func hasSubtitles(version: FileVersion) -> Bool {
-        !(version.subtitleTracks ?? []).isEmpty
     }
 
     static func formatRuntime(_ minutes: Int) -> String {

--- a/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
+++ b/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
@@ -23,7 +23,7 @@ struct TVMarqueeContent: Equatable {
     /// Optional server logo art that may replace the text title once
     /// cached — the title always renders as text first.
     let logoUrl: String?
-    /// Codec/HDR + content-rating chips (`4K · DOLBY VISION · ATMOS · TV-MA`).
+    /// Editorial badge chips, currently the uppercased content rating.
     let badges: [String]
     /// Dot-joined meta tokens after the badges: year · genre · runtime,
     /// or `S2 E7 · episode title · 45 min · 23 min left` for episodes.
@@ -62,10 +62,9 @@ extension TVMarqueeContent {
             if let rating = item.ratingImdb { meta.append(String(format: "%.1f", rating)) }
         }
 
-        var badges = Self.badges(from: item.overlaySummary)
-        if let contentRating = Self.nonEmpty(item.contentRating) {
-            badges.append(contentRating.uppercased())
-        }
+        let badges = Self.nonEmpty(item.contentRating).map {
+            [$0.uppercased()]
+        } ?? []
 
         self.init(
             id: "\(rowTitle)#\(item.contentId)",
@@ -113,35 +112,6 @@ extension TVMarqueeContent {
 
     // MARK: Formatting
 
-    /// Badge chips from the section payload's `OverlaySummary` — the
-    /// marquee shows the headline trio (resolution, dynamic range,
-    /// audio), uppercased to the §4.1 badge style.
-    private static func badges(from summary: OverlaySummary?) -> [String] {
-        guard let summary else { return [] }
-        var badges: [String] = []
-        if let resolution = prettyResolution(summary.resolution) {
-            badges.append(resolution)
-        }
-        if let hdr = nonEmpty(summary.hdr) {
-            badges.append(hdr.localizedCaseInsensitiveContains("dv") || hdr.localizedCaseInsensitiveContains("dolby")
-                ? "DOLBY VISION"
-                : hdr.uppercased())
-        }
-        if let audio = nonEmpty(summary.audio) {
-            badges.append(audio.localizedCaseInsensitiveContains("atmos") ? "ATMOS" : audio.uppercased())
-        }
-        return badges
-    }
-
-    private static func prettyResolution(_ value: String?) -> String? {
-        guard let value = nonEmpty(value) else { return nil }
-        switch value.lowercased() {
-        case "2160p", "4k", "uhd": return "4K"
-        case "4320p", "8k": return "8K"
-        default: return value.uppercased()
-        }
-    }
-
     private static func episodeToken(season: Int?, episode: Int?) -> String? {
         switch (season, episode) {
         case let (season?, episode?): return "S\(season) E\(episode)"
@@ -188,11 +158,11 @@ extension TVMarqueeContent {
 
 // MARK: - Detail enrichment
 
-/// Fields the marquee wants but section payloads don't carry yet (§9:
-/// air date, cast) — backfilled from a cached, low-priority item-detail
-/// fetch that never blocks or delays the marquee itself.
+/// Air-date and artwork fields the marquee wants but section payloads
+/// don't carry yet (§9) — backfilled from a cached, low-priority
+/// item-detail fetch that never blocks or delays the marquee itself.
 struct TVMarqueeEnrichment: Equatable {
-    /// `Aired Mar 12, 2026 · Pedro Pascal, Bella Ramsey, Anna Torv`
+    /// `Aired Mar 12, 2026`
     let detailLine: String?
     /// The detail-level backdrop. For episodes this is the series backdrop —
     /// far higher-res than the episode still the section payload carries — so
@@ -203,19 +173,7 @@ struct TVMarqueeEnrichment: Equatable {
     init(detail: ItemDetail) {
         backdropUrl = detail.backdropUrl
         backdropThumbhash = detail.backdropThumbhash
-        var parts: [String] = []
-        if let airDate = Self.airDateText(detail.airDate) {
-            parts.append("Aired \(airDate)")
-        }
-        let cast = (detail.cast ?? [])
-            .sorted { ($0.order ?? Int.max) < ($1.order ?? Int.max) }
-            .prefix(3)
-            .map(\.name)
-            .filter { !$0.isEmpty }
-        if !cast.isEmpty {
-            parts.append(cast.joined(separator: ", "))
-        }
-        detailLine = parts.isEmpty ? nil : parts.joined(separator: " · ")
+        detailLine = Self.airDateText(detail.airDate).map { "Aired \($0)" }
     }
 
     /// Mirrors PlayerView's air-date formatting, with a date-only
@@ -243,7 +201,7 @@ final class TVFocusMarqueeModel {
     /// The rested, currently-displayed content. `nil` until the first
     /// row reports focus — the marquee region stays scrim-only (§8).
     private(set) var content: TVMarqueeContent?
-    /// Detail backfill (§9: air date, cast) for the displayed content.
+    /// Detail backfill (§9: air date and artwork) for the displayed content.
     /// Arrives after a low-priority fetch and fades in; `nil` until then.
     private(set) var enrichment: TVMarqueeEnrichment?
     /// Dominant-color wash behind the backdrop, sampled per displayed
@@ -307,8 +265,8 @@ final class TVFocusMarqueeModel {
         loadEnrichment(for: candidate)
     }
 
-    /// The §9 backfill: fields the section payload doesn't carry (air
-    /// date, cast) come from the item-detail endpoint after the marquee
+    /// The §9 backfill: air date and artwork fields the section payload
+    /// doesn't carry come from the item-detail endpoint after the marquee
     /// has already displayed — never blocking it, cached per item, and
     /// rate-limited by the rest debounce upstream.
     private func loadEnrichment(for candidate: TVMarqueeContent) {
@@ -568,7 +526,7 @@ private struct TVMarqueeBlock: View {
         return (titleWrapsTwoLines || logoImage != nil) ? min(cap, 2) : cap
     }
 
-    /// Air date + top-billed cast (§9 backfill). For any item that can
+    /// Air date (§9 backfill). For any item that can
     /// enrich (has a contentId) an invisible one-line sizer always holds the
     /// row's height, and the real line fades into an *overlay* on top of it.
     /// Because the overlay never contributes to layout, the bottom-anchored

--- a/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
+++ b/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
@@ -25,7 +25,7 @@ struct TVMarqueeContent: Equatable {
     let logoUrl: String?
     /// Editorial badge chips, currently the uppercased content rating.
     let badges: [String]
-    /// Dot-joined meta tokens after the badges: year · genre · runtime,
+    /// Dot-joined editorial tokens before the content-rating badge: year · runtime · IMDb · genres,
     /// or `S2 E7 · episode title · 45 min · 23 min left` for episodes.
     let metaParts: [String]
     let synopsis: String?
@@ -43,10 +43,16 @@ extension TVMarqueeContent {
 
         var meta: [String] = []
         if isEpisode {
-            if let token = Self.episodeToken(season: item.seasonNumber, episode: item.episodeNumber) {
+            if let token = HeroEditorialMetadata.episodeIdentity(
+                season: item.seasonNumber,
+                episode: item.episodeNumber,
+                style: .compact
+            ) {
                 meta.append(token)
             }
-            meta.append(item.title)
+            if let title = HeroEditorialMetadata.normalizedValue(item.title) {
+                meta.append(title)
+            }
             if let length = Self.lengthText(runtimeMinutes: item.runtime, durationSeconds: item.durationSeconds) {
                 meta.append(length)
             }
@@ -54,15 +60,18 @@ extension TVMarqueeContent {
                 meta.append(timeLeft)
             }
         } else {
-            if let year = item.year, year > 0 { meta.append(String(year)) }
-            if let genre = item.genres?.first(where: { !$0.isEmpty }) { meta.append(genre) }
-            if let length = Self.lengthText(runtimeMinutes: item.runtime, durationSeconds: item.durationSeconds) {
-                meta.append(length)
-            }
-            if let rating = item.ratingImdb { meta.append(String(format: "%.1f", rating)) }
+            meta = HeroEditorialMetadata.browseMetadataParts(
+                year: item.year,
+                runtime: Self.lengthText(
+                    runtimeMinutes: item.runtime,
+                    durationSeconds: item.durationSeconds
+                ),
+                imdbRating: item.ratingImdb,
+                genres: item.genres
+            )
         }
 
-        let badges = Self.nonEmpty(item.contentRating).map {
+        let badges = HeroEditorialMetadata.normalizedValue(item.contentRating).map {
             [$0.uppercased()]
         } ?? []
 
@@ -72,7 +81,9 @@ extension TVMarqueeContent {
             eyebrow: rowTitle,
             // Episodes headline with their series (`SEVERANCE`); the
             // episode itself moves to the meta line per §5.4.
-            title: isEpisode ? (item.seriesTitle ?? item.title) : item.title,
+            title: isEpisode
+                ? (HeroEditorialMetadata.normalizedValue(item.seriesTitle) ?? item.title)
+                : item.title,
             logoUrl: item.logoUrl,
             badges: badges,
             metaParts: meta,
@@ -111,15 +122,6 @@ extension TVMarqueeContent {
     }
 
     // MARK: Formatting
-
-    private static func episodeToken(season: Int?, episode: Int?) -> String? {
-        switch (season, episode) {
-        case let (season?, episode?): return "S\(season) E\(episode)"
-        case let (season?, nil): return "Season \(season)"
-        case let (nil, episode?): return "Episode \(episode)"
-        default: return nil
-        }
-    }
 
     /// `23 min left` for items with a live resume point, mirroring the
     /// progress rules MediaRow uses for its bars.
@@ -432,6 +434,7 @@ struct TVFocusMarquee: View {
         guard let content else { return "" }
         let parts = [content.eyebrow, content.title]
             + content.metaParts
+            + content.badges
             + [content.synopsis ?? "", enrichment?.detailLine ?? ""]
         return parts
             .filter { !$0.isEmpty }
@@ -584,15 +587,15 @@ private struct TVMarqueeBlock: View {
     private var metaLine: some View {
         if !content.badges.isEmpty || !content.metaParts.isEmpty {
             HStack(spacing: 10) {
-                ForEach(content.badges, id: \.self) { badge in
-                    badgeChip(badge)
-                }
-
                 if !content.metaParts.isEmpty {
                     Text(content.metaParts.joined(separator: " · "))
                         .font(.system(size: scale.metaSize, weight: .medium))
                         .foregroundStyle(Color.continuumSecondaryText)
                         .lineLimit(1)
+                }
+
+                ForEach(content.badges, id: \.self) { badge in
+                    badgeChip(badge)
                 }
             }
         }

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVDetailHero.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVDetailHero.swift
@@ -396,62 +396,38 @@ enum TVHeroMetadata {
     // Source row (type · genres)
 
     static func movieSourceTokens(from detail: ItemDetail) -> [String] {
-        if detail.type == "episode" {
+        if detail.type.lowercased() == "episode" {
             var tokens: [String] = []
-            if let label = episodeNumberLabel(from: detail) {
+            if let label = HeroEditorialMetadata.episodeIdentity(
+                season: detail.seasonNumber,
+                episode: detail.episodeNumber,
+                style: .detail
+            ) {
                 tokens.append(label)
             }
-            if let genres = detail.genres, !genres.isEmpty {
-                tokens.append(contentsOf: genres.prefix(1))
-            }
+            tokens.append(contentsOf: HeroEditorialMetadata.normalizedGenres(detail.genres, limit: 1))
             return tokens
         }
         var tokens: [String] = [typeLabel(detail: detail)]
-        if let genres = detail.genres, !genres.isEmpty {
-            tokens.append(contentsOf: genres.prefix(2))
-        }
+        tokens.append(contentsOf: HeroEditorialMetadata.normalizedGenres(detail.genres, limit: 2))
         return tokens
-    }
-
-    /// "Season 3 · Episode 8" (or "Specials · Episode 5" / "Episode 5")
-    /// for an episode `ItemDetail`.
-    private static func episodeNumberLabel(from detail: ItemDetail) -> String? {
-        let seasonPart: String?
-        if let season = detail.seasonNumber {
-            seasonPart = season == 0 ? "Specials" : "Season \(season)"
-        } else {
-            seasonPart = nil
-        }
-        let episodePart = detail.episodeNumber.flatMap { n in n > 0 ? "Episode \(n)" : nil }
-
-        switch (seasonPart, episodePart) {
-        case let (.some(s), .some(e)): return "\(s) \u{00B7} \(e)"
-        case let (.some(s), .none):    return s
-        case let (.none, .some(e)):    return e
-        case (.none, .none):           return nil
-        }
     }
 
     static func seriesSourceTokens(from detail: ItemDetail) -> [String] {
         var tokens: [String] = ["TV Show"]
-        if let genres = detail.genres, !genres.isEmpty {
-            tokens.append(contentsOf: genres.prefix(2))
-        }
+        tokens.append(contentsOf: HeroEditorialMetadata.normalizedGenres(detail.genres, limit: 2))
         return tokens
     }
 
     static func contentRatingChip(from detail: ItemDetail) -> String? {
-        guard let rating = detail.contentRating?
-            .trimmingCharacters(in: .whitespaces), !rating.isEmpty
-        else { return nil }
-        return rating
+        HeroEditorialMetadata.normalizedValue(detail.contentRating)
     }
 
     // Editorial facts line (year · runtime · rating)
 
     static func movieFactsLine(from detail: ItemDetail) -> [TVHeroFactToken] {
         var tokens: [TVHeroFactToken] = []
-        if detail.type == "episode",
+        if detail.type.lowercased() == "episode",
            let airDate = DetailDateFormatting.abbreviatedDate(detail.airDate) {
             tokens.append(.text(airDate))
         } else if let year = detail.year, year > 0 {
@@ -460,8 +436,8 @@ enum TVHeroMetadata {
         if let runtime = detail.runtime, runtime > 0 {
             tokens.append(.text(formatRuntime(runtime)))
         }
-        if let imdb = detail.ratingImdb {
-            tokens.append(.text(String(format: "★ %.1f", imdb)))
+        if let imdb = HeroEditorialMetadata.imdbRatingText(detail.ratingImdb) {
+            tokens.append(.text("★ \(imdb)"))
         }
         return tokens
     }
@@ -474,8 +450,8 @@ enum TVHeroMetadata {
         if let count = detail.seasonCount, count > 0 {
             tokens.append(.text("\(count) Season\(count == 1 ? "" : "s")"))
         }
-        if let imdb = detail.ratingImdb {
-            tokens.append(.text(String(format: "★ %.1f", imdb)))
+        if let imdb = HeroEditorialMetadata.imdbRatingText(detail.ratingImdb) {
+            tokens.append(.text("★ \(imdb)"))
         }
         return tokens
     }
@@ -483,15 +459,13 @@ enum TVHeroMetadata {
     // Eyebrow (short editorial line)
 
     static func eyebrow(from detail: ItemDetail) -> String? {
-        if detail.type == "episode" {
-            if let seriesTitle = detail.seriesTitle?.trimmingCharacters(in: .whitespaces),
-               !seriesTitle.isEmpty {
+        if detail.type.lowercased() == "episode" {
+            if let seriesTitle = HeroEditorialMetadata.normalizedValue(detail.seriesTitle) {
                 return seriesTitle
             }
         }
-        if let status = detail.status?.trimmingCharacters(in: .whitespaces),
-           !status.isEmpty,
-           detail.type == "series" {
+        if let status = HeroEditorialMetadata.normalizedValue(detail.status),
+           detail.type.lowercased() == "series" {
             switch status.lowercased() {
             case "continuing", "returning series", "returning":
                 return "Continuing Series"

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVDetailHero.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVDetailHero.swift
@@ -4,8 +4,7 @@ import SwiftUI
 /// Full-bleed cinematic hero for the tvOS item-detail screen. Modeled
 /// after Apple TV's detail page: a nearly full-viewport backdrop layered
 /// with a tall left-column editorial stack (eyebrow pill → title →
-/// source row → overview → facts+quality → actions) and a quiet
-/// right-side "Starring ..." line positioned mid-hero.
+/// source row → overview → facts → actions).
 ///
 /// The intent is to show enough of the below-fold rail peeking at the
 /// bottom that the viewer instinctively drifts down when they want
@@ -26,13 +25,8 @@ struct TVDetailHero<Actions: View, BelowSynopsis: View>: View {
     let ratingChip: String?
     /// Short description shown in the hero. Clamped to 3 lines.
     let overview: String?
-    /// Inline facts row shown above the action buttons. Mixes plain text
-    /// (year / runtime / maturity) and outlined quality chips
-    /// (4K / HDR / ATMOS / CC).
+    /// Inline editorial facts row shown above the action buttons.
     let factsLine: [TVHeroFactToken]
-    /// Optional "Starring A, B, C" line floated on the right of the hero
-    /// at mid-height. Hidden when nil.
-    let starringText: String?
     @ViewBuilder let actions: () -> Actions
     /// Affordance rendered directly under the synopsis (e.g. the on-view
     /// description-translation control). Pass `{ EmptyView() }` when there's
@@ -49,7 +43,6 @@ struct TVDetailHero<Actions: View, BelowSynopsis: View>: View {
             bottomFade
             content
         }
-        .overlay(alignment: .trailing) { starringOverlay }
         .frame(height: heroHeight)
         .frame(maxWidth: .infinity)
         .clipped()
@@ -195,7 +188,7 @@ struct TVDetailHero<Actions: View, BelowSynopsis: View>: View {
         }
     }
 
-    // MARK: - Facts + quality row
+    // MARK: - Editorial facts row
 
     @ViewBuilder
     private var factsRow: some View {
@@ -229,34 +222,6 @@ struct TVDetailHero<Actions: View, BelowSynopsis: View>: View {
                     .font(.system(size: 22, weight: .medium))
                     .foregroundColor(Color.white.opacity(0.88))
             }
-        case .chip(let value):
-            Text(value)
-                .font(.system(size: 16, weight: .heavy))
-                .tracking(1.0)
-                .foregroundColor(.white)
-                .padding(.horizontal, 9)
-                .padding(.vertical, 4)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 4)
-                        .stroke(Color.white.opacity(0.65), lineWidth: 1.2)
-                )
-        }
-    }
-
-    // MARK: - Starring overlay (right-aligned, vertical center)
-
-    @ViewBuilder
-    private var starringOverlay: some View {
-        if let starringText, !starringText.isEmpty {
-            Text(starringText)
-                .font(.system(size: 24, weight: .regular))
-                .foregroundColor(Color.white.opacity(0.8))
-                .multilineTextAlignment(.trailing)
-                .lineLimit(2)
-                .frame(maxWidth: 460, alignment: .trailing)
-                .shadow(color: .black.opacity(0.55), radius: 6, y: 2)
-                .padding(.trailing, ContinuumTheme.safePadding)
-                .padding(.bottom, heroHeight * 0.45)
         }
     }
 }
@@ -418,13 +383,11 @@ private struct TVHeroEyebrow: View {
 
 // MARK: - Tokens
 
-/// A token in the combined facts row. `.text` items get pipe separators
-/// between them; `.rating` renders a green check + maturity label;
-/// `.chip` renders an outlined pill (e.g. 4K / HDR / ATMOS).
+/// A token in the combined editorial facts row. `.text` items get
+/// separators; `.rating` retains the supported rating treatment.
 enum TVHeroFactToken: Hashable {
     case text(String)
     case rating(String)
-    case chip(String)
 }
 
 // MARK: - Metadata builders
@@ -484,9 +447,9 @@ enum TVHeroMetadata {
         return rating
     }
 
-    // Facts line (year · runtime · maturity · quality chips)
+    // Editorial facts line (year · runtime · rating)
 
-    static func movieFactsLine(from detail: ItemDetail, version selectedVersion: FileVersion? = nil) -> [TVHeroFactToken] {
+    static func movieFactsLine(from detail: ItemDetail) -> [TVHeroFactToken] {
         var tokens: [TVHeroFactToken] = []
         if detail.type == "episode",
            let airDate = DetailDateFormatting.abbreviatedDate(detail.airDate) {
@@ -500,7 +463,6 @@ enum TVHeroMetadata {
         if let imdb = detail.ratingImdb {
             tokens.append(.text(String(format: "★ %.1f", imdb)))
         }
-        tokens.append(contentsOf: qualityTokens(from: detail, version: selectedVersion))
         return tokens
     }
 
@@ -515,7 +477,6 @@ enum TVHeroMetadata {
         if let imdb = detail.ratingImdb {
             tokens.append(.text(String(format: "★ %.1f", imdb)))
         }
-        tokens.append(contentsOf: qualityTokens(from: detail))
         return tokens
     }
 
@@ -544,15 +505,6 @@ enum TVHeroMetadata {
         return nil
     }
 
-    // Starring (first 3 cast names)
-
-    static func starringText(from detail: ItemDetail) -> String? {
-        guard let cast = detail.cast, !cast.isEmpty else { return nil }
-        let names = cast.prefix(3).map(\.name)
-        guard !names.isEmpty else { return nil }
-        return "Starring " + names.joined(separator: ", ")
-    }
-
     // MARK: - Helpers
 
     private static func typeLabel(detail: ItemDetail) -> String {
@@ -562,75 +514,6 @@ enum TVHeroMetadata {
         case "episode": return "Episode"
         default: return detail.type.capitalized
         }
-    }
-
-    private static func qualityTokens(from detail: ItemDetail, version selectedVersion: FileVersion? = nil) -> [TVHeroFactToken] {
-        guard let version = selectedVersion ?? preferredVersion(from: detail) else { return [] }
-        var tokens: [TVHeroFactToken] = []
-        if let res = resolutionLabel(version.resolution) {
-            tokens.append(.chip(res))
-        }
-        if version.hdr == true {
-            tokens.append(.chip(dolbyVisionLabel(version: version) ?? "HDR"))
-        }
-        if let audio = primaryAudioLabel(version: version) {
-            tokens.append(.chip(audio))
-        }
-        if hasSubtitles(version: version) {
-            tokens.append(.chip("CC"))
-        }
-        return tokens
-    }
-
-    private static func preferredVersion(from detail: ItemDetail) -> FileVersion? {
-        guard let versions = detail.versions, !versions.isEmpty else { return nil }
-        if let lastId = detail.userData?.lastFileId,
-           let lastVersion = versions.first(where: { $0.fileId == lastId }) {
-            return lastVersion
-        }
-        return versions.first
-    }
-
-    private static func resolutionLabel(_ raw: String?) -> String? {
-        guard let raw = raw?.lowercased() else { return nil }
-        if raw.contains("2160") || raw.contains("4k") { return "4K" }
-        if raw.contains("1080") { return "HD" }
-        if raw.contains("720") { return "HD" }
-        if raw.contains("480") { return "SD" }
-        return nil
-    }
-
-    private static func dolbyVisionLabel(version: FileVersion) -> String? {
-        let videoTracks = version.videoTracks ?? []
-        if videoTracks.contains(where: { ($0.dolbyVision ?? "").isEmpty == false }) {
-            return "DOLBY VISION"
-        }
-        return nil
-    }
-
-    private static func primaryAudioLabel(version: FileVersion) -> String? {
-        let tracks = version.audioTracks ?? []
-        let defaultTrack = tracks.first(where: { $0.isDefault == true }) ?? tracks.first
-        guard let track = defaultTrack else { return nil }
-
-        if let layout = track.channelLayout?.lowercased() {
-            if layout.contains("atmos") { return "ATMOS" }
-            if layout.contains("7.1") { return "7.1" }
-            if layout.contains("5.1") { return "5.1" }
-            if layout.contains("stereo") || layout == "2.0" { return nil }
-        }
-        if let channels = track.channels {
-            switch channels {
-            case 8: return "7.1"
-            case 6: return "5.1"
-            default: return nil
-            }
-        }
-        return nil
-    }
-
-    private static func hasSubtitles(version: FileVersion) -> Bool {
-        !(version.subtitleTracks ?? []).isEmpty
     }
 
     private static func formatRuntime(_ minutes: Int) -> String {

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
@@ -88,8 +88,7 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
                         sourceTokens: TVHeroMetadata.movieSourceTokens(from: detail),
                         ratingChip: TVHeroMetadata.contentRatingChip(from: detail),
                         overview: detail.overview,
-                        factsLine: TVHeroMetadata.movieFactsLine(from: detail, version: currentVersion),
-                        starringText: TVHeroMetadata.starringText(from: detail),
+                        factsLine: TVHeroMetadata.movieFactsLine(from: detail),
                         actions: { actionColumn },
                         belowSynopsis: belowSynopsis
                     )

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
@@ -80,7 +80,6 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
                         ratingChip: nil,
                         overview: detail.overview,
                         factsLine: [],
-                        starringText: TVHeroMetadata.starringText(from: detail),
                         actions: { actionColumn },
                         belowSynopsis: belowSynopsis
                     )

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
@@ -277,9 +277,7 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
         } else if !episodes.isEmpty {
             tokens.append("\(episodes.count) Episode\(episodes.count == 1 ? "" : "s")")
         }
-        if let genres = detail.genres, !genres.isEmpty {
-            tokens.append(contentsOf: genres.prefix(2))
-        }
+        tokens.append(contentsOf: HeroEditorialMetadata.normalizedGenres(detail.genres, limit: 2))
         return tokens
     }
 

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -134,7 +134,6 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
             ratingChip: TVHeroMetadata.contentRatingChip(from: detail),
             overview: detail.overview,
             factsLine: TVHeroMetadata.seriesFactsLine(from: detail),
-            starringText: TVHeroMetadata.starringText(from: detail),
             actions: { actionColumn },
             belowSynopsis: belowSynopsis
         )


### PR DESCRIPTION
## Summary
- keep iOS/macOS and tvOS detail hero facts editorial by removing hard-coded technical quality tokens
- normalize shared IMDb ratings, genres, content ratings, and episode identity before display
- keep the tvOS Home/library marquee in the intended editorial order with up to two genres
- preserve technical playback selectors, episode backdrop enrichment, cast rails, configurable overlays, and content-rating badges
- include the tvOS marquee content rating in its VoiceOver description

## Verification
- focused `HeroEditorialMetadataTests`: 7 passed, 0 failed
- full `SiloTests` on the PR: 1,267 passed, 8 failed
- untouched `main` on the same iPhone 17 Pro simulator immediately afterward: 1,260 passed, the exact same 8 tests failed
- unsigned iOS simulator build passed
- unsigned tvOS simulator build passed
- unsigned macOS build passed
- signed authenticated iOS simulator side-by-side smoke passed

The eight full-suite failures reproduce on untouched `main` and are not introduced by this PR:
- `PlayerSettingsFlushTests`: 4 failures
- `ProfileAndQualitySettingsTests`: 2 failures
- `UICustomizationPreferencesTests`: 2 failures

## Review corrections completed
- corrected marquee ordering and added two-genre support
- added shared normalization for IMDb, genres, content ratings, and episode identity
- filtered non-finite, non-positive, and out-of-range IMDb values
- added the marquee content-rating badge to VoiceOver output
- expanded regression coverage for movie, series, episode, normalization, priority, and technical-selector preservation

## Simulator result
- `main` hero facts: `2016 · 1h 44m · 4K · DOLBY VISION · 7.1 · CC`
- PR hero facts: `2016 · 1h 44m`
- both builds retain `Version: 2160p · HEVC · DV · TrueHD`, `Audio: English · TrueHD · 7.1`, and `Subtitles: Auto`

## Remaining coverage
- authenticated tvOS visual smoke was not rerun after the final remediation
- downloaded-state styling was not independently exercised
- exact episode-enrichment fetch timing was not instrumented


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Hero sections now present cleaner, editorial metadata across iOS, macOS, and tvOS.
  - Improved formatting for ratings, genres, content ratings, runtimes, and episode identities.
  - tvOS hero badges now focus on content ratings, with episode air dates retained.

- **Bug Fixes**
  - Removed technical file details, quality indicators, and duplicate cast overlays from hero surfaces.
  - Added validation and fallback handling for missing or invalid metadata.
  - Added regression coverage for movie, series, and episode metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->