### PR TITLE
fix(overlays): read card overlays from the settings contract

### DIFF
--- a/iosApp/iosApp/Networking/OverlayPrefsStore.swift
+++ b/iosApp/iosApp/Networking/OverlayPrefsStore.swift
@@ -5,11 +5,21 @@
 //  Cached card-overlay configuration for the signed-in profile.
 //  Resolves a single rendered `CardOverlayPrefs` from one of two
 //  sources, in this priority:
-//    1. The user's saved prefs (`GET /settings/card_overlays`) — if
-//       present, this is the entire source of truth.
+//    1. The user's saved prefs — the contract key `ui.card_overlays`
+//       at profile scope, read through the canonical
+//       `GET /settings/values/effective` endpoint. If present, this is
+//       the entire source of truth.
 //    2. Otherwise, the admin-configured baseline JSON from
 //       `GET /settings/overlay-config` (`defaults` field).
 //    3. Otherwise, registry defaults (`OverlaySchema.buildDefaults()`).
+//
+//  The contract stores the document as a JSON object (jsonb), not the
+//  JSON string the retired legacy endpoint carried, so reads and
+//  writes bridge between `SettingJSONValue` and `OverlaySchema`'s
+//  string codec here. Servers that predate the canonical settings API
+//  are detected via `SettingsAPIError.serverUpgradeRequired` and fall
+//  back to the legacy `card_overlays` user setting, which those
+//  servers still accept.
 //
 //  This is winner-take-all, not layered merging — `setPrefs(_:)`
 //  always saves a full document (not a diff), and the matching
