### PR TITLE
fix(player): stop the tvOS resumable-stream cancellation storm

### DIFF
--- a/iosApp/Tests/PlaybackOriginStreamPolicyTests.swift
+++ b/iosApp/Tests/PlaybackOriginStreamPolicyTests.swift
@@ -206,6 +206,33 @@ final class PlaybackOriginDetachGraceTests: XCTestCase {
         XCTAssertLessThanOrEqual(grace, PlaybackOriginStreamPolicy.detachGraceCeilingSeconds)
     }
 
+    func testSlowPlaybackRateStretchesTheGrace() {
+        // At 0.75x the 19.4 Mbps title drains 64 MiB in ~36.9s, past the
+        // 1x grace — the rate must scale the drain estimate.
+        let gap: Int64 = 64 * 1024 * 1024
+        let slowDrain = Double(gap) * 8.0 / (19_400_000 * 0.75)
+        let grace = PlaybackOriginStreamPolicy.detachGraceSeconds(
+            hysteresisGapBytes: gap,
+            sourceBitrateBps: 19_400_000,
+            playbackRate: 0.75
+        )
+        XCTAssertGreaterThan(grace, slowDrain)
+        XCTAssertLessThanOrEqual(grace, PlaybackOriginStreamPolicy.detachGraceCeilingSeconds)
+        // Zero/negative rates (paused, backends reporting 0) fall back to 1x
+        // instead of producing an infinite drain.
+        XCTAssertEqual(
+            PlaybackOriginStreamPolicy.detachGraceSeconds(
+                hysteresisGapBytes: gap,
+                sourceBitrateBps: 19_400_000,
+                playbackRate: 0
+            ),
+            PlaybackOriginStreamPolicy.detachGraceSeconds(
+                hysteresisGapBytes: gap,
+                sourceBitrateBps: 19_400_000
+            )
+        )
+    }
+
     func testVerySlowSourceClampsToProxySafeCeiling() {
         // 4 Mbps would drain 64 MiB in ~134s; the grace must still close
         // the connection before reverse-proxy client-send timeouts reap it.

--- a/iosApp/Tests/PlaybackOriginStreamPolicyTests.swift
+++ b/iosApp/Tests/PlaybackOriginStreamPolicyTests.swift
@@ -122,6 +122,103 @@ final class PlaybackOriginRoutingPolicyTests: XCTestCase {
     }
 }
 
+final class PlaybackWindowClaimPolicyTests: XCTestCase {
+
+    private let owner = UUID()
+    private let rival = UUID()
+
+    func testUnownedWindowGrantsAnyClaim() {
+        XCTAssertEqual(
+            PlaybackWindowClaimPolicy.arbitrate(claimant: rival, owner: nil, ownerIsAlive: false),
+            .retarget
+        )
+        XCTAssertEqual(
+            PlaybackWindowClaimPolicy.arbitrate(claimant: nil, owner: nil, ownerIsAlive: false),
+            .retarget
+        )
+    }
+
+    func testOwnerReclaimsItsOwnWindow() {
+        XCTAssertEqual(
+            PlaybackWindowClaimPolicy.arbitrate(claimant: owner, owner: owner, ownerIsAlive: true),
+            .retarget
+        )
+    }
+
+    func testRivalCannotStealLiveOwnersWindow() {
+        // The 2026-07 tvOS storm: two full-rate readers alternately
+        // retargeting the window, cancelling each other's origin connection
+        // every 1-2s. The rival must be served by a chunk instead.
+        XCTAssertEqual(
+            PlaybackWindowClaimPolicy.arbitrate(claimant: rival, owner: owner, ownerIsAlive: true),
+            .chunk
+        )
+        XCTAssertEqual(
+            PlaybackWindowClaimPolicy.arbitrate(claimant: nil, owner: owner, ownerIsAlive: true),
+            .chunk
+        )
+    }
+
+    func testDeadOwnerFreesTheWindow() {
+        // A seek closes the old serve connection and opens a new one; the
+        // new consumer must be able to re-anchor immediately.
+        XCTAssertEqual(
+            PlaybackWindowClaimPolicy.arbitrate(claimant: rival, owner: owner, ownerIsAlive: false),
+            .retarget
+        )
+    }
+}
+
+final class PlaybackOriginDetachGraceTests: XCTestCase {
+
+    func testUnknownBitrateFallsBackToFixedGrace() {
+        XCTAssertEqual(
+            PlaybackOriginStreamPolicy.detachGraceSeconds(
+                hysteresisGapBytes: 64 * 1024 * 1024,
+                sourceBitrateBps: nil
+            ),
+            PlaybackOriginStreamPolicy.detachAfterSeconds
+        )
+    }
+
+    func testFastSourceKeepsFloorGrace() {
+        // 80 Mbps drains 64 MiB in ~6.7s; grace stays at the floor.
+        XCTAssertEqual(
+            PlaybackOriginStreamPolicy.detachGraceSeconds(
+                hysteresisGapBytes: 64 * 1024 * 1024,
+                sourceBitrateBps: 80_000_000
+            ),
+            PlaybackOriginStreamPolicy.detachAfterSeconds
+        )
+    }
+
+    func testMastersBitrateOutlivesTheDrain() {
+        // The regression file: 19.4 Mbps drains the 64 MiB gap in ~27.7s,
+        // past the fixed 25s grace. The adaptive grace must cover the drain
+        // plus margin so demand resumes the parked task instead of paying a
+        // detach + reconnect every cycle.
+        let drain = Double(64 * 1024 * 1024) * 8.0 / 19_400_000
+        let grace = PlaybackOriginStreamPolicy.detachGraceSeconds(
+            hysteresisGapBytes: 64 * 1024 * 1024,
+            sourceBitrateBps: 19_400_000
+        )
+        XCTAssertGreaterThan(grace, drain)
+        XCTAssertLessThanOrEqual(grace, PlaybackOriginStreamPolicy.detachGraceCeilingSeconds)
+    }
+
+    func testVerySlowSourceClampsToProxySafeCeiling() {
+        // 4 Mbps would drain 64 MiB in ~134s; the grace must still close
+        // the connection before reverse-proxy client-send timeouts reap it.
+        XCTAssertEqual(
+            PlaybackOriginStreamPolicy.detachGraceSeconds(
+                hysteresisGapBytes: 64 * 1024 * 1024,
+                sourceBitrateBps: 4_000_000
+            ),
+            PlaybackOriginStreamPolicy.detachGraceCeilingSeconds
+        )
+    }
+}
+
 final class PlaybackOriginStreamPolicyTests: XCTestCase {
 
     func testWindowPausesOnlyOnGlobalBudget() {

--- a/iosApp/iosApp/Screens/Player/PlaybackSourceOriginStream.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSourceOriginStream.swift
@@ -54,6 +54,32 @@ enum PlaybackOriginRoutingPolicy {
     }
 }
 
+/// Who may re-anchor the streaming window when a qualified (≥
+/// `windowClaimBytes`) demand misses. Two concurrent long-lived readers —
+/// e.g. the demuxer's video read plus a second full-rate audio/extractor
+/// read — can BOTH pass the claim threshold; letting each steal the window
+/// on every miss produced a retarget storm (production tvOS logs,
+/// 2026-07-29: an origin cancel + fresh range request every 1–2 s, each
+/// discarding 10–30 MB of delivered bytes). The window belongs to one serve
+/// connection at a time; a contested claim is served by a discrete chunk,
+/// which never disturbs the window. Ownership frees when the owning serve
+/// connection ends, so an ordinary seek (close + new connection) still
+/// re-anchors immediately.
+enum PlaybackWindowClaimPolicy {
+    enum Verdict: Equatable {
+        /// The claimant may re-anchor (or spawn) the window.
+        case retarget
+        /// A live owner holds the window; serve this demand with a chunk.
+        case chunk
+    }
+
+    static func arbitrate(claimant: UUID?, owner: UUID?, ownerIsAlive: Bool) -> Verdict {
+        guard let owner, ownerIsAlive else { return .retarget }
+        guard let claimant else { return .chunk }
+        return claimant == owner ? .retarget : .chunk
+    }
+}
+
 /// Pause/backpressure decisions for the window stream plus its snapshot
 /// type. (Routing across multiple streams lived here before the
 /// window+chunk split — see `PlaybackOriginRoutingPolicy`.)
@@ -62,6 +88,31 @@ enum PlaybackOriginStreamPolicy {
     /// closes before ordinary reverse-proxy client-send timeouts can reap it.
     /// `var` so tests can drive the lifecycle without wall-clock waits.
     static var detachAfterSeconds: TimeInterval = 25
+    /// Upper bound for the adaptive grace below: parked connections must
+    /// still close before common reverse-proxy client-send timeouts (60 s)
+    /// can reap them mid-park.
+    static var detachGraceCeilingSeconds: TimeInterval = 45
+    /// Headroom added to the computed drain time so the low-water resume
+    /// always lands before the detach timer, not in a race with it.
+    static let detachDrainMarginSeconds: TimeInterval = 5
+
+    /// Grace before a budget-parked stream detaches, sized to the cache
+    /// hysteresis drain time when the source bitrate is known. The fixed
+    /// 25 s grace detached ~2.7 s BEFORE the low-water resume for a
+    /// 19.4 Mbps source draining the 64 MiB hysteresis gap (~27.7 s), so
+    /// every park cycle paid a full reconnect instead of a task resume —
+    /// and every title under ~21.5 Mbps hit the same cliff.
+    static func detachGraceSeconds(
+        hysteresisGapBytes: Int64,
+        sourceBitrateBps: Double?
+    ) -> TimeInterval {
+        guard let bps = sourceBitrateBps, bps > 0, hysteresisGapBytes > 0 else {
+            return detachAfterSeconds
+        }
+        let drainSeconds = Double(hysteresisGapBytes) * 8.0 / bps
+        let ceiling = max(detachAfterSeconds, detachGraceCeilingSeconds)
+        return min(max(drainSeconds + detachDrainMarginSeconds, detachAfterSeconds), ceiling)
+    }
 
     /// The window's fetch region: where it started and how far it has
     /// filled. All the state the routing and hint paths need.
@@ -266,6 +317,10 @@ final class PlaybackOriginStream {
     private let callbacks: Callbacks
     private let resumeCapable: Bool
     private let clock: PlaybackOriginStreamClock
+    /// Grace before a park becomes a detach. Supplied by the owner when it
+    /// can size the grace to the cache drain time; nil falls back to the
+    /// fixed `PlaybackOriginStreamPolicy.detachAfterSeconds`.
+    private let detachGraceSecondsProvider: (() -> TimeInterval)?
 
     private let lock = NSLock()
     private var generation: UInt64 = 0
@@ -314,7 +369,8 @@ final class PlaybackOriginStream {
         resumeCapable: Bool = false,
         initialEntityETag: String? = nil,
         initialResponseRequiresEntityValidation: Bool = false,
-        clock: PlaybackOriginStreamClock = SystemPlaybackOriginStreamClock()
+        clock: PlaybackOriginStreamClock = SystemPlaybackOriginStreamClock(),
+        detachGraceSecondsProvider: (() -> TimeInterval)? = nil
     ) {
         self.originURL = originURL
         self.originHeaders = originHeaders
@@ -328,6 +384,7 @@ final class PlaybackOriginStream {
         self.entityETag = initialEntityETag
         self.initialResponseRequiresEntityValidation = initialResponseRequiresEntityValidation
         self.clock = clock
+        self.detachGraceSecondsProvider = detachGraceSecondsProvider
         self.lastDataAt = clock.now()
     }
 
@@ -597,6 +654,7 @@ final class PlaybackOriginStream {
 
     private func detachIfParkedPastGrace() {
         let now = clock.now()
+        let grace = detachGraceSecondsProvider?() ?? PlaybackOriginStreamPolicy.detachAfterSeconds
         lock.lock()
         guard resumeCapable,
               parked,
@@ -604,7 +662,7 @@ final class PlaybackOriginStream {
               !cancelled,
               !finished,
               let parkedAt,
-              now.timeIntervalSince(parkedAt) >= PlaybackOriginStreamPolicy.detachAfterSeconds,
+              now.timeIntervalSince(parkedAt) >= grace,
               let oldTask = task,
               let oldTaskID = currentTaskID else {
             lock.unlock()

--- a/iosApp/iosApp/Screens/Player/PlaybackSourceOriginStream.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSourceOriginStream.swift
@@ -101,15 +101,20 @@ enum PlaybackOriginStreamPolicy {
     /// 25 s grace detached ~2.7 s BEFORE the low-water resume for a
     /// 19.4 Mbps source draining the 64 MiB hysteresis gap (~27.7 s), so
     /// every park cycle paid a full reconnect instead of a task resume —
-    /// and every title under ~21.5 Mbps hit the same cliff.
+    /// and every title under ~21.5 Mbps hit the same cliff. The cache
+    /// drains at the CONSUMPTION rate, not the nominal file rate: slow-speed
+    /// playback (0.75×) stretches the drain proportionally, so the grace
+    /// scales by `playbackRate` (non-positive/unknown rates fall back to 1×).
     static func detachGraceSeconds(
         hysteresisGapBytes: Int64,
-        sourceBitrateBps: Double?
+        sourceBitrateBps: Double?,
+        playbackRate: Double = 1.0
     ) -> TimeInterval {
         guard let bps = sourceBitrateBps, bps > 0, hysteresisGapBytes > 0 else {
             return detachAfterSeconds
         }
-        let drainSeconds = Double(hysteresisGapBytes) * 8.0 / bps
+        let rate = playbackRate > 0 ? playbackRate : 1.0
+        let drainSeconds = Double(hysteresisGapBytes) * 8.0 / (bps * rate)
         let ceiling = max(detachAfterSeconds, detachGraceCeilingSeconds)
         return min(max(drainSeconds + detachDrainMarginSeconds, detachAfterSeconds), ceiling)
     }

--- a/iosApp/iosApp/Screens/Player/PlaybackSourceProxy.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSourceProxy.swift
@@ -264,6 +264,19 @@ final class PlaybackSourceCache {
         return lastReadEnd == nil ? Int64(cachedBytes) : forwardCachedBytesLocked()
     }
 
+    /// Bytes consumption must drain between the park (high water) and the
+    /// prefetch re-arm (low water) — the interval a parked origin stream
+    /// waits before demand resumes it.
+    var hysteresisGapBytes: Int64 {
+        Int64(highWaterBytes - lowWaterBytes)
+    }
+
+    func currentSourceBitrateBps() -> Double? {
+        lock.lock()
+        defer { lock.unlock() }
+        return sourceBitrateBps
+    }
+
     func setTotalLength(_ length: Int64?) {
         guard let length, length > 0 else { return }
         lock.lock()
@@ -718,6 +731,16 @@ private final class PlaybackSourceResource {
     /// completion fires. Guarded by `stateLock`.
     private var serveTasks: [UUID: Task<Void, Never>] = [:]
     private var completedServeTaskIDs: Set<UUID> = []
+    /// Serve connections currently inside their response loop, keyed by the
+    /// same id as `serveTasks`. Inserted before the task body can run so
+    /// window-claim arbitration always sees a live claimant.
+    private var activeServeIDs: Set<UUID> = []
+    /// The serve connection that last re-anchored (or spawned) the streaming
+    /// window. While it is alive, other serve connections' qualified misses
+    /// are served by chunks instead of stealing the window
+    /// (`PlaybackWindowClaimPolicy`) — the fix for the 2026-07 tvOS
+    /// cancellation/range-request storm.
+    private var windowOwnerServeID: UUID?
 
     init(
         originURL: URL,
@@ -975,12 +998,15 @@ private final class PlaybackSourceResource {
             return
         }
         let id = UUID()
+        stateLock.lock()
+        activeServeIDs.insert(id)
+        stateLock.unlock()
         let task = Task.detached(priority: .userInitiated) { [weak self, weak connection] in
             if let self, let connection {
                 if method == "HEAD" {
                     await self.respondHead(on: connection)
                 } else {
-                    await self.respondGet(rangeHeader: rangeHeader, on: connection)
+                    await self.respondGet(rangeHeader: rangeHeader, on: connection, serveID: id)
                 }
             }
             self?.serveTaskFinished(id)
@@ -1009,6 +1035,10 @@ private final class PlaybackSourceResource {
 
     private func serveTaskFinished(_ id: UUID) {
         stateLock.lock()
+        activeServeIDs.remove(id)
+        if windowOwnerServeID == id {
+            windowOwnerServeID = nil
+        }
         if serveTasks.removeValue(forKey: id) == nil,
            !cancelled,
            !sourceEntityInvalidated {
@@ -1029,7 +1059,11 @@ private final class PlaybackSourceResource {
         _ = await send(Data(header.utf8), on: connection, close: true)
     }
 
-    private func respondGet(rangeHeader: String?, on connection: NWConnection) async {
+    private func respondGet(
+        rangeHeader: String?,
+        on connection: NWConnection,
+        serveID: UUID
+    ) async {
         let request = PlaybackSourceRangeRequest.parse(rangeHeader)
         let total = await awaitTotalLength(hint: request.start)
         let resolved = resolveRequest(request, totalLength: total)
@@ -1092,7 +1126,11 @@ private final class PlaybackSourceResource {
                 continue
             }
             cache.recordCacheMiss(byteCount: Int64(max(1, sendLength)))
-            switch await awaitData(at: cursor, servedSequentialBytes: cursor - resolved.start) {
+            switch await awaitData(
+                at: cursor,
+                servedSequentialBytes: cursor - resolved.start,
+                serveID: serveID
+            ) {
             case .available:
                 continue
             case .eof:
@@ -1171,7 +1209,11 @@ private final class PlaybackSourceResource {
     /// has already streamed enough to prove it is the playback reader), or
     /// fetch a discrete chunk for everything else so probes never disturb
     /// the warm window connection.
-    private func routeMiss(for offset: Int64, servedSequentialBytes: Int64) {
+    private func routeMiss(
+        for offset: Int64,
+        servedSequentialBytes: Int64,
+        serveID: UUID? = nil
+    ) {
         var toStart: PlaybackOriginStream?
         var toNote: PlaybackOriginStream?
         var toRetarget: PlaybackOriginStream?
@@ -1200,17 +1242,32 @@ private final class PlaybackSourceResource {
         case .rideWindow:
             toNote = windowStream
         case .claimWindow:
-            if let window = windowStream {
-                toRetarget = window
-            } else {
-                let stream = makeStream(startOffset: offset, order: order)
-                windowStream = stream
-                // Pair the gauge while still holding the lock: stop()
-                // snapshots the window and ends its request, so begin must
-                // not trail publication or a racing stop leaves the count
-                // stranded.
-                cache.beginOriginRequest()
-                toStart = stream
+            let ownerIsAlive = windowOwnerServeID.map { activeServeIDs.contains($0) } ?? false
+            switch PlaybackWindowClaimPolicy.arbitrate(
+                claimant: serveID,
+                owner: windowOwnerServeID,
+                ownerIsAlive: ownerIsAlive
+            ) {
+            case .retarget:
+                windowOwnerServeID = serveID
+                if let window = windowStream {
+                    toRetarget = window
+                } else {
+                    let stream = makeStream(startOffset: offset, order: order)
+                    windowStream = stream
+                    // Pair the gauge while still holding the lock: stop()
+                    // snapshots the window and ends its request, so begin must
+                    // not trail publication or a racing stop leaves the count
+                    // stranded.
+                    cache.beginOriginRequest()
+                    toStart = stream
+                }
+            case .chunk:
+                Self.logger.info(
+                    "[CMP-SOURCE-CACHE] window claim contested offset=\(offset, privacy: .public) served=\(servedSequentialBytes, privacy: .public) routed=chunk"
+                )
+                chunk = true
+                deferChunkUntilEntityKnown = resumeCapable && sourceEntityETag == nil
             }
         case .chunk:
             chunk = true
@@ -1379,6 +1436,7 @@ private final class PlaybackSourceResource {
     /// toward data we already have.
     private func noteDemandHint(at offset: Int64) {
         var toNote: PlaybackOriginStream?
+        var toNudge: PlaybackOriginStream?
         var order: UInt64 = 0
         stateLock.lock()
         guard !cancelled, !sourceEntityInvalidated else {
@@ -1392,10 +1450,19 @@ private final class PlaybackSourceResource {
             if offset >= snapshot.startOffset,
                offset <= snapshot.writeCursor + PlaybackOriginRoutingPolicy.rideThroughBytes {
                 toNote = window
+            } else {
+                // The read is outside the window's region (e.g. the window
+                // was re-anchored ahead by a seek while this consumer still
+                // drains behind it). Its consumption still frees the global
+                // budget, so a parked/detached window must re-check the
+                // low-water re-arm here — a cache miss when playback is
+                // already starved must not be the only wake-up.
+                toNudge = window
             }
         }
         stateLock.unlock()
         toNote?.noteDemand(offset: offset, order: order)
+        toNudge?.resumeFillingIfNeeded()
     }
 
     /// Suspend the serve loop until the byte at `offset` is cached, the file
@@ -1403,7 +1470,11 @@ private final class PlaybackSourceResource {
     /// `servedSequentialBytes` is how much this serve connection has already
     /// delivered sequentially — the signal that separates the playback
     /// reader (which may re-anchor the window) from short-lived probes.
-    private func awaitData(at offset: Int64, servedSequentialBytes: Int64) async -> WaitOutcome {
+    private func awaitData(
+        at offset: Int64,
+        servedSequentialBytes: Int64,
+        serveID: UUID? = nil
+    ) async -> WaitOutcome {
         let state = currentState()
         if state.cancelled || state.sourceEntityInvalidated { return .failed }
         if let total = state.total, offset >= total { return .eof }
@@ -1421,7 +1492,11 @@ private final class PlaybackSourceResource {
                 // Route the demand only after the waiter is registered, so a
                 // fetch give-up can never fire between routing and
                 // registration and leave this waiter stranded.
-                routeMiss(for: offset, servedSequentialBytes: servedSequentialBytes)
+                routeMiss(
+                    for: offset,
+                    servedSequentialBytes: servedSequentialBytes,
+                    serveID: serveID
+                )
                 // The bytes may also have landed between the cache miss and
                 // the registration above; re-check so the waiter can't sleep
                 // through its own wake-up.
@@ -1536,7 +1611,16 @@ private final class PlaybackSourceResource {
             resumeCapable: resumeCapable,
             initialEntityETag: resumeCapable ? sourceEntityETag : nil,
             initialResponseRequiresEntityValidation: resumeCapable && sawOriginResponse,
-            clock: originStreamClock
+            clock: originStreamClock,
+            detachGraceSecondsProvider: { [weak cache] in
+                guard let cache else {
+                    return PlaybackOriginStreamPolicy.detachAfterSeconds
+                }
+                return PlaybackOriginStreamPolicy.detachGraceSeconds(
+                    hysteresisGapBytes: cache.hysteresisGapBytes,
+                    sourceBitrateBps: cache.currentSourceBitrateBps()
+                )
+            }
         )
     }
 

--- a/iosApp/iosApp/Screens/Player/PlaybackSourceProxy.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSourceProxy.swift
@@ -239,9 +239,15 @@ final class PlaybackSourceCache {
     var shouldPrefetch: Bool {
         var didRearm = false
         lock.lock()
-        let cachedAhead = lastReadEnd == nil
+        // Anchor at the actual recent read position, like disk eviction does:
+        // monotonic `lastReadEnd` stays pinned ahead after a backward seek, so
+        // a consumer draining behind it would never shrink the forward count
+        // and the low-water re-arm would only fire on a cache miss — when
+        // playback is already starved.
+        let anchor = lastReadPosition ?? lastReadEnd
+        let cachedAhead = anchor == nil
             ? Int64(cachedBytes)
-            : forwardCachedBytesLocked()
+            : forwardCachedBytesLocked(from: anchor! + 1)
         if prefetchArmed, cachedAhead >= Int64(highWaterBytes) {
             prefetchArmed = false
         } else if !prefetchArmed, cachedAhead <= Int64(lowWaterBytes) {
@@ -582,7 +588,11 @@ final class PlaybackSourceCache {
 
     private func forwardCachedBytesLocked() -> Int64 {
         guard let readEnd = lastReadEnd else { return 0 }
-        var cursor = readEnd + 1
+        return forwardCachedBytesLocked(from: readEnd + 1)
+    }
+
+    private func forwardCachedBytesLocked(from start: Int64) -> Int64 {
+        var cursor = start
         var bytes: Int64 = 0
         for range in cachedRangesLocked() {
             if range.upperBound < cursor { continue }
@@ -721,6 +731,10 @@ private final class PlaybackSourceResource {
     private var windowStream: PlaybackOriginStream?
     private var chunkFetcher: PlaybackOriginChunkFetcher?
     private var demandCounter: UInt64 = 0
+    /// Current playback rate (1.0 = normal). Cache drain time — and thus the
+    /// adaptive detach grace — scales with consumption speed, not the file's
+    /// nominal bitrate. Guarded by `stateLock`.
+    private var playbackRate: Double = 1.0
     private var dataWaiters: [UUID: (offset: Int64, continuation: CheckedContinuation<WaitOutcome, Never>)] = [:]
     private var totalWaiters: [UUID: CheckedContinuation<Int64?, Never>] = [:]
     /// Detached serve tasks hold strong `self` for their whole body, so an
@@ -735,6 +749,11 @@ private final class PlaybackSourceResource {
     /// same id as `serveTasks`. Inserted before the task body can run so
     /// window-claim arbitration always sees a live claimant.
     private var activeServeIDs: Set<UUID> = []
+    /// Serve id per client socket, so a peer disconnect can cancel the serve
+    /// task immediately. Without this, a task suspended in `awaitData` when
+    /// its client vanished would stay "alive" — and keep window ownership —
+    /// until origin bytes arrived and the send failed.
+    private var serveIDsByConnection: [ObjectIdentifier: UUID] = [:]
     /// The serve connection that last re-anchored (or spawned) the streaming
     /// window. While it is alive, other serve connections' qualified misses
     /// are served by chunks instead of stealing the window
@@ -789,6 +808,9 @@ private final class PlaybackSourceResource {
         let serving = serveTasks
         serveTasks.removeAll()
         completedServeTaskIDs.removeAll()
+        activeServeIDs.removeAll()
+        serveIDsByConnection.removeAll()
+        windowOwnerServeID = nil
         stateLock.unlock()
         probeToCancel?.cancel()
         if let windowToCancel {
@@ -825,6 +847,7 @@ private final class PlaybackSourceResource {
         originHeaders = headers
         windowToCancel = windowStream
         windowStream = nil
+        windowOwnerServeID = nil
         fetcherToCancel = chunkFetcher
         chunkFetcher = nil
         // A renewed session resolves any outage the dead session caused;
@@ -989,6 +1012,18 @@ private final class PlaybackSourceResource {
         Self.logger.info("[CMP-SOURCE-CACHE] source bitrate=\(bps ?? 0, privacy: .public)")
     }
 
+    func setPlaybackRate(_ rate: Double) {
+        stateLock.lock()
+        playbackRate = rate
+        stateLock.unlock()
+    }
+
+    private func currentPlaybackRate() -> Double {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return playbackRate
+    }
+
     func handle(method: String, rangeHeader: String?, on connection: NWConnection) {
         stateLock.lock()
         let alreadyStopped = cancelled || sourceEntityInvalidated
@@ -1000,6 +1035,7 @@ private final class PlaybackSourceResource {
         let id = UUID()
         stateLock.lock()
         activeServeIDs.insert(id)
+        serveIDsByConnection[ObjectIdentifier(connection)] = id
         stateLock.unlock()
         let task = Task.detached(priority: .userInitiated) { [weak self, weak connection] in
             if let self, let connection {
@@ -1039,12 +1075,29 @@ private final class PlaybackSourceResource {
         if windowOwnerServeID == id {
             windowOwnerServeID = nil
         }
+        if let key = serveIDsByConnection.first(where: { $0.value == id })?.key {
+            serveIDsByConnection.removeValue(forKey: key)
+        }
         if serveTasks.removeValue(forKey: id) == nil,
            !cancelled,
            !sourceEntityInvalidated {
             completedServeTaskIDs.insert(id)
         }
         stateLock.unlock()
+    }
+
+    /// The client socket died (peer closed, reset). Cancel the serve task now
+    /// so its `awaitData` unwinds and `serveTaskFinished` releases window
+    /// ownership — a dead client must not hold the window against a live
+    /// replacement request (e.g. the demuxer reopening after a seek).
+    func connectionClosed(key: ObjectIdentifier) {
+        var toCancel: Task<Void, Never>?
+        stateLock.lock()
+        if let id = serveIDsByConnection.removeValue(forKey: key) {
+            toCancel = serveTasks[id]
+        }
+        stateLock.unlock()
+        toCancel?.cancel()
     }
 
     private func respondHead(on connection: NWConnection) async {
@@ -1612,13 +1665,14 @@ private final class PlaybackSourceResource {
             initialEntityETag: resumeCapable ? sourceEntityETag : nil,
             initialResponseRequiresEntityValidation: resumeCapable && sawOriginResponse,
             clock: originStreamClock,
-            detachGraceSecondsProvider: { [weak cache] in
-                guard let cache else {
+            detachGraceSecondsProvider: { [weak self] in
+                guard let self else {
                     return PlaybackOriginStreamPolicy.detachAfterSeconds
                 }
                 return PlaybackOriginStreamPolicy.detachGraceSeconds(
-                    hysteresisGapBytes: cache.hysteresisGapBytes,
-                    sourceBitrateBps: cache.currentSourceBitrateBps()
+                    hysteresisGapBytes: self.cache.hysteresisGapBytes,
+                    sourceBitrateBps: self.cache.currentSourceBitrateBps(),
+                    playbackRate: self.currentPlaybackRate()
                 )
             }
         )
@@ -1771,6 +1825,9 @@ private final class PlaybackSourceResource {
         let wasTracked = windowStream === stream
         if wasTracked {
             windowStream = nil
+            // The window is gone; a live owner reference would force every
+            // later claim into chunks with no window left to protect.
+            windowOwnerServeID = nil
         }
         // Safe lock nesting: the fetcher never calls back into the resource
         // while holding its own lock, so stateLock → fetcher.lock is the
@@ -2134,6 +2191,12 @@ final class PlaybackSourceProxy {
         resource.setSourceBitrate(bps)
     }
 
+    /// Playback rate feeds the adaptive detach grace: the cache drains at
+    /// consumption speed, so slow-speed playback needs a longer parked grace.
+    func setPlaybackRate(_ rate: Double) {
+        resource.setPlaybackRate(rate)
+    }
+
     private var isStopped: Bool {
         lock.lock()
         let value = stopped
@@ -2173,6 +2236,7 @@ final class PlaybackSourceProxy {
         lock.lock()
         connections.removeValue(forKey: id)
         lock.unlock()
+        resource.connectionClosed(key: id)
     }
 
     private func receive(on connection: NWConnection, accumulated: Data = Data()) {

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -2365,6 +2365,7 @@ class PlayerViewModel {
             return
         }
         sourceProxy = prepared.proxy
+        sourceProxy?.setPlaybackRate(settings.playbackSpeed)
         sourceProxyFileId = prepared.proxy != nil ? currentSelectedVersion?.fileId : nil
         let loadPlan = prepared.plan
         activeExecutionPlan = loadPlan
@@ -2853,6 +2854,7 @@ class PlayerViewModel {
     func setPlaybackSpeed(_ rate: Double) {
         settings.setPlaybackSpeed(rate)
         activePlayer.setSpeed(settings.playbackSpeed)
+        sourceProxy?.setPlaybackRate(settings.playbackSpeed)
         scheduleHideControls()
     }
 


### PR DESCRIPTION
## Problem

Multiple users on tvOS builds 16/17 hit visible buffering during direct-stream playback. Production logs showed the client cancelling its origin connection (`client_gone`) and opening a fresh range request every 1–2 seconds, discarding 10–30 MB of successfully delivered bytes per cycle. Server throughput was fine — every cancel was client-initiated.

The regression window starts with #100 (2026-07-24, build 16): bounded detach for budget-parked origin streams plus prefetch hysteresis. Build 17's only intervening commit is `#if !os(tvOS)` home-feed code, so builds 16 and 17 share identical tvOS playback behavior.

## Root causes and fixes

**1. Window claim ping-pong (the storm).** Any serve connection that had streamed ≥ 8 MiB (`windowClaimBytes`) could re-anchor the streaming window on a cache miss. Two concurrent full-rate readers could alternately steal the window from each other, each theft cancelling the warm origin connection mid-transfer and re-driving all waiters — which re-missed and stole it right back.

Fix: `PlaybackWindowClaimPolicy` — the window belongs to the serve connection that last anchored it. While that connection is alive, a rival's qualified miss is served by a discrete chunk fetch (which never disturbs the window). Ownership frees when the owning connection ends, so seeks re-anchor exactly as before. Contested claims log `[CMP-SOURCE-CACHE] window claim contested` for field confirmation.

**2. Detach grace shorter than the hysteresis drain.** The fixed 25 s park-to-detach grace expired ~2.7 s *before* the low-water resume for a 19.4 Mbps source draining the 64 MiB hysteresis gap (~27.7 s). Every park cycle paid a detach + full reconnect instead of a `task.resume()`, and every title under ~21.5 Mbps hit the same cliff.

Fix: `detachGraceSeconds(hysteresisGapBytes:sourceBitrateBps:)` sizes the grace to drain time + 5 s margin, clamped to [25 s, 45 s] — the ceiling still closes parked connections before common reverse-proxy 60 s client-send timeouts. Unknown bitrate falls back to the fixed 25 s.

**3. Missed low-water wake for out-of-region reads.** When the window had been re-anchored ahead while a consumer drained behind it, cached reads never nudged the parked/detached window — a cache miss during starvation was the only wake-up. `noteDemandHint` now nudges the window via `resumeFillingIfNeeded()` in that case, without moving its demand mark.

## Testing

- New unit suites: `PlaybackWindowClaimPolicyTests` (ownership arbitration incl. the storm scenario), `PlaybackOriginDetachGraceTests` (floor / Masters-bitrate / ceiling clamps).
- All existing playback suites pass on the iPhone 17 Pro simulator: resume, routing/policy, reconnect, outage, retarget, throughput, disk spill, buffering policy.
- `SiloTV` (generic/tvOS) and `SiloMac` compile clean via mac-builder.
- Not yet verified on a physical Apple TV — a new build with a high-bitrate title and a log capture is the intended field verification (grep for `window claim contested`, `origin stream detached` cadence, `hysteresis re-arm`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback handling when multiple streaming windows compete for ownership.
  * Prevented active playback windows from being disrupted by competing requests.
  * Improved recovery when cached content falls outside the active playback window.
  * Added adaptive stream detach timing based on bitrate, playback speed, and cache conditions.
  * Added safeguards for reclaiming windows after an owner disconnects.
  * Kept stream timing aligned when playback speed changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->