### PR TITLE
Cleanup the search UI

### DIFF
--- a/iosApp/iosApp/Extensions/SearchCancelButtonSuppressor.swift
+++ b/iosApp/iosApp/Extensions/SearchCancelButtonSuppressor.swift
@@ -1,0 +1,48 @@
+#if os(iOS)
+import SwiftUI
+import UIKit
+
+/// Hides the search bar's Cancel button (an "✕" pill on iOS 26) so the search
+/// field's own clear button stays the single way to empty the query and the
+/// navigation bar's back button stays the single way to leave the screen.
+///
+/// SwiftUI exposes no modifier for this, so the representable walks the
+/// responder chain to the hosting controller and turns the button off on the
+/// `UISearchController` that `.searchable` installed. Pair it with
+/// `.searchPresentationToolbarBehavior(.avoidHidingContent)`, which keeps the
+/// back button on screen while the field is focused.
+struct SearchCancelButtonSuppressor: UIViewRepresentable {
+    func makeUIView(context: Context) -> UIView {
+        let view = SuppressorView()
+        view.isUserInteractionEnabled = false
+        view.isAccessibilityElement = false
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {}
+
+    final class SuppressorView: UIView {
+        override func didMoveToWindow() {
+            super.didMoveToWindow()
+            guard window != nil else { return }
+            // The search controller is attached during the same layout pass
+            // that installs this view, so apply on the next runloop turn.
+            DispatchQueue.main.async { [weak self] in
+                self?.suppressCancelButton()
+            }
+        }
+
+        private func suppressCancelButton() {
+            var responder: UIResponder? = self
+            while let current = responder {
+                if let controller = (current as? UIViewController)?.navigationItem.searchController {
+                    controller.automaticallyShowsCancelButton = false
+                    controller.searchBar.setShowsCancelButton(false, animated: false)
+                    return
+                }
+                responder = current.next
+            }
+        }
+    }
+}
+#endif

--- a/iosApp/iosApp/Extensions/ViewExtensions.swift
+++ b/iosApp/iosApp/Extensions/ViewExtensions.swift
@@ -118,11 +118,16 @@ extension View {
         #elseif os(macOS)
         self.searchable(text: text, prompt: prompt)
         #else
+        // Keep the navigation bar's back button and title visible while the
+        // field is focused, and drop the search bar's Cancel button so the
+        // field's own clear button is the only way to empty the query.
         self.searchable(
             text: text,
             placement: .navigationBarDrawer(displayMode: .always),
             prompt: prompt
         )
+        .searchPresentationToolbarBehavior(.avoidHidingContent)
+        .background(SearchCancelButtonSuppressor().frame(width: 0, height: 0))
         #endif
     }
 


### PR DESCRIPTION
This cleans up search and request so that it no longer has a clunk big `X` with the small native `x` as well. We also always show the back button for exiting search so exiting becomes one click rather than two

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search presentation on iOS by hiding the system-provided Cancel button.
  * Search fields, navigation controls, and titles remain visible and accessible while searching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->