@@ -50,6 +60,10 @@ final class OverlayPrefsStore: ObservableObject {
 
     private var hasHydrated = false
     private var adminDefaultsRaw: String?
+    /// `true` once a read established that this server predates the
+    /// canonical settings API. Writes then target the legacy endpoint
+    /// the old server still accepts instead of failing every save.
+    private var usesLegacyAPI = false
     /// Invalidates an older refresh when the active server changes or a newer
     /// refresh starts, preventing late responses from repopulating stale prefs.
     private var refreshGeneration: UInt = 0
@@ -85,9 +99,9 @@ final class OverlayPrefsStore: ObservableObject {
     /// local state matches what the server just stored.
     ///
     /// Failure semantics:
-    /// - A 404 on the user setting means "not set yet" and is treated
-    ///   as success — `userRaw` stays nil and we render from admin
-    ///   defaults or registry defaults.
+    /// - "No value stored yet" (a contract default answer, or a legacy
+    ///   404) is success — `userRaw` stays nil and we render from
+    ///   admin defaults or registry defaults.
     /// - Any other transport error (on either endpoint) leaves
     ///   `hasHydrated` false so the next `hydrateIfNeeded()` retries.
     ///   This matters most for the admin kill switch: if
@@ -128,11 +142,30 @@ final class OverlayPrefsStore: ObservableObject {
 
         var userRaw: String?
         var userFetchFailed = false
+        var resolvedLegacyAPI = usesLegacyAPI
         do {
-            let entry = try await api.getUserSetting(key: OverlayPrefsStore.settingKey)
-            userRaw = entry.value
-        } catch HTTPError.http(let code, _) where code == 404 {
-            userRaw = nil
+            let response = try await api.getEffectiveValues(keys: [.uiCardOverlays])
+            if let entry = response.value(for: .uiCardOverlays),
+               entry.source == .scope(.profile),
+               entry.value != .null {
+                userRaw = Self.jsonString(from: entry.value)
+            }
+            resolvedLegacyAPI = false
+        } catch SettingsAPIError.serverUpgradeRequired {
+            // Pre-contract server: the canonical routes don't exist.
+            // Read the legacy string-valued user setting instead, where
+            // a 404 is the documented "not set yet".
+            resolvedLegacyAPI = true
+            do {
+                let entry = try await api.getUserSetting(key: Self.legacySettingKey)
+                userRaw = entry.value
+            } catch HTTPError.http(let code, _) where code == 404 {
+                userRaw = nil
+            } catch {
+                resolvedError = (error as? LocalizedError)?.errorDescription
+                    ?? String(describing: error)
+                userFetchFailed = true
+            }
         } catch {
             resolvedError = (error as? LocalizedError)?.errorDescription
                 ?? String(describing: error)
@@ -151,6 +184,9 @@ final class OverlayPrefsStore: ObservableObject {
         if !configFetchFailed {
             self.enabled = resolvedEnabled
             self.adminDefaultsRaw = resolvedAdminDefaults
+        }
+        if !userFetchFailed {
+            self.usesLegacyAPI = resolvedLegacyAPI
         }
         self.hasUserOverride = userFetchFailed ? hasUserOverride : (userRaw != nil)
         if !userFetchFailed {
@@ -213,12 +249,8 @@ final class OverlayPrefsStore: ObservableObject {
         while let snapshot = pendingSnapshot {
             if Task.isCancelled { return }
             pendingSnapshot = nil
-            let json = OverlaySchema.serialize(snapshot)
             do {
-                try await ContinuumAPI.shared.setSetting(
-                    key: OverlayPrefsStore.settingKey,
-                    value: json
-                )
+                try await persist(snapshot)
             } catch {
                 // `clear()` was called mid-write (e.g. sign-out). Bail
                 // before touching state that no longer belongs to this
@@ -231,6 +263,33 @@ final class OverlayPrefsStore: ObservableObject {
                 // next loop iteration handles a queued snapshot, or
                 // exits if pendingSnapshot is still nil.
             }
+        }
+    }
+
+    /// One full-document write, routed to whichever settings API this
+    /// server speaks. A canonical attempt that discovers a legacy
+    /// server mid-session (`serverUpgradeRequired`) retries the legacy
+    /// endpoint once rather than surfacing an error for a save the old
+    /// API can still honor.
+    private func persist(_ snapshot: CardOverlayPrefs) async throws {
+        let json = OverlaySchema.serialize(snapshot)
+        if usesLegacyAPI {
+            try await ContinuumAPI.shared.setSetting(key: Self.legacySettingKey, value: json)
+            return
+        }
+        guard let value = Self.jsonValue(from: json) else {
+            throw SettingsAPIError.invalidValue(message: "Overlay prefs did not serialize to JSON.")
+        }
+        do {
+            try await ContinuumAPI.shared.putValue(
+                key: .uiCardOverlays,
+                scope: .profile,
+                value: value,
+                mutationId: newSettingMutationId()
+            )
+        } catch SettingsAPIError.serverUpgradeRequired {
+            usesLegacyAPI = true
+            try await ContinuumAPI.shared.setSetting(key: Self.legacySettingKey, value: json)
         }
     }
 
@@ -256,10 +315,17 @@ final class OverlayPrefsStore: ObservableObject {
         }
 
         do {
-            try await ContinuumAPI.shared.deleteSetting(key: OverlayPrefsStore.settingKey)
+            if usesLegacyAPI {
+                try await ContinuumAPI.shared.deleteSetting(key: Self.legacySettingKey)
+            } else {
+                try await ContinuumAPI.shared.deleteValue(key: .uiCardOverlays, scope: .profile)
+            }
+            hasUserOverride = false
+        } catch SettingsAPIError.noValueAtScope {
+            // Already gone.
             hasUserOverride = false
         } catch HTTPError.http(let code, _) where code == 404 {
-            // Already gone.
+            // Already gone (legacy endpoint).
             hasUserOverride = false
         } catch {
             lastError = (error as? LocalizedError)?.errorDescription
@@ -291,10 +357,32 @@ final class OverlayPrefsStore: ObservableObject {
         enabled = true
         prefs = OverlaySchema.buildDefaults()
         adminDefaultsRaw = nil
+        usesLegacyAPI = false
         hasUserOverride = false
         hasHydrated = false
         lastError = nil
     }
 
-    static let settingKey = "card_overlays"
+    // MARK: - Wire bridging
+
+    /// The contract stores the document as a JSON object; `OverlaySchema`
+    /// speaks JSON strings (shared with the admin `overlay-config`
+    /// baseline, which still travels as a string). These two hops keep
+    /// one codec — `OverlaySchema` — as the single interpreter of the
+    /// document shape.
+    private static func jsonString(from value: SettingJSONValue) -> String? {
+        guard let data = try? SettingsWireCoding.makeEncoder().encode(value) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private static func jsonValue(from raw: String) -> SettingJSONValue? {
+        guard let data = raw.data(using: .utf8) else { return nil }
+        return try? SettingsWireCoding.makeDecoder().decode(SettingJSONValue.self, from: data)
+    }
+
+    /// The pre-contract account-scoped user-setting key. Only used
+    /// against servers that predate the canonical settings API; new
+    /// servers reject it (the contract renamed it `ui.card_overlays`
+    /// and migrates stored rows server-side).
+    static let legacySettingKey = "card_overlays"
 }

--- a/iosApp/iosApp/Overlays/CardOverlays.swift
+++ b/iosApp/iosApp/Overlays/CardOverlays.swift
@@ -171,7 +171,7 @@ struct OverlayBadgeView: View {
                     tint: preset.foregroundColor(state.accentColor)
                 )
             }
-            if !state.iconOnly || state.iconId == nil {
+            if (!state.iconOnly || state.iconId == nil) && !labelRedundantWithIcon {
                 badgeText
             }
         }
@@ -180,6 +180,16 @@ struct OverlayBadgeView: View {
         .background(background)
         .overlay(border)
         .clipShape(shape)
+    }
+
+    /// A wordmark icon (HDR10, ATMOS, …) spells its text as the mark
+    /// itself; when the label says the same thing, showing both reads
+    /// "HDR10 HDR10". Mirrors web's `labelRedundantWithIcon`.
+    private var labelRedundantWithIcon: Bool {
+        guard let iconId = state.iconId, let mark = iconId.wordmarkText else { return false }
+        return mark.lowercased() == state.label
+            .trimmingCharacters(in: .whitespaces)
+            .lowercased()
     }
 
     @ViewBuilder

--- a/iosApp/iosApp/Overlays/OverlayRegistry.swift
+++ b/iosApp/iosApp/Overlays/OverlayRegistry.swift
@@ -2,10 +2,12 @@ import Foundation
 
 /// Single source of truth for which overlays exist. Order within the
 /// array determines the default render order within each corner. The
-/// 26 entries here mirror `web/src/lib/overlays/registry/*.ts` —
-/// adding/removing one here MUST be mirrored on the web side, and the
-/// `OverlayId` enum, or stored prefs from one platform will silently
-/// drop on another.
+/// entries here mirror `web/src/lib/overlays/registry/*.ts` and the
+/// contract's `card-overlays.json` id enum — adding/removing one here
+/// MUST be mirrored there, and in the `OverlayId` enum, or stored
+/// prefs from one platform will silently drop on another. (The two
+/// planned ribbon ids, `imdb_top_250` and `rt_certified_fresh`, are
+/// schema-legal but not yet in the web registry.)
 enum OverlayRegistry {
 
     static let all: [OverlayDef] = tech + ratings + metadata + ribbons
@@ -96,11 +98,23 @@ private extension OverlayRegistry {
         return value.contains("DV") ? "DV" : "HDR"
     }
 
+    /// Mirrors web's `hdrIcon`: only exact wordmark matches get a brand
+    /// mark; anything else (HLG, combined strings like "HDR10+") renders
+    /// as plain text with no icon rather than a wrong generic mark.
     static func hdrIcon(_ value: String?) -> OverlayIconId? {
         guard let value, !value.isEmpty else { return nil }
         if value.contains("DV") { return .dolbyVision }
-        if value.contains("HDR10") { return .hdr10 }
-        return .hdr
+        if value == "HDR10" { return .hdr10 }
+        if value == "HDR" { return .hdr }
+        return nil
+    }
+
+    /// The combined badge's label already carries an "HDR" suffix, so the
+    /// only icon worth doubling up is the Dolby Vision mark — mirrors
+    /// web's `resolution_hdr.getIcon`.
+    static func resolutionHdrIcon(_ value: String?) -> OverlayIconId? {
+        guard let value, value.contains("DV") else { return nil }
+        return .dolbyVision
     }
 
     static func audioIcon(_ value: String?) -> OverlayIconId? {
@@ -127,7 +141,9 @@ private extension OverlayRegistry {
             defaultEnabled: true,
             iconId: .monitor,
             iconCapable: true,
-            getValue: { $0.resolution?.uppercased() }
+            // `prettyResolution`, not raw uppercase: web renders "4K" for a
+            // `2160p` payload and the standalone badge must match it.
+            getValue: { prettyResolution($0.resolution) }
         ),
         OverlayDef(
             id: .hdr,
@@ -153,7 +169,7 @@ private extension OverlayRegistry {
                 if let hdr = compactHdrSuffix(data.hdr) { return "\(res) \(hdr)" }
                 return res
             },
-            getIcon: { hdrIcon($0.hdr) }
+            getIcon: { resolutionHdrIcon($0.hdr) }
         ),
         OverlayDef(
             id: .audio,
@@ -348,6 +364,21 @@ private extension OverlayRegistry {
         return h > 0 ? "\(h)h \(m)m" : "\(m)m"
     }
 
+    /// English display name for a language tag, matching web's
+    /// `formatLanguage` (English CLDR names, so "en" → "English" not
+    /// "EN"). A tag CLDR can't name falls back to the uppercased code
+    /// rather than web's "Unknown language (…)" sentence, which doesn't
+    /// fit a badge.
+    static func formatLanguageName(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let english = Locale(identifier: "en")
+        let name = english.localizedString(forIdentifier: trimmed)
+            ?? english.localizedString(forLanguageCode: trimmed)
+        return name?.capitalized ?? trimmed.uppercased()
+    }
+
     static let metadata: [OverlayDef] = [
         OverlayDef(
             id: .year,
@@ -382,7 +413,7 @@ private extension OverlayRegistry {
             defaultEnabled: false,
             iconId: .globe,
             iconCapable: true,
-            getValue: { $0.originalLanguage?.uppercased() }
+            getValue: { formatLanguageName($0.originalLanguage) }
         ),
         OverlayDef(
             id: .studio,
@@ -413,15 +444,20 @@ private extension OverlayRegistry {
 
 private extension OverlayRegistry {
 
+    /// Mirrors web's `formatShowStatus` — the recognized spellings and
+    /// the pass-through default must stay identical or the same library
+    /// renders different ribbons per platform.
     static func formatShowStatus(_ value: String?) -> String? {
-        guard let value else { return nil }
+        guard let value, !value.isEmpty else { return nil }
         switch value.lowercased() {
-        case "returning", "returning series", "in_production", "in production":
+        case "returning", "returning series", "continuing", "in_production", "in production":
             return "Returning"
         case "ended":
             return "Ended"
         case "cancelled", "canceled":
             return "Cancelled"
+        case "upcoming", "planned":
+            return "Upcoming"
         default:
             return value
         }

--- a/iosApp/iosApp/Overlays/OverlaySchema.swift
+++ b/iosApp/iosApp/Overlays/OverlaySchema.swift
@@ -1,9 +1,12 @@
 import Foundation
 
-/// Encodes/decodes `CardOverlayPrefs` to/from the JSON string the server
-/// stores under the `card_overlays` user setting. The shape must stay
-/// compatible with the web's `parseOverlayPrefs` in
-/// `web/src/lib/overlays/schema.ts` since clients share the setting.
+/// Encodes/decodes `CardOverlayPrefs` to/from the JSON document the server
+/// stores under the `ui.card_overlays` contract setting (and, on
+/// pre-contract servers, the legacy `card_overlays` user setting). The
+/// shape must stay compatible with the web's `parseOverlayPrefs` in
+/// `web/src/lib/overlays/schema.ts` and the contract schema
+/// `contracts/settings/v1/schemas/card-overlays.json`, since clients
+/// share the setting.
 enum OverlaySchema {
 
     /// Build the default prefs document from the registry. Used the

--- a/iosApp/iosApp/Overlays/OverlayTypes.swift
+++ b/iosApp/iosApp/Overlays/OverlayTypes.swift
@@ -250,6 +250,20 @@ enum OverlayIconId: String, Hashable {
     case atmos
     case av1
     case tomato
+
+    /// The text a wordmark icon already spells out as the mark itself.
+    /// Mirrors web's `WORDMARK_TEXT`: when a badge's label matches its
+    /// mark, the renderer suppresses the label so the badge doesn't
+    /// read "HDR10 HDR10".
+    var wordmarkText: String? {
+        switch self {
+        case .hdr: return "HDR"
+        case .hdr10: return "HDR10"
+        case .atmos: return "ATMOS"
+        case .av1: return "AV1"
+        default: return nil
+        }
+    }
 }
 
 /// How the preset paints the accent color. Mirrors web's


### PR DESCRIPTION
## Summary

Card-overlay settings configured on the web `/settings/card-overlays` page had no effect on iOS/tvOS (reported via an internal Discord thread, iOS 1.0.0 build 20): cards always rendered the default badge set.

Root cause: `OverlayPrefsStore` still read the retired account-scoped `card_overlays` key through the legacy string-settings registry. The settings contract renamed the key to `ui.card_overlays` (profile scope, object-valued) and current servers answer the legacy read with 400 — which this store treated as a transient failure, so it fell back to registry defaults forever and re-fetched on every card-bearing view appearance.

## Changes

- `OverlayPrefsStore` reads the profile-scoped `ui.card_overlays` through `GET /settings/values/effective` and writes full documents via `putValue`/`deleteValue` with idempotent mutation ids. A contract-default/null answer falls through to the admin `overlay-config` baseline exactly as before.
- Pre-contract servers (missing-route 404 → `serverUpgradeRequired`) are detected on read and served through the legacy `card_overlays` key they still accept, including the write and reset paths.
- Render parity fixes against web `web/src/lib/overlays` found while auditing all clients:
  - standalone `resolution` badge uses `prettyResolution` ("4K", not "2160P")
  - `show_status` recognizes `continuing` and `upcoming`/`planned`, and drops empty strings
  - HDR icon selection matches web's exact-match rules; the combined `resolution_hdr` badge only doubles up the Dolby Vision mark
  - wordmark icons (HDR/HDR10/ATMOS/AV1) suppress a same-text label ("HDR10 HDR10" → mark only)
  - `original_language` renders an English language name, not a raw uppercased tag

## Validation

- iOS (`Silo`), tvOS (`SiloTV`), and macOS (`SiloMac`) simulator/host builds succeed on mac-builder.
- Full `SiloTests` run: 957 tests, 12 failures — the same 12 failures reproduce on unmodified `origin/main` (they are in `PlayerSettingsFlushTests` / `ProfileAndQualitySettingsTests`, pre-existing and unrelated to this change). No new failures introduced.

## Coordinated changes

- silo-android has the same defect (`OverlayPrefsStore.kt` uses the legacy key); companion PR incoming.
- silo-server: `ui.card_overlays` manifest `platforms` should include the native clients; companion PR incoming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved overlay preference synchronization with support for both current and older server versions.
  * Added more accurate overlay badges, including suppression of redundant wordmark text.
  * Improved display of HDR, Dolby Vision, resolution, language, and show-status information.
  * Added support for wordmark text associated with select overlay icons.
* **Bug Fixes**
  * Overlay settings now recover more reliably when switching between supported server APIs or signing out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->