### PR TITLE
fix(tvos): focus Play when detail pages open

### DIFF
--- a/iosApp/iosApp/tvOS/Screens/Detail/TVAudiobookDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVAudiobookDetailView.swift
@@ -23,6 +23,7 @@ struct TVAudiobookDetailView: View {
 
     @FocusState private var focusedAction: Action?
     @State private var showChapters = false
+    @State private var didClaimInitialActionFocus = false
 
     private enum Action: Hashable { case primary, chapters, startOver }
 
@@ -310,6 +311,7 @@ struct TVAudiobookDetailView: View {
                 model.performPrimary(audioStore)
             }
             .focused($focusedAction, equals: .primary)
+            .onAppear(perform: claimInitialActionFocus)
 
             if model.showsChapters {
                 TVSecondaryPillButton(icon: "list.bullet", title: "Chapters") {
@@ -324,6 +326,12 @@ struct TVAudiobookDetailView: View {
             .focused($focusedAction, equals: .startOver)
         }
         .defaultFocus($focusedAction, .primary)
+    }
+
+    private func claimInitialActionFocus() {
+        guard !didClaimInitialActionFocus else { return }
+        didClaimInitialActionFocus = true
+        focusedAction = .primary
     }
 }
 #endif

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
@@ -49,6 +49,11 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
     /// True while focus sits anywhere in the hero's primary action row —
     /// drives the scroll back to the page-entry (hero at top) framing.
     @FocusState private var actionRowFocused: Bool
+    /// `defaultFocus` participates in focus evaluation, but a detail page can
+    /// inherit the synopsis focus when it is pushed from a card. Claim Play
+    /// once when the real button mounts so cache-hit and freshly-loaded pages
+    /// have the same entry focus without stealing it again later.
+    @State private var didClaimInitialPlayFocus = false
 
     // Plain constants (not `static`) — the generic BelowSynopsis parameter
     // forbids static stored properties on this type.
@@ -137,6 +142,7 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
                 action: { onPlay(false) },
                 focused: $playFocused
             )
+            .onAppear(perform: claimInitialPlayFocus)
 
             if hasResumeProgress {
                 TVSecondaryPillButton(
@@ -184,6 +190,12 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
         // on the nearest action button. Buttons stay left-aligned.
         .frame(maxWidth: .infinity, alignment: .leading)
         .focusSection()
+    }
+
+    private func claimInitialPlayFocus() {
+        guard !didClaimInitialPlayFocus else { return }
+        didClaimInitialPlayFocus = true
+        playFocused = true
     }
 
     // MARK: - More menu

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
@@ -104,10 +104,7 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
             .defaultFocus($playFocused, true, priority: .userInitiated)
             .onChange(of: nextUpEpisode?.contentId) { _, newValue in
                 guard newValue != nil else { return }
-                let seasonKey = selectedSeason?.contentId ?? ""
-                guard autoFocusedSeasonKey != seasonKey else { return }
-                autoFocusedSeasonKey = seasonKey
-                playFocused = true
+                claimInitialPlayFocus()
             }
             .detailFocusScroll(
                 proxy: scrollProxy,
@@ -156,6 +153,7 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
                     action: { onPlayEpisode(nextUp.contentId, selectedNextUpFileId, false) },
                     focused: $playFocused
                 )
+                .onAppear(perform: claimInitialPlayFocus)
                 if nextUp.userData?.isInProgress == true {
                     TVSecondaryPillButton(
                         icon: "backward.end.fill",
@@ -203,6 +201,13 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
         // on the nearest action button. Buttons stay left-aligned.
         .frame(maxWidth: .infinity, alignment: .leading)
         .focusSection()
+    }
+
+    private func claimInitialPlayFocus() {
+        let seasonKey = selectedSeason?.contentId ?? ""
+        guard autoFocusedSeasonKey != seasonKey else { return }
+        autoFocusedSeasonKey = seasonKey
+        playFocused = true
     }
 
     private var hasMoreMenu: Bool {

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
@@ -102,7 +102,7 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
             .ignoresSafeArea()
             .focusScope(detailFocusNamespace)
             .defaultFocus($playFocused, true, priority: .userInitiated)
-            .onChange(of: nextUpEpisode?.contentId) { _, newValue in
+            .onChange(of: selectedSeason?.contentId) { _, newValue in
                 guard newValue != nil else { return }
                 claimInitialPlayFocus()
             }
@@ -204,7 +204,7 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
     }
 
     private func claimInitialPlayFocus() {
-        let seasonKey = selectedSeason?.contentId ?? ""
+        guard let seasonKey = selectedSeason?.contentId else { return }
         guard autoFocusedSeasonKey != seasonKey else { return }
         autoFocusedSeasonKey = seasonKey
         playFocused = true

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -86,10 +86,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
             .defaultFocus($playFocused, true, priority: .userInitiated)
             .onChange(of: nextUpEpisode?.contentId) { _, newValue in
                 guard newValue != nil else { return }
-                let seasonKey = selectedSeason?.contentId ?? ""
-                guard autoFocusedSeasonKey != seasonKey else { return }
-                autoFocusedSeasonKey = seasonKey
-                playFocused = true
+                claimInitialPlayFocus()
             }
             .detailFocusScroll(
                 proxy: scrollProxy,
@@ -162,6 +159,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                     action: { onPlayEpisode(nextUp.contentId, selectedFileId(for: nextUp), false) },
                     focused: $playFocused
                 )
+                .onAppear(perform: claimInitialPlayFocus)
                 if nextUp.userData?.isInProgress == true {
                     TVSecondaryPillButton(
                         icon: "backward.end.fill",
@@ -205,6 +203,13 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         // on the nearest action button. Buttons stay left-aligned.
         .frame(maxWidth: .infinity, alignment: .leading)
         .focusSection()
+    }
+
+    private func claimInitialPlayFocus() {
+        let seasonKey = selectedSeason?.contentId ?? ""
+        guard autoFocusedSeasonKey != seasonKey else { return }
+        autoFocusedSeasonKey = seasonKey
+        playFocused = true
     }
 
     /// Best "Play" target for the series: an in-progress episode if there

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -84,7 +84,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
             .ignoresSafeArea()
             .focusScope(detailFocusNamespace)
             .defaultFocus($playFocused, true, priority: .userInitiated)
-            .onChange(of: nextUpEpisode?.contentId) { _, newValue in
+            .onChange(of: selectedSeason?.contentId) { _, newValue in
                 guard newValue != nil else { return }
                 claimInitialPlayFocus()
             }
@@ -206,7 +206,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     }
 
     private func claimInitialPlayFocus() {
-        let seasonKey = selectedSeason?.contentId ?? ""
+        guard let seasonKey = selectedSeason?.contentId else { return }
         guard autoFocusedSeasonKey != seasonKey else { return }
         autoFocusedSeasonKey = seasonKey
         playFocused = true


### PR DESCRIPTION
## Summary

- Default tvOS detail-page focus to the primary Play button for movies, series, seasons, and audiobooks.
- Reapply the preferred focus when detail content changes so navigation lands on the main action consistently.

## Testing

- Not run (change request content generated from the supplied diff).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initial focus behavior on tvOS detail screens for audiobooks, movies, seasons, and series.
  * Play and primary action buttons now receive focus reliably when content first appears.
  * Prevented focus from being unexpectedly reset during subsequent view updates, season changes, or episode changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->