### PR TITLE
feat: add synced navigation and card customization

### DIFF
--- a/iosApp/Tests/DeviceSnapshotBuilderTests.swift
+++ b/iosApp/Tests/DeviceSnapshotBuilderTests.swift
@@ -59,7 +59,12 @@ final class DeviceSnapshotBuilderTests: XCTestCase {
     ) -> DeviceSnapshotBuilder {
         DeviceSnapshotBuilder(
             identityProvider: {
-                AppleDeviceIdentity(id: "device-id", name: "Unit Test iPhone", platform: "iOS")
+                AppleDeviceIdentity(
+                    id: "device-id",
+                    name: "Unit Test iPhone",
+                    platform: "iOS",
+                    clientFamily: "mobile"
+                )
             },
             playbackSnapshotProvider: {
                 DiagnosticsCapabilityProbe.Snapshot(

--- a/iosApp/Tests/Fixtures/SettingsContract/SOURCE
+++ b/iosApp/Tests/Fixtures/SettingsContract/SOURCE
@@ -1,6 +1,6 @@
 repository=https://github.com/Silo-Server/silo-server
 path=contracts/settings/v1
-manifest_revision=2
+manifest_revision=5
 fixture_version=1
 
 Both files are byte-identical copies of the server's canonical settings
@@ -11,9 +11,9 @@ vendored manifest's revision, and the generated SettingKey.revision stop
 agreeing, which is the whole point of carrying the pair rather than the
 fixture alone.
 
-conformance.json commit=025083159f9624269483479cc05de02a822c6cd2
-manifest.json    commit=025083159f9624269483479cc05de02a822c6cd2
-copied from      commit=025083159f9624269483479cc05de02a822c6cd2
+conformance.json commit=dfa78454cf97412db0760576312d0061c0ac2e8a
+manifest.json    commit=dfa78454cf97412db0760576312d0061c0ac2e8a
+copied from      commit=dfa78454cf97412db0760576312d0061c0ac2e8a
 
 manifest.json is vendored whole, including the maintainer `notes` the server
 strips before serving /api/v1/settings/contract. Keeping it byte-identical is

--- a/iosApp/Tests/Fixtures/SettingsContract/conformance.json
+++ b/iosApp/Tests/Fixtures/SettingsContract/conformance.json
@@ -1,8 +1,82 @@
 {
   "fixture_version": 1,
-  "manifest_revision": 2,
+  "manifest_revision": 5,
   "description": "Cross-platform conformance cases for settings resolution. Every case runs against the shipped manifest in this directory: definitions are referenced by key, never restated, so an expectation can only be satisfied by resolving the real contract. Each platform's resolver (Go in internal/settingsresolve, TypeScript in web/src/lib/settingsResolve.ts, Kotlin and Swift in the client repos) runs every case through a hand-written runner; a runner must fail on any fixture field it does not know, because schema drift in the fixture itself is drift. A case's constraint_bindings attach a constraint to a copy of a real definition so constraint semantics stay testable even while no shipped definition carries that constraint kind. In expected entries, constrained:true requires stored_value and constraint_kind to be present, and stored_value may be null to mean the authored value was JSON null.",
   "cases": [
+    {
+      "name": "profile_client_sits_between_device_and_profile",
+      "description": "Presentation values roam across like clients, while an exact-device override remains more specific and a profile value remains the cross-family fallback.",
+      "keys": ["ui.card_presentation"],
+      "context": { "profile_id": "p1", "client_family": "tv", "device_id": "living-room" },
+      "stored": [
+        {
+          "key": "ui.card_presentation",
+          "scope": "profile",
+          "profile_id": "p1",
+          "value": { "poster_size": "standard", "caption": "title" }
+        },
+        {
+          "key": "ui.card_presentation",
+          "scope": "profile_client",
+          "profile_id": "p1",
+          "client_family": "tv",
+          "value": { "poster_size": "large", "caption": "artwork" }
+        },
+        {
+          "key": "ui.card_presentation",
+          "scope": "profile_device",
+          "profile_id": "p1",
+          "device_id": "living-room",
+          "value": { "poster_size": "compact", "caption": "title_metadata" }
+        }
+      ],
+      "expected": [
+        {
+          "key": "ui.card_presentation",
+          "value": { "poster_size": "compact", "caption": "title_metadata" },
+          "source": "profile_device"
+        }
+      ]
+    },
+    {
+      "name": "profile_client_roams_only_within_its_family",
+      "description": "A television menu applies to another television identity but not to mobile; the family is explicit resolution context rather than inferred from device metadata.",
+      "keys": ["nav.primary_menu"],
+      "context": { "profile_id": "p1", "client_family": "tv", "device_id": "bedroom-tv" },
+      "stored": [
+        {
+          "key": "nav.primary_menu",
+          "scope": "profile_client",
+          "profile_id": "p1",
+          "client_family": "mobile",
+          "value": { "items": [{ "type": "builtin", "destination": "home" }] }
+        },
+        {
+          "key": "nav.primary_menu",
+          "scope": "profile_client",
+          "profile_id": "p1",
+          "client_family": "tv",
+          "value": {
+            "items": [
+              { "type": "builtin", "destination": "home" },
+              { "type": "builtin", "destination": "movies" }
+            ]
+          }
+        }
+      ],
+      "expected": [
+        {
+          "key": "nav.primary_menu",
+          "value": {
+            "items": [
+              { "type": "builtin", "destination": "home" },
+              { "type": "builtin", "destination": "movies" }
+            ]
+          },
+          "source": "profile_client"
+        }
+      ]
+    },
     {
       "name": "resolution_order_series_wins",
       "description": "The full ladder: with values stored at every scope a content key allows, profile_series beats profile_library, profile_device, and profile.",
@@ -437,6 +511,27 @@
       ],
       "constraints": { "allowed_metadata_languages": ["en", "fr"] },
       "expected": [{ "key": "catalog.metadata_language", "value": "fr", "source": "profile" }]
+    },
+    {
+      "name": "metadata_language_exceptions_resolve_as_one_object",
+      "description": "The original-language exception map is a single profile-scoped value; resolution preserves every source-to-target entry together.",
+      "keys": ["catalog.metadata_language_overrides"],
+      "context": { "profile_id": "p1" },
+      "stored": [
+        {
+          "key": "catalog.metadata_language_overrides",
+          "scope": "profile",
+          "profile_id": "p1",
+          "value": { "ja": "en", "no": "x-silo-original" }
+        }
+      ],
+      "expected": [
+        {
+          "key": "catalog.metadata_language_overrides",
+          "value": { "ja": "en", "no": "x-silo-original" },
+          "source": "profile"
+        }
+      ]
     },
     {
       "name": "locked_replaces_a_differing_choice",

--- a/iosApp/Tests/Fixtures/SettingsContract/manifest.json
+++ b/iosApp/Tests/Fixtures/SettingsContract/manifest.json
@@ -1,6 +1,6 @@
 {
   "api_version": 1,
-  "revision": 2,
+  "revision": 5,
   "option_sets": {
     "playback_audio_languages": {
       "type": "language_tag",
@@ -384,11 +384,28 @@
       "default_value": null,
       "category": "catalog",
       "label": "Metadata language",
-      "description": "Language Silo prefers for titles, descriptions, and artwork.",
+      "description": "Fallback language Silo prefers for titles, descriptions, and artwork.",
       "recommended_control": "select",
       "suggested_options": "catalog_metadata_languages",
       "unset_label": "Library default",
-      "notes": "Migrates user_profiles.preferred_metadata_language; that column is NOT NULL DEFAULT '', and the empty string means unset, so migration writes a row only where it is non-empty. Deliberately carries no constrained_by. An earlier draft declared an allowlist on policy input profile_preferred_metadata_language, which is circular: internal/policy/input.go populates that field from this very column and vendor/scope.rego relays it unchanged as a preference. Policy narrows nothing here, and an allowlist bound to a scalar equal to the current value would either be a no-op or reject every change the user makes."
+      "notes": "Migrates user_profiles.preferred_metadata_language; that column is NOT NULL DEFAULT '', and the empty string means unset, so migration writes a row only where it is non-empty. Deliberately carries no constrained_by. An earlier draft declared an allowlist on policy input profile_preferred_metadata_language, which is circular: internal/policy/input.go populates that field from this very column and vendor/scope.rego relays it unchanged as a preference. Policy narrows nothing here, and an allowlist bound to a scalar equal to the current value would either be a no-op or reject every change the user makes. From revision 3, the private-use tag x-silo-original means resolve the target from each media item's original_language. It remains a valid value of the existing language_tag schema, so this is additive rather than a response-field type change."
+    },
+    {
+      "key": "catalog.metadata_language_overrides",
+      "introduced_in": 3,
+      "persistence": "remote",
+      "allowed_scopes": ["profile"],
+      "resolution_order": ["profile", "default"],
+      "value_schema": {
+        "type": "object",
+        "schema_ref": "metadata-language-overrides.json"
+      },
+      "default_value": {},
+      "category": "catalog",
+      "label": "Metadata language exceptions",
+      "description": "Preferred metadata language for items in specific original languages.",
+      "recommended_control": "panel",
+      "notes": "Keys are canonical catalog original_language codes. Values are target BCP 47 language tags; x-silo-original means retain that source language. This key is separate from catalog.metadata_language so existing clients can continue changing the fallback without rewriting or discarding exceptions."
     },
     {
       "key": "player.hdr_enabled",
@@ -411,6 +428,7 @@
       "resolution_order": ["profile_device", "default"],
       "value_schema": { "type": "boolean" },
       "default_value": true,
+      "platforms": ["ios", "tvos", "macos", "android", "android_tv"],
       "category": "player",
       "label": "Dolby Vision",
       "description": "Allow Dolby Vision output on this device.",
@@ -424,6 +442,7 @@
       "resolution_order": ["profile_device", "default"],
       "value_schema": { "type": "boolean" },
       "default_value": false,
+      "platforms": ["ios", "tvos", "macos", "android", "android_tv"],
       "category": "player",
       "label": "Dolby Vision Profile 7 fallback",
       "description": "Play Profile 7 sources as HDR10 when this device cannot decode them natively.",
@@ -481,6 +500,7 @@
       "resolution_order": ["profile_device", "default"],
       "value_schema": { "type": "integer", "minimum": -5000, "maximum": 5000 },
       "default_value": 0,
+      "platforms": ["ios", "tvos", "macos", "android", "android_tv"],
       "unit": "milliseconds",
       "category": "player",
       "label": "Audio sync offset",
@@ -781,7 +801,7 @@
         "nullable": true
       },
       "default_value": null,
-      "platforms": ["web"],
+      "platforms": ["web", "ios", "tvos", "macos", "android", "android_tv"],
       "category": "appearance",
       "label": "Poster badges",
       "description": "Which badges appear on poster cards, and where.",
@@ -806,6 +826,59 @@
       "description": "Whether upcoming episodes stay with Continue Watching or get their own row.",
       "recommended_control": "select",
       "notes": "Registered from the legacy unprefixed key next_up_mode. The server reads it directly when assembling home sections, so it cannot be client-local; that read moves to the canonical resolver at cutover. The legacy value was untyped and absent meant combined, which is why combined is the default rather than a third \"unset\" member."
+    },
+    {
+      "key": "nav.primary_menu",
+      "introduced_in": 5,
+      "persistence": "remote",
+      "allowed_scopes": ["profile_client", "profile_device"],
+      "resolution_order": ["profile_device", "profile_client", "default"],
+      "value_schema": {
+        "type": "object",
+        "schema_ref": "primary-menu.json",
+        "nullable": true
+      },
+      "default_value": null,
+      "platforms": ["web", "ios", "tvos", "macos", "android", "android_tv"],
+      "category": "navigation",
+      "label": "Primary menu",
+      "description": "The ordered visible destinations shared by like clients.",
+      "recommended_control": "panel",
+      "notes": "Search and profile remain fixed client utilities. Home is required by primary-menu.json; omitting any other supported built-in hides it. Semantic destination identities are unique even when labels differ. A null default lets each family keep its native baseline until the user customizes it. Family scope synchronizes like clients while profile_device remains an explicit escape hatch for one screen; clients ignore built-in destinations they do not support."
+    },
+    {
+      "key": "nav.shortcuts",
+      "introduced_in": 5,
+      "persistence": "remote",
+      "allowed_scopes": ["profile"],
+      "resolution_order": ["profile", "default"],
+      "value_schema": {
+        "type": "object",
+        "schema_ref": "navigation-shortcuts.json"
+      },
+      "default_value": { "items": [] },
+      "category": "navigation",
+      "label": "Navigation shortcuts",
+      "description": "Libraries, sections, and collections pinned for use across navigation surfaces.",
+      "notes": "Profile-wide catalog; individual client families decide which shortcuts to place in their primary menu. Semantic destination identities are unique even when labels differ. The profile_client migration keeps ui.sidebar_pins unchanged and seeds this key from convertible legacy web pins only when this key has no authored row."
+    },
+    {
+      "key": "ui.card_presentation",
+      "introduced_in": 5,
+      "persistence": "remote",
+      "allowed_scopes": ["profile", "profile_client", "profile_device"],
+      "resolution_order": ["profile_device", "profile_client", "profile", "default"],
+      "value_schema": {
+        "type": "object",
+        "schema_ref": "card-presentation.json"
+      },
+      "default_value": { "poster_size": "standard", "caption": "title_metadata" },
+      "platforms": ["web", "ios", "tvos", "macos", "android", "android_tv"],
+      "category": "appearance",
+      "label": "Media cards",
+      "description": "Poster size and caption detail used by media cards.",
+      "recommended_control": "panel",
+      "notes": "Semantic presets roam between like devices without forcing identical pixel dimensions across platforms. A profile fallback can opt into one presentation everywhere; family and exact-device values remain more specific."
     },
     {
       "key": "ui.sidebar_pins",

--- a/iosApp/Tests/MetricKitCaptureTests.swift
+++ b/iosApp/Tests/MetricKitCaptureTests.swift
@@ -57,7 +57,12 @@ final class MetricKitCaptureTests: XCTestCase {
     private func makeDeviceSnapshotBuilder() -> DeviceSnapshotBuilder {
         DeviceSnapshotBuilder(
             identityProvider: {
-                AppleDeviceIdentity(id: "device-id", name: "Unit Test iPhone", platform: "iOS")
+                AppleDeviceIdentity(
+                    id: "device-id",
+                    name: "Unit Test iPhone",
+                    platform: "iOS",
+                    clientFamily: "mobile"
+                )
             },
             playbackSnapshotProvider: {
                 DiagnosticsCapabilityProbe.Snapshot(

--- a/iosApp/Tests/PairingCoordinatorTests.swift
+++ b/iosApp/Tests/PairingCoordinatorTests.swift
@@ -337,6 +337,7 @@ final class ReceiverPairingCoordinatorTests: XCTestCase {
     private func makeCoordinator(api: FakePairingAPI, recorder: PersistRecorder) -> ReceiverPairingCoordinator {
         ReceiverPairingCoordinator(api: api) { url, _, access, _ in
             recorder.persisted.append(Persisted(url: url, access: access))
+            return true
         }
     }
 
@@ -479,4 +480,63 @@ final class ReceiverPairingCoordinatorTests: XCTestCase {
         XCTAssertEqual(names, ["Home"])
         XCTAssertEqual(recorder.persisted.map(\.url), ["https://home.example"])
     }
+
+    /// A peer cancellation can arrive while the persistence transaction is
+    /// queued behind another identity transition. If the lease is never
+    /// acquired, the coordinator must not publish a sign-in that did not
+    /// commit or include it in the completion summary.
+    func testCancelledQueuedPersistDoesNotPublishSignedIn() async {
+        let http = HTTPClient()
+        guard let blockingLease = await http.beginIdentityTransition() else {
+            return XCTFail("blocking transition was unexpectedly cancelled")
+        }
+        let channel = FakePairingChannel()
+        let api = FakePairingAPI()
+        api.pollResponse = approvedPoll
+        let recorder = PersistRecorder()
+        let coordinator = ReceiverPairingCoordinator(api: api) { url, _, access, _ in
+            guard let lease = await http.beginIdentityTransition() else {
+                return false
+            }
+            recorder.persisted.append(Persisted(url: url, access: access))
+            await http.endIdentityTransition(lease)
+            return true
+        }
+        let runTask = Task { await coordinator.run(session: channel, stream: channel.stream) }
+
+        channel.deliver(.pushServer(serverURL: "https://home.example", serverName: "Home"))
+        await expectEventually("consent prompt") {
+            if case .consentRequested = coordinator.state { return true }
+            return false
+        }
+        coordinator.allowPendingServer()
+        guard await waitForIdentityTransitionWaiter(http) else {
+            await http.endIdentityTransition(blockingLease)
+            channel.dropConnection()
+            await runTask.value
+            return XCTFail("pairing persistence did not queue behind the active transition")
+        }
+
+        channel.deliver(.cancel(reason: "test_cancel"))
+        await runTask.value
+        XCTAssertEqual(coordinator.state, .idle)
+        XCTAssertTrue(recorder.persisted.isEmpty)
+        XCTAssertFalse(channel.sent.contains {
+            if case .serverResult(_, .signedIn, _) = $0 { return true }
+            return false
+        })
+
+        await http.endIdentityTransition(blockingLease)
+    }
+}
+
+private func waitForIdentityTransitionWaiter(_ http: HTTPClient) async -> Bool {
+    let deadline = ContinuousClock.now + .seconds(2)
+    while ContinuousClock.now < deadline {
+        if await http.pendingIdentityTransitionCount() > 0 {
+            return true
+        }
+        try? await Task.sleep(for: .milliseconds(10))
+    }
+    return false
 }

--- a/iosApp/Tests/SettingValuesAPITests.swift
+++ b/iosApp/Tests/SettingValuesAPITests.swift
@@ -693,6 +693,1216 @@ final class SettingValuesAPITests: XCTestCase {
         XCTAssertEqual(sessionExpiredCount.value, 0)
     }
 
+    func testFailedScopedRefreshExpiresOrdinaryJoinerWithoutAnonymousRetry() async throws {
+        SettingsStubProtocol.reset(mode: .mixedRefreshScopedFailure)
+        let suiteName = "settings-refresh-mixed-failure-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        addTeardownBlock {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+        }
+        let tokenStore = TokenStore(
+            keychain: SharedKeychain(
+                service: "SettingValuesMixedRefreshFailureTests.\(UUID().uuidString)",
+                accessGroup: nil
+            ),
+            defaults: SharedDefaults(suite: suite, standard: suite)
+        )
+        let identity = HTTPRequestIdentity(
+            serverId: "server-a",
+            serverURL: "http://settings-test.invalid",
+            profileId: "profile-a",
+            clientFamily: "mobile"
+        )
+        await tokenStore.switchActiveServer(serverId: identity.serverId)
+        await tokenStore.setServerUrl(identity.serverURL)
+        await tokenStore.setProfileId(identity.profileId)
+        await tokenStore.saveTokens(accessToken: "fake", refreshToken: "dummy")
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [SettingsStubProtocol.self]
+        let ordinaryJoinCount = LockedCounter()
+        let http = HTTPClient(
+            session: URLSession(configuration: config),
+            tokenStore: tokenStore,
+            refreshFlightJoinObserver: { kind in
+                if case .ordinary = kind {
+                    ordinaryJoinCount.increment()
+                }
+            }
+        )
+        let sessionExpiredCount = LockedCounter()
+        let observer = NotificationCenter.default.addObserver(
+            forName: .continuumSessionExpired,
+            object: nil,
+            queue: nil
+        ) { _ in
+            sessionExpiredCount.increment()
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        async let scoped: HTTPRawResponse = http.requestData(
+            method: "GET",
+            path: "/api/v1/settings/contract/capabilities",
+            headers: ["X-Test-Refresh-Flow": "scoped"],
+            requestIdentity: identity
+        )
+        async let ordinary: HTTPRawResponse = http.requestData(
+            method: "GET",
+            path: "/api/v1/settings/contract/capabilities",
+            headers: ["X-Test-Refresh-Flow": "ordinary"]
+        )
+
+        defer { SettingsStubProtocol.releaseMixedRefresh() }
+        guard await waitForCounter(ordinaryJoinCount, atLeast: 1) else {
+            return XCTFail("the ordinary 401 never joined the scoped-owned refresh flight")
+        }
+        SettingsStubProtocol.releaseMixedRefresh()
+
+        do {
+            _ = try await ordinary
+            XCTFail("The ordinary joiner must fail when the shared refresh is rejected")
+        } catch {
+            XCTAssertEqual((error as? HTTPError)?.statusCode, 401)
+        }
+        do {
+            _ = try await scoped
+            XCTFail("The scoped owner must fail when its refresh is rejected")
+        } catch {
+            XCTAssertEqual((error as? HTTPError)?.statusCode, 401)
+        }
+
+        let state = SettingsStubProtocol.state()
+        XCTAssertEqual(state.requestCounts["/api/v1/auth/refresh"], 1)
+        XCTAssertEqual(state.requestCounts["/api/v1/settings/contract/capabilities"], 2)
+        let accessToken = await tokenStore.getAccessToken()
+        let refreshToken = await tokenStore.getRefreshToken()
+        XCTAssertNil(accessToken)
+        XCTAssertNil(refreshToken)
+        XCTAssertEqual(sessionExpiredCount.value, 1)
+    }
+
+    func testTransientScopedRefreshFailurePreservesCredentialsWithoutExpiryAndCanRetry() async throws {
+        let harness = try await makeRefreshHarness(testName: "TransientRefresh")
+        let sessionExpiredCount = LockedCounter()
+        let observer = NotificationCenter.default.addObserver(
+            forName: .continuumSessionExpired,
+            object: nil,
+            queue: nil
+        ) { _ in
+            sessionExpiredCount.increment()
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        for status in [429, 503] {
+            SettingsStubProtocol.reset(mode: .mixedRefreshScopedTransientFailure(status: status))
+            async let scoped: HTTPRawResponse = harness.http.requestData(
+                method: "GET",
+                path: "/api/v1/settings/contract/capabilities",
+                headers: ["X-Test-Refresh-Flow": "scoped"],
+                requestIdentity: harness.identity
+            )
+            async let ordinary: HTTPRawResponse = harness.http.requestData(
+                method: "GET",
+                path: "/api/v1/settings/contract/capabilities",
+                headers: ["X-Test-Refresh-Flow": "ordinary"]
+            )
+
+            do {
+                _ = try await ordinary
+                XCTFail("The ordinary joiner must keep the original 401 after refresh HTTP \(status)")
+            } catch {
+                XCTAssertEqual((error as? HTTPError)?.statusCode, 401)
+            }
+            do {
+                _ = try await scoped
+                XCTFail("The scoped owner must keep the original 401 after refresh HTTP \(status)")
+            } catch {
+                XCTAssertEqual((error as? HTTPError)?.statusCode, 401)
+            }
+
+            let state = SettingsStubProtocol.state()
+            XCTAssertEqual(state.requestCounts["/api/v1/auth/refresh"], 1)
+            XCTAssertEqual(state.requestCounts["/api/v1/settings/contract/capabilities"], 2)
+            let accessToken = await harness.tokenStore.getAccessToken()
+            let refreshToken = await harness.tokenStore.getRefreshToken()
+            XCTAssertEqual(accessToken, "fake", "HTTP \(status) must preserve the access token")
+            XCTAssertEqual(refreshToken, "dummy", "HTTP \(status) must preserve the refresh token")
+            XCTAssertEqual(sessionExpiredCount.value, 0)
+        }
+
+        // A later 401 wave must be able to submit the preserved refresh token
+        // and rotate the account credentials normally.
+        SettingsStubProtocol.reset(mode: .mixedRefreshScopedWins)
+        let retried = try await harness.http.requestData(
+            method: "GET",
+            path: "/api/v1/settings/contract/capabilities",
+            headers: ["X-Test-Refresh-Flow": "scoped"],
+            requestIdentity: harness.identity
+        )
+        XCTAssertEqual(retried.statusCode, 200)
+        let accessToken = await harness.tokenStore.getAccessToken()
+        let refreshToken = await harness.tokenStore.getRefreshToken()
+        XCTAssertEqual(accessToken, "placeholder")
+        XCTAssertEqual(refreshToken, "redacted")
+        XCTAssertEqual(sessionExpiredCount.value, 0)
+    }
+
+    func testMalformedSuccessfulScopedRefreshDoesNotMarkServerUnreachable() async throws {
+        SettingsStubProtocol.reset(mode: .mixedRefreshScopedMalformedSuccess)
+        let harness = try await makeRefreshHarness(testName: "MalformedRefresh")
+        let sessionExpiredCount = LockedCounter()
+        let observer = NotificationCenter.default.addObserver(
+            forName: .continuumSessionExpired,
+            object: nil,
+            queue: nil
+        ) { _ in
+            sessionExpiredCount.increment()
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+        await MainActor.run {
+            ConnectionMonitor.shared.noteServerResponded()
+        }
+
+        async let scoped: HTTPRawResponse = harness.http.requestData(
+            method: "GET",
+            path: "/api/v1/settings/contract/capabilities",
+            headers: ["X-Test-Refresh-Flow": "scoped"],
+            requestIdentity: harness.identity
+        )
+        async let ordinary: HTTPRawResponse = harness.http.requestData(
+            method: "GET",
+            path: "/api/v1/settings/contract/capabilities",
+            headers: ["X-Test-Refresh-Flow": "ordinary"]
+        )
+
+        do {
+            _ = try await ordinary
+            XCTFail("The ordinary joiner must keep the original 401 when refresh decoding fails")
+        } catch {
+            XCTAssertEqual((error as? HTTPError)?.statusCode, 401)
+        }
+        do {
+            _ = try await scoped
+            XCTFail("The scoped owner must keep the original 401 when refresh decoding fails")
+        } catch {
+            XCTAssertEqual((error as? HTTPError)?.statusCode, 401)
+        }
+
+        let markedUnreachable = await MainActor.run {
+            if case .unreachable = ConnectionMonitor.shared.serverStatus {
+                return true
+            }
+            return false
+        }
+        XCTAssertFalse(markedUnreachable, "a malformed HTTP 200 is not a transport failure")
+        let accessToken = await harness.tokenStore.getAccessToken()
+        let refreshToken = await harness.tokenStore.getRefreshToken()
+        XCTAssertEqual(accessToken, "fake")
+        XCTAssertEqual(refreshToken, "dummy")
+        XCTAssertEqual(sessionExpiredCount.value, 0)
+    }
+
+    func testRefreshFailureClassifierMatchesAndroid() {
+        for status in [400, 401, 403] {
+            XCTAssertTrue(
+                HTTPClient.shouldInvalidateSessionAfterRefreshFailure(status),
+                "HTTP \(status) is a terminal refresh rejection"
+            )
+        }
+        for status in [408, 429, 500, 502, 503, 504] {
+            XCTAssertFalse(
+                HTTPClient.shouldInvalidateSessionAfterRefreshFailure(status),
+                "HTTP \(status) must remain retryable"
+            )
+        }
+    }
+
+    func testOrdinaryUnauthorizedResponseCannotRefreshAccountSelectedAfterRequestWasSent() async throws {
+        SettingsStubProtocol.reset(mode: .ordinaryUnauthorizedDelayed)
+        let harness = try await makeRefreshHarness(testName: "UnauthorizedServerSwitch")
+
+        let requestTask = Task {
+            try await harness.http.requestData(
+                method: "GET",
+                path: "/api/v1/settings/contract/capabilities"
+            )
+        }
+        guard await waitForPendingOrdinaryUnauthorized() else {
+            SettingsStubProtocol.releaseOrdinaryUnauthorized()
+            return XCTFail("ordinary request did not reach the delayed 401")
+        }
+
+        // Keep the same origin so only the captured server-account ID can
+        // prevent B's token from being treated as a successful refresh of A.
+        await harness.tokenStore.switchActiveServer(serverId: "server-b")
+        await harness.tokenStore.setServerUrl(harness.identity.serverURL)
+        await harness.tokenStore.setProfileId("profile-b")
+        await harness.tokenStore.saveTokens(
+            accessToken: "example",
+            refreshToken: "sample"
+        )
+        SettingsStubProtocol.releaseOrdinaryUnauthorized()
+
+        do {
+            _ = try await requestTask.value
+            XCTFail("the server-A 401 must not refresh or retry under server B")
+        } catch {
+            XCTAssertEqual((error as? HTTPError)?.statusCode, 401)
+        }
+        let accessToken = await harness.tokenStore.getAccessToken()
+        let refreshToken = await harness.tokenStore.getRefreshToken()
+        XCTAssertEqual(accessToken, "example")
+        XCTAssertEqual(refreshToken, "sample")
+        let state = SettingsStubProtocol.state()
+        XCTAssertEqual(state.requestCounts["/api/v1/auth/refresh"] ?? 0, 0)
+        XCTAssertEqual(state.requestCounts["/api/v1/settings/contract/capabilities"], 1)
+    }
+
+    func testOrdinaryUnauthorizedResponseCannotRefreshSameServerSessionInstalledAfterLogout() async throws {
+        SettingsStubProtocol.reset(mode: .ordinaryUnauthorizedDelayed)
+        let harness = try await makeRefreshHarness(testName: "UnauthorizedSameServerRelogin")
+
+        let requestTask = Task {
+            try await harness.http.requestData(
+                method: "GET",
+                path: "/api/v1/settings/contract/capabilities"
+            )
+        }
+        guard await waitForPendingOrdinaryUnauthorized() else {
+            SettingsStubProtocol.releaseOrdinaryUnauthorized()
+            return XCTFail("ordinary request did not reach the delayed 401")
+        }
+
+        await harness.tokenStore.clearTokens()
+        await harness.tokenStore.saveTokens(
+            accessToken: "placeholder",
+            refreshToken: "redacted"
+        )
+        await harness.tokenStore.setProfileId(harness.identity.profileId)
+        SettingsStubProtocol.releaseOrdinaryUnauthorized()
+
+        do {
+            _ = try await requestTask.value
+            XCTFail("the previous login epoch must not refresh or retry as a same-server replacement")
+        } catch {
+            XCTAssertEqual((error as? HTTPError)?.statusCode, 401)
+        }
+        let accessToken = await harness.tokenStore.getAccessToken()
+        let refreshToken = await harness.tokenStore.getRefreshToken()
+        XCTAssertEqual(accessToken, "placeholder")
+        XCTAssertEqual(refreshToken, "redacted")
+        let state = SettingsStubProtocol.state()
+        XCTAssertEqual(state.requestCounts["/api/v1/auth/refresh"] ?? 0, 0)
+        XCTAssertEqual(state.requestCounts["/api/v1/settings/contract/capabilities"], 1)
+    }
+
+    func testScopedUnauthorizedResponseCannotRefreshSameServerSessionInstalledAfterLogout() async throws {
+        SettingsStubProtocol.reset(mode: .ordinaryUnauthorizedDelayed)
+        let harness = try await makeRefreshHarness(testName: "ScopedUnauthorizedSameServerRelogin")
+
+        let requestTask = Task {
+            try await harness.http.requestData(
+                method: "GET",
+                path: "/api/v1/settings/contract/capabilities",
+                requestIdentity: harness.identity
+            )
+        }
+        guard await waitForPendingOrdinaryUnauthorized() else {
+            SettingsStubProtocol.releaseOrdinaryUnauthorized()
+            return XCTFail("scoped request did not reach the delayed 401")
+        }
+
+        await harness.tokenStore.clearTokens()
+        await harness.tokenStore.saveTokens(
+            accessToken: "placeholder",
+            refreshToken: "redacted"
+        )
+        await harness.tokenStore.setProfileId(harness.identity.profileId)
+        SettingsStubProtocol.releaseOrdinaryUnauthorized()
+
+        do {
+            _ = try await requestTask.value
+            XCTFail("the scoped request must not refresh or retry as a same-server replacement epoch")
+        } catch {
+            XCTAssertEqual((error as? HTTPError)?.statusCode, 401)
+        }
+        let accessToken = await harness.tokenStore.getAccessToken()
+        let refreshToken = await harness.tokenStore.getRefreshToken()
+        XCTAssertEqual(accessToken, "placeholder")
+        XCTAssertEqual(refreshToken, "redacted")
+        let state = SettingsStubProtocol.state()
+        XCTAssertEqual(state.requestCounts["/api/v1/auth/refresh"] ?? 0, 0)
+        XCTAssertEqual(state.requestCounts["/api/v1/settings/contract/capabilities"], 1)
+    }
+
+    func testOrdinaryUnauthorizedResponseCannotRetryAfterProfileSwitch() async throws {
+        SettingsStubProtocol.reset(mode: .ordinaryUnauthorizedDelayed)
+        let harness = try await makeRefreshHarness(testName: "UnauthorizedProfileSwitch")
+        await harness.tokenStore.setProfileToken("decoy-token")
+
+        let requestTask = Task {
+            try await harness.http.requestData(
+                method: "GET",
+                path: "/api/v1/settings/contract/capabilities"
+            )
+        }
+        guard await waitForPendingOrdinaryUnauthorized() else {
+            SettingsStubProtocol.releaseOrdinaryUnauthorized()
+            return XCTFail("ordinary request did not reach the delayed 401")
+        }
+
+        await harness.tokenStore.setProfileId("profile-b")
+        await harness.tokenStore.setProfileToken("gateway-token")
+        SettingsStubProtocol.releaseOrdinaryUnauthorized()
+
+        do {
+            _ = try await requestTask.value
+            XCTFail("the profile-A request must not refresh or retry as profile B")
+        } catch {
+            XCTAssertEqual((error as? HTTPError)?.statusCode, 401)
+        }
+        let state = SettingsStubProtocol.state()
+        XCTAssertEqual(state.requestCounts["/api/v1/auth/refresh"] ?? 0, 0)
+        XCTAssertEqual(state.requestCounts["/api/v1/settings/contract/capabilities"], 1)
+        XCTAssertEqual(state.lastRequest?.header("X-Profile-Id"), "profile-a")
+        XCTAssertEqual(state.lastRequest?.header("X-Profile-Token"), "decoy-token")
+    }
+
+    func testOrdinaryUnauthorizedResponseCannotCrossFromPersistentIntoTemporaryCredentials() async throws {
+        SettingsStubProtocol.reset(mode: .ordinaryUnauthorizedDelayed)
+        let harness = try await makeRefreshHarness(testName: "PersistentToTemporary")
+        await harness.tokenStore.setProfileToken("test-auth-token")
+
+        let requestTask = Task {
+            try await harness.http.requestData(
+                method: "GET",
+                path: "/api/v1/settings/contract/capabilities"
+            )
+        }
+        guard await waitForPendingOrdinaryUnauthorized() else {
+            SettingsStubProtocol.releaseOrdinaryUnauthorized()
+            return XCTFail("persistent request did not reach the delayed 401")
+        }
+
+        let temporary = TemporaryAuthScope(
+            serverId: harness.identity.serverId,
+            serverURL: harness.identity.serverURL,
+            accessToken: "example",
+            refreshToken: "sample",
+            profileId: harness.identity.profileId,
+            profileToken: "test-auth-token",
+            controllerDeviceId: "controller",
+            expiresAt: Date().addingTimeInterval(60)
+        )
+        await harness.tokenStore.beginTemporaryScope(temporary)
+        SettingsStubProtocol.releaseOrdinaryUnauthorized()
+
+        do {
+            _ = try await requestTask.value
+            XCTFail("a persistent 401 must not consume the same-account temporary overlay")
+        } catch {
+            XCTAssertEqual((error as? HTTPError)?.statusCode, 401)
+        }
+        let current = await harness.tokenStore.getTemporaryScope()
+        XCTAssertEqual(current?.credentialGenerationID, temporary.credentialGenerationID)
+        XCTAssertEqual(current?.accessToken, "example")
+        XCTAssertEqual(current?.refreshToken, "sample")
+        let state = SettingsStubProtocol.state()
+        XCTAssertEqual(state.requestCounts["/api/v1/auth/refresh"] ?? 0, 0)
+        XCTAssertEqual(state.requestCounts["/api/v1/settings/contract/capabilities"], 1)
+    }
+
+    func testOrdinaryUnauthorizedResponseCannotCrossFromTemporaryIntoPersistentCredentials() async throws {
+        SettingsStubProtocol.reset(mode: .ordinaryUnauthorizedDelayed)
+        let harness = try await makeRefreshHarness(testName: "TemporaryToPersistent")
+        await harness.tokenStore.setProfileToken("test-auth-token")
+        let temporary = TemporaryAuthScope(
+            serverId: harness.identity.serverId,
+            serverURL: harness.identity.serverURL,
+            accessToken: "example",
+            refreshToken: "sample",
+            profileId: harness.identity.profileId,
+            profileToken: "test-auth-token",
+            controllerDeviceId: "controller",
+            expiresAt: Date().addingTimeInterval(60)
+        )
+        await harness.tokenStore.beginTemporaryScope(temporary)
+
+        let requestTask = Task {
+            try await harness.http.requestData(
+                method: "GET",
+                path: "/api/v1/settings/contract/capabilities"
+            )
+        }
+        guard await waitForPendingOrdinaryUnauthorized() else {
+            SettingsStubProtocol.releaseOrdinaryUnauthorized()
+            return XCTFail("temporary request did not reach the delayed 401")
+        }
+
+        _ = await harness.tokenStore.endTemporaryScope()
+        SettingsStubProtocol.releaseOrdinaryUnauthorized()
+
+        do {
+            _ = try await requestTask.value
+            XCTFail("a temporary 401 must not fall through to the persistent account")
+        } catch {
+            XCTAssertEqual((error as? HTTPError)?.statusCode, 401)
+        }
+        let accessToken = await harness.tokenStore.getAccessToken()
+        let refreshToken = await harness.tokenStore.getRefreshToken()
+        XCTAssertEqual(accessToken, "fake")
+        XCTAssertEqual(refreshToken, "dummy")
+        let state = SettingsStubProtocol.state()
+        XCTAssertEqual(state.requestCounts["/api/v1/auth/refresh"] ?? 0, 0)
+        XCTAssertEqual(state.requestCounts["/api/v1/settings/contract/capabilities"], 1)
+    }
+
+    func testRejectedTemporaryGenerationRefreshesAndExpiresOnlyOnce() async throws {
+        SettingsStubProtocol.reset(mode: .temporaryRefreshRejected)
+        let harness = try await makeRefreshHarness(testName: "RejectedTemporaryGeneration")
+        let temporary = TemporaryAuthScope(
+            serverId: harness.identity.serverId,
+            serverURL: harness.identity.serverURL,
+            accessToken: "example",
+            refreshToken: "sample",
+            profileId: harness.identity.profileId,
+            profileToken: "decoy-token",
+            controllerDeviceId: "controller",
+            expiresAt: Date().addingTimeInterval(60)
+        )
+        await harness.tokenStore.beginTemporaryScope(temporary)
+        let expiryCount = LockedCounter()
+        let expiryEvents = LockedSessionExpiryEvents()
+        let observer = NotificationCenter.default.addObserver(
+            forName: .temporaryRemoteAuthExpired,
+            object: nil,
+            queue: nil
+        ) { notification in
+            expiryCount.increment()
+            if let event = notification.object as? SessionExpiryEvent {
+                expiryEvents.append(event)
+            }
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        for wave in 1...2 {
+            do {
+                _ = try await harness.http.requestData(
+                    method: "GET",
+                    path: "/api/v1/settings/contract/capabilities"
+                )
+                XCTFail("temporary 401 wave \(wave) must remain unauthorized")
+            } catch {
+                XCTAssertEqual((error as? HTTPError)?.statusCode, 401)
+            }
+        }
+
+        let state = SettingsStubProtocol.state()
+        XCTAssertEqual(state.requestCounts["/api/v1/auth/refresh"], 1)
+        XCTAssertEqual(state.requestCounts["/api/v1/settings/contract/capabilities"], 2)
+        XCTAssertEqual(expiryCount.value, 1)
+        let current = await harness.tokenStore.getTemporaryScope()
+        XCTAssertEqual(current?.credentialGenerationID, temporary.credentialGenerationID)
+        XCTAssertEqual(current?.accessToken, "example")
+        XCTAssertEqual(current?.refreshToken, "sample")
+        XCTAssertEqual(expiryEvents.values, [SessionExpiryEvent(
+            account: RefreshAccountIdentity(
+                serverId: temporary.serverId,
+                serverURL: temporary.serverURL,
+                credentialGenerationID: temporary.credentialGenerationID
+            ),
+            disposition: .temporarySessionExpired
+        )])
+    }
+
+    func testPersistentExpiryEventIsRejectedAfterSameServerSessionReplacement() async throws {
+        SettingsStubProtocol.reset(mode: .normal)
+        let harness = try await makeRefreshHarness(testName: "PersistentExpiryEpoch")
+        let accountValue = await harness.tokenStore.refreshAccountIdentity()
+        let account = try XCTUnwrap(accountValue)
+        let capturedValue = await harness.tokenStore.captureRefreshCredential(expected: account)
+        let captured = try XCTUnwrap(capturedValue)
+        let dispositionValue = await harness.tokenStore.invalidateRejectedRefresh(captured)
+        let disposition = try XCTUnwrap(dispositionValue)
+        let event = SessionExpiryEvent(account: account, disposition: disposition)
+
+        XCTAssertEqual(disposition, .persistentSessionCleared)
+        let consumableBeforeReplacement = await harness.tokenStore.shouldConsumeSessionExpiryEvent(event)
+        XCTAssertTrue(consumableBeforeReplacement)
+
+        await harness.tokenStore.saveTokens(
+            accessToken: "placeholder",
+            refreshToken: "redacted"
+        )
+        await harness.tokenStore.setProfileId(harness.identity.profileId)
+
+        let consumableAfterReplacement = await harness.tokenStore.shouldConsumeSessionExpiryEvent(event)
+        XCTAssertFalse(
+            consumableAfterReplacement,
+            "a queued rejection from the prior epoch must not sign out a same-server replacement"
+        )
+    }
+
+    func testTemporaryExpiryTeardownCannotRemoveReplacementAfterConsumerValidation() async throws {
+        SettingsStubProtocol.reset(mode: .normal)
+        let harness = try await makeRefreshHarness(testName: "TemporaryExpiryReplacement")
+        let rejected = TemporaryAuthScope(
+            serverId: harness.identity.serverId,
+            serverURL: harness.identity.serverURL,
+            accessToken: "fake",
+            refreshToken: "dummy",
+            profileId: harness.identity.profileId,
+            profileToken: "gateway-token",
+            controllerDeviceId: "controller-a",
+            expiresAt: Date().addingTimeInterval(60)
+        )
+        await harness.tokenStore.beginTemporaryScope(rejected)
+        let accountValue = await harness.tokenStore.refreshAccountIdentity()
+        let account = try XCTUnwrap(accountValue)
+        let capturedValue = await harness.tokenStore.captureRefreshCredential(expected: account)
+        let captured = try XCTUnwrap(capturedValue)
+        let dispositionValue = await harness.tokenStore.invalidateRejectedRefresh(captured)
+        let disposition = try XCTUnwrap(dispositionValue)
+        let event = SessionExpiryEvent(account: account, disposition: disposition)
+
+        XCTAssertEqual(disposition, .temporarySessionExpired)
+        let consumableBeforeReplacement = await harness.tokenStore.shouldConsumeSessionExpiryEvent(event)
+        XCTAssertTrue(consumableBeforeReplacement)
+
+        // Model replacement after ContentView consumed the event but before
+        // player cleanup completed and the TV identity manager reached its
+        // destructive scope-removal step.
+        let replacement = TemporaryAuthScope(
+            serverId: rejected.serverId,
+            serverURL: rejected.serverURL,
+            accessToken: "placeholder",
+            refreshToken: "redacted",
+            profileId: rejected.profileId,
+            profileToken: "test-token-placeholder",
+            controllerDeviceId: "controller-b",
+            expiresAt: Date().addingTimeInterval(120)
+        )
+        await harness.tokenStore.beginTemporaryScope(replacement)
+
+        let removed = await harness.tokenStore.endTemporaryScope(
+            expectedGenerationID: rejected.credentialGenerationID
+        )
+        XCTAssertNil(removed)
+        let currentScope = await harness.tokenStore.getTemporaryScope()
+        let consumableAfterReplacement = await harness.tokenStore.shouldConsumeSessionExpiryEvent(event)
+        XCTAssertEqual(currentScope, replacement)
+        XCTAssertFalse(consumableAfterReplacement)
+    }
+
+    func testReplacementCancellationWaitsForOldEndBeforeStartingNewGenerationRequest() async throws {
+        SettingsStubProtocol.reset(mode: .normal)
+        let harness = try await makeRefreshHarness(testName: "SerializedIdentityCancellation")
+        let barrier = SerializedCancellationPassBarrier()
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [SettingsStubProtocol.self]
+        let http = HTTPClient(
+            session: URLSession(configuration: config),
+            tokenStore: harness.tokenStore,
+            cancellationPassBarrier: { await barrier.enter() }
+        )
+
+        // Model an old end already enumerating URLSession work when a
+        // replacement activation begins its own cancellation pass.
+        let oldEnd = Task { await http.cancelInFlightRequests() }
+        guard await waitForCancellationPass(barrier, count: 1) else {
+            return XCTFail("old-generation cancellation pass did not start")
+        }
+        let replacement = Task {
+            await http.cancelInFlightRequests()
+            return try await http.requestData(
+                method: "GET",
+                path: "/api/v1/settings/contract/capabilities"
+            )
+        }
+
+        try? await Task.sleep(for: .milliseconds(50))
+        let overlappingPassCount = await barrier.entryCount
+        XCTAssertEqual(
+            overlappingPassCount,
+            1,
+            "replacement cancellation must queue instead of overlapping the old enumeration"
+        )
+        XCTAssertEqual(
+            SettingsStubProtocol.state().requestCounts["/api/v1/settings/contract/capabilities"] ?? 0,
+            0,
+            "replacement work must not start while an old cancellation can still enumerate it"
+        )
+
+        await barrier.release(pass: 1)
+        await oldEnd.value
+        guard await waitForCancellationPass(barrier, count: 2) else {
+            return XCTFail("replacement cancellation pass did not start after the old pass")
+        }
+        XCTAssertEqual(
+            SettingsStubProtocol.state().requestCounts["/api/v1/settings/contract/capabilities"] ?? 0,
+            0
+        )
+        await barrier.release(pass: 2)
+
+        let response = try await replacement.value
+        XCTAssertEqual(response.statusCode, 200)
+        XCTAssertEqual(
+            SettingsStubProtocol.state().requestCounts["/api/v1/settings/contract/capabilities"],
+            1
+        )
+    }
+
+    func testScopedRefreshCannotRetryAsSameServerReplacementInstalledAfterRefresh() async throws {
+        SettingsStubProtocol.reset(mode: .mixedRefreshScopedWins)
+        let harness = try await makeRefreshHarness(testName: "ScopedPostRefreshReplacement")
+        let barrier = SerializedCancellationPassBarrier()
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [SettingsStubProtocol.self]
+        let http = HTTPClient(
+            session: URLSession(configuration: config),
+            tokenStore: harness.tokenStore,
+            scopedRefreshRetryBarrier: { await barrier.enter() }
+        )
+
+        let request = Task {
+            try await http.requestData(
+                method: "GET",
+                path: "/api/v1/settings/contract/capabilities",
+                headers: ["X-Test-Refresh-Flow": "scoped"],
+                requestIdentity: harness.identity
+            )
+        }
+        guard await waitForCancellationPass(barrier, count: 1) else {
+            return XCTFail("scoped request did not reach its post-refresh retry boundary")
+        }
+        await harness.tokenStore.clearTokens()
+        await harness.tokenStore.saveTokens(
+            accessToken: "placeholder",
+            refreshToken: "redacted"
+        )
+        await harness.tokenStore.setProfileId(harness.identity.profileId)
+        await barrier.release(pass: 1)
+
+        do {
+            _ = try await request.value
+            XCTFail("the prior epoch must not retry under a same-server replacement")
+        } catch {
+            XCTAssertEqual((error as? HTTPError)?.statusCode, 401)
+        }
+        let replacementAccess = await harness.tokenStore.getAccessToken()
+        let replacementRefresh = await harness.tokenStore.getRefreshToken()
+        XCTAssertEqual(replacementAccess, "placeholder")
+        XCTAssertEqual(replacementRefresh, "redacted")
+        let state = SettingsStubProtocol.state()
+        XCTAssertEqual(state.requestCounts["/api/v1/auth/refresh"], 1)
+        XCTAssertEqual(state.requestCounts["/api/v1/settings/contract/capabilities"], 1)
+    }
+
+    func testCancelledTemporaryReplacementRestoresPriorOwnerGeneration() async throws {
+        SettingsStubProtocol.reset(mode: .normal)
+        let harness = try await makeRefreshHarness(testName: "TemporaryActivationRollback")
+        let previous = TemporaryAuthScope(
+            serverId: harness.identity.serverId,
+            serverURL: harness.identity.serverURL,
+            accessToken: "fake",
+            refreshToken: "dummy",
+            profileId: harness.identity.profileId,
+            profileToken: "decoy-token",
+            controllerDeviceId: "controller-a",
+            expiresAt: Date().addingTimeInterval(60)
+        )
+        let replacement = TemporaryAuthScope(
+            serverId: previous.serverId,
+            serverURL: previous.serverURL,
+            accessToken: "placeholder",
+            refreshToken: "redacted",
+            profileId: previous.profileId,
+            profileToken: "test-token-placeholder",
+            controllerDeviceId: "controller-b",
+            expiresAt: Date().addingTimeInterval(120)
+        )
+        await harness.tokenStore.beginTemporaryScope(previous)
+        let barrier = SerializedCancellationPassBarrier()
+
+        let activation = Task {
+            let displaced = await harness.tokenStore.beginTemporaryScope(replacement)
+            await barrier.enter()
+            guard !Task.isCancelled else {
+                return await harness.tokenStore.restoreTemporaryScope(
+                    displaced,
+                    replacingGenerationID: replacement.credentialGenerationID
+                )
+            }
+            return false
+        }
+        guard await waitForCancellationPass(barrier, count: 1) else {
+            return XCTFail("replacement was not installed before cancellation")
+        }
+        activation.cancel()
+        await barrier.release(pass: 1)
+        let restored = await activation.value
+        let restoredScope = await harness.tokenStore.getTemporaryScope()
+        let restoredAccount = await harness.tokenStore.refreshAccountIdentity()
+        XCTAssertTrue(restored)
+        XCTAssertEqual(restoredScope, previous)
+        XCTAssertEqual(
+            restoredAccount?.credentialGenerationID,
+            previous.credentialGenerationID,
+            "TokenStore must remain aligned with the manager's prior active generation"
+        )
+    }
+
+    func testRequestStartingBetweenCancellationSessionSnapshotsIsRejected() async throws {
+        SettingsStubProtocol.reset(mode: .normal)
+        let harness = try await makeRefreshHarness(testName: "CancellationSnapshotGate")
+        let barrier = SerializedCancellationPassBarrier()
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [SettingsStubProtocol.self]
+        let http = HTTPClient(
+            session: URLSession(configuration: config),
+            tokenStore: harness.tokenStore,
+            cancellationSessionBarrier: { index in
+                if index == 1 { await barrier.enter() }
+            }
+        )
+
+        let cancellation = Task { await http.cancelInFlightRequests() }
+        guard await waitForCancellationPass(barrier, count: 1) else {
+            return XCTFail("cancellation did not pause between session snapshots")
+        }
+        do {
+            _ = try await http.requestData(
+                method: "GET",
+                path: "/api/v1/settings/contract/capabilities"
+            )
+            XCTFail("dispatch must remain closed between cancellation snapshots")
+        } catch HTTPError.requestIdentityChanged {
+            // Expected.
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+        XCTAssertEqual(
+            SettingsStubProtocol.state().requestCounts["/api/v1/settings/contract/capabilities"] ?? 0,
+            0
+        )
+        await barrier.release(pass: 1)
+        await cancellation.value
+    }
+
+    func testPublishedServerHydrationWaitsUntilCancellationAndTransitionAreOpen() async throws {
+        SettingsStubProtocol.reset(mode: .normal)
+        let harness = try await makeRefreshHarness(testName: "PublishedServerHydrationGate")
+        let cancellationBarrier = SerializedCancellationPassBarrier()
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [SettingsStubProtocol.self]
+        let http = HTTPClient(
+            session: URLSession(configuration: config),
+            tokenStore: harness.tokenStore,
+            cancellationPassBarrier: { await cancellationBarrier.enter() }
+        )
+        guard let lease = await http.beginIdentityTransition() else {
+            return XCTFail("identity transition was unexpectedly cancelled")
+        }
+
+        let cancellation = Task { await http.cancelInFlightRequests() }
+        guard await waitForCancellationPass(cancellationBarrier, count: 1) else {
+            await http.endIdentityTransition(lease)
+            return XCTFail("cancellation pass did not reach its barrier")
+        }
+
+        // Mirrors ServerRegistry publishing `activeServerId` before releasing
+        // the transition lease, which starts ContentView's keyed hydration.
+        let activeServerPublications = LockedCounter()
+        let hydrationStarts = LockedCounter()
+        activeServerPublications.increment()
+        let hydration = Task {
+            guard await http.waitForRequestDispatchOpen() else { return false }
+            guard !Task.isCancelled else { return false }
+            hydrationStarts.increment()
+            return true
+        }
+        guard await waitForRequestDispatchWaiter(http) else {
+            await cancellationBarrier.release(pass: 1)
+            await cancellation.value
+            await http.endIdentityTransition(lease)
+            return XCTFail("published-server hydration did not wait for dispatch")
+        }
+        XCTAssertEqual(activeServerPublications.value, 1)
+        XCTAssertEqual(hydrationStarts.value, 0)
+
+        await cancellationBarrier.release(pass: 1)
+        await cancellation.value
+        XCTAssertEqual(
+            hydrationStarts.value,
+            0,
+            "finishing cancellation alone must not bypass the published switch lease"
+        )
+
+        await http.endIdentityTransition(lease)
+        let hydrationCompleted = await hydration.value
+        XCTAssertTrue(hydrationCompleted)
+        XCTAssertEqual(hydrationStarts.value, 1)
+    }
+
+    func testCancelledDispatchOpenWaiterPerformsNoHydrationWork() async throws {
+        SettingsStubProtocol.reset(mode: .normal)
+        let harness = try await makeRefreshHarness(testName: "CancelledHydrationWaiter")
+        guard let lease = await harness.http.beginIdentityTransition() else {
+            return XCTFail("identity transition was unexpectedly cancelled")
+        }
+
+        let hydrationStarts = LockedCounter()
+        let hydration = Task {
+            guard await harness.http.waitForRequestDispatchOpen() else { return false }
+            guard !Task.isCancelled else { return false }
+            hydrationStarts.increment()
+            return true
+        }
+        guard await waitForRequestDispatchWaiter(harness.http) else {
+            await harness.http.endIdentityTransition(lease)
+            return XCTFail("hydration did not queue behind the transition")
+        }
+
+        hydration.cancel()
+        let hydrationCompleted = await hydration.value
+        let pendingWaiters = await harness.http.pendingRequestDispatchWaiterCount()
+        XCTAssertFalse(hydrationCompleted)
+        XCTAssertEqual(hydrationStarts.value, 0)
+        XCTAssertEqual(pendingWaiters, 0)
+
+        await harness.http.endIdentityTransition(lease)
+        XCTAssertEqual(hydrationStarts.value, 0)
+    }
+
+    func testRequestCaptureCannotSurviveCompletedIdentityRetarget() async throws {
+        SettingsStubProtocol.reset(mode: .normal)
+        let harness = try await makeRefreshHarness(testName: "CaptureDuringRetarget")
+        let barrier = SerializedCancellationPassBarrier()
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [SettingsStubProtocol.self]
+        let http = HTTPClient(
+            session: URLSession(configuration: config),
+            tokenStore: harness.tokenStore,
+            requestCaptureBarrier: { await barrier.enter() }
+        )
+
+        let request = Task {
+            try await http.requestData(
+                method: "GET",
+                path: "/api/v1/settings/contract/capabilities"
+            )
+        }
+        guard await waitForCancellationPass(barrier, count: 1) else {
+            return XCTFail("request did not pause before credential capture")
+        }
+        guard let lease = await http.beginIdentityTransition() else {
+            return XCTFail("identity transition was unexpectedly cancelled")
+        }
+        await http.cancelInFlightRequests()
+        await harness.tokenStore.setServerUrl("http://replacement.invalid")
+        await harness.tokenStore.switchActiveServer(serverId: "server-b")
+        await harness.tokenStore.setProfileId("profile-b")
+        await harness.tokenStore.saveTokens(accessToken: "example", refreshToken: "sample")
+        await http.endIdentityTransition(lease)
+        await barrier.release(pass: 1)
+
+        do {
+            _ = try await request.value
+            XCTFail("a pre-retarget dispatch revision must not send after the gate reopens")
+        } catch HTTPError.requestIdentityChanged {
+            // Expected.
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+        XCTAssertNil(SettingsStubProtocol.state().lastRequest)
+    }
+
+    func testCompletedResponseIsRejectedWhenIdentityTransitionsBeforeDelivery() async throws {
+        SettingsStubProtocol.reset(mode: .normal)
+        let harness = try await makeRefreshHarness(testName: "ResponseDuringTransition")
+        let barrier = SerializedCancellationPassBarrier()
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [SettingsStubProtocol.self]
+        let http = HTTPClient(
+            session: URLSession(configuration: config),
+            tokenStore: harness.tokenStore,
+            responseReceivedBarrier: { await barrier.enter() }
+        )
+
+        let request = Task {
+            try await http.requestData(
+                method: "GET",
+                path: "/api/v1/settings/contract/capabilities"
+            )
+        }
+        guard await waitForCancellationPass(barrier, count: 1) else {
+            return XCTFail("request did not pause after URLSession completed")
+        }
+        guard let lease = await http.beginIdentityTransition() else {
+            return XCTFail("identity transition was unexpectedly cancelled")
+        }
+        await http.cancelInFlightRequests()
+        await http.endIdentityTransition(lease)
+        await barrier.release(pass: 1)
+
+        do {
+            _ = try await request.value
+            XCTFail("a completed old-generation response must fail closed")
+        } catch HTTPError.requestIdentityChanged {
+            // Expected.
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+        XCTAssertEqual(
+            SettingsStubProtocol.state().requestCounts["/api/v1/settings/contract/capabilities"],
+            1
+        )
+    }
+
+    func testCandidateProbeDoesNotChangeActiveServerReachability() async throws {
+        SettingsStubProtocol.reset(mode: .normal)
+        let harness = try await makeRefreshHarness(testName: "CandidateReachabilityIsolation")
+        await MainActor.run { ConnectionMonitor.shared.noteServerUnreachable() }
+
+        let health: HealthStatus = try await harness.http.getUnauthenticated(
+            serverURL: harness.identity.serverURL,
+            path: "/api/v1/health"
+        )
+        XCTAssertEqual(health.status, "ok")
+        let activeStillUnreachable = await MainActor.run {
+            if case .unreachable = ConnectionMonitor.shared.serverStatus { return true }
+            return false
+        }
+        XCTAssertTrue(
+            activeStillUnreachable,
+            "a candidate response must not mark the unrelated active server healthy"
+        )
+        await MainActor.run { ConnectionMonitor.shared.noteServerResponded() }
+    }
+
+    func testCancelledQueuedSessionInstallNeverAcquiresLeaseOrWritesTokens() async throws {
+        SettingsStubProtocol.reset(mode: .normal)
+        let harness = try await makeRefreshHarness(testName: "CancelledQueuedInstall")
+        guard let blockingLease = await harness.http.beginIdentityTransition() else {
+            return XCTFail("blocking transition was unexpectedly cancelled")
+        }
+
+        let queuedInstall = Task {
+            guard let lease = await harness.http.beginIdentityTransition() else {
+                return false
+            }
+            guard !Task.isCancelled else {
+                await harness.http.endIdentityTransition(lease)
+                return false
+            }
+            await harness.tokenStore.saveTokens(
+                accessToken: "placeholder",
+                refreshToken: "redacted"
+            )
+            await harness.http.endIdentityTransition(lease)
+            return true
+        }
+        guard await waitForIdentityTransitionWaiter(harness.http) else {
+            await harness.http.endIdentityTransition(blockingLease)
+            return XCTFail("session install did not queue behind the active transition")
+        }
+        queuedInstall.cancel()
+        let installCommitted = await queuedInstall.value
+        XCTAssertFalse(installCommitted)
+        let accessBeforeRelease = await harness.tokenStore.getAccessToken()
+        let refreshBeforeRelease = await harness.tokenStore.getRefreshToken()
+        XCTAssertEqual(accessBeforeRelease, "fake")
+        XCTAssertEqual(refreshBeforeRelease, "dummy")
+
+        await harness.http.endIdentityTransition(blockingLease)
+        guard let nextLease = await harness.http.beginIdentityTransition() else {
+            return XCTFail("queue did not progress after removing the cancelled waiter")
+        }
+        await harness.http.endIdentityTransition(nextLease)
+    }
+
+    func testAccountBoundLogoutCannotDispatchAfterServerSwitch() async throws {
+        SettingsStubProtocol.reset(mode: .normal)
+        let harness = try await makeRefreshHarness(testName: "BoundLogoutServerSwitch")
+        let accountValue = await harness.tokenStore.refreshAccountIdentity()
+        let account = try XCTUnwrap(accountValue)
+        let barrier = SerializedCancellationPassBarrier()
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [SettingsStubProtocol.self]
+        let http = HTTPClient(
+            session: URLSession(configuration: config),
+            tokenStore: harness.tokenStore,
+            requestCaptureBarrier: { await barrier.enter() }
+        )
+
+        let logout = Task {
+            try await http.postVoid(
+                "/api/v1/auth/logout",
+                expectedAccount: account
+            )
+        }
+        guard await waitForCancellationPass(barrier, count: 1) else {
+            return XCTFail("logout did not pause before its bound account capture")
+        }
+        guard let lease = await http.beginIdentityTransition() else {
+            return XCTFail("server switch transition was unexpectedly cancelled")
+        }
+        await http.cancelInFlightRequests()
+        await harness.tokenStore.setServerUrl("http://replacement.invalid")
+        await harness.tokenStore.switchActiveServer(serverId: "server-b")
+        await harness.tokenStore.setProfileId("profile-b")
+        await harness.tokenStore.saveTokens(accessToken: "example", refreshToken: "sample")
+        await http.endIdentityTransition(lease)
+        await barrier.release(pass: 1)
+
+        do {
+            try await logout.value
+            XCTFail("logout bound to server A must not dispatch under server B")
+        } catch HTTPError.requestIdentityChanged {
+            // Expected.
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+        XCTAssertEqual(SettingsStubProtocol.state().requestCounts["/api/v1/auth/logout"] ?? 0, 0)
+        let currentAccess = await harness.tokenStore.getAccessToken()
+        XCTAssertEqual(currentAccess, "example")
+    }
+
+    func testOrdinaryRefreshLateSuccessCannotWriteAcrossServerSwitch() async throws {
+        SettingsStubProtocol.reset(mode: .ordinaryRefreshDelayed)
+        let harness = try await makeRefreshHarness(testName: "RefreshServerSwitch")
+        let sessionExpiredCount = LockedCounter()
+        let observer = NotificationCenter.default.addObserver(
+            forName: .continuumSessionExpired,
+            object: nil,
+            queue: nil
+        ) { _ in
+            sessionExpiredCount.increment()
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        let requestTask = Task {
+            try await harness.http.requestData(
+                method: "GET",
+                path: "/api/v1/settings/contract/capabilities"
+            )
+        }
+        guard await waitForPendingOrdinaryRefresh() else {
+            SettingsStubProtocol.releaseOrdinaryRefresh(status: 503)
+            return XCTFail("ordinary refresh did not reach the delayed response")
+        }
+
+        await harness.tokenStore.switchActiveServer(serverId: "server-b")
+        await harness.tokenStore.setServerUrl("http://settings-test.invalid/server-b")
+        await harness.tokenStore.setProfileId("profile-b")
+        await harness.tokenStore.saveTokens(
+            accessToken: "example",
+            refreshToken: "sample"
+        )
+        SettingsStubProtocol.releaseOrdinaryRefresh(status: 200)
+
+        do {
+            _ = try await requestTask.value
+            XCTFail("the server-A request must keep its original 401 after switching to server B")
+        } catch {
+            XCTAssertEqual((error as? HTTPError)?.statusCode, 401)
+        }
+        let serverBAccess = await harness.tokenStore.getAccessToken()
+        let serverBRefresh = await harness.tokenStore.getRefreshToken()
+        XCTAssertEqual(serverBAccess, "example")
+        XCTAssertEqual(serverBRefresh, "sample")
+        XCTAssertEqual(sessionExpiredCount.value, 0)
+        let state = SettingsStubProtocol.state()
+        XCTAssertEqual(state.requestCounts["/api/v1/auth/refresh"], 1)
+        XCTAssertEqual(state.requestCounts["/api/v1/settings/contract/capabilities"], 1)
+    }
+
+    func testOrdinaryRefreshLateSuccessCannotRestoreSignedOutSession() async throws {
+        SettingsStubProtocol.reset(mode: .ordinaryRefreshDelayed)
+        let harness = try await makeRefreshHarness(testName: "RefreshSignOut")
+        let sessionExpiredCount = LockedCounter()
+        let observer = NotificationCenter.default.addObserver(
+            forName: .continuumSessionExpired,
+            object: nil,
+            queue: nil
+        ) { _ in
+            sessionExpiredCount.increment()
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        let requestTask = Task {
+            try await harness.http.requestData(
+                method: "GET",
+                path: "/api/v1/settings/contract/capabilities"
+            )
+        }
+        guard await waitForPendingOrdinaryRefresh() else {
+            SettingsStubProtocol.releaseOrdinaryRefresh(status: 503)
+            return XCTFail("ordinary refresh did not reach the delayed response")
+        }
+
+        await harness.tokenStore.clearTokens()
+        SettingsStubProtocol.releaseOrdinaryRefresh(status: 200)
+
+        do {
+            _ = try await requestTask.value
+            XCTFail("a late refresh response must not sign the user back in")
+        } catch {
+            XCTAssertEqual((error as? HTTPError)?.statusCode, 401)
+        }
+        let accessToken = await harness.tokenStore.getAccessToken()
+        let refreshToken = await harness.tokenStore.getRefreshToken()
+        XCTAssertNil(accessToken)
+        XCTAssertNil(refreshToken)
+        XCTAssertEqual(sessionExpiredCount.value, 0)
+    }
+
+    func testOrdinaryRejectedRefreshCannotClearNewerCredentials() async throws {
+        SettingsStubProtocol.reset(mode: .ordinaryRefreshDelayed)
+        let harness = try await makeRefreshHarness(testName: "RefreshNewerToken")
+        let sessionExpiredCount = LockedCounter()
+        let observer = NotificationCenter.default.addObserver(
+            forName: .continuumSessionExpired,
+            object: nil,
+            queue: nil
+        ) { _ in
+            sessionExpiredCount.increment()
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        let requestTask = Task {
+            try await harness.http.requestData(
+                method: "GET",
+                path: "/api/v1/settings/contract/capabilities"
+            )
+        }
+        guard await waitForPendingOrdinaryRefresh() else {
+            SettingsStubProtocol.releaseOrdinaryRefresh(status: 503)
+            return XCTFail("ordinary refresh did not reach the delayed response")
+        }
+
+        await harness.tokenStore.saveTokens(
+            accessToken: "placeholder",
+            refreshToken: "redacted"
+        )
+        SettingsStubProtocol.releaseOrdinaryRefresh(status: 403)
+
+        do {
+            _ = try await requestTask.value
+            XCTFail("the rejected request must not retry as a replacement login epoch")
+        } catch {
+            XCTAssertEqual((error as? HTTPError)?.statusCode, 401)
+        }
+        let accessToken = await harness.tokenStore.getAccessToken()
+        let refreshToken = await harness.tokenStore.getRefreshToken()
+        XCTAssertEqual(accessToken, "placeholder")
+        XCTAssertEqual(refreshToken, "redacted")
+        XCTAssertEqual(sessionExpiredCount.value, 0)
+        let state = SettingsStubProtocol.state()
+        XCTAssertEqual(state.requestCounts["/api/v1/auth/refresh"], 1)
+        XCTAssertEqual(state.requestCounts["/api/v1/settings/contract/capabilities"], 1)
+    }
+
     func testScopedRefreshPersistsServerAccountRotationAcrossProfileChange() async throws {
         let suiteName = "settings-refresh-profile-switch-\(UUID().uuidString)"
         let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
@@ -793,6 +2003,14 @@ final class SettingValuesAPITests: XCTestCase {
         let refreshAfterStale = await tokenStore.getRefreshToken()
         XCTAssertFalse(staleStored)
         XCTAssertEqual(refreshAfterStale, "redacted")
+        let staleCleared = await tokenStore.clearTokensAfterRejectedRefresh(
+            replacing: "dummy",
+            expected: identity,
+            credentialOwner: .persistentServer(serverId: identity.serverId)
+        )
+        let refreshAfterStaleClear = await tokenStore.getRefreshToken()
+        XCTAssertFalse(staleCleared)
+        XCTAssertEqual(refreshAfterStaleClear, "redacted")
 
         let temporary = TemporaryAuthScope(
             serverId: identity.serverId,
@@ -842,9 +2060,15 @@ final class SettingValuesAPITests: XCTestCase {
             expected: identity,
             credentialOwner: .persistentServer(serverId: identity.serverId)
         )
+        let crossServerCleared = await tokenStore.clearTokensAfterRejectedRefresh(
+            replacing: "redacted",
+            expected: identity,
+            credentialOwner: .persistentServer(serverId: identity.serverId)
+        )
         let serverBAccess = await tokenStore.getAccessToken()
         let serverBRefresh = await tokenStore.getRefreshToken()
         XCTAssertFalse(crossServerStored)
+        XCTAssertFalse(crossServerCleared)
         XCTAssertEqual(serverBAccess, "gateway-token")
         XCTAssertEqual(serverBRefresh, "decoy-token")
     }
@@ -1046,6 +2270,109 @@ final class SettingValuesAPITests: XCTestCase {
         let http = HTTPClient(session: URLSession(configuration: config), tokenStore: tokenStore)
         return ContinuumAPI(http: http, tokenStore: tokenStore)
     }
+
+    private func makeRefreshHarness(testName: String) async throws -> (
+        tokenStore: TokenStore,
+        identity: HTTPRequestIdentity,
+        http: HTTPClient
+    ) {
+        let suiteName = "settings-refresh-\(testName)-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        addTeardownBlock {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+        }
+        let tokenStore = TokenStore(
+            keychain: SharedKeychain(
+                service: "SettingValues\(testName)Tests.\(UUID().uuidString)",
+                accessGroup: nil
+            ),
+            defaults: SharedDefaults(suite: suite, standard: suite)
+        )
+        let identity = HTTPRequestIdentity(
+            serverId: "server-a",
+            serverURL: "http://settings-test.invalid",
+            profileId: "profile-a",
+            clientFamily: "mobile"
+        )
+        await tokenStore.switchActiveServer(serverId: identity.serverId)
+        await tokenStore.setServerUrl(identity.serverURL)
+        await tokenStore.setProfileId(identity.profileId)
+        await tokenStore.saveTokens(accessToken: "fake", refreshToken: "dummy")
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [SettingsStubProtocol.self]
+        let http = HTTPClient(session: URLSession(configuration: config), tokenStore: tokenStore)
+        return (tokenStore, identity, http)
+    }
+
+    private func waitForPendingOrdinaryRefresh() async -> Bool {
+        let deadline = ContinuousClock.now + .seconds(2)
+        while ContinuousClock.now < deadline {
+            if SettingsStubProtocol.hasPendingOrdinaryRefresh() {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return false
+    }
+
+    private func waitForPendingOrdinaryUnauthorized() async -> Bool {
+        let deadline = ContinuousClock.now + .seconds(2)
+        while ContinuousClock.now < deadline {
+            if SettingsStubProtocol.hasPendingOrdinaryUnauthorized() {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return false
+    }
+
+    private func waitForCounter(_ counter: LockedCounter, atLeast target: Int) async -> Bool {
+        let deadline = ContinuousClock.now + .seconds(2)
+        while ContinuousClock.now < deadline {
+            if counter.value >= target {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return false
+    }
+
+    private func waitForCancellationPass(
+        _ barrier: SerializedCancellationPassBarrier,
+        count: Int
+    ) async -> Bool {
+        let deadline = ContinuousClock.now + .seconds(2)
+        while ContinuousClock.now < deadline {
+            if await barrier.entryCount >= count {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return false
+    }
+
+    private func waitForIdentityTransitionWaiter(_ http: HTTPClient) async -> Bool {
+        let deadline = ContinuousClock.now + .seconds(2)
+        while ContinuousClock.now < deadline {
+            if await http.pendingIdentityTransitionCount() > 0 {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return false
+    }
+
+    private func waitForRequestDispatchWaiter(_ http: HTTPClient) async -> Bool {
+        let deadline = ContinuousClock.now + .seconds(2)
+        while ContinuousClock.now < deadline {
+            if await http.pendingRequestDispatchWaiterCount() > 0 {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return false
+    }
 }
 
 /// In-process stub for the canonical settings endpoints. State is static
@@ -1067,6 +2394,18 @@ final class SettingsStubProtocol: URLProtocol {
         case concurrentScopedRefresh
         /// A scoped request owns refresh while an ordinary 401 joins it.
         case mixedRefreshScopedWins
+        /// A scoped-owned refresh rejects while an ordinary 401 joins it.
+        case mixedRefreshScopedFailure
+        /// A scoped-owned refresh receives a retryable 429 or 5xx response.
+        case mixedRefreshScopedTransientFailure(status: Int)
+        /// A scoped-owned refresh receives HTTP 200 with an invalid token body.
+        case mixedRefreshScopedMalformedSuccess
+        /// An ordinary request's refresh waits for an explicit test release.
+        case ordinaryRefreshDelayed
+        /// An ordinary request's initial 401 waits across a server switch.
+        case ordinaryUnauthorizedDelayed
+        /// A temporary credential generation is terminally rejected.
+        case temporaryRefreshRejected
     }
 
     struct RecordedRequest {
@@ -1093,14 +2432,26 @@ final class SettingsStubProtocol: URLProtocol {
     private static var current = State()
     private static var pendingConcurrentUnauthorized: [SettingsStubProtocol] = []
     private static var pendingMixedOrdinaryUnauthorized: SettingsStubProtocol?
+    private static var pendingOrdinaryRefresh: SettingsStubProtocol?
+    private static var pendingOrdinaryUnauthorized: SettingsStubProtocol?
+    private static var pendingMixedRefresh: (
+        request: SettingsStubProtocol,
+        status: Int,
+        body: String
+    )?
     private static var mixedRefreshStarted = false
+    private static var ordinaryUnauthorizedReleased = false
 
     static func reset(mode: Mode) {
         lock.lock()
         current = State(mode: mode)
         pendingConcurrentUnauthorized.removeAll()
         pendingMixedOrdinaryUnauthorized = nil
+        pendingOrdinaryRefresh = nil
+        pendingOrdinaryUnauthorized = nil
+        pendingMixedRefresh = nil
         mixedRefreshStarted = false
+        ordinaryUnauthorizedReleased = false
         lock.unlock()
     }
 
@@ -1108,6 +2459,54 @@ final class SettingsStubProtocol: URLProtocol {
         lock.lock()
         defer { lock.unlock() }
         return current
+    }
+
+    static func hasPendingOrdinaryRefresh() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return pendingOrdinaryRefresh != nil
+    }
+
+    static func releaseOrdinaryRefresh(status: Int) {
+        let pending: SettingsStubProtocol?
+        lock.lock()
+        pending = pendingOrdinaryRefresh
+        pendingOrdinaryRefresh = nil
+        lock.unlock()
+
+        let body: String
+        if (200..<300).contains(status) {
+            body = #"{"access_token":"placeholder","refresh_token":"redacted","expires_in":3600}"#
+        } else {
+            body = #"{"error":"invalid_token"}"#
+        }
+        pending?.respond(status: status, body: body)
+    }
+
+    static func hasPendingOrdinaryUnauthorized() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return pendingOrdinaryUnauthorized != nil
+    }
+
+    static func releaseOrdinaryUnauthorized() {
+        let pending: SettingsStubProtocol?
+        lock.lock()
+        pending = pendingOrdinaryUnauthorized
+        pendingOrdinaryUnauthorized = nil
+        ordinaryUnauthorizedReleased = true
+        lock.unlock()
+        pending?.respond(status: 401, body: #"{"error":"unauthorized"}"#)
+    }
+
+    static func releaseMixedRefresh() {
+        let pending: (request: SettingsStubProtocol, status: Int, body: String)?
+        lock.lock()
+        pending = pendingMixedRefresh
+        pendingMixedRefresh = nil
+        lock.unlock()
+        guard let pending else { return }
+        pending.request.respond(status: pending.status, body: pending.body)
     }
 
     private static func mutate(_ apply: (inout State) -> Void) {
@@ -1143,6 +2542,25 @@ final class SettingsStubProtocol: URLProtocol {
         }
 
         let mode = Self.state().mode
+        if mode == .ordinaryRefreshDelayed {
+            handleOrdinaryDelayedRefresh(recorded)
+            return
+        }
+        if mode == .ordinaryUnauthorizedDelayed {
+            handleOrdinaryUnauthorizedDelayed(recorded)
+            return
+        }
+        if mode == .temporaryRefreshRejected {
+            switch (recorded.method, recorded.path) {
+            case ("GET", "/api/v1/settings/contract/capabilities"):
+                respond(status: 401, body: #"{"error":"unauthorized"}"#)
+            case ("POST", "/api/v1/auth/refresh"):
+                respond(status: 401, body: #"{"error":"invalid_token"}"#)
+            default:
+                respond(status: 404, body: #"{"error":"not_found"}"#)
+            }
+            return
+        }
         if mode == .concurrentScopedRefresh {
             switch (recorded.method, recorded.path) {
             case ("POST", "/api/v1/auth/refresh"):
@@ -1169,9 +2587,38 @@ final class SettingsStubProtocol: URLProtocol {
             }
             return
         }
-        if mode == .mixedRefreshScopedWins {
-            handleMixedRefreshScopedWins(recorded)
+        switch mode {
+        case .mixedRefreshScopedWins:
+            handleMixedRefreshScopedFlight(
+                recorded,
+                refreshStatus: 200,
+                refreshBody: #"{"access_token":"placeholder","refresh_token":"redacted","expires_in":3600}"#
+            )
             return
+        case .mixedRefreshScopedFailure:
+            handleMixedRefreshScopedFlight(
+                recorded,
+                refreshStatus: 401,
+                refreshBody: #"{"error":"invalid_token"}"#,
+                holdRefreshForExplicitRelease: true
+            )
+            return
+        case .mixedRefreshScopedTransientFailure(let status):
+            handleMixedRefreshScopedFlight(
+                recorded,
+                refreshStatus: status,
+                refreshBody: #"{"error":"temporarily_unavailable"}"#
+            )
+            return
+        case .mixedRefreshScopedMalformedSuccess:
+            handleMixedRefreshScopedFlight(
+                recorded,
+                refreshStatus: 200,
+                refreshBody: #"{"access_token":"placeholder"}"#
+            )
+            return
+        default:
+            break
         }
         if mode == .serverTooOld {
             // The chi router's own 404: plain text, no Silo error envelope.
@@ -1183,6 +2630,8 @@ final class SettingsStubProtocol: URLProtocol {
             : SettingKey.revision
 
         switch (recorded.method, recorded.path) {
+        case ("GET", "/api/v1/health"):
+            respond(status: 200, body: #"{"status":"ok","server_name":"Candidate"}"#)
         case ("GET", "/api/v1/settings/contract/capabilities"):
             respond(status: 200, body: """
             {"api_version":1,"revision":\(responseRevision),"contract_etag":"\\"etag\\"","definition_count":48,
@@ -1254,7 +2703,12 @@ final class SettingsStubProtocol: URLProtocol {
         }
     }
 
-    private func handleMixedRefreshScopedWins(_ recorded: RecordedRequest) {
+    private func handleMixedRefreshScopedFlight(
+        _ recorded: RecordedRequest,
+        refreshStatus: Int,
+        refreshBody: String,
+        holdRefreshForExplicitRelease: Bool = false
+    ) {
         switch (recorded.method, recorded.path) {
         case ("GET", "/api/v1/settings/contract/capabilities"):
             if recorded.header("Authorization") == "Bearer placeholder" {
@@ -1291,18 +2745,83 @@ final class SettingsStubProtocol: URLProtocol {
             Self.mixedRefreshStarted = true
             pendingOrdinary = Self.pendingMixedOrdinaryUnauthorized
             Self.pendingMixedOrdinaryUnauthorized = nil
+            if holdRefreshForExplicitRelease {
+                Self.pendingMixedRefresh = (self, refreshStatus, refreshBody)
+            }
             Self.lock.unlock()
             pendingOrdinary?.respond(status: 401, body: #"{"error":"unauthorized"}"#)
 
-            // Keep the scoped-owned refresh in flight long enough for the
-            // ordinary 401 to reach HTTPClient's shared account slot.
-            Task { @MainActor [weak self] in
-                try? await Task.sleep(for: .milliseconds(100))
-                self?.respond(
-                    status: 200,
-                    body: #"{"access_token":"placeholder","refresh_token":"redacted","expires_in":3600}"#
-                )
+            if !holdRefreshForExplicitRelease {
+                // Keep the scoped-owned refresh in flight long enough for the
+                // ordinary 401 to reach HTTPClient's shared account slot.
+                Task { @MainActor [weak self] in
+                    try? await Task.sleep(for: .milliseconds(100))
+                    self?.respond(status: refreshStatus, body: refreshBody)
+                }
             }
+
+        default:
+            respond(status: 404, body: #"{"error":"not_found"}"#)
+        }
+    }
+
+    private func handleOrdinaryDelayedRefresh(_ recorded: RecordedRequest) {
+        switch (recorded.method, recorded.path) {
+        case ("GET", "/api/v1/settings/contract/capabilities"):
+            if ["Bearer placeholder", "Bearer newer-access"].contains(
+                recorded.header("Authorization")
+            ) {
+                respond(
+                    status: 200,
+                    body: """
+                    {"api_version":1,"revision":\(SettingKey.revision),"contract_etag":"\\"etag\\"","definition_count":48,
+                     "scopes":["account","profile","profile_device","profile_library","profile_series"],
+                     "supports_batched_effective":true,"supports_idempotent_writes":true,
+                     "supports_atomic_shortcuts":true}
+                    """
+                )
+            } else {
+                respond(status: 401, body: #"{"error":"unauthorized"}"#)
+            }
+
+        case ("POST", "/api/v1/auth/refresh"):
+            Self.lock.lock()
+            Self.pendingOrdinaryRefresh = self
+            Self.lock.unlock()
+
+        default:
+            respond(status: 404, body: #"{"error":"not_found"}"#)
+        }
+    }
+
+    private func handleOrdinaryUnauthorizedDelayed(_ recorded: RecordedRequest) {
+        switch (recorded.method, recorded.path) {
+        case ("GET", "/api/v1/settings/contract/capabilities"):
+            let unauthorizedWasReleased: Bool
+            Self.lock.lock()
+            unauthorizedWasReleased = Self.ordinaryUnauthorizedReleased
+            Self.lock.unlock()
+            if unauthorizedWasReleased || recorded.header("Authorization") == "Bearer placeholder" {
+                respond(
+                    status: 200,
+                    body: """
+                    {"api_version":1,"revision":\(SettingKey.revision),"contract_etag":"\\"etag\\"","definition_count":48,
+                     "scopes":["account","profile","profile_device","profile_library","profile_series"],
+                     "supports_batched_effective":true,"supports_idempotent_writes":true,
+                     "supports_atomic_shortcuts":true}
+                    """
+                )
+            } else {
+                Self.lock.lock()
+                Self.pendingOrdinaryUnauthorized = self
+                Self.lock.unlock()
+            }
+
+        case ("POST", "/api/v1/auth/refresh"):
+            respond(
+                status: 200,
+                body: #"{"access_token":"placeholder","refresh_token":"redacted","expires_in":3600}"#
+            )
 
         default:
             respond(status: 404, body: #"{"error":"not_found"}"#)
@@ -1405,5 +2924,39 @@ private final class LockedCounter: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return count
+    }
+}
+
+private final class LockedSessionExpiryEvents: @unchecked Sendable {
+    private let lock = NSLock()
+    private var events: [SessionExpiryEvent] = []
+
+    func append(_ event: SessionExpiryEvent) {
+        lock.lock()
+        events.append(event)
+        lock.unlock()
+    }
+
+    var values: [SessionExpiryEvent] {
+        lock.lock()
+        defer { lock.unlock() }
+        return events
+    }
+}
+
+private actor SerializedCancellationPassBarrier {
+    private(set) var entryCount = 0
+    private var releases: [Int: CheckedContinuation<Void, Never>] = [:]
+
+    func enter() async {
+        entryCount += 1
+        let pass = entryCount
+        await withCheckedContinuation { continuation in
+            releases[pass] = continuation
+        }
+    }
+
+    func release(pass: Int) {
+        releases.removeValue(forKey: pass)?.resume()
     }
 }

--- a/iosApp/Tests/SettingValuesAPITests.swift
+++ b/iosApp/Tests/SettingValuesAPITests.swift
@@ -228,6 +228,21 @@ final class SettingValuesAPITests: XCTestCase {
         XCTAssertNil(fromDefault.storedValue)
     }
 
+    func testProfileClientEnvelopeKeepsTheResolvedFamily() throws {
+        let effective = try SettingsWireCoding.makeDecoder()
+            .decode(EffectiveSettingValue.self, from: Data("""
+            {"key":"ui.card_presentation",
+             "value":{"poster_size":"large","caption":"artwork"},
+             "source":"profile_client","scope":"profile_client",
+             "profile_id":"p1","client_family":"tv"}
+            """.utf8))
+
+        XCTAssertEqual(effective.source, .scope(.profileClient))
+        XCTAssertEqual(effective.scope, .profileClient)
+        XCTAssertEqual(effective.clientFamily, "tv")
+        XCTAssertEqual(effective.storedAt, .profileClient)
+    }
+
     func testConstrainedValueKeepsTheAuthoredChoice() throws {
         // Mirrors a conformance case: policy caps a 4K preference at 1080p,
         // and the authored value is reported so the UI can say "capped" rather
@@ -289,6 +304,7 @@ final class SettingValuesAPITests: XCTestCase {
     func testScopeIdentitiesCarryTheirIdsInTheQuery() {
         XCTAssertEqual(SettingScopeIdentity.account.queryItems, ["scope": "account"])
         XCTAssertEqual(SettingScopeIdentity.profile.queryItems, ["scope": "profile"])
+        XCTAssertEqual(SettingScopeIdentity.profileClient.queryItems, ["scope": "profile_client"])
         // The device half comes from the X-Silo-Device-Id header the client
         // already attaches, never the query — sending it twice is the bug.
         XCTAssertEqual(SettingScopeIdentity.profileDevice.queryItems, ["scope": "profile_device"])
@@ -316,6 +332,10 @@ final class SettingValuesAPITests: XCTestCase {
         XCTAssertEqual(capabilities.definitionCount, 48)
         XCTAssertTrue(capabilities.supportsBatchedEffective)
         XCTAssertTrue(capabilities.supportsIdempotentWrites)
+        XCTAssertFalse(
+            capabilities.supportsAtomicShortcuts,
+            "a missing revision-5 feature flag must decode fail-closed"
+        )
         XCTAssertEqual(capabilities.contractIsAheadOfServer, SettingKey.revision > 1)
     }
 
@@ -448,6 +468,7 @@ final class SettingValuesAPITests: XCTestCase {
         }
         XCTAssertEqual(capabilities.revision, SettingKey.revision)
         XCTAssertTrue(capabilities.supportsIdempotentWrites)
+        XCTAssertTrue(capabilities.supportsAtomicShortcuts)
     }
 
     func testGetContractCapabilitiesRequiresTheServersRevisionToBeCurrent() async throws {
@@ -482,6 +503,10 @@ final class SettingValuesAPITests: XCTestCase {
         // profile header, which the client previously never sent.
         XCTAssertEqual(recorded.header("X-Profile-Id"), Self.stubProfileId)
         XCTAssertEqual(recorded.header("X-Silo-Device-Id")?.isEmpty, false)
+        XCTAssertEqual(
+            recorded.header("X-Silo-Client-Family"),
+            AppleDeviceIdentity.current.clientFamily
+        )
         // And the body must carry the value's keys verbatim.
         let body = String(data: recorded.body ?? Data(), encoding: .utf8) ?? ""
         XCTAssertTrue(body.contains("\"fontSize\""), "body must keep camelCase value keys: \(body)")
@@ -506,6 +531,383 @@ final class SettingValuesAPITests: XCTestCase {
             "profile-captured-with-write",
             "the queued profile must override a newer session header"
         )
+    }
+
+    func testCapturedSettingsRequestRefusesToFollowANewActiveIdentity() async throws {
+        SettingsStubProtocol.reset(mode: .normal)
+        let suiteName = "settings-identity-race-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        addTeardownBlock {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+        }
+        let tokenStore = TokenStore(
+            keychain: SharedKeychain(
+                service: "SettingValuesIdentityTests.\(UUID().uuidString)",
+                accessGroup: nil
+            ),
+            defaults: SharedDefaults(suite: suite, standard: suite)
+        )
+        await tokenStore.switchActiveServer(serverId: "server-a")
+        await tokenStore.setServerUrl("http://settings-test.invalid")
+        await tokenStore.setProfileId("profile-a")
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [SettingsStubProtocol.self]
+        let http = HTTPClient(session: URLSession(configuration: config), tokenStore: tokenStore)
+        let captured = HTTPRequestIdentity(
+            serverId: "server-a",
+            serverURL: "http://settings-test.invalid",
+            profileId: "profile-a",
+            clientFamily: "mobile"
+        )
+
+        await tokenStore.switchActiveServer(serverId: "server-b")
+        await tokenStore.setServerUrl("http://server-b.invalid")
+        await tokenStore.setProfileId("profile-b")
+
+        do {
+            _ = try await http.requestData(
+                method: "GET",
+                path: "/api/v1/settings/contract/capabilities",
+                requestIdentity: captured
+            )
+            XCTFail("a captured server/profile request must fail rather than follow the new session")
+        } catch HTTPError.requestIdentityChanged {
+            // Expected: no URL request was built or sent.
+        }
+        XCTAssertNil(SettingsStubProtocol.state().lastRequest)
+    }
+
+    func testConcurrentScopedUnauthorizedResponsesShareOneRotatingRefresh() async throws {
+        SettingsStubProtocol.reset(mode: .concurrentScopedRefresh)
+        let suiteName = "settings-refresh-single-flight-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        addTeardownBlock {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+        }
+        let tokenStore = TokenStore(
+            keychain: SharedKeychain(
+                service: "SettingValuesRefreshSingleFlightTests.\(UUID().uuidString)",
+                accessGroup: nil
+            ),
+            defaults: SharedDefaults(suite: suite, standard: suite)
+        )
+        let identity = HTTPRequestIdentity(
+            serverId: "server-a",
+            serverURL: "http://settings-test.invalid",
+            profileId: "profile-a",
+            clientFamily: "mobile"
+        )
+        await tokenStore.switchActiveServer(serverId: identity.serverId)
+        await tokenStore.setServerUrl(identity.serverURL)
+        await tokenStore.setProfileId(identity.profileId)
+        await tokenStore.saveTokens(accessToken: "fake", refreshToken: "dummy")
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [SettingsStubProtocol.self]
+        let http = HTTPClient(session: URLSession(configuration: config), tokenStore: tokenStore)
+        async let first = http.requestData(
+            method: "GET",
+            path: "/api/v1/settings/contract/capabilities",
+            requestIdentity: identity
+        )
+        async let second = http.requestData(
+            method: "GET",
+            path: "/api/v1/settings/contract/capabilities",
+            requestIdentity: identity
+        )
+
+        let (firstResponse, secondResponse) = try await (first, second)
+
+        XCTAssertEqual(firstResponse.statusCode, 200)
+        XCTAssertEqual(secondResponse.statusCode, 200)
+        let state = SettingsStubProtocol.state()
+        XCTAssertEqual(state.requestCounts["/api/v1/auth/refresh"], 1)
+        XCTAssertEqual(state.requestCounts["/api/v1/settings/contract/capabilities"], 4)
+        let accessToken = await tokenStore.getAccessToken()
+        let refreshToken = await tokenStore.getRefreshToken()
+        XCTAssertEqual(accessToken, "placeholder")
+        XCTAssertEqual(refreshToken, "redacted")
+    }
+
+    func testScopedAndOrdinaryUnauthorizedResponsesShareAccountRefreshFlight() async throws {
+        SettingsStubProtocol.reset(mode: .mixedRefreshScopedWins)
+        let suiteName = "settings-refresh-mixed-flight-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        addTeardownBlock {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+        }
+        let tokenStore = TokenStore(
+            keychain: SharedKeychain(
+                service: "SettingValuesMixedRefreshTests.\(UUID().uuidString)",
+                accessGroup: nil
+            ),
+            defaults: SharedDefaults(suite: suite, standard: suite)
+        )
+        let identity = HTTPRequestIdentity(
+            serverId: "server-a",
+            serverURL: "http://settings-test.invalid",
+            profileId: "profile-a",
+            clientFamily: "mobile"
+        )
+        await tokenStore.switchActiveServer(serverId: identity.serverId)
+        await tokenStore.setServerUrl(identity.serverURL)
+        await tokenStore.setProfileId(identity.profileId)
+        await tokenStore.saveTokens(accessToken: "fake", refreshToken: "dummy")
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [SettingsStubProtocol.self]
+        let http = HTTPClient(session: URLSession(configuration: config), tokenStore: tokenStore)
+        let sessionExpiredCount = LockedCounter()
+        let observer = NotificationCenter.default.addObserver(
+            forName: .continuumSessionExpired,
+            object: nil,
+            queue: nil
+        ) { _ in
+            sessionExpiredCount.increment()
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        async let scoped = http.requestData(
+            method: "GET",
+            path: "/api/v1/settings/contract/capabilities",
+            headers: ["X-Test-Refresh-Flow": "scoped"],
+            requestIdentity: identity
+        )
+        async let ordinary = http.requestData(
+            method: "GET",
+            path: "/api/v1/settings/contract/capabilities",
+            headers: ["X-Test-Refresh-Flow": "ordinary"]
+        )
+
+        let (scopedResponse, ordinaryResponse) = try await (scoped, ordinary)
+
+        XCTAssertEqual(scopedResponse.statusCode, 200)
+        XCTAssertEqual(ordinaryResponse.statusCode, 200)
+        let state = SettingsStubProtocol.state()
+        XCTAssertEqual(state.requestCounts["/api/v1/auth/refresh"], 1)
+        XCTAssertEqual(state.requestCounts["/api/v1/settings/contract/capabilities"], 4)
+        let accessToken = await tokenStore.getAccessToken()
+        let refreshToken = await tokenStore.getRefreshToken()
+        XCTAssertEqual(accessToken, "placeholder")
+        XCTAssertEqual(refreshToken, "redacted")
+        XCTAssertEqual(sessionExpiredCount.value, 0)
+    }
+
+    func testScopedRefreshPersistsServerAccountRotationAcrossProfileChange() async throws {
+        let suiteName = "settings-refresh-profile-switch-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        addTeardownBlock {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+        }
+        let keychain = SharedKeychain(
+            service: "SettingValuesRefreshProfileTests.\(UUID().uuidString)",
+            accessGroup: nil
+        )
+        let tokenStore = TokenStore(
+            keychain: keychain,
+            defaults: SharedDefaults(suite: suite, standard: suite)
+        )
+        let identity = HTTPRequestIdentity(
+            serverId: "server-a",
+            serverURL: "http://settings-test.invalid",
+            profileId: "profile-a",
+            clientFamily: "mobile"
+        )
+
+        await tokenStore.switchActiveServer(serverId: identity.serverId)
+        await tokenStore.setServerUrl(identity.serverURL)
+        await tokenStore.setProfileId(identity.profileId)
+        await tokenStore.saveTokens(accessToken: "fake", refreshToken: "dummy")
+        await tokenStore.setProfileToken("example")
+
+        // The account refresh began under profile A, but profile B became
+        // active before the server returned its rotated account credentials.
+        await tokenStore.setProfileId("profile-b")
+        await tokenStore.setProfileToken("sample")
+        let stored = await tokenStore.saveRefreshedTokens(
+            "placeholder",
+            "redacted",
+            replacing: "dummy",
+            expected: identity,
+            credentialOwner: .persistentServer(serverId: identity.serverId)
+        )
+
+        XCTAssertTrue(stored)
+        let currentAccess = await tokenStore.getAccessToken()
+        let currentRefresh = await tokenStore.getRefreshToken()
+        let currentProfileId = await tokenStore.getProfileId()
+        let currentProfileValue = await tokenStore.getProfileToken()
+        XCTAssertEqual(currentAccess, "placeholder")
+        XCTAssertEqual(currentRefresh, "redacted")
+        XCTAssertEqual(currentProfileId, "profile-b")
+        XCTAssertEqual(currentProfileValue, "sample")
+    }
+
+    func testScopedRefreshRejectsChangedServerAccountAndTemporaryScope() async throws {
+        let suiteName = "settings-refresh-account-boundary-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        addTeardownBlock {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+        }
+        let keychain = SharedKeychain(
+            service: "SettingValuesRefreshBoundaryTests.\(UUID().uuidString)",
+            accessGroup: nil
+        )
+        let tokenStore = TokenStore(
+            keychain: keychain,
+            defaults: SharedDefaults(suite: suite, standard: suite)
+        )
+        let identity = HTTPRequestIdentity(
+            serverId: "server-a",
+            serverURL: "http://settings-test.invalid",
+            profileId: "profile-a",
+            clientFamily: "mobile"
+        )
+
+        await tokenStore.switchActiveServer(serverId: identity.serverId)
+        await tokenStore.setServerUrl(identity.serverURL)
+        await tokenStore.setProfileId(identity.profileId)
+        await tokenStore.saveTokens(accessToken: "fake", refreshToken: "dummy")
+
+        await tokenStore.setServerUrl("http://changed-url.invalid")
+        let wrongURLStored = await tokenStore.saveRefreshedTokens(
+            "example",
+            "sample",
+            replacing: "dummy",
+            expected: identity,
+            credentialOwner: .persistentServer(serverId: identity.serverId)
+        )
+        let refreshAfterWrongURL = await tokenStore.getRefreshToken()
+        XCTAssertFalse(wrongURLStored)
+        XCTAssertEqual(refreshAfterWrongURL, "dummy")
+
+        await tokenStore.setServerUrl(identity.serverURL)
+        await tokenStore.saveTokens(accessToken: "placeholder", refreshToken: "redacted")
+        let staleStored = await tokenStore.saveRefreshedTokens(
+            "not-a-real",
+            "changeme",
+            replacing: "dummy",
+            expected: identity,
+            credentialOwner: .persistentServer(serverId: identity.serverId)
+        )
+        let refreshAfterStale = await tokenStore.getRefreshToken()
+        XCTAssertFalse(staleStored)
+        XCTAssertEqual(refreshAfterStale, "redacted")
+
+        let temporary = TemporaryAuthScope(
+            serverId: identity.serverId,
+            serverURL: identity.serverURL,
+            accessToken: "test-auth-token",
+            // Match the persistent value so credential provenance, rather
+            // than value inequality, is what prevents the write.
+            refreshToken: "redacted",
+            profileId: "temporary-profile",
+            profileToken: "secret-token",
+            controllerDeviceId: "controller",
+            expiresAt: Date().addingTimeInterval(60)
+        )
+        await tokenStore.beginTemporaryScope(temporary)
+        let temporaryIdentity = HTTPRequestIdentity(
+            serverId: identity.serverId,
+            serverURL: identity.serverURL,
+            profileId: temporary.profileId,
+            clientFamily: identity.clientFamily
+        )
+        let capturedTemporary = try await tokenStore.captureRequestAuth(expected: temporaryIdentity)
+        _ = await tokenStore.endTemporaryScope()
+        let temporaryStored = await tokenStore.saveRefreshedTokens(
+            "test-token-placeholder",
+            "token-oversized",
+            replacing: "redacted",
+            expected: temporaryIdentity,
+            credentialOwner: capturedTemporary.credentialOwner
+        )
+        let refreshAfterTemporary = await tokenStore.getRefreshToken()
+        XCTAssertFalse(temporaryStored)
+        XCTAssertEqual(capturedTemporary.credentialOwner, .temporary)
+        XCTAssertEqual(
+            refreshAfterTemporary,
+            "redacted",
+            "credentials captured from a temporary scope must never redirect into persistent storage"
+        )
+
+        await tokenStore.switchActiveServer(serverId: "server-b")
+        await tokenStore.setServerUrl("http://server-b.invalid")
+        await tokenStore.setProfileId("profile-b")
+        await tokenStore.saveTokens(accessToken: "gateway-token", refreshToken: "decoy-token")
+        let crossServerStored = await tokenStore.saveRefreshedTokens(
+            "clawrouter-e2e-secret",
+            "very-long-browser-token-0123456789",
+            replacing: "redacted",
+            expected: identity,
+            credentialOwner: .persistentServer(serverId: identity.serverId)
+        )
+        let serverBAccess = await tokenStore.getAccessToken()
+        let serverBRefresh = await tokenStore.getRefreshToken()
+        XCTAssertFalse(crossServerStored)
+        XCTAssertEqual(serverBAccess, "gateway-token")
+        XCTAssertEqual(serverBRefresh, "decoy-token")
+    }
+
+    func testPutNavigationShortcutItemSendsAtomicBodyMutationAndProfileHeaders() async throws {
+        SettingsStubProtocol.reset(mode: .normal)
+        let api = await makeStubbedAPI()
+        let mutationId = newSettingMutationId()
+        let item = PrimaryMenuItem.section(
+            libraryId: 7,
+            sectionId: "recently-added",
+            label: "Recently Added"
+        )
+
+        let receipt = try await api.putNavigationShortcutItem(
+            item,
+            present: true,
+            mutationId: mutationId
+        )
+
+        XCTAssertEqual(receipt.value.settingKey, .navShortcuts)
+        XCTAssertEqual(
+            try receipt.value.value.decoded(as: NavigationShortcutsPreference.self),
+            NavigationShortcutsPreference(items: [item])
+        )
+
+        let recorded = try XCTUnwrap(SettingsStubProtocol.state().lastRequest)
+        XCTAssertEqual(recorded.method, "PUT")
+        XCTAssertEqual(recorded.path, "/api/v1/settings/values/nav.shortcuts/item")
+        XCTAssertTrue(recorded.query.isEmpty)
+        XCTAssertEqual(recorded.header("X-Silo-Mutation-Id"), mutationId)
+        XCTAssertEqual(recorded.header("X-Profile-Id"), Self.stubProfileId)
+
+        let body = try XCTUnwrap(recorded.body)
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: body) as? [String: Any]
+        )
+        XCTAssertEqual(object["present"] as? Bool, true)
+        let encodedItem = try XCTUnwrap(object["item"] as? [String: Any])
+        XCTAssertEqual(encodedItem["type"] as? String, "section")
+        XCTAssertEqual(encodedItem["library_id"] as? Int, 7)
+        XCTAssertEqual(encodedItem["section_id"] as? String, "recently-added")
+        XCTAssertEqual(encodedItem["label"] as? String, "Recently Added")
+    }
+
+    func testPutNavigationShortcutItemRejectsBuiltinsBeforeSending() async throws {
+        SettingsStubProtocol.reset(mode: .normal)
+        let api = await makeStubbedAPI()
+
+        do {
+            _ = try await api.putNavigationShortcutItem(
+                .builtin(.home),
+                present: true,
+                mutationId: newSettingMutationId()
+            )
+            XCTFail("built-in destinations are not valid nav.shortcuts items")
+        } catch let error as SettingsAPIError {
+            guard case .invalidValue = error else {
+                return XCTFail("expected a local invalid-value error, got \(error)")
+            }
+        }
+
+        XCTAssertNil(SettingsStubProtocol.state().lastRequest)
     }
 
     func testPutValueSurfacesAnIdempotentReplay() async throws {
@@ -661,6 +1063,10 @@ final class SettingsStubProtocol: URLProtocol {
         case idempotentReplay
         /// A delete addressing a scope with no stored value.
         case nothingStored
+        /// Two expired scoped requests race one rotating account refresh.
+        case concurrentScopedRefresh
+        /// A scoped request owns refresh while an ordinary 401 joins it.
+        case mixedRefreshScopedWins
     }
 
     struct RecordedRequest {
@@ -680,14 +1086,21 @@ final class SettingsStubProtocol: URLProtocol {
     struct State {
         var mode: Mode = .normal
         var lastRequest: RecordedRequest?
+        var requestCounts: [String: Int] = [:]
     }
 
     private static let lock = NSLock()
     private static var current = State()
+    private static var pendingConcurrentUnauthorized: [SettingsStubProtocol] = []
+    private static var pendingMixedOrdinaryUnauthorized: SettingsStubProtocol?
+    private static var mixedRefreshStarted = false
 
     static func reset(mode: Mode) {
         lock.lock()
         current = State(mode: mode)
+        pendingConcurrentUnauthorized.removeAll()
+        pendingMixedOrdinaryUnauthorized = nil
+        mixedRefreshStarted = false
         lock.unlock()
     }
 
@@ -724,9 +1137,42 @@ final class SettingsStubProtocol: URLProtocol {
             headers: Self.lowercasedHeaders(request.allHTTPHeaderFields ?? [:]),
             body: Self.requestBody(of: request)
         )
-        Self.mutate { $0.lastRequest = recorded }
+        Self.mutate {
+            $0.lastRequest = recorded
+            $0.requestCounts[recorded.path, default: 0] += 1
+        }
 
         let mode = Self.state().mode
+        if mode == .concurrentScopedRefresh {
+            switch (recorded.method, recorded.path) {
+            case ("POST", "/api/v1/auth/refresh"):
+                respond(
+                    status: 200,
+                    body: #"{"access_token":"placeholder","refresh_token":"redacted","expires_in":3600}"#
+                )
+            case ("GET", "/api/v1/settings/contract/capabilities"):
+                if recorded.header("Authorization") == "Bearer placeholder" {
+                    respond(
+                        status: 200,
+                        body: """
+                        {"api_version":1,"revision":\(SettingKey.revision),"contract_etag":"\\"etag\\"","definition_count":48,
+                         "scopes":["account","profile","profile_device","profile_library","profile_series"],
+                         "supports_batched_effective":true,"supports_idempotent_writes":true,
+                         "supports_atomic_shortcuts":true}
+                        """
+                    )
+                } else {
+                    holdConcurrentUnauthorizedUntilBothExpiredRequestsArrive()
+                }
+            default:
+                respond(status: 404, body: #"{"error":"not_found"}"#)
+            }
+            return
+        }
+        if mode == .mixedRefreshScopedWins {
+            handleMixedRefreshScopedWins(recorded)
+            return
+        }
         if mode == .serverTooOld {
             // The chi router's own 404: plain text, no Silo error envelope.
             respond(status: 404, body: "404 page not found\n", contentType: "text/plain", headers: [:])
@@ -741,13 +1187,26 @@ final class SettingsStubProtocol: URLProtocol {
             respond(status: 200, body: """
             {"api_version":1,"revision":\(responseRevision),"contract_etag":"\\"etag\\"","definition_count":48,
              "scopes":["account","profile","profile_device","profile_library","profile_series"],
-             "supports_batched_effective":true,"supports_idempotent_writes":true}
+             "supports_batched_effective":true,"supports_idempotent_writes":true,
+             "supports_atomic_shortcuts":true}
             """)
         case ("GET", "/api/v1/settings/values/effective"):
             respond(status: 200, body: """
             {"settings":[{"key":"playback.auto_play_next","value":true,"source":"default"}],
              "revision":\(responseRevision)}
             """)
+        case ("PUT", "/api/v1/settings/values/nav.shortcuts/item"):
+            let value = Self.shortcutValueFromMutationBody(recorded.body) ?? #"{"items":[]}"#
+            let replay = mode == .idempotentReplay
+            respond(
+                status: 200,
+                body: """
+                {"key":"nav.shortcuts","scope":"profile",
+                 "value":\(value),"revision":\(replay ? 0 : 3)}
+                """,
+                contentType: "application/json",
+                headers: replay ? ["X-Silo-Idempotent-Replay": "true"] : [:]
+            )
         case ("PUT", let path) where path.hasPrefix("/api/v1/settings/values/"):
             let key = String(path.dropFirst("/api/v1/settings/values/".count))
             let value = Self.valueFromWriteBody(recorded.body) ?? "null"
@@ -774,6 +1233,82 @@ final class SettingsStubProtocol: URLProtocol {
 
     override func stopLoading() {}
 
+    /// Release both initial 401s together so the regression deterministically
+    /// exercises two already-sent requests joining the same refresh flight.
+    /// Retaining the protocol instances avoids blocking URLSession's loader
+    /// queue while waiting for the second request.
+    private func holdConcurrentUnauthorizedUntilBothExpiredRequestsArrive() {
+        let ready: [SettingsStubProtocol]
+        Self.lock.lock()
+        Self.pendingConcurrentUnauthorized.append(self)
+        if Self.pendingConcurrentUnauthorized.count >= 2 {
+            ready = Self.pendingConcurrentUnauthorized
+            Self.pendingConcurrentUnauthorized.removeAll()
+        } else {
+            ready = []
+        }
+        Self.lock.unlock()
+
+        for pending in ready {
+            pending.respond(status: 401, body: #"{"error":"unauthorized"}"#)
+        }
+    }
+
+    private func handleMixedRefreshScopedWins(_ recorded: RecordedRequest) {
+        switch (recorded.method, recorded.path) {
+        case ("GET", "/api/v1/settings/contract/capabilities"):
+            if recorded.header("Authorization") == "Bearer placeholder" {
+                respond(
+                    status: 200,
+                    body: """
+                    {"api_version":1,"revision":\(SettingKey.revision),"contract_etag":"\\"etag\\"","definition_count":48,
+                     "scopes":["account","profile","profile_device","profile_library","profile_series"],
+                     "supports_batched_effective":true,"supports_idempotent_writes":true,
+                     "supports_atomic_shortcuts":true}
+                    """
+                )
+                return
+            }
+            if recorded.header("X-Test-Refresh-Flow") == "scoped" {
+                respond(status: 401, body: #"{"error":"unauthorized"}"#)
+                return
+            }
+
+            let refreshAlreadyStarted: Bool
+            Self.lock.lock()
+            refreshAlreadyStarted = Self.mixedRefreshStarted
+            if !refreshAlreadyStarted {
+                Self.pendingMixedOrdinaryUnauthorized = self
+            }
+            Self.lock.unlock()
+            if refreshAlreadyStarted {
+                respond(status: 401, body: #"{"error":"unauthorized"}"#)
+            }
+
+        case ("POST", "/api/v1/auth/refresh"):
+            let pendingOrdinary: SettingsStubProtocol?
+            Self.lock.lock()
+            Self.mixedRefreshStarted = true
+            pendingOrdinary = Self.pendingMixedOrdinaryUnauthorized
+            Self.pendingMixedOrdinaryUnauthorized = nil
+            Self.lock.unlock()
+            pendingOrdinary?.respond(status: 401, body: #"{"error":"unauthorized"}"#)
+
+            // Keep the scoped-owned refresh in flight long enough for the
+            // ordinary 401 to reach HTTPClient's shared account slot.
+            Task { @MainActor [weak self] in
+                try? await Task.sleep(for: .milliseconds(100))
+                self?.respond(
+                    status: 200,
+                    body: #"{"access_token":"placeholder","refresh_token":"redacted","expires_in":3600}"#
+                )
+            }
+
+        default:
+            respond(status: 404, body: #"{"error":"not_found"}"#)
+        }
+    }
+
     /// Pull the raw `value` back out of a `{"value": …}` body without
     /// re-encoding it, so a test can assert the stub echoed exactly what the
     /// client sent.
@@ -785,6 +1320,20 @@ final class SettingsStubProtocol: URLProtocol {
         guard let data = try? JSONSerialization.data(
             withJSONObject: value,
             options: [.fragmentsAllowed, .sortedKeys]
+        ) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private static func shortcutValueFromMutationBody(_ body: Data?) -> String? {
+        guard let body,
+              let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
+              let item = object["item"] as? [String: Any],
+              let present = object["present"] as? Bool
+        else { return nil }
+        let value: [String: Any] = ["items": present ? [item] : []]
+        guard let data = try? JSONSerialization.data(
+            withJSONObject: value,
+            options: [.sortedKeys]
         ) else { return nil }
         return String(data: data, encoding: .utf8)
     }
@@ -839,5 +1388,22 @@ final class SettingsStubProtocol: URLProtocol {
             client.urlProtocol(self, didLoad: Data(body.utf8))
         }
         client.urlProtocolDidFinishLoading(self)
+    }
+}
+
+private final class LockedCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    func increment() {
+        lock.lock()
+        count += 1
+        lock.unlock()
+    }
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
     }
 }

--- a/iosApp/Tests/SettingValuesAPITests.swift
+++ b/iosApp/Tests/SettingValuesAPITests.swift
@@ -1215,6 +1215,110 @@ final class SettingValuesAPITests: XCTestCase {
         )])
     }
 
+    func testRejectedTemporaryScopedRefreshPostsTemporaryExpiryNotification() async throws {
+        SettingsStubProtocol.reset(mode: .temporaryRefreshRejected)
+        let harness = try await makeRefreshHarness(testName: "RejectedTemporaryScopedGeneration")
+        let temporary = TemporaryAuthScope(
+            serverId: harness.identity.serverId,
+            serverURL: harness.identity.serverURL,
+            accessToken: "example",
+            refreshToken: "sample",
+            profileId: harness.identity.profileId,
+            profileToken: "decoy-token",
+            controllerDeviceId: "controller",
+            expiresAt: Date().addingTimeInterval(60)
+        )
+        await harness.tokenStore.beginTemporaryScope(temporary)
+        let temporaryExpiryCount = LockedCounter()
+        let persistentExpiryCount = LockedCounter()
+        let expiryEvents = LockedSessionExpiryEvents()
+        let temporaryObserver = NotificationCenter.default.addObserver(
+            forName: .temporaryRemoteAuthExpired,
+            object: nil,
+            queue: nil
+        ) { notification in
+            temporaryExpiryCount.increment()
+            if let event = notification.object as? SessionExpiryEvent {
+                expiryEvents.append(event)
+            }
+        }
+        let persistentObserver = NotificationCenter.default.addObserver(
+            forName: .continuumSessionExpired,
+            object: nil,
+            queue: nil
+        ) { _ in
+            persistentExpiryCount.increment()
+        }
+        defer {
+            NotificationCenter.default.removeObserver(temporaryObserver)
+            NotificationCenter.default.removeObserver(persistentObserver)
+        }
+
+        do {
+            _ = try await harness.http.requestData(
+                method: "GET",
+                path: "/api/v1/settings/contract/capabilities",
+                requestIdentity: harness.identity
+            )
+            XCTFail("the scoped temporary request must remain unauthorized")
+        } catch {
+            XCTAssertEqual((error as? HTTPError)?.statusCode, 401)
+        }
+
+        let state = SettingsStubProtocol.state()
+        XCTAssertEqual(state.requestCounts["/api/v1/auth/refresh"], 1)
+        XCTAssertEqual(state.requestCounts["/api/v1/settings/contract/capabilities"], 1)
+        XCTAssertEqual(temporaryExpiryCount.value, 1)
+        XCTAssertEqual(persistentExpiryCount.value, 0)
+        XCTAssertEqual(expiryEvents.values, [SessionExpiryEvent(
+            account: RefreshAccountIdentity(
+                serverId: temporary.serverId,
+                serverURL: temporary.serverURL,
+                credentialGenerationID: temporary.credentialGenerationID
+            ),
+            disposition: .temporarySessionExpired
+        )])
+    }
+
+    func testSuccessfulTemporaryScopedRefreshRotatesOnlyTemporaryGeneration() async throws {
+        SettingsStubProtocol.reset(mode: .mixedRefreshScopedWins)
+        let harness = try await makeRefreshHarness(testName: "SuccessfulTemporaryScopedGeneration")
+        let temporary = TemporaryAuthScope(
+            serverId: harness.identity.serverId,
+            serverURL: harness.identity.serverURL,
+            accessToken: "example",
+            refreshToken: "sample",
+            profileId: harness.identity.profileId,
+            profileToken: "decoy-token",
+            controllerDeviceId: "controller",
+            expiresAt: Date().addingTimeInterval(60)
+        )
+        await harness.tokenStore.beginTemporaryScope(temporary)
+
+        let response = try await harness.http.requestData(
+            method: "GET",
+            path: "/api/v1/settings/contract/capabilities",
+            headers: ["X-Test-Refresh-Flow": "scoped"],
+            requestIdentity: harness.identity
+        )
+
+        XCTAssertEqual(response.statusCode, 200)
+        let activeScope = await harness.tokenStore.getTemporaryScope()
+        XCTAssertEqual(activeScope?.credentialGenerationID, temporary.credentialGenerationID)
+        XCTAssertEqual(activeScope?.accessToken, "placeholder")
+        XCTAssertEqual(activeScope?.refreshToken, "redacted")
+        _ = await harness.tokenStore.endTemporaryScope(
+            expectedGenerationID: temporary.credentialGenerationID
+        )
+        let persistentAccess = await harness.tokenStore.getAccessToken()
+        let persistentRefresh = await harness.tokenStore.getRefreshToken()
+        XCTAssertEqual(persistentAccess, "fake")
+        XCTAssertEqual(persistentRefresh, "dummy")
+        let state = SettingsStubProtocol.state()
+        XCTAssertEqual(state.requestCounts["/api/v1/auth/refresh"], 1)
+        XCTAssertEqual(state.requestCounts["/api/v1/settings/contract/capabilities"], 2)
+    }
+
     func testPersistentExpiryEventIsRejectedAfterSameServerSessionReplacement() async throws {
         SettingsStubProtocol.reset(mode: .normal)
         let harness = try await makeRefreshHarness(testName: "PersistentExpiryEpoch")

--- a/iosApp/Tests/SettingValuesAPITests.swift
+++ b/iosApp/Tests/SettingValuesAPITests.swift
@@ -1388,14 +1388,150 @@ final class SettingValuesAPITests: XCTestCase {
         )
         await harness.tokenStore.beginTemporaryScope(replacement)
 
-        let removed = await harness.tokenStore.endTemporaryScope(
+        let endResult = await harness.tokenStore.endTemporaryScope(
             expectedGenerationID: rejected.credentialGenerationID
         )
-        XCTAssertNil(removed)
+        XCTAssertEqual(
+            endResult,
+            .differentGeneration(
+                activeGenerationID: replacement.credentialGenerationID
+            )
+        )
         let currentScope = await harness.tokenStore.getTemporaryScope()
         let consumableAfterReplacement = await harness.tokenStore.shouldConsumeSessionExpiryEvent(event)
         XCTAssertEqual(currentScope, replacement)
         XCTAssertFalse(consumableAfterReplacement)
+    }
+
+    func testTemporaryScopeTeardownDistinguishesAbsenceFromReplacementGeneration() async throws {
+        SettingsStubProtocol.reset(mode: .normal)
+        let harness = try await makeRefreshHarness(testName: "TemporaryScopeEndResult")
+        let ending = TemporaryAuthScope(
+            serverId: harness.identity.serverId,
+            serverURL: harness.identity.serverURL,
+            accessToken: "ending-access",
+            refreshToken: "ending-refresh",
+            profileId: harness.identity.profileId,
+            profileToken: "ending-profile",
+            controllerDeviceId: "controller-a",
+            expiresAt: Date().addingTimeInterval(60)
+        )
+        await harness.tokenStore.beginTemporaryScope(ending)
+
+        await harness.tokenStore.clearTokens()
+        let absentResult = await harness.tokenStore.endTemporaryScope(
+            expectedGenerationID: ending.credentialGenerationID
+        )
+        XCTAssertEqual(absentResult, .alreadyAbsent)
+
+        let replacement = TemporaryAuthScope(
+            serverId: ending.serverId,
+            serverURL: ending.serverURL,
+            accessToken: "replacement-access",
+            refreshToken: "replacement-refresh",
+            profileId: ending.profileId,
+            profileToken: "replacement-profile",
+            controllerDeviceId: "controller-b",
+            expiresAt: Date().addingTimeInterval(120)
+        )
+        await harness.tokenStore.beginTemporaryScope(replacement)
+
+        let replacementResult = await harness.tokenStore.endTemporaryScope(
+            expectedGenerationID: ending.credentialGenerationID
+        )
+        let currentScope = await harness.tokenStore.getTemporaryScope()
+        XCTAssertEqual(
+            replacementResult,
+            .differentGeneration(
+                activeGenerationID: replacement.credentialGenerationID
+            )
+        )
+        XCTAssertEqual(currentScope, replacement)
+    }
+
+    func testRemotePlaybackEndPolicyAcceptsExpectedGenerationWhenScopeIsAlreadyAbsent() {
+        let endingGenerationID = UUID()
+        let replacementGenerationID = UUID()
+
+        XCTAssertEqual(
+            RemotePlaybackIdentityEndPolicy.endingGenerationID(
+                activeIdentityGenerationID: endingGenerationID,
+                scopeGenerationID: nil,
+                expectedGenerationID: endingGenerationID
+            ),
+            endingGenerationID,
+            "delayed cleanup must clear a matching identity after its scope was already removed"
+        )
+        XCTAssertNil(
+            RemotePlaybackIdentityEndPolicy.endingGenerationID(
+                activeIdentityGenerationID: endingGenerationID,
+                scopeGenerationID: replacementGenerationID,
+                expectedGenerationID: endingGenerationID
+            ),
+            "a replacement scope must remain protected"
+        )
+        XCTAssertNil(
+            RemotePlaybackIdentityEndPolicy.endingGenerationID(
+                activeIdentityGenerationID: replacementGenerationID,
+                scopeGenerationID: nil,
+                expectedGenerationID: endingGenerationID
+            ),
+            "a replacement manager identity must remain protected"
+        )
+    }
+
+    func testSignOutAuthorizationAllowsIncompleteLocalStateAndRefusesTemporaryOwner() {
+        let account = RefreshAccountIdentity(
+            serverId: "server-a",
+            serverURL: "http://settings-test.invalid",
+            credentialGenerationID: UUID()
+        )
+        let persistentAuth = CapturedOrdinaryRequestAuth(
+            account: account,
+            credentialOwner: .persistentServer(serverId: account.serverId),
+            accessToken: "persistent-access",
+            profileId: "profile-a",
+            profileToken: "persistent-profile"
+        )
+        let temporaryAuth = CapturedOrdinaryRequestAuth(
+            account: account,
+            credentialOwner: .temporary,
+            accessToken: "temporary-access",
+            profileId: "profile-a",
+            profileToken: "temporary-profile"
+        )
+
+        XCTAssertEqual(
+            AuthService.signOutAuthorization(
+                activeServerId: account.serverId,
+                capturedAuth: persistentAuth
+            ),
+            .allowed(account: account)
+        )
+        XCTAssertEqual(
+            AuthService.signOutAuthorization(
+                activeServerId: account.serverId,
+                capturedAuth: nil
+            ),
+            .allowed(account: nil),
+            "an incomplete URL/defaults mirror must not strand local credentials"
+        )
+        XCTAssertEqual(
+            AuthService.signOutAuthorization(
+                activeServerId: account.serverId,
+                capturedAuth: temporaryAuth
+            ),
+            .refused,
+            "the temporary identity owner must be torn down before persistent sign-out"
+        )
+        XCTAssertEqual(
+            AuthService.signOutAuthorization(
+                activeServerId: "server-b",
+                capturedAuth: persistentAuth
+            ),
+            .refused,
+            "a stale capture must not clear another active server"
+        )
     }
 
     func testReplacementCancellationWaitsForOldEndBeforeStartingNewGenerationRequest() async throws {

--- a/iosApp/Tests/SettingsConformanceTests.swift
+++ b/iosApp/Tests/SettingsConformanceTests.swift
@@ -98,12 +98,14 @@ final class SettingsConformanceTests: XCTestCase {
 
     private struct ConformanceContext: Decodable {
         let profileId: String?
+        let clientFamily: String?
         let deviceId: String?
         let libraryIds: [Int]
         let seriesIds: [String]
 
         enum CodingKeys: String, CodingKey {
             case profileId = "profile_id"
+            case clientFamily = "client_family"
             case deviceId = "device_id"
             case libraryIds = "library_ids"
             case seriesIds = "series_ids"
@@ -112,6 +114,7 @@ final class SettingsConformanceTests: XCTestCase {
         init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             profileId = try container.decodeIfPresent(String.self, forKey: .profileId)
+            clientFamily = try container.decodeIfPresent(String.self, forKey: .clientFamily)
             deviceId = try container.decodeIfPresent(String.self, forKey: .deviceId)
             libraryIds = try container.decodeIfPresent([Int].self, forKey: .libraryIds) ?? []
             seriesIds = try container.decodeIfPresent([String].self, forKey: .seriesIds) ?? []
@@ -122,6 +125,7 @@ final class SettingsConformanceTests: XCTestCase {
         let key: String
         let scope: String
         let profileId: String?
+        let clientFamily: String?
         let deviceId: String?
         let libraryId: Int?
         let seriesId: String?
@@ -134,6 +138,7 @@ final class SettingsConformanceTests: XCTestCase {
             case key
             case scope
             case profileId = "profile_id"
+            case clientFamily = "client_family"
             case deviceId = "device_id"
             case libraryId = "library_id"
             case seriesId = "series_id"
@@ -202,9 +207,12 @@ final class SettingsConformanceTests: XCTestCase {
             "name", "description", "keys", "context", "stored",
             "constraints", "constraint_bindings", "expected",
         ]
-        static let context = ["profile_id", "device_id", "library_ids", "series_ids"]
+        static let context = [
+            "profile_id", "client_family", "device_id", "library_ids", "series_ids",
+        ]
         static let row = [
-            "key", "scope", "profile_id", "device_id", "library_id", "series_id", "value",
+            "key", "scope", "profile_id", "client_family", "device_id", "library_id",
+            "series_id", "value",
         ]
         static let binding = ["key", "policy_input", "constraint"]
         static let expected = [
@@ -549,6 +557,7 @@ final class SettingsConformanceTests: XCTestCase {
                     key: row.key,
                     scope: row.scope,
                     profileId: row.profileId,
+                    clientFamily: row.clientFamily,
                     deviceId: row.deviceId,
                     libraryId: row.libraryId,
                     seriesId: row.seriesId,
@@ -557,6 +566,7 @@ final class SettingsConformanceTests: XCTestCase {
             },
             context: SettingResolutionContext(
                 profileId: testCase.context?.profileId,
+                clientFamily: testCase.context?.clientFamily,
                 deviceId: testCase.context?.deviceId,
                 libraryIds: testCase.context?.libraryIds ?? [],
                 seriesIds: testCase.context?.seriesIds ?? []

--- a/iosApp/Tests/SettingsContractResolve.swift
+++ b/iosApp/Tests/SettingsContractResolve.swift
@@ -219,6 +219,7 @@ enum SettingsContractSource {
     static let `default` = "default"
     static let account = "account"
     static let profile = "profile"
+    static let profileClient = "profile_client"
     static let profileDevice = "profile_device"
     static let profileLibrary = "profile_library"
     static let profileSeries = "profile_series"
@@ -229,6 +230,7 @@ struct StoredSettingRow {
     let key: String
     let scope: String
     var profileId: String?
+    var clientFamily: String?
     var deviceId: String?
     var libraryId: Int?
     var seriesId: String?
@@ -238,6 +240,7 @@ struct StoredSettingRow {
 /// The identity a resolution happens against. An absent field drops its scopes.
 struct SettingResolutionContext {
     var profileId: String?
+    var clientFamily: String?
     var deviceId: String?
     var libraryIds: [Int] = []
     var seriesIds: [String] = []
@@ -342,6 +345,7 @@ private func pickForScope(
     context: SettingResolutionContext
 ) -> StoredSettingRow? {
     let profileId = context.profileId ?? ""
+    let clientFamily = context.clientFamily ?? ""
     let deviceId = context.deviceId ?? ""
 
     let matches = candidates.filter { row in
@@ -351,6 +355,10 @@ private func pickForScope(
             return true
         case SettingsContractSource.profile:
             return (row.profileId ?? "") == profileId
+        case SettingsContractSource.profileClient:
+            return (row.profileId ?? "") == profileId
+                && (row.clientFamily ?? "") == clientFamily
+                && ["tv", "mobile", "tablet", "desktop", "web"].contains(clientFamily)
         case SettingsContractSource.profileDevice:
             return (row.profileId ?? "") == profileId
                 && (row.deviceId ?? "") == deviceId

--- a/iosApp/Tests/UICustomizationPreferencesTests.swift
+++ b/iosApp/Tests/UICustomizationPreferencesTests.swift
@@ -44,6 +44,45 @@ final class UICustomizationPreferencesTests: XCTestCase {
         XCTAssertEqual(CardPosterSize.large.scale, 1.2, accuracy: 0.001)
     }
 
+    func testVisibleRootChangesOnlyRearmTheAffectedFocusOwner() {
+        XCTAssertEqual(
+            tvVisibleRootsFocusRearm(
+                menuOwnedFocus: false,
+                isShowingRoot: true,
+                selectedRootWasRemoved: false
+            ),
+            .none,
+            "reordering an unrelated root must preserve the currently focused card"
+        )
+        XCTAssertEqual(
+            tvVisibleRootsFocusRearm(
+                menuOwnedFocus: false,
+                isShowingRoot: true,
+                selectedRootWasRemoved: true
+            ),
+            .content,
+            "removing content's selected root must hand focus to the Home content"
+        )
+        XCTAssertEqual(
+            tvVisibleRootsFocusRearm(
+                menuOwnedFocus: true,
+                isShowingRoot: true,
+                selectedRootWasRemoved: false
+            ),
+            .topMenu,
+            "a changing focus graph must explicitly re-arm the top menu when it owns focus"
+        )
+        XCTAssertEqual(
+            tvVisibleRootsFocusRearm(
+                menuOwnedFocus: true,
+                isShowingRoot: false,
+                selectedRootWasRemoved: true
+            ),
+            .none,
+            "a pushed route must not re-arm hidden root content"
+        )
+    }
+
     func testCaptionStylesGateTitleAndMetadataIndependently() {
         XCTAssertTrue(CardCaptionStyle.titleMetadata.showsTitle)
         XCTAssertTrue(CardCaptionStyle.titleMetadata.showsMetadata)
@@ -286,6 +325,43 @@ final class UICustomizationPreferencesTests: XCTestCase {
         XCTAssertEqual(knownEmpty.map(\.id), [.app(.home)])
     }
 
+    func testLibraryTabRequestUsesFirstAuthoredLibraryRoot() {
+        let authoredDestinations: [MainTabDestination] = [
+            .app(.home),
+            .libraryCategory(.series),
+            .library(id: 8, label: "Pinned"),
+            .app(.downloads),
+        ]
+        XCTAssertEqual(
+            resolvedRequestedMainTabDestination(
+                .libraries,
+                visibleDestinations: authoredDestinations
+            ),
+            .libraryCategory(.series),
+            "Browse Libraries should follow authored menu order when the aggregate root is hidden"
+        )
+
+        let aggregateDestinations: [MainTabDestination] = [
+            .app(.home),
+            .app(.libraries),
+            .libraryCategory(.series),
+        ]
+        XCTAssertEqual(
+            resolvedRequestedMainTabDestination(
+                .libraries,
+                visibleDestinations: aggregateDestinations
+            ),
+            .app(.libraries)
+        )
+        XCTAssertEqual(
+            resolvedRequestedMainTabDestination(
+                .libraries,
+                visibleDestinations: [.app(.home), .app(.downloads)]
+            ),
+            .app(.home)
+        )
+    }
+
     func testMainTabProjectionOnlyShowsCategoriesBackedByCurrentLibraries() {
         let menu = PrimaryMenuPreference(items: [
             .builtin(.home),
@@ -488,6 +564,77 @@ final class UICustomizationPreferencesTests: XCTestCase {
             second.id,
             "changing a reused fixed-root scope must immediately select the new exact library"
         )
+    }
+
+    func testLibrarySelectionPersistenceIsScopedByAuthorityAndRoot() throws {
+        let firstAuthority = try XCTUnwrap(
+            MainTabLibraryAuthority(serverId: "server", profileId: "profile-a")
+        )
+        let secondAuthority = try XCTUnwrap(
+            MainTabLibraryAuthority(serverId: "server", profileId: "profile-b")
+        )
+        let aggregateKey = try XCTUnwrap(
+            librarySelectionStorageKey(
+                category: nil,
+                fixedLibraryId: nil,
+                authority: firstAuthority
+            )
+        )
+        let moviesKey = try XCTUnwrap(
+            librarySelectionStorageKey(
+                category: .movies,
+                fixedLibraryId: nil,
+                authority: firstAuthority
+            )
+        )
+        let seriesKey = try XCTUnwrap(
+            librarySelectionStorageKey(
+                category: .series,
+                fixedLibraryId: nil,
+                authority: firstAuthority
+            )
+        )
+        let otherProfileMoviesKey = try XCTUnwrap(
+            librarySelectionStorageKey(
+                category: .movies,
+                fixedLibraryId: nil,
+                authority: secondAuthority
+            )
+        )
+
+        XCTAssertEqual(aggregateKey, "librariesTabSelectedLibraryId")
+        XCTAssertNotEqual(moviesKey, seriesKey)
+        XCTAssertNotEqual(moviesKey, otherProfileMoviesKey)
+        XCTAssertNil(
+            librarySelectionStorageKey(
+                category: nil,
+                fixedLibraryId: 7,
+                authority: firstAuthority
+            ),
+            "a fixed root derives its selection from the destination and must not persist it"
+        )
+        XCTAssertNil(
+            librarySelectionStorageKey(
+                category: .movies,
+                fixedLibraryId: nil,
+                authority: nil
+            ),
+            "an unauthenticated category root must not persist under a shared none:none key"
+        )
+
+        let suiteName = "library-selection-scope-suite-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { UserDefaults().removePersistentDomain(forName: suiteName) }
+        defaults.set(8, forKey: aggregateKey)
+        XCTAssertEqual(
+            storedLibrarySelectionId(for: moviesKey, defaults: defaults),
+            8,
+            "a missing scoped value seeds from the legacy aggregate selection"
+        )
+        defaults.set(9, forKey: moviesKey)
+        defaults.set(10, forKey: seriesKey)
+        XCTAssertEqual(storedLibrarySelectionId(for: moviesKey, defaults: defaults), 9)
+        XCTAssertEqual(storedLibrarySelectionId(for: seriesKey, defaults: defaults), 10)
     }
 
     func testDirectTVLibraryShortcutDoesNotInheritCategoryPillState() {
@@ -2407,6 +2554,293 @@ final class UICustomizationPreferencesTests: XCTestCase {
         XCTAssertTrue(preferences.hasDeviceOverrides)
     }
 
+    func testSuccessfulDeviceDeleteReconcilesWhenSiblingFailsAndOnlyFailureReplays() async throws {
+        let suiteName = "ui-customization-partial-device-delete-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-partial-device-delete-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let cacheKey = "silo.uiCustomization.server.profile.tv"
+        let defaults = SharedDefaults(suite: suite, standard: standard)
+        let transport = DeviceOverrideDeleteProbe(deleteFailureKey: .navPrimaryMenu)
+        let preferences = UICustomizationPreferences(
+            defaults: defaults,
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+        await preferences.refresh()
+        XCTAssertTrue(preferences.primaryMenuUsesDeviceOverride)
+        XCTAssertTrue(preferences.cardPresentationUsesDeviceOverride)
+
+        preferences.useFamilySettings()
+        while preferences.isSaving { await Task.yield() }
+
+        XCTAssertTrue(
+            preferences.primaryMenuUsesDeviceOverride,
+            "the failed device delete must keep its effective value and source"
+        )
+        XCTAssertFalse(
+            preferences.cardPresentationUsesDeviceOverride,
+            "the successful sibling must reconcile even while another delete remains pending"
+        )
+        XCTAssertEqual(preferences.cardPresentation, .standard)
+        XCTAssertNotNil(preferences.syncErrorMessage)
+
+        var snapshot = await transport.snapshot()
+        XCTAssertEqual(snapshot.deleteKeys, [.navPrimaryMenu, .uiCardPresentation])
+        XCTAssertEqual(snapshot.targetedReadKeys, [.uiCardPresentation])
+
+        let restarted = UICustomizationPreferences(
+            defaults: defaults,
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+        await restarted.refresh()
+
+        snapshot = await transport.snapshot()
+        XCTAssertEqual(
+            snapshot.deleteKeys,
+            [.navPrimaryMenu, .uiCardPresentation, .navPrimaryMenu],
+            "restart must replay only the failed device delete"
+        )
+        XCTAssertFalse(restarted.cardPresentationUsesDeviceOverride)
+        XCTAssertEqual(restarted.cardPresentation, .standard)
+    }
+
+    func testDeviceDeleteReadFailureRemainsDurableUntilRestartReconcilesIt() async throws {
+        let suiteName = "ui-customization-device-delete-read-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-device-delete-read-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let cacheKey = "silo.uiCustomization.server.profile.tv"
+        let defaults = SharedDefaults(suite: suite, standard: standard)
+        let transport = DeviceOverrideDeleteProbe(
+            targetedReadFailureKey: .navPrimaryMenu
+        )
+        let preferences = UICustomizationPreferences(
+            defaults: defaults,
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+        await preferences.refresh()
+        preferences.useFamilySettings()
+        while preferences.isSaving { await Task.yield() }
+
+        XCTAssertTrue(
+            preferences.primaryMenuUsesDeviceOverride,
+            "a successful delete without its inherited value must retain the safe cached pair"
+        )
+        XCTAssertFalse(preferences.cardPresentationUsesDeviceOverride)
+        XCTAssertNotNil(preferences.syncErrorMessage)
+
+        let restarted = UICustomizationPreferences(
+            defaults: defaults,
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+        await restarted.refresh()
+
+        let snapshot = await transport.snapshot()
+        XCTAssertEqual(
+            snapshot.deleteKeys,
+            [.navPrimaryMenu, .uiCardPresentation, .navPrimaryMenu],
+            "only the delete whose effective read failed remains in the durable outbox"
+        )
+        XCTAssertEqual(
+            snapshot.targetedReadKeys,
+            [.navPrimaryMenu, .uiCardPresentation, .navPrimaryMenu]
+        )
+        XCTAssertFalse(restarted.primaryMenuUsesDeviceOverride)
+        XCTAssertFalse(restarted.cardPresentationUsesDeviceOverride)
+        XCTAssertEqual(
+            restarted.primaryMenu,
+            PrimaryMenuPreference(items: [.builtin(.home), .builtin(.series)])
+        )
+        XCTAssertEqual(restarted.cardPresentation, .standard)
+        XCTAssertNil(restarted.syncErrorMessage)
+    }
+
+    func testRefreshReconcilesValidKeysAndPreservesEachInvalidValueAndSource() async throws {
+        let suiteName = "ui-customization-independent-decode-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-independent-decode-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let originalMenu = PrimaryMenuPreference(items: [
+            .builtin(.home),
+            .builtin(.movies),
+        ])
+        let updatedMenu = PrimaryMenuPreference(items: [
+            .builtin(.home),
+            .builtin(.series),
+        ])
+        let updatedShortcuts = NavigationShortcutsPreference(items: [
+            .library(libraryId: 8, label: "Pinned"),
+        ])
+        let initialResponse = EffectiveSettingValuesResponse(
+            settings: [
+                EffectiveSettingValue(
+                    key: SettingKey.navPrimaryMenu.rawValue,
+                    value: try SettingJSONValue.encoding(originalMenu),
+                    source: .scope(.profileDevice),
+                    scope: .profileDevice,
+                    profileId: "profile",
+                    deviceId: "device"
+                ),
+                EffectiveSettingValue(
+                    key: SettingKey.navShortcuts.rawValue,
+                    value: try SettingJSONValue.encoding(NavigationShortcutsPreference.empty),
+                    source: .scope(.profile),
+                    scope: .profile,
+                    profileId: "profile"
+                ),
+                EffectiveSettingValue(
+                    key: SettingKey.uiCardPresentation.rawValue,
+                    value: try SettingJSONValue.encoding(
+                        CardPresentationPreset.compact.presentation
+                    ),
+                    source: .scope(.profileDevice),
+                    scope: .profileDevice,
+                    profileId: "profile",
+                    deviceId: "device"
+                ),
+            ],
+            revision: SettingKey.revision
+        )
+        let transport = MutableEffectiveValuesProbe(response: initialResponse)
+        let cacheKey = "silo.uiCustomization.server.profile.mobile"
+        let preferences = UICustomizationPreferences(
+            defaults: SharedDefaults(suite: suite, standard: standard),
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+        await preferences.refresh()
+
+        await transport.setResponse(EffectiveSettingValuesResponse(
+            settings: [
+                EffectiveSettingValue(
+                    key: SettingKey.navPrimaryMenu.rawValue,
+                    value: try SettingJSONValue.encoding(updatedMenu),
+                    source: .scope(.profileClient),
+                    scope: .profileClient,
+                    profileId: "profile",
+                    clientFamily: "mobile"
+                ),
+                EffectiveSettingValue(
+                    key: SettingKey.navShortcuts.rawValue,
+                    value: try SettingJSONValue.encoding(updatedShortcuts),
+                    source: .scope(.profile),
+                    scope: .profile,
+                    profileId: "profile"
+                ),
+                EffectiveSettingValue(
+                    key: SettingKey.uiCardPresentation.rawValue,
+                    value: .object([
+                        "poster_size": .string("future-size"),
+                        "caption": .string("title"),
+                    ]),
+                    source: .scope(.profileClient),
+                    scope: .profileClient,
+                    profileId: "profile",
+                    clientFamily: "mobile"
+                ),
+            ],
+            revision: SettingKey.revision
+        ))
+        await preferences.refresh()
+
+        XCTAssertEqual(preferences.primaryMenu, updatedMenu)
+        XCTAssertFalse(preferences.primaryMenuUsesDeviceOverride)
+        XCTAssertEqual(preferences.shortcuts, updatedShortcuts)
+        XCTAssertEqual(preferences.cardPresentation, CardPresentationPreset.compact.presentation)
+        XCTAssertTrue(
+            preferences.cardPresentationUsesDeviceOverride,
+            "a failed decode must retain the matching prior source with its prior value"
+        )
+        XCTAssertNotNil(preferences.syncErrorMessage)
+
+        let invalidMenu = PrimaryMenuPreference(items: [.builtin(.movies)])
+        await transport.setResponse(EffectiveSettingValuesResponse(
+            settings: [
+                EffectiveSettingValue(
+                    key: SettingKey.navPrimaryMenu.rawValue,
+                    value: try SettingJSONValue.encoding(invalidMenu),
+                    source: .scope(.profileDevice),
+                    scope: .profileDevice,
+                    profileId: "profile",
+                    deviceId: "device"
+                ),
+                EffectiveSettingValue(
+                    key: SettingKey.navShortcuts.rawValue,
+                    value: try SettingJSONValue.encoding(updatedShortcuts),
+                    source: .scope(.profile),
+                    scope: .profile,
+                    profileId: "profile"
+                ),
+                EffectiveSettingValue(
+                    key: SettingKey.uiCardPresentation.rawValue,
+                    value: try SettingJSONValue.encoding(
+                        CardPresentationPreset.artworkOnly.presentation
+                    ),
+                    source: .scope(.profileClient),
+                    scope: .profileClient,
+                    profileId: "profile",
+                    clientFamily: "mobile"
+                ),
+            ],
+            revision: SettingKey.revision
+        ))
+        await preferences.refresh()
+
+        XCTAssertEqual(preferences.primaryMenu, updatedMenu)
+        XCTAssertFalse(
+            preferences.primaryMenuUsesDeviceOverride,
+            "an invalid menu must not pair its source with the previous valid menu"
+        )
+        XCTAssertEqual(
+            preferences.cardPresentation,
+            CardPresentationPreset.artworkOnly.presentation
+        )
+        XCTAssertFalse(preferences.cardPresentationUsesDeviceOverride)
+        XCTAssertNotNil(preferences.syncErrorMessage)
+
+        let cached = UICustomizationPreferences(
+            defaults: SharedDefaults(suite: suite, standard: standard),
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+        XCTAssertEqual(cached.primaryMenu, updatedMenu)
+        XCTAssertEqual(cached.shortcuts, updatedShortcuts)
+        XCTAssertEqual(cached.cardPresentation, CardPresentationPreset.artworkOnly.presentation)
+        XCTAssertFalse(cached.primaryMenuUsesDeviceOverride)
+        XCTAssertFalse(cached.cardPresentationUsesDeviceOverride)
+    }
+
     func testDeviceMenuOverrideDoesNotBlockProfileLibraryPin() async throws {
         let suiteName = "ui-customization-device-menu-pin-suite-\(UUID().uuidString)"
         let standardName = "ui-customization-device-menu-pin-standard-\(UUID().uuidString)"
@@ -2667,6 +3101,37 @@ private func testCapabilities(
     )
 }
 
+private func completeCustomizationEffectiveResponse(
+    keys: [SettingKey],
+    settings: [EffectiveSettingValue]
+) throws -> EffectiveSettingValuesResponse {
+    var completed = settings
+    let presentKeys = Set(settings.compactMap(\.settingKey))
+    for key in keys where !presentKeys.contains(key) {
+        let value: SettingJSONValue
+        switch key {
+        case .navPrimaryMenu:
+            value = .null
+        case .navShortcuts:
+            value = try SettingJSONValue.encoding(NavigationShortcutsPreference.empty)
+        case .uiCardPresentation:
+            value = try SettingJSONValue.encoding(CardPresentationPreference.standard)
+        default:
+            continue
+        }
+        completed.append(EffectiveSettingValue(
+            key: key.rawValue,
+            value: value,
+            source: .contractDefault,
+            profileId: "profile"
+        ))
+    }
+    return EffectiveSettingValuesResponse(
+        settings: completed,
+        revision: SettingKey.revision
+    )
+}
+
 private final class MutableRequestIdentity: @unchecked Sendable {
     var value: HTTPRequestIdentity
 
@@ -2762,6 +3227,147 @@ private actor CapabilityGateProbe: UICustomizationTransport {
     }
 }
 
+private actor MutableEffectiveValuesProbe: CurrentCapabilitiesTransport {
+    private var response: EffectiveSettingValuesResponse
+
+    init(response: EffectiveSettingValuesResponse) {
+        self.response = response
+    }
+
+    func effectiveValues(
+        keys: [SettingKey],
+        requestIdentity: HTTPRequestIdentity
+    ) async throws -> EffectiveSettingValuesResponse {
+        response
+    }
+
+    func putValue(
+        key: SettingKey,
+        scope: SettingScopeIdentity,
+        value: SettingJSONValue,
+        mutationId: String,
+        requestIdentity: HTTPRequestIdentity
+    ) async throws {}
+
+    func setResponse(_ response: EffectiveSettingValuesResponse) {
+        self.response = response
+    }
+}
+
+private actor DeviceOverrideDeleteProbe: CurrentCapabilitiesTransport {
+    private let deleteFailureKey: SettingKey?
+    private let targetedReadFailureKey: SettingKey?
+    private var didFailTargetedRead = false
+    private var deviceOverrideKeys: Set<SettingKey> = [
+        .navPrimaryMenu,
+        .uiCardPresentation,
+    ]
+    private var deleteKeys: [SettingKey] = []
+    private var targetedReadKeys: [SettingKey] = []
+
+    init(
+        deleteFailureKey: SettingKey? = nil,
+        targetedReadFailureKey: SettingKey? = nil
+    ) {
+        self.deleteFailureKey = deleteFailureKey
+        self.targetedReadFailureKey = targetedReadFailureKey
+    }
+
+    func effectiveValues(
+        keys: [SettingKey],
+        requestIdentity: HTTPRequestIdentity
+    ) async throws -> EffectiveSettingValuesResponse {
+        if keys.count == 1, let key = keys.first {
+            targetedReadKeys.append(key)
+            if key == targetedReadFailureKey, !didFailTargetedRead {
+                didFailTargetedRead = true
+                throw URLError(.notConnectedToInternet)
+            }
+        }
+        var settings: [EffectiveSettingValue] = []
+        for key in keys {
+            if let value = try effectiveValue(for: key) {
+                settings.append(value)
+            }
+        }
+        return EffectiveSettingValuesResponse(
+            settings: settings,
+            revision: SettingKey.revision
+        )
+    }
+
+    func putValue(
+        key: SettingKey,
+        scope: SettingScopeIdentity,
+        value: SettingJSONValue,
+        mutationId: String,
+        requestIdentity: HTTPRequestIdentity
+    ) async throws {}
+
+    func deleteValue(
+        key: SettingKey,
+        scope: SettingScopeIdentity,
+        requestIdentity: HTTPRequestIdentity
+    ) async throws {
+        deleteKeys.append(key)
+        if key == deleteFailureKey {
+            throw URLError(.notConnectedToInternet)
+        }
+        guard deviceOverrideKeys.remove(key) != nil else {
+            throw SettingsAPIError.noValueAtScope
+        }
+    }
+
+    func snapshot() -> (deleteKeys: [SettingKey], targetedReadKeys: [SettingKey]) {
+        (deleteKeys, targetedReadKeys)
+    }
+
+    private func effectiveValue(for key: SettingKey) throws -> EffectiveSettingValue? {
+        switch key {
+        case .navPrimaryMenu:
+            let hasDeviceOverride = deviceOverrideKeys.contains(key)
+            let menu = PrimaryMenuPreference(items: [
+                .builtin(.home),
+                .builtin(hasDeviceOverride ? .movies : .series),
+            ])
+            return EffectiveSettingValue(
+                key: key.rawValue,
+                value: try SettingJSONValue.encoding(menu),
+                source: .scope(hasDeviceOverride ? .profileDevice : .profileClient),
+                scope: hasDeviceOverride ? .profileDevice : .profileClient,
+                profileId: "profile",
+                clientFamily: hasDeviceOverride ? nil : "tv",
+                deviceId: hasDeviceOverride ? "device" : nil
+            )
+        case .navShortcuts:
+            return EffectiveSettingValue(
+                key: key.rawValue,
+                value: try SettingJSONValue.encoding(NavigationShortcutsPreference.empty),
+                source: .scope(.profile),
+                scope: .profile,
+                profileId: "profile"
+            )
+        case .uiCardPresentation:
+            let hasDeviceOverride = deviceOverrideKeys.contains(key)
+            let presentation = hasDeviceOverride
+                ? CardPresentationPreset.compact.presentation
+                : CardPresentationPreference.standard
+            return EffectiveSettingValue(
+                key: key.rawValue,
+                value: try SettingJSONValue.encoding(presentation),
+                source: hasDeviceOverride
+                    ? .scope(.profileDevice)
+                    : .contractDefault,
+                scope: hasDeviceOverride ? .profileDevice : nil,
+                profileId: "profile",
+                deviceId: hasDeviceOverride ? "device" : nil
+            )
+        default:
+            return nil
+        }
+    }
+}
+
 private actor RecoveringDeleteProbe: CurrentCapabilitiesTransport {
     private var deletesOnline = false
     private var familyRowPresent = true
@@ -2778,7 +3384,8 @@ private actor RecoveringDeleteProbe: CurrentCapabilitiesTransport {
         let presentation = familyRowPresent
             ? CardPresentationPreset.compact.presentation
             : CardPresentationPreference.standard
-        return EffectiveSettingValuesResponse(
+        return try completeCustomizationEffectiveResponse(
+            keys: keys,
             settings: [
                 EffectiveSettingValue(
                     key: SettingKey.uiCardPresentation.rawValue,
@@ -2788,8 +3395,7 @@ private actor RecoveringDeleteProbe: CurrentCapabilitiesTransport {
                     profileId: "profile",
                     clientFamily: familyRowPresent ? "mobile" : nil
                 ),
-            ],
-            revision: SettingKey.revision
+            ]
         )
     }
 
@@ -3122,7 +3728,8 @@ private actor ShortcutOrderingProbe: CurrentCapabilitiesTransport {
         requestIdentity: HTTPRequestIdentity
     ) async throws -> EffectiveSettingValuesResponse {
         if effectiveFails { throw URLError(.notConnectedToInternet) }
-        return EffectiveSettingValuesResponse(
+        return try completeCustomizationEffectiveResponse(
+            keys: keys,
             settings: [
                 EffectiveSettingValue(
                     key: SettingKey.navPrimaryMenu.rawValue,
@@ -3141,8 +3748,7 @@ private actor ShortcutOrderingProbe: CurrentCapabilitiesTransport {
                     scope: .profile,
                     profileId: "profile"
                 ),
-            ],
-            revision: SettingKey.revision
+            ]
         )
     }
 
@@ -3313,7 +3919,8 @@ private actor RecoveringWriteProbe: CurrentCapabilitiesTransport {
         requestIdentity: HTTPRequestIdentity
     ) async throws -> EffectiveSettingValuesResponse {
         events.append("effective")
-        return EffectiveSettingValuesResponse(
+        return try completeCustomizationEffectiveResponse(
+            keys: keys,
             settings: [
                 EffectiveSettingValue(
                     key: SettingKey.uiCardPresentation.rawValue,
@@ -3323,8 +3930,7 @@ private actor RecoveringWriteProbe: CurrentCapabilitiesTransport {
                     profileId: "profile",
                     clientFamily: "mobile"
                 ),
-            ],
-            revision: SettingKey.revision
+            ]
         )
     }
 
@@ -3385,6 +3991,7 @@ private actor RecoveringShortcutProbe: CurrentCapabilitiesTransport {
     private var genericPutWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
     private var events: [String] = []
     private var storedShortcuts: [PrimaryMenuItem] = []
+    private var storedMenu: PrimaryMenuPreference?
     private let offlineFailure: SettingsAPIError?
 
     init(offlineFailure: SettingsAPIError? = nil) {
@@ -3396,19 +4003,30 @@ private actor RecoveringShortcutProbe: CurrentCapabilitiesTransport {
         requestIdentity: HTTPRequestIdentity
     ) async throws -> EffectiveSettingValuesResponse {
         events.append("effective")
-        return EffectiveSettingValuesResponse(
-            settings: [
-                EffectiveSettingValue(
-                    key: SettingKey.navShortcuts.rawValue,
-                    value: try SettingJSONValue.encoding(
-                        NavigationShortcutsPreference(items: storedShortcuts)
-                    ),
-                    source: .scope(.profile),
-                    scope: .profile,
-                    profileId: "profile"
+        var settings = [
+            EffectiveSettingValue(
+                key: SettingKey.navShortcuts.rawValue,
+                value: try SettingJSONValue.encoding(
+                    NavigationShortcutsPreference(items: storedShortcuts)
                 ),
-            ],
-            revision: SettingKey.revision
+                source: .scope(.profile),
+                scope: .profile,
+                profileId: "profile"
+            ),
+        ]
+        if let storedMenu {
+            settings.append(EffectiveSettingValue(
+                key: SettingKey.navPrimaryMenu.rawValue,
+                value: try SettingJSONValue.encoding(storedMenu),
+                source: .scope(.profileClient),
+                scope: .profileClient,
+                profileId: "profile",
+                clientFamily: requestIdentity.clientFamily
+            ))
+        }
+        return try completeCustomizationEffectiveResponse(
+            keys: keys,
+            settings: settings
         )
     }
 
@@ -3440,6 +4058,9 @@ private actor RecoveringShortcutProbe: CurrentCapabilitiesTransport {
     ) async throws {
         genericPutCount += 1
         events.append("put-\(key.rawValue)")
+        if key == .navPrimaryMenu {
+            storedMenu = try value.decoded(as: PrimaryMenuPreference.self)
+        }
         let ready = genericPutWaiters.filter { genericPutCount >= $0.0 }
         genericPutWaiters.removeAll { genericPutCount >= $0.0 }
         ready.forEach { $0.1.resume() }
@@ -3506,7 +4127,8 @@ private actor BlockingShortcutProbe: CurrentCapabilitiesTransport {
         keys: [SettingKey],
         requestIdentity: HTTPRequestIdentity
     ) async throws -> EffectiveSettingValuesResponse {
-        EffectiveSettingValuesResponse(
+        try completeCustomizationEffectiveResponse(
+            keys: keys,
             settings: [
                 EffectiveSettingValue(
                     key: SettingKey.navShortcuts.rawValue,
@@ -3517,8 +4139,7 @@ private actor BlockingShortcutProbe: CurrentCapabilitiesTransport {
                     scope: .profile,
                     profileId: "profile"
                 ),
-            ],
-            revision: SettingKey.revision
+            ]
         )
     }
 

--- a/iosApp/Tests/UICustomizationPreferencesTests.swift
+++ b/iosApp/Tests/UICustomizationPreferencesTests.swift
@@ -1,0 +1,3612 @@
+import XCTest
+@testable import Silo
+
+@MainActor
+final class UICustomizationPreferencesTests: XCTestCase {
+    func testNamedPresetsMatchTheCrossClientRecipes() {
+        XCTAssertEqual(
+            CardPresentationPreset.balanced.presentation,
+            .init(posterSize: .standard, caption: .titleMetadata)
+        )
+        XCTAssertEqual(
+            CardPresentationPreset.compact.presentation,
+            .init(posterSize: .compact, caption: .title)
+        )
+        XCTAssertEqual(
+            CardPresentationPreset.cinema.presentation,
+            .init(posterSize: .large, caption: .title)
+        )
+        XCTAssertEqual(
+            CardPresentationPreset.artworkOnly.presentation,
+            .init(posterSize: .large, caption: .artwork)
+        )
+    }
+
+    func testPosterSizeAdjustsTVGridDensityAndArtworkScale() {
+        XCTAssertEqual(
+            AdaptiveColumns.tvPosterCount(standardCount: 6, posterSize: .compact),
+            6
+        )
+        XCTAssertEqual(
+            AdaptiveColumns.tvPosterCount(standardCount: 6, posterSize: .standard),
+            6
+        )
+        XCTAssertEqual(
+            AdaptiveColumns.tvPosterCount(standardCount: 6, posterSize: .large),
+            5
+        )
+        XCTAssertEqual(
+            AdaptiveColumns.tvPosterCount(standardCount: 3, posterSize: .large),
+            3
+        )
+        XCTAssertEqual(CardPosterSize.compact.scale, 0.86, accuracy: 0.001)
+        XCTAssertEqual(CardPosterSize.standard.scale, 1, accuracy: 0.001)
+        XCTAssertEqual(CardPosterSize.large.scale, 1.2, accuracy: 0.001)
+    }
+
+    func testCaptionStylesGateTitleAndMetadataIndependently() {
+        XCTAssertTrue(CardCaptionStyle.titleMetadata.showsTitle)
+        XCTAssertTrue(CardCaptionStyle.titleMetadata.showsMetadata)
+        XCTAssertTrue(CardCaptionStyle.title.showsTitle)
+        XCTAssertFalse(CardCaptionStyle.title.showsMetadata)
+        XCTAssertFalse(CardCaptionStyle.artwork.showsTitle)
+        XCTAssertFalse(CardCaptionStyle.artwork.showsMetadata)
+    }
+
+    func testCardAccessibilityLabelsRetainHiddenIdentityAndStatus() {
+        XCTAssertEqual(
+            mediaCardAccessibilityLabel(
+                title: "The Episode",
+                episodeBadge: "S2 · E10",
+                year: 2026,
+                isWatched: true
+            ),
+            "The Episode, S2 · E10, 2026, Watched"
+        )
+        XCTAssertEqual(
+            episodeRailAccessibilityLabel(
+                seasonNumber: 2,
+                episodeNumber: 10,
+                title: "The Episode",
+                metadata: "Aug 3 · 52m",
+                isCurrent: true,
+                isPlayed: true
+            ),
+            "Season 2, Episode 10, The Episode, Aug 3 · 52m, Now viewing, Watched"
+        )
+    }
+
+    func testSpecializedCardAccessibilityLabelsIncludeOverlayMetadata() {
+        let event = CalendarEvent(
+            contentId: "event-1",
+            type: "episode",
+            title: "The Show",
+            episodeTitle: "Finale",
+            seriesId: "series-1",
+            seasonNumber: 1,
+            episodeNumber: 8,
+            airDate: nil,
+            airTime: nil,
+            airAt: nil,
+            airTimezone: nil,
+            localAirDate: nil,
+            posterUrl: nil,
+            posterThumbhash: nil,
+            watched: true,
+            badges: ["series_premiere", "finale"]
+        )
+        XCTAssertEqual(
+            calendarEventAccessibilityLabel(event),
+            "The Show, S1 · E8, Finale, SERIES PREMIERE, FINALE, Watched"
+        )
+
+        let collection = LibraryCollection(
+            id: "collection-1",
+            name: "Favorites",
+            collectionType: "movies",
+            itemCount: 12
+        )
+        XCTAssertEqual(
+            libraryCollectionAccessibilityLabel(collection),
+            "Favorites, Movies, 12 items"
+        )
+        XCTAssertEqual(
+            libraryCollectionAccessibilityLabel(
+                LibraryCollection(id: "empty", name: "Empty", itemCount: 0)
+            ),
+            "Empty, Collection, 0 items"
+        )
+
+        let audiobook = AudiobookRelatedItem(
+            contentId: "book-1",
+            title: "The Next Book",
+            year: 2024,
+            posterUrl: nil,
+            seriesIndex: 3
+        )
+        XCTAssertEqual(
+            audiobookRelatedItemAccessibilityLabel(audiobook),
+            "The Next Book, Book 3, 2024"
+        )
+
+        let movie = CalendarEvent(
+            contentId: "movie-1",
+            type: "movie",
+            title: "The Movie",
+            episodeTitle: nil,
+            seriesId: nil,
+            seasonNumber: nil,
+            episodeNumber: nil,
+            airDate: nil,
+            airTime: nil,
+            airAt: nil,
+            airTimezone: nil,
+            localAirDate: nil,
+            posterUrl: nil,
+            posterThumbhash: nil,
+            watched: false,
+            badges: nil
+        )
+        XCTAssertEqual(calendarEventAccessibilityLabel(movie), "The Movie, Movie")
+    }
+
+    func testCustomizationModelsUseTheExactSettingsContractShape() throws {
+        let cards = CardPresentationPreference(posterSize: .large, caption: .artwork)
+        XCTAssertEqual(
+            String(data: try SettingsWireCoding.makeEncoder().encode(cards), encoding: .utf8),
+            #"{"caption":"artwork","poster_size":"large"}"#
+        )
+
+        let menu = PrimaryMenuPreference(items: [
+            .builtin(.home),
+            .library(libraryId: 7, label: "Movies"),
+            .section(libraryId: 7, sectionId: "recently-added", label: "Recently Added"),
+            .collection(collectionId: "favorites", label: "Favorites", libraryId: 7),
+        ])
+        let encoded = try SettingsWireCoding.makeEncoder().encode(menu)
+        let decoded = try SettingsWireCoding.makeDecoder().decode(
+            PrimaryMenuPreference.self,
+            from: encoded
+        )
+
+        XCTAssertEqual(decoded, menu)
+        XCTAssertTrue(decoded.isValid)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        let items = try XCTUnwrap(json["items"] as? [[String: Any]])
+        XCTAssertEqual(items[0]["type"] as? String, "builtin")
+        XCTAssertEqual(items[0]["destination"] as? String, "home")
+        XCTAssertEqual(items[1]["library_id"] as? Int, 7)
+        XCTAssertEqual(items[2]["section_id"] as? String, "recently-added")
+        XCTAssertEqual(items[3]["collection_id"] as? String, "favorites")
+    }
+
+    func testCollectionIdentityIsStructuredWithoutChangingTheWireFormat() throws {
+        let unscoped = PrimaryMenuItem.collection(
+            collectionId: "12:featured",
+            label: "Featured",
+            libraryId: nil
+        )
+        let scoped = PrimaryMenuItem.collection(
+            collectionId: "featured",
+            label: "Featured",
+            libraryId: 12
+        )
+        let renamed = PrimaryMenuItem.collection(
+            collectionId: "12:featured",
+            label: "Renamed",
+            libraryId: nil
+        )
+
+        XCTAssertEqual(unscoped.id, "collection|0|0#|11#12:featured")
+        XCTAssertEqual(scoped.id, "collection|1|2#12|8#featured")
+        XCTAssertNotEqual(unscoped.id, scoped.id)
+        XCTAssertEqual(unscoped.id, renamed.id, "a display label is not semantic identity")
+
+        let data = try SettingsWireCoding.makeEncoder().encode(unscoped)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(object["type"] as? String, "collection")
+        XCTAssertEqual(object["collection_id"] as? String, "12:featured")
+        XCTAssertNil(object["library_id"])
+        XCTAssertNil(object["id"], "the structured client identity must not enter the wire contract")
+    }
+
+    func testMainTabProjectionKeepsLibraryIdentityAndHidesUnsupportedShortcuts() {
+        let movie = Library(id: 7, name: "Movies", type: "movies", sortOrder: 0, posterUrl: nil)
+        let series = Library(id: 8, name: "Series", type: "series", sortOrder: 1, posterUrl: nil)
+        let audiobook = Library(
+            id: 9,
+            name: "Audiobooks",
+            type: "audiobooks",
+            sortOrder: 2,
+            posterUrl: nil
+        )
+        let menu = PrimaryMenuPreference(items: [
+            .builtin(.home),
+            .builtin(.movies),
+            .builtin(.series),
+            .builtin(.music),
+            .builtin(.audiobooks),
+            .section(libraryId: 7, sectionId: "recent", label: "Recently Added"),
+            .library(libraryId: 7, label: "Movies"),
+            .collection(collectionId: "favorites", label: "Favorites", libraryId: 7),
+            .library(libraryId: 7, label: "Renamed Movies"),
+            .builtin(.calendar),
+        ])
+
+        let destinations = projectedMainTabDestinations(
+            primaryMenu: menu,
+            availableLibraries: [movie, series, audiobook]
+        )
+
+        XCTAssertEqual(
+            destinations.map(\.id),
+            [
+                .app(.home),
+                .libraryCategory(.movies),
+                .libraryCategory(.series),
+                .libraryCategory(.audiobooks),
+                .library(7),
+                .app(.calendar),
+            ]
+        )
+        XCTAssertEqual(destinations[4].title, "Movies")
+        XCTAssertFalse(
+            destinations.contains { $0.id == .app(.libraries) },
+            "authored categories and unsupported shortcut IDs must not collapse into an aggregate tab"
+        )
+    }
+
+    func testMainTabProjectionFailsClosedAndFiltersUnavailableLibraries() {
+        let menu = PrimaryMenuPreference(items: [
+            .builtin(.home),
+            .library(libraryId: 7, label: "Removed"),
+            .library(libraryId: 8, label: "Visible"),
+        ])
+
+        let unavailable = projectedMainTabDestinations(primaryMenu: menu)
+        XCTAssertEqual(unavailable.map(\.id), [.app(.home)])
+
+        let known = projectedMainTabDestinations(
+            primaryMenu: menu,
+            availableLibraries: [
+                Library(id: 8, name: "Visible", type: "movies", sortOrder: 0, posterUrl: nil)
+            ]
+        )
+        XCTAssertEqual(known.map(\.id), [.app(.home), .library(8)])
+        XCTAssertEqual(
+            resolvedVisibleMainTabDestination(.library(7), visibleDestinations: known),
+            .app(.home)
+        )
+        XCTAssertEqual(
+            resolvedVisibleMainTabDestination(.library(8), visibleDestinations: known),
+            .library(8)
+        )
+
+        let knownEmpty = projectedMainTabDestinations(primaryMenu: menu, availableLibraries: [])
+        XCTAssertEqual(knownEmpty.map(\.id), [.app(.home)])
+    }
+
+    func testMainTabProjectionOnlyShowsCategoriesBackedByCurrentLibraries() {
+        let menu = PrimaryMenuPreference(items: [
+            .builtin(.home),
+            .builtin(.movies),
+            .builtin(.series),
+            .builtin(.audiobooks),
+        ])
+        XCTAssertEqual(
+            projectedMainTabDestinations(primaryMenu: menu).map(\.id),
+            [.app(.home)],
+            "authored categories with no matching profile library must not render dead roots"
+        )
+
+        let mixed = Library(id: 4, name: "Mixed", type: "mixed", sortOrder: 0, posterUrl: nil)
+        XCTAssertEqual(
+            projectedMainTabDestinations(
+                primaryMenu: menu,
+                availableLibraries: [mixed]
+            ).map(\.id),
+            [.app(.home), .libraryCategory(.movies), .libraryCategory(.series)]
+        )
+
+        let audiobook = Library(
+            id: 5,
+            name: "Audiobooks",
+            type: "audiobooks",
+            sortOrder: 0,
+            posterUrl: nil
+        )
+        XCTAssertEqual(
+            projectedMainTabDestinations(
+                primaryMenu: menu,
+                availableLibraries: [audiobook]
+            ).map(\.id),
+            [.app(.home), .libraryCategory(.audiobooks)]
+        )
+        XCTAssertTrue(
+            mainTabSupportsDestination(.builtin(.audiobooks), availableLibraries: [audiobook]),
+            "the editor and runtime share this availability decision"
+        )
+        XCTAssertFalse(
+            mainTabSupportsDestination(.builtin(.movies), availableLibraries: [audiobook])
+        )
+    }
+
+    func testMainTabLibrarySnapshotRejectsPreviousProfileWithOverlappingId() throws {
+        let serverId = "server"
+        let firstProfile = try XCTUnwrap(
+            MainTabLibraryAuthority(serverId: serverId, profileId: "profile-a")
+        )
+        let secondProfile = try XCTUnwrap(
+            MainTabLibraryAuthority(serverId: serverId, profileId: "profile-b")
+        )
+        let library = Library(
+            id: 7,
+            name: "Same Numeric ID",
+            type: "movies",
+            sortOrder: 0,
+            posterUrl: nil
+        )
+        let menu = PrimaryMenuPreference(items: [
+            .builtin(.home),
+            .library(libraryId: library.id, label: library.name),
+        ])
+        let staleSnapshot = MainTabLibrarySnapshot(
+            authority: firstProfile,
+            libraries: [library]
+        )
+
+        let staleProjection = projectedMainTabDestinations(
+            primaryMenu: menu,
+            availableLibraries: staleSnapshot.availableLibraries(for: secondProfile)
+        )
+        XCTAssertEqual(staleProjection.map(\.id), [.app(.home)])
+        XCTAssertEqual(
+            resolvedVisibleMainTabDestination(
+                .library(library.id),
+                visibleDestinations: staleProjection
+            ),
+            .app(.home)
+        )
+
+        let currentSnapshot = MainTabLibrarySnapshot(
+            authority: secondProfile,
+            libraries: [library]
+        )
+        let currentProjection = projectedMainTabDestinations(
+            primaryMenu: menu,
+            availableLibraries: currentSnapshot.availableLibraries(for: secondProfile)
+        )
+        XCTAssertEqual(currentProjection.map(\.id), [.app(.home), .library(library.id)])
+
+        let revokedProjection = projectedMainTabDestinations(
+            primaryMenu: menu,
+            availableLibraries: MainTabLibrarySnapshot(
+                authority: secondProfile,
+                libraries: []
+            ).availableLibraries(for: secondProfile)
+        )
+        XCTAssertEqual(revokedProjection.map(\.id), [.app(.home)])
+        XCTAssertEqual(
+            resolvedVisibleMainTabDestination(
+                .library(library.id),
+                visibleDestinations: revokedProjection
+            ),
+            .app(.home),
+            "a same-authority access revocation must remove the pin and select Home"
+        )
+    }
+
+    func testAvailableLibraryShortcutsExcludeInaccessibleAndVisibleItems() {
+        let removed = PrimaryMenuItem.library(libraryId: 7, label: "Removed")
+        let available = PrimaryMenuItem.library(libraryId: 8, label: "Available")
+        let alreadyVisible = PrimaryMenuItem.library(libraryId: 9, label: "Visible")
+        let section = PrimaryMenuItem.section(
+            libraryId: 8,
+            sectionId: "recent",
+            label: "Recent"
+        )
+
+        XCTAssertEqual(
+            availablePrimaryMenuLibraryShortcuts(
+                [removed, available, alreadyVisible, section],
+                visibleIds: [alreadyVisible.id],
+                availableLibraryIds: [8, 9]
+            ),
+            [available]
+        )
+    }
+
+    func testPrimaryMenuLibraryCategoriesKeepTheirAuthoredMediaScope() {
+        let movie = Library(id: 1, name: "Movies", type: "movies", sortOrder: 0, posterUrl: nil)
+        let series = Library(id: 2, name: "Shows", type: "series", sortOrder: 1, posterUrl: nil)
+        let mixed = Library(id: 3, name: "Mixed", type: "mixed", sortOrder: 2, posterUrl: nil)
+        let audiobook = Library(
+            id: 4,
+            name: "Audiobooks",
+            type: "audiobooks",
+            sortOrder: 3,
+            posterUrl: nil
+        )
+
+        XCTAssertTrue(libraryMatchesPrimaryMenuCategory(movie, category: .movies))
+        XCTAssertTrue(libraryMatchesPrimaryMenuCategory(mixed, category: .movies))
+        XCTAssertFalse(libraryMatchesPrimaryMenuCategory(series, category: .movies))
+        XCTAssertTrue(libraryMatchesPrimaryMenuCategory(series, category: .series))
+        XCTAssertTrue(libraryMatchesPrimaryMenuCategory(mixed, category: .series))
+        XCTAssertFalse(libraryMatchesPrimaryMenuCategory(movie, category: .series))
+        XCTAssertTrue(libraryMatchesPrimaryMenuCategory(audiobook, category: .audiobooks))
+        XCTAssertFalse(libraryMatchesPrimaryMenuCategory(movie, category: .audiobooks))
+        XCTAssertFalse(libraryMatchesPrimaryMenuCategory(movie, category: .music))
+    }
+
+    func testDirectLibraryRootUsesExactAccessibleLibraryAndFixedChrome() {
+        let first = Library(id: 7, name: "First", type: "movies", sortOrder: 0, posterUrl: nil)
+        let second = Library(id: 8, name: "Second", type: "series", sortOrder: 1, posterUrl: nil)
+
+        XCTAssertEqual(
+            visibleLibrariesForRoot(
+                [first, second],
+                category: nil,
+                fixedLibraryId: second.id,
+                showAudiobooks: true
+            ),
+            [second]
+        )
+        XCTAssertTrue(
+            visibleLibrariesForRoot(
+                [first, second],
+                category: nil,
+                fixedLibraryId: 99,
+                showAudiobooks: true
+            ).isEmpty,
+            "an inaccessible pinned ID must not fall through to another library"
+        )
+        XCTAssertFalse(
+            libraryRootCanSwitch(fixedLibraryId: second.id, visibleLibraryCount: 2),
+            "a direct root keeps top-bar utilities but disables the library picker"
+        )
+        XCTAssertTrue(libraryRootCanSwitch(fixedLibraryId: nil, visibleLibraryCount: 2))
+
+        XCTAssertEqual(
+            resolvedLibraryIdForRoot(
+                [first, second],
+                category: nil,
+                fixedLibraryId: first.id,
+                showAudiobooks: true,
+                storedLibraryId: second.id
+            ),
+            first.id
+        )
+        XCTAssertEqual(
+            resolvedLibraryIdForRoot(
+                [first, second],
+                category: nil,
+                fixedLibraryId: second.id,
+                showAudiobooks: true,
+                storedLibraryId: first.id
+            ),
+            second.id,
+            "changing a reused fixed-root scope must immediately select the new exact library"
+        )
+    }
+
+    func testDirectTVLibraryShortcutDoesNotInheritCategoryPillState() {
+        XCTAssertEqual(
+            resolvedLibraryRootPill(
+                categorySelection: .browse,
+                directSelection: nil,
+                isDirectLibraryShortcut: true
+            ),
+            .recommended
+        )
+        XCTAssertEqual(
+            resolvedLibraryRootPill(
+                categorySelection: .collections,
+                directSelection: nil,
+                isDirectLibraryShortcut: true
+            ),
+            .recommended
+        )
+        XCTAssertEqual(
+            resolvedLibraryRootPill(
+                categorySelection: .browse,
+                directSelection: nil,
+                isDirectLibraryShortcut: false
+            ),
+            .browse
+        )
+        XCTAssertEqual(
+            resolvedLibraryRootPill(
+                categorySelection: .collections,
+                directSelection: .browse,
+                isDirectLibraryShortcut: true
+            ),
+            .browse,
+            "the direct pin's cascade owns a writable section independent of its category"
+        )
+        XCTAssertTrue(TVLibraryMenuRootKind.category.hasSectionCascade)
+        XCTAssertTrue(
+            TVLibraryMenuRootKind.directShortcut.hasSectionCascade,
+            "D-pad Down on a direct pin must enter its one-library section cascade"
+        )
+        XCTAssertFalse(TVLibraryMenuRootKind.staticRoot.hasSectionCascade)
+    }
+
+    func testTVCustomizationControlsDisableAcrossCapabilityChanges() {
+        XCTAssertTrue(
+            tvCustomizationMutationIsEnabled(
+                allowsEditing: true,
+                usesDeviceMenuOverride: false,
+                changesFamilyMenu: true
+            )
+        )
+        XCTAssertFalse(
+            tvCustomizationMutationIsEnabled(
+                allowsEditing: false,
+                usesDeviceMenuOverride: false,
+                changesFamilyMenu: true
+            ),
+            "an already-presented menu or picker must stop accepting mutations"
+        )
+        XCTAssertFalse(
+            tvCustomizationMutationIsEnabled(
+                allowsEditing: true,
+                usesDeviceMenuOverride: true,
+                changesFamilyMenu: true
+            )
+        )
+        XCTAssertTrue(
+            tvCustomizationMutationIsEnabled(
+                allowsEditing: true,
+                usesDeviceMenuOverride: true,
+                changesFamilyMenu: false
+            ),
+            "profile shortcut membership remains editable under a device menu override"
+        )
+        XCTAssertFalse(
+            tvCustomizationMutationIsEnabled(
+                allowsEditing: false,
+                usesDeviceMenuOverride: true,
+                changesFamilyMenu: false
+            )
+        )
+    }
+
+    func testHiddenRequestedTabFallsBackToHomeAfterMenuReordering() {
+        let visible = [
+            MainTabDestination.app(.calendar),
+            MainTabDestination.library(id: 7, label: "Movies"),
+            MainTabDestination.app(.home),
+        ]
+
+        XCTAssertEqual(
+            resolvedRequestedMainTabDestination(
+                .recommendations,
+                visibleDestinations: visible
+            ),
+            .app(.home)
+        )
+        XCTAssertEqual(
+            resolvedRequestedMainTabDestination(.calendar, visibleDestinations: visible),
+            .app(.calendar)
+        )
+    }
+
+    func testLegacyCollectionOutboxIdentityMigratesToStructuredIdentity() async throws {
+        let suiteName = "ui-customization-legacy-collection-id-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-legacy-collection-id-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let cacheKey = "silo.uiCustomization.server.profile.mobile"
+        let item: [String: Any] = [
+            "type": "collection",
+            "collection_id": "featured:2026",
+            "label": "Featured",
+        ]
+        let legacyIdentity = "collection:all:featured:2026"
+        let cache: [String: Any] = [
+            "shortcuts": ["items": [item]],
+            "cardPresentation": [
+                "poster_size": "standard",
+                "caption": "title_metadata",
+            ],
+            "pendingShortcutOperations": [
+                legacyIdentity: [
+                    "item": item,
+                    "present": true,
+                    "mutationId": "legacy-collection-mutation",
+                    "sequence": 7,
+                ],
+            ],
+        ]
+        let defaults = SharedDefaults(suite: suite, standard: standard)
+        defaults.set(
+            try JSONSerialization.data(withJSONObject: cache, options: [.sortedKeys]),
+            forKey: cacheKey
+        )
+
+        let transport = RecoveringShortcutProbe()
+        await transport.setOnline()
+        let preferences = UICustomizationPreferences(
+            defaults: defaults,
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) }
+        )
+        await preferences.refresh()
+
+        let snapshot = await transport.snapshot()
+        let operation = try XCTUnwrap(snapshot.shortcutOperations.first)
+        XCTAssertEqual(snapshot.shortcutOperations.count, 1)
+        XCTAssertEqual(operation.item.id, "collection|0|0#|13#featured:2026")
+        XCTAssertEqual(operation.mutationId, "legacy-collection-mutation")
+        XCTAssertEqual(preferences.shortcuts.items.map(\.id), [operation.item.id])
+    }
+
+    func testPrimaryMenuRejectsMissingOrDuplicateHomeAndDuplicateShortcuts() {
+        XCTAssertFalse(PrimaryMenuPreference(items: [.builtin(.movies)]).isValid)
+        XCTAssertFalse(
+            PrimaryMenuPreference(items: [.builtin(.home), .builtin(.home)]).isValid
+        )
+        XCTAssertFalse(
+            PrimaryMenuPreference(items: [
+                .builtin(.home),
+                .library(libraryId: 7, label: "Movies"),
+                .library(libraryId: 7, label: "Renamed Movies"),
+            ]).isValid
+        )
+        XCTAssertFalse(
+            PrimaryMenuPreference(items: [
+                .builtin(.home),
+                .library(libraryId: 7, label: "  \n"),
+            ]).isValid
+        )
+        XCTAssertFalse(
+            PrimaryMenuPreference(items: [
+                .builtin(.home),
+                .section(libraryId: 7, sectionId: " \n ", label: "Recent"),
+            ]).isValid
+        )
+        XCTAssertFalse(
+            PrimaryMenuPreference(items: [
+                .builtin(.home),
+                .collection(collectionId: "\t", label: "Favorites", libraryId: nil),
+            ]).isValid
+        )
+    }
+
+    func testRapidEditsAreWrittenInOrderAndSavingCoversTheWholeQueue() async throws {
+        let suiteName = "ui-customization-writes-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-writes-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let transport = OrderedWriteProbe()
+        let preferences = UICustomizationPreferences(
+            defaults: SharedDefaults(suite: suite, standard: standard),
+            transport: transport,
+            cacheKey: { "silo.uiCustomization.server.profile.mobile" },
+            requestIdentity: { testRequestIdentity(family: "mobile") },
+            initialCapabilityState: .supported
+        )
+
+        preferences.setCardPresentation(CardPresentationPreset.compact.presentation)
+        preferences.setCardPresentation(CardPresentationPreset.artworkOnly.presentation)
+        XCTAssertTrue(preferences.isSaving)
+
+        let release = Task {
+            await transport.waitForStartedWrites(1)
+            try? await Task.sleep(nanoseconds: 50_000_000)
+            await transport.releaseFirstWrite()
+        }
+        await transport.waitForCompletedWrites(2)
+        await release.value
+        try await Task.sleep(nanoseconds: 20_000_000)
+
+        let snapshot = await transport.snapshot()
+        let presentations = try snapshot.values.map {
+            try $0.decoded(as: CardPresentationPreference.self)
+        }
+        XCTAssertEqual(snapshot.maxInFlight, 1, "writes must never overtake one another")
+        XCTAssertEqual(
+            presentations,
+            [
+                CardPresentationPreset.compact.presentation,
+                CardPresentationPreset.artworkOnly.presentation,
+            ]
+        )
+        XCTAssertFalse(preferences.isSaving, "saving ends only after the queue drains")
+    }
+
+    func testCardPresentationAndOutboxShareOneDurableCacheSnapshot() async throws {
+        let suiteName = "ui-customization-card-cache-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-card-cache-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let defaults = SharedDefaults(suite: suite, standard: standard)
+        let cacheKey = "silo.uiCustomization.server.profile.mobile"
+        let transport = OrderedWriteProbe()
+        let preferences = UICustomizationPreferences(
+            defaults: defaults,
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+        let desired = CardPresentationPreset.artworkOnly.presentation
+
+        preferences.setCardPresentation(desired)
+        await transport.waitForStartedWrites(1)
+
+        let cachedData = try XCTUnwrap(defaults.data(forKey: cacheKey))
+        let cache = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: cachedData) as? [String: Any]
+        )
+        let card = try XCTUnwrap(cache["cardPresentation"] as? [String: Any])
+        let pending = try XCTUnwrap(cache["pendingSyncWrites"] as? [String: Any])
+        XCTAssertEqual(card["poster_size"] as? String, "large")
+        XCTAssertNotNil(pending[SettingKey.uiCardPresentation.rawValue])
+
+        await transport.releaseFirstWrite()
+        await transport.waitForCompletedWrites(1)
+    }
+
+    func testAcceptedPinDurablyTransitionsToMenuOutboxBeforeTransportCompletion() async throws {
+        let suiteName = "ui-customization-pin-crash-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-pin-crash-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let defaults = SharedDefaults(suite: suite, standard: standard)
+        let cacheKey = "silo.uiCustomization.server.profile.tv"
+        let transport = AcceptedMenuCrashProbe()
+        let preferences = UICustomizationPreferences(
+            defaults: defaults,
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+        let library = Library(
+            id: 7,
+            name: "Accepted",
+            type: "movies",
+            sortOrder: 0,
+            posterUrl: nil
+        )
+        let item = PrimaryMenuItem.library(libraryId: 7, label: "Accepted")
+
+        preferences.setLibraryPinned(library, isPinned: true)
+        await transport.waitForMenuWriteStarted()
+
+        let cachedData = try XCTUnwrap(defaults.data(forKey: cacheKey))
+        let cache = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: cachedData) as? [String: Any]
+        )
+        let pendingWrites = try XCTUnwrap(cache["pendingSyncWrites"] as? [String: Any])
+        XCTAssertNil(cache["pendingShortcutOperations"])
+        XCTAssertNotNil(pendingWrites[SettingKey.navPrimaryMenu.rawValue])
+
+        let replayTransport = ShortcutOrderingProbe(
+            outcomes: [:],
+            initialShortcuts: [item]
+        )
+        let restarted = UICustomizationPreferences(
+            defaults: defaults,
+            transport: replayTransport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+        await restarted.refresh()
+
+        let replaySnapshot = await replayTransport.snapshot()
+        XCTAssertEqual(replaySnapshot.menuWrites.count, 1)
+        XCTAssertTrue(replaySnapshot.menuWrites[0].items.contains { $0.id == item.id })
+        XCTAssertTrue(restarted.isLibraryPinned(7))
+
+        await transport.releaseMenuWrite()
+        await transport.waitForMenuWriteCompleted()
+    }
+
+    func testSuccessfulMenuWriteDoesNotClearShortcutWriteFailure() async throws {
+        let suiteName = "ui-customization-partial-failure-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-partial-failure-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let transport = SelectiveFailureWriteProbe(failingKey: .navShortcuts)
+        let preferences = UICustomizationPreferences(
+            defaults: SharedDefaults(suite: suite, standard: standard),
+            transport: transport,
+            cacheKey: { "silo.uiCustomization.server.profile.tv" },
+            requestIdentity: { testRequestIdentity(family: "tv") },
+            initialCapabilityState: .supported
+        )
+        let library = Library(
+            id: 7,
+            name: "Movies",
+            type: "movies",
+            sortOrder: 0,
+            posterUrl: nil
+        )
+
+        preferences.setLibraryPinned(library, isPinned: true)
+        preferences.setPrimaryMenuItems([
+            .builtin(.home),
+            .builtin(.forYou),
+        ])
+        await transport.waitForCompletedWrites(2)
+        try await Task.sleep(nanoseconds: 20_000_000)
+        let writtenKeys = await transport.writtenKeys()
+        let wholeShortcutPutCount = await transport.wholeShortcutPutCount()
+
+        XCTAssertEqual(writtenKeys, [.navShortcuts, .navPrimaryMenu])
+        XCTAssertEqual(
+            wholeShortcutPutCount,
+            0,
+            "shortcut edits must use the atomic item endpoint, never a whole-value PUT"
+        )
+        XCTAssertNotNil(
+            preferences.syncErrorMessage,
+            "a later menu success must not hide the failed profile shortcut write"
+        )
+        XCTAssertFalse(preferences.isSaving)
+    }
+
+    func testSuccessfulShortcutDoesNotClearDifferentPendingShortcutFailure() async throws {
+        let suiteName = "ui-customization-per-shortcut-error-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-per-shortcut-error-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let defaults = SharedDefaults(suite: suite, standard: standard)
+        let cacheKey = "silo.uiCustomization.server.profile.tv"
+        let failedLibrary = Library(
+            id: 7,
+            name: "Failed Library",
+            type: "movies",
+            sortOrder: 0,
+            posterUrl: nil
+        )
+        let successfulLibrary = Library(
+            id: 8,
+            name: "Successful Library",
+            type: "movies",
+            sortOrder: 1,
+            posterUrl: nil
+        )
+        let transport = SelectiveFailureWriteProbe(
+            failingShortcutIds: ["library:7"]
+        )
+        let preferences = UICustomizationPreferences(
+            defaults: defaults,
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+
+        preferences.setLibraryPinned(failedLibrary, isPinned: true)
+        preferences.setLibraryPinned(successfulLibrary, isPinned: true)
+        await transport.waitForCompletedWrites(3)
+
+        XCTAssertNotNil(
+            preferences.syncErrorMessage,
+            "shortcut B succeeding must not hide shortcut A's pending failure"
+        )
+
+        let restarted = UICustomizationPreferences(
+            defaults: defaults,
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+        await restarted.refresh()
+        let attemptedShortcutIds = await transport.shortcutItemIds()
+
+        XCTAssertEqual(
+            attemptedShortcutIds,
+            ["library:7", "library:8", "library:7"],
+            "only the still-failed shortcut must survive and replay from the outbox"
+        )
+        XCTAssertNotNil(restarted.syncErrorMessage)
+    }
+
+    func testOverlappingAcceptedPinsPersistOnlyAcceptedMenuSnapshots() async throws {
+        let suiteName = "ui-customization-overlap-success-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-overlap-success-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let transport = ShortcutOrderingProbe(outcomes: [
+            "library:7": [.success],
+            "library:8": [.success],
+        ])
+        let preferences = UICustomizationPreferences(
+            defaults: SharedDefaults(suite: suite, standard: standard),
+            transport: transport,
+            cacheKey: { "silo.uiCustomization.server.profile.tv" },
+            requestIdentity: { testRequestIdentity(family: "tv") },
+            initialCapabilityState: .supported
+        )
+        let first = Library(
+            id: 7,
+            name: "First",
+            type: "movies",
+            sortOrder: 0,
+            posterUrl: nil
+        )
+        let second = Library(
+            id: 8,
+            name: "Second",
+            type: "movies",
+            sortOrder: 1,
+            posterUrl: nil
+        )
+
+        preferences.setLibraryPinned(first, isPinned: true)
+        preferences.setLibraryPinned(second, isPinned: true)
+        await transport.waitForCompletedWrites(4)
+
+        let snapshot = await transport.snapshot()
+        XCTAssertEqual(snapshot.shortcutAttempts.map(\.item.id), ["library:7", "library:8"])
+        XCTAssertEqual(snapshot.menuWrites.count, 2)
+        XCTAssertTrue(snapshot.menuWrites[0].items.contains { $0.id == "library:7" })
+        XCTAssertFalse(snapshot.menuWrites[0].items.contains { $0.id == "library:8" })
+        XCTAssertTrue(snapshot.menuWrites[1].items.contains { $0.id == "library:7" })
+        XCTAssertTrue(snapshot.menuWrites[1].items.contains { $0.id == "library:8" })
+    }
+
+    func testLaterRejectedPinNeverEntersEarlierAcceptedPinMenuWrite() async throws {
+        let suiteName = "ui-customization-overlap-rejection-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-overlap-rejection-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let transport = ShortcutOrderingProbe(outcomes: [
+            "library:7": [.success],
+            "library:8": [.definitiveFailure],
+        ])
+        let cacheKey = "silo.uiCustomization.server.profile.tv"
+        let preferences = UICustomizationPreferences(
+            defaults: SharedDefaults(suite: suite, standard: standard),
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+        let first = Library(
+            id: 7,
+            name: "Accepted",
+            type: "movies",
+            sortOrder: 0,
+            posterUrl: nil
+        )
+        let second = Library(
+            id: 8,
+            name: "Rejected",
+            type: "movies",
+            sortOrder: 1,
+            posterUrl: nil
+        )
+
+        preferences.setLibraryPinned(first, isPinned: true)
+        preferences.setLibraryPinned(second, isPinned: true)
+        await transport.waitForCompletedWrites(3)
+        await preferences.refresh()
+
+        let snapshot = await transport.snapshot()
+        XCTAssertEqual(snapshot.menuWrites.count, 1)
+        XCTAssertTrue(snapshot.menuWrites[0].items.contains { $0.id == "library:7" })
+        XCTAssertFalse(snapshot.menuWrites[0].items.contains { $0.id == "library:8" })
+        XCTAssertTrue(preferences.isLibraryPinned(7))
+        XCTAssertFalse(preferences.isLibraryPinned(8))
+        XCTAssertFalse(
+            preferences.resolvedPrimaryMenuItems().contains { $0.id == "library:8" }
+        )
+    }
+
+    func testDefinitiveRejectionRollsBackOnlyRejectedShortcutWhenRefreshFails() async throws {
+        let suiteName = "ui-customization-rejection-rollback-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-rejection-rollback-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let transport = ShortcutOrderingProbe(
+            outcomes: [
+                "library:7": [.success],
+                "library:8": [.definitiveFailure],
+            ],
+            effectiveFails: true
+        )
+        let cacheKey = "silo.uiCustomization.server.profile.tv"
+        let preferences = UICustomizationPreferences(
+            defaults: SharedDefaults(suite: suite, standard: standard),
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+        let first = Library(
+            id: 7,
+            name: "Accepted",
+            type: "movies",
+            sortOrder: 0,
+            posterUrl: nil
+        )
+        let second = Library(
+            id: 8,
+            name: "Rejected",
+            type: "movies",
+            sortOrder: 1,
+            posterUrl: nil
+        )
+
+        preferences.setLibraryPinned(first, isPinned: true)
+        preferences.setLibraryPinned(second, isPinned: true)
+        await transport.waitForCompletedWrites(3)
+        try await Task.sleep(nanoseconds: 30_000_000)
+
+        XCTAssertTrue(preferences.isLibraryPinned(7))
+        XCTAssertFalse(
+            preferences.isLibraryPinned(8),
+            "a failed reconciliation must not leave a quarantined pin projected forever"
+        )
+        XCTAssertNotNil(preferences.syncErrorMessage)
+
+        let cachedData = try XCTUnwrap(
+            SharedDefaults(suite: suite, standard: standard).data(forKey: cacheKey)
+        )
+        let cache = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: cachedData) as? [String: Any]
+        )
+        XCTAssertNil(cache["pendingShortcutOperations"])
+    }
+
+    func testEarlierTransientPinReplaysIntoItsAuthoredOrderAfterLaterSuccess() async throws {
+        let suiteName = "ui-customization-overlap-retry-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-overlap-retry-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let transport = ShortcutOrderingProbe(outcomes: [
+            "library:7": [.transientFailure, .success],
+            "library:8": [.success],
+        ])
+        let cacheKey = "silo.uiCustomization.server.profile.tv"
+        let preferences = UICustomizationPreferences(
+            defaults: SharedDefaults(suite: suite, standard: standard),
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+        let first = Library(
+            id: 7,
+            name: "First",
+            type: "movies",
+            sortOrder: 0,
+            posterUrl: nil
+        )
+        let second = Library(
+            id: 8,
+            name: "Second",
+            type: "movies",
+            sortOrder: 1,
+            posterUrl: nil
+        )
+
+        preferences.setLibraryPinned(first, isPinned: true)
+        preferences.setLibraryPinned(second, isPinned: true)
+        await transport.waitForCompletedWrites(3)
+
+        var snapshot = await transport.snapshot()
+        XCTAssertEqual(snapshot.menuWrites.count, 1)
+        XCTAssertFalse(snapshot.menuWrites[0].items.contains { $0.id == "library:7" })
+        XCTAssertTrue(snapshot.menuWrites[0].items.contains { $0.id == "library:8" })
+
+        await preferences.refresh()
+
+        snapshot = await transport.snapshot()
+        XCTAssertEqual(
+            snapshot.shortcutAttempts.map(\.item.id),
+            ["library:7", "library:8", "library:7"]
+        )
+        let finalIds = snapshot.menuWrites.last?.items.map(\.id) ?? []
+        let firstIndex = try XCTUnwrap(finalIds.firstIndex(of: "library:7"))
+        let secondIndex = try XCTUnwrap(finalIds.firstIndex(of: "library:8"))
+        XCTAssertLessThan(firstIndex, secondIndex)
+        XCTAssertNil(preferences.syncErrorMessage)
+    }
+
+    func testNewerExplicitMenuSupersedesInFlightPinPlacement() async throws {
+        let suiteName = "ui-customization-explicit-inflight-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-explicit-inflight-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let transport = BlockingShortcutProbe()
+        let preferences = UICustomizationPreferences(
+            defaults: SharedDefaults(suite: suite, standard: standard),
+            transport: transport,
+            cacheKey: { "silo.uiCustomization.server.profile.tv" },
+            requestIdentity: { testRequestIdentity(family: "tv") },
+            initialCapabilityState: .supported
+        )
+        let library = Library(
+            id: 7,
+            name: "Pending",
+            type: "movies",
+            sortOrder: 0,
+            posterUrl: nil
+        )
+        let explicitMenu = PrimaryMenuPreference(items: [
+            .builtin(.home),
+            .builtin(.calendar),
+        ])
+
+        preferences.setLibraryPinned(library, isPinned: true)
+        await transport.waitForStartedShortcutOperations(1)
+        preferences.setPrimaryMenuItems(explicitMenu.items)
+        await transport.releaseFirstShortcutOperation()
+        await transport.waitForCompletedShortcutOperations(1)
+        await transport.waitForGenericPuts(1)
+        try await Task.sleep(nanoseconds: 30_000_000)
+
+        let snapshot = await transport.snapshot()
+        XCTAssertEqual(snapshot.genericPutCount, 1)
+        XCTAssertEqual(snapshot.menuWrites, [explicitMenu])
+        XCTAssertEqual(preferences.primaryMenu, explicitMenu)
+        XCTAssertTrue(preferences.isLibraryPinned(7))
+        XCTAssertFalse(preferences.isSaving)
+    }
+
+    func testPendingPinCannotBeExplicitlyPlacedBeforeAcceptance() async throws {
+        let suiteName = "ui-customization-pending-placement-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-pending-placement-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let transport = BlockingShortcutProbe()
+        let preferences = UICustomizationPreferences(
+            defaults: SharedDefaults(suite: suite, standard: standard),
+            transport: transport,
+            cacheKey: { "silo.uiCustomization.server.profile.tv" },
+            requestIdentity: { testRequestIdentity(family: "tv") },
+            initialCapabilityState: .supported
+        )
+        let library = Library(
+            id: 7,
+            name: "Pending",
+            type: "movies",
+            sortOrder: 0,
+            posterUrl: nil
+        )
+        let pendingItem = PrimaryMenuItem.library(libraryId: 7, label: "Pending")
+
+        preferences.setLibraryPinned(library, isPinned: true)
+        await transport.waitForStartedShortcutOperations(1)
+        preferences.setPrimaryMenuItems([.builtin(.home), pendingItem])
+
+        XCTAssertNil(preferences.primaryMenu)
+        XCTAssertTrue(preferences.syncErrorMessage?.contains("finish syncing") == true)
+
+        await transport.releaseFirstShortcutOperation()
+        await transport.waitForCompletedShortcutOperations(1)
+        await transport.waitForGenericPuts(1)
+        let snapshot = await transport.snapshot()
+        XCTAssertEqual(snapshot.genericPutCount, 1)
+        XCTAssertTrue(snapshot.menuWrites[0].items.contains { $0.id == pendingItem.id })
+        XCTAssertNil(preferences.syncErrorMessage)
+    }
+
+    func testPendingPinCannotBePlacedAfterAnEarlierExplicitSupersession() async throws {
+        let suiteName = "ui-customization-pending-resupersession-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-pending-resupersession-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let transport = BlockingShortcutProbe()
+        let preferences = UICustomizationPreferences(
+            defaults: SharedDefaults(suite: suite, standard: standard),
+            transport: transport,
+            cacheKey: { "silo.uiCustomization.server.profile.tv" },
+            requestIdentity: { testRequestIdentity(family: "tv") },
+            initialCapabilityState: .supported
+        )
+        let library = Library(
+            id: 7,
+            name: "Pending",
+            type: "movies",
+            sortOrder: 0,
+            posterUrl: nil
+        )
+        let item = PrimaryMenuItem.library(libraryId: 7, label: "Pending")
+        let firstExplicitMenu = PrimaryMenuPreference(items: [
+            .builtin(.home),
+            .builtin(.calendar),
+        ])
+
+        preferences.setLibraryPinned(library, isPinned: true)
+        await transport.waitForStartedShortcutOperations(1)
+        preferences.setPrimaryMenuItems(firstExplicitMenu.items)
+        preferences.setPrimaryMenuItems(firstExplicitMenu.items + [item])
+
+        XCTAssertEqual(preferences.primaryMenu, firstExplicitMenu)
+        XCTAssertTrue(preferences.syncErrorMessage?.contains("finish syncing") == true)
+
+        await transport.releaseFirstShortcutOperation()
+        await transport.waitForCompletedShortcutOperations(1)
+        await transport.waitForGenericPuts(1)
+        try await Task.sleep(nanoseconds: 30_000_000)
+
+        let snapshot = await transport.snapshot()
+        XCTAssertEqual(snapshot.genericPutCount, 1)
+        XCTAssertEqual(snapshot.menuWrites, [firstExplicitMenu])
+        XCTAssertNil(preferences.syncErrorMessage)
+    }
+
+    func testPendingPlacementErrorTracksOnlyBlockedPinAcrossRestart() async throws {
+        let suiteName = "ui-customization-pending-blocked-id-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-pending-blocked-id-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let defaults = SharedDefaults(suite: suite, standard: standard)
+        let cacheKey = "silo.uiCustomization.server.profile.tv"
+        let first = PrimaryMenuItem.library(libraryId: 7, label: "First")
+        let second = PrimaryMenuItem.library(libraryId: 8, label: "Second")
+        let offlineTransport = ShortcutOrderingProbe(outcomes: [
+            first.id: [.transientFailure],
+            second.id: [.transientFailure],
+        ])
+        let authored = UICustomizationPreferences(
+            defaults: defaults,
+            transport: offlineTransport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+
+        authored.setLibraryPinned(
+            Library(id: 7, name: "First", type: "movies", sortOrder: 0, posterUrl: nil),
+            isPinned: true
+        )
+        authored.setLibraryPinned(
+            Library(id: 8, name: "Second", type: "movies", sortOrder: 1, posterUrl: nil),
+            isPinned: true
+        )
+        authored.setPrimaryMenuItems([.builtin(.home), first])
+        await offlineTransport.waitForCompletedWrites(2)
+
+        XCTAssertTrue(authored.syncErrorMessage?.contains("finish syncing") == true)
+        let blockedCacheData = try XCTUnwrap(defaults.data(forKey: cacheKey))
+        let blockedCache = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: blockedCacheData) as? [String: Any]
+        )
+        XCTAssertEqual(
+            blockedCache["pendingShortcutPlacementBlockedIds"] as? [String],
+            [first.id]
+        )
+
+        let replayTransport = ShortcutOrderingProbe(outcomes: [
+            first.id: [.success],
+            second.id: [.transientFailure],
+        ])
+        let restarted = UICustomizationPreferences(
+            defaults: defaults,
+            transport: replayTransport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+        XCTAssertTrue(restarted.syncErrorMessage?.contains("finish syncing") == true)
+
+        await restarted.refresh()
+
+        let replay = await replayTransport.snapshot()
+        XCTAssertEqual(replay.shortcutAttempts.map(\.item.id), [first.id, second.id])
+        XCTAssertFalse(restarted.syncErrorMessage?.contains("finish syncing") == true)
+        let reconciledCacheData = try XCTUnwrap(defaults.data(forKey: cacheKey))
+        let reconciledCache = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: reconciledCacheData) as? [String: Any]
+        )
+        XCTAssertNil(reconciledCache["pendingShortcutPlacementBlockedIds"])
+    }
+
+    func testExplicitMenuSupersessionSurvivesPendingPinRestart() async throws {
+        let suiteName = "ui-customization-explicit-restart-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-explicit-restart-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let defaults = SharedDefaults(suite: suite, standard: standard)
+        let transport = RecoveringShortcutProbe()
+        let cacheKey = "silo.uiCustomization.server.profile.tv"
+        let preferences = UICustomizationPreferences(
+            defaults: defaults,
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+        let library = Library(
+            id: 7,
+            name: "Pending",
+            type: "movies",
+            sortOrder: 0,
+            posterUrl: nil
+        )
+        let explicitMenu = PrimaryMenuPreference(items: [
+            .builtin(.home),
+            .builtin(.calendar),
+        ])
+
+        preferences.setLibraryPinned(library, isPinned: true)
+        await transport.waitForShortcutAttempts(1)
+        preferences.setPrimaryMenuItems(explicitMenu.items)
+        await transport.waitForGenericPuts(1)
+
+        let cachedData = try XCTUnwrap(defaults.data(forKey: cacheKey))
+        let cache = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: cachedData) as? [String: Any]
+        )
+        let pending = try XCTUnwrap(
+            cache["pendingShortcutOperations"] as? [String: [String: Any]]
+        )
+        XCTAssertEqual(pending["library:7"]?["updatesPrimaryMenu"] as? Bool, false)
+
+        await transport.setOnline()
+        let restarted = UICustomizationPreferences(
+            defaults: defaults,
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+        await restarted.refresh()
+
+        let snapshot = await transport.snapshot()
+        XCTAssertEqual(snapshot.shortcutOperations.count, 2)
+        XCTAssertEqual(snapshot.genericPutCount, 1)
+        XCTAssertEqual(restarted.primaryMenu, explicitMenu)
+        XCTAssertTrue(restarted.isLibraryPinned(7))
+    }
+
+    func testNewerExplicitMenuKeepsItemAfterPendingUnpinSucceeds() async throws {
+        let suiteName = "ui-customization-explicit-unpin-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-explicit-unpin-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let item = PrimaryMenuItem.library(libraryId: 7, label: "Pinned")
+        let initialMenu = PrimaryMenuPreference(items: [
+            .builtin(.home),
+            item,
+            .builtin(.forYou),
+        ])
+        let explicitMenu = PrimaryMenuPreference(items: [
+            .builtin(.home),
+            .builtin(.forYou),
+            item,
+        ])
+        let transport = ShortcutOrderingProbe(
+            outcomes: ["library:7": [.transientFailure, .success]],
+            initialMenu: initialMenu,
+            initialShortcuts: [item]
+        )
+        let cacheKey = "silo.uiCustomization.server.profile.tv"
+        let preferences = UICustomizationPreferences(
+            defaults: SharedDefaults(suite: suite, standard: standard),
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+        await preferences.refresh()
+
+        preferences.setLibraryPinned(
+            Library(id: 7, name: "Pinned", type: "movies", sortOrder: 0, posterUrl: nil),
+            isPinned: false
+        )
+        await transport.waitForCompletedWrites(1)
+        preferences.setPrimaryMenuItems(explicitMenu.items)
+        await transport.waitForCompletedWrites(2)
+        await preferences.refresh()
+
+        let snapshot = await transport.snapshot()
+        XCTAssertEqual(snapshot.menuWrites, [explicitMenu])
+        XCTAssertFalse(preferences.isLibraryPinned(7))
+        XCTAssertEqual(preferences.primaryMenu, explicitMenu)
+    }
+
+    func testPendingRemovalKeepsLaterAcceptedPinAfterItsProjectedPredecessor() async throws {
+        let suiteName = "ui-customization-mixed-retry-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-mixed-retry-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let firstItem = PrimaryMenuItem.library(libraryId: 7, label: "First")
+        let initialMenu = PrimaryMenuPreference(items: [
+            .builtin(.home),
+            firstItem,
+            .builtin(.forYou),
+        ])
+        let transport = ShortcutOrderingProbe(
+            outcomes: [
+                "library:7": [.transientFailure, .success],
+                "library:8": [.success],
+            ],
+            initialMenu: initialMenu,
+            initialShortcuts: [firstItem]
+        )
+        let cacheKey = "silo.uiCustomization.server.profile.tv"
+        let preferences = UICustomizationPreferences(
+            defaults: SharedDefaults(suite: suite, standard: standard),
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+        await preferences.refresh()
+        let first = Library(
+            id: 7,
+            name: "First",
+            type: "movies",
+            sortOrder: 0,
+            posterUrl: nil
+        )
+        let second = Library(
+            id: 8,
+            name: "Second",
+            type: "movies",
+            sortOrder: 1,
+            posterUrl: nil
+        )
+
+        preferences.setLibraryPinned(first, isPinned: false)
+        preferences.setLibraryPinned(second, isPinned: true)
+        await transport.waitForCompletedWrites(3)
+
+        var snapshot = await transport.snapshot()
+        XCTAssertEqual(
+            snapshot.menuWrites.first?.items.map(\.id),
+            ["builtin:home", "library:7", "builtin:for_you", "library:8"]
+        )
+
+        await preferences.refresh()
+
+        snapshot = await transport.snapshot()
+        XCTAssertEqual(
+            snapshot.menuWrites.last?.items.map(\.id),
+            ["builtin:home", "builtin:for_you", "library:8"]
+        )
+    }
+
+    func testRejectedRemovalPreservesSiblingAndLaterAcceptedPinOrdering() async throws {
+        let suiteName = "ui-customization-mixed-rejection-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-mixed-rejection-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let firstItem = PrimaryMenuItem.library(libraryId: 7, label: "First")
+        let initialMenu = PrimaryMenuPreference(items: [
+            .builtin(.home),
+            firstItem,
+            .builtin(.forYou),
+        ])
+        let transport = ShortcutOrderingProbe(
+            outcomes: [
+                "library:7": [.definitiveFailure],
+                "library:8": [.success],
+            ],
+            initialMenu: initialMenu,
+            initialShortcuts: [firstItem]
+        )
+        let cacheKey = "silo.uiCustomization.server.profile.tv"
+        let preferences = UICustomizationPreferences(
+            defaults: SharedDefaults(suite: suite, standard: standard),
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+        await preferences.refresh()
+        let first = Library(
+            id: 7,
+            name: "First",
+            type: "movies",
+            sortOrder: 0,
+            posterUrl: nil
+        )
+        let second = Library(
+            id: 8,
+            name: "Second",
+            type: "movies",
+            sortOrder: 1,
+            posterUrl: nil
+        )
+
+        preferences.setLibraryPinned(first, isPinned: false)
+        preferences.setLibraryPinned(second, isPinned: true)
+        await transport.waitForCompletedWrites(3)
+        await preferences.refresh()
+
+        let snapshot = await transport.snapshot()
+        XCTAssertEqual(
+            snapshot.menuWrites.last?.items.map(\.id),
+            ["builtin:home", "library:7", "builtin:for_you", "library:8"]
+        )
+        XCTAssertTrue(preferences.isLibraryPinned(7))
+        XCTAssertTrue(preferences.isLibraryPinned(8))
+    }
+
+    func testPinningBeyondShortcutLimitPreservesStateAndOutbox() throws {
+        let suiteName = "ui-customization-shortcut-limit-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-shortcut-limit-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let cacheKey = "silo.uiCustomization.server.profile.mobile"
+        let shortcutItems: [[String: Any]] = (1...256).map { libraryId in
+            [
+                "type": "library",
+                "library_id": libraryId,
+                "label": "Library \(libraryId)",
+            ]
+        }
+        let cache: [String: Any] = [
+            "shortcuts": ["items": shortcutItems],
+            "cardPresentation": [
+                "poster_size": "standard",
+                "caption": "title_metadata",
+            ],
+            "supportProjection": "supported",
+        ]
+        let cachedData = try JSONSerialization.data(withJSONObject: cache, options: [.sortedKeys])
+        let defaults = SharedDefaults(suite: suite, standard: standard)
+        defaults.set(cachedData, forKey: cacheKey)
+        let transport = UICustomizationTransportStub(
+            result: .success(.init(settings: [], revision: SettingKey.revision))
+        )
+        let preferences = UICustomizationPreferences(
+            defaults: defaults,
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+        let overflowLibrary = Library(
+            id: 257,
+            name: "Overflow Library",
+            type: "movies",
+            sortOrder: 256,
+            posterUrl: nil
+        )
+
+        preferences.setLibraryPinned(overflowLibrary, isPinned: true)
+
+        XCTAssertEqual(preferences.shortcuts.items.count, 256)
+        XCTAssertFalse(preferences.isLibraryPinned(overflowLibrary.id))
+        XCTAssertFalse(preferences.isSaving, "a rejected add must not enqueue any writes")
+        XCTAssertEqual(
+            defaults.data(forKey: cacheKey),
+            cachedData,
+            "the rejected add must leave the durable shortcut list and outbox untouched"
+        )
+        XCTAssertTrue(preferences.syncErrorMessage?.contains("256") == true)
+    }
+
+    func testRedundantPinRequestsAreNoOpsAndPreserveCatalogState() async throws {
+        let suiteName = "ui-customization-redundant-pin-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-redundant-pin-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let pinned = PrimaryMenuItem.library(libraryId: 7, label: "Pinned")
+        let response = EffectiveSettingValuesResponse(
+            settings: [
+                try effective(
+                    .navShortcuts,
+                    NavigationShortcutsPreference(items: [pinned]),
+                    scope: .profile
+                ),
+            ],
+            revision: SettingKey.revision
+        )
+        let transport = SelectiveFailureWriteProbe(
+            failingShortcutIds: [],
+            effectiveResponse: response
+        )
+        let preferences = UICustomizationPreferences(
+            defaults: SharedDefaults(suite: suite, standard: standard),
+            transport: transport,
+            cacheKey: { "silo.uiCustomization.server.profile.tv" },
+            requestIdentity: { testRequestIdentity(family: "tv") },
+            initialCapabilityState: .supported
+        )
+        await preferences.refresh()
+
+        preferences.setLibraryPinned(
+            Library(id: 7, name: "Pinned", type: "movies", sortOrder: 0, posterUrl: nil),
+            isPinned: true
+        )
+        preferences.setLibraryPinned(
+            Library(id: 8, name: "Absent", type: "movies", sortOrder: 1, posterUrl: nil),
+            isPinned: false
+        )
+
+        XCTAssertTrue(preferences.isLibraryPinned(7))
+        XCTAssertFalse(preferences.isLibraryPinned(8))
+        XCTAssertFalse(preferences.isSaving)
+        let writtenKeys = await transport.writtenKeys()
+        XCTAssertTrue(writtenKeys.isEmpty)
+    }
+
+    func testPinningIntoFullPrimaryMenuRejectsTheCompoundMutation() throws {
+        let suiteName = "ui-customization-menu-limit-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-menu-limit-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let cacheKey = "silo.uiCustomization.server.profile.mobile"
+        let menuItems: [[String: Any]] = [
+            ["type": "builtin", "destination": "home"],
+        ] + (1...63).map { libraryId in
+            [
+                "type": "library",
+                "library_id": libraryId,
+                "label": "Library \(libraryId)",
+            ]
+        }
+        let cache: [String: Any] = [
+            "primaryMenu": ["items": menuItems],
+            "shortcuts": ["items": []],
+            "cardPresentation": [
+                "poster_size": "standard",
+                "caption": "title_metadata",
+            ],
+            "supportProjection": "supported",
+        ]
+        let cachedData = try JSONSerialization.data(withJSONObject: cache, options: [.sortedKeys])
+        let defaults = SharedDefaults(suite: suite, standard: standard)
+        defaults.set(cachedData, forKey: cacheKey)
+        let preferences = UICustomizationPreferences(
+            defaults: defaults,
+            transport: UICustomizationTransportStub(
+                result: .success(.init(settings: [], revision: SettingKey.revision))
+            ),
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+        let overflowLibrary = Library(
+            id: 64,
+            name: "Overflow Library",
+            type: "movies",
+            sortOrder: 63,
+            posterUrl: nil
+        )
+
+        preferences.setLibraryPinned(overflowLibrary, isPinned: true)
+
+        XCTAssertEqual(preferences.primaryMenu?.items.count, 64)
+        XCTAssertTrue(preferences.shortcuts.items.isEmpty)
+        XCTAssertFalse(preferences.isSaving, "a rejected compound add must not enqueue either write")
+        XCTAssertEqual(defaults.data(forKey: cacheKey), cachedData)
+        XCTAssertTrue(preferences.syncErrorMessage?.contains("64") == true)
+    }
+
+    func testDefinitiveShortcutRejectionReconcilesWithoutReplayingTheOutbox() async throws {
+        let suiteName = "ui-customization-definitive-rejection-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-definitive-rejection-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let cacheKey = "silo.uiCustomization.server.profile.tv"
+        let defaults = SharedDefaults(suite: suite, standard: standard)
+        let transport = DefinitiveShortcutRejectionProbe()
+        let preferences = UICustomizationPreferences(
+            defaults: defaults,
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+        let racedLibrary = Library(
+            id: 257,
+            name: "Raced Pin",
+            type: "movies",
+            sortOrder: 256,
+            posterUrl: nil
+        )
+
+        await preferences.refresh()
+        XCTAssertEqual(preferences.shortcuts.items.count, 255)
+        XCTAssertFalse(preferences.primaryMenuUsesDeviceOverride)
+
+        preferences.setLibraryPinned(racedLibrary, isPinned: true)
+        await transport.waitForCompletedWrites(1)
+        await preferences.refresh()
+        await preferences.refresh()
+
+        let snapshot = await transport.snapshot()
+        XCTAssertEqual(snapshot.shortcutWriteAttempts, 1)
+        XCTAssertEqual(
+            snapshot.primaryMenuWriteAttempts,
+            0,
+            "a rejected profile shortcut must not commit only its family-menu placement"
+        )
+        XCTAssertGreaterThanOrEqual(
+            snapshot.effectiveReads,
+            2,
+            "overlapping refreshes may coalesce, but one authoritative read must follow the rejection"
+        )
+        XCTAssertEqual(preferences.shortcuts.items.count, 256)
+        XCTAssertFalse(preferences.isLibraryPinned(racedLibrary.id))
+        XCTAssertEqual(preferences.primaryMenu?.items, [.builtin(.home)])
+        XCTAssertTrue(preferences.syncErrorMessage?.contains("256") == true)
+
+        let cachedData = try XCTUnwrap(defaults.data(forKey: cacheKey))
+        let cache = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: cachedData) as? [String: Any]
+        )
+        XCTAssertNil(
+            cache["pendingShortcutOperations"],
+            "a definitive rejection must be quarantined from the durable retry outbox"
+        )
+    }
+
+    func testOfflineShortcutOperationIsDurablyReplayedWithTheSameMutationId() async throws {
+        let suiteName = "ui-customization-shortcut-outbox-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-shortcut-outbox-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let defaults = SharedDefaults(suite: suite, standard: standard)
+        let transport = RecoveringShortcutProbe()
+        let cacheKey = "silo.uiCustomization.server.profile.mobile"
+        let library = Library(
+            id: 7,
+            name: "Movies",
+            type: "movies",
+            sortOrder: 0,
+            posterUrl: nil
+        )
+        let offline = UICustomizationPreferences(
+            defaults: defaults,
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+
+        offline.setLibraryPinned(library, isPinned: true)
+        await transport.waitForShortcutAttempts(1)
+        await transport.setOnline()
+
+        let restarted = UICustomizationPreferences(
+            defaults: defaults,
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+        XCTAssertEqual(restarted.shortcuts.items.map(\.id), ["library:7"])
+
+        await restarted.refresh()
+
+        let snapshot = await transport.snapshot()
+        XCTAssertEqual(
+            snapshot.events,
+            ["shortcut-failed", "shortcut-succeeded", "put-nav.primary_menu", "effective"]
+        )
+        XCTAssertEqual(snapshot.shortcutOperations.map(\.present), [true, true])
+        XCTAssertEqual(snapshot.shortcutOperations.count, 2)
+        XCTAssertEqual(
+            Set(snapshot.shortcutOperations.map(\.mutationId)).count,
+            1,
+            "an ambiguous atomic operation must retain its idempotency key across restart"
+        )
+        XCTAssertEqual(restarted.shortcuts.items.map(\.id), ["library:7"])
+        XCTAssertNil(restarted.syncErrorMessage)
+    }
+
+    func testAuthenticationFailureKeepsShortcutIntentForReplay() async throws {
+        let suiteName = "ui-customization-shortcut-auth-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-shortcut-auth-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let defaults = SharedDefaults(suite: suite, standard: standard)
+        let transport = RecoveringShortcutProbe(
+            offlineFailure: .server(
+                status: 401,
+                code: "unauthorized",
+                message: "profile authentication expired"
+            )
+        )
+        let cacheKey = "silo.uiCustomization.server.profile.mobile"
+        let preferences = UICustomizationPreferences(
+            defaults: defaults,
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+        let library = Library(
+            id: 7,
+            name: "Movies",
+            type: "movies",
+            sortOrder: 0,
+            posterUrl: nil
+        )
+
+        preferences.setLibraryPinned(library, isPinned: true)
+        await transport.waitForShortcutAttempts(1)
+        let failedCacheData = try XCTUnwrap(defaults.data(forKey: cacheKey))
+        let failedCache = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: failedCacheData) as? [String: Any]
+        )
+        XCTAssertNotNil(
+            failedCache["pendingShortcutOperations"],
+            "authentication failures must retain replayable user intent"
+        )
+
+        await transport.setOnline()
+        await preferences.refresh()
+
+        let snapshot = await transport.snapshot()
+        XCTAssertEqual(snapshot.shortcutOperations.count, 2)
+        XCTAssertEqual(Set(snapshot.shortcutOperations.map(\.mutationId)).count, 1)
+        XCTAssertTrue(preferences.isLibraryPinned(library.id))
+        XCTAssertNil(preferences.syncErrorMessage)
+    }
+
+    func testOfflineShortcutOperationsPreserveCrossIdentityOrderAfterRestart() async throws {
+        let suiteName = "ui-customization-shortcut-sequence-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-shortcut-sequence-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let defaults = SharedDefaults(suite: suite, standard: standard)
+        let transport = RecoveringShortcutProbe()
+        let cacheKey = "silo.uiCustomization.server.profile.tv"
+        let libraryB = Library(
+            id: 20,
+            name: "Library B",
+            type: "movies",
+            sortOrder: 0,
+            posterUrl: nil
+        )
+        let libraryA = Library(
+            id: 10,
+            name: "Library A",
+            type: "movies",
+            sortOrder: 1,
+            posterUrl: nil
+        )
+        let offline = UICustomizationPreferences(
+            defaults: defaults,
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+
+        offline.setLibraryPinned(libraryB, isPinned: true)
+        await transport.waitForShortcutAttempts(1)
+        offline.setLibraryPinned(libraryA, isPinned: true)
+        await transport.waitForShortcutAttempts(2)
+        await transport.setOnline()
+
+        let restarted = UICustomizationPreferences(
+            defaults: defaults,
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+        XCTAssertEqual(restarted.shortcuts.items.map(\.id), ["library:20", "library:10"])
+
+        await restarted.refresh()
+
+        let snapshot = await transport.snapshot()
+        XCTAssertEqual(
+            snapshot.shortcutOperations.map(\.item.id),
+            ["library:20", "library:10", "library:20", "library:10"],
+            "restart replay must follow the user's cross-library edit order, not semantic ID order"
+        )
+        XCTAssertEqual(snapshot.storedShortcuts.map(\.id), ["library:20", "library:10"])
+        XCTAssertEqual(restarted.shortcuts.items.map(\.id), ["library:20", "library:10"])
+        XCTAssertNil(restarted.syncErrorMessage)
+    }
+
+    func testNewerOppositeShortcutIntentSurvivesOlderInFlightSuccess() async throws {
+        let suiteName = "ui-customization-shortcut-order-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-shortcut-order-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let defaults = SharedDefaults(suite: suite, standard: standard)
+        let transport = BlockingShortcutProbe()
+        let cacheKey = "silo.uiCustomization.server.profile.tv"
+        let library = Library(
+            id: 9,
+            name: "Documentaries",
+            type: "movies",
+            sortOrder: 0,
+            posterUrl: nil
+        )
+        let preferences = UICustomizationPreferences(
+            defaults: defaults,
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+
+        preferences.setLibraryPinned(library, isPinned: true)
+        await transport.waitForStartedShortcutOperations(1)
+        preferences.setLibraryPinned(library, isPinned: false)
+        XCTAssertFalse(preferences.shortcuts.items.contains { $0.id == "library:9" })
+
+        await transport.releaseFirstShortcutOperation()
+        await transport.waitForCompletedShortcutOperations(2)
+
+        let firstSnapshot = await transport.snapshot()
+        XCTAssertEqual(firstSnapshot.shortcutOperations.map(\.present), [true, false])
+        XCTAssertEqual(Set(firstSnapshot.shortcutOperations.map(\.mutationId)).count, 2)
+        XCTAssertTrue(firstSnapshot.storedShortcuts.isEmpty)
+        XCTAssertEqual(
+            firstSnapshot.genericPutCount,
+            0,
+            "a superseded add followed by an accepted remove leaves the family menu unchanged"
+        )
+
+        // If the first success had cleared the newer cached operation, this
+        // restart would replay the add or leave a pending add behind.
+        let restarted = UICustomizationPreferences(
+            defaults: defaults,
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+        await restarted.refresh()
+
+        let finalSnapshot = await transport.snapshot()
+        XCTAssertEqual(finalSnapshot.shortcutOperations.count, 2)
+        XCTAssertTrue(restarted.shortcuts.items.isEmpty)
+        XCTAssertNil(restarted.syncErrorMessage)
+    }
+
+    func testOfflineWriteIsDurablyReplayedBeforeEffectiveRefresh() async throws {
+        let suiteName = "ui-customization-outbox-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-outbox-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let defaults = SharedDefaults(suite: suite, standard: standard)
+        let transport = RecoveringWriteProbe()
+        let cacheKey = "silo.uiCustomization.server.profile.mobile"
+        let offline = UICustomizationPreferences(
+            defaults: defaults,
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+        let desired = CardPresentationPreset.artworkOnly.presentation
+
+        offline.setCardPresentation(desired)
+        await transport.waitForPutAttempts(1)
+        await transport.setOnline()
+
+        // A fresh store proves the failed write was journaled in the cache,
+        // not merely retained by the first in-memory instance.
+        let restarted = UICustomizationPreferences(
+            defaults: defaults,
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+        XCTAssertEqual(restarted.cardPresentation, desired)
+
+        await restarted.refresh()
+
+        let snapshot = await transport.snapshot()
+        XCTAssertEqual(snapshot.events, ["put-failed", "put-succeeded", "effective"])
+        XCTAssertEqual(snapshot.mutationIds.count, 2)
+        XCTAssertEqual(
+            Set(snapshot.mutationIds).count,
+            1,
+            "a connectivity retry must reuse the original idempotency key"
+        )
+        XCTAssertEqual(snapshot.storedPresentation, desired)
+        XCTAssertEqual(restarted.cardPresentation, desired)
+        XCTAssertNil(restarted.syncErrorMessage)
+    }
+
+    func testUnavailableOrOldCapabilitiesDoNotDrainRevisionFiveOutbox() async throws {
+        let suiteName = "ui-customization-capability-gate-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-capability-gate-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let defaults = SharedDefaults(suite: suite, standard: standard)
+        let cacheKey = "silo.uiCustomization.server.profile.mobile"
+        let transport = CapabilityGateProbe(
+            capabilities: .failed(.transport(description: "offline"))
+        )
+        let desired = CardPresentationPreset.artworkOnly.presentation
+        let authored = UICustomizationPreferences(
+            defaults: defaults,
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+
+        authored.setCardPresentation(desired)
+        let customMenu = PrimaryMenuPreference(items: [
+            .builtin(.home),
+            .builtin(.calendar),
+        ])
+        authored.setPrimaryMenuItems(customMenu.items)
+        await transport.waitForPutAttempts(2)
+
+        let unavailable = UICustomizationPreferences(
+            defaults: defaults,
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) }
+        )
+        await unavailable.refresh()
+
+        var snapshot = await transport.snapshot()
+        XCTAssertEqual(unavailable.capabilityState, .unavailable)
+        XCTAssertEqual(unavailable.supportProjection, .unknown)
+        XCTAssertFalse(unavailable.allowsEditing)
+        XCTAssertEqual(unavailable.cardPresentation, desired)
+        XCTAssertEqual(unavailable.primaryMenu, customMenu)
+        XCTAssertEqual(snapshot.putAttempts, 2)
+        XCTAssertEqual(snapshot.effectiveReads, 0)
+
+        await transport.setCapabilities(.serverUpgradeRequired)
+        await unavailable.refresh()
+
+        snapshot = await transport.snapshot()
+        XCTAssertEqual(unavailable.capabilityState, .serverUpgradeRequired)
+        XCTAssertEqual(unavailable.supportProjection, .knownUnsupported)
+        XCTAssertEqual(unavailable.cardPresentation, .standard)
+        XCTAssertNil(unavailable.primaryMenu)
+        XCTAssertEqual(snapshot.putAttempts, 2, "a known old server must not receive the outbox")
+        XCTAssertEqual(snapshot.effectiveReads, 0)
+
+        await transport.setCapabilities(.available(testCapabilities(batchedEffective: false)))
+        await unavailable.refresh()
+
+        snapshot = await transport.snapshot()
+        XCTAssertEqual(unavailable.capabilityState, .serverUpgradeRequired)
+        XCTAssertEqual(unavailable.supportProjection, .knownUnsupported)
+        XCTAssertFalse(unavailable.allowsEditing)
+        XCTAssertEqual(unavailable.cardPresentation, .standard)
+        XCTAssertNil(unavailable.primaryMenu)
+        XCTAssertFalse(unavailable.hasExplicitPrimaryMenu)
+        XCTAssertEqual(
+            snapshot.putAttempts,
+            2,
+            "the client must not use a multi-key read when the server does not advertise it"
+        )
+        XCTAssertEqual(snapshot.effectiveReads, 0)
+
+        await transport.setCapabilities(.failed(.transport(description: "offline again")))
+        await unavailable.refresh()
+
+        snapshot = await transport.snapshot()
+        XCTAssertEqual(unavailable.capabilityState, .unavailable)
+        XCTAssertEqual(
+            unavailable.supportProjection,
+            .knownUnsupported,
+            "a later transient probe failure must not forget an explicit incompatibility"
+        )
+        XCTAssertEqual(unavailable.cardPresentation, .standard)
+        XCTAssertNil(unavailable.primaryMenu)
+        XCTAssertEqual(snapshot.putAttempts, 2)
+        XCTAssertEqual(snapshot.effectiveReads, 0)
+
+        let restartedKnownUnsupported = UICustomizationPreferences(
+            defaults: defaults,
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) }
+        )
+        await restartedKnownUnsupported.refresh()
+        XCTAssertEqual(restartedKnownUnsupported.capabilityState, .unavailable)
+        XCTAssertEqual(restartedKnownUnsupported.supportProjection, .knownUnsupported)
+        XCTAssertEqual(restartedKnownUnsupported.cardPresentation, .standard)
+        XCTAssertNil(restartedKnownUnsupported.primaryMenu)
+
+        await transport.setCapabilities(.available(testCapabilities(atomicShortcuts: false)))
+        await unavailable.refresh()
+
+        snapshot = await transport.snapshot()
+        XCTAssertEqual(unavailable.capabilityState, .serverUpgradeRequired)
+        XCTAssertFalse(unavailable.allowsEditing)
+        XCTAssertEqual(unavailable.cardPresentation, .standard)
+        XCTAssertNil(unavailable.primaryMenu)
+        XCTAssertEqual(snapshot.putAttempts, 2, "an old server must not receive revision-5 writes")
+        XCTAssertEqual(snapshot.effectiveReads, 0)
+
+        await transport.setCapabilities(.available(testCapabilities(idempotentWrites: false)))
+        await unavailable.refresh()
+
+        snapshot = await transport.snapshot()
+        XCTAssertEqual(unavailable.capabilityState, .serverUpgradeRequired)
+        XCTAssertFalse(unavailable.allowsEditing)
+        XCTAssertEqual(unavailable.cardPresentation, .standard)
+        XCTAssertNil(unavailable.primaryMenu)
+        XCTAssertEqual(
+            snapshot.putAttempts,
+            2,
+            "an outbox must not replay when the server cannot deduplicate an ambiguous retry"
+        )
+        XCTAssertEqual(snapshot.effectiveReads, 0)
+    }
+
+    func testProfileClientCardResetIsDurableAndResolvesInheritedValueAfterRestart() async throws {
+        let suiteName = "ui-customization-card-reset-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-card-reset-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let defaults = SharedDefaults(suite: suite, standard: standard)
+        let cacheKey = "silo.uiCustomization.server.profile.mobile"
+        let transport = RecoveringDeleteProbe()
+        let preferences = UICustomizationPreferences(
+            defaults: defaults,
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) }
+        )
+
+        await preferences.refresh()
+        XCTAssertTrue(preferences.cardPresentationUsesFamilyOverride)
+        XCTAssertEqual(preferences.cardPresentation, CardPresentationPreset.compact.presentation)
+
+        await transport.clearEvents()
+        preferences.resetCardPresentationToInherited()
+        await transport.waitForDeleteAttempts(1)
+        await transport.setDeletesOnline()
+
+        let restarted = UICustomizationPreferences(
+            defaults: defaults,
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) }
+        )
+        await restarted.refresh()
+
+        let snapshot = await transport.snapshot()
+        XCTAssertEqual(snapshot.events, ["delete-failed", "delete-succeeded", "effective"])
+        XCTAssertEqual(snapshot.deleteScopes, [.profileClient, .profileClient])
+        XCTAssertEqual(restarted.cardPresentation, .standard)
+        XCTAssertFalse(restarted.cardPresentationUsesFamilyOverride)
+        XCTAssertNil(restarted.syncErrorMessage)
+    }
+
+    func testQueuedWriteNeverFollowsAChangedServerProfileIdentity() async throws {
+        let suiteName = "ui-customization-identity-race-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-identity-race-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let identity = MutableRequestIdentity(testRequestIdentity(family: "mobile"))
+        let transport = OrderedWriteProbe()
+        let preferences = UICustomizationPreferences(
+            defaults: SharedDefaults(suite: suite, standard: standard),
+            transport: transport,
+            cacheKey: { testCacheKey(for: identity.value) },
+            requestIdentity: { identity.value },
+            initialCapabilityState: .supported
+        )
+
+        preferences.setCardPresentation(CardPresentationPreset.compact.presentation)
+        preferences.setCardPresentation(CardPresentationPreset.artworkOnly.presentation)
+        await transport.waitForStartedWrites(1)
+
+        identity.value = HTTPRequestIdentity(
+            serverId: "server-b",
+            serverURL: "http://server-b.invalid",
+            profileId: "profile-b",
+            clientFamily: "mobile"
+        )
+        await transport.releaseFirstWrite()
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        let snapshot = await transport.snapshot()
+        XCTAssertEqual(snapshot.identities, [testRequestIdentity(family: "mobile")])
+        XCTAssertEqual(
+            snapshot.values.count,
+            1,
+            "queued work for the old cache must be retained, not sent through the new identity"
+        )
+        XCTAssertFalse(preferences.isSaving)
+    }
+
+    func testRefreshPreservesHigherPrecedenceDeviceOverrideSource() async throws {
+        let suiteName = "ui-customization-source-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-source-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let menu = PrimaryMenuPreference(items: [.builtin(.home), .builtin(.movies)])
+        let response = EffectiveSettingValuesResponse(
+            settings: [
+                EffectiveSettingValue(
+                    key: SettingKey.navPrimaryMenu.rawValue,
+                    value: try SettingJSONValue.encoding(menu),
+                    source: .scope(.profileDevice),
+                    scope: .profileDevice,
+                    profileId: "profile",
+                    deviceId: "device"
+                ),
+                EffectiveSettingValue(
+                    key: SettingKey.uiCardPresentation.rawValue,
+                    value: try SettingJSONValue.encoding(CardPresentationPreset.compact.presentation),
+                    source: .scope(.profileDevice),
+                    scope: .profileDevice,
+                    profileId: "profile",
+                    deviceId: "device"
+                ),
+            ],
+            revision: SettingKey.revision
+        )
+        let preferences = UICustomizationPreferences(
+            defaults: SharedDefaults(suite: suite, standard: standard),
+            transport: UICustomizationTransportStub(result: .success(response)),
+            cacheKey: { "silo.uiCustomization.server.profile.tv" },
+            requestIdentity: { testRequestIdentity(family: "tv") },
+            initialCapabilityState: .supported
+        )
+
+        await preferences.refresh()
+
+        XCTAssertTrue(preferences.primaryMenuUsesDeviceOverride)
+        XCTAssertTrue(preferences.cardPresentationUsesDeviceOverride)
+        XCTAssertTrue(preferences.hasDeviceOverrides)
+    }
+
+    func testDeviceMenuOverrideDoesNotBlockProfileLibraryPin() async throws {
+        let suiteName = "ui-customization-device-menu-pin-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-device-menu-pin-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let deviceMenu = PrimaryMenuPreference(items: [
+            .builtin(.home),
+            .builtin(.movies),
+        ])
+        let response = EffectiveSettingValuesResponse(
+            settings: [
+                EffectiveSettingValue(
+                    key: SettingKey.navPrimaryMenu.rawValue,
+                    value: try SettingJSONValue.encoding(deviceMenu),
+                    source: .scope(.profileDevice),
+                    scope: .profileDevice,
+                    profileId: "profile",
+                    deviceId: "device"
+                ),
+            ],
+            revision: SettingKey.revision
+        )
+        let transport = SelectiveFailureWriteProbe(
+            failingShortcutIds: [],
+            effectiveResponse: response
+        )
+        let cacheKey = "silo.uiCustomization.server.profile.tv"
+        let preferences = UICustomizationPreferences(
+            defaults: SharedDefaults(suite: suite, standard: standard),
+            transport: transport,
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+        let library = Library(
+            id: 7,
+            name: "Movies",
+            type: "movies",
+            sortOrder: 0,
+            posterUrl: nil
+        )
+
+        await preferences.refresh()
+        preferences.setLibraryPinned(library, isPinned: true)
+        await transport.waitForCompletedWrites(1)
+        let writtenKeys = await transport.writtenKeys()
+
+        XCTAssertTrue(preferences.primaryMenuUsesDeviceOverride)
+        XCTAssertEqual(preferences.primaryMenu, deviceMenu)
+        XCTAssertTrue(preferences.isLibraryPinned(library.id))
+        XCTAssertEqual(
+            writtenKeys,
+            [.navShortcuts],
+            "the independent profile shortcut should sync without rewriting the device menu"
+        )
+    }
+
+    func testPinnedLibraryStateTracksShortcutCatalogInsteadOfMenuPlacement() async throws {
+        let suiteName = "ui-customization-pinned-state-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-pinned-state-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let shortcutOnly = PrimaryMenuItem.library(libraryId: 7, label: "Hidden Pin")
+        let menuOnly = PrimaryMenuItem.library(libraryId: 9, label: "Menu Only")
+        let response = EffectiveSettingValuesResponse(
+            settings: [
+                try effective(
+                    .navPrimaryMenu,
+                    PrimaryMenuPreference(items: [.builtin(.home), menuOnly]),
+                    scope: .profileClient
+                ),
+                try effective(
+                    .navShortcuts,
+                    NavigationShortcutsPreference(items: [shortcutOnly]),
+                    scope: .profile
+                ),
+            ],
+            revision: SettingKey.revision
+        )
+        let preferences = UICustomizationPreferences(
+            defaults: SharedDefaults(suite: suite, standard: standard),
+            transport: UICustomizationTransportStub(result: .success(response)),
+            cacheKey: { "silo.uiCustomization.server.profile.mobile" },
+            requestIdentity: { testRequestIdentity(family: "mobile") },
+            initialCapabilityState: .supported
+        )
+
+        await preferences.refresh()
+
+        XCTAssertTrue(
+            preferences.isLibraryPinned(7),
+            "hiding a library from this family's menu must not turn off its profile shortcut toggle"
+        )
+        XCTAssertFalse(
+            preferences.isLibraryPinned(9),
+            "menu placement alone is not membership in the profile shortcut catalog"
+        )
+    }
+
+    func testProfileShortcutDoesNotPopulateFamilyDefaultMenu() async throws {
+        let suiteName = "ui-customization-family-default-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-family-default-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let shortcut = PrimaryMenuItem.library(libraryId: 7, label: "Movies")
+        let response = EffectiveSettingValuesResponse(
+            settings: [
+                try effective(
+                    .navShortcuts,
+                    NavigationShortcutsPreference(items: [shortcut]),
+                    scope: .profile
+                ),
+            ],
+            revision: SettingKey.revision
+        )
+        let preferences = UICustomizationPreferences(
+            defaults: SharedDefaults(suite: suite, standard: standard),
+            transport: UICustomizationTransportStub(result: .success(response)),
+            cacheKey: { "silo.uiCustomization.server.profile.tv" },
+            requestIdentity: { testRequestIdentity(family: "tv") },
+            initialCapabilityState: .supported
+        )
+
+        await preferences.refresh()
+
+        XCTAssertTrue(preferences.isLibraryPinned(7))
+        XCTAssertNil(preferences.primaryMenu)
+        XCTAssertFalse(
+            preferences.resolvedPrimaryMenuItems().contains { $0.id == shortcut.id },
+            "a profile shortcut must remain hidden until this family authors its placement"
+        )
+    }
+
+    func testRefreshReconcilesTheFamilyScopedCacheAndOfflineRestoreKeepsIt() async throws {
+        let suiteName = "ui-customization-suite-\(UUID().uuidString)"
+        let standardName = "ui-customization-standard-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let standard = try XCTUnwrap(UserDefaults(suiteName: standardName))
+        defer {
+            UserDefaults().removePersistentDomain(forName: suiteName)
+            UserDefaults().removePersistentDomain(forName: standardName)
+        }
+
+        let menu = PrimaryMenuPreference(items: [
+            .builtin(.home),
+            .library(libraryId: 7, label: "Movies"),
+            .builtin(.forYou),
+        ])
+        let shortcuts = NavigationShortcutsPreference(items: [
+            .builtin(.calendar), // Invalid for nav.shortcuts and must be discarded.
+            .section(libraryId: 7, sectionId: "recently-added", label: "Recently Added"),
+        ])
+        let cards = CardPresentationPreference(posterSize: .large, caption: .artwork)
+        let response = EffectiveSettingValuesResponse(
+            settings: [
+                try effective(.navPrimaryMenu, menu, scope: .profileClient),
+                try effective(.navShortcuts, shortcuts, scope: .profile),
+                try effective(.uiCardPresentation, cards, scope: .profileClient),
+            ],
+            revision: SettingKey.revision
+        )
+        let defaults = SharedDefaults(suite: suite, standard: standard)
+        let cacheKey = "silo.uiCustomization.server.profile.mobile"
+        let online = UICustomizationPreferences(
+            defaults: defaults,
+            transport: UICustomizationTransportStub(result: .success(response)),
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+
+        await online.refresh()
+
+        XCTAssertEqual(online.primaryMenu, menu)
+        XCTAssertEqual(online.shortcuts.items, Array(shortcuts.items.dropFirst()))
+        XCTAssertEqual(online.cardPresentation, cards)
+        XCTAssertNil(online.syncErrorMessage)
+
+        let offline = UICustomizationPreferences(
+            defaults: defaults,
+            transport: UICustomizationTransportStub(result: .failure(URLError(.notConnectedToInternet))),
+            cacheKey: { cacheKey },
+            requestIdentity: { testRequestIdentity(for: cacheKey) },
+            initialCapabilityState: .supported
+        )
+        XCTAssertEqual(offline.primaryMenu, menu)
+        XCTAssertEqual(offline.cardPresentation, cards)
+
+        await offline.refresh()
+
+        XCTAssertEqual(offline.primaryMenu, menu, "a failed refresh must not erase the cached menu")
+        XCTAssertEqual(offline.cardPresentation, cards)
+        XCTAssertNotNil(offline.syncErrorMessage)
+    }
+
+    private func effective<T: Encodable>(
+        _ key: SettingKey,
+        _ value: T,
+        scope: SettingScope
+    ) throws -> EffectiveSettingValue {
+        EffectiveSettingValue(
+            key: key.rawValue,
+            value: try SettingJSONValue.encoding(value),
+            source: .scope(scope),
+            scope: scope,
+            profileId: "profile",
+            clientFamily: scope == .profileClient ? "mobile" : nil
+        )
+    }
+}
+
+private func testRequestIdentity(family: String) -> HTTPRequestIdentity {
+    HTTPRequestIdentity(
+        serverId: "server",
+        serverURL: "http://settings-test.invalid",
+        profileId: "profile",
+        clientFamily: family
+    )
+}
+
+private func testRequestIdentity(for cacheKey: String) -> HTTPRequestIdentity {
+    testRequestIdentity(family: cacheKey.split(separator: ".").last.map(String.init) ?? "mobile")
+}
+
+private func testCacheKey(for identity: HTTPRequestIdentity) -> String {
+    "silo.uiCustomization.\(identity.serverId).\(identity.profileId).\(identity.clientFamily)"
+}
+
+private func testCapabilities(
+    batchedEffective: Bool = true,
+    idempotentWrites: Bool = true,
+    atomicShortcuts: Bool = true
+) -> SettingsContractCapabilities {
+    SettingsContractCapabilities(
+        apiVersion: 1,
+        revision: SettingKey.revision,
+        contractEtag: "test",
+        definitionCount: 3,
+        scopes: ["profile", "profile_client", "profile_device"],
+        supportsBatchedEffective: batchedEffective,
+        supportsIdempotentWrites: idempotentWrites,
+        supportsAtomicShortcuts: atomicShortcuts
+    )
+}
+
+private final class MutableRequestIdentity: @unchecked Sendable {
+    var value: HTTPRequestIdentity
+
+    init(_ value: HTTPRequestIdentity) {
+        self.value = value
+    }
+}
+
+private protocol CurrentCapabilitiesTransport: UICustomizationTransport {}
+
+private extension CurrentCapabilitiesTransport {
+    func contractCapabilities(
+        requestIdentity: HTTPRequestIdentity
+    ) async -> SettingsCapabilitiesResult {
+        .available(testCapabilities())
+    }
+}
+
+private final class UICustomizationTransportStub: CurrentCapabilitiesTransport, @unchecked Sendable {
+    private let result: Result<EffectiveSettingValuesResponse, Error>
+
+    init(result: Result<EffectiveSettingValuesResponse, Error>) {
+        self.result = result
+    }
+
+    func effectiveValues(
+        keys: [SettingKey],
+        requestIdentity: HTTPRequestIdentity
+    ) async throws -> EffectiveSettingValuesResponse {
+        try result.get()
+    }
+
+    func putValue(
+        key: SettingKey,
+        scope: SettingScopeIdentity,
+        value: SettingJSONValue,
+        mutationId: String,
+        requestIdentity: HTTPRequestIdentity
+    ) async throws {}
+}
+
+private actor CapabilityGateProbe: UICustomizationTransport {
+    private var capabilities: SettingsCapabilitiesResult
+    private var putAttempts = 0
+    private var effectiveReads = 0
+    private var putWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+
+    init(capabilities: SettingsCapabilitiesResult) {
+        self.capabilities = capabilities
+    }
+
+    func contractCapabilities(
+        requestIdentity: HTTPRequestIdentity
+    ) async -> SettingsCapabilitiesResult {
+        capabilities
+    }
+
+    func effectiveValues(
+        keys: [SettingKey],
+        requestIdentity: HTTPRequestIdentity
+    ) async throws -> EffectiveSettingValuesResponse {
+        effectiveReads += 1
+        return EffectiveSettingValuesResponse(settings: [], revision: SettingKey.revision)
+    }
+
+    func putValue(
+        key: SettingKey,
+        scope: SettingScopeIdentity,
+        value: SettingJSONValue,
+        mutationId: String,
+        requestIdentity: HTTPRequestIdentity
+    ) async throws {
+        putAttempts += 1
+        let ready = putWaiters.filter { putAttempts >= $0.0 }
+        putWaiters.removeAll { putAttempts >= $0.0 }
+        ready.forEach { $0.1.resume() }
+        throw URLError(.notConnectedToInternet)
+    }
+
+    func waitForPutAttempts(_ count: Int) async {
+        guard putAttempts < count else { return }
+        await withCheckedContinuation { continuation in
+            putWaiters.append((count, continuation))
+        }
+    }
+
+    func setCapabilities(_ capabilities: SettingsCapabilitiesResult) {
+        self.capabilities = capabilities
+    }
+
+    func snapshot() -> (putAttempts: Int, effectiveReads: Int) {
+        (putAttempts, effectiveReads)
+    }
+}
+
+private actor RecoveringDeleteProbe: CurrentCapabilitiesTransport {
+    private var deletesOnline = false
+    private var familyRowPresent = true
+    private var deleteAttempts = 0
+    private var deleteScopes: [SettingScopeIdentity] = []
+    private var events: [String] = []
+    private var deleteWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+
+    func effectiveValues(
+        keys: [SettingKey],
+        requestIdentity: HTTPRequestIdentity
+    ) async throws -> EffectiveSettingValuesResponse {
+        events.append("effective")
+        let presentation = familyRowPresent
+            ? CardPresentationPreset.compact.presentation
+            : CardPresentationPreference.standard
+        return EffectiveSettingValuesResponse(
+            settings: [
+                EffectiveSettingValue(
+                    key: SettingKey.uiCardPresentation.rawValue,
+                    value: try SettingJSONValue.encoding(presentation),
+                    source: familyRowPresent ? .scope(.profileClient) : .contractDefault,
+                    scope: familyRowPresent ? .profileClient : nil,
+                    profileId: "profile",
+                    clientFamily: familyRowPresent ? "mobile" : nil
+                ),
+            ],
+            revision: SettingKey.revision
+        )
+    }
+
+    func putValue(
+        key: SettingKey,
+        scope: SettingScopeIdentity,
+        value: SettingJSONValue,
+        mutationId: String,
+        requestIdentity: HTTPRequestIdentity
+    ) async throws {}
+
+    func deleteValue(
+        key: SettingKey,
+        scope: SettingScopeIdentity,
+        requestIdentity: HTTPRequestIdentity
+    ) async throws {
+        deleteAttempts += 1
+        deleteScopes.append(scope)
+        let ready = deleteWaiters.filter { deleteAttempts >= $0.0 }
+        deleteWaiters.removeAll { deleteAttempts >= $0.0 }
+        ready.forEach { $0.1.resume() }
+        guard deletesOnline else {
+            events.append("delete-failed")
+            throw URLError(.notConnectedToInternet)
+        }
+        familyRowPresent = false
+        events.append("delete-succeeded")
+    }
+
+    func waitForDeleteAttempts(_ count: Int) async {
+        guard deleteAttempts < count else { return }
+        await withCheckedContinuation { continuation in
+            deleteWaiters.append((count, continuation))
+        }
+    }
+
+    func setDeletesOnline() {
+        deletesOnline = true
+    }
+
+    func clearEvents() {
+        events.removeAll()
+    }
+
+    func snapshot() -> (events: [String], deleteScopes: [SettingScopeIdentity]) {
+        (events, deleteScopes)
+    }
+}
+
+private actor OrderedWriteProbe: CurrentCapabilitiesTransport {
+    private var values: [SettingJSONValue] = []
+    private var identities: [HTTPRequestIdentity] = []
+    private var inFlight = 0
+    private var maxInFlight = 0
+    private var completedWrites = 0
+    private var firstWriteReleased = false
+    private var firstWriteGate: CheckedContinuation<Void, Never>?
+    private var startedWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+    private var completedWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+
+    func effectiveValues(
+        keys: [SettingKey],
+        requestIdentity: HTTPRequestIdentity
+    ) async throws -> EffectiveSettingValuesResponse {
+        EffectiveSettingValuesResponse(settings: [], revision: SettingKey.revision)
+    }
+
+    func putValue(
+        key: SettingKey,
+        scope: SettingScopeIdentity,
+        value: SettingJSONValue,
+        mutationId: String,
+        requestIdentity: HTTPRequestIdentity
+    ) async throws {
+        inFlight += 1
+        maxInFlight = max(maxInFlight, inFlight)
+        values.append(value)
+        identities.append(requestIdentity)
+        let ordinal = values.count
+        resumeStartedWaiters()
+
+        if ordinal == 1, !firstWriteReleased {
+            await withCheckedContinuation { continuation in
+                if firstWriteReleased {
+                    continuation.resume()
+                } else {
+                    firstWriteGate = continuation
+                }
+            }
+        }
+
+        inFlight -= 1
+        completedWrites += 1
+        resumeCompletedWaiters()
+    }
+
+    func waitForStartedWrites(_ count: Int) async {
+        guard values.count < count else { return }
+        await withCheckedContinuation { continuation in
+            startedWaiters.append((count, continuation))
+        }
+    }
+
+    func waitForCompletedWrites(_ count: Int) async {
+        guard completedWrites < count else { return }
+        await withCheckedContinuation { continuation in
+            completedWaiters.append((count, continuation))
+        }
+    }
+
+    func releaseFirstWrite() {
+        firstWriteReleased = true
+        firstWriteGate?.resume()
+        firstWriteGate = nil
+    }
+
+    func snapshot() -> (
+        values: [SettingJSONValue],
+        identities: [HTTPRequestIdentity],
+        maxInFlight: Int
+    ) {
+        (values, identities, maxInFlight)
+    }
+
+    private func resumeStartedWaiters() {
+        let ready = startedWaiters.filter { values.count >= $0.0 }
+        startedWaiters.removeAll { values.count >= $0.0 }
+        ready.forEach { $0.1.resume() }
+    }
+
+    private func resumeCompletedWaiters() {
+        let ready = completedWaiters.filter { completedWrites >= $0.0 }
+        completedWaiters.removeAll { completedWrites >= $0.0 }
+        ready.forEach { $0.1.resume() }
+    }
+}
+
+private actor AcceptedMenuCrashProbe: CurrentCapabilitiesTransport {
+    private var storedShortcuts: [PrimaryMenuItem] = []
+    private var menuWriteStarted = false
+    private var menuWriteCompleted = false
+    private var menuWriteGate: CheckedContinuation<Void, Never>?
+    private var startedWaiters: [CheckedContinuation<Void, Never>] = []
+    private var completedWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func effectiveValues(
+        keys: [SettingKey],
+        requestIdentity: HTTPRequestIdentity
+    ) async throws -> EffectiveSettingValuesResponse {
+        EffectiveSettingValuesResponse(settings: [], revision: SettingKey.revision)
+    }
+
+    func putShortcutItem(
+        _ item: PrimaryMenuItem,
+        present: Bool,
+        mutationId: String,
+        requestIdentity: HTTPRequestIdentity
+    ) async throws {
+        storedShortcuts.removeAll { $0.id == item.id }
+        if present { storedShortcuts.append(item) }
+    }
+
+    func putValue(
+        key: SettingKey,
+        scope: SettingScopeIdentity,
+        value: SettingJSONValue,
+        mutationId: String,
+        requestIdentity: HTTPRequestIdentity
+    ) async throws {
+        guard key == .navPrimaryMenu else { return }
+        menuWriteStarted = true
+        let waiters = startedWaiters
+        startedWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+        await withCheckedContinuation { continuation in
+            menuWriteGate = continuation
+        }
+        menuWriteCompleted = true
+        let completed = completedWaiters
+        completedWaiters.removeAll()
+        completed.forEach { $0.resume() }
+    }
+
+    func waitForMenuWriteStarted() async {
+        guard !menuWriteStarted else { return }
+        await withCheckedContinuation { continuation in
+            startedWaiters.append(continuation)
+        }
+    }
+
+    func releaseMenuWrite() {
+        menuWriteGate?.resume()
+        menuWriteGate = nil
+    }
+
+    func waitForMenuWriteCompleted() async {
+        guard !menuWriteCompleted else { return }
+        await withCheckedContinuation { continuation in
+            completedWaiters.append(continuation)
+        }
+    }
+}
+
+private actor SelectiveFailureWriteProbe: CurrentCapabilitiesTransport {
+    private let failingKey: SettingKey?
+    private let failingShortcutIds: Set<String>
+    private let effectiveResponse: EffectiveSettingValuesResponse
+    private var keys: [SettingKey] = []
+    private var shortcutIds: [String] = []
+    private var wholeShortcutPuts = 0
+    private var completedWrites = 0
+    private var completedWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+
+    init(failingKey: SettingKey) {
+        self.failingKey = failingKey
+        failingShortcutIds = []
+        effectiveResponse = .init(settings: [], revision: SettingKey.revision)
+    }
+
+    init(
+        failingShortcutIds: Set<String>,
+        effectiveResponse: EffectiveSettingValuesResponse = .init(
+            settings: [],
+            revision: SettingKey.revision
+        )
+    ) {
+        failingKey = nil
+        self.failingShortcutIds = failingShortcutIds
+        self.effectiveResponse = effectiveResponse
+    }
+
+    func effectiveValues(
+        keys: [SettingKey],
+        requestIdentity: HTTPRequestIdentity
+    ) async throws -> EffectiveSettingValuesResponse {
+        effectiveResponse
+    }
+
+    func putValue(
+        key: SettingKey,
+        scope: SettingScopeIdentity,
+        value: SettingJSONValue,
+        mutationId: String,
+        requestIdentity: HTTPRequestIdentity
+    ) async throws {
+        keys.append(key)
+        if key == .navShortcuts { wholeShortcutPuts += 1 }
+        defer { completeWrite() }
+        if key == failingKey {
+            throw URLError(.notConnectedToInternet)
+        }
+    }
+
+    func putShortcutItem(
+        _ item: PrimaryMenuItem,
+        present: Bool,
+        mutationId: String,
+        requestIdentity: HTTPRequestIdentity
+    ) async throws {
+        keys.append(.navShortcuts)
+        shortcutIds.append(item.id)
+        defer { completeWrite() }
+        if failingKey == .navShortcuts || failingShortcutIds.contains(item.id) {
+            throw URLError(.notConnectedToInternet)
+        }
+    }
+
+    func waitForCompletedWrites(_ count: Int) async {
+        guard completedWrites < count else { return }
+        await withCheckedContinuation { continuation in
+            completedWaiters.append((count, continuation))
+        }
+    }
+
+    func writtenKeys() -> [SettingKey] {
+        keys
+    }
+
+    func wholeShortcutPutCount() -> Int {
+        wholeShortcutPuts
+    }
+
+    func shortcutItemIds() -> [String] {
+        shortcutIds
+    }
+
+    private func completeWrite() {
+        completedWrites += 1
+        let ready = completedWaiters.filter { completedWrites >= $0.0 }
+        completedWaiters.removeAll { completedWrites >= $0.0 }
+        ready.forEach { $0.1.resume() }
+    }
+}
+
+private actor ShortcutOrderingProbe: CurrentCapabilitiesTransport {
+    enum Outcome: Sendable {
+        case success
+        case transientFailure
+        case definitiveFailure
+    }
+
+    struct ShortcutAttempt: Sendable {
+        let item: PrimaryMenuItem
+        let present: Bool
+    }
+
+    private var outcomes: [String: [Outcome]]
+    private var shortcutAttempts: [ShortcutAttempt] = []
+    private var storedShortcuts: [PrimaryMenuItem]
+    private var storedMenu: PrimaryMenuPreference
+    private var menuWrites: [PrimaryMenuPreference] = []
+    private var completedWrites = 0
+    private var completedWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+    private let effectiveFails: Bool
+
+    init(
+        outcomes: [String: [Outcome]],
+        initialMenu: PrimaryMenuPreference = .init(items: [.builtin(.home)]),
+        initialShortcuts: [PrimaryMenuItem] = [],
+        effectiveFails: Bool = false
+    ) {
+        self.outcomes = outcomes
+        storedMenu = initialMenu
+        storedShortcuts = initialShortcuts
+        self.effectiveFails = effectiveFails
+    }
+
+    func effectiveValues(
+        keys: [SettingKey],
+        requestIdentity: HTTPRequestIdentity
+    ) async throws -> EffectiveSettingValuesResponse {
+        if effectiveFails { throw URLError(.notConnectedToInternet) }
+        return EffectiveSettingValuesResponse(
+            settings: [
+                EffectiveSettingValue(
+                    key: SettingKey.navPrimaryMenu.rawValue,
+                    value: try SettingJSONValue.encoding(storedMenu),
+                    source: .scope(.profileClient),
+                    scope: .profileClient,
+                    profileId: "profile",
+                    clientFamily: "tv"
+                ),
+                EffectiveSettingValue(
+                    key: SettingKey.navShortcuts.rawValue,
+                    value: try SettingJSONValue.encoding(
+                        NavigationShortcutsPreference(items: storedShortcuts)
+                    ),
+                    source: .scope(.profile),
+                    scope: .profile,
+                    profileId: "profile"
+                ),
+            ],
+            revision: SettingKey.revision
+        )
+    }
+
+    func putShortcutItem(
+        _ item: PrimaryMenuItem,
+        present: Bool,
+        mutationId: String,
+        requestIdentity: HTTPRequestIdentity
+    ) async throws {
+        shortcutAttempts.append(.init(item: item, present: present))
+        let outcome: Outcome
+        if var remaining = outcomes[item.id], !remaining.isEmpty {
+            outcome = remaining.removeFirst()
+            outcomes[item.id] = remaining
+        } else {
+            outcome = .success
+        }
+        defer { completeWrite() }
+        switch outcome {
+        case .success:
+            storedShortcuts.removeAll { $0.id == item.id }
+            if present { storedShortcuts.append(item) }
+        case .transientFailure:
+            throw URLError(.notConnectedToInternet)
+        case .definitiveFailure:
+            throw SettingsAPIError.invalidValue(message: "shortcut rejected")
+        }
+    }
+
+    func putValue(
+        key: SettingKey,
+        scope: SettingScopeIdentity,
+        value: SettingJSONValue,
+        mutationId: String,
+        requestIdentity: HTTPRequestIdentity
+    ) async throws {
+        defer { completeWrite() }
+        guard key == .navPrimaryMenu else { return }
+        let menu = try value.decoded(as: PrimaryMenuPreference.self)
+        storedMenu = menu
+        menuWrites.append(menu)
+    }
+
+    func waitForCompletedWrites(_ count: Int) async {
+        guard completedWrites < count else { return }
+        await withCheckedContinuation { continuation in
+            completedWaiters.append((count, continuation))
+        }
+    }
+
+    func snapshot() -> (
+        shortcutAttempts: [ShortcutAttempt],
+        menuWrites: [PrimaryMenuPreference]
+    ) {
+        (shortcutAttempts, menuWrites)
+    }
+
+    private func completeWrite() {
+        completedWrites += 1
+        let ready = completedWaiters.filter { completedWrites >= $0.0 }
+        completedWaiters.removeAll { completedWrites >= $0.0 }
+        ready.forEach { $0.1.resume() }
+    }
+}
+
+private actor DefinitiveShortcutRejectionProbe: CurrentCapabilitiesTransport {
+    private var didReject = false
+    private var shortcutWriteAttempts = 0
+    private var effectiveReads = 0
+    private var primaryMenuWriteAttempts = 0
+    private var completedWrites = 0
+    private var completedWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+
+    func effectiveValues(
+        keys: [SettingKey],
+        requestIdentity: HTTPRequestIdentity
+    ) async throws -> EffectiveSettingValuesResponse {
+        effectiveReads += 1
+        let shortcutCount = didReject ? 256 : 255
+        let items = (1...shortcutCount).map {
+            PrimaryMenuItem.library(libraryId: $0, label: "Library \($0)")
+        }
+        return EffectiveSettingValuesResponse(
+            settings: [
+                EffectiveSettingValue(
+                    key: SettingKey.navPrimaryMenu.rawValue,
+                    value: try SettingJSONValue.encoding(
+                        PrimaryMenuPreference(items: [.builtin(.home)])
+                    ),
+                    source: .scope(.profileClient),
+                    scope: .profileClient,
+                    profileId: "profile",
+                    clientFamily: "tv"
+                ),
+                EffectiveSettingValue(
+                    key: SettingKey.navShortcuts.rawValue,
+                    value: try SettingJSONValue.encoding(
+                        NavigationShortcutsPreference(items: items)
+                    ),
+                    source: .scope(.profile),
+                    scope: .profile,
+                    profileId: "profile"
+                ),
+            ],
+            revision: SettingKey.revision
+        )
+    }
+
+    func putShortcutItem(
+        _ item: PrimaryMenuItem,
+        present: Bool,
+        mutationId: String,
+        requestIdentity: HTTPRequestIdentity
+    ) async throws {
+        shortcutWriteAttempts += 1
+        didReject = true
+        completeWrite()
+        throw SettingsAPIError.invalidValue(
+            message: "items must contain at most 256 entries"
+        )
+    }
+
+    func putValue(
+        key: SettingKey,
+        scope: SettingScopeIdentity,
+        value: SettingJSONValue,
+        mutationId: String,
+        requestIdentity: HTTPRequestIdentity
+    ) async throws {
+        if key == .navPrimaryMenu {
+            primaryMenuWriteAttempts += 1
+        }
+    }
+
+    func waitForCompletedWrites(_ count: Int) async {
+        guard completedWrites < count else { return }
+        await withCheckedContinuation { continuation in
+            completedWaiters.append((count, continuation))
+        }
+    }
+
+    func snapshot() -> (
+        shortcutWriteAttempts: Int,
+        effectiveReads: Int,
+        primaryMenuWriteAttempts: Int
+    ) {
+        (shortcutWriteAttempts, effectiveReads, primaryMenuWriteAttempts)
+    }
+
+    private func completeWrite() {
+        completedWrites += 1
+        let ready = completedWaiters.filter { completedWrites >= $0.0 }
+        completedWaiters.removeAll { completedWrites >= $0.0 }
+        ready.forEach { $0.1.resume() }
+    }
+}
+
+private actor RecoveringWriteProbe: CurrentCapabilitiesTransport {
+    private var isOnline = false
+    private var putAttempts = 0
+    private var putWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+    private var events: [String] = []
+    private var mutationIds: [String] = []
+    private var storedPresentation = CardPresentationPreference.standard
+
+    func effectiveValues(
+        keys: [SettingKey],
+        requestIdentity: HTTPRequestIdentity
+    ) async throws -> EffectiveSettingValuesResponse {
+        events.append("effective")
+        return EffectiveSettingValuesResponse(
+            settings: [
+                EffectiveSettingValue(
+                    key: SettingKey.uiCardPresentation.rawValue,
+                    value: try SettingJSONValue.encoding(storedPresentation),
+                    source: .scope(.profileClient),
+                    scope: .profileClient,
+                    profileId: "profile",
+                    clientFamily: "mobile"
+                ),
+            ],
+            revision: SettingKey.revision
+        )
+    }
+
+    func putValue(
+        key: SettingKey,
+        scope: SettingScopeIdentity,
+        value: SettingJSONValue,
+        mutationId: String,
+        requestIdentity: HTTPRequestIdentity
+    ) async throws {
+        putAttempts += 1
+        mutationIds.append(mutationId)
+        let ready = putWaiters.filter { putAttempts >= $0.0 }
+        putWaiters.removeAll { putAttempts >= $0.0 }
+        ready.forEach { $0.1.resume() }
+
+        guard isOnline else {
+            events.append("put-failed")
+            throw URLError(.notConnectedToInternet)
+        }
+        if key == .uiCardPresentation {
+            storedPresentation = try value.decoded(as: CardPresentationPreference.self)
+        }
+        events.append("put-succeeded")
+    }
+
+    func waitForPutAttempts(_ count: Int) async {
+        guard putAttempts < count else { return }
+        await withCheckedContinuation { continuation in
+            putWaiters.append((count, continuation))
+        }
+    }
+
+    func setOnline() {
+        isOnline = true
+    }
+
+    func snapshot() -> (
+        events: [String],
+        mutationIds: [String],
+        storedPresentation: CardPresentationPreference
+    ) {
+        (events, mutationIds, storedPresentation)
+    }
+}
+
+private actor RecoveringShortcutProbe: CurrentCapabilitiesTransport {
+    struct Operation: Sendable {
+        let item: PrimaryMenuItem
+        let present: Bool
+        let mutationId: String
+    }
+
+    private var isOnline = false
+    private var shortcutOperations: [Operation] = []
+    private var shortcutWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+    private var genericPutCount = 0
+    private var genericPutWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+    private var events: [String] = []
+    private var storedShortcuts: [PrimaryMenuItem] = []
+    private let offlineFailure: SettingsAPIError?
+
+    init(offlineFailure: SettingsAPIError? = nil) {
+        self.offlineFailure = offlineFailure
+    }
+
+    func effectiveValues(
+        keys: [SettingKey],
+        requestIdentity: HTTPRequestIdentity
+    ) async throws -> EffectiveSettingValuesResponse {
+        events.append("effective")
+        return EffectiveSettingValuesResponse(
+            settings: [
+                EffectiveSettingValue(
+                    key: SettingKey.navShortcuts.rawValue,
+                    value: try SettingJSONValue.encoding(
+                        NavigationShortcutsPreference(items: storedShortcuts)
+                    ),
+                    source: .scope(.profile),
+                    scope: .profile,
+                    profileId: "profile"
+                ),
+            ],
+            revision: SettingKey.revision
+        )
+    }
+
+    func putShortcutItem(
+        _ item: PrimaryMenuItem,
+        present: Bool,
+        mutationId: String,
+        requestIdentity: HTTPRequestIdentity
+    ) async throws {
+        shortcutOperations.append(.init(item: item, present: present, mutationId: mutationId))
+        resumeShortcutWaiters()
+        guard isOnline else {
+            events.append("shortcut-failed")
+            if let offlineFailure {
+                throw offlineFailure
+            }
+            throw URLError(.notConnectedToInternet)
+        }
+        apply(item: item, present: present)
+        events.append("shortcut-succeeded")
+    }
+
+    func putValue(
+        key: SettingKey,
+        scope: SettingScopeIdentity,
+        value: SettingJSONValue,
+        mutationId: String,
+        requestIdentity: HTTPRequestIdentity
+    ) async throws {
+        genericPutCount += 1
+        events.append("put-\(key.rawValue)")
+        let ready = genericPutWaiters.filter { genericPutCount >= $0.0 }
+        genericPutWaiters.removeAll { genericPutCount >= $0.0 }
+        ready.forEach { $0.1.resume() }
+    }
+
+    func waitForShortcutAttempts(_ count: Int) async {
+        guard shortcutOperations.count < count else { return }
+        await withCheckedContinuation { continuation in
+            shortcutWaiters.append((count, continuation))
+        }
+    }
+
+    func waitForGenericPuts(_ count: Int) async {
+        guard genericPutCount < count else { return }
+        await withCheckedContinuation { continuation in
+            genericPutWaiters.append((count, continuation))
+        }
+    }
+
+    func setOnline() {
+        isOnline = true
+    }
+
+    func snapshot() -> (
+        events: [String],
+        shortcutOperations: [Operation],
+        storedShortcuts: [PrimaryMenuItem],
+        genericPutCount: Int
+    ) {
+        (events, shortcutOperations, storedShortcuts, genericPutCount)
+    }
+
+    private func resumeShortcutWaiters() {
+        let ready = shortcutWaiters.filter { shortcutOperations.count >= $0.0 }
+        shortcutWaiters.removeAll { shortcutOperations.count >= $0.0 }
+        ready.forEach { $0.1.resume() }
+    }
+
+    private func apply(item: PrimaryMenuItem, present: Bool) {
+        storedShortcuts.removeAll { $0.id == item.id }
+        if present { storedShortcuts.append(item) }
+    }
+}
+
+private actor BlockingShortcutProbe: CurrentCapabilitiesTransport {
+    struct Operation: Sendable {
+        let item: PrimaryMenuItem
+        let present: Bool
+        let mutationId: String
+    }
+
+    private var shortcutOperations: [Operation] = []
+    private var storedShortcuts: [PrimaryMenuItem] = []
+    private var completedShortcutOperations = 0
+    private var genericPutCount = 0
+    private var menuWrites: [PrimaryMenuPreference] = []
+    private var firstOperationReleased = false
+    private var firstOperationGate: CheckedContinuation<Void, Never>?
+    private var startedWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+    private var completedWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+    private var genericPutWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+
+    func effectiveValues(
+        keys: [SettingKey],
+        requestIdentity: HTTPRequestIdentity
+    ) async throws -> EffectiveSettingValuesResponse {
+        EffectiveSettingValuesResponse(
+            settings: [
+                EffectiveSettingValue(
+                    key: SettingKey.navShortcuts.rawValue,
+                    value: try SettingJSONValue.encoding(
+                        NavigationShortcutsPreference(items: storedShortcuts)
+                    ),
+                    source: .scope(.profile),
+                    scope: .profile,
+                    profileId: "profile"
+                ),
+            ],
+            revision: SettingKey.revision
+        )
+    }
+
+    func putShortcutItem(
+        _ item: PrimaryMenuItem,
+        present: Bool,
+        mutationId: String,
+        requestIdentity: HTTPRequestIdentity
+    ) async throws {
+        shortcutOperations.append(.init(item: item, present: present, mutationId: mutationId))
+        let ordinal = shortcutOperations.count
+        resumeStartedWaiters()
+        if ordinal == 1, !firstOperationReleased {
+            await withCheckedContinuation { continuation in
+                if firstOperationReleased {
+                    continuation.resume()
+                } else {
+                    firstOperationGate = continuation
+                }
+            }
+        }
+        storedShortcuts.removeAll { $0.id == item.id }
+        if present { storedShortcuts.append(item) }
+        completedShortcutOperations += 1
+        resumeCompletedWaiters()
+    }
+
+    func putValue(
+        key: SettingKey,
+        scope: SettingScopeIdentity,
+        value: SettingJSONValue,
+        mutationId: String,
+        requestIdentity: HTTPRequestIdentity
+    ) async throws {
+        genericPutCount += 1
+        if key == .navPrimaryMenu {
+            menuWrites.append(try value.decoded(as: PrimaryMenuPreference.self))
+        }
+        let ready = genericPutWaiters.filter { genericPutCount >= $0.0 }
+        genericPutWaiters.removeAll { genericPutCount >= $0.0 }
+        ready.forEach { $0.1.resume() }
+    }
+
+    func waitForStartedShortcutOperations(_ count: Int) async {
+        guard shortcutOperations.count < count else { return }
+        await withCheckedContinuation { continuation in
+            startedWaiters.append((count, continuation))
+        }
+    }
+
+    func waitForCompletedShortcutOperations(_ count: Int) async {
+        guard completedShortcutOperations < count else { return }
+        await withCheckedContinuation { continuation in
+            completedWaiters.append((count, continuation))
+        }
+    }
+
+    func waitForGenericPuts(_ count: Int) async {
+        guard genericPutCount < count else { return }
+        await withCheckedContinuation { continuation in
+            genericPutWaiters.append((count, continuation))
+        }
+    }
+
+    func releaseFirstShortcutOperation() {
+        firstOperationReleased = true
+        firstOperationGate?.resume()
+        firstOperationGate = nil
+    }
+
+    func snapshot() -> (
+        shortcutOperations: [Operation],
+        storedShortcuts: [PrimaryMenuItem],
+        genericPutCount: Int,
+        menuWrites: [PrimaryMenuPreference]
+    ) {
+        (shortcutOperations, storedShortcuts, genericPutCount, menuWrites)
+    }
+
+    private func resumeStartedWaiters() {
+        let ready = startedWaiters.filter { shortcutOperations.count >= $0.0 }
+        startedWaiters.removeAll { shortcutOperations.count >= $0.0 }
+        ready.forEach { $0.1.resume() }
+    }
+
+    private func resumeCompletedWaiters() {
+        let ready = completedWaiters.filter { completedShortcutOperations >= $0.0 }
+        completedWaiters.removeAll { completedShortcutOperations >= $0.0 }
+        ready.forEach { $0.1.resume() }
+    }
+}

--- a/iosApp/iosApp/Components/AdaptiveLayout.swift
+++ b/iosApp/iosApp/Components/AdaptiveLayout.swift
@@ -7,18 +7,44 @@ import SwiftUI
 /// and landscape report `.regular` and get 5 columns, so posters render at
 /// their intended density instead of stretching to nearly 2× width.
 ///
-/// tvOS views use their own hand-tuned column counts (see `TVCatalogGrid`)
-/// and don't consume this helper.
 enum AdaptiveColumns {
     static func posters(
         for sizeClass: UserInterfaceSizeClass?,
+        posterSize: CardPosterSize = .standard,
         spacing: CGFloat = 12
     ) -> [GridItem] {
-        let count = (sizeClass == .regular) ? 5 : 3
+        let standardCount = (sizeClass == .regular) ? 5 : 3
+        let count: Int
+        switch posterSize {
+        case .compact:
+            count = sizeClass == .regular ? standardCount + 1 : standardCount
+        case .standard:
+            count = standardCount
+        case .large:
+            count = max(2, standardCount - 1)
+        }
         return Array(
             repeating: GridItem(.flexible(), spacing: spacing),
             count: count
         )
+    }
+
+    /// Keeps tvOS poster grids dense enough for compact artwork while making
+    /// room for large artwork and its native focus lift. Six columns is the
+    /// safe upper bound inside the standard 1,760-point content width.
+    static func tvPosterCount(
+        standardCount: Int,
+        posterSize: CardPosterSize,
+        minimumCount: Int = 3
+    ) -> Int {
+        switch posterSize {
+        case .compact:
+            return min(6, standardCount + 1)
+        case .standard:
+            return standardCount
+        case .large:
+            return max(minimumCount, standardCount - 1)
+        }
     }
 }
 
@@ -32,4 +58,3 @@ extension View {
             .frame(maxWidth: .infinity, alignment: .center)
     }
 }
-

--- a/iosApp/iosApp/Components/EpisodeThumbCard.swift
+++ b/iosApp/iosApp/Components/EpisodeThumbCard.swift
@@ -21,6 +21,7 @@ struct EpisodeThumbCard: View {
     var onSetWatched: ((Bool) async -> Bool)? = nil
 
     @State private var playedOverride: Bool?
+    @State private var uiCustomization = UICustomizationPreferences.shared
     @EnvironmentObject private var overlayStore: OverlayPrefsStore
     /// iOS 26 zoom transition namespace, shared from `MainTabView`. Lets the
     /// tapped thumbnail act as the `.matchedTransitionSource` for the zoom into
@@ -34,8 +35,12 @@ struct EpisodeThumbCard: View {
     @State private var zoomInstanceID = UUID()
     #endif
 
-    private var cardWidth: CGFloat { ContinuumTheme.thumbnailCardWidth }
-    private var cardHeight: CGFloat { ContinuumTheme.thumbnailCardHeight }
+    private var cardWidth: CGFloat {
+        ContinuumTheme.thumbnailCardWidth * uiCustomization.cardPresentation.posterSize.scale
+    }
+    private var cardHeight: CGFloat {
+        cardWidth * (ContinuumTheme.thumbnailCardHeight / ContinuumTheme.thumbnailCardWidth)
+    }
 
     #if os(tvOS)
     @FocusState private var isFocused: Bool
@@ -46,21 +51,28 @@ struct EpisodeThumbCard: View {
         VStack(alignment: .leading, spacing: 14) {
             thumbnailButton
 
-            VStack(alignment: .leading, spacing: 4) {
-                Text(displayTitle)
-                    .font(.continuumSubheadline)
-                    .foregroundColor(isFocused ? .continuumOnSurface : .continuumOnSurface.opacity(0.85))
-                    .lineLimit(1)
-                    .animation(.easeOut(duration: 0.15), value: isFocused)
-
-                if let subtitle = subtitleLine {
-                    Text(subtitle)
-                        .font(.continuumCaption)
-                        .foregroundColor(.continuumSecondaryText)
+            if uiCustomization.cardPresentation.caption.showsTitle {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(displayTitle)
+                        .font(.continuumSubheadline)
+                        .foregroundStyle(
+                            isFocused
+                                ? Color.continuumOnSurface
+                                : Color.continuumOnSurface.opacity(0.85)
+                        )
                         .lineLimit(1)
+                        .animation(.easeOut(duration: 0.15), value: isFocused)
+
+                    if uiCustomization.cardPresentation.caption.showsMetadata,
+                       let subtitle = subtitleLine {
+                        Text(subtitle)
+                            .font(.continuumCaption)
+                            .foregroundStyle(Color.continuumSecondaryText)
+                            .lineLimit(1)
+                    }
                 }
+                .frame(width: cardWidth, alignment: .leading)
             }
-            .frame(width: cardWidth, alignment: .leading)
         }
         .frame(width: cardWidth)
         .focusSection()
@@ -92,11 +104,14 @@ struct EpisodeThumbCard: View {
         } label: {
             VStack(alignment: .leading, spacing: 6) {
                 thumbnail
-                Text(displayTitle)
-                    .font(.continuumSubheadline)
-                    .foregroundColor(.continuumOnSurface)
-                    .lineLimit(1)
-                if let subtitle = subtitleLine {
+                if uiCustomization.cardPresentation.caption.showsTitle {
+                    Text(displayTitle)
+                        .font(.continuumSubheadline)
+                        .foregroundStyle(Color.continuumOnSurface)
+                        .lineLimit(1)
+                }
+                if uiCustomization.cardPresentation.caption.showsMetadata,
+                   let subtitle = subtitleLine {
                     Text(subtitle)
                         .font(.continuumCaption)
                         .foregroundColor(.continuumSecondaryText)
@@ -106,6 +121,8 @@ struct EpisodeThumbCard: View {
             .zoomTransitionSource(id: zoomInstanceID.uuidString, in: zoomNamespace)
         }
         .buttonStyle(.plain)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityDescription)
     }
     #endif
 
@@ -224,6 +241,20 @@ struct EpisodeThumbCard: View {
         return nil
     }
 
+    private var accessibilityDescription: String {
+        var components = [displayTitle]
+        if let episodeBadge {
+            components.append(episodeBadge)
+        }
+        if let subtitleLine {
+            components.append(subtitleLine)
+        }
+        if isPlayed {
+            components.append("Watched")
+        }
+        return components.joined(separator: ", ")
+    }
+
     /// "S1 · E4" badge if we have season+episode numbers.
     private var episodeBadge: String? {
         if let season = item.seasonNumber, let episode = item.episodeNumber {
@@ -294,6 +325,8 @@ struct EpisodeThumbCard: View {
         .focused($isFocused)
         .applyRowFocus(focusedItemId, itemId: item.contentId)
         .applyEpisodePlayPauseAction(playAction)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityDescription)
 
         thumbnailButtonWithContext(button)
     }

--- a/iosApp/iosApp/Components/ErrorState.swift
+++ b/iosApp/iosApp/Components/ErrorState.swift
@@ -48,6 +48,8 @@ struct ErrorState: Equatable {
         switch httpError {
         case .serverUrlNotConfigured:
             return "No server is configured."
+        case .requestIdentityChanged:
+            return "The active server or profile changed. Try again."
         case .invalidURL:
             return "The request URL was invalid."
         case .invalidResponse:

--- a/iosApp/iosApp/Components/MediaCard.swift
+++ b/iosApp/iosApp/Components/MediaCard.swift
@@ -35,7 +35,8 @@ func episodeRailAccessibilityLabel(
     isCurrent: Bool,
     isPlayed: Bool
 ) -> String {
-    var components = ["Season \(seasonNumber), Episode \(episodeNumber)"]
+    let seasonLabel = seasonNumber == 0 ? "Specials" : "Season \(seasonNumber)"
+    var components = ["\(seasonLabel), Episode \(episodeNumber)"]
     if let title, !title.isEmpty {
         components.append(title)
     }

--- a/iosApp/iosApp/Components/MediaCard.swift
+++ b/iosApp/iosApp/Components/MediaCard.swift
@@ -8,6 +8,49 @@ enum MediaCardAspect {
     case square
 }
 
+func mediaCardAccessibilityLabel(
+    title: String,
+    episodeBadge: String?,
+    year: Int?,
+    isWatched: Bool
+) -> String {
+    var components = [title]
+    if let episodeBadge, !episodeBadge.isEmpty {
+        components.append(episodeBadge)
+    }
+    if let year {
+        components.append(String(year))
+    }
+    if isWatched {
+        components.append("Watched")
+    }
+    return components.joined(separator: ", ")
+}
+
+func episodeRailAccessibilityLabel(
+    seasonNumber: Int,
+    episodeNumber: Int,
+    title: String?,
+    metadata: String?,
+    isCurrent: Bool,
+    isPlayed: Bool
+) -> String {
+    var components = ["Season \(seasonNumber), Episode \(episodeNumber)"]
+    if let title, !title.isEmpty {
+        components.append(title)
+    }
+    if let metadata, !metadata.isEmpty {
+        components.append(metadata)
+    }
+    if isCurrent {
+        components.append("Now viewing")
+    }
+    if isPlayed {
+        components.append("Watched")
+    }
+    return components.joined(separator: ", ")
+}
+
 /// A poster-style media card with title, year, and optional progress.
 /// On tvOS the card uses `.buttonStyle(.card)` which gives proper focus lift,
 /// parallax, and title reveal — no manual focus effects required.
@@ -53,6 +96,7 @@ struct MediaCard: View {
     @State private var playedOverride: Bool?
     @State private var favoriteOverride: Bool?
     @State private var watchlistOverride: Bool?
+    @State private var uiCustomization = UICustomizationPreferences.shared
     @EnvironmentObject private var overlayStore: OverlayPrefsStore
     /// iOS 26 zoom transition namespace, shared from `MainTabView`. When
     /// present (and `contentId` is non-nil) the poster acts as the
@@ -70,7 +114,10 @@ struct MediaCard: View {
     @State private var zoomInstanceID = UUID()
     #endif
 
-    private var cardWidth: CGFloat { cardWidthOverride ?? ContinuumTheme.posterCardWidth }
+    private var cardWidth: CGFloat {
+        (cardWidthOverride ?? ContinuumTheme.posterCardWidth)
+            * uiCustomization.cardPresentation.posterSize.scale
+    }
     private var cardHeight: CGFloat {
         switch aspect {
         case .poster:
@@ -87,6 +134,8 @@ struct MediaCard: View {
         FocusableMediaCard(
             title: title,
             year: year,
+            episodeBadge: episodeBadge,
+            captionStyle: uiCustomization.cardPresentation.caption,
             cardWidth: cardWidth,
             action: action,
             playAction: playAction,
@@ -151,6 +200,8 @@ struct MediaCard: View {
                 .buttonStyle(.plain)
             }
         }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityDescription)
     }
 
     private var hasIOSContextActions: Bool {
@@ -258,8 +309,12 @@ struct MediaCard: View {
     private var cardContent: some View {
         VStack(alignment: .leading, spacing: 4) {
             posterImage
-            titleText
-            yearText
+            if uiCustomization.cardPresentation.caption.showsTitle {
+                titleText
+            }
+            if uiCustomization.cardPresentation.caption.showsMetadata {
+                yearText
+            }
         }
     }
 
@@ -337,6 +392,15 @@ struct MediaCard: View {
 
     private var isPlayed: Bool {
         playedOverride ?? (userState?.played == true)
+    }
+
+    private var accessibilityDescription: String {
+        mediaCardAccessibilityLabel(
+            title: title,
+            episodeBadge: episodeBadge,
+            year: year,
+            isWatched: isPlayed
+        )
     }
 
     private var titleText: some View {
@@ -435,6 +499,8 @@ extension View {
 private struct FocusableMediaCard<Content: View>: View {
     let title: String
     let year: Int?
+    let episodeBadge: String?
+    let captionStyle: CardCaptionStyle
     let cardWidth: CGFloat
     let action: () -> Void
     let playAction: (() -> Void)?
@@ -458,23 +524,29 @@ private struct FocusableMediaCard<Content: View>: View {
         VStack(alignment: .leading, spacing: 22) {
             mediaButton
 
-            VStack(alignment: .leading, spacing: 4) {
-                Text(title)
-                    .font(.continuumSubheadline)
-                    .foregroundColor(isFocused ? .continuumOnSurface : .continuumOnSurface.opacity(0.85))
-                    // Single line, truncated — keeps poster cards a uniform
-                    // height and the row short under the bottom-anchored marquee.
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                    .animation(.easeOut(duration: 0.15), value: isFocused)
+            if captionStyle.showsTitle {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.continuumSubheadline)
+                        .foregroundStyle(
+                            isFocused
+                                ? Color.continuumOnSurface
+                                : Color.continuumOnSurface.opacity(0.85)
+                        )
+                        // Single line, truncated — keeps poster cards a uniform
+                        // height and the row short under the bottom-anchored marquee.
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .animation(.easeOut(duration: 0.15), value: isFocused)
 
-                if let year {
-                    Text(String(year))
-                        .font(.continuumCaption)
-                        .foregroundColor(.continuumSecondaryText)
+                    if captionStyle.showsMetadata, let year {
+                        Text(String(year))
+                            .font(.continuumCaption)
+                            .foregroundStyle(Color.continuumSecondaryText)
+                    }
                 }
+                .frame(width: cardWidth, alignment: .leading)
             }
-            .frame(width: cardWidth, alignment: .leading)
         }
         .frame(width: cardWidth)
     }
@@ -488,6 +560,8 @@ private struct FocusableMediaCard<Content: View>: View {
         .focused($isFocused)
         .applyRowFocus(focusedItemId, itemId: itemId)
         .applyPlayPauseAction(playAction)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityDescription)
 
         mediaButtonWithContext(button)
     }
@@ -505,6 +579,15 @@ private struct FocusableMediaCard<Content: View>: View {
 
     private var hasContextActions: Bool {
         onSetWatched != nil || onRemoveFromContinueWatching != nil || personalItems != nil
+    }
+
+    private var accessibilityDescription: String {
+        mediaCardAccessibilityLabel(
+            title: title,
+            episodeBadge: episodeBadge,
+            year: year,
+            isWatched: isWatched
+        )
     }
 
     @ViewBuilder

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -86,13 +86,21 @@ struct ContentView: View {
             }
             #endif
         }
-        .onReceive(NotificationCenter.default.publisher(for: .continuumSessionExpired)) { _ in
-            audioStore.dismissFullPlayer()
-            Task { await audioStore.player.close() }
-            #if !os(tvOS)
-            DownloadManager.shared.clearForSignOut()
-            #endif
-            router.expiredSession()
+        .onReceive(NotificationCenter.default.publisher(for: .continuumSessionExpired)) { notification in
+            guard let event = notification.object as? SessionExpiryEvent,
+                  event.disposition == .persistentSessionCleared else { return }
+            Task { @MainActor in
+                // Delivery is asynchronous. Revalidate at the destructive
+                // consumer so a same-server login that replaced this epoch
+                // after posting cannot be routed back to login.
+                guard await TokenStore.shared.shouldConsumeSessionExpiryEvent(event) else { return }
+                audioStore.dismissFullPlayer()
+                Task { await audioStore.player.close() }
+                #if !os(tvOS)
+                DownloadManager.shared.clearForSignOut()
+                #endif
+                router.expiredSession()
+            }
         }
         #if os(iOS) || os(tvOS)
         .onReceive(NotificationCenter.default.publisher(for: .diagnosticsPendingReportCreated)) { _ in
@@ -101,8 +109,13 @@ struct ContentView: View {
         }
         #endif
         #if os(tvOS)
-        .onReceive(NotificationCenter.default.publisher(for: .temporaryRemoteAuthExpired)) { _ in
-            TVControlReceiver.shared.temporaryAuthExpired()
+        .onReceive(NotificationCenter.default.publisher(for: .temporaryRemoteAuthExpired)) { notification in
+            guard let event = notification.object as? SessionExpiryEvent,
+                  event.disposition == .temporarySessionExpired else { return }
+            Task { @MainActor in
+                guard await TokenStore.shared.shouldConsumeSessionExpiryEvent(event) else { return }
+                TVControlReceiver.shared.temporaryAuthExpired(expected: event)
+            }
         }
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.willTerminateNotification)) { _ in
             ExitSentinel.shared.appWillTerminate()
@@ -165,6 +178,13 @@ struct ContentView: View {
             }
         }
         .task(id: serverRegistry.activeServerId) {
+            // ServerRegistry publishes the destination ID while its identity
+            // transition lease is still held. Wait before reading or
+            // retargeting any server-scoped state so this task cannot race the
+            // final token commit. A superseded SwiftUI task is cancelled while
+            // queued and must perform no work for the stale destination.
+            guard await HTTPClient.shared.waitForRequestDispatchOpen() else { return }
+            guard !Task.isCancelled else { return }
             #if os(iOS) || os(tvOS)
             diagnosticsModel.reset()
             #endif
@@ -876,7 +896,19 @@ func resolvedRequestedMainTabDestination(
     _ requestedTab: AppTab,
     visibleDestinations: [MainTabDestination]
 ) -> MainTabDestinationID {
-    resolvedVisibleMainTabDestination(
+    if requestedTab == .libraries,
+       !visibleDestinations.contains(where: { $0.id == .app(.libraries) }),
+       let authoredLibraryRoot = visibleDestinations.first(where: {
+           switch $0.id {
+           case .libraryCategory, .library:
+               return true
+           case .app:
+               return false
+           }
+       }) {
+        return authoredLibraryRoot.id
+    }
+    return resolvedVisibleMainTabDestination(
         .app(requestedTab),
         visibleDestinations: visibleDestinations
     )

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -26,6 +26,10 @@ struct ContentView: View {
     /// the first .authenticated transition so cards stay visible during
     /// the brief window between sign-in and the overlay-config fetch.
     @StateObject private var overlayPrefs = OverlayPrefsStore.shared
+    /// Server-synced navigation and card presentation for this client family.
+    /// The store paints its offline cache first, then reconciles whenever the
+    /// authenticated server/profile boundary changes.
+    @State private var uiCustomization = UICustomizationPreferences.shared
     /// Used to retry overlay hydration on foreground transitions: if the
     /// initial fetch failed transiently, `hydrateIfNeeded()` will retry
     /// because the store left `hasHydrated == false`. Idempotent when
@@ -151,6 +155,7 @@ struct ContentView: View {
                 // failure-tolerant, so double-calling with `selectProfile` is safe.
                 await AICapabilities.shared.refresh()
                 await RequestsFeatureStore.shared.refresh()
+                await uiCustomization.refresh()
                 #if os(iOS)
                 await ApplePushRegistrationCoordinator.shared.prepareForAuthenticatedProfile()
                 #endif
@@ -172,20 +177,24 @@ struct ContentView: View {
             )
             overlayPrefs.clear()
             if router.authState == .authenticated {
+                await uiCustomization.refresh()
                 await overlayPrefs.hydrateIfNeeded()
                 #if os(iOS) || os(tvOS)
                 await diagnosticsModel.handleForeground()
                 #endif
             }
         }
-        #if os(iOS) || os(tvOS)
         .task(id: serverRegistry.activeProfileId) {
+            #if os(iOS) || os(tvOS)
             diagnosticsModel.reset()
+            #endif
             if router.authState == .authenticated {
+                await uiCustomization.refresh()
+                #if os(iOS) || os(tvOS)
                 await diagnosticsModel.handleForeground()
+                #endif
             }
         }
-        #endif
         .onChange(of: scenePhase) { _, newPhase in
             #if os(iOS) || os(tvOS)
             DiagnosticsCoordinator.recordBreadcrumb(
@@ -247,6 +256,7 @@ struct ContentView: View {
             // happy path costs nothing.
             Task { await AICapabilities.shared.refresh() }
             Task { await RequestsFeatureStore.shared.refresh() }
+            Task { await uiCustomization.refresh() }
             #if os(iOS)
             Task {
                 await ApplePushRegistrationCoordinator.shared.prepareForAuthenticatedProfile()
@@ -738,15 +748,194 @@ extension EnvironmentValues {
 
 // MARK: - Main Tab View
 
+enum MainTabDestinationID: Hashable {
+    case app(AppTab)
+    case libraryCategory(PrimaryMenuBuiltin)
+    case library(Int)
+}
+
+struct MainTabDestination: Identifiable, Equatable {
+    let id: MainTabDestinationID
+    let title: String
+    let icon: String
+    let selectedIcon: String
+
+    static func app(_ tab: AppTab) -> MainTabDestination {
+        .init(id: .app(tab), title: tab.rawValue, icon: tab.icon, selectedIcon: tab.selectedIcon)
+    }
+
+    static func library(id: Int, label: String) -> MainTabDestination {
+        .init(
+            id: .library(id),
+            title: label,
+            icon: "rectangle.stack",
+            selectedIcon: "rectangle.stack.fill"
+        )
+    }
+
+    static func libraryCategory(_ category: PrimaryMenuBuiltin) -> MainTabDestination {
+        let icon: String
+        switch category {
+        case .movies: icon = "film.stack"
+        case .series: icon = "tv"
+        case .audiobooks: icon = "book.closed"
+        default: icon = "rectangle.stack"
+        }
+        return .init(
+            id: .libraryCategory(category),
+            title: category.title,
+            icon: icon,
+            selectedIcon: icon
+        )
+    }
+}
+
+/// Projects the cross-client menu into roots this Apple shell can navigate
+/// without discarding destination identity. Sections and collections remain
+/// stored in the synced document, but stay hidden until this shell has a
+/// destination-specific root for them.
+func projectedMainTabDestinations(
+    primaryMenu: PrimaryMenuPreference?,
+    availableLibraries: [Library] = []
+) -> [MainTabDestination] {
+    guard let primaryMenu else {
+        return AppTab.visibleCases.map(MainTabDestination.app)
+    }
+
+    var destinations: [MainTabDestination] = []
+    for item in primaryMenu.items {
+        guard mainTabSupportsDestination(item, availableLibraries: availableLibraries) else {
+            continue
+        }
+        let destination: MainTabDestination?
+        switch item {
+        case .builtin(.home): destination = .app(.home)
+        case .builtin(.movies): destination = .libraryCategory(.movies)
+        case .builtin(.series): destination = .libraryCategory(.series)
+        case .builtin(.audiobooks): destination = .libraryCategory(.audiobooks)
+        case .builtin(.music): destination = nil
+        case .builtin(.forYou): destination = .app(.recommendations)
+        case .builtin(.calendar): destination = .app(.calendar)
+        case .library(let libraryId, let label):
+            destination = .library(id: libraryId, label: label)
+        case .section, .collection:
+            destination = nil
+        }
+        if let destination,
+           !destinations.contains(where: { $0.id == destination.id }) {
+            destinations.append(destination)
+        }
+    }
+    if !destinations.contains(where: { $0.id == .app(.home) }) {
+        destinations.insert(.app(.home), at: 0)
+    }
+    return destinations
+}
+
+/// Runtime/editor capability gate for the non-tvOS Apple main shell. The
+/// synced document remains untouched; roots that the active profile cannot
+/// currently open simply stay out of the rendered navigation and editor.
+func mainTabSupportsDestination(
+    _ item: PrimaryMenuItem,
+    availableLibraries: [Library]
+) -> Bool {
+    switch item {
+    case .builtin(.movies):
+        return availableLibraries.contains {
+            libraryMatchesPrimaryMenuCategory($0, category: .movies)
+        }
+    case .builtin(.series):
+        return availableLibraries.contains {
+            libraryMatchesPrimaryMenuCategory($0, category: .series)
+        }
+    case .builtin(.audiobooks):
+        return availableLibraries.contains {
+            libraryMatchesPrimaryMenuCategory($0, category: .audiobooks)
+        }
+    case .builtin(.music):
+        return false
+    case .builtin(.home), .builtin(.forYou), .builtin(.calendar):
+        return true
+    case .library(let libraryId, _):
+        return availableLibraries.contains { $0.id == libraryId }
+    case .section, .collection:
+        return false
+    }
+}
+
+func resolvedVisibleMainTabDestination(
+    _ requestedDestination: MainTabDestinationID,
+    visibleDestinations: [MainTabDestination]
+) -> MainTabDestinationID {
+    visibleDestinations.contains { $0.id == requestedDestination }
+        ? requestedDestination
+        : .app(.home)
+}
+
+func resolvedRequestedMainTabDestination(
+    _ requestedTab: AppTab,
+    visibleDestinations: [MainTabDestination]
+) -> MainTabDestinationID {
+    resolvedVisibleMainTabDestination(
+        .app(requestedTab),
+        visibleDestinations: visibleDestinations
+    )
+}
+
+struct MainTabLibraryAuthority: Hashable {
+    let serverId: String
+    let profileId: String
+
+    init?(serverId: String?, profileId: String?) {
+        guard let serverId, !serverId.isEmpty,
+              let profileId, !profileId.isEmpty else { return nil }
+        self.serverId = serverId
+        self.profileId = profileId
+    }
+}
+
+struct MainTabLibrarySnapshot: Equatable {
+    let authority: MainTabLibraryAuthority?
+    let libraries: [Library]
+
+    func availableLibraries(
+        for currentAuthority: MainTabLibraryAuthority?
+    ) -> [Library] {
+        guard let currentAuthority, authority == currentAuthority else { return [] }
+        return libraries
+    }
+
+    @MainActor
+    static func cachedForCurrentAuthority() -> Self {
+        let registry = ServerRegistry.shared
+        let authority = MainTabLibraryAuthority(
+            serverId: registry.activeServerId,
+            profileId: registry.activeProfileId
+        )
+        let libraries = ResponseCache.shared.get(
+            CacheKey.userLibraries,
+            as: LibrariesResponse.self
+        )?.libraries ?? []
+        return .init(authority: authority, libraries: libraries)
+    }
+}
+
 struct MainTabView: View {
     @Bindable var router: AppRouter
-    @State private var selectedTab: AppTab = .home
+    @State private var selectedDestinationID: MainTabDestinationID = .app(.home)
+    @State private var uiCustomization = UICustomizationPreferences.shared
+    @State private var serverRegistry = ServerRegistry.shared
+    /// Tagged with the server/profile that authorized the library list. A
+    /// profile transition fails direct roots closed immediately, even before
+    /// its cache invalidation and network refresh finish.
+    @State private var librarySnapshot = MainTabLibrarySnapshot.cachedForCurrentAuthority()
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
     /// Shared namespace for the poster → detail zoom transition. Injected into
     /// the environment (`\.zoomNamespace`) so both the cards and the central
     /// detail destination resolve the same identity.
     @Namespace private var zoomNamespace
     @Environment(AudioPlaybackStore.self) private var audioStore
+    @Environment(\.scenePhase) private var scenePhase
     #if os(iOS)
     @Environment(SiloControlClient.self) private var siloControl
     #endif
@@ -763,6 +952,14 @@ struct MainTabView: View {
             }
         }
         .tint(.continuumOnSurface)
+        .task(id: currentLibraryAuthority) {
+            await loadVisibleLibraries(for: currentLibraryAuthority)
+        }
+        .onChange(of: scenePhase) { _, phase in
+            guard phase == .active else { return }
+            let authority = currentLibraryAuthority
+            Task { await loadVisibleLibraries(for: authority) }
+        }
         #if !os(tvOS)
         // Mirror Android's offline start-destination: launching with no
         // network but playable local downloads lands on Downloads instead of
@@ -780,9 +977,9 @@ struct MainTabView: View {
                   DownloadManager.shared.records.contains(where: { $0.isPlayableOffline }),
                   // Don't clobber a tab the user (or a deep link) already
                   // selected while this task was waiting.
-                  selectedTab == .home, router.requestedTab == nil
+                  selectedDestinationID == .app(.home), router.requestedTab == nil
             else { return }
-            selectedTab = .downloads
+            selectedDestinationID = .app(.downloads)
         }
         #endif
         #if os(iOS)
@@ -794,8 +991,23 @@ struct MainTabView: View {
         #endif
         .onChange(of: router.requestedTab) { _, tab in
             guard let tab else { return }
-            selectedTab = tab
+            selectedDestinationID = resolvedRequestedMainTabDestination(
+                tab,
+                visibleDestinations: visibleDestinations
+            )
             router.requestedTab = nil
+        }
+        .onChange(of: uiCustomization.primaryMenu) { _, _ in
+            selectedDestinationID = resolvedVisibleMainTabDestination(
+                selectedDestinationID,
+                visibleDestinations: visibleDestinations
+            )
+        }
+        .onChange(of: librarySnapshot) { _, _ in
+            selectedDestinationID = resolvedVisibleMainTabDestination(
+                selectedDestinationID,
+                visibleDestinations: visibleDestinations
+            )
         }
         #if !os(macOS)
         .fullScreenCover(isPresented: Binding(
@@ -846,36 +1058,72 @@ struct MainTabView: View {
     /// downloads capability for this profile. Reading
     /// `DownloadManager.shared.downloadsEnabled` here registers the tab bar
     /// as an observer, so the tab appears as soon as capability loads.
-    private var visibleTabs: [AppTab] {
-        var tabs = AppTab.visibleCases
+    private var visibleDestinations: [MainTabDestination] {
+        var destinations = projectedMainTabDestinations(
+            primaryMenu: uiCustomization.primaryMenu,
+            availableLibraries: librarySnapshot.availableLibraries(
+                for: currentLibraryAuthority
+            )
+        )
         #if !os(tvOS)
-        if DownloadManager.shared.downloadsEnabled {
-            tabs.append(.downloads)
+        if DownloadManager.shared.downloadsEnabled,
+           !destinations.contains(where: { $0.id == .app(.downloads) }) {
+            destinations.append(.app(.downloads))
         }
         #endif
-        return tabs
+        return destinations
+    }
+
+    private var currentLibraryAuthority: MainTabLibraryAuthority? {
+        MainTabLibraryAuthority(
+            serverId: serverRegistry.activeServerId,
+            profileId: serverRegistry.activeProfileId
+        )
+    }
+
+    private func loadVisibleLibraries(for authority: MainTabLibraryAuthority?) async {
+        let retainedLibraries = librarySnapshot.authority == authority
+            ? librarySnapshot.libraries
+            : []
+        librarySnapshot = .init(authority: authority, libraries: retainedLibraries)
+        guard let authority else { return }
+        do {
+            let response = try await StartupContentPrefetcher.fetchUserLibraries()
+            guard !Task.isCancelled, currentLibraryAuthority == authority else { return }
+            librarySnapshot = .init(authority: authority, libraries: response.libraries)
+        } catch {
+            // Keep the active-profile cache, or fail closed with no direct
+            // library roots when there is no safe offline routing metadata.
+        }
+    }
+
+    private var selectedDestination: MainTabDestination {
+        visibleDestinations.first(where: { $0.id == selectedDestinationID })
+            ?? .app(.home)
     }
 
     /// iPhone + iPad compact width: bottom tab bar, single navigation stack.
     private var tabLayout: some View {
         NavigationStack(path: $router.path) {
-            TabView(selection: $selectedTab) {
-                ForEach(visibleTabs) { tab in
+            TabView(selection: $selectedDestinationID) {
+                ForEach(visibleDestinations) { destination in
                     #if os(tvOS)
                     // Text-only tabs on tvOS keep the top bar compact — adding an
                     // icon blows up each tab's focus pill. The value-based `Tab`
                     // initializer requires an image on tvOS, so this arm stays on
                     // the `.tabItem { Text }` form to preserve the text-only look.
-                    tabContent(for: tab)
-                        .tabItem { Text(tab.rawValue) }
-                        .tag(tab)
+                    destinationContent(for: destination)
+                        .tabItem { Text(destination.title) }
+                        .tag(destination.id)
                     #else
                     Tab(
-                        tab.rawValue,
-                        systemImage: selectedTab == tab ? tab.selectedIcon : tab.icon,
-                        value: tab
+                        destination.title,
+                        systemImage: selectedDestinationID == destination.id
+                            ? destination.selectedIcon
+                            : destination.icon,
+                        value: destination.id
                     ) {
-                        tabContent(for: tab)
+                        destinationContent(for: destination)
                     }
                     #endif
                 }
@@ -903,22 +1151,25 @@ struct MainTabView: View {
     /// `router.presentedPlayer` rather than pushed into the detail pane.
     private var sidebarLayout: some View {
         NavigationSplitView(columnVisibility: $columnVisibility) {
-            List(selection: Binding<AppTab?>(
-                get: { selectedTab },
-                set: { if let v = $0 { selectedTab = v } }
+            List(selection: Binding<MainTabDestinationID?>(
+                get: { selectedDestinationID },
+                set: { if let value = $0 { selectedDestinationID = value } }
             )) {
-                ForEach(visibleTabs) { tab in
+                ForEach(visibleDestinations) { destination in
                     Label(
-                        tab.rawValue,
-                        systemImage: selectedTab == tab ? tab.selectedIcon : tab.icon
+                        destination.title,
+                        systemImage: selectedDestinationID == destination.id
+                            ? destination.selectedIcon
+                            : destination.icon
                     )
-                    .tag(tab)
+                    .tag(destination.id)
                 }
             }
             .navigationTitle("Silo")
         } detail: {
             NavigationStack(path: $router.path) {
-                tabContent(for: selectedTab)
+                destinationContent(for: selectedDestination)
+                    .id(selectedDestination.id)
                     .navigationDestination(for: Route.self) { route in
                         routeContent(for: route)
                     }
@@ -940,13 +1191,44 @@ struct MainTabView: View {
     }
 
     @ViewBuilder
+    private func destinationContent(for destination: MainTabDestination) -> some View {
+        switch destination.id {
+        case .app(let tab):
+            tabContent(for: tab)
+        case .libraryCategory(let category):
+            LibrariesTabView(
+                category: category,
+                libraryAuthority: currentLibraryAuthority,
+                onLibrariesLoaded: acceptLoadedLibraries
+            )
+        case .library(let libraryId):
+            LibrariesTabView(
+                fixedLibraryId: libraryId,
+                libraryAuthority: currentLibraryAuthority,
+                onLibrariesLoaded: acceptLoadedLibraries
+            )
+        }
+    }
+
+    private func acceptLoadedLibraries(
+        authority: MainTabLibraryAuthority?,
+        libraries: [Library]
+    ) {
+        guard let authority, authority == currentLibraryAuthority else { return }
+        librarySnapshot = .init(authority: authority, libraries: libraries)
+    }
+
+    @ViewBuilder
     private func tabContent(for tab: AppTab) -> some View {
         switch tab {
         case .home:
             HomeView()
 
         case .libraries:
-            LibrariesTabView()
+            LibrariesTabView(
+                libraryAuthority: currentLibraryAuthority,
+                onLibrariesLoaded: acceptLoadedLibraries
+            )
 
         case .search:
             SearchView()

--- a/iosApp/iosApp/Control/tvOS/RemotePlaybackIdentityManager.swift
+++ b/iosApp/iosApp/Control/tvOS/RemotePlaybackIdentityManager.swift
@@ -1,6 +1,32 @@
-#if os(tvOS)
 import Foundation
 
+/// Pure entry policy for temporary-identity teardown. Kept outside the tvOS
+/// conditional so the generation rules can be regression-tested without a
+/// simulator-only test target.
+enum RemotePlaybackIdentityEndPolicy {
+    static func endingGenerationID(
+        activeIdentityGenerationID: UUID?,
+        scopeGenerationID: UUID?,
+        expectedGenerationID: UUID?
+    ) -> UUID? {
+        if let expectedGenerationID {
+            guard activeIdentityGenerationID == expectedGenerationID,
+                  scopeGenerationID == nil || scopeGenerationID == expectedGenerationID else {
+                return nil
+            }
+            return expectedGenerationID
+        }
+
+        guard let currentGenerationID = activeIdentityGenerationID ?? scopeGenerationID,
+              activeIdentityGenerationID == nil || activeIdentityGenerationID == currentGenerationID,
+              scopeGenerationID == nil || scopeGenerationID == currentGenerationID else {
+            return nil
+        }
+        return currentGenerationID
+    }
+}
+
+#if os(tvOS)
 @MainActor
 final class RemotePlaybackIdentityManager {
     static let shared = RemotePlaybackIdentityManager()
@@ -168,23 +194,12 @@ final class RemotePlaybackIdentityManager {
         notifyServer: Bool = true
     ) async -> Bool {
         let scope = await TokenStore.shared.getTemporaryScope()
-        guard activationGenerationPending == nil else { return false }
-        let endingGenerationID: UUID
-        if let expectedGenerationID {
-            guard activeIdentity?.generationID == expectedGenerationID,
-                  scope?.credentialGenerationID == expectedGenerationID else {
-                return false
-            }
-            endingGenerationID = expectedGenerationID
-        } else {
-            guard let currentGenerationID = activeIdentity?.generationID
-                    ?? scope?.credentialGenerationID,
-                  activeIdentity == nil || activeIdentity?.generationID == currentGenerationID,
-                  scope == nil || scope?.credentialGenerationID == currentGenerationID else {
-                return false
-            }
-            endingGenerationID = currentGenerationID
-        }
+        guard activationGenerationPending == nil,
+              let endingGenerationID = RemotePlaybackIdentityEndPolicy.endingGenerationID(
+                  activeIdentityGenerationID: activeIdentity?.generationID,
+                  scopeGenerationID: scope?.credentialGenerationID,
+                  expectedGenerationID: expectedGenerationID
+              ) else { return false }
         if let scope, notifyServer {
             try? await HTTPClient.shared.postVoid(
                 "/api/v1/auth/logout",
@@ -218,12 +233,16 @@ final class RemotePlaybackIdentityManager {
               activeIdentity == nil || activeIdentity?.generationID == endingGenerationID else {
             return await releaseIdentityTransition(transitionLease, returning: false)
         }
-        if scope != nil {
-            guard await TokenStore.shared.endTemporaryScope(
-                expectedGenerationID: endingGenerationID
-            ) != nil else {
-                return await releaseIdentityTransition(transitionLease, returning: false)
-            }
+        switch await TokenStore.shared.endTemporaryScope(
+            expectedGenerationID: endingGenerationID
+        ) {
+        case .ended, .alreadyAbsent:
+            break
+        case .differentGeneration:
+            // A replacement generation owns the credential slot. Its
+            // activation will publish the matching identity after this
+            // transition lease is released, so preserve manager state.
+            return await releaseIdentityTransition(transitionLease, returning: false)
         }
         activeIdentity = nil
         AuthService.shared.clearCachesForTemporaryIdentityChange()

--- a/iosApp/iosApp/Control/tvOS/RemotePlaybackIdentityManager.swift
+++ b/iosApp/iosApp/Control/tvOS/RemotePlaybackIdentityManager.swift
@@ -43,6 +43,10 @@ final class RemotePlaybackIdentityManager {
 
     private(set) var activeIdentity: ActiveIdentity?
     private let api = PairingDeviceAPI()
+    /// Set synchronously before a replacement begins global request
+    /// cancellation. An older re-entrant `end` must not cancel or remove work
+    /// after this generation has claimed the transition.
+    private var activationGenerationPending: UUID?
 
     private init() {}
 
@@ -124,7 +128,7 @@ final class RemotePlaybackIdentityManager {
                 }
                 let expiresAt = poll.sessionExpiresAt.flatMap(Self.parseISO8601)
                     ?? Date().addingTimeInterval(24 * 60 * 60)
-                await activate(TemporaryAuthScope(
+                guard await activate(TemporaryAuthScope(
                     serverId: offer.serverId,
                     serverURL: normalizedURL,
                     accessToken: accessToken,
@@ -137,7 +141,9 @@ final class RemotePlaybackIdentityManager {
                     serverName: offer.serverName,
                     profileName: offer.profileName,
                     controllerDeviceName: controllerDeviceName
-                )
+                ) else {
+                    throw CancellationError()
+                }
                 return SiloControlHandoffReady(
                     requestId: offer.requestId,
                     serverId: offer.serverId,
@@ -156,16 +162,72 @@ final class RemotePlaybackIdentityManager {
         throw HandoffError.expired
     }
 
-    func end() async {
-        let hasTemporaryScope = await TokenStore.shared.hasTemporaryScope()
-        guard activeIdentity != nil || hasTemporaryScope else { return }
-        if hasTemporaryScope {
-            try? await HTTPClient.shared.postVoid("/api/v1/auth/logout")
+    @discardableResult
+    func end(
+        expectedGenerationID: UUID? = nil,
+        notifyServer: Bool = true
+    ) async -> Bool {
+        let scope = await TokenStore.shared.getTemporaryScope()
+        guard activationGenerationPending == nil else { return false }
+        let endingGenerationID: UUID
+        if let expectedGenerationID {
+            guard activeIdentity?.generationID == expectedGenerationID,
+                  scope?.credentialGenerationID == expectedGenerationID else {
+                return false
+            }
+            endingGenerationID = expectedGenerationID
+        } else {
+            guard let currentGenerationID = activeIdentity?.generationID
+                    ?? scope?.credentialGenerationID,
+                  activeIdentity == nil || activeIdentity?.generationID == currentGenerationID,
+                  scope == nil || scope?.credentialGenerationID == currentGenerationID else {
+                return false
+            }
+            endingGenerationID = currentGenerationID
+        }
+        if let scope, notifyServer {
+            try? await HTTPClient.shared.postVoid(
+                "/api/v1/auth/logout",
+                expectedAccount: RefreshAccountIdentity(
+                    serverId: scope.serverId,
+                    serverURL: scope.serverURL,
+                    credentialGenerationID: scope.credentialGenerationID
+                )
+            )
+        }
+        // A replacement can start while logout is suspended. It sets the
+        // pending marker before its own queued cancellation pass, so the old
+        // generation must stop here without globally cancelling new work.
+        guard activationGenerationPending == nil,
+              activeIdentity == nil || activeIdentity?.generationID == endingGenerationID,
+              !Task.isCancelled else {
+            return false
+        }
+        guard let transitionLease = await HTTPClient.shared.beginIdentityTransition() else {
+            return false
+        }
+        guard activationGenerationPending == nil,
+              activeIdentity == nil || activeIdentity?.generationID == endingGenerationID,
+              !Task.isCancelled else {
+            return await releaseIdentityTransition(transitionLease, returning: false)
         }
         await HTTPClient.shared.cancelInFlightRequests()
-        _ = await TokenStore.shared.endTemporaryScope()
+        // Every await above can admit a replacement handoff. Re-check both
+        // owners, then make scope removal itself generation-conditional.
+        guard activationGenerationPending == nil,
+              activeIdentity == nil || activeIdentity?.generationID == endingGenerationID else {
+            return await releaseIdentityTransition(transitionLease, returning: false)
+        }
+        if scope != nil {
+            guard await TokenStore.shared.endTemporaryScope(
+                expectedGenerationID: endingGenerationID
+            ) != nil else {
+                return await releaseIdentityTransition(transitionLease, returning: false)
+            }
+        }
         activeIdentity = nil
         AuthService.shared.clearCachesForTemporaryIdentityChange()
+        return await releaseIdentityTransition(transitionLease, returning: true)
     }
 
     private func activate(
@@ -173,13 +235,53 @@ final class RemotePlaybackIdentityManager {
         serverName: String?,
         profileName: String?,
         controllerDeviceName: String?
-    ) async {
+    ) async -> Bool {
+        let generationID = scope.credentialGenerationID
+        guard let transitionLease = await HTTPClient.shared.beginIdentityTransition() else {
+            return false
+        }
+        guard !Task.isCancelled,
+              activationGenerationPending == nil else {
+            return await releaseIdentityTransition(transitionLease, returning: false)
+        }
+        activationGenerationPending = generationID
+        let previousIdentity = activeIdentity
         let usesDifferentServer = scope.serverId != ServerRegistry.shared.activeServerId
         await HTTPClient.shared.cancelInFlightRequests()
+        guard activationGenerationPending == generationID,
+              !Task.isCancelled else {
+            if activationGenerationPending == generationID {
+                activationGenerationPending = nil
+            }
+            return await releaseIdentityTransition(transitionLease, returning: false)
+        }
         AuthService.shared.clearCachesForTemporaryIdentityChange()
-        await TokenStore.shared.beginTemporaryScope(scope)
+        let previousScope = await TokenStore.shared.beginTemporaryScope(scope)
+        let previousOwnersAligned = previousIdentity?.generationID
+            == previousScope.scope?.credentialGenerationID
+        guard activationGenerationPending == generationID,
+              !Task.isCancelled,
+              previousOwnersAligned else {
+            let restored = await TokenStore.shared.restoreTemporaryScope(
+                previousScope,
+                replacingGenerationID: generationID
+            )
+            if restored {
+                activeIdentity = previousIdentity
+            } else {
+                let currentScope = await TokenStore.shared.getTemporaryScope()
+                if activeIdentity?.generationID != currentScope?.credentialGenerationID {
+                    activeIdentity = nil
+                }
+            }
+            if activationGenerationPending == generationID {
+                activationGenerationPending = nil
+            }
+            AuthService.shared.clearCachesForTemporaryIdentityChange()
+            return await releaseIdentityTransition(transitionLease, returning: false)
+        }
         activeIdentity = ActiveIdentity(
-            generationID: UUID(),
+            generationID: generationID,
             serverId: scope.serverId,
             serverURL: scope.serverURL,
             serverName: serverName,
@@ -190,6 +292,16 @@ final class RemotePlaybackIdentityManager {
             usesDifferentServer: usesDifferentServer,
             sessionExpiresAt: scope.expiresAt
         )
+        activationGenerationPending = nil
+        return await releaseIdentityTransition(transitionLease, returning: true)
+    }
+
+    private func releaseIdentityTransition(
+        _ lease: HTTPIdentityTransitionLease,
+        returning result: Bool
+    ) async -> Bool {
+        await HTTPClient.shared.endIdentityTransition(lease)
+        return result
     }
 
     private static func iso8601(_ date: Date) -> String {

--- a/iosApp/iosApp/Control/tvOS/TVControlReceiver.swift
+++ b/iosApp/iosApp/Control/tvOS/TVControlReceiver.swift
@@ -42,6 +42,11 @@ final class TVControlReceiver {
     private var playerContentId: String?
     private var playerHandoffGeneration: UUID?
     private var pendingPlayerHandoffGeneration: UUID?
+    /// A terminally rejected handoff does not need a best-effort logout, but
+    /// player teardown is asynchronous. Carry its exact generation through
+    /// `unregisterPlayer` so a replacement handoff is never treated as the
+    /// rejected one.
+    private var rejectedPlayerHandoffGeneration: UUID?
     private var remoteControllerName: String?
     private var remoteControllerDeviceId: String?
     private var remoteControllerServerId: String?
@@ -159,13 +164,25 @@ final class TVControlReceiver {
         closeActiveSession(sendClose: true)
     }
 
-    func temporaryAuthExpired() {
+    func temporaryAuthExpired(expected event: SessionExpiryEvent) {
+        let expectedGenerationID = event.account.credentialGenerationID
+        guard event.disposition == .temporarySessionExpired,
+              RemotePlaybackIdentityManager.shared.activeIdentity?.generationID == expectedGenerationID else {
+            return
+        }
+        rejectedPlayerHandoffGeneration = expectedGenerationID
         sendError(code: "temporary_session_expired", message: "The phone profile session expired.")
         let hadPlayer = playerViewModel != nil
         stopRemotePlayback()
         if !hadPlayer {
             Task { @MainActor [weak self] in
-                await RemotePlaybackIdentityManager.shared.end()
+                guard await RemotePlaybackIdentityManager.shared.end(
+                    expectedGenerationID: expectedGenerationID,
+                    notifyServer: false
+                ) else { return }
+                if self?.rejectedPlayerHandoffGeneration == expectedGenerationID {
+                    self?.rejectedPlayerHandoffGeneration = nil
+                }
                 self?.refreshAdvertisement()
                 self?.reconcileAuthorizationAfterRestore()
             }
@@ -200,7 +217,14 @@ final class TVControlReceiver {
            RemotePlaybackIdentityManager.shared.activeIdentity?.generationID == endingGeneration {
             Task { @MainActor [weak self, weak viewModel] in
                 await viewModel?.waitForCleanupCompletion()
-                await RemotePlaybackIdentityManager.shared.end()
+                let notifyServer = self?.rejectedPlayerHandoffGeneration != endingGeneration
+                guard await RemotePlaybackIdentityManager.shared.end(
+                    expectedGenerationID: endingGeneration,
+                    notifyServer: notifyServer
+                ) else { return }
+                if self?.rejectedPlayerHandoffGeneration == endingGeneration {
+                    self?.rejectedPlayerHandoffGeneration = nil
+                }
                 self?.refreshAdvertisement()
                 self?.reconcileAuthorizationAfterRestore()
                 self?.refreshStandbyState()

--- a/iosApp/iosApp/Downloads/DownloadSessionDelegate.swift
+++ b/iosApp/iosApp/Downloads/DownloadSessionDelegate.swift
@@ -205,6 +205,7 @@ enum DownloadAuthHeaders {
         request.setValue(device.id, forHTTPHeaderField: "X-Silo-Device-Id")
         request.setValue(device.name, forHTTPHeaderField: "X-Silo-Device-Name")
         request.setValue(device.platform, forHTTPHeaderField: "X-Silo-Device-Platform")
+        request.setValue(device.clientFamily, forHTTPHeaderField: "X-Silo-Client-Family")
         return request
     }
 }

--- a/iosApp/iosApp/Navigation/AppRouter.swift
+++ b/iosApp/iosApp/Navigation/AppRouter.swift
@@ -246,7 +246,7 @@ class AppRouter {
     /// buttons and error-screen callbacks don't spell out a `Task`.
     func signOutAndReset() {
         Task {
-            await AuthService.shared.signOut()
+            guard await completeRequestedSignOut() else { return }
             await MainActor.run {
                 if ServerRegistry.shared.hasActiveServer {
                     self.resetToLogin()
@@ -263,7 +263,7 @@ class AppRouter {
     func signOutRemoveServerAndReset() {
         Task {
             let serverId = ServerRegistry.shared.activeServerId
-            await AuthService.shared.signOut()
+            guard await completeRequestedSignOut() else { return }
             if let serverId {
                 await ServerRegistry.shared.remove(serverId: serverId)
             }
@@ -280,6 +280,23 @@ class AppRouter {
                 }
             }
         }
+    }
+
+    /// A user-initiated tvOS sign-out first retires a playback-only overlay if
+    /// it owns request authentication, then retries against the persistent
+    /// account. Other refusals leave navigation and credentials untouched.
+    private func completeRequestedSignOut() async -> Bool {
+        if await AuthService.shared.signOut() {
+            return true
+        }
+        #if os(tvOS)
+        guard await RemotePlaybackIdentityManager.shared.end() else {
+            return false
+        }
+        return await AuthService.shared.signOut()
+        #else
+        return false
+        #endif
     }
 
     /// A refresh failed for the active server. Keep the registry entry,

--- a/iosApp/iosApp/Navigation/UICustomizationPreferences.swift
+++ b/iosApp/iosApp/Navigation/UICustomizationPreferences.swift
@@ -1,0 +1,1687 @@
+import Foundation
+import Observation
+
+// MARK: - Shared wire models
+
+enum CardPosterSize: String, Codable, CaseIterable, Identifiable, Sendable {
+    case compact
+    case standard
+    case large
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .compact: return "Compact"
+        case .standard: return "Standard"
+        case .large: return "Large"
+        }
+    }
+
+    /// Artwork scale used by free-scrolling rails and standalone cards.
+    /// Grids also adjust their column count so the selected size never causes
+    /// overlapping focus frames.
+    var scale: CGFloat {
+        switch self {
+        case .compact: return 0.86
+        case .standard: return 1
+        case .large: return 1.2
+        }
+    }
+}
+
+enum CardCaptionStyle: String, Codable, CaseIterable, Identifiable, Sendable {
+    case titleMetadata = "title_metadata"
+    case title
+    case artwork
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .titleMetadata: return "Title & Metadata"
+        case .title: return "Title Only"
+        case .artwork: return "Artwork Only"
+        }
+    }
+
+    var showsTitle: Bool { self != .artwork }
+    var showsMetadata: Bool { self == .titleMetadata }
+}
+
+struct CardPresentationPreference: Codable, Equatable, Sendable {
+    var posterSize: CardPosterSize
+    var caption: CardCaptionStyle
+
+    enum CodingKeys: String, CodingKey {
+        case posterSize = "poster_size"
+        case caption
+    }
+
+    static let standard = CardPresentationPreference(
+        posterSize: .standard,
+        caption: .titleMetadata
+    )
+
+    var preset: CardPresentationPreset? {
+        CardPresentationPreset.allCases.first(where: { $0.presentation == self })
+    }
+}
+
+/// Friendly cross-client recipes over the two contract axes. The server keeps
+/// the normalized size/caption object, so a user can start from a preset and
+/// still fine-tune either control without inventing another wire format.
+enum CardPresentationPreset: String, CaseIterable, Identifiable, Sendable {
+    case balanced
+    case compact
+    case cinema
+    case artworkOnly = "artwork_only"
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .balanced: return "Balanced"
+        case .compact: return "Compact"
+        case .cinema: return "Cinema"
+        case .artworkOnly: return "Artwork Only"
+        }
+    }
+
+    var presentation: CardPresentationPreference {
+        switch self {
+        case .balanced:
+            return .standard
+        case .compact:
+            return .init(posterSize: .compact, caption: .title)
+        case .cinema:
+            return .init(posterSize: .large, caption: .title)
+        case .artworkOnly:
+            return .init(posterSize: .large, caption: .artwork)
+        }
+    }
+}
+
+enum PrimaryMenuBuiltin: String, Codable, CaseIterable, Identifiable, Sendable {
+    case home
+    case movies
+    case series
+    case music
+    case audiobooks
+    case forYou = "for_you"
+    case calendar
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .home: return "Home"
+        case .movies: return "Movies"
+        case .series: return "Series"
+        case .music: return "Music"
+        case .audiobooks: return "Audiobooks"
+        case .forYou: return "For You"
+        case .calendar: return "Calendar"
+        }
+    }
+}
+
+/// One item in `nav.primary_menu` or `nav.shortcuts`.
+///
+/// The associated-value representation keeps impossible combinations out of
+/// app state while custom coding preserves the contract's flat tagged object.
+enum PrimaryMenuItem: Hashable, Identifiable, Sendable {
+    case builtin(PrimaryMenuBuiltin)
+    case library(libraryId: Int, label: String)
+    case section(libraryId: Int, sectionId: String, label: String)
+    case collection(collectionId: String, label: String, libraryId: Int?)
+
+    var id: String {
+        switch self {
+        case .builtin(let destination):
+            return "builtin:\(destination.rawValue)"
+        case .library(let libraryId, _):
+            return "library:\(libraryId)"
+        case .section(let libraryId, let sectionId, _):
+            return "section:\(libraryId):\(sectionId)"
+        case .collection(let collectionId, _, let libraryId):
+            let libraryValue = libraryId.map(String.init) ?? ""
+            let libraryPresence = libraryId == nil ? "0" : "1"
+            return "collection|\(libraryPresence)"
+                + "|\(Self.identityComponent(libraryValue))"
+                + "|\(Self.identityComponent(collectionId))"
+        }
+    }
+
+    /// Pre-structured identity used by caches written before collection IDs
+    /// became length-prefixed. It is accepted only while migrating an outbox;
+    /// all live equality, deduplication, and focus identity uses ``id``.
+    fileprivate var legacyUnstructuredId: String {
+        switch self {
+        case .collection(let collectionId, _, let libraryId):
+            return "collection:\(libraryId.map(String.init) ?? "all"):\(collectionId)"
+        default:
+            return id
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .builtin(let destination): return destination.title
+        case .library(_, let label), .section(_, _, let label), .collection(_, let label, _):
+            return label
+        }
+    }
+
+    var isHome: Bool { self == .builtin(.home) }
+
+    var isContractValid: Bool {
+        switch self {
+        case .builtin:
+            return true
+        case .library(let libraryId, let label):
+            return libraryId > 0 && Self.isValidLabel(label)
+        case .section(let libraryId, let sectionId, let label):
+            return libraryId > 0
+                && Self.isValidTargetId(sectionId)
+                && Self.isValidLabel(label)
+        case .collection(let collectionId, let label, let libraryId):
+            return (libraryId.map { $0 > 0 } ?? true)
+                && Self.isValidTargetId(collectionId)
+                && Self.isValidLabel(label)
+        }
+    }
+
+    var libraryId: Int? {
+        switch self {
+        case .library(let id, _), .section(let id, _, _): return id
+        case .collection(_, _, let id): return id
+        case .builtin: return nil
+        }
+    }
+
+    private static func isValidLabel(_ value: String) -> Bool {
+        value.count <= 256
+            && !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private static func isValidTargetId(_ value: String) -> Bool {
+        value.count <= 128
+            && !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private static func identityComponent(_ value: String) -> String {
+        "\(value.utf8.count)#\(value)"
+    }
+}
+
+extension PrimaryMenuItem: Codable {
+    private enum ItemType: String, Codable {
+        case builtin
+        case library
+        case section
+        case collection
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case destination
+        case libraryId = "library_id"
+        case sectionId = "section_id"
+        case collectionId = "collection_id"
+        case label
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        switch try container.decode(ItemType.self, forKey: .type) {
+        case .builtin:
+            self = .builtin(try container.decode(PrimaryMenuBuiltin.self, forKey: .destination))
+        case .library:
+            self = .library(
+                libraryId: try container.decode(Int.self, forKey: .libraryId),
+                label: try container.decode(String.self, forKey: .label)
+            )
+        case .section:
+            self = .section(
+                libraryId: try container.decode(Int.self, forKey: .libraryId),
+                sectionId: try container.decode(String.self, forKey: .sectionId),
+                label: try container.decode(String.self, forKey: .label)
+            )
+        case .collection:
+            self = .collection(
+                collectionId: try container.decode(String.self, forKey: .collectionId),
+                label: try container.decode(String.self, forKey: .label),
+                libraryId: try container.decodeIfPresent(Int.self, forKey: .libraryId)
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .builtin(let destination):
+            try container.encode(ItemType.builtin, forKey: .type)
+            try container.encode(destination, forKey: .destination)
+        case .library(let libraryId, let label):
+            try container.encode(ItemType.library, forKey: .type)
+            try container.encode(libraryId, forKey: .libraryId)
+            try container.encode(label, forKey: .label)
+        case .section(let libraryId, let sectionId, let label):
+            try container.encode(ItemType.section, forKey: .type)
+            try container.encode(libraryId, forKey: .libraryId)
+            try container.encode(sectionId, forKey: .sectionId)
+            try container.encode(label, forKey: .label)
+        case .collection(let collectionId, let label, let libraryId):
+            try container.encode(ItemType.collection, forKey: .type)
+            try container.encode(collectionId, forKey: .collectionId)
+            try container.encode(label, forKey: .label)
+            try container.encodeIfPresent(libraryId, forKey: .libraryId)
+        }
+    }
+}
+
+struct PrimaryMenuPreference: Codable, Equatable, Sendable {
+    var items: [PrimaryMenuItem]
+
+    /// The server validates this too. Rechecking at the client boundary makes
+    /// a corrupt offline cache harmless instead of rendering a focus graph
+    /// with no Home anchor or duplicate identities.
+    var isValid: Bool {
+        items.count >= 1
+            && items.count <= 64
+            && items.allSatisfy(\.isContractValid)
+            && items.filter(\.isHome).count == 1
+            && Set(items.map(\.id)).count == items.count
+    }
+}
+
+struct NavigationShortcutsPreference: Codable, Equatable, Sendable {
+    var items: [PrimaryMenuItem]
+
+    static let empty = NavigationShortcutsPreference(items: [])
+}
+
+// MARK: - Transport
+
+protocol UICustomizationTransport: AnyObject, Sendable {
+    func contractCapabilities(
+        requestIdentity: HTTPRequestIdentity
+    ) async -> SettingsCapabilitiesResult
+    func effectiveValues(
+        keys: [SettingKey],
+        requestIdentity: HTTPRequestIdentity
+    ) async throws -> EffectiveSettingValuesResponse
+    func putShortcutItem(
+        _ item: PrimaryMenuItem,
+        present: Bool,
+        mutationId: String,
+        requestIdentity: HTTPRequestIdentity
+    ) async throws
+    func putValue(
+        key: SettingKey,
+        scope: SettingScopeIdentity,
+        value: SettingJSONValue,
+        mutationId: String,
+        requestIdentity: HTTPRequestIdentity
+    ) async throws
+    func deleteValue(
+        key: SettingKey,
+        scope: SettingScopeIdentity,
+        requestIdentity: HTTPRequestIdentity
+    ) async throws
+}
+
+extension UICustomizationTransport {
+    func contractCapabilities(
+        requestIdentity: HTTPRequestIdentity
+    ) async -> SettingsCapabilitiesResult {
+        .serverUpgradeRequired
+    }
+
+    func putShortcutItem(
+        _ item: PrimaryMenuItem,
+        present: Bool,
+        mutationId: String,
+        requestIdentity: HTTPRequestIdentity
+    ) async throws {
+        throw URLError(.unsupportedURL)
+    }
+
+    func deleteValue(
+        key: SettingKey,
+        scope: SettingScopeIdentity,
+        requestIdentity: HTTPRequestIdentity
+    ) async throws {
+        throw URLError(.unsupportedURL)
+    }
+}
+
+final class ContinuumUICustomizationTransport: UICustomizationTransport {
+    private let api: ContinuumAPI
+
+    init(api: ContinuumAPI = .shared) {
+        self.api = api
+    }
+
+    func contractCapabilities(
+        requestIdentity: HTTPRequestIdentity
+    ) async -> SettingsCapabilitiesResult {
+        await api.getContractCapabilities(requestIdentity: requestIdentity)
+    }
+
+    func effectiveValues(
+        keys: [SettingKey],
+        requestIdentity: HTTPRequestIdentity
+    ) async throws -> EffectiveSettingValuesResponse {
+        try await api.getEffectiveValues(
+            keys: keys,
+            profileId: requestIdentity.profileId,
+            requestIdentity: requestIdentity
+        )
+    }
+
+    func putShortcutItem(
+        _ item: PrimaryMenuItem,
+        present: Bool,
+        mutationId: String,
+        requestIdentity: HTTPRequestIdentity
+    ) async throws {
+        _ = try await api.putNavigationShortcutItem(
+            item,
+            present: present,
+            mutationId: mutationId,
+            profileId: requestIdentity.profileId,
+            requestIdentity: requestIdentity
+        )
+    }
+
+    func putValue(
+        key: SettingKey,
+        scope: SettingScopeIdentity,
+        value: SettingJSONValue,
+        mutationId: String,
+        requestIdentity: HTTPRequestIdentity
+    ) async throws {
+        _ = try await api.putValue(
+            key: key,
+            scope: scope,
+            value: value,
+            mutationId: mutationId,
+            profileId: requestIdentity.profileId,
+            requestIdentity: requestIdentity
+        )
+    }
+
+    func deleteValue(
+        key: SettingKey,
+        scope: SettingScopeIdentity,
+        requestIdentity: HTTPRequestIdentity
+    ) async throws {
+        try await api.deleteValue(
+            key: key,
+            scope: scope,
+            profileId: requestIdentity.profileId,
+            requestIdentity: requestIdentity
+        )
+    }
+}
+
+enum UICustomizationCapabilityState: Equatable, Sendable {
+    case checking
+    case supported
+    case serverUpgradeRequired
+    case unavailable
+
+    var allowsEditing: Bool { self == .supported }
+
+    var userMessage: String? {
+        switch self {
+        case .checking:
+            return "Checking whether this server supports synced interface settings…"
+        case .supported:
+            return nil
+        case .serverUpgradeRequired:
+            return "Update this Silo server to use synced interface settings."
+        case .unavailable:
+            return "Interface settings are read-only until server support can be verified."
+        }
+    }
+}
+
+/// Last authoritative compatibility conclusion for one server/profile/family
+/// cache. Probe failures are deliberately not conclusions: offline clients can
+/// keep rendering a previously valid cache, while an explicitly older server
+/// must not keep revision-5 navigation or card presentation active.
+enum UICustomizationSupportProjection: String, Codable, Equatable, Sendable {
+    case unknown
+    case supported
+    case knownUnsupported = "known_unsupported"
+
+    var projectsCachedValues: Bool { self != .knownUnsupported }
+}
+
+// MARK: - Observable preference store
+
+/// Effective UI customization for the active profile and client family.
+///
+/// Server values are authoritative when reachable. A per-profile/family cache
+/// is painted first and updated optimistically so navigation and poster layout
+/// remain useful offline; a failed sync never erases the last working UI.
+@MainActor
+@Observable
+final class UICustomizationPreferences {
+    static let shared = UICustomizationPreferences()
+
+    private var storedPrimaryMenu: PrimaryMenuPreference?
+    private var storedShortcuts: NavigationShortcutsPreference = .empty
+    private var storedCardPresentation: CardPresentationPreference = .standard
+    private var storedPrimaryMenuSource: SettingSource?
+    private var storedCardPresentationSource: SettingSource?
+    private(set) var isRefreshing = false
+    private(set) var isSaving = false
+    private(set) var syncErrorMessage: String?
+    private(set) var capabilityState: UICustomizationCapabilityState = .checking
+    private(set) var supportProjection: UICustomizationSupportProjection = .unknown
+
+    var primaryMenu: PrimaryMenuPreference? {
+        supportProjection.projectsCachedValues ? storedPrimaryMenu : nil
+    }
+    var shortcuts: NavigationShortcutsPreference {
+        supportProjection.projectsCachedValues ? storedShortcuts : .empty
+    }
+    var cardPresentation: CardPresentationPreference {
+        supportProjection.projectsCachedValues ? storedCardPresentation : .standard
+    }
+    var primaryMenuSource: SettingSource? {
+        supportProjection.projectsCachedValues ? storedPrimaryMenuSource : nil
+    }
+    var cardPresentationSource: SettingSource? {
+        supportProjection.projectsCachedValues ? storedCardPresentationSource : nil
+    }
+
+    var allowsEditing: Bool { capabilityState.allowsEditing }
+    var capabilityMessage: String? { capabilityState.userMessage }
+
+    @ObservationIgnored private let defaults: SharedDefaults
+    @ObservationIgnored private let transport: UICustomizationTransport
+    @ObservationIgnored private let cacheKey: @MainActor () -> String?
+    @ObservationIgnored private let requestIdentity: @MainActor () -> HTTPRequestIdentity?
+    @ObservationIgnored private var refreshSequence = 0
+    @ObservationIgnored private var localMutationRevision = 0
+    @ObservationIgnored private var saveTail: Task<Void, Never>?
+    @ObservationIgnored private var pendingSaveCount = 0
+    @ObservationIgnored private var syncErrorsByKey: [String: String] = [:]
+    @ObservationIgnored private var shortcutSyncErrorsByIdentity: [String: String] = [:]
+    @ObservationIgnored private var refreshSyncErrorMessage: String?
+    @ObservationIgnored private var loadedCacheKey: String?
+    @ObservationIgnored private var pendingSyncWrites: [String: PendingSyncWrite] = [:]
+    @ObservationIgnored private var pendingShortcutOperations: [String: PendingShortcutOperation] = [:]
+    @ObservationIgnored private var pendingShortcutPlacementBlockedIds: Set<String> = []
+    @ObservationIgnored private var pendingDeletes: [String: PendingDelete] = [:]
+    @ObservationIgnored private var nextShortcutOperationSequence: UInt64 = 0
+
+    private struct OperationContext {
+        let cacheKey: String
+        let requestIdentity: HTTPRequestIdentity
+    }
+
+    private struct PendingSyncWrite: Codable {
+        let value: SettingJSONValue
+        /// The settings API requires one stable idempotency key for the whole
+        /// lifetime of a retry. A new user edit replaces this record and gets
+        /// a new mutation id; connectivity retries reuse the existing one.
+        let mutationId: String
+    }
+
+    private struct PendingShortcutOperation: Codable {
+        let item: PrimaryMenuItem
+        let present: Bool
+        /// True when this shortcut edit also authored this family's primary
+        /// menu placement. The dependent menu write waits for shortcut
+        /// acceptance so a rejected profile pin cannot commit only one half.
+        let updatesPrimaryMenu: Bool
+        /// Intended family-menu position for an accepted add. Keeping the
+        /// authored index lets an earlier offline pin land ahead of later
+        /// accepted pins when it is eventually replayed.
+        let primaryMenuIndex: Int?
+        /// Stable neighbor from the projected authored menu. The anchor keeps
+        /// placement correct when an earlier pending removal still occupies an
+        /// absolute slot at the time this add is accepted.
+        let primaryMenuPredecessorId: String?
+        /// Original catalog position used to restore a definitively rejected
+        /// removal without replacing unrelated optimistic shortcut edits.
+        let shortcutIndex: Int?
+        /// Stable for every retry of this exact desired-presence operation.
+        let mutationId: String
+        /// Preserves user intent order across identities after a restart.
+        let sequence: UInt64
+
+        private enum CodingKeys: String, CodingKey {
+            case item
+            case present
+            case updatesPrimaryMenu
+            case primaryMenuIndex
+            case primaryMenuPredecessorId
+            case shortcutIndex
+            case mutationId
+            case sequence
+        }
+
+        init(
+            item: PrimaryMenuItem,
+            present: Bool,
+            updatesPrimaryMenu: Bool,
+            primaryMenuIndex: Int?,
+            primaryMenuPredecessorId: String?,
+            shortcutIndex: Int?,
+            mutationId: String,
+            sequence: UInt64
+        ) {
+            self.item = item
+            self.present = present
+            self.updatesPrimaryMenu = updatesPrimaryMenu
+            self.primaryMenuIndex = primaryMenuIndex
+            self.primaryMenuPredecessorId = primaryMenuPredecessorId
+            self.shortcutIndex = shortcutIndex
+            self.mutationId = mutationId
+            self.sequence = sequence
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let decodedItem = try container.decode(PrimaryMenuItem.self, forKey: .item)
+            item = decodedItem
+            present = try container.decode(Bool.self, forKey: .present)
+            updatesPrimaryMenu = try container.decodeIfPresent(
+                Bool.self,
+                forKey: .updatesPrimaryMenu
+            ) ?? {
+                if case .library = decodedItem { return true }
+                return false
+            }()
+            primaryMenuIndex = try container.decodeIfPresent(Int.self, forKey: .primaryMenuIndex)
+            primaryMenuPredecessorId = try container.decodeIfPresent(
+                String.self,
+                forKey: .primaryMenuPredecessorId
+            )
+            shortcutIndex = try container.decodeIfPresent(Int.self, forKey: .shortcutIndex)
+            mutationId = try container.decode(String.self, forKey: .mutationId)
+            sequence = try container.decodeIfPresent(UInt64.self, forKey: .sequence) ?? 0
+        }
+
+        func supersedingPrimaryMenuPlacement() -> Self {
+            Self(
+                item: item,
+                present: present,
+                updatesPrimaryMenu: false,
+                primaryMenuIndex: primaryMenuIndex,
+                primaryMenuPredecessorId: primaryMenuPredecessorId,
+                shortcutIndex: shortcutIndex,
+                mutationId: mutationId,
+                sequence: sequence
+            )
+        }
+    }
+
+    private struct PendingDelete: Codable {
+        let scope: SettingScope
+        /// A local operation identity prevents an older queued DELETE from
+        /// clearing a newer same-scope reset that still needs to be replayed.
+        let operationId: String
+
+        private enum CodingKeys: String, CodingKey {
+            case scope
+            case operationId
+        }
+
+        init(scope: SettingScope, operationId: String = newSettingMutationId()) {
+            self.scope = scope
+            self.operationId = operationId
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            scope = try container.decode(SettingScope.self, forKey: .scope)
+            operationId = try container.decodeIfPresent(String.self, forKey: .operationId)
+                ?? newSettingMutationId()
+        }
+
+        var scopeIdentity: SettingScopeIdentity? {
+            switch scope {
+            case .profileClient: return .profileClient
+            case .profileDevice: return .profileDevice
+            default: return nil
+            }
+        }
+    }
+
+    private struct Cache: Codable {
+        let primaryMenu: PrimaryMenuPreference?
+        let shortcuts: NavigationShortcutsPreference
+        let cardPresentation: CardPresentationPreference
+        let primaryMenuSource: SettingSource?
+        let cardPresentationSource: SettingSource?
+        let supportProjection: UICustomizationSupportProjection?
+        let pendingSyncWrites: [String: PendingSyncWrite]?
+        let pendingShortcutOperations: [String: PendingShortcutOperation]?
+        let pendingShortcutPlacementBlockedIds: [String]?
+        let pendingDeletes: [String: PendingDelete]?
+    }
+
+    init(
+        defaults: SharedDefaults = .shared,
+        transport: UICustomizationTransport = ContinuumUICustomizationTransport(),
+        cacheKey: @escaping @MainActor () -> String? = UICustomizationPreferences.activeCacheKey,
+        requestIdentity: @escaping @MainActor () -> HTTPRequestIdentity? = UICustomizationPreferences.activeRequestIdentity,
+        initialCapabilityState: UICustomizationCapabilityState = .checking
+    ) {
+        self.defaults = defaults
+        self.transport = transport
+        self.cacheKey = cacheKey
+        self.requestIdentity = requestIdentity
+        capabilityState = initialCapabilityState
+        loadCache(for: cacheKey())
+    }
+
+    /// Repaint from the active identity's cache, then reconcile from the
+    /// server. Transiently unknown servers retain the last compatible cache;
+    /// explicitly older servers project the legacy/default presentation.
+    func refresh() async {
+        AppNavPreferences.shared.refresh()
+        let targetCacheKey = cacheKey()
+        loadCache(for: targetCacheKey)
+        refreshSequence += 1
+        let sequence = refreshSequence
+        let mutationRevision = localMutationRevision
+        isRefreshing = true
+        defer {
+            if refreshSequence == sequence {
+                isRefreshing = false
+            }
+        }
+
+        guard let identity = capturedIdentity(for: targetCacheKey) else {
+            capabilityState = .unavailable
+            refreshSyncErrorMessage = capabilityState.userMessage
+            updateSyncErrorMessage()
+            return
+        }
+
+        capabilityState = .checking
+        // A new probe supersedes the prior probe/read failure. Per-key outbox
+        // failures remain visible until their own retry succeeds.
+        refreshSyncErrorMessage = nil
+        updateSyncErrorMessage()
+        let capabilities = await transport.contractCapabilities(requestIdentity: identity)
+        guard refreshSequence == sequence,
+              localMutationRevision == mutationRevision,
+              cacheKey() == targetCacheKey,
+              capturedIdentity(for: targetCacheKey) == identity else { return }
+
+        switch capabilities {
+        case .available(let capabilities) where capabilities.supportsUICustomizationRevision:
+            capabilityState = .supported
+            supportProjection = .supported
+            saveCache(for: targetCacheKey)
+        case .available, .serverUpgradeRequired:
+            capabilityState = .serverUpgradeRequired
+            supportProjection = .knownUnsupported
+            refreshSyncErrorMessage = capabilityState.userMessage
+            updateSyncErrorMessage()
+            saveCache(for: targetCacheKey)
+            return
+        case .failed:
+            capabilityState = .unavailable
+            refreshSyncErrorMessage = capabilityState.userMessage
+            updateSyncErrorMessage()
+            return
+        }
+
+        do {
+            guard await drainPendingWrites(
+                targetCacheKey: targetCacheKey,
+                requestIdentity: identity,
+                sequence: sequence,
+                mutationRevision: mutationRevision
+            ) else { return }
+            let response = try await transport.effectiveValues(
+                keys: Self.keys,
+                requestIdentity: identity
+            )
+            guard refreshSequence == sequence,
+                  localMutationRevision == mutationRevision,
+                  cacheKey() == targetCacheKey,
+                  capturedIdentity(for: targetCacheKey) == identity else { return }
+            let values = response.byKey
+
+            if let row = values[.navPrimaryMenu] {
+                storedPrimaryMenuSource = row.source
+                if row.value.isNull {
+                    storedPrimaryMenu = nil
+                } else {
+                    let decoded = try row.value.decoded(as: PrimaryMenuPreference.self)
+                    storedPrimaryMenu = decoded.isValid ? decoded : nil
+                }
+            }
+            if let row = values[.navShortcuts] {
+                let decoded = try row.value.decoded(as: NavigationShortcutsPreference.self)
+                storedShortcuts = Self.sanitizedShortcuts(decoded)
+            }
+            if let row = values[.uiCardPresentation] {
+                storedCardPresentationSource = row.source
+                storedCardPresentation = try row.value.decoded(as: CardPresentationPreference.self)
+            }
+
+            clearReconciledSyncErrors()
+            saveCache(for: targetCacheKey)
+        } catch {
+            guard refreshSequence == sequence,
+                  localMutationRevision == mutationRevision,
+                  cacheKey() == targetCacheKey,
+                  capturedIdentity(for: targetCacheKey) == identity else { return }
+            refreshSyncErrorMessage = Self.message(for: error)
+            updateSyncErrorMessage()
+        }
+    }
+
+    func setCardPresentation(_ value: CardPresentationPreference) {
+        guard !cardPresentationUsesDeviceOverride,
+              let context = operationContext() else { return }
+        localMutationRevision += 1
+        storedCardPresentation = value
+        storedCardPresentationSource = .scope(.profileClient)
+        pendingDeletes.removeValue(
+            forKey: Self.deleteIdentity(key: .uiCardPresentation, scope: .profileClient)
+        )
+        persist(
+            key: .uiCardPresentation,
+            scope: .profileClient,
+            value: value,
+            context: context
+        )
+    }
+
+    func setPosterSize(_ value: CardPosterSize) {
+        var updated = cardPresentation
+        updated.posterSize = value
+        setCardPresentation(updated)
+    }
+
+    func setCaptionStyle(_ value: CardCaptionStyle) {
+        var updated = cardPresentation
+        updated.caption = value
+        setCardPresentation(updated)
+    }
+
+    func setPrimaryMenuItems(_ items: [PrimaryMenuItem]) {
+        guard !primaryMenuUsesDeviceOverride,
+              let context = operationContext() else { return }
+        let acceptedIds = Set(resolvedPrimaryMenuItems().map(\.id))
+        let unacceptedPinIds = Set(pendingShortcutOperations.values.compactMap { operation in
+            operation.present ? operation.item.id : nil
+        }).subtracting(acceptedIds)
+        let blockedIds = Set(items.map(\.id)).intersection(unacceptedPinIds)
+        guard blockedIds.isEmpty else {
+            pendingShortcutPlacementBlockedIds = blockedIds
+            setSyncError(Self.pendingShortcutPlacementMessage, for: .navPrimaryMenu)
+            saveCache(for: context.cacheKey)
+            return
+        }
+        let clearedPlacementBlock = !pendingShortcutPlacementBlockedIds.isEmpty
+            || syncErrorsByKey[SettingKey.navPrimaryMenu.rawValue]
+                == Self.pendingShortcutPlacementMessage
+        pendingShortcutPlacementBlockedIds.removeAll()
+        let didPersist = setPrimaryMenuItems(
+            items,
+            context: context,
+            supersedesPendingShortcutPlacements: true
+        )
+        if clearedPlacementBlock && !didPersist {
+            saveCache(for: context.cacheKey)
+        }
+    }
+
+    @discardableResult
+    private func setPrimaryMenuItems(
+        _ items: [PrimaryMenuItem],
+        context: OperationContext,
+        advancesMutationRevision: Bool = true,
+        supersedesPendingShortcutPlacements: Bool = false
+    ) -> Bool {
+        let normalized = Self.normalizedPrimaryMenuItems(items)
+        guard normalized.count <= Self.maximumPrimaryMenuCount else {
+            setSyncError(Self.primaryMenuLimitMessage, for: .navPrimaryMenu)
+            return false
+        }
+        let value = PrimaryMenuPreference(items: normalized)
+        guard value.isValid else { return false }
+        if let menuError = syncErrorsByKey[SettingKey.navPrimaryMenu.rawValue],
+           menuError == Self.primaryMenuLimitMessage
+            || (menuError == Self.pendingShortcutPlacementMessage
+                && pendingShortcutPlacementBlockedIds.isEmpty) {
+            setSyncError(nil, for: .navPrimaryMenu)
+        }
+        if advancesMutationRevision {
+            localMutationRevision += 1
+        }
+        if supersedesPendingShortcutPlacements {
+            supersedePendingShortcutPlacements()
+        }
+        storedPrimaryMenu = value
+        storedPrimaryMenuSource = .scope(.profileClient)
+        pendingDeletes.removeValue(
+            forKey: Self.deleteIdentity(key: .navPrimaryMenu, scope: .profileClient)
+        )
+        return persist(
+            key: .navPrimaryMenu,
+            scope: .profileClient,
+            value: value,
+            context: context
+        )
+    }
+
+    func setLibraryPinned(_ library: Library, isPinned: Bool) {
+        guard let context = operationContext() else { return }
+        let item = PrimaryMenuItem.library(libraryId: library.id, label: library.name)
+        guard item.isContractValid else { return }
+        let currentShortcuts = shortcuts.items
+        let alreadyPinned = currentShortcuts.contains { $0.id == item.id }
+        guard alreadyPinned != isPinned else { return }
+        guard !isPinned
+                || currentShortcuts.count < Self.maximumShortcutCount else {
+            setSyncError(Self.shortcutLimitMessage, for: .navShortcuts)
+            return
+        }
+
+        var updatedMenu: [PrimaryMenuItem]?
+        if !primaryMenuUsesDeviceOverride {
+            var candidate = projectedPrimaryMenuItems().filter { $0.id != item.id }
+            if isPinned { candidate.append(item) }
+            let normalized = Self.normalizedPrimaryMenuItems(candidate)
+            guard normalized.count <= Self.maximumPrimaryMenuCount else {
+                setSyncError(Self.primaryMenuLimitMessage, for: .navPrimaryMenu)
+                return
+            }
+            updatedMenu = normalized
+        }
+
+        setSyncError(nil, for: .navShortcuts)
+        localMutationRevision += 1
+        var updatedShortcuts = currentShortcuts.filter { $0.id != item.id }
+        if isPinned { updatedShortcuts.append(item) }
+        storedShortcuts = Self.sanitizedShortcuts(.init(items: updatedShortcuts))
+
+        nextShortcutOperationSequence += 1
+        let primaryMenuIndex = isPinned
+            ? updatedMenu?.firstIndex(where: { $0.id == item.id })
+            : nil
+        let operation = PendingShortcutOperation(
+            item: item,
+            present: isPinned,
+            updatesPrimaryMenu: updatedMenu != nil,
+            primaryMenuIndex: primaryMenuIndex,
+            primaryMenuPredecessorId: primaryMenuIndex.flatMap { index in
+                guard index > 0 else { return nil }
+                return updatedMenu?[index - 1].id
+            },
+            shortcutIndex: currentShortcuts.firstIndex(where: { $0.id == item.id }),
+            mutationId: newSettingMutationId(),
+            sequence: nextShortcutOperationSequence
+        )
+        pendingShortcutOperations[item.id] = operation
+        reconcilePendingShortcutPlacementError()
+
+        saveCache(for: context.cacheKey)
+        enqueueShortcutOperation(
+            operation,
+            context: context
+        )
+    }
+
+    func isLibraryPinned(_ libraryId: Int) -> Bool {
+        shortcuts.items.contains {
+            if case .library(let id, _) = $0 { return id == libraryId }
+            return false
+        }
+    }
+
+    /// The app-defined menu used when the contract value is null. Legacy
+    /// audiobook opt-in remains part of that default until the user authors a
+    /// new menu. Profile-wide shortcuts stay available to every family, but
+    /// only an explicit family menu places them in that family's navigation.
+    func resolvedPrimaryMenuItems(availableLibraries _: [Library] = []) -> [PrimaryMenuItem] {
+        if let primaryMenu, primaryMenu.isValid {
+            return primaryMenu.items
+        }
+
+        var items: [PrimaryMenuItem] = [
+            .builtin(.home),
+            .builtin(.movies),
+            .builtin(.series),
+            .builtin(.music),
+        ]
+        #if os(tvOS)
+        // TVNavPreferences is the semantic owner used by the legacy tvOS
+        // settings row (currently a typealias of AppNavPreferences).
+        let legacyShowsAudiobooks = TVNavPreferences.shared.showAudiobooks
+        #else
+        let legacyShowsAudiobooks = AppNavPreferences.shared.showAudiobooks
+        #endif
+        if legacyShowsAudiobooks {
+            items.append(.builtin(.audiobooks))
+        }
+        items.append(contentsOf: [.builtin(.forYou), .builtin(.calendar)])
+        return Array(Self.deduplicated(items).prefix(Self.maximumPrimaryMenuCount))
+    }
+
+    var hasExplicitPrimaryMenu: Bool { primaryMenu != nil }
+    var primaryMenuUsesDeviceOverride: Bool {
+        primaryMenuSource == .scope(.profileDevice)
+    }
+    var cardPresentationUsesDeviceOverride: Bool {
+        cardPresentationSource == .scope(.profileDevice)
+    }
+    var cardPresentationUsesFamilyOverride: Bool {
+        cardPresentationSource == .scope(.profileClient)
+    }
+    var hasDeviceOverrides: Bool {
+        primaryMenuUsesDeviceOverride || cardPresentationUsesDeviceOverride
+    }
+
+    /// Clear higher-precedence per-device rows so the family-scoped controls
+    /// can truthfully represent and sync the effective value again.
+    func useFamilySettings() {
+        guard let context = operationContext() else { return }
+        if primaryMenuUsesDeviceOverride {
+            scheduleDelete(
+                key: .navPrimaryMenu,
+                scope: .profileDevice,
+                context: context
+            )
+        }
+        if cardPresentationUsesDeviceOverride {
+            scheduleDelete(
+                key: .uiCardPresentation,
+                scope: .profileDevice,
+                context: context
+            )
+        }
+        let deletes = saveTail
+        Task { @MainActor [weak self] in
+            await deletes?.value
+            guard let self,
+                  self.contextIsCurrent(context),
+                  self.syncErrorsByKey.isEmpty else { return }
+            await self.refresh()
+        }
+    }
+
+    /// Remove this family's explicit card row so resolution falls through to
+    /// the profile-wide value or the contract default. This is distinct from
+    /// clearing an older per-device row, which only exposes the family row.
+    func resetCardPresentationToInherited() {
+        guard let context = operationContext() else { return }
+        localMutationRevision += 1
+        pendingSyncWrites.removeValue(forKey: SettingKey.uiCardPresentation.rawValue)
+        storedCardPresentationSource = nil
+        scheduleDelete(
+            key: .uiCardPresentation,
+            scope: .profileClient,
+            context: context
+        )
+        let delete = saveTail
+        Task { @MainActor [weak self] in
+            await delete?.value
+            guard let self,
+                  self.contextIsCurrent(context),
+                  self.syncErrorsByKey[SettingKey.uiCardPresentation.rawValue] == nil else { return }
+            await self.refresh()
+        }
+    }
+
+    @discardableResult
+    private func persist<T: Encodable>(
+        key: SettingKey,
+        scope: SettingScopeIdentity,
+        value: T,
+        context: OperationContext
+    ) -> Bool {
+        let encodedValue: SettingJSONValue
+        do {
+            encodedValue = try SettingJSONValue.encoding(value)
+        } catch {
+            setSyncError(Self.message(for: error), for: key)
+            return false
+        }
+        let pendingWrite = PendingSyncWrite(
+            value: encodedValue,
+            mutationId: newSettingMutationId()
+        )
+        pendingSyncWrites[key.rawValue] = pendingWrite
+        saveCache(for: context.cacheKey)
+        enqueuePersist(
+            key: key,
+            scope: scope,
+            write: pendingWrite,
+            context: context
+        )
+        return true
+    }
+
+    private func enqueuePersist(
+        key: SettingKey,
+        scope: SettingScopeIdentity,
+        write: PendingSyncWrite,
+        context: OperationContext
+    ) {
+        let previousSave = saveTail
+        pendingSaveCount += 1
+        isSaving = true
+
+        let save = Task { @MainActor [weak self] in
+            await previousSave?.value
+            guard let self else { return }
+            defer { self.completeSave() }
+            guard contextIsCurrent(context) else { return }
+            do {
+                try await transport.putValue(
+                    key: key,
+                    scope: scope,
+                    value: write.value,
+                    mutationId: write.mutationId,
+                    requestIdentity: context.requestIdentity
+                )
+                guard contextIsCurrent(context) else { return }
+                if pendingSyncWrites[key.rawValue]?.mutationId == write.mutationId {
+                    pendingSyncWrites.removeValue(forKey: key.rawValue)
+                    saveCache(for: context.cacheKey)
+                }
+                setSyncError(nil, for: key)
+            } catch {
+                guard contextIsCurrent(context) else { return }
+                // Keep the optimistic cache. A later refresh or another edit
+                // retries against the server without making the app unusable
+                // while offline.
+                setSyncError(Self.message(for: error), for: key)
+            }
+        }
+        saveTail = save
+    }
+
+    private func enqueueShortcutOperation(
+        _ operation: PendingShortcutOperation,
+        context: OperationContext
+    ) {
+        let previousSave = saveTail
+        pendingSaveCount += 1
+        isSaving = true
+
+        let save = Task { @MainActor [weak self] in
+            await previousSave?.value
+            guard let self else { return }
+            defer { self.completeSave() }
+            guard contextIsCurrent(context) else { return }
+            do {
+                try await transport.putShortcutItem(
+                    operation.item,
+                    present: operation.present,
+                    mutationId: operation.mutationId,
+                    requestIdentity: context.requestIdentity
+                )
+                guard contextIsCurrent(context) else { return }
+                let identity = operation.item.id
+                if let currentOperation = pendingShortcutOperations[identity],
+                   currentOperation.mutationId == operation.mutationId {
+                    pendingShortcutOperations.removeValue(forKey: identity)
+                    shortcutSyncErrorsByIdentity.removeValue(forKey: identity)
+                    reconcilePendingShortcutPlacementError()
+                    let didPersistMenu = persistPrimaryMenuAfterShortcutAcceptance(
+                        currentOperation,
+                        context: context
+                    )
+                    if !didPersistMenu {
+                        saveCache(for: context.cacheKey)
+                    }
+                    updateSyncErrorMessage()
+                }
+            } catch {
+                guard contextIsCurrent(context) else { return }
+                let identity = operation.item.id
+                guard pendingShortcutOperations[identity]?.mutationId == operation.mutationId else {
+                    return
+                }
+                shortcutSyncErrorsByIdentity[identity] = Self.shortcutMessage(for: error)
+                if Self.isDefinitiveShortcutRejection(error) {
+                    // The server proved this operation can never land as
+                    // authored. Quarantine it from the durable outbox so a
+                    // refresh can adopt the authoritative shortcut document
+                    // instead of retrying forever from stale optimistic state.
+                    pendingShortcutOperations.removeValue(forKey: identity)
+                    rollbackRejectedShortcut(operation)
+                    reconcilePendingShortcutPlacementError()
+                    saveCache(for: context.cacheKey)
+                    Task { @MainActor [weak self] in
+                        guard let self, self.contextIsCurrent(context) else { return }
+                        await self.refresh()
+                    }
+                }
+                updateSyncErrorMessage()
+            }
+        }
+        saveTail = save
+    }
+
+    private func rollbackRejectedShortcut(_ operation: PendingShortcutOperation) {
+        var items = storedShortcuts.items.filter { $0.id != operation.item.id }
+        if !operation.present {
+            let index = min(max(operation.shortcutIndex ?? items.count, 0), items.count)
+            items.insert(operation.item, at: index)
+        }
+        storedShortcuts = Self.sanitizedShortcuts(.init(items: items))
+    }
+
+    /// A rejected explicit menu edit records the exact optimistic pins it
+    /// attempted to place. Unrelated pending pins must not keep that edit's
+    /// validation error alive after its own blockers have settled.
+    private func reconcilePendingShortcutPlacementError() {
+        let acceptedIds = Set(resolvedPrimaryMenuItems().map(\.id))
+        let unacceptedPinIds = Set(pendingShortcutOperations.values.compactMap { operation in
+            operation.present && !acceptedIds.contains(operation.item.id)
+                ? operation.item.id
+                : nil
+        })
+        pendingShortcutPlacementBlockedIds.formIntersection(unacceptedPinIds)
+        if pendingShortcutPlacementBlockedIds.isEmpty {
+            guard syncErrorsByKey[SettingKey.navPrimaryMenu.rawValue]
+                    == Self.pendingShortcutPlacementMessage else { return }
+            setSyncError(nil, for: .navPrimaryMenu)
+        } else {
+            setSyncError(Self.pendingShortcutPlacementMessage, for: .navPrimaryMenu)
+        }
+    }
+
+    @discardableResult
+    private func persistPrimaryMenuAfterShortcutAcceptance(
+        _ operation: PendingShortcutOperation,
+        context: OperationContext
+    ) -> Bool {
+        guard operation.updatesPrimaryMenu,
+              !primaryMenuUsesDeviceOverride else { return false }
+        let previousItems = resolvedPrimaryMenuItems()
+        var items = previousItems.filter { $0.id != operation.item.id }
+        if operation.present {
+            let index = primaryMenuInsertionIndex(for: operation, in: items)
+            items.insert(operation.item, at: index)
+        }
+        let normalized = Self.normalizedPrimaryMenuItems(items)
+        guard normalized != previousItems else { return false }
+        let value = PrimaryMenuPreference(items: normalized)
+        if let encoded = try? SettingJSONValue.encoding(value),
+           pendingSyncWrites[SettingKey.navPrimaryMenu.rawValue]?.value == encoded {
+            // A later explicit edit already queued this exact menu.
+            return false
+        }
+        return setPrimaryMenuItems(
+            normalized,
+            context: context,
+            advancesMutationRevision: false
+        )
+    }
+
+    private func supersedePendingShortcutPlacements() {
+        for (identity, operation) in pendingShortcutOperations
+            where operation.updatesPrimaryMenu {
+            pendingShortcutOperations[identity] = operation.supersedingPrimaryMenuPlacement()
+        }
+    }
+
+    /// Project the final authored menu for validation without exposing an
+    /// unaccepted shortcut as a live family-menu destination. Accepted
+    /// callbacks apply these same ordered deltas to storedPrimaryMenu one at a
+    /// time, so retries and definitive rejections cannot leak sibling intent.
+    private func projectedPrimaryMenuItems() -> [PrimaryMenuItem] {
+        var items = resolvedPrimaryMenuItems()
+        let operations = pendingShortcutOperations.values.sorted {
+            if $0.sequence == $1.sequence { return $0.item.id < $1.item.id }
+            return $0.sequence < $1.sequence
+        }
+        for operation in operations where operation.updatesPrimaryMenu {
+            items.removeAll { $0.id == operation.item.id }
+            guard operation.present else { continue }
+            let index = primaryMenuInsertionIndex(for: operation, in: items)
+            items.insert(operation.item, at: index)
+        }
+        return Self.normalizedPrimaryMenuItems(items)
+    }
+
+    private func primaryMenuInsertionIndex(
+        for operation: PendingShortcutOperation,
+        in items: [PrimaryMenuItem]
+    ) -> Int {
+        if let predecessorId = operation.primaryMenuPredecessorId,
+           let predecessorIndex = items.firstIndex(where: { $0.id == predecessorId }) {
+            return predecessorIndex + 1
+        }
+        return min(max(operation.primaryMenuIndex ?? items.count, 0), items.count)
+    }
+
+    private func scheduleDelete(
+        key: SettingKey,
+        scope: SettingScopeIdentity,
+        context: OperationContext
+    ) {
+        if scope.scope == .profileClient {
+            pendingSyncWrites.removeValue(forKey: key.rawValue)
+        }
+        let pendingDelete = PendingDelete(scope: scope.scope)
+        pendingDeletes[Self.deleteIdentity(key: key, scope: scope.scope)] = pendingDelete
+        saveCache(for: context.cacheKey)
+        enqueueDelete(
+            key: key,
+            scope: scope,
+            pendingDelete: pendingDelete,
+            context: context
+        )
+    }
+
+    private func enqueueDelete(
+        key: SettingKey,
+        scope: SettingScopeIdentity,
+        pendingDelete: PendingDelete,
+        context: OperationContext
+    ) {
+        let previousSave = saveTail
+        pendingSaveCount += 1
+        isSaving = true
+
+        let save = Task { @MainActor [weak self] in
+            await previousSave?.value
+            guard let self else { return }
+            defer { self.completeSave() }
+            guard contextIsCurrent(context) else { return }
+            do {
+                try await transport.deleteValue(
+                    key: key,
+                    scope: scope,
+                    requestIdentity: context.requestIdentity
+                )
+                guard contextIsCurrent(context) else { return }
+                let identity = Self.deleteIdentity(key: key, scope: scope.scope)
+                if pendingDeletes[identity]?.operationId == pendingDelete.operationId {
+                    pendingDeletes.removeValue(forKey: identity)
+                }
+                saveCache(for: context.cacheKey)
+                setSyncError(nil, for: key)
+            } catch {
+                guard contextIsCurrent(context) else { return }
+                if case .noValueAtScope = SettingsAPIError.from(error) {
+                    let identity = Self.deleteIdentity(key: key, scope: scope.scope)
+                    if pendingDeletes[identity]?.operationId == pendingDelete.operationId {
+                        pendingDeletes.removeValue(forKey: identity)
+                    }
+                    saveCache(for: context.cacheKey)
+                    setSyncError(nil, for: key)
+                } else {
+                    setSyncError("Could not reset this setting to its inherited value.", for: key)
+                }
+            }
+        }
+        saveTail = save
+    }
+
+    /// Durable optimistic writes are replayed before reading effective values.
+    /// Otherwise an online refresh after an offline edit would replace the
+    /// user's cached choice with the server's older value before retrying it.
+    private func drainPendingWrites(
+        targetCacheKey: String?,
+        requestIdentity: HTTPRequestIdentity,
+        sequence: Int,
+        mutationRevision: Int
+    ) async -> Bool {
+        await saveTail?.value
+        guard refreshSequence == sequence,
+              localMutationRevision == mutationRevision,
+              cacheKey() == targetCacheKey,
+              capturedIdentity(for: targetCacheKey) == requestIdentity else { return false }
+
+        guard let targetCacheKey else { return false }
+        let context = OperationContext(
+            cacheKey: targetCacheKey,
+            requestIdentity: requestIdentity
+        )
+        let deletes = pendingDeletes.sorted(by: { $0.key < $1.key })
+        let pendingShortcuts = pendingShortcutOperations.values.sorted {
+            if $0.sequence == $1.sequence { return $0.item.id < $1.item.id }
+            return $0.sequence < $1.sequence
+        }
+        let pending = Self.keys.compactMap { key -> (SettingKey, PendingSyncWrite)? in
+            guard let write = pendingSyncWrites[key.rawValue],
+                  Self.writeScope(for: key) != nil else { return nil }
+            return (key, write)
+        }
+        guard !deletes.isEmpty || !pendingShortcuts.isEmpty || !pending.isEmpty else { return true }
+
+        for (identity, delete) in deletes {
+            guard let keyRaw = identity.split(separator: "|", maxSplits: 1).first,
+                  let key = SettingKey(rawValue: String(keyRaw)),
+                  let scope = delete.scopeIdentity else { continue }
+            enqueueDelete(
+                key: key,
+                scope: scope,
+                pendingDelete: delete,
+                context: context
+            )
+        }
+        for operation in pendingShortcuts {
+            enqueueShortcutOperation(
+                operation,
+                context: context
+            )
+        }
+        for (key, write) in pending {
+            guard let scope = Self.writeScope(for: key) else { continue }
+            enqueuePersist(
+                key: key,
+                scope: scope,
+                write: write,
+                context: context
+            )
+        }
+        let replayTail = saveTail
+        await replayTail?.value
+        // An accepted shortcut may enqueue its dependent family-menu write.
+        // Capture the new tail after the shortcut completes so refresh does
+        // not return early with half of the compound pin still pending.
+        await saveTail?.value
+        guard refreshSequence == sequence,
+              localMutationRevision == mutationRevision,
+              cacheKey() == targetCacheKey,
+              capturedIdentity(for: targetCacheKey) == requestIdentity else { return false }
+        return pendingSyncWrites.isEmpty
+            && pendingShortcutOperations.isEmpty
+            && pendingDeletes.isEmpty
+    }
+
+    private func completeSave() {
+        pendingSaveCount = max(0, pendingSaveCount - 1)
+        isSaving = pendingSaveCount > 0
+    }
+
+    private func loadCache(for key: String?) {
+        if loadedCacheKey != key {
+            if loadedCacheKey != nil {
+                capabilityState = .checking
+            }
+            loadedCacheKey = key
+            clearSyncErrors()
+        }
+        storedPrimaryMenu = nil
+        storedShortcuts = .empty
+        storedCardPresentation = .standard
+        storedPrimaryMenuSource = nil
+        storedCardPresentationSource = nil
+        supportProjection = .unknown
+        pendingSyncWrites = [:]
+        pendingShortcutOperations = [:]
+        pendingShortcutPlacementBlockedIds = []
+        pendingDeletes = [:]
+        nextShortcutOperationSequence = 0
+        guard let key,
+              let data = defaults.data(forKey: key),
+              let cached = try? SettingsWireCoding.makeDecoder().decode(Cache.self, from: data)
+        else { return }
+        storedPrimaryMenu = cached.primaryMenu?.isValid == true ? cached.primaryMenu : nil
+        storedShortcuts = Self.sanitizedShortcuts(cached.shortcuts)
+        storedCardPresentation = cached.cardPresentation
+        storedPrimaryMenuSource = cached.primaryMenuSource
+        storedCardPresentationSource = cached.cardPresentationSource
+        supportProjection = cached.supportProjection ?? .unknown
+        pendingSyncWrites = cached.pendingSyncWrites ?? [:]
+        // Whole-document shortcut retries predate the atomic endpoint and
+        // cannot be safely replayed without reintroducing lost updates.
+        pendingSyncWrites.removeValue(forKey: SettingKey.navShortcuts.rawValue)
+        pendingShortcutOperations = Self.validPendingShortcutOperations(
+            cached.pendingShortcutOperations ?? [:]
+        )
+        pendingShortcutPlacementBlockedIds = Set(
+            cached.pendingShortcutPlacementBlockedIds ?? []
+        )
+        pendingDeletes = Self.validPendingDeletes(cached.pendingDeletes ?? [:])
+        nextShortcutOperationSequence = pendingShortcutOperations.values
+            .map(\.sequence)
+            .max() ?? 0
+        reconcilePendingShortcutPlacementError()
+    }
+
+    private func saveCache(for key: String?) {
+        guard let key,
+              let data = try? SettingsWireCoding.makeEncoder().encode(Cache(
+                primaryMenu: storedPrimaryMenu,
+                shortcuts: storedShortcuts,
+                cardPresentation: storedCardPresentation,
+                primaryMenuSource: storedPrimaryMenuSource,
+                cardPresentationSource: storedCardPresentationSource,
+                supportProjection: supportProjection,
+                pendingSyncWrites: pendingSyncWrites.isEmpty ? nil : pendingSyncWrites,
+                pendingShortcutOperations: pendingShortcutOperations.isEmpty
+                    ? nil
+                    : pendingShortcutOperations,
+                pendingShortcutPlacementBlockedIds: pendingShortcutPlacementBlockedIds.isEmpty
+                    ? nil
+                    : pendingShortcutPlacementBlockedIds.sorted(),
+                pendingDeletes: pendingDeletes.isEmpty ? nil : pendingDeletes
+              ))
+        else { return }
+        defaults.set(data, forKey: key)
+    }
+
+    /// Writes are serialized, but a later successful setting must not erase a
+    /// failure from an earlier key (pinning a library writes shortcuts and the
+    /// family menu back-to-back). A successful refresh is the only operation
+    /// that proves the complete effective bundle reconciled.
+    private func setSyncError(_ message: String?, for key: SettingKey) {
+        if let message {
+            syncErrorsByKey[key.rawValue] = message
+        } else {
+            syncErrorsByKey.removeValue(forKey: key.rawValue)
+        }
+        updateSyncErrorMessage()
+    }
+
+    private func clearSyncErrors() {
+        syncErrorsByKey.removeAll()
+        shortcutSyncErrorsByIdentity.removeAll()
+        refreshSyncErrorMessage = nil
+        updateSyncErrorMessage()
+    }
+
+    /// A successful effective read resolves ordinary write/read failures, but
+    /// a definitive shortcut rejection remains useful after the optimistic
+    /// state snaps back: it tells the user why their pin did not stick. The
+    /// next successful operation for that semantic identity clears it.
+    private func clearReconciledSyncErrors() {
+        syncErrorsByKey.removeAll()
+        refreshSyncErrorMessage = nil
+        reconcilePendingShortcutPlacementError()
+        updateSyncErrorMessage()
+    }
+
+    private func updateSyncErrorMessage() {
+        let shortcutMessage = shortcutSyncErrorsByIdentity
+            .sorted { $0.key < $1.key }
+            .first?.value
+        syncErrorMessage = refreshSyncErrorMessage
+            ?? Self.keys.lazy.compactMap { key in
+                self.syncErrorsByKey[key.rawValue]
+                    ?? (key == .navShortcuts ? shortcutMessage : nil)
+            }.first
+    }
+
+    private func operationContext() -> OperationContext? {
+        guard allowsEditing,
+              let targetCacheKey = cacheKey(),
+              let identity = capturedIdentity(for: targetCacheKey) else { return nil }
+        return OperationContext(cacheKey: targetCacheKey, requestIdentity: identity)
+    }
+
+    private func contextIsCurrent(_ context: OperationContext) -> Bool {
+        cacheKey() == context.cacheKey
+            && capturedIdentity(for: context.cacheKey) == context.requestIdentity
+    }
+
+    private func capturedIdentity(for targetCacheKey: String?) -> HTTPRequestIdentity? {
+        guard let targetCacheKey,
+              let identity = requestIdentity(),
+              Self.cacheKey(for: identity) == targetCacheKey else { return nil }
+        return identity
+    }
+
+    private static func activeCacheKey() -> String? {
+        guard let identity = activeRequestIdentity() else { return nil }
+        return cacheKey(for: identity)
+    }
+
+    private static func activeRequestIdentity() -> HTTPRequestIdentity? {
+        guard let server = ServerRegistry.shared.activeServer,
+              ServerRegistry.shared.activeServerId == server.id,
+              let profileId = AuthService.shared.profileId,
+              !profileId.isEmpty,
+              server.profileId == profileId else { return nil }
+        return HTTPRequestIdentity(
+            serverId: server.id,
+            serverURL: server.url,
+            profileId: profileId,
+            clientFamily: AppleDeviceIdentity.current.clientFamily
+        )
+    }
+
+    private static func cacheKey(for identity: HTTPRequestIdentity) -> String {
+        "silo.uiCustomization.\(identity.serverId).\(identity.profileId).\(identity.clientFamily)"
+    }
+
+    private static func deleteIdentity(key: SettingKey, scope: SettingScope) -> String {
+        "\(key.rawValue)|\(scope.rawValue)"
+    }
+
+    private static let keys: [SettingKey] = [
+        .navPrimaryMenu,
+        .navShortcuts,
+        .uiCardPresentation,
+    ]
+
+    private static let maximumPrimaryMenuCount = 64
+    private static let maximumShortcutCount = 256
+    private static let primaryMenuLimitMessage = "You can show up to 64 top-menu destinations."
+    private static let shortcutLimitMessage = "You can pin up to 256 navigation shortcuts."
+    private static let pendingShortcutPlacementMessage =
+        "Wait for this library pin to finish syncing before placing it in the top menu."
+
+    private static func writeScope(for key: SettingKey) -> SettingScopeIdentity? {
+        switch key {
+        case .navPrimaryMenu, .uiCardPresentation:
+            return .profileClient
+        default:
+            return nil
+        }
+    }
+
+    private static func validPendingShortcutOperations(
+        _ operations: [String: PendingShortcutOperation]
+    ) -> [String: PendingShortcutOperation] {
+        var migrated: [String: PendingShortcutOperation] = [:]
+        for (persistedIdentity, operation) in operations {
+            let canonicalIdentity = operation.item.id
+            guard (persistedIdentity == canonicalIdentity
+                    || persistedIdentity == operation.item.legacyUnstructuredId),
+                  operation.item.isContractValid,
+                  !operation.mutationId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            else { continue }
+            if case .builtin = operation.item { continue }
+
+            if let existing = migrated[canonicalIdentity] {
+                let existingWins = existing.sequence > operation.sequence
+                    || (existing.sequence == operation.sequence
+                        && existing.mutationId >= operation.mutationId)
+                if existingWins { continue }
+            }
+            migrated[canonicalIdentity] = operation
+        }
+        return migrated
+    }
+
+    private static func validPendingDeletes(
+        _ deletes: [String: PendingDelete]
+    ) -> [String: PendingDelete] {
+        deletes.filter { identity, delete in
+            guard let keyRaw = identity.split(separator: "|", maxSplits: 1).first,
+                  let key = SettingKey(rawValue: String(keyRaw)),
+                  let scope = delete.scopeIdentity,
+                  !delete.operationId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            else { return false }
+            return identity == deleteIdentity(key: key, scope: scope.scope)
+                && (key == .navPrimaryMenu || key == .uiCardPresentation)
+        }
+    }
+
+    private static func sanitizedShortcuts(
+        _ value: NavigationShortcutsPreference
+    ) -> NavigationShortcutsPreference {
+        let withoutBuiltins = value.items.filter {
+            guard $0.isContractValid else { return false }
+            if case .builtin = $0 { return false }
+            return true
+        }
+        return .init(items: Array(deduplicated(withoutBuiltins).prefix(maximumShortcutCount)))
+    }
+
+    private static func deduplicated(_ items: [PrimaryMenuItem]) -> [PrimaryMenuItem] {
+        var seen = Set<String>()
+        return items.filter { seen.insert($0.id).inserted }
+    }
+
+    private static func normalizedPrimaryMenuItems(
+        _ items: [PrimaryMenuItem]
+    ) -> [PrimaryMenuItem] {
+        var normalized = deduplicated(items)
+        if !normalized.contains(where: \.isHome) {
+            normalized.insert(.builtin(.home), at: 0)
+        }
+        return normalized
+    }
+
+    private static func message(for error: Error) -> String {
+        switch SettingsAPIError.from(error) {
+        case .serverUpgradeRequired, .unknownSetting:
+            return "Update this Silo server to sync interface preferences."
+        case .transport:
+            return "Saved on this device. Sync will resume when the server is reachable."
+        default:
+            return "Saved on this device, but the server did not accept the change."
+        }
+    }
+
+    private static func shortcutMessage(for error: Error) -> String {
+        switch SettingsAPIError.from(error) {
+        case .invalidValue(let message) where message.contains("256"):
+            return "This profile already has 256 navigation shortcuts. Unpin one and try again."
+        case .invalidValue:
+            return "The server rejected this shortcut. Check the selection and try again."
+        case .mutationIdConflict:
+            return "Another device changed this shortcut. The menu was refreshed; try again."
+        default:
+            return Self.message(for: error)
+        }
+    }
+
+    private static func isDefinitiveShortcutRejection(_ error: Error) -> Bool {
+        switch SettingsAPIError.from(error) {
+        case .transport, .serverUpgradeRequired, .profileRequired,
+             .unknownSetting, .server:
+            return false
+        case .clientLocalSetting, .scopeNotAllowed, .invalidValue,
+             .mutationIdConflict, .noValueAtScope:
+            return true
+        }
+    }
+}

--- a/iosApp/iosApp/Navigation/UICustomizationPreferences.swift
+++ b/iosApp/iosApp/Navigation/UICustomizationPreferences.swift
@@ -754,26 +754,23 @@ final class UICustomizationPreferences {
                   cacheKey() == targetCacheKey,
                   capturedIdentity(for: targetCacheKey) == identity else { return }
             let values = response.byKey
-
-            if let row = values[.navPrimaryMenu] {
-                storedPrimaryMenuSource = row.source
-                if row.value.isNull {
-                    storedPrimaryMenu = nil
-                } else {
-                    let decoded = try row.value.decoded(as: PrimaryMenuPreference.self)
-                    storedPrimaryMenu = decoded.isValid ? decoded : nil
+            var decodedEveryValue = true
+            for key in Self.keys {
+                guard let row = values[key] else {
+                    setSyncError(Self.missingEffectiveValueMessage, for: key)
+                    decodedEveryValue = false
+                    continue
                 }
-            }
-            if let row = values[.navShortcuts] {
-                let decoded = try row.value.decoded(as: NavigationShortcutsPreference.self)
-                storedShortcuts = Self.sanitizedShortcuts(decoded)
-            }
-            if let row = values[.uiCardPresentation] {
-                storedCardPresentationSource = row.source
-                storedCardPresentation = try row.value.decoded(as: CardPresentationPreference.self)
+                decodedEveryValue = applyEffectiveValue(row, for: key) && decodedEveryValue
             }
 
-            clearReconciledSyncErrors()
+            if decodedEveryValue {
+                clearReconciledSyncErrors()
+            } else {
+                refreshSyncErrorMessage = nil
+                reconcilePendingShortcutPlacementError()
+                updateSyncErrorMessage()
+            }
             saveCache(for: targetCacheKey)
         } catch {
             guard refreshSequence == sequence,
@@ -1307,27 +1304,115 @@ final class UICustomizationPreferences {
                     requestIdentity: context.requestIdentity
                 )
                 guard contextIsCurrent(context) else { return }
-                let identity = Self.deleteIdentity(key: key, scope: scope.scope)
-                if pendingDeletes[identity]?.operationId == pendingDelete.operationId {
-                    pendingDeletes.removeValue(forKey: identity)
-                }
-                saveCache(for: context.cacheKey)
-                setSyncError(nil, for: key)
+                await finishAcceptedDelete(
+                    key: key,
+                    scope: scope,
+                    pendingDelete: pendingDelete,
+                    context: context
+                )
             } catch {
                 guard contextIsCurrent(context) else { return }
                 if case .noValueAtScope = SettingsAPIError.from(error) {
-                    let identity = Self.deleteIdentity(key: key, scope: scope.scope)
-                    if pendingDeletes[identity]?.operationId == pendingDelete.operationId {
-                        pendingDeletes.removeValue(forKey: identity)
-                    }
-                    saveCache(for: context.cacheKey)
-                    setSyncError(nil, for: key)
+                    await finishAcceptedDelete(
+                        key: key,
+                        scope: scope,
+                        pendingDelete: pendingDelete,
+                        context: context
+                    )
                 } else {
+                    let identity = Self.deleteIdentity(key: key, scope: scope.scope)
+                    guard pendingDeletes[identity]?.operationId == pendingDelete.operationId else {
+                        return
+                    }
                     setSyncError("Could not reset this setting to its inherited value.", for: key)
                 }
             }
         }
         saveTail = save
+    }
+
+    /// A successful device-row delete changes the effective value immediately,
+    /// even if another queued delete fails. Reconcile only this accepted key so
+    /// a failed sibling remains durable for retry without blocking the value
+    /// that the server has already exposed underneath the deleted override.
+    private func finishAcceptedDelete(
+        key: SettingKey,
+        scope: SettingScopeIdentity,
+        pendingDelete: PendingDelete,
+        context: OperationContext
+    ) async {
+        let identity = Self.deleteIdentity(key: key, scope: scope.scope)
+        guard pendingDeletes[identity]?.operationId == pendingDelete.operationId else { return }
+
+        guard scope.scope == .profileDevice else {
+            pendingDeletes.removeValue(forKey: identity)
+            saveCache(for: context.cacheKey)
+            setSyncError(nil, for: key)
+            return
+        }
+
+        do {
+            let response = try await transport.effectiveValues(
+                keys: [key],
+                requestIdentity: context.requestIdentity
+            )
+            guard contextIsCurrent(context),
+                  pendingDeletes[identity]?.operationId == pendingDelete.operationId else { return }
+            guard let row = response.byKey[key] else {
+                setSyncError(Self.missingEffectiveValueMessage, for: key)
+                return
+            }
+            guard applyEffectiveValue(row, for: key) else { return }
+            pendingDeletes.removeValue(forKey: identity)
+            saveCache(for: context.cacheKey)
+        } catch {
+            guard contextIsCurrent(context),
+                  pendingDeletes[identity]?.operationId == pendingDelete.operationId else { return }
+            setSyncError(Self.message(for: error), for: key)
+        }
+    }
+
+    /// Decode and apply one key atomically. A future value for one setting must
+    /// not prevent compatible siblings from reconciling, and its source must
+    /// never be paired with a stale value from an earlier successful read.
+    @discardableResult
+    private func applyEffectiveValue(
+        _ row: EffectiveSettingValue,
+        for key: SettingKey
+    ) -> Bool {
+        do {
+            switch key {
+            case .navPrimaryMenu:
+                let menu: PrimaryMenuPreference?
+                if row.value.isNull {
+                    menu = nil
+                } else {
+                    let decoded = try row.value.decoded(as: PrimaryMenuPreference.self)
+                    guard decoded.isValid else {
+                        throw SettingsAPIError.invalidValue(
+                            message: "The primary menu value is not valid for this client."
+                        )
+                    }
+                    menu = decoded
+                }
+                storedPrimaryMenu = menu
+                storedPrimaryMenuSource = row.source
+            case .navShortcuts:
+                let decoded = try row.value.decoded(as: NavigationShortcutsPreference.self)
+                storedShortcuts = Self.sanitizedShortcuts(decoded)
+            case .uiCardPresentation:
+                let presentation = try row.value.decoded(as: CardPresentationPreference.self)
+                storedCardPresentation = presentation
+                storedCardPresentationSource = row.source
+            default:
+                throw SettingsAPIError.unknownSetting(key: key.rawValue)
+            }
+            setSyncError(nil, for: key)
+            return true
+        } catch {
+            setSyncError(Self.effectiveValueDecodeMessage, for: key)
+            return false
+        }
     }
 
     /// Durable optimistic writes are replayed before reading effective values.
@@ -1576,6 +1661,10 @@ final class UICustomizationPreferences {
     private static let shortcutLimitMessage = "You can pin up to 256 navigation shortcuts."
     private static let pendingShortcutPlacementMessage =
         "Wait for this library pin to finish syncing before placing it in the top menu."
+    private static let effectiveValueDecodeMessage =
+        "Could not read this interface preference from the server."
+    private static let missingEffectiveValueMessage =
+        "The server did not return this interface preference."
 
     private static func writeScope(for key: SettingKey) -> SettingScopeIdentity? {
         switch key {

--- a/iosApp/iosApp/Networking/AuthTokenModels.swift
+++ b/iosApp/iosApp/Networking/AuthTokenModels.swift
@@ -44,6 +44,14 @@ struct ImpersonationInfo: Codable {
 /// Body for POST /api/v1/auth/refresh.
 struct RefreshRequest: Codable {
     let refreshToken: String
+
+    init(refreshToken value: String) {
+        refreshToken = value
+    }
+
+    init(_ value: String) {
+        refreshToken = value
+    }
 }
 
 /// Response from POST /api/v1/auth/refresh.

--- a/iosApp/iosApp/Networking/ContinuumAPI+Settings.swift
+++ b/iosApp/iosApp/Networking/ContinuumAPI+Settings.swift
@@ -34,14 +34,17 @@ extension ContinuumAPI {
     /// Needs no profile: the contract is the same for every profile on the
     /// server, so this route sits outside the server's `RequireProfile` group
     /// and can be probed before profile selection.
-    func getContractCapabilities() async -> SettingsCapabilitiesResult {
+    func getContractCapabilities(
+        requestIdentity: HTTPRequestIdentity? = nil
+    ) async -> SettingsCapabilitiesResult {
         do {
             let response = try await http.requestData(
                 method: "GET",
                 path: "/api/v1/settings/contract/capabilities",
                 // A 404 here is the documented "server is too old" signal, not
                 // a failure worth logging as one.
-                quietStatuses: [404]
+                quietStatuses: [404],
+                requestIdentity: requestIdentity
             )
             let capabilities = try SettingsWireCoding.makeDecoder()
                 .decode(SettingsContractCapabilities.self, from: response.data)
@@ -73,7 +76,8 @@ extension ContinuumAPI {
         keys: [SettingKey] = [],
         libraryIds: [Int] = [],
         seriesIds: [String] = [],
-        profileId: String? = nil
+        profileId: String? = nil,
+        requestIdentity: HTTPRequestIdentity? = nil
     ) async throws -> EffectiveSettingValuesResponse {
         let headers = try await profileHeaders(explicit: profileId)
 
@@ -93,7 +97,8 @@ extension ContinuumAPI {
                 method: "GET",
                 path: "/api/v1/settings/values/effective",
                 query: query,
-                headers: headers
+                headers: headers,
+                requestIdentity: requestIdentity
             )
             let decoded = try SettingsWireCoding.makeDecoder()
                 .decode(EffectiveSettingValuesResponse.self, from: response.data)
@@ -128,7 +133,8 @@ extension ContinuumAPI {
         scope: SettingScopeIdentity,
         value: SettingJSONValue,
         mutationId: String,
-        profileId: String? = nil
+        profileId: String? = nil,
+        requestIdentity: HTTPRequestIdentity? = nil
     ) async throws -> SettingValueWriteReceipt {
         let trimmedMutationId = mutationId.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedMutationId.isEmpty else {
@@ -144,7 +150,8 @@ extension ContinuumAPI {
                 path: "/api/v1/settings/values/\(key.rawValue)",
                 query: scope.queryItems,
                 body: body,
-                headers: headers
+                headers: headers,
+                requestIdentity: requestIdentity
             )
             let stored = try SettingsWireCoding.makeDecoder()
                 .decode(StoredSettingValue.self, from: response.data)
@@ -157,6 +164,60 @@ extension ContinuumAPI {
         }
     }
 
+    /// Atomically add or remove one semantic shortcut from `nav.shortcuts`.
+    ///
+    /// Unlike a whole-value PUT, this operation is safe when multiple clients
+    /// edit different shortcuts from stale effective snapshots. The mutation
+    /// id still belongs to one exact `{item, present}` operation and must be
+    /// reused when its response is ambiguous.
+    @discardableResult
+    func putNavigationShortcutItem(
+        _ item: PrimaryMenuItem,
+        present: Bool,
+        mutationId: String,
+        profileId: String? = nil,
+        requestIdentity: HTTPRequestIdentity? = nil
+    ) async throws -> SettingValueWriteReceipt {
+        guard item.isContractValid else {
+            throw SettingsAPIError.invalidValue(message: "Shortcut item is invalid.")
+        }
+        if case .builtin = item {
+            throw SettingsAPIError.invalidValue(message: "Built-in destinations cannot be shortcuts.")
+        }
+        let trimmedMutationId = mutationId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedMutationId.isEmpty else {
+            throw SettingsAPIError.invalidValue(message: "Mutation ID must not be blank.")
+        }
+
+        var headers = try await profileHeaders(explicit: profileId)
+        headers["X-Silo-Mutation-Id"] = trimmedMutationId
+
+        do {
+            let body = try SettingsWireCoding.makeEncoder().encode(
+                NavigationShortcutItemWriteRequest(item: item, present: present)
+            )
+            let response = try await http.requestData(
+                method: "PUT",
+                path: "/api/v1/settings/values/\(SettingKey.navShortcuts.rawValue)/item",
+                body: body,
+                headers: headers,
+                requestIdentity: requestIdentity
+            )
+            let stored = try SettingsWireCoding.makeDecoder()
+                .decode(StoredSettingValue.self, from: response.data)
+            return SettingValueWriteReceipt(
+                value: stored,
+                isIdempotentReplay: response.header("X-Silo-Idempotent-Replay") == "true"
+            )
+        } catch {
+            throw SettingsAPIError.from(
+                error,
+                key: SettingKey.navShortcuts.rawValue,
+                scope: .profile
+            )
+        }
+    }
+
     /// Clear the explicit value at one scope, so the setting inherits again.
     ///
     /// Throws ``SettingsAPIError/noValueAtScope`` when nothing was stored
@@ -165,7 +226,8 @@ extension ContinuumAPI {
     func deleteValue(
         key: SettingKey,
         scope: SettingScopeIdentity,
-        profileId: String? = nil
+        profileId: String? = nil,
+        requestIdentity: HTTPRequestIdentity? = nil
     ) async throws {
         let headers = try await profileHeaders(explicit: profileId)
         do {
@@ -174,7 +236,8 @@ extension ContinuumAPI {
                 path: "/api/v1/settings/values/\(key.rawValue)",
                 query: scope.queryItems,
                 headers: headers,
-                quietStatuses: [404]
+                quietStatuses: [404],
+                requestIdentity: requestIdentity
             )
         } catch {
             throw SettingsAPIError.from(error, key: key.rawValue, scope: scope.scope)
@@ -206,4 +269,9 @@ extension ContinuumAPI {
         }
         return ["X-Profile-Id": profile]
     }
+}
+
+private struct NavigationShortcutItemWriteRequest: Encodable {
+    let item: PrimaryMenuItem
+    let present: Bool
 }

--- a/iosApp/iosApp/Networking/ContinuumAPI+Settings.swift
+++ b/iosApp/iosApp/Networking/ContinuumAPI+Settings.swift
@@ -126,7 +126,8 @@ extension ContinuumAPI {
     /// A value that exceeds a policy restriction is stored, not rejected: the
     /// restriction filters what the preference does at resolution time, so a
     /// successful write does not mean playback will use this value. Call
-    /// ``getEffectiveValues(keys:libraryIds:seriesIds:profileId:)`` for that.
+    /// ``getEffectiveValues(keys:libraryIds:seriesIds:profileId:requestIdentity:)``
+    /// for that.
     @discardableResult
     func putValue(
         key: SettingKey,

--- a/iosApp/iosApp/Networking/HTTPClient.swift
+++ b/iosApp/iosApp/Networking/HTTPClient.swift
@@ -18,6 +18,7 @@ enum CapturedHTTPRequestCredentialOwner: Equatable, Sendable {
 }
 
 struct CapturedHTTPRequestAuth: Sendable {
+    let account: RefreshAccountIdentity
     let serverURL: String
     let accessToken: String?
     let refreshToken: String?
@@ -26,6 +27,7 @@ struct CapturedHTTPRequestAuth: Sendable {
     let credentialOwner: CapturedHTTPRequestCredentialOwner
 
     init(
+        account: RefreshAccountIdentity,
         serverURL: String,
         accessValue: String?,
         refreshValue value: String?,
@@ -33,6 +35,7 @@ struct CapturedHTTPRequestAuth: Sendable {
         profileValue otherValue: String?,
         credentialOwner: CapturedHTTPRequestCredentialOwner
     ) {
+        self.account = account
         self.serverURL = serverURL
         accessToken = accessValue
         refreshToken = value
@@ -40,6 +43,20 @@ struct CapturedHTTPRequestAuth: Sendable {
         profileToken = otherValue
         self.credentialOwner = credentialOwner
     }
+}
+
+/// Test-visible signal for proving that two request paths reached the same
+/// keyed refresh flight before its owner is released.
+enum RefreshFlightJoinKind: Sendable {
+    case scoped
+    case ordinary
+}
+
+/// Exclusive lease spanning an identity switch from its first cancellation
+/// through the final defaults/TokenStore commit. Requests are rejected while
+/// a lease is held so they cannot capture a half-retargeted credential set.
+struct HTTPIdentityTransitionLease: Hashable, Sendable {
+    fileprivate let id: UUID
 }
 
 /// URLSession-backed HTTP client for the Silo server.
@@ -76,6 +93,19 @@ actor HTTPClient {
     private let tokenStore: TokenStore
     private let decoder: JSONDecoder
     private let encoder: JSONEncoder
+    private let refreshFlightJoinObserver: (@Sendable (RefreshFlightJoinKind) -> Void)?
+    /// Test barrier used to make overlapping cancellation attempts
+    /// deterministic. Production passes nil.
+    private let cancellationPassBarrier: (@Sendable () async -> Void)?
+    /// Test barrier after each URLSession cancellation snapshot. Production
+    /// passes nil; requests are rejected while any such pass remains active.
+    private let cancellationSessionBarrier: (@Sendable (Int) async -> Void)?
+    /// Test barrier between a successful scoped refresh and its retry
+    /// recapture. Production passes nil. The recapture after this suspension
+    /// is deliberately generation-checked against the original request.
+    private let scopedRefreshRetryBarrier: (@Sendable () async -> Void)?
+    private let requestCaptureBarrier: (@Sendable () async -> Void)?
+    private let responseReceivedBarrier: (@Sendable () async -> Void)?
 
     /// Refresh tokens rotate at server-account scope. Ordinary requests and
     /// captured-identity settings requests therefore share this one keyed
@@ -88,12 +118,55 @@ actor HTTPClient {
         let task: Task<Bool, Never>
     }
 
-    init(session: URLSession? = nil, tokenStore: TokenStore = .shared) {
+    /// Global URLSession enumeration is asynchronous. Queue cancellation
+    /// passes so a replacement identity can await its own pass before it is
+    /// installed, without an older pass later enumerating replacement work.
+    private var cancellationTail: CancellationFlight?
+
+    private struct CancellationFlight {
+        let id: UUID
+        let task: Task<Void, Never>
+    }
+
+    private var activeIdentityTransitionLease: HTTPIdentityTransitionLease?
+    private var identityTransitionWaiters: [IdentityTransitionWaiter] = []
+    private var requestDispatchWaiters: [RequestDispatchWaiter] = []
+    /// Invalidates request captures even when a short transition begins and
+    /// completes entirely while the request is suspended on another actor.
+    private var requestDispatchRevision: UInt64 = 0
+
+    private struct IdentityTransitionWaiter {
+        let id: UUID
+        let lease: HTTPIdentityTransitionLease
+        let continuation: CheckedContinuation<HTTPIdentityTransitionLease?, Never>
+    }
+
+    private struct RequestDispatchWaiter {
+        let id: UUID
+        let continuation: CheckedContinuation<Bool, Never>
+    }
+
+    init(
+        session: URLSession? = nil,
+        tokenStore: TokenStore = .shared,
+        refreshFlightJoinObserver: (@Sendable (RefreshFlightJoinKind) -> Void)? = nil,
+        cancellationPassBarrier: (@Sendable () async -> Void)? = nil,
+        cancellationSessionBarrier: (@Sendable (Int) async -> Void)? = nil,
+        scopedRefreshRetryBarrier: (@Sendable () async -> Void)? = nil,
+        requestCaptureBarrier: (@Sendable () async -> Void)? = nil,
+        responseReceivedBarrier: (@Sendable () async -> Void)? = nil
+    ) {
         // An injected session (tests) serves both timeout classes so mocks
         // observe every request regardless of the caller's timeout choice.
         self.session = session ?? Self.makeSession(requestTimeout: 15)
         self.longWaitSession = session ?? Self.makeSession(requestTimeout: 90)
         self.tokenStore = tokenStore
+        self.refreshFlightJoinObserver = refreshFlightJoinObserver
+        self.cancellationPassBarrier = cancellationPassBarrier
+        self.cancellationSessionBarrier = cancellationSessionBarrier
+        self.scopedRefreshRetryBarrier = scopedRefreshRetryBarrier
+        self.requestCaptureBarrier = requestCaptureBarrier
+        self.responseReceivedBarrier = responseReceivedBarrier
 
         self.decoder = Self.makeJSONDecoder()
 
@@ -162,6 +235,39 @@ actor HTTPClient {
         try await send(method: "GET", path: path, query: query, body: Optional<String>.none)
     }
 
+    /// Probe a candidate server without mutating global routing state or
+    /// attaching credentials from the currently active server.
+    func getUnauthenticated<T: Decodable>(
+        serverURL: String,
+        path: String
+    ) async throws -> T {
+        let dispatchRevision = try captureRequestDispatchRevision()
+        let request = try buildRequest(
+            serverUrl: ServerRegistry.normalize(url: serverURL),
+            method: "GET",
+            path: path,
+            query: [:],
+            body: Optional<String>.none
+        )
+        let (data, response) = try await perform(
+            request: request,
+            dispatchRevision: dispatchRevision,
+            reportReachability: false
+        )
+        try ensureSuccess(data, response, method: "GET")
+        do {
+            return try decoder.decode(T.self, from: data)
+        } catch {
+            Self.logDecodingFailure(
+                type: String(describing: T.self),
+                path: path,
+                error: error,
+                data: data
+            )
+            throw HTTPError.decodingFailed(type: String(describing: T.self), underlying: error)
+        }
+    }
+
     func post<T: Decodable>(
         _ path: String,
         body: (any Encodable)? = nil,
@@ -174,9 +280,24 @@ actor HTTPClient {
     func postVoid(
         _ path: String,
         body: (any Encodable)? = nil,
-        query: [String: String] = [:]
+        query: [String: String] = [:],
+        expectedAccount: RefreshAccountIdentity? = nil
     ) async throws {
-        _ = try await sendRaw(method: "POST", path: path, query: query, body: body)
+        _ = try await performWithAuthRetry(
+            method: "POST",
+            path: path,
+            quietStatuses: [],
+            timeout: .standard,
+            expectedAccount: expectedAccount
+        ) { serverUrl in
+            try self.buildRequest(
+                serverUrl: serverUrl,
+                method: "POST",
+                path: path,
+                query: query,
+                body: body
+            )
+        }
     }
 
     func postMultipart<T: Decodable>(
@@ -288,6 +409,10 @@ actor HTTPClient {
         requestIdentity: HTTPRequestIdentity? = nil
     ) async throws -> HTTPRawResponse {
         if let requestIdentity {
+            let dispatchRevision = try captureRequestDispatchRevision()
+            if let requestCaptureBarrier {
+                await requestCaptureBarrier()
+            }
             var auth = try await tokenStore.captureRequestAuth(expected: requestIdentity)
             var request = try scopedRequest(
                 method: method,
@@ -298,22 +423,51 @@ actor HTTPClient {
                 headers: headers,
                 auth: auth
             )
-            var (data, response) = try await perform(request: request, timeout: timeout)
+            var (data, response) = try await perform(
+                request: request,
+                timeout: timeout,
+                dispatchRevision: dispatchRevision
+            )
 
             if response.statusCode == 401,
                shouldAttemptRefresh(path: path),
-               await refreshScopedTokens(auth: auth, expected: requestIdentity) {
-                auth = try await tokenStore.captureRequestAuth(expected: requestIdentity)
-                request = try scopedRequest(
-                    method: method,
-                    path: path,
-                    query: query,
-                    body: body,
-                    contentType: contentType,
-                    headers: headers,
-                    auth: auth
-                )
-                (data, response) = try await perform(request: request, timeout: timeout)
+               await refreshScopedTokens(
+                   auth: auth,
+                   expected: requestIdentity,
+                   dispatchRevision: dispatchRevision
+               ) {
+                let originalAuth = auth
+                if let scopedRefreshRetryBarrier {
+                    await scopedRefreshRetryBarrier()
+                }
+                // The caller-supplied routing identity does not contain the
+                // process-local credential epoch. Re-capture after every
+                // suspension and retry only under the exact owner/generation
+                // that sent the rejected request.
+                if let refreshedAuth = try? await tokenStore.captureRequestAuth(
+                    expected: requestIdentity
+                ),
+                   refreshedAuth.account == originalAuth.account,
+                   refreshedAuth.credentialOwner == originalAuth.credentialOwner,
+                   refreshedAuth.accessToken != nil,
+                   refreshedAuth.accessToken != originalAuth.accessToken
+                       || refreshedAuth.refreshToken != originalAuth.refreshToken {
+                    auth = refreshedAuth
+                    request = try scopedRequest(
+                        method: method,
+                        path: path,
+                        query: query,
+                        body: body,
+                        contentType: contentType,
+                        headers: headers,
+                        auth: auth
+                    )
+                    (data, response) = try await perform(
+                        request: request,
+                        timeout: timeout,
+                        dispatchRevision: dispatchRevision
+                    )
+                }
             }
             try ensureSuccess(data, response, method: method, quietStatuses: quietStatuses)
             return HTTPRawResponse(
@@ -381,14 +535,159 @@ actor HTTPClient {
     /// bridge it with a continuation — the caller must be able to wait
     /// for cancellation to actually complete before retargeting.
     func cancelInFlightRequests() async {
+        requestDispatchRevision &+= 1
+        let previous = cancellationTail?.task
+        let flightId = UUID()
+        let task = Task { [weak self] in
+            await previous?.value
+            guard let self else { return }
+            await self.performCancellationPass()
+        }
+        cancellationTail = .init(id: flightId, task: task)
+        await task.value
+        if cancellationTail?.id == flightId {
+            cancellationTail = nil
+        }
+        resumeRequestDispatchWaitersIfOpen()
+    }
+
+    /// Wait until a caller can safely begin capturing request identity.
+    ///
+    /// Unlike an ordinary request, this is used before any URL or credential
+    /// snapshot exists. Waiting is therefore safe: identity transitions and
+    /// URLSession cancellation passes may finish, and the caller captures only
+    /// the fully committed identity after the gate reopens.
+    func waitForRequestDispatchOpen() async -> Bool {
+        guard !Task.isCancelled else { return false }
+        guard isRequestDispatchBlocked else { return true }
+
+        let waiterID = UUID()
+        let opened = await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                if Task.isCancelled {
+                    continuation.resume(returning: false)
+                } else if !isRequestDispatchBlocked {
+                    continuation.resume(returning: true)
+                } else {
+                    requestDispatchWaiters.append(.init(
+                        id: waiterID,
+                        continuation: continuation
+                    ))
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelRequestDispatchWaiter(id: waiterID) }
+        }
+        return opened && !Task.isCancelled
+    }
+
+    /// Acquire the exclusive gate for a complete server or temporary-owner
+    /// transition. Concurrent transitions queue in acquisition order; request
+    /// entry, credential refresh, and final dispatch remain closed until the
+    /// holder explicitly commits or rolls back and releases the lease.
+    func beginIdentityTransition() async -> HTTPIdentityTransitionLease? {
+        guard !Task.isCancelled else { return nil }
+        let lease = HTTPIdentityTransitionLease(id: UUID())
+        guard activeIdentityTransitionLease != nil else {
+            requestDispatchRevision &+= 1
+            activeIdentityTransitionLease = lease
+            if Task.isCancelled {
+                endIdentityTransition(lease)
+                return nil
+            }
+            return lease
+        }
+        let waiterID = UUID()
+        let granted = await withTaskCancellationHandler {
+            await withCheckedContinuation {
+                (continuation: CheckedContinuation<HTTPIdentityTransitionLease?, Never>) in
+                if Task.isCancelled {
+                    continuation.resume(returning: nil)
+                } else {
+                    identityTransitionWaiters.append(.init(
+                        id: waiterID,
+                        lease: lease,
+                        continuation: continuation
+                    ))
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelIdentityTransitionWaiter(id: waiterID) }
+        }
+        guard let granted else { return nil }
+        if Task.isCancelled {
+            endIdentityTransition(granted)
+            return nil
+        }
+        return granted
+    }
+
+    func endIdentityTransition(_ lease: HTTPIdentityTransitionLease) {
+        guard activeIdentityTransitionLease == lease else { return }
+        guard !identityTransitionWaiters.isEmpty else {
+            activeIdentityTransitionLease = nil
+            resumeRequestDispatchWaitersIfOpen()
+            return
+        }
+        let next = identityTransitionWaiters.removeFirst()
+        activeIdentityTransitionLease = next.lease
+        next.continuation.resume(returning: next.lease)
+    }
+
+    private func cancelIdentityTransitionWaiter(id: UUID) {
+        guard let index = identityTransitionWaiters.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        let waiter = identityTransitionWaiters.remove(at: index)
+        waiter.continuation.resume(returning: nil)
+    }
+
+    private func cancelRequestDispatchWaiter(id: UUID) {
+        guard let index = requestDispatchWaiters.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        let waiter = requestDispatchWaiters.remove(at: index)
+        waiter.continuation.resume(returning: false)
+    }
+
+    private func resumeRequestDispatchWaitersIfOpen() {
+        guard !isRequestDispatchBlocked, !requestDispatchWaiters.isEmpty else {
+            return
+        }
+        let waiters = requestDispatchWaiters
+        requestDispatchWaiters.removeAll()
+        for waiter in waiters {
+            waiter.continuation.resume(returning: true)
+        }
+    }
+
+    func isIdentityTransitionActive(_ lease: HTTPIdentityTransitionLease) -> Bool {
+        activeIdentityTransitionLease == lease
+    }
+
+    func pendingIdentityTransitionCount() -> Int {
+        identityTransitionWaiters.count
+    }
+
+    func pendingRequestDispatchWaiterCount() -> Int {
+        requestDispatchWaiters.count
+    }
+
+    private func performCancellationPass() async {
+        if let cancellationPassBarrier {
+            await cancellationPassBarrier()
+        }
         inFlightRefreshes.values.forEach { $0.task.cancel() }
         inFlightRefreshes.removeAll()
-        for session in [session, longWaitSession] {
+        for (index, session) in [session, longWaitSession].enumerated() {
             await withCheckedContinuation { continuation in
                 session.getAllTasks { tasks in
                     for task in tasks { task.cancel() }
                     continuation.resume()
                 }
+            }
+            if let cancellationSessionBarrier {
+                await cancellationSessionBarrier(index + 1)
             }
         }
     }
@@ -507,29 +806,62 @@ actor HTTPClient {
         additionalHeaders: [String: String] = [:],
         quietStatuses: Set<Int> = [],
         timeout: HTTPTimeout,
+        expectedAccount: RefreshAccountIdentity? = nil,
         makeRequest: (String) throws -> URLRequest
     ) async throws -> (Data, HTTPURLResponse) {
-        let serverUrl = await tokenStore.getServerUrl()
+        let dispatchRevision = try captureRequestDispatchRevision()
+        if let requestCaptureBarrier {
+            await requestCaptureBarrier()
+        }
+        let capturedAuth = await tokenStore.captureOrdinaryRequestAuth()
+        if let expectedAccount,
+           capturedAuth?.account != expectedAccount {
+            throw HTTPError.requestIdentityChanged
+        }
+        let serverUrl = if let capturedAuth {
+            capturedAuth.account.serverURL
+        } else {
+            await tokenStore.getServerUrl()
+        }
         guard !serverUrl.isEmpty else {
             throw HTTPError.serverUrlNotConfigured
         }
 
-        let tokenBeforeRequest = await tokenStore.getAccessToken()
         var request = try makeRequest(serverUrl)
-        await attachAuthHeaders(&request, accessToken: tokenBeforeRequest)
+        if let capturedAuth {
+            attachOrdinaryAuthHeaders(&request, auth: capturedAuth)
+        } else {
+            await attachLegacyAuthHeaders(&request)
+        }
         Self.apply(additionalHeaders, to: &request)
 
-        let (data, response) = try await perform(request: request, timeout: timeout)
+        let (data, response) = try await perform(
+            request: request,
+            timeout: timeout,
+            dispatchRevision: dispatchRevision
+        )
 
         if response.statusCode == 401, shouldAttemptRefresh(path: path) {
-            let refreshed = await refreshTokens(tokenAtRequestTime: tokenBeforeRequest)
-            if refreshed {
-                // Rebuild the request so headers reflect the new access token.
-                let refreshedToken = await tokenStore.getAccessToken()
+            if let capturedAuth,
+               let refreshedAuth = await refreshTokens(
+                   expected: capturedAuth,
+                   dispatchRevision: dispatchRevision
+               ),
+               refreshedAuth.accessToken != nil,
+               await tokenStore.currentOrdinaryRequestAuth(
+                   matchingIdentityOf: refreshedAuth
+               ) == refreshedAuth {
+                // Rebuild from one account-owner/profile snapshot. If any of
+                // those identities changed during the shared flight, keep the
+                // original 401 instead of sending mixed credentials.
                 var retry = try makeRequest(serverUrl)
-                await attachAuthHeaders(&retry, accessToken: refreshedToken)
+                attachOrdinaryAuthHeaders(&retry, auth: refreshedAuth)
                 Self.apply(additionalHeaders, to: &retry)
-                let (retryData, retryResponse) = try await perform(request: retry, timeout: timeout)
+                let (retryData, retryResponse) = try await perform(
+                    request: retry,
+                    timeout: timeout,
+                    dispatchRevision: dispatchRevision
+                )
                 try ensureSuccess(retryData, retryResponse, method: method, quietStatuses: quietStatuses)
                 return (retryData, retryResponse)
             }
@@ -651,7 +983,10 @@ actor HTTPClient {
         return body
     }
 
-    private func attachAuthHeaders(_ request: inout URLRequest, accessToken: String?) async {
+    /// Compatibility path for the pre-registry/no-active-server state. Normal
+    /// authenticated requests use `attachOrdinaryAuthHeaders`, whose complete
+    /// credential snapshot is captured in one TokenStore actor turn.
+    private func attachLegacyAuthHeaders(_ request: inout URLRequest) async {
         let path = request.url?.path ?? ""
         // Skip auth injection for /auth/refresh (avoid recursion) and
         // /auth/login (a prior expired token can't authorize a fresh login).
@@ -660,7 +995,7 @@ actor HTTPClient {
         }
 
         var attached: [String] = []
-        if let token = accessToken {
+        if let token = await tokenStore.getAccessToken() {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
             attached.append("auth")
         }
@@ -669,6 +1004,42 @@ actor HTTPClient {
             attached.append("profile")
         }
         if let profileToken = await tokenStore.getProfileToken() {
+            request.setValue(profileToken, forHTTPHeaderField: "X-Profile-Token")
+            attached.append("profileToken")
+        }
+        let device = AppleDeviceIdentity.current
+        request.setValue(device.id, forHTTPHeaderField: "X-Silo-Device-Id")
+        request.setValue(device.name, forHTTPHeaderField: "X-Silo-Device-Name")
+        request.setValue(device.platform, forHTTPHeaderField: "X-Silo-Device-Platform")
+        request.setValue(device.clientFamily, forHTTPHeaderField: "X-Silo-Client-Family")
+        attached.append("device=\(device.platform)/\(device.clientFamily)")
+        let method = request.httpMethod ?? ""
+        let attachedDesc = attached.joined(separator: ", ")
+        Self.logger.debug("→ \(method, privacy: .public) \(path, privacy: .public) headers=[\(attachedDesc, privacy: .public)]")
+    }
+
+    /// Attach the immutable account-owner/profile snapshot captured before the
+    /// request was built. There are no actor hops between the individual
+    /// headers, so temporary handoff or profile changes cannot mix identities.
+    private func attachOrdinaryAuthHeaders(
+        _ request: inout URLRequest,
+        auth: CapturedOrdinaryRequestAuth
+    ) {
+        let path = request.url?.path ?? ""
+        if path.hasSuffix("/auth/refresh") || path.hasSuffix("/auth/login") {
+            return
+        }
+
+        var attached: [String] = []
+        if let token = auth.accessToken {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+            attached.append("auth")
+        }
+        if let profileId = auth.profileId {
+            request.setValue(profileId, forHTTPHeaderField: "X-Profile-Id")
+            attached.append("profile")
+        }
+        if let profileToken = auth.profileToken {
             request.setValue(profileToken, forHTTPHeaderField: "X-Profile-Token")
             attached.append("profileToken")
         }
@@ -706,32 +1077,64 @@ actor HTTPClient {
 
     // MARK: - Response handling
 
-    private func perform(request: URLRequest, timeout: HTTPTimeout = .standard) async throws -> (Data, HTTPURLResponse) {
+    private func perform(
+        request: URLRequest,
+        timeout: HTTPTimeout = .standard,
+        dispatchRevision: UInt64,
+        reportReachability: Bool = true
+    ) async throws -> (Data, HTTPURLResponse) {
+        // A cancellation pass takes asynchronous snapshots of both sessions.
+        // Dispatching between those snapshots could let an old-identity
+        // request start after its session was already enumerated and survive
+        // a registry or temporary-owner transition. Reject it; waiting would
+        // send a request built from credentials captured before the switch.
+        try ensureRequestDispatchAllowed(expectedRevision: dispatchRevision)
         let data: Data
         let response: URLResponse
         do {
             let session = timeout == .extended ? longWaitSession : session
             (data, response) = try await session.data(for: request)
         } catch {
+            if isRequestDispatchBlocked || requestDispatchRevision != dispatchRevision {
+                throw HTTPError.requestIdentityChanged
+            }
             // Feed ConnectionMonitor from every transport failure so the app
             // learns "server down" passively. Cancellation says nothing about
             // reachability, so it is excluded.
-            if (error as? URLError)?.code != .cancelled {
-                Task { @MainActor in
-                    ConnectionMonitor.shared.noteServerUnreachable()
-                }
+            if reportReachability {
+                await Self.noteServerUnreachable(for: error)
             }
             throw HTTPError.network(underlying: error)
         }
+        if let responseReceivedBarrier {
+            await responseReceivedBarrier()
+        }
+        // URLSession cancellation is best-effort: a completed response can
+        // race the transition's task enumeration. Reject it before it can
+        // update reachability or flow into any response/cache consumer.
+        try ensureRequestDispatchAllowed(expectedRevision: dispatchRevision)
         guard let http = response as? HTTPURLResponse else {
             throw HTTPError.invalidResponse
         }
         // Any HTTP response — success or error status — proves the server is
         // alive.
-        Task { @MainActor in
-            ConnectionMonitor.shared.noteServerResponded()
+        if reportReachability {
+            await MainActor.run {
+                ConnectionMonitor.shared.noteServerResponded()
+            }
         }
         return (data, http)
+    }
+
+    /// Only the absence of an HTTP response is a reachability signal. Decode,
+    /// validation, and other response-processing errors still prove that the
+    /// server answered and must not start the offline reprobe loop.
+    private static func noteServerUnreachable(for error: Error) async {
+        guard let urlError = error as? URLError,
+              urlError.code != .cancelled else { return }
+        await MainActor.run {
+            ConnectionMonitor.shared.noteServerUnreachable()
+        }
     }
 
     private func ensureSuccess(_ data: Data, _ response: HTTPURLResponse, method: String, quietStatuses: Set<Int> = []) throws {
@@ -757,12 +1160,33 @@ actor HTTPClient {
         !path.hasSuffix("/auth/refresh") && !path.hasSuffix("/auth/login")
     }
 
+    private var isRequestDispatchBlocked: Bool {
+        cancellationTail != nil || activeIdentityTransitionLease != nil
+    }
+
+    private func captureRequestDispatchRevision() throws -> UInt64 {
+        try ensureRequestDispatchAllowed(expectedRevision: requestDispatchRevision)
+        return requestDispatchRevision
+    }
+
+    private func ensureRequestDispatchAllowed(expectedRevision: UInt64) throws {
+        guard !isRequestDispatchBlocked,
+              requestDispatchRevision == expectedRevision else {
+            throw HTTPError.requestIdentityChanged
+        }
+    }
+
     private func refreshScopedTokens(
         auth: CapturedHTTPRequestAuth,
-        expected: HTTPRequestIdentity
+        expected: HTTPRequestIdentity,
+        dispatchRevision: UInt64
     ) async -> Bool {
+        guard !isRequestDispatchBlocked,
+              requestDispatchRevision == dispatchRevision else { return false }
         guard case .persistentServer(let credentialServerId) = auth.credentialOwner,
               credentialServerId == expected.serverId,
+              auth.account.serverId == expected.serverId,
+              auth.account.serverURL == ServerRegistry.normalize(url: expected.serverURL),
               let refreshValue = auth.refreshToken, !refreshValue.isEmpty,
               URL(string: auth.serverURL + "/api/v1/auth/refresh") != nil else {
             return false
@@ -770,21 +1194,19 @@ actor HTTPClient {
         if await scopedCredentialsChanged(since: auth, expected: expected) {
             return true
         }
+        guard !isRequestDispatchBlocked,
+              requestDispatchRevision == dispatchRevision else { return false }
 
-        let key = RefreshAccountIdentity(
-            serverId: expected.serverId,
-            serverURL: ServerRegistry.normalize(url: expected.serverURL)
-        )
+        let key = auth.account
         if let existing = inFlightRefreshes[key] {
-            let refreshed = await existing.task.value
-            if refreshed { return true }
+            refreshFlightJoinObserver?(.scoped)
+            _ = await existing.task.value
             return await scopedCredentialsChanged(since: auth, expected: expected)
         }
 
         let task = Task<Bool, Never> { [tokenStore, session, decoder, encoder] in
             await Self.performScopedRefresh(
                 auth: auth,
-                expected: expected,
                 tokenStore: tokenStore,
                 session: session,
                 decoder: decoder,
@@ -793,11 +1215,10 @@ actor HTTPClient {
         }
         let flightId = UUID()
         inFlightRefreshes[key] = .init(id: flightId, task: task)
-        let refreshed = await task.value
+        _ = await task.value
         if inFlightRefreshes[key]?.id == flightId {
             inFlightRefreshes.removeValue(forKey: key)
         }
-        if refreshed { return true }
         return await scopedCredentialsChanged(since: auth, expected: expected)
     }
 
@@ -806,14 +1227,15 @@ actor HTTPClient {
         expected: HTTPRequestIdentity
     ) async -> Bool {
         guard let current = try? await tokenStore.captureRequestAuth(expected: expected),
-              current.credentialOwner == auth.credentialOwner else { return false }
+              current.account == auth.account,
+              current.credentialOwner == auth.credentialOwner,
+              current.accessToken != nil else { return false }
         return current.accessToken != auth.accessToken
             || current.refreshToken != auth.refreshToken
     }
 
     private static func performScopedRefresh(
         auth: CapturedHTTPRequestAuth,
-        expected: HTTPRequestIdentity,
         tokenStore: TokenStore,
         session: URLSession,
         decoder: JSONDecoder,
@@ -823,6 +1245,14 @@ actor HTTPClient {
               let url = URL(string: auth.serverURL + "/api/v1/auth/refresh") else {
             return false
         }
+        let captured = CapturedRefreshCredential(
+            account: auth.account,
+            refreshToken: refreshValue,
+            owner: auth.credentialOwner
+        )
+        guard await tokenStore.captureRefreshCredential(expected: auth.account) == captured else {
+            return false
+        }
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -830,18 +1260,53 @@ actor HTTPClient {
         do {
             request.httpBody = try encoder.encode(RefreshRequest(refreshValue))
             let (data, response) = try await session.data(for: request)
-            guard !Task.isCancelled,
-                  let http = response as? HTTPURLResponse,
-                  (200..<300).contains(http.statusCode) else { return false }
-            let tokens = try decoder.decode(RefreshResponse.self, from: data)
-            return await tokenStore.saveRefreshedTokens(
-                tokens.accessToken,
-                tokens.refreshToken,
-                replacing: refreshValue,
-                expected: expected,
-                credentialOwner: auth.credentialOwner
+            guard !Task.isCancelled else { return false }
+            guard let http = response as? HTTPURLResponse else {
+                Self.logger.error("Scoped refresh: non-HTTP response")
+                return false
+            }
+            await MainActor.run {
+                ConnectionMonitor.shared.noteServerResponded()
+            }
+            if (200..<300).contains(http.statusCode) {
+                let tokens = try decoder.decode(RefreshResponse.self, from: data)
+                return await tokenStore.saveRefreshedTokens(
+                    tokens.accessToken,
+                    tokens.refreshToken,
+                    replacing: captured
+                )
+            }
+
+            let body = String(data: data, encoding: .utf8) ?? ""
+            Self.logger.error(
+                "Scoped refresh failed: status=\(http.statusCode, privacy: .public) body=\(body, privacy: .private)"
             )
+            guard shouldInvalidateSessionAfterRefreshFailure(http.statusCode) else {
+                return false
+            }
+            let disposition = await tokenStore.invalidateRejectedRefresh(captured)
+            if let disposition,
+               !Task.isCancelled,
+               await tokenStore.shouldConsumeSessionExpiryEvent(
+                   SessionExpiryEvent(account: captured.account, disposition: disposition)
+               ),
+               !Task.isCancelled {
+                let event = SessionExpiryEvent(
+                    account: captured.account,
+                    disposition: disposition
+                )
+                await MainActor.run {
+                    guard !Task.isCancelled else { return }
+                    NotificationCenter.default.post(
+                        name: .continuumSessionExpired,
+                        object: event
+                    )
+                }
+            }
+            return false
         } catch {
+            await noteServerUnreachable(for: error)
+            Self.logger.error("Scoped refresh threw: \(String(describing: error), privacy: .public)")
             return false
         }
     }
@@ -860,27 +1325,44 @@ actor HTTPClient {
     /// 3. The in-flight task clears itself after completion so the next 401
     ///    wave can start a fresh refresh.
     ///
-    /// Re-entrancy note: `await tokenStore.getAccessToken()` releases the
-    /// actor, so another 401'd caller may interleave. Capturing the account
-    /// key first, then double-checking the access token immediately before
-    /// the keyed slot, catches a refresh that completed during that await.
-    private func refreshTokens(tokenAtRequestTime: String?) async -> Bool {
-        guard let key = await tokenStore.refreshAccountIdentity() else {
-            return false
+    /// Re-entrancy note: each TokenStore check re-captures account owner,
+    /// temporary generation, access token, and profile together. A caller can
+    /// use a token rotated by another flight only when the rest of that exact
+    /// request identity is still current.
+    private func refreshTokens(
+        expected: CapturedOrdinaryRequestAuth,
+        dispatchRevision: UInt64
+    ) async -> CapturedOrdinaryRequestAuth? {
+        guard !isRequestDispatchBlocked,
+              requestDispatchRevision == dispatchRevision else { return nil }
+        guard let current = await tokenStore.currentOrdinaryRequestAuth(
+            matchingIdentityOf: expected
+        ) else {
+            return nil
         }
-        if let current = await tokenStore.getAccessToken(),
-           current != tokenAtRequestTime {
-            return true
+        if current.accessToken != expected.accessToken,
+           current.accessToken != nil {
+            return current
         }
+        guard !isRequestDispatchBlocked,
+              requestDispatchRevision == dispatchRevision else { return nil }
 
+        let key = expected.account
         if let existing = inFlightRefreshes[key] {
-            let refreshed = await existing.task.value
-            if refreshed { return true }
-            return await tokenStore.getAccessToken() != tokenAtRequestTime
+            refreshFlightJoinObserver?(.ordinary)
+            _ = await existing.task.value
+            if let current = await tokenStore.currentOrdinaryRequestAuth(
+                matchingIdentityOf: expected
+            ), current.accessToken != expected.accessToken,
+               current.accessToken != nil {
+                return current
+            }
+            return nil
         }
 
         let task = Task<Bool, Never> { [tokenStore, session, decoder, encoder] in
             await Self.performRefresh(
+                expected: key,
                 tokenStore: tokenStore,
                 session: session,
                 decoder: decoder,
@@ -889,32 +1371,32 @@ actor HTTPClient {
         }
         let flightId = UUID()
         inFlightRefreshes[key] = .init(id: flightId, task: task)
-        let result = await task.value
+        _ = await task.value
         if inFlightRefreshes[key]?.id == flightId {
             inFlightRefreshes.removeValue(forKey: key)
         }
-        if result { return true }
-        return await tokenStore.getAccessToken() != tokenAtRequestTime
+        if let current = await tokenStore.currentOrdinaryRequestAuth(
+            matchingIdentityOf: expected
+        ), current.accessToken != expected.accessToken,
+           current.accessToken != nil {
+            return current
+        }
+        return nil
     }
 
     private static func performRefresh(
+        expected: RefreshAccountIdentity,
         tokenStore: TokenStore,
         session: URLSession,
         decoder: JSONDecoder,
         encoder: JSONEncoder
     ) async -> Bool {
-        let serverUrl = await tokenStore.getServerUrl()
-        guard !serverUrl.isEmpty else {
-            Self.logger.error("Refresh skipped: no server URL configured")
-            return false
-        }
-        guard let refreshToken = await tokenStore.getRefreshToken(),
-              !refreshToken.isEmpty else {
+        guard let captured = await tokenStore.captureRefreshCredential(expected: expected) else {
             Self.logger.error("Refresh skipped: no refresh token stored")
             return false
         }
 
-        guard let url = URL(string: serverUrl + "/api/v1/auth/refresh") else {
+        guard let url = URL(string: expected.serverURL + "/api/v1/auth/refresh") else {
             Self.logger.error("Refresh skipped: invalid server URL")
             return false
         }
@@ -924,7 +1406,7 @@ actor HTTPClient {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         do {
-            request.httpBody = try encoder.encode(RefreshRequest(refreshToken: refreshToken))
+            request.httpBody = try encoder.encode(RefreshRequest(refreshToken: captured.refreshToken))
         } catch {
             Self.logger.error("Refresh encode failed: \(String(describing: error), privacy: .public)")
             return false
@@ -945,43 +1427,57 @@ actor HTTPClient {
                 return false
             }
             // Refresh bypasses perform(), so feed reachability from here too.
-            Task { @MainActor in
+            await MainActor.run {
                 ConnectionMonitor.shared.noteServerResponded()
             }
             if (200..<300).contains(http.statusCode) {
                 let tokens = try decoder.decode(RefreshResponse.self, from: data)
-                await tokenStore.saveTokens(
-                    accessToken: tokens.accessToken,
-                    refreshToken: tokens.refreshToken
+                return await tokenStore.saveRefreshedTokens(
+                    tokens.accessToken,
+                    tokens.refreshToken,
+                    replacing: captured
                 )
-                return true
             } else {
                 let body = String(data: data, encoding: .utf8) ?? ""
                 Self.logger.error("Refresh failed: status=\(http.statusCode, privacy: .public) body=\(body, privacy: .private)")
-                let temporaryScopeExpired = await tokenStore.hasTemporaryScope()
-                if !temporaryScopeExpired {
-                    await tokenStore.clearTokens()
+                guard shouldInvalidateSessionAfterRefreshFailure(http.statusCode) else {
+                    return false
                 }
+                let disposition = await tokenStore.invalidateRejectedRefresh(captured)
+                let event = disposition.map {
+                    SessionExpiryEvent(account: captured.account, disposition: $0)
+                }
+                guard let disposition,
+                      let event,
+                      !Task.isCancelled,
+                      await tokenStore.shouldConsumeSessionExpiryEvent(event),
+                      !Task.isCancelled else { return false }
                 // Tell the UI to route back to login for the current
                 // server. The registry entry (URL + display name) is
                 // preserved so the user doesn't have to re-add it.
                 await MainActor.run {
+                    guard !Task.isCancelled else { return }
                     NotificationCenter.default.post(
-                        name: temporaryScopeExpired ? .temporaryRemoteAuthExpired : .continuumSessionExpired,
-                        object: nil
+                        name: disposition == .temporarySessionExpired
+                            ? .temporaryRemoteAuthExpired
+                            : .continuumSessionExpired,
+                        object: event
                     )
                 }
                 return false
             }
         } catch {
-            if (error as? URLError)?.code != .cancelled {
-                Task { @MainActor in
-                    ConnectionMonitor.shared.noteServerUnreachable()
-                }
-            }
+            await noteServerUnreachable(for: error)
             Self.logger.error("Refresh threw: \(String(describing: error), privacy: .public)")
             return false
         }
+    }
+
+    /// Match Android's refresh-failure classifier. Client/auth rejection is
+    /// terminal; rate limits, gateway failures, and server faults are
+    /// retryable and must preserve the current credential snapshot.
+    static func shouldInvalidateSessionAfterRefreshFailure(_ statusCode: Int) -> Bool {
+        statusCode == 400 || statusCode == 401 || statusCode == 403
     }
 }
 

--- a/iosApp/iosApp/Networking/HTTPClient.swift
+++ b/iosApp/iosApp/Networking/HTTPClient.swift
@@ -1,6 +1,47 @@
 import Foundation
 import OSLog
 
+/// Immutable routing identity for a request that must not follow the app's
+/// mutable active server/profile. Settings outbox work captures this before it
+/// enters a queue; ``TokenStore`` then verifies and snapshots matching auth in
+/// one actor turn before any bytes are sent.
+struct HTTPRequestIdentity: Equatable, Sendable {
+    let serverId: String
+    let serverURL: String
+    let profileId: String
+    let clientFamily: String
+}
+
+enum CapturedHTTPRequestCredentialOwner: Equatable, Sendable {
+    case persistentServer(serverId: String)
+    case temporary
+}
+
+struct CapturedHTTPRequestAuth: Sendable {
+    let serverURL: String
+    let accessToken: String?
+    let refreshToken: String?
+    let profileId: String
+    let profileToken: String?
+    let credentialOwner: CapturedHTTPRequestCredentialOwner
+
+    init(
+        serverURL: String,
+        accessValue: String?,
+        refreshValue value: String?,
+        profileId: String,
+        profileValue otherValue: String?,
+        credentialOwner: CapturedHTTPRequestCredentialOwner
+    ) {
+        self.serverURL = serverURL
+        accessToken = accessValue
+        refreshToken = value
+        self.profileId = profileId
+        profileToken = otherValue
+        self.credentialOwner = credentialOwner
+    }
+}
+
 /// URLSession-backed HTTP client for the Silo server.
 ///
 /// Responsibilities:
@@ -36,9 +77,16 @@ actor HTTPClient {
     private let decoder: JSONDecoder
     private let encoder: JSONEncoder
 
-    /// When non-nil, a refresh is in flight. Concurrent 401s await this task
-    /// instead of issuing their own refresh request.
-    private var inFlightRefresh: Task<Bool, Never>?
+    /// Refresh tokens rotate at server-account scope. Ordinary requests and
+    /// captured-identity settings requests therefore share this one keyed
+    /// flight registry; neither path may submit the same credential while the
+    /// other owns its rotation.
+    private var inFlightRefreshes: [RefreshAccountIdentity: RefreshFlight] = [:]
+
+    private struct RefreshFlight {
+        let id: UUID
+        let task: Task<Bool, Never>
+    }
 
     init(session: URLSession? = nil, tokenStore: TokenStore = .shared) {
         // An injected session (tests) serves both timeout classes so mocks
@@ -236,8 +284,45 @@ actor HTTPClient {
         contentType: String = "application/json",
         headers: [String: String] = [:],
         quietStatuses: Set<Int> = [],
-        timeout: HTTPTimeout = .standard
+        timeout: HTTPTimeout = .standard,
+        requestIdentity: HTTPRequestIdentity? = nil
     ) async throws -> HTTPRawResponse {
+        if let requestIdentity {
+            var auth = try await tokenStore.captureRequestAuth(expected: requestIdentity)
+            var request = try scopedRequest(
+                method: method,
+                path: path,
+                query: query,
+                body: body,
+                contentType: contentType,
+                headers: headers,
+                auth: auth
+            )
+            var (data, response) = try await perform(request: request, timeout: timeout)
+
+            if response.statusCode == 401,
+               shouldAttemptRefresh(path: path),
+               await refreshScopedTokens(auth: auth, expected: requestIdentity) {
+                auth = try await tokenStore.captureRequestAuth(expected: requestIdentity)
+                request = try scopedRequest(
+                    method: method,
+                    path: path,
+                    query: query,
+                    body: body,
+                    contentType: contentType,
+                    headers: headers,
+                    auth: auth
+                )
+                (data, response) = try await perform(request: request, timeout: timeout)
+            }
+            try ensureSuccess(data, response, method: method, quietStatuses: quietStatuses)
+            return HTTPRawResponse(
+                data: data,
+                statusCode: response.statusCode,
+                headers: response.allHeaderFields
+            )
+        }
+
         let (data, response) = try await performWithAuthRetry(
             method: method,
             path: path,
@@ -261,6 +346,31 @@ actor HTTPClient {
         return HTTPRawResponse(data: data, statusCode: response.statusCode, headers: response.allHeaderFields)
     }
 
+    private func scopedRequest(
+        method: String,
+        path: String,
+        query: [String: String],
+        body: Data?,
+        contentType: String,
+        headers: [String: String],
+        auth: CapturedHTTPRequestAuth
+    ) throws -> URLRequest {
+        var request = try buildRequest(
+            serverUrl: auth.serverURL,
+            method: method,
+            path: path,
+            query: query,
+            body: Optional<String>.none
+        )
+        if let body {
+            request.httpBody = body
+            request.setValue(contentType, forHTTPHeaderField: "Content-Type")
+        }
+        attachCapturedAuthHeaders(&request, auth: auth)
+        Self.apply(headers, to: &request)
+        return request
+    }
+
     /// Cancel all in-flight tasks on the shared session and drop any
     /// pending refresh. Called by the registry *before* retargeting
     /// `TokenStore` on a server switch so a response from the old server
@@ -271,8 +381,8 @@ actor HTTPClient {
     /// bridge it with a continuation — the caller must be able to wait
     /// for cancellation to actually complete before retargeting.
     func cancelInFlightRequests() async {
-        inFlightRefresh?.cancel()
-        inFlightRefresh = nil
+        inFlightRefreshes.values.forEach { $0.task.cancel() }
+        inFlightRefreshes.removeAll()
         for session in [session, longWaitSession] {
             await withCheckedContinuation { continuation in
                 session.getAllTasks { tasks in
@@ -566,10 +676,32 @@ actor HTTPClient {
         request.setValue(device.id, forHTTPHeaderField: "X-Silo-Device-Id")
         request.setValue(device.name, forHTTPHeaderField: "X-Silo-Device-Name")
         request.setValue(device.platform, forHTTPHeaderField: "X-Silo-Device-Platform")
-        attached.append("device=\(device.platform)")
+        request.setValue(device.clientFamily, forHTTPHeaderField: "X-Silo-Client-Family")
+        attached.append("device=\(device.platform)/\(device.clientFamily)")
         let method = request.httpMethod ?? ""
         let attachedDesc = attached.joined(separator: ", ")
         Self.logger.debug("→ \(method, privacy: .public) \(path, privacy: .public) headers=[\(attachedDesc, privacy: .public)]")
+    }
+
+    /// Attach one actor-consistent auth snapshot. Scoped requests deliberately
+    /// do not use the global refresh path: after an identity switch, a 401 is
+    /// safer than refreshing or storing credentials in the wrong server slot.
+    private func attachCapturedAuthHeaders(
+        _ request: inout URLRequest,
+        auth: CapturedHTTPRequestAuth
+    ) {
+        if let token = auth.accessToken {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        request.setValue(auth.profileId, forHTTPHeaderField: "X-Profile-Id")
+        if let profileToken = auth.profileToken {
+            request.setValue(profileToken, forHTTPHeaderField: "X-Profile-Token")
+        }
+        let device = AppleDeviceIdentity.current
+        request.setValue(device.id, forHTTPHeaderField: "X-Silo-Device-Id")
+        request.setValue(device.name, forHTTPHeaderField: "X-Silo-Device-Name")
+        request.setValue(device.platform, forHTTPHeaderField: "X-Silo-Device-Platform")
+        request.setValue(device.clientFamily, forHTTPHeaderField: "X-Silo-Client-Family")
     }
 
     // MARK: - Response handling
@@ -625,6 +757,95 @@ actor HTTPClient {
         !path.hasSuffix("/auth/refresh") && !path.hasSuffix("/auth/login")
     }
 
+    private func refreshScopedTokens(
+        auth: CapturedHTTPRequestAuth,
+        expected: HTTPRequestIdentity
+    ) async -> Bool {
+        guard case .persistentServer(let credentialServerId) = auth.credentialOwner,
+              credentialServerId == expected.serverId,
+              let refreshValue = auth.refreshToken, !refreshValue.isEmpty,
+              URL(string: auth.serverURL + "/api/v1/auth/refresh") != nil else {
+            return false
+        }
+        if await scopedCredentialsChanged(since: auth, expected: expected) {
+            return true
+        }
+
+        let key = RefreshAccountIdentity(
+            serverId: expected.serverId,
+            serverURL: ServerRegistry.normalize(url: expected.serverURL)
+        )
+        if let existing = inFlightRefreshes[key] {
+            let refreshed = await existing.task.value
+            if refreshed { return true }
+            return await scopedCredentialsChanged(since: auth, expected: expected)
+        }
+
+        let task = Task<Bool, Never> { [tokenStore, session, decoder, encoder] in
+            await Self.performScopedRefresh(
+                auth: auth,
+                expected: expected,
+                tokenStore: tokenStore,
+                session: session,
+                decoder: decoder,
+                encoder: encoder
+            )
+        }
+        let flightId = UUID()
+        inFlightRefreshes[key] = .init(id: flightId, task: task)
+        let refreshed = await task.value
+        if inFlightRefreshes[key]?.id == flightId {
+            inFlightRefreshes.removeValue(forKey: key)
+        }
+        if refreshed { return true }
+        return await scopedCredentialsChanged(since: auth, expected: expected)
+    }
+
+    private func scopedCredentialsChanged(
+        since auth: CapturedHTTPRequestAuth,
+        expected: HTTPRequestIdentity
+    ) async -> Bool {
+        guard let current = try? await tokenStore.captureRequestAuth(expected: expected),
+              current.credentialOwner == auth.credentialOwner else { return false }
+        return current.accessToken != auth.accessToken
+            || current.refreshToken != auth.refreshToken
+    }
+
+    private static func performScopedRefresh(
+        auth: CapturedHTTPRequestAuth,
+        expected: HTTPRequestIdentity,
+        tokenStore: TokenStore,
+        session: URLSession,
+        decoder: JSONDecoder,
+        encoder: JSONEncoder
+    ) async -> Bool {
+        guard let refreshValue = auth.refreshToken,
+              let url = URL(string: auth.serverURL + "/api/v1/auth/refresh") else {
+            return false
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        do {
+            request.httpBody = try encoder.encode(RefreshRequest(refreshValue))
+            let (data, response) = try await session.data(for: request)
+            guard !Task.isCancelled,
+                  let http = response as? HTTPURLResponse,
+                  (200..<300).contains(http.statusCode) else { return false }
+            let tokens = try decoder.decode(RefreshResponse.self, from: data)
+            return await tokenStore.saveRefreshedTokens(
+                tokens.accessToken,
+                tokens.refreshToken,
+                replacing: refreshValue,
+                expected: expected,
+                credentialOwner: auth.credentialOwner
+            )
+        } catch {
+            return false
+        }
+    }
+
     // MARK: - Refresh (single-flight)
 
     /// Refresh tokens at most once per wave of concurrent 401s.
@@ -633,25 +854,29 @@ actor HTTPClient {
     /// 1. Check whether another caller already refreshed: if the token now
     ///    stored differs from the token this caller originally sent, it was
     ///    refreshed in the meantime and we can just signal "yes, retry."
-    /// 2. Otherwise, if no refresh is in flight, start one; every concurrent
-    ///    401 awaits the same `Task` so only one network call is made.
+    /// 2. Otherwise, if no account refresh is in flight, start one; ordinary
+    ///    and captured-identity 401s await the same `Task` so only one network
+    ///    call is made.
     /// 3. The in-flight task clears itself after completion so the next 401
     ///    wave can start a fresh refresh.
     ///
     /// Re-entrancy note: `await tokenStore.getAccessToken()` releases the
-    /// actor, so another 401'd caller may interleave and arrive at the
-    /// `inFlightRefresh` check before this caller does. The `inFlightRefresh`
-    /// slot is single-assignment per wave, and the `tokenAtRequestTime`
-    /// check catches the case where a second caller resumes *after* the
-    /// first caller's refresh has already completed and cleared the slot.
+    /// actor, so another 401'd caller may interleave. Capturing the account
+    /// key first, then double-checking the access token immediately before
+    /// the keyed slot, catches a refresh that completed during that await.
     private func refreshTokens(tokenAtRequestTime: String?) async -> Bool {
+        guard let key = await tokenStore.refreshAccountIdentity() else {
+            return false
+        }
         if let current = await tokenStore.getAccessToken(),
            current != tokenAtRequestTime {
             return true
         }
 
-        if let existing = inFlightRefresh {
-            return await existing.value
+        if let existing = inFlightRefreshes[key] {
+            let refreshed = await existing.task.value
+            if refreshed { return true }
+            return await tokenStore.getAccessToken() != tokenAtRequestTime
         }
 
         let task = Task<Bool, Never> { [tokenStore, session, decoder, encoder] in
@@ -662,10 +887,14 @@ actor HTTPClient {
                 encoder: encoder
             )
         }
-        inFlightRefresh = task
+        let flightId = UUID()
+        inFlightRefreshes[key] = .init(id: flightId, task: task)
         let result = await task.value
-        inFlightRefresh = nil
-        return result
+        if inFlightRefreshes[key]?.id == flightId {
+            inFlightRefreshes.removeValue(forKey: key)
+        }
+        if result { return true }
+        return await tokenStore.getAccessToken() != tokenAtRequestTime
     }
 
     private static func performRefresh(
@@ -808,6 +1037,7 @@ struct HTTPRawResponse: Sendable {
 
 enum HTTPError: LocalizedError, CustomStringConvertible {
     case serverUrlNotConfigured
+    case requestIdentityChanged
     case invalidURL(String)
     case invalidResponse
     case network(underlying: Error)
@@ -819,6 +1049,8 @@ enum HTTPError: LocalizedError, CustomStringConvertible {
         switch self {
         case .serverUrlNotConfigured:
             return "Server URL is not configured."
+        case .requestIdentityChanged:
+            return "The active server or profile changed before the request could start."
         case .invalidURL(let url):
             return "Invalid URL: \(url)"
         case .invalidResponse:
@@ -843,6 +1075,8 @@ enum HTTPError: LocalizedError, CustomStringConvertible {
         switch self {
         case .serverUrlNotConfigured:
             return "server_url_not_configured"
+        case .requestIdentityChanged:
+            return "request_identity_changed"
         case .invalidURL:
             return "invalid_url"
         case .invalidResponse:

--- a/iosApp/iosApp/Networking/HTTPClient.swift
+++ b/iosApp/iosApp/Networking/HTTPClient.swift
@@ -1183,8 +1183,13 @@ actor HTTPClient {
     ) async -> Bool {
         guard !isRequestDispatchBlocked,
               requestDispatchRevision == dispatchRevision else { return false }
-        guard case .persistentServer(let credentialServerId) = auth.credentialOwner,
-              credentialServerId == expected.serverId,
+        let ownerMatchesExpectedServer = switch auth.credentialOwner {
+        case .temporary:
+            true
+        case .persistentServer(let credentialServerId):
+            credentialServerId == expected.serverId
+        }
+        guard ownerMatchesExpectedServer,
               auth.account.serverId == expected.serverId,
               auth.account.serverURL == ServerRegistry.normalize(url: expected.serverURL),
               let refreshValue = auth.refreshToken, !refreshValue.isEmpty,
@@ -1298,7 +1303,9 @@ actor HTTPClient {
                 await MainActor.run {
                     guard !Task.isCancelled else { return }
                     NotificationCenter.default.post(
-                        name: .continuumSessionExpired,
+                        name: disposition == .temporarySessionExpired
+                            ? .temporaryRemoteAuthExpired
+                            : .continuumSessionExpired,
                         object: event
                     )
                 }

--- a/iosApp/iosApp/Networking/ServerRegistry.swift
+++ b/iosApp/iosApp/Networking/ServerRegistry.swift
@@ -168,13 +168,60 @@ final class ServerRegistry {
             Self.logger.error("switchTo called with unknown server id")
             return
         }
-        // Cancel before retargeting: a response from the old server must
-        // not be able to land on the new server's token slot. See
-        // `HTTPClient.cancelInFlightRequests` for the ordering contract.
+        guard let transitionLease = await HTTPClient.shared.beginIdentityTransition() else {
+            return
+        }
+        guard !Task.isCancelled else {
+            await HTTPClient.shared.endIdentityTransition(transitionLease)
+            return
+        }
         await HTTPClient.shared.cancelInFlightRequests()
-        await AuthService.shared.clearCachesForServerChange()
+        guard !Task.isCancelled else {
+            await HTTPClient.shared.endIdentityTransition(transitionLease)
+            return
+        }
+        guard await commitSwitchTo(serverId: serverId, abortIfCancelled: true) else {
+            await HTTPClient.shared.endIdentityTransition(transitionLease)
+            return
+        }
+        await HTTPClient.shared.endIdentityTransition(transitionLease)
+        await refreshFeaturesAfterServerSwitch()
+    }
 
-        let entry = entries.first(where: { $0.id == serverId })!
+    /// Commit while the caller already holds HTTPClient's transition lease.
+    /// Pairing uses this to publish its new tokens, defaults, and observable
+    /// active server with no ungated A/B routing interval.
+    func commitSwitchTo(
+        serverId: String,
+        holding transitionLease: HTTPIdentityTransitionLease
+    ) async {
+        guard entries.contains(where: { $0.id == serverId }),
+              await HTTPClient.shared.isIdentityTransitionActive(transitionLease) else {
+            Self.logger.error("gated switchTo called without its identity transition")
+            return
+        }
+        // Pairing has already written the new credential slot under this
+        // lease. Finish the registry/default commit even if cancellation
+        // arrives now; aborting would publish a split A/B routing state.
+        _ = await commitSwitchTo(serverId: serverId, abortIfCancelled: false)
+    }
+
+    func refreshFeaturesAfterGatedServerSwitch() async {
+        await refreshFeaturesAfterServerSwitch()
+    }
+
+    @discardableResult
+    private func commitSwitchTo(
+        serverId: String,
+        abortIfCancelled: Bool
+    ) async -> Bool {
+        guard let entry = entries.first(where: { $0.id == serverId }) else {
+            Self.logger.error("switchTo target was removed while waiting for transition")
+            return false
+        }
+        await AuthService.shared.clearCachesForServerChange()
+        guard !abortIfCancelled || !Task.isCancelled else { return false }
+
         defaults.set(entry.url, forKey: "serverUrl")
         if let pid = entry.profileId {
             defaults.set(pid, forKey: "profileId")
@@ -196,7 +243,10 @@ final class ServerRegistry {
         // the restored profile against the newly selected server.
         DiagnosticsCoordinator.activeProfileDidChange()
         #endif
+        return true
+    }
 
+    private func refreshFeaturesAfterServerSwitch() async {
         // Switching between already-added servers is a per-server boundary too:
         // drop the previous server's AI capability/quota probes after the URL,
         // profile, active id, and token slot have all been retargeted so any
@@ -226,12 +276,18 @@ final class ServerRegistry {
     /// `purgeCurrentBinding: false` when the caller already purged the active
     /// binding while still authenticated (AuthService.signOut does, so the
     /// binding resolves against a live session) to avoid duplicate current work.
-    func signOut(serverId: String, purgeCurrentBinding: Bool = true) async {
+    func signOut(
+        serverId: String,
+        purgeCurrentBinding: Bool = true,
+        purgeRegistryBindings: Bool = true
+    ) async {
         #if os(iOS) || os(tvOS)
         if purgeCurrentBinding, serverId == activeServerId {
             await DiagnosticsCoordinator.shared.purgeDiagnosticsForCurrentBinding()
         }
-        await DiagnosticsCoordinator.shared.purgeDiagnosticsForServerRegistryID(serverId)
+        if purgeRegistryBindings {
+            await DiagnosticsCoordinator.shared.purgeDiagnosticsForServerRegistryID(serverId)
+        }
         #endif
         await TokenStore.shared.deleteTokens(for: serverId)
         if let idx = entries.firstIndex(where: { $0.id == serverId }) {
@@ -247,6 +303,17 @@ final class ServerRegistry {
     /// next-most-recent server becomes active; if none remain, the active
     /// slot is cleared.
     func remove(serverId: String) async {
+        guard let transitionLease = await HTTPClient.shared.beginIdentityTransition() else {
+            return
+        }
+        guard !Task.isCancelled else {
+            await HTTPClient.shared.endIdentityTransition(transitionLease)
+            return
+        }
+        guard entries.contains(where: { $0.id == serverId }) else {
+            await HTTPClient.shared.endIdentityTransition(transitionLease)
+            return
+        }
         let removesActiveServer = activeServerId == serverId
         #if os(iOS) || os(tvOS)
         if removesActiveServer {
@@ -257,11 +324,19 @@ final class ServerRegistry {
         }
         await DiagnosticsCoordinator.shared.purgeDiagnosticsForServerRegistryID(serverId)
         #endif
+        guard !Task.isCancelled else {
+            await HTTPClient.shared.endIdentityTransition(transitionLease)
+            return
+        }
         if removesActiveServer {
             // Stop old-server responses and clear every process-wide cache
             // before publishing the fallback ID to observing views.
             await HTTPClient.shared.cancelInFlightRequests()
             await AuthService.shared.clearCachesForServerChange()
+            guard !Task.isCancelled else {
+                await HTTPClient.shared.endIdentityTransition(transitionLease)
+                return
+            }
         }
         await TokenStore.shared.deleteTokens(for: serverId)
         entries.removeAll(where: { $0.id == serverId })
@@ -288,6 +363,10 @@ final class ServerRegistry {
             // profile is confirmed, same as `switchTo`.
             DiagnosticsCoordinator.activeProfileDidChange()
             #endif
+        }
+        persist()
+        await HTTPClient.shared.endIdentityTransition(transitionLease)
+        if removesActiveServer {
             await MainActor.run {
                 AICapabilities.shared.reset()
                 RequestsFeatureStore.shared.reset()
@@ -298,7 +377,6 @@ final class ServerRegistry {
                 Task { await RequestsFeatureStore.shared.refresh() }
             }
         }
-        persist()
     }
 
     // MARK: - ID derivation

--- a/iosApp/iosApp/Networking/SettingKeys.generated.swift
+++ b/iosApp/iosApp/Networking/SettingKeys.generated.swift
@@ -27,12 +27,18 @@ public struct SettingPresentation: Hashable, Sendable {
 public enum SettingKey: String, CaseIterable, Sendable {
     /// Metadata language
     case catalogMetadataLanguage = "catalog.metadata_language"
+    /// Metadata language exceptions
+    case catalogMetadataLanguageOverrides = "catalog.metadata_language_overrides"
     /// Download quality
     case downloadsDefaultQuality = "downloads.default_quality"
     /// Keep watched downloads
     case downloadsKeepWatched = "downloads.keep_watched"
     /// Download over Wi-Fi only
     case downloadsWifiOnly = "downloads.wifi_only"
+    /// Primary menu
+    case navPrimaryMenu = "nav.primary_menu"
+    /// Navigation shortcuts
+    case navShortcuts = "nav.shortcuts"
     /// Show audiobooks
     case navShowAudiobooks = "nav.show_audiobooks"
     /// Preferred audio language
@@ -95,6 +101,8 @@ public enum SettingKey: String, CaseIterable, Sendable {
     case subtitleMatchesDevice = "subtitle.matches_device"
     /// Poster badges
     case uiCardOverlays = "ui.card_overlays"
+    /// Media cards
+    case uiCardPresentation = "ui.card_presentation"
     /// Custom CSS
     case uiCustomCss = "ui.custom_css"
     /// Custom theme variables
@@ -126,11 +134,14 @@ public enum SettingKey: String, CaseIterable, Sendable {
 }
 
 public extension SettingKey {
-    static let revision = 2
+    static let revision = 5
 
     /// Keys the server stores. The rest never leave the device.
     static let remote: [SettingKey] = [
         .catalogMetadataLanguage,
+        .catalogMetadataLanguageOverrides,
+        .navPrimaryMenu,
+        .navShortcuts,
         .playbackAudioLanguage,
         .playbackAutoPlayNext,
         .playbackAutoPlayNextPreview,
@@ -157,6 +168,7 @@ public extension SettingKey {
         .playerVideoGravity,
         .searchMediaScope,
         .uiCardOverlays,
+        .uiCardPresentation,
         .uiCustomCss,
         .uiCustomThemeVars,
         .uiDateFormat,

--- a/iosApp/iosApp/Networking/SettingValueModels.swift
+++ b/iosApp/iosApp/Networking/SettingValueModels.swift
@@ -261,6 +261,7 @@ extension SettingJSONValue: ExpressibleByBooleanLiteral,
 enum SettingScope: RawRepresentable, Hashable, Sendable {
     case account
     case profile
+    case profileClient
     case profileDevice
     case profileLibrary
     case profileSeries
@@ -270,6 +271,7 @@ enum SettingScope: RawRepresentable, Hashable, Sendable {
         switch rawValue {
         case "account": self = .account
         case "profile": self = .profile
+        case "profile_client": self = .profileClient
         case "profile_device": self = .profileDevice
         case "profile_library": self = .profileLibrary
         case "profile_series": self = .profileSeries
@@ -281,6 +283,7 @@ enum SettingScope: RawRepresentable, Hashable, Sendable {
         switch self {
         case .account: return "account"
         case .profile: return "profile"
+        case .profileClient: return "profile_client"
         case .profileDevice: return "profile_device"
         case .profileLibrary: return "profile_library"
         case .profileSeries: return "profile_series"
@@ -392,6 +395,7 @@ extension SettingConstraintKind: Codable {
 enum SettingScopeIdentity: Hashable, Sendable {
     case account
     case profile
+    case profileClient
     case profileDevice
     case profileLibrary(libraryId: Int)
     case profileSeries(seriesId: String)
@@ -400,6 +404,7 @@ enum SettingScopeIdentity: Hashable, Sendable {
         switch self {
         case .account: return .account
         case .profile: return .profile
+        case .profileClient: return .profileClient
         case .profileDevice: return .profileDevice
         case .profileLibrary: return .profileLibrary
         case .profileSeries: return .profileSeries
@@ -415,7 +420,7 @@ enum SettingScopeIdentity: Hashable, Sendable {
             query["library_id"] = String(libraryId)
         case .profileSeries(let seriesId):
             query["series_id"] = seriesId
-        case .account, .profile, .profileDevice:
+        case .account, .profile, .profileClient, .profileDevice:
             break
         }
         return query
@@ -429,6 +434,7 @@ struct StoredSettingValue: Codable, Hashable, Sendable {
     let key: String
     let scope: SettingScope
     let profileId: String?
+    let clientFamily: String?
     let deviceId: String?
     let libraryId: Int?
     let seriesId: String?
@@ -443,6 +449,7 @@ struct StoredSettingValue: Codable, Hashable, Sendable {
         case key
         case scope
         case profileId = "profile_id"
+        case clientFamily = "client_family"
         case deviceId = "device_id"
         case libraryId = "library_id"
         case seriesId = "series_id"
@@ -480,6 +487,7 @@ struct EffectiveSettingValue: Codable, Hashable, Sendable {
     /// Absent for a contract default.
     let scope: SettingScope?
     let profileId: String?
+    let clientFamily: String?
     let deviceId: String?
     let libraryId: Int?
     let seriesId: String?
@@ -494,6 +502,7 @@ struct EffectiveSettingValue: Codable, Hashable, Sendable {
         case suggestedValues = "suggested_values"
         case scope
         case profileId = "profile_id"
+        case clientFamily = "client_family"
         case deviceId = "device_id"
         case libraryId = "library_id"
         case seriesId = "series_id"
@@ -514,6 +523,7 @@ struct EffectiveSettingValue: Codable, Hashable, Sendable {
         suggestedValues = try container.decodeIfPresent([String].self, forKey: .suggestedValues)
         scope = try container.decodeIfPresent(SettingScope.self, forKey: .scope)
         profileId = try container.decodeIfPresent(String.self, forKey: .profileId)
+        clientFamily = try container.decodeIfPresent(String.self, forKey: .clientFamily)
         deviceId = try container.decodeIfPresent(String.self, forKey: .deviceId)
         libraryId = try container.decodeIfPresent(Int.self, forKey: .libraryId)
         seriesId = try container.decodeIfPresent(String.self, forKey: .seriesId)
@@ -529,6 +539,7 @@ struct EffectiveSettingValue: Codable, Hashable, Sendable {
         suggestedValues: [String]? = nil,
         scope: SettingScope? = nil,
         profileId: String? = nil,
+        clientFamily: String? = nil,
         deviceId: String? = nil,
         libraryId: Int? = nil,
         seriesId: String? = nil
@@ -542,6 +553,7 @@ struct EffectiveSettingValue: Codable, Hashable, Sendable {
         self.suggestedValues = suggestedValues
         self.scope = scope
         self.profileId = profileId
+        self.clientFamily = clientFamily
         self.deviceId = deviceId
         self.libraryId = libraryId
         self.seriesId = seriesId
@@ -558,6 +570,7 @@ struct EffectiveSettingValue: Codable, Hashable, Sendable {
         switch scope {
         case .account: return .account
         case .profile: return .profile
+        case .profileClient: return .profileClient
         case .profileDevice: return .profileDevice
         case .profileLibrary: return libraryId.map { .profileLibrary(libraryId: $0) }
         case .profileSeries: return seriesId.map { .profileSeries(seriesId: $0) }
@@ -614,6 +627,10 @@ struct SettingsContractCapabilities: Codable, Hashable, Sendable {
     let scopes: [String]
     let supportsBatchedEffective: Bool
     let supportsIdempotentWrites: Bool
+    /// Revision-5 semantic shortcut mutations. Whole-document shortcut PUTs
+    /// are intentionally not a safe fallback because concurrent clients can
+    /// otherwise replace one another's pins.
+    let supportsAtomicShortcuts: Bool
 
     enum CodingKeys: String, CodingKey {
         case apiVersion = "api_version"
@@ -623,6 +640,44 @@ struct SettingsContractCapabilities: Codable, Hashable, Sendable {
         case scopes
         case supportsBatchedEffective = "supports_batched_effective"
         case supportsIdempotentWrites = "supports_idempotent_writes"
+        case supportsAtomicShortcuts = "supports_atomic_shortcuts"
+    }
+
+    init(
+        apiVersion: Int,
+        revision: Int,
+        contractEtag: String,
+        definitionCount: Int,
+        scopes: [String],
+        supportsBatchedEffective: Bool,
+        supportsIdempotentWrites: Bool,
+        supportsAtomicShortcuts: Bool
+    ) {
+        self.apiVersion = apiVersion
+        self.revision = revision
+        self.contractEtag = contractEtag
+        self.definitionCount = definitionCount
+        self.scopes = scopes
+        self.supportsBatchedEffective = supportsBatchedEffective
+        self.supportsIdempotentWrites = supportsIdempotentWrites
+        self.supportsAtomicShortcuts = supportsAtomicShortcuts
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        apiVersion = try container.decode(Int.self, forKey: .apiVersion)
+        revision = try container.decode(Int.self, forKey: .revision)
+        contractEtag = try container.decode(String.self, forKey: .contractEtag)
+        definitionCount = try container.decode(Int.self, forKey: .definitionCount)
+        scopes = try container.decode([String].self, forKey: .scopes)
+        supportsBatchedEffective = try container.decode(Bool.self, forKey: .supportsBatchedEffective)
+        supportsIdempotentWrites = try container.decode(Bool.self, forKey: .supportsIdempotentWrites)
+        // Older capability payloads predate the flag. Missing must fail
+        // closed, never silently opt into the atomic-only UI.
+        supportsAtomicShortcuts = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .supportsAtomicShortcuts
+        ) ?? false
     }
 
     /// True when this build was generated from a newer manifest than the
@@ -630,6 +685,13 @@ struct SettingsContractCapabilities: Codable, Hashable, Sendable {
     /// know rather than offer a choice it will refuse.
     var contractIsAheadOfServer: Bool {
         SettingKey.revision > revision
+    }
+
+    var supportsUICustomizationRevision: Bool {
+        revision >= 5
+            && supportsBatchedEffective
+            && supportsIdempotentWrites
+            && supportsAtomicShortcuts
     }
 }
 

--- a/iosApp/iosApp/Networking/TokenStore.swift
+++ b/iosApp/iosApp/Networking/TokenStore.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+struct RefreshAccountIdentity: Hashable, Sendable {
+    let serverId: String
+    let serverURL: String
+}
+
 struct TemporaryAuthScope: Equatable, Sendable {
     let serverId: String
     let serverURL: String
@@ -123,6 +128,20 @@ actor TokenStore {
     /// The current active server ID. Empty string if none.
     func getActiveServerId() -> String { temporaryScope?.serverId ?? activeServerId }
 
+    /// Atomically capture the account-level identity that owns refresh-token
+    /// rotation. Both ordinary and captured-identity HTTP requests use this
+    /// key to join one refresh flight.
+    func refreshAccountIdentity() -> RefreshAccountIdentity? {
+        let serverId = temporaryScope?.serverId ?? activeServerId
+        let serverURL = ServerRegistry.normalize(
+            url: temporaryScope?.serverURL
+                ?? defaults.string(forKey: serverUrlDefaultsKey)
+                ?? ""
+        )
+        guard !serverId.isEmpty, !serverURL.isEmpty else { return nil }
+        return RefreshAccountIdentity(serverId: serverId, serverURL: serverURL)
+    }
+
     func beginTemporaryScope(_ scope: TemporaryAuthScope) {
         temporaryScope = scope
     }
@@ -136,6 +155,89 @@ actor TokenStore {
     func getTemporaryScope() -> TemporaryAuthScope? { temporaryScope }
 
     func hasTemporaryScope() -> Bool { temporaryScope != nil }
+
+    /// Atomically verify a queued request's routing identity and snapshot the
+    /// matching credentials. No mutable global scope is installed: the caller
+    /// carries this value for one explicit request only.
+    func captureRequestAuth(expected: HTTPRequestIdentity) throws -> CapturedHTTPRequestAuth {
+        let expectedURL = ServerRegistry.normalize(url: expected.serverURL)
+        let currentServerId = temporaryScope?.serverId ?? activeServerId
+        let currentURL = ServerRegistry.normalize(
+            url: temporaryScope?.serverURL
+                ?? defaults.string(forKey: serverUrlDefaultsKey)
+                ?? ""
+        )
+        let currentProfileId = temporaryScope?.profileId
+            ?? defaults.string(forKey: profileIdDefaultsKey)
+
+        guard !expected.serverId.isEmpty,
+              !expectedURL.isEmpty,
+              !expected.profileId.isEmpty,
+              currentServerId == expected.serverId,
+              currentURL == expectedURL,
+              currentProfileId == expected.profileId else {
+            throw HTTPError.requestIdentityChanged
+        }
+
+        if let temporaryScope {
+            return CapturedHTTPRequestAuth(
+                serverURL: expectedURL,
+                accessValue: temporaryScope.accessToken,
+                refreshValue: temporaryScope.refreshToken,
+                profileId: expected.profileId,
+                profileValue: temporaryScope.profileToken,
+                credentialOwner: .temporary
+            )
+        }
+
+        ensureLoaded()
+        return CapturedHTTPRequestAuth(
+            serverURL: expectedURL,
+            accessValue: cachedAccessToken,
+            refreshValue: cachedRefreshToken,
+            profileId: expected.profileId,
+            profileValue: cachedProfileToken,
+            credentialOwner: .persistentServer(serverId: expected.serverId)
+        )
+    }
+
+    /// Store a scoped refresh only if the same server account and refresh
+    /// value are still active. Access/refresh credentials belong to the
+    /// server account, not one selected profile, so a profile switch must not
+    /// discard a successful rotation and strand that server's slot.
+    func saveRefreshedTokens(
+        _ accessValue: String,
+        _ value: String,
+        replacing previousValue: String?,
+        expected: HTTPRequestIdentity,
+        credentialOwner: CapturedHTTPRequestCredentialOwner
+    ) -> Bool {
+        let expectedURL = ServerRegistry.normalize(url: expected.serverURL)
+        let currentURL = ServerRegistry.normalize(
+            url: defaults.string(forKey: serverUrlDefaultsKey) ?? ""
+        )
+        guard temporaryScope == nil,
+              credentialOwner == .persistentServer(serverId: expected.serverId),
+              !expected.serverId.isEmpty,
+              !expectedURL.isEmpty,
+              let previousValue,
+              !previousValue.isEmpty,
+              activeServerId == expected.serverId,
+              currentURL == expectedURL else { return false }
+
+        ensureLoaded()
+        let expectedRefreshKey = Self.refreshTokenKey(for: expected.serverId)
+        guard cachedRefreshToken == previousValue else { return false }
+
+        cachedAccessToken = accessValue
+        cachedRefreshToken = value
+        keychain.set(accessValue, for: Self.accessTokenKey(for: expected.serverId))
+        keychain.set(value, for: expectedRefreshKey)
+        // Account refresh must not re-mirror a stale profile credential
+        // during an in-progress profile transition.
+        mirrorActiveAccessValueForExtension()
+        return true
+    }
 
     // MARK: - Tokens
 
@@ -314,6 +416,18 @@ actor TokenStore {
                 keychain.delete(SharedStorage.mirroredProfileTokenAccount)
             }
             lastMirroredProfileToken = cachedProfileToken
+        }
+    }
+
+    private func mirrorActiveAccessValueForExtension() {
+        if cachedAccessToken != lastMirroredAccessToken {
+            if let value = cachedAccessToken {
+                keychain.set(value, for: SharedStorage.mirroredAccessTokenAccount)
+                lastMirroredAccessToken = value
+            } else {
+                keychain.delete(SharedStorage.mirroredAccessTokenAccount)
+                lastMirroredAccessToken = nil
+            }
         }
     }
 

--- a/iosApp/iosApp/Networking/TokenStore.swift
+++ b/iosApp/iosApp/Networking/TokenStore.swift
@@ -3,9 +3,57 @@ import Foundation
 struct RefreshAccountIdentity: Hashable, Sendable {
     let serverId: String
     let serverURL: String
+    /// Process-local epoch for the exact credential owner. Persistent epochs
+    /// change on login/sign-out/retarget; temporary scopes supply their stable
+    /// handoff generation. Guarded refresh rotation preserves the epoch.
+    let credentialGenerationID: UUID
+
+    init(
+        serverId: String,
+        serverURL: String,
+        credentialGenerationID: UUID
+    ) {
+        self.serverId = serverId
+        self.serverURL = serverURL
+        self.credentialGenerationID = credentialGenerationID
+    }
+}
+
+struct CapturedRefreshCredential: Equatable, Sendable {
+    let account: RefreshAccountIdentity
+    let refreshToken: String
+    let owner: CapturedHTTPRequestCredentialOwner
+}
+
+/// One actor-consistent snapshot of every mutable credential field an
+/// ordinary request sends. The account includes temporary-owner generation;
+/// profile identity is kept alongside it so a 401 can never retry under a
+/// profile selected after the original request left the client.
+struct CapturedOrdinaryRequestAuth: Equatable, Sendable {
+    let account: RefreshAccountIdentity
+    let credentialOwner: CapturedHTTPRequestCredentialOwner
+    let accessToken: String?
+    let profileId: String?
+    let profileToken: String?
+}
+
+enum RejectedRefreshDisposition: Equatable, Sendable {
+    case persistentSessionCleared
+    case temporarySessionExpired
+}
+
+/// Nonsecret notification payload identifying the exact rejected credential
+/// epoch. Consumers revalidate it with TokenStore immediately before routing
+/// or tearing down a temporary playback identity.
+struct SessionExpiryEvent: Equatable, Sendable {
+    let account: RefreshAccountIdentity
+    let disposition: RejectedRefreshDisposition
 }
 
 struct TemporaryAuthScope: Equatable, Sendable {
+    /// Stable for this installed credential overlay and replaced whenever a
+    /// new remote-playback handoff is activated.
+    let credentialGenerationID: UUID
     let serverId: String
     let serverURL: String
     var accessToken: String
@@ -14,6 +62,37 @@ struct TemporaryAuthScope: Equatable, Sendable {
     var profileToken: String
     let controllerDeviceId: String
     let expiresAt: Date
+
+    init(
+        credentialGenerationID: UUID = UUID(),
+        serverId: String,
+        serverURL: String,
+        accessToken: String,
+        refreshToken: String,
+        profileId: String,
+        profileToken: String,
+        controllerDeviceId: String,
+        expiresAt: Date
+    ) {
+        self.credentialGenerationID = credentialGenerationID
+        self.serverId = serverId
+        self.serverURL = serverURL
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+        self.profileId = profileId
+        self.profileToken = profileToken
+        self.controllerDeviceId = controllerDeviceId
+        self.expiresAt = expiresAt
+    }
+}
+
+/// Exact temporary-owner state displaced by a handoff activation. Keeping the
+/// rejection bit with the credentials lets a cancelled replacement restore
+/// the prior generation without silently making a terminally rejected scope
+/// refreshable again.
+struct TemporaryAuthScopeSnapshot: Equatable, Sendable {
+    let scope: TemporaryAuthScope?
+    fileprivate let wasRefreshRejected: Bool
 }
 
 /// Persistent, thread-safe store for Continuum session state.
@@ -76,9 +155,17 @@ actor TokenStore {
     private var cachedAccessToken: String?
     private var cachedRefreshToken: String?
     private var cachedProfileToken: String?
+    /// Process-local identity for the persistent credential slot currently
+    /// selected by `activeServerId`. Refresh rotation leaves it unchanged;
+    /// every session replacement or routing boundary installs a fresh epoch.
+    private var persistentCredentialGenerationID = UUID()
     /// Playback-scoped credentials received by a TV through remote handoff.
     /// They are process-only and never written into normal per-server slots.
     private var temporaryScope: TemporaryAuthScope?
+    /// A terminally rejected temporary generation remains installed until
+    /// remote-playback teardown, but it must never submit its refresh token
+    /// again or emit duplicate expiry notifications.
+    private var rejectedTemporaryCredentialGenerations: Set<UUID> = []
     /// Server the current cache was loaded for. Nil means the cache is
     /// invalid and must be re-read on next access.
     private var loadedForServerId: String?
@@ -103,6 +190,7 @@ actor TokenStore {
     /// Idempotent: a no-op if `serverId` is already active.
     func switchActiveServer(serverId: String) {
         if serverId == activeServerId { return }
+        persistentCredentialGenerationID = UUID()
         activeServerId = serverId
         cachedAccessToken = nil
         cachedRefreshToken = nil
@@ -118,6 +206,7 @@ actor TokenStore {
     /// the full token load + Top Shelf mirror before SwiftUI leaves `.loading`.
     func retargetActiveServer(serverId: String) {
         if serverId == activeServerId { return }
+        persistentCredentialGenerationID = UUID()
         activeServerId = serverId
         cachedAccessToken = nil
         cachedRefreshToken = nil
@@ -132,24 +221,136 @@ actor TokenStore {
     /// rotation. Both ordinary and captured-identity HTTP requests use this
     /// key to join one refresh flight.
     func refreshAccountIdentity() -> RefreshAccountIdentity? {
-        let serverId = temporaryScope?.serverId ?? activeServerId
+        let scope = temporaryScope
+        let serverId = scope?.serverId ?? activeServerId
         let serverURL = ServerRegistry.normalize(
-            url: temporaryScope?.serverURL
+            url: scope?.serverURL
                 ?? defaults.string(forKey: serverUrlDefaultsKey)
                 ?? ""
         )
         guard !serverId.isEmpty, !serverURL.isEmpty else { return nil }
-        return RefreshAccountIdentity(serverId: serverId, serverURL: serverURL)
+        return RefreshAccountIdentity(
+            serverId: serverId,
+            serverURL: serverURL,
+            credentialGenerationID: scope?.credentialGenerationID
+                ?? persistentCredentialGenerationID
+        )
     }
 
-    func beginTemporaryScope(_ scope: TemporaryAuthScope) {
-        temporaryScope = scope
+    /// Capture the account, credential owner, and complete request auth header
+    /// set in one actor turn. The request carries this immutable identity
+    /// through its 401 path so a later server, temporary-owner, or profile
+    /// switch cannot redirect its refresh or produce mixed headers.
+    func captureOrdinaryRequestAuth() -> CapturedOrdinaryRequestAuth? {
+        guard let account = refreshAccountIdentity() else { return nil }
+        if let temporaryScope {
+            return CapturedOrdinaryRequestAuth(
+                account: account,
+                credentialOwner: .temporary,
+                accessToken: temporaryScope.accessToken,
+                profileId: temporaryScope.profileId,
+                profileToken: temporaryScope.profileToken
+            )
+        }
+
+        ensureLoaded()
+        return CapturedOrdinaryRequestAuth(
+            account: account,
+            credentialOwner: .persistentServer(serverId: account.serverId),
+            accessToken: cachedAccessToken,
+            profileId: defaults.string(forKey: profileIdDefaultsKey),
+            profileToken: cachedProfileToken
+        )
+    }
+
+    /// Capture the refresh credential and its owner in the same actor turn as
+    /// the account identity check. A refresh response must carry this snapshot
+    /// back to its save/invalidation operation so it cannot affect credentials
+    /// installed by a later server switch, sign-out, or token rotation.
+    func captureRefreshCredential(expected: RefreshAccountIdentity) -> CapturedRefreshCredential? {
+        guard refreshAccountIdentity() == expected else { return nil }
+        if let temporaryScope {
+            guard expected.credentialGenerationID == temporaryScope.credentialGenerationID,
+                  !rejectedTemporaryCredentialGenerations.contains(temporaryScope.credentialGenerationID),
+                  !temporaryScope.refreshToken.isEmpty else { return nil }
+            return CapturedRefreshCredential(
+                account: expected,
+                refreshToken: temporaryScope.refreshToken,
+                owner: .temporary
+            )
+        }
+
+        ensureLoaded()
+        guard let cachedRefreshToken, !cachedRefreshToken.isEmpty else { return nil }
+        return CapturedRefreshCredential(
+            account: expected,
+            refreshToken: cachedRefreshToken,
+            owner: .persistentServer(serverId: expected.serverId)
+        )
+    }
+
+    /// Atomically re-capture the current ordinary-request auth only if its
+    /// account owner/generation and profile identity still match `expected`.
+    /// Access-token rotation is intentionally excluded from the identity
+    /// comparison so callers can detect a completed shared refresh.
+    func currentOrdinaryRequestAuth(
+        matchingIdentityOf expected: CapturedOrdinaryRequestAuth
+    ) -> CapturedOrdinaryRequestAuth? {
+        guard let current = captureOrdinaryRequestAuth(),
+              current.account == expected.account,
+              current.credentialOwner == expected.credentialOwner,
+              current.profileId == expected.profileId,
+              current.profileToken == expected.profileToken else {
+            return nil
+        }
+        return current
     }
 
     @discardableResult
-    func endTemporaryScope() -> TemporaryAuthScope? {
-        defer { temporaryScope = nil }
-        return temporaryScope
+    func beginTemporaryScope(_ scope: TemporaryAuthScope) -> TemporaryAuthScopeSnapshot {
+        let previous = TemporaryAuthScopeSnapshot(
+            scope: temporaryScope,
+            wasRefreshRejected: temporaryScope.map {
+                rejectedTemporaryCredentialGenerations.contains($0.credentialGenerationID)
+            } ?? false
+        )
+        if let previous = temporaryScope,
+           previous.credentialGenerationID != scope.credentialGenerationID {
+            rejectedTemporaryCredentialGenerations.remove(previous.credentialGenerationID)
+        }
+        temporaryScope = scope
+        return previous
+    }
+
+    /// Roll back a just-installed scope only while it is still the active
+    /// generation. A newer activation wins and is never overwritten by a
+    /// delayed cancellation cleanup.
+    @discardableResult
+    func restoreTemporaryScope(
+        _ snapshot: TemporaryAuthScopeSnapshot,
+        replacingGenerationID: UUID
+    ) -> Bool {
+        guard temporaryScope?.credentialGenerationID == replacingGenerationID else {
+            return false
+        }
+        rejectedTemporaryCredentialGenerations.remove(replacingGenerationID)
+        temporaryScope = snapshot.scope
+        if snapshot.wasRefreshRejected, let restored = snapshot.scope {
+            rejectedTemporaryCredentialGenerations.insert(restored.credentialGenerationID)
+        }
+        return true
+    }
+
+    @discardableResult
+    func endTemporaryScope(expectedGenerationID: UUID? = nil) -> TemporaryAuthScope? {
+        guard let scope = temporaryScope else { return nil }
+        if let expectedGenerationID,
+           scope.credentialGenerationID != expectedGenerationID {
+            return nil
+        }
+        rejectedTemporaryCredentialGenerations.remove(scope.credentialGenerationID)
+        temporaryScope = nil
+        return scope
     }
 
     func getTemporaryScope() -> TemporaryAuthScope? { temporaryScope }
@@ -161,6 +362,9 @@ actor TokenStore {
     /// carries this value for one explicit request only.
     func captureRequestAuth(expected: HTTPRequestIdentity) throws -> CapturedHTTPRequestAuth {
         let expectedURL = ServerRegistry.normalize(url: expected.serverURL)
+        guard let account = refreshAccountIdentity() else {
+            throw HTTPError.requestIdentityChanged
+        }
         let currentServerId = temporaryScope?.serverId ?? activeServerId
         let currentURL = ServerRegistry.normalize(
             url: temporaryScope?.serverURL
@@ -175,12 +379,15 @@ actor TokenStore {
               !expected.profileId.isEmpty,
               currentServerId == expected.serverId,
               currentURL == expectedURL,
+              account.serverId == expected.serverId,
+              account.serverURL == expectedURL,
               currentProfileId == expected.profileId else {
             throw HTTPError.requestIdentityChanged
         }
 
         if let temporaryScope {
             return CapturedHTTPRequestAuth(
+                account: account,
                 serverURL: expectedURL,
                 accessValue: temporaryScope.accessToken,
                 refreshValue: temporaryScope.refreshToken,
@@ -192,6 +399,7 @@ actor TokenStore {
 
         ensureLoaded()
         return CapturedHTTPRequestAuth(
+            account: account,
             serverURL: expectedURL,
             accessValue: cachedAccessToken,
             refreshValue: cachedRefreshToken,
@@ -213,30 +421,160 @@ actor TokenStore {
         credentialOwner: CapturedHTTPRequestCredentialOwner
     ) -> Bool {
         let expectedURL = ServerRegistry.normalize(url: expected.serverURL)
-        let currentURL = ServerRegistry.normalize(
-            url: defaults.string(forKey: serverUrlDefaultsKey) ?? ""
-        )
-        guard temporaryScope == nil,
-              credentialOwner == .persistentServer(serverId: expected.serverId),
+        guard credentialOwner == .persistentServer(serverId: expected.serverId),
               !expected.serverId.isEmpty,
               !expectedURL.isEmpty,
               let previousValue,
-              !previousValue.isEmpty,
-              activeServerId == expected.serverId,
-              currentURL == expectedURL else { return false }
+              !previousValue.isEmpty else { return false }
+        guard let account = refreshAccountIdentity(),
+              account.serverId == expected.serverId,
+              account.serverURL == expectedURL else { return false }
+        return saveRefreshedTokens(
+            accessValue,
+            value,
+            replacing: CapturedRefreshCredential(
+                account: RefreshAccountIdentity(
+                    serverId: expected.serverId,
+                    serverURL: expectedURL,
+                    credentialGenerationID: account.credentialGenerationID
+                ),
+                refreshToken: previousValue,
+                owner: credentialOwner
+            )
+        )
+    }
 
-        ensureLoaded()
-        let expectedRefreshKey = Self.refreshTokenKey(for: expected.serverId)
-        guard cachedRefreshToken == previousValue else { return false }
+    /// Store rotated credentials only if the exact account, credential owner,
+    /// and refresh token captured before the network call are still current.
+    func saveRefreshedTokens(
+        _ accessValue: String,
+        _ value: String,
+        replacing captured: CapturedRefreshCredential
+    ) -> Bool {
+        guard refreshAccountIdentity() == captured.account else { return false }
 
-        cachedAccessToken = accessValue
-        cachedRefreshToken = value
-        keychain.set(accessValue, for: Self.accessTokenKey(for: expected.serverId))
-        keychain.set(value, for: expectedRefreshKey)
-        // Account refresh must not re-mirror a stale profile credential
-        // during an in-progress profile transition.
-        mirrorActiveAccessValueForExtension()
-        return true
+        switch captured.owner {
+        case .temporary:
+            let generationID = captured.account.credentialGenerationID
+            guard temporaryScope?.credentialGenerationID == generationID,
+                  !rejectedTemporaryCredentialGenerations.contains(generationID),
+                  temporaryScope?.refreshToken == captured.refreshToken else { return false }
+            temporaryScope?.accessToken = accessValue
+            temporaryScope?.refreshToken = value
+            return true
+
+        case .persistentServer(let serverId):
+            guard temporaryScope == nil,
+                  serverId == captured.account.serverId,
+                  activeServerId == serverId else { return false }
+            ensureLoaded()
+            guard cachedRefreshToken == captured.refreshToken else { return false }
+
+            cachedAccessToken = accessValue
+            cachedRefreshToken = value
+            keychain.set(accessValue, for: Self.accessTokenKey(for: serverId))
+            keychain.set(value, for: Self.refreshTokenKey(for: serverId))
+            // Account refresh must not re-mirror a stale profile credential
+            // during an in-progress profile transition.
+            mirrorActiveAccessValueForExtension()
+            return true
+        }
+    }
+
+    /// Clear a rejected captured refresh only if it still belongs to the same
+    /// active server account and no newer refresh token has replaced it. This
+    /// is the failure-side counterpart to `saveRefreshedTokens`: a late scoped
+    /// response must never sign out a server selected while it was in flight.
+    func clearTokensAfterRejectedRefresh(
+        replacing previousValue: String?,
+        expected: HTTPRequestIdentity,
+        credentialOwner: CapturedHTTPRequestCredentialOwner
+    ) -> Bool {
+        let expectedURL = ServerRegistry.normalize(url: expected.serverURL)
+        guard credentialOwner == .persistentServer(serverId: expected.serverId),
+              !expected.serverId.isEmpty,
+              !expectedURL.isEmpty,
+              let previousValue,
+              !previousValue.isEmpty else { return false }
+        guard let account = refreshAccountIdentity(),
+              account.serverId == expected.serverId,
+              account.serverURL == expectedURL else { return false }
+        let disposition = invalidateRejectedRefresh(
+            CapturedRefreshCredential(
+                account: RefreshAccountIdentity(
+                    serverId: expected.serverId,
+                    serverURL: expectedURL,
+                    credentialGenerationID: account.credentialGenerationID
+                ),
+                refreshToken: previousValue,
+                owner: credentialOwner
+            )
+        )
+        return disposition == .persistentSessionCleared
+    }
+
+    /// Invalidate only the credential snapshot the server rejected. Temporary
+    /// playback credentials stay installed until their teardown path removes
+    /// them, preventing a fall-through to the owner's persistent account.
+    func invalidateRejectedRefresh(
+        _ captured: CapturedRefreshCredential
+    ) -> RejectedRefreshDisposition? {
+        guard refreshAccountIdentity() == captured.account else { return nil }
+
+        switch captured.owner {
+        case .temporary:
+            let generationID = captured.account.credentialGenerationID
+            guard temporaryScope?.credentialGenerationID == generationID,
+                  temporaryScope?.refreshToken == captured.refreshToken,
+                  rejectedTemporaryCredentialGenerations.insert(generationID).inserted else {
+                return nil
+            }
+            return .temporarySessionExpired
+
+        case .persistentServer(let serverId):
+            guard temporaryScope == nil,
+                  serverId == captured.account.serverId,
+                  activeServerId == serverId else { return nil }
+            ensureLoaded()
+            guard cachedRefreshToken == captured.refreshToken else { return nil }
+
+            cachedAccessToken = nil
+            cachedRefreshToken = nil
+            cachedProfileToken = nil
+            keychain.delete(Self.accessTokenKey(for: serverId))
+            keychain.delete(Self.refreshTokenKey(for: serverId))
+            keychain.delete(Self.profileTokenKey(for: serverId))
+            defaults.removeObject(forKey: profileIdDefaultsKey)
+            clearMirroredTokensForExtension()
+            return .persistentSessionCleared
+        }
+    }
+
+    /// Verify that an expiry event still describes the active credential
+    /// state after invalidation. Registry and temporary-scope switches cancel
+    /// refresh tasks before installing the replacement; this final actor check
+    /// prevents a late event from routing or tearing down that replacement.
+    func shouldConsumeSessionExpiryEvent(_ event: SessionExpiryEvent) -> Bool {
+        guard refreshAccountIdentity() == event.account else { return false }
+
+        switch event.disposition {
+        case .temporarySessionExpired:
+            let generationID = event.account.credentialGenerationID
+            return temporaryScope?.credentialGenerationID == generationID
+                && rejectedTemporaryCredentialGenerations.contains(generationID)
+
+        case .persistentSessionCleared:
+            guard temporaryScope == nil,
+                  activeServerId == event.account.serverId,
+                  persistentCredentialGenerationID == event.account.credentialGenerationID else {
+                return false
+            }
+            ensureLoaded()
+            return cachedAccessToken == nil
+                && cachedRefreshToken == nil
+                && cachedProfileToken == nil
+                && defaults.string(forKey: profileIdDefaultsKey) == nil
+        }
     }
 
     // MARK: - Tokens
@@ -285,6 +623,7 @@ actor TokenStore {
         }
         guard !activeServerId.isEmpty else { return }
         ensureLoaded()
+        persistentCredentialGenerationID = UUID()
         cachedAccessToken = accessToken
         cachedRefreshToken = refreshToken
         keychain.set(accessToken, for: accessTokenKey)
@@ -296,11 +635,13 @@ actor TokenStore {
     /// stored tokens intact and leaves the active-server registry entry
     /// in place (sign-out keeps the URL / name).
     func clearTokens() {
-        if temporaryScope != nil {
-            temporaryScope = nil
+        if let temporaryScope {
+            rejectedTemporaryCredentialGenerations.remove(temporaryScope.credentialGenerationID)
+            self.temporaryScope = nil
             return
         }
         ensureLoaded()
+        persistentCredentialGenerationID = UUID()
         cachedAccessToken = nil
         cachedRefreshToken = nil
         cachedProfileToken = nil
@@ -320,6 +661,7 @@ actor TokenStore {
         keychain.delete(Self.refreshTokenKey(for: serverId))
         keychain.delete(Self.profileTokenKey(for: serverId))
         if serverId == activeServerId {
+            persistentCredentialGenerationID = UUID()
             cachedAccessToken = nil
             cachedRefreshToken = nil
             cachedProfileToken = nil

--- a/iosApp/iosApp/Networking/TokenStore.swift
+++ b/iosApp/iosApp/Networking/TokenStore.swift
@@ -95,6 +95,15 @@ struct TemporaryAuthScopeSnapshot: Equatable, Sendable {
     fileprivate let wasRefreshRejected: Bool
 }
 
+/// Atomic result of ending one temporary credential generation. Callers must
+/// distinguish an already-absent scope (the requested generation is gone) from
+/// a different installed generation (a replacement owns the slot).
+enum TemporaryAuthScopeEndResult: Equatable, Sendable {
+    case ended(TemporaryAuthScope)
+    case alreadyAbsent
+    case differentGeneration(activeGenerationID: UUID)
+}
+
 /// Persistent, thread-safe store for Continuum session state.
 ///
 /// Mirrors the surface of the shared Kotlin `TokenManager`, but persists
@@ -342,15 +351,19 @@ actor TokenStore {
     }
 
     @discardableResult
-    func endTemporaryScope(expectedGenerationID: UUID? = nil) -> TemporaryAuthScope? {
-        guard let scope = temporaryScope else { return nil }
+    func endTemporaryScope(
+        expectedGenerationID: UUID? = nil
+    ) -> TemporaryAuthScopeEndResult {
+        guard let scope = temporaryScope else { return .alreadyAbsent }
         if let expectedGenerationID,
            scope.credentialGenerationID != expectedGenerationID {
-            return nil
+            return .differentGeneration(
+                activeGenerationID: scope.credentialGenerationID
+            )
         }
         rejectedTemporaryCredentialGenerations.remove(scope.credentialGenerationID)
         temporaryScope = nil
-        return scope
+        return .ended(scope)
     }
 
     func getTemporaryScope() -> TemporaryAuthScope? { temporaryScope }

--- a/iosApp/iosApp/Pairing/PairingDeviceAPI.swift
+++ b/iosApp/iosApp/Pairing/PairingDeviceAPI.swift
@@ -169,6 +169,7 @@ struct PairingDeviceAPI: PairingDeviceAuthorizing {
         request.setValue(device.id, forHTTPHeaderField: "X-Silo-Device-Id")
         request.setValue(device.name, forHTTPHeaderField: "X-Silo-Device-Name")
         request.setValue(device.platform, forHTTPHeaderField: "X-Silo-Device-Platform")
+        request.setValue(device.clientFamily, forHTTPHeaderField: "X-Silo-Client-Family")
     }
 
     private func send<R: Decodable>(_ request: URLRequest) async throws -> R {

--- a/iosApp/iosApp/Pairing/Receiver/ReceiverPairingCoordinator.swift
+++ b/iosApp/iosApp/Pairing/Receiver/ReceiverPairingCoordinator.swift
@@ -52,7 +52,7 @@ final class ReceiverPairingCoordinator {
     private(set) var state: State = .idle
 
     private let api: any PairingDeviceAuthorizing
-    private let persist: @MainActor (_ url: String, _ fetchedName: String?, _ access: String, _ refresh: String) async -> Void
+    private let persist: @MainActor (_ url: String, _ fetchedName: String?, _ access: String, _ refresh: String) async -> Bool
     private var signedInNames: [String] = []
     private var consented = false
     private var pendingPush: (serverURL: String, serverName: String?)?
@@ -66,7 +66,7 @@ final class ReceiverPairingCoordinator {
 
     init(
         api: any PairingDeviceAuthorizing = PairingDeviceAPI(),
-        persist: @escaping @MainActor (String, String?, String, String) async -> Void = ReceiverPairingCoordinator.persistServer
+        persist: @escaping @MainActor (String, String?, String, String) async -> Bool = ReceiverPairingCoordinator.persistServer
     ) {
         self.api = api
         self.persist = persist
@@ -207,7 +207,7 @@ final class ReceiverPairingCoordinator {
     /// flight (a poll is bounded by the server's own device-code expiry).
     private func armIdleTimer(_ session: any PairingChannel) {
         idleTask?.cancel()
-        idleTask = Task { [weak self] in
+        idleTask = Task {
             try? await Task.sleep(for: Self.idleTimeout)
             guard !Task.isCancelled else { return }
             Self.logger.notice("pairing session idle timeout; dropping peer")
@@ -229,7 +229,7 @@ final class ReceiverPairingCoordinator {
         idleTask?.cancel()
         pollTask = Task { [weak self] in
             await self?.handlePushServer(serverURL: serverURL, serverName: serverName, session: session, automatic: automatic)
-            await self?.attemptEnded(session)
+            self?.attemptEnded(session)
         }
     }
 
@@ -259,7 +259,9 @@ final class ReceiverPairingCoordinator {
                     guard let access = poll.accessToken, let refresh = poll.refreshToken else {
                         throw PairingDeviceAPI.APIError.decode
                     }
-                    await persist(normalized, serverName, access, refresh)
+                    guard await persist(normalized, serverName, access, refresh) else {
+                        return
+                    }
                     signedInNames.append(displayName)
                     state = .signedIn(serverCount: signedInNames.count)
                     // Best-effort: the tokens are committed, so a lost
@@ -290,18 +292,39 @@ final class ReceiverPairingCoordinator {
     }
 
     /// Commit the now-trusted server + tokens. Runs only after a successful poll.
-    static func persistServer(url: String, fetchedName: String?, access: String, refresh: String) async {
+    static func persistServer(url: String, fetchedName: String?, access: String, refresh: String) async -> Bool {
         let id = ServerRegistry.serverId(for: url)
         let entry = ServerEntry(id: id, url: url, fetchedName: fetchedName, profileId: nil, lastUsedAt: Date())
         // Device authorization can replace the account for an already-saved
         // server URL. Preserve its name, but never carry the previous account's
         // profile selection across that credential boundary.
+        guard let transitionLease = await HTTPClient.shared.beginIdentityTransition() else {
+            return false
+        }
+        guard !Task.isCancelled else {
+            await HTTPClient.shared.endIdentityTransition(transitionLease)
+            return false
+        }
+        await HTTPClient.shared.cancelInFlightRequests()
+        guard !Task.isCancelled else {
+            await HTTPClient.shared.endIdentityTransition(transitionLease)
+            return false
+        }
+        // From this first persistent mutation onward the transaction must
+        // finish even if the pairing task is cancelled. Publishing failure
+        // after committed credentials would make the phone and TV disagree.
         ServerRegistry.shared.addOrUpdate(entry, preservingProfile: false)
         await TokenStore.shared.setServerUrl(url)
         await TokenStore.shared.switchActiveServer(serverId: id)
         await TokenStore.shared.setProfileId(nil)
         await TokenStore.shared.setProfileToken(nil)
         await TokenStore.shared.saveTokens(accessToken: access, refreshToken: refresh)
-        await ServerRegistry.shared.switchTo(serverId: id)
+        await ServerRegistry.shared.commitSwitchTo(
+            serverId: id,
+            holding: transitionLease
+        )
+        await HTTPClient.shared.endIdentityTransition(transitionLease)
+        await ServerRegistry.shared.refreshFeaturesAfterGatedServerSwitch()
+        return true
     }
 }

--- a/iosApp/iosApp/Screens/Auth/AuthService.swift
+++ b/iosApp/iosApp/Screens/Auth/AuthService.swift
@@ -12,6 +12,11 @@ final class AuthService: @unchecked Sendable {
     static let shared = AuthService()
     private let defaults = SharedDefaults.shared
 
+    enum SignOutAuthorization: Equatable, Sendable {
+        case allowed(account: RefreshAccountIdentity?)
+        case refused
+    }
+
     private init() {}
 
     // MARK: - Stored State Accessors
@@ -297,19 +302,17 @@ final class AuthService: @unchecked Sendable {
     /// display name) so the user can log back in without re-adding the
     /// server. Call `ServerRegistry.shared.remove(serverId:)` to fully
     /// forget a server instead.
-    func signOut() async {
+    @discardableResult
+    func signOut() async -> Bool {
         let signingOutServerId = ServerRegistry.shared.activeServerId
         let signingOutAuth = await TokenStore.shared.captureOrdinaryRequestAuth()
-        if let signingOutServerId {
-            guard let signingOutAuth,
-                  signingOutAuth.credentialOwner == .persistentServer(
-                      serverId: signingOutServerId
-                  ),
-                  signingOutAuth.account.serverId == signingOutServerId else {
-                return
-            }
+        let authorization = Self.signOutAuthorization(
+            activeServerId: signingOutServerId,
+            capturedAuth: signingOutAuth
+        )
+        guard case .allowed(let signingOutAccount) = authorization else {
+            return false
         }
-        let signingOutAccount = signingOutAuth?.account
         #if os(iOS) || os(tvOS)
         // Purge the active binding now, while still authenticated: the /logout
         // below invalidates the session, after which the binding could only be
@@ -344,18 +347,18 @@ final class AuthService: @unchecked Sendable {
         }
         #endif
         guard let transitionLease = await HTTPClient.shared.beginIdentityTransition() else {
-            return
+            return false
         }
         guard !Task.isCancelled else {
             await HTTPClient.shared.endIdentityTransition(transitionLease)
-            return
+            return false
         }
         await HTTPClient.shared.cancelInFlightRequests()
         guard !Task.isCancelled,
               ServerRegistry.shared.activeServerId == signingOutServerId,
               await TokenStore.shared.refreshAccountIdentity() == signingOutAccount else {
             await HTTPClient.shared.endIdentityTransition(transitionLease)
-            return
+            return false
         }
         if let signingOutServerId {
             await ServerRegistry.shared.signOut(
@@ -368,6 +371,32 @@ final class AuthService: @unchecked Sendable {
         }
         await clearAllCaches()
         await HTTPClient.shared.endIdentityTransition(transitionLease)
+        return true
+    }
+
+    /// Decide whether a captured credential can authorize local sign-out.
+    /// Missing capture data is allowed so a damaged URL/defaults mirror cannot
+    /// strand Keychain credentials. A temporary playback overlay is refused:
+    /// its owner must end that generation before persistent state is touched.
+    static func signOutAuthorization(
+        activeServerId: String?,
+        capturedAuth: CapturedOrdinaryRequestAuth?
+    ) -> SignOutAuthorization {
+        if capturedAuth?.credentialOwner == .temporary {
+            return .refused
+        }
+        guard let activeServerId, !activeServerId.isEmpty else {
+            return .allowed(account: capturedAuth?.account)
+        }
+        guard let capturedAuth else {
+            return .allowed(account: nil)
+        }
+        guard capturedAuth.credentialOwner == .persistentServer(
+            serverId: activeServerId
+        ), capturedAuth.account.serverId == activeServerId else {
+            return .refused
+        }
+        return .allowed(account: capturedAuth.account)
     }
 
     /// Wipe every cached response. Sign-out boundary: tokens are gone,

--- a/iosApp/iosApp/Screens/Auth/AuthService.swift
+++ b/iosApp/iosApp/Screens/Auth/AuthService.swift
@@ -76,39 +76,30 @@ final class AuthService: @unchecked Sendable {
     /// return the setup status so the caller can decide between initial
     /// setup and login.
     ///
-    /// The sequence matters: we set the URL first because `HTTPClient`
-    /// needs it to build requests, then upsert the registry entry with
-    /// the advertised server identity. If the health probe fails
-    /// (older server, 404) we still register the entry so the user can
-    /// proceed — the display name falls back to the URL.
+    /// Candidate probes use their explicit URL and no active credentials.
+    /// Global registry/default/token routing changes only after setup status
+    /// succeeds. If the optional health probe fails, the display name falls
+    /// back to the URL.
     func checkServer(url: String) async throws -> SetupStatus {
         let normalized = ServerRegistry.normalize(url: url)
         let id = ServerRegistry.serverId(for: normalized)
-        let previousActiveId = ServerRegistry.shared.activeServerId
 
-        // Point HTTPClient + TokenStore at this server before any probe.
-        await TokenStore.shared.setServerUrl(normalized)
-        await TokenStore.shared.switchActiveServer(serverId: id)
-
-        // Fetch identity. Tolerate failure: older servers omit these
-        // fields and we still want the URL to work.
+        // Probe the candidate by explicit URL without touching the active
+        // defaults or credential slot. This prevents candidate discovery from
+        // exposing a global A/B routing mixture to unrelated requests.
         var fetchedName: String?
-        if let health: HealthStatus = try? await HTTPClient.shared.get("/api/v1/health") {
+        if let health: HealthStatus = try? await HTTPClient.shared.getUnauthenticated(
+            serverURL: normalized,
+            path: "/api/v1/health"
+        ) {
             fetchedName = health.serverName
         }
 
-        // Probe /auth/setup BEFORE committing. If it fails we must
-        // restore the previous active server so the user isn't silently
-        // switched into a half-configured one.
-        let status: SetupStatus
-        do {
-            status = try await HTTPClient.shared.get("/api/v1/auth/setup")
-        } catch {
-            if let previousActiveId, previousActiveId != id {
-                await ServerRegistry.shared.switchTo(serverId: previousActiveId)
-            }
-            throw error
-        }
+        // Commit only after the candidate proves it can serve setup status.
+        let status: SetupStatus = try await HTTPClient.shared.getUnauthenticated(
+            serverURL: normalized,
+            path: "/api/v1/auth/setup"
+        )
 
         // Success: upsert the registry entry and make it active.
         let entry = ServerEntry(
@@ -129,22 +120,39 @@ final class AuthService: @unchecked Sendable {
     // MARK: - Authentication
 
     func login(username: String, password: String) async throws {
+        guard let expectedAccount = await TokenStore.shared.refreshAccountIdentity() else {
+            throw HTTPError.serverUrlNotConfigured
+        }
         let response: LoginResponse = try await HTTPClient.shared.post(
             "/api/v1/auth/login",
             body: LoginRequest(username: username, password: password)
         )
-        await startSession(accessToken: response.accessToken, refreshToken: response.refreshToken)
+        try await installSession(
+            accessToken: response.accessToken,
+            refreshToken: response.refreshToken,
+            expectedAccount: expectedAccount
+        )
     }
 
     func setupAdmin(username: String, email: String, password: String) async throws {
+        guard let expectedAccount = await TokenStore.shared.refreshAccountIdentity() else {
+            throw HTTPError.serverUrlNotConfigured
+        }
         let response: LoginResponse = try await HTTPClient.shared.post(
             "/api/v1/auth/setup",
             body: SetupRequest(username: username, email: email, password: password)
         )
-        await startSession(accessToken: response.accessToken, refreshToken: response.refreshToken)
+        try await installSession(
+            accessToken: response.accessToken,
+            refreshToken: response.refreshToken,
+            expectedAccount: expectedAccount
+        )
     }
 
     func signup(username: String, email: String, password: String, inviteCode: String) async throws {
+        guard let expectedAccount = await TokenStore.shared.refreshAccountIdentity() else {
+            throw HTTPError.serverUrlNotConfigured
+        }
         let response: LoginResponse = try await HTTPClient.shared.post(
             "/api/v1/auth/signup",
             body: SignupRequest(
@@ -154,19 +162,43 @@ final class AuthService: @unchecked Sendable {
                 inviteCode: inviteCode
             )
         )
-        await startSession(accessToken: response.accessToken, refreshToken: response.refreshToken)
+        try await installSession(
+            accessToken: response.accessToken,
+            refreshToken: response.refreshToken,
+            expectedAccount: expectedAccount
+        )
     }
 
     /// A login response establishes a brand-new session. Wipe every piece of
     /// prior auth state before persisting the new tokens — no need to carry
     /// `profileId` or `profileToken` across the boundary, and keeping them
     /// just strands stale values that the server rejects.
-    private func startSession(accessToken: String, refreshToken: String) async {
+    func installSession(
+        accessToken: String,
+        refreshToken: String,
+        expectedAccount: RefreshAccountIdentity
+    ) async throws {
+        guard let transitionLease = await HTTPClient.shared.beginIdentityTransition() else {
+            throw CancellationError()
+        }
+        guard !Task.isCancelled else {
+            await HTTPClient.shared.endIdentityTransition(transitionLease)
+            throw CancellationError()
+        }
+        await HTTPClient.shared.cancelInFlightRequests()
+        guard !Task.isCancelled,
+              await TokenStore.shared.refreshAccountIdentity() == expectedAccount else {
+            await HTTPClient.shared.endIdentityTransition(transitionLease)
+            if Task.isCancelled { throw CancellationError() }
+            throw HTTPError.requestIdentityChanged
+        }
         await TokenStore.shared.clearTokens()
         await TokenStore.shared.saveTokens(
             accessToken: accessToken,
             refreshToken: refreshToken
         )
+        await clearAllCaches()
+        await HTTPClient.shared.endIdentityTransition(transitionLease)
     }
 
     // MARK: - Profiles
@@ -266,6 +298,18 @@ final class AuthService: @unchecked Sendable {
     /// server. Call `ServerRegistry.shared.remove(serverId:)` to fully
     /// forget a server instead.
     func signOut() async {
+        let signingOutServerId = ServerRegistry.shared.activeServerId
+        let signingOutAuth = await TokenStore.shared.captureOrdinaryRequestAuth()
+        if let signingOutServerId {
+            guard let signingOutAuth,
+                  signingOutAuth.credentialOwner == .persistentServer(
+                      serverId: signingOutServerId
+                  ),
+                  signingOutAuth.account.serverId == signingOutServerId else {
+                return
+            }
+        }
+        let signingOutAccount = signingOutAuth?.account
         #if os(iOS) || os(tvOS)
         // Purge the active binding now, while still authenticated: the /logout
         // below invalidates the session, after which the binding could only be
@@ -279,22 +323,51 @@ final class AuthService: @unchecked Sendable {
         // Best-effort server-side logout; never block sign-out on a
         // server-side error, since the client wants to end the session
         // regardless.
-        do {
-            try await HTTPClient.shared.postVoid("/api/v1/auth/logout")
-        } catch {
-            // Swallow; state will still be cleared locally.
+        if let signingOutAccount {
+            do {
+                try await HTTPClient.shared.postVoid(
+                    "/api/v1/auth/logout",
+                    expectedAccount: signingOutAccount
+                )
+            } catch {
+                // Swallow; the captured account check below still prevents
+                // clearing a server selected while logout was in flight.
+            }
         }
-        if let activeId = ServerRegistry.shared.activeServerId {
-            // Only skip the redundant current-binding purge if it already
-            // succeeded above; the registry-wide purge runs either way.
+        #if os(iOS) || os(tvOS)
+        if !purgedCurrentBinding,
+           ServerRegistry.shared.activeServerId == signingOutServerId {
+            _ = await DiagnosticsCoordinator.shared.purgeDiagnosticsForCurrentBinding()
+        }
+        if let signingOutServerId {
+            await DiagnosticsCoordinator.shared.purgeDiagnosticsForServerRegistryID(signingOutServerId)
+        }
+        #endif
+        guard let transitionLease = await HTTPClient.shared.beginIdentityTransition() else {
+            return
+        }
+        guard !Task.isCancelled else {
+            await HTTPClient.shared.endIdentityTransition(transitionLease)
+            return
+        }
+        await HTTPClient.shared.cancelInFlightRequests()
+        guard !Task.isCancelled,
+              ServerRegistry.shared.activeServerId == signingOutServerId,
+              await TokenStore.shared.refreshAccountIdentity() == signingOutAccount else {
+            await HTTPClient.shared.endIdentityTransition(transitionLease)
+            return
+        }
+        if let signingOutServerId {
             await ServerRegistry.shared.signOut(
-                serverId: activeId,
-                purgeCurrentBinding: !purgedCurrentBinding
+                serverId: signingOutServerId,
+                purgeCurrentBinding: false,
+                purgeRegistryBindings: false
             )
         } else {
             await TokenStore.shared.clearTokens()
         }
         await clearAllCaches()
+        await HTTPClient.shared.endIdentityTransition(transitionLease)
     }
 
     /// Wipe every cached response. Sign-out boundary: tokens are gone,

--- a/iosApp/iosApp/Screens/Auth/QRLoginViewModel.swift
+++ b/iosApp/iosApp/Screens/Auth/QRLoginViewModel.swift
@@ -26,6 +26,7 @@ class QRLoginViewModel {
     private var countdownTask: Task<Void, Never>?
     private var deviceName: String = ""
     private var devicePlatform: String = ""
+    private var expectedAccount: RefreshAccountIdentity?
 
     private let auth = AuthService.shared
 
@@ -50,10 +51,17 @@ class QRLoginViewModel {
     private func startSession() async {
         state = .starting
         do {
+            guard let account = await TokenStore.shared.refreshAccountIdentity() else {
+                throw HTTPError.serverUrlNotConfigured
+            }
             let session = try await auth.startDeviceLogin(
                 deviceName: deviceName,
                 devicePlatform: devicePlatform
             )
+            guard await TokenStore.shared.refreshAccountIdentity() == account else {
+                throw HTTPError.requestIdentityChanged
+            }
+            expectedAccount = account
             state = .awaiting(session)
             startCountdown(expiresAt: session.expiresAt)
             startPolling(session: session)
@@ -100,13 +108,15 @@ class QRLoginViewModel {
                 return
             case .approved:
                 guard let accessToken = response.accessToken,
-                      let refreshToken = response.refreshToken else {
+                      let refreshToken = response.refreshToken,
+                      let expectedAccount else {
                     finalize(.error(message: "Server approved the session but did not return tokens."))
                     return
                 }
-                await TokenStore.shared.saveTokens(
+                try await auth.installSession(
                     accessToken: accessToken,
-                    refreshToken: refreshToken
+                    refreshToken: refreshToken,
+                    expectedAccount: expectedAccount
                 )
                 finalize(.approved)
             case .denied:
@@ -121,6 +131,8 @@ class QRLoginViewModel {
         } catch HTTPError.http(let code, _) where code == 404 {
             // Server cleaned up the pairing row before it was approved.
             finalize(.error(message: "This sign-in request has expired."))
+        } catch HTTPError.requestIdentityChanged {
+            finalize(.error(message: "The active server changed during sign-in. Please try again."))
         } catch {
             // Transient network error — keep trying until the countdown
             // times out the session server-side.

--- a/iosApp/iosApp/Screens/Browse/CatalogGrid.swift
+++ b/iosApp/iosApp/Screens/Browse/CatalogGrid.swift
@@ -10,17 +10,27 @@ struct CatalogGrid: View {
     let onItemTap: (String) -> Void
     let onLoadMore: () -> Void
     @Environment(AppRouter.self) private var router
+    @State private var uiCustomization = UICustomizationPreferences.shared
 
     #if os(tvOS)
-    private let columns = Array(
-        repeating: GridItem(.flexible(), spacing: 40, alignment: .top),
-        count: 6
-    )
+    private var columns: [GridItem] {
+        Array(
+            repeating: GridItem(.flexible(), spacing: 40, alignment: .top),
+            count: AdaptiveColumns.tvPosterCount(
+                standardCount: 6,
+                posterSize: uiCustomization.cardPresentation.posterSize
+            )
+        )
+    }
     private let rowSpacing: CGFloat = 60
     #else
     @Environment(\.horizontalSizeClass) private var hSize
     private var columns: [GridItem] {
-        AdaptiveColumns.posters(for: hSize, spacing: 8)
+        AdaptiveColumns.posters(
+            for: hSize,
+            posterSize: uiCustomization.cardPresentation.posterSize,
+            spacing: 8
+        )
     }
     private let rowSpacing: CGFloat = 12
     #endif

--- a/iosApp/iosApp/Screens/Browse/LibrariesTabView.swift
+++ b/iosApp/iosApp/Screens/Browse/LibrariesTabView.swift
@@ -74,6 +74,35 @@ private func libraryRootScopeID(
     return "\(authority?.serverId ?? "none"):\(authority?.profileId ?? "none"):\(destination)"
 }
 
+func librarySelectionStorageKey(
+    category: PrimaryMenuBuiltin?,
+    fixedLibraryId: Int?,
+    authority: MainTabLibraryAuthority?
+) -> String? {
+    guard fixedLibraryId == nil else { return nil }
+    guard category != nil else { return "librariesTabSelectedLibraryId" }
+    guard authority != nil else { return nil }
+    let scopeId = libraryRootScopeID(
+        category: category,
+        fixedLibraryId: nil,
+        authority: authority
+    )
+    return "librariesTabSelectedLibraryId.\(scopeId)"
+}
+
+func storedLibrarySelectionId(
+    for storageKey: String?,
+    defaults: UserDefaults = .standard
+) -> Int {
+    guard let storageKey else { return 0 }
+    if defaults.object(forKey: storageKey) != nil {
+        return defaults.integer(forKey: storageKey)
+    }
+    // Seed new category-scoped selections from the legacy aggregate choice.
+    // The first resolved selection is persisted under its own scoped key.
+    return defaults.integer(forKey: "librariesTabSelectedLibraryId")
+}
+
 /// Root of the Libraries tab.
 ///
 /// Mirrors the Plex/Android flow: the tab lands directly on the active
@@ -95,10 +124,11 @@ struct LibrariesTabView: View {
     @State private var currentProfile: UserProfile?
     @State private var navPrefs = AppNavPreferences.shared
 
-    /// Persist the last-selected library across launches so the user lands
-    /// back where they left off. Stored as Int because `@AppStorage` does
-    /// not support `Int?` directly; `0` represents "no stored value".
-    @AppStorage("librariesTabSelectedLibraryId") private var storedLibraryId: Int = 0
+    /// Persist the last-selected library per authored root so visiting Series
+    /// cannot replace the Movies or aggregate selection. Fixed-library roots
+    /// have no persistence key because their destination already fixes the ID.
+    private let selectionStorageKey: String?
+    @State private var storedLibraryId: Int
 
     @Environment(AppRouter.self) private var router
 
@@ -112,6 +142,13 @@ struct LibrariesTabView: View {
         self.fixedLibraryId = fixedLibraryId
         self.libraryAuthority = libraryAuthority
         self.onLibrariesLoaded = onLibrariesLoaded
+        let storageKey = librarySelectionStorageKey(
+            category: category,
+            fixedLibraryId: fixedLibraryId,
+            authority: libraryAuthority
+        )
+        selectionStorageKey = storageKey
+        _storedLibraryId = State(initialValue: storedLibrarySelectionId(for: storageKey))
     }
 
     var body: some View {
@@ -140,6 +177,7 @@ struct LibrariesTabView: View {
             authority: libraryAuthority
         )) {
             navPrefs.refresh()
+            storedLibraryId = storedLibrarySelectionId(for: selectionStorageKey)
             // SwiftUI can preserve this view while a split-view selection
             // changes from one direct library root to another. Reconcile the
             // selection before awaiting I/O so the old library never renders
@@ -157,7 +195,7 @@ struct LibrariesTabView: View {
                 selectedLibraryId: selectedLibraryId,
                 onSelect: { id in
                     selectedLibraryId = id
-                    storedLibraryId = id
+                    persistLibrarySelection(id)
                     showPicker = false
                     StartupContentPrefetcher.prefetchLibraryLanding(libraryId: id)
                 }
@@ -277,7 +315,13 @@ struct LibrariesTabView: View {
             storedLibraryId: storedLibraryId
         )
         selectedLibraryId = resolved
-        if fixedLibraryId == nil, let resolved { storedLibraryId = resolved }
+        if let resolved { persistLibrarySelection(resolved) }
+    }
+
+    private func persistLibrarySelection(_ libraryId: Int) {
+        guard let selectionStorageKey else { return }
+        storedLibraryId = libraryId
+        UserDefaults.standard.set(libraryId, forKey: selectionStorageKey)
     }
 
     /// Load the currently-selected profile so we can render its avatar in

--- a/iosApp/iosApp/Screens/Browse/LibrariesTabView.swift
+++ b/iosApp/iosApp/Screens/Browse/LibrariesTabView.swift
@@ -1,5 +1,79 @@
 import SwiftUI
 
+func libraryMatchesPrimaryMenuCategory(
+    _ library: Library,
+    category: PrimaryMenuBuiltin
+) -> Bool {
+    switch category {
+    case .movies:
+        return library.isMovieLibrary || library.isMixedLibrary
+    case .series:
+        return library.isSeriesLibrary || library.isMixedLibrary
+    case .audiobooks:
+        return library.isAudiobookLibrary
+    case .home, .music, .forYou, .calendar:
+        return false
+    }
+}
+
+func visibleLibrariesForRoot(
+    _ libraries: [Library],
+    category: PrimaryMenuBuiltin?,
+    fixedLibraryId: Int?,
+    showAudiobooks: Bool
+) -> [Library] {
+    if let fixedLibraryId {
+        return libraries.filter { $0.id == fixedLibraryId }
+    }
+    guard let category else {
+        return libraries.filter { showAudiobooks || !$0.isAudiobookLibrary }
+    }
+    return libraries.filter { libraryMatchesPrimaryMenuCategory($0, category: category) }
+}
+
+func libraryRootCanSwitch(fixedLibraryId: Int?, visibleLibraryCount: Int) -> Bool {
+    fixedLibraryId == nil && visibleLibraryCount > 1
+}
+
+func resolvedLibraryIdForRoot(
+    _ libraries: [Library],
+    category: PrimaryMenuBuiltin?,
+    fixedLibraryId: Int?,
+    showAudiobooks: Bool,
+    storedLibraryId: Int
+) -> Int? {
+    let visible = visibleLibrariesForRoot(
+        libraries,
+        category: category,
+        fixedLibraryId: fixedLibraryId,
+        showAudiobooks: showAudiobooks
+    )
+    if fixedLibraryId != nil {
+        return visible.first?.id
+    }
+    if storedLibraryId != 0,
+       let restored = visible.first(where: { $0.id == storedLibraryId }) {
+        return restored.id
+    }
+    return visible.first?.id
+}
+
+private func libraryRootScopeID(
+    category: PrimaryMenuBuiltin?,
+    fixedLibraryId: Int?,
+    authority: MainTabLibraryAuthority?
+) -> String {
+    let destination: String
+    if let fixedLibraryId {
+        destination = "library:\(fixedLibraryId)"
+    } else if let category {
+        destination = "category:\(category.rawValue)"
+    } else {
+        destination = "all"
+    }
+    return "\(authority?.serverId ?? "none"):\(authority?.profileId ?? "none"):\(destination)"
+}
+
 /// Root of the Libraries tab.
 ///
 /// Mirrors the Plex/Android flow: the tab lands directly on the active
@@ -7,6 +81,11 @@ import SwiftUI
 /// top bar — library selector on the left, search/saved/profile actions
 /// on the right.
 struct LibrariesTabView: View {
+    let category: PrimaryMenuBuiltin?
+    let fixedLibraryId: Int?
+    let libraryAuthority: MainTabLibraryAuthority?
+    let onLibrariesLoaded: ((MainTabLibraryAuthority?, [Library]) -> Void)?
+
     @State private var libraries: [Library] = []
     @State private var selectedLibraryId: Int?
     @State private var selectedTab: LibraryPageTab = .recommended
@@ -22,6 +101,18 @@ struct LibrariesTabView: View {
     @AppStorage("librariesTabSelectedLibraryId") private var storedLibraryId: Int = 0
 
     @Environment(AppRouter.self) private var router
+
+    init(
+        category: PrimaryMenuBuiltin? = nil,
+        fixedLibraryId: Int? = nil,
+        libraryAuthority: MainTabLibraryAuthority? = nil,
+        onLibrariesLoaded: ((MainTabLibraryAuthority?, [Library]) -> Void)? = nil
+    ) {
+        self.category = category
+        self.fixedLibraryId = fixedLibraryId
+        self.libraryAuthority = libraryAuthority
+        self.onLibrariesLoaded = onLibrariesLoaded
+    }
 
     var body: some View {
         Group {
@@ -43,8 +134,17 @@ struct LibrariesTabView: View {
         #if !os(macOS)
         .toolbar(.hidden, for: .navigationBar)
         #endif
-        .task {
+        .task(id: libraryRootScopeID(
+            category: category,
+            fixedLibraryId: fixedLibraryId,
+            authority: libraryAuthority
+        )) {
             navPrefs.refresh()
+            // SwiftUI can preserve this view while a split-view selection
+            // changes from one direct library root to another. Reconcile the
+            // selection before awaiting I/O so the old library never renders
+            // under the new destination.
+            applyLibrarySelection()
             await loadLibraries()
             await loadCurrentProfile()
         }
@@ -96,9 +196,14 @@ struct LibrariesTabView: View {
         VStack(spacing: 0) {
             LibrariesTopBar(
                 activeLibrary: activeLibrary,
-                canSwitch: visibleLibraries.count > 1,
+                canSwitch: libraryRootCanSwitch(
+                    fixedLibraryId: fixedLibraryId,
+                    visibleLibraryCount: visibleLibraries.count
+                ),
                 profile: currentProfile,
-                onLibraryTap: { showPicker = true },
+                onLibraryTap: {
+                    if fixedLibraryId == nil { showPicker = true }
+                },
                 onSearch: { router.navigate(to: .search) },
                 onOpenSettings: { router.navigate(to: .settings) },
                 onOpenRequests: { router.navigate(to: .requestsHub) },
@@ -123,7 +228,12 @@ struct LibrariesTabView: View {
     }
 
     private var visibleLibraries: [Library] {
-        libraries.filter { navPrefs.showAudiobooks || !$0.isAudiobookLibrary }
+        visibleLibrariesForRoot(
+            libraries,
+            category: category,
+            fixedLibraryId: fixedLibraryId,
+            showAudiobooks: navPrefs.showAudiobooks
+        )
     }
 
     private func loadLibraries() async {
@@ -133,6 +243,7 @@ struct LibrariesTabView: View {
            let cached: LibrariesResponse = ResponseCache.shared.get(CacheKey.userLibraries) {
             libraries = cached.libraries
             applyLibrarySelection()
+            onLibrariesLoaded?(libraryAuthority, cached.libraries)
         }
         if libraries.isEmpty {
             isLoading = true
@@ -140,8 +251,10 @@ struct LibrariesTabView: View {
         error = nil
         do {
             let response = try await StartupContentPrefetcher.fetchUserLibraries()
+            guard !Task.isCancelled else { return }
             libraries = response.libraries
             applyLibrarySelection()
+            onLibrariesLoaded?(libraryAuthority, response.libraries)
             if let selectedLibraryId {
                 StartupContentPrefetcher.prefetchLibraryLanding(libraryId: selectedLibraryId)
             }
@@ -156,13 +269,15 @@ struct LibrariesTabView: View {
     /// Preserve the stored selection if it still exists; otherwise fall
     /// back to the first available library.
     private func applyLibrarySelection() {
-        let selectableLibraries = visibleLibraries
-        let restored = storedLibraryId != 0
-            ? selectableLibraries.first(where: { $0.id == storedLibraryId })?.id
-            : nil
-        let resolved = restored ?? selectableLibraries.first?.id
+        let resolved = resolvedLibraryIdForRoot(
+            libraries,
+            category: category,
+            fixedLibraryId: fixedLibraryId,
+            showAudiobooks: navPrefs.showAudiobooks,
+            storedLibraryId: storedLibraryId
+        )
         selectedLibraryId = resolved
-        if let resolved { storedLibraryId = resolved }
+        if fixedLibraryId == nil, let resolved { storedLibraryId = resolved }
     }
 
     /// Load the currently-selected profile so we can render its avatar in
@@ -232,7 +347,7 @@ private struct LibrarySelectorButton: View {
                 HStack(spacing: 6) {
                     Text(library.name)
                         .font(.continuumTitle)
-                        .foregroundColor(.continuumOnSurface)
+                    .foregroundStyle(Color.continuumOnSurface)
                         .lineLimit(1)
                     if canSwitch {
                         Image(systemName: "chevron.down")
@@ -242,7 +357,7 @@ private struct LibrarySelectorButton: View {
                 }
                 Text(typeLabel)
                     .font(.continuumCaption)
-                    .foregroundColor(.continuumSecondaryText)
+                    .foregroundStyle(Color.continuumSecondaryText)
                     .lineLimit(1)
             }
         }

--- a/iosApp/iosApp/Screens/Calendar/CalendarEventCard.swift
+++ b/iosApp/iosApp/Screens/Calendar/CalendarEventCard.swift
@@ -1,5 +1,27 @@
 import SwiftUI
 
+func calendarEventAccessibilityLabel(_ event: CalendarEvent) -> String {
+    var components = [event.title]
+    components.append(contentsOf: [
+        event.episodeSubtitle,
+        event.episodeTitle,
+    ].compactMap { value in
+        guard let value, !value.isEmpty else { return nil }
+        return value
+    })
+    if event.type == "movie" {
+        components.append("Movie")
+    }
+    if let displayAirTime = event.displayAirTime {
+        components.append(displayAirTime)
+    }
+    components.append(contentsOf: event.displayBadges.map(\.label))
+    if event.isWatched {
+        components.append("Watched")
+    }
+    return components.joined(separator: ", ")
+}
+
 /// Poster card for a single calendar event: badge pills, watched check,
 /// air-time caption, and an episode subtitle line. Purpose-built rather
 /// than wrapping `MediaCard` so badge overlays live inside the tvOS
@@ -10,15 +32,21 @@ struct CalendarEventCard: View {
     /// tvOS-only: parent shelf's focus tracking, so the shelf can route
     /// default focus to a specific card.
     var focusedItemId: FocusState<String?>.Binding? = nil
+    @State private var uiCustomization = UICustomizationPreferences.shared
 
-    private var cardWidth: CGFloat { ContinuumTheme.posterCardWidth }
-    private var cardHeight: CGFloat { ContinuumTheme.posterCardHeight }
+    private var cardWidth: CGFloat {
+        ContinuumTheme.posterCardWidth * uiCustomization.cardPresentation.posterSize.scale
+    }
+    private var cardHeight: CGFloat {
+        cardWidth * (ContinuumTheme.posterCardHeight / ContinuumTheme.posterCardWidth)
+    }
 
     var body: some View {
         #if os(tvOS)
         FocusableCalendarCard(
             event: event,
             cardWidth: cardWidth,
+            captionStyle: uiCustomization.cardPresentation.caption,
             action: action,
             focusedItemId: focusedItemId
         ) {
@@ -28,11 +56,15 @@ struct CalendarEventCard: View {
         Button(action: action) {
             VStack(alignment: .leading, spacing: 4) {
                 posterImage
-                captionText
+                if uiCustomization.cardPresentation.caption.showsTitle {
+                    captionText
+                }
             }
         }
         .buttonStyle(.plain)
         .frame(width: cardWidth)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityDescription)
         #endif
     }
 
@@ -93,7 +125,15 @@ struct CalendarEventCard: View {
 
     @ViewBuilder
     fileprivate var captionText: some View {
-        CalendarCardCaption(event: event, cardWidth: cardWidth)
+        CalendarCardCaption(
+            event: event,
+            cardWidth: cardWidth,
+            showsMetadata: uiCustomization.cardPresentation.caption.showsMetadata
+        )
+    }
+
+    private var accessibilityDescription: String {
+        calendarEventAccessibilityLabel(event)
     }
 
     // MARK: - Metrics
@@ -205,6 +245,7 @@ private struct CalendarBadgePill: View {
 private struct CalendarCardCaption: View {
     let event: CalendarEvent
     let cardWidth: CGFloat
+    var showsMetadata: Bool = true
     var isFocused: Bool = false
 
     var body: some View {
@@ -214,7 +255,7 @@ private struct CalendarCardCaption: View {
                 .foregroundColor(isFocused ? .continuumOnSurface : .continuumOnSurface.opacity(0.85))
                 .lineLimit(2, reservesSpace: true)
 
-            if let subtitle {
+            if showsMetadata, let subtitle {
                 Text(subtitle)
                     .font(.continuumCaption)
                     .foregroundColor(.continuumSecondaryText)
@@ -250,6 +291,7 @@ private struct CalendarCardCaption: View {
 private struct FocusableCalendarCard<Content: View>: View {
     let event: CalendarEvent
     let cardWidth: CGFloat
+    let captionStyle: CardCaptionStyle
     let action: () -> Void
     let focusedItemId: FocusState<String?>.Binding?
     @ViewBuilder var content: () -> Content
@@ -264,11 +306,24 @@ private struct FocusableCalendarCard<Content: View>: View {
             .buttonStyle(.card)
             .focused($isFocused)
             .applyShelfFocus(focusedItemId, itemId: event.contentId)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(accessibilityDescription)
 
-            CalendarCardCaption(event: event, cardWidth: cardWidth, isFocused: isFocused)
+            if captionStyle.showsTitle {
+                CalendarCardCaption(
+                    event: event,
+                    cardWidth: cardWidth,
+                    showsMetadata: captionStyle.showsMetadata,
+                    isFocused: isFocused
+                )
                 .animation(.easeOut(duration: 0.15), value: isFocused)
+            }
         }
         .frame(width: cardWidth)
+    }
+
+    private var accessibilityDescription: String {
+        calendarEventAccessibilityLabel(event)
     }
 }
 

--- a/iosApp/iosApp/Screens/Collections/CollectionDetailView.swift
+++ b/iosApp/iosApp/Screens/Collections/CollectionDetailView.swift
@@ -7,11 +7,15 @@ struct CollectionDetailView: View {
     @State private var items: [BrowseItem] = []
     @State private var isLoading = false
     @State private var error: ErrorState?
+    @State private var uiCustomization = UICustomizationPreferences.shared
     @Environment(AppRouter.self) private var router
     @Environment(\.horizontalSizeClass) private var hSize
 
     private var columns: [GridItem] {
-        AdaptiveColumns.posters(for: hSize)
+        AdaptiveColumns.posters(
+            for: hSize,
+            posterSize: uiCustomization.cardPresentation.posterSize
+        )
     }
 
     var body: some View {

--- a/iosApp/iosApp/Screens/Collections/CollectionsView.swift
+++ b/iosApp/iosApp/Screens/Collections/CollectionsView.swift
@@ -1,5 +1,17 @@
 import SwiftUI
 
+func libraryCollectionAccessibilityLabel(_ collection: LibraryCollection) -> String {
+    let type = collection.kind == .userCollections
+        ? "User collection"
+        : collection.collectionType?.capitalized ?? "Collection"
+    let count = if let itemCount = collection.itemCount {
+        "\(itemCount) item\(itemCount == 1 ? "" : "s")"
+    } else {
+        "Smart"
+    }
+    return [collection.name, type, count].joined(separator: ", ")
+}
+
 /// List of user-created collections, grouped into named buckets +
 /// "Ungrouped". Mirrors the web app's `Collections` page.
 struct CollectionsView: View {
@@ -264,10 +276,10 @@ private struct GroupActionSheet: View {
             VStack(spacing: ContinuumTheme.padding) {
                 Text("Delete “\(group.name)”?")
                     .font(.continuumTitle)
-                    .foregroundColor(.continuumOnSurface)
+                    .foregroundStyle(Color.continuumOnSurface)
                 Text("Collections in this group will move to Ungrouped. This cannot be undone.")
                     .font(.continuumBody)
-                    .foregroundColor(.continuumSecondaryText)
+                    .foregroundStyle(Color.continuumSecondaryText)
                     .multilineTextAlignment(.center)
                 errorBanner
                 Spacer()
@@ -425,10 +437,14 @@ struct LibraryCollectionsView: View {
     let libraryId: Int
 
     @State private var viewModel = LibraryCollectionsViewModel()
+    @State private var uiCustomization = UICustomizationPreferences.shared
     @Environment(\.horizontalSizeClass) private var hSize
 
     private var columns: [GridItem] {
-        AdaptiveColumns.posters(for: hSize)
+        AdaptiveColumns.posters(
+            for: hSize,
+            posterSize: uiCustomization.cardPresentation.posterSize
+        )
     }
 
     var body: some View {
@@ -486,6 +502,8 @@ struct LibraryCollectionsView: View {
                     }
                     .buttonStyle(.plain)
                     .frame(maxWidth: .infinity)
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel(libraryCollectionAccessibilityLabel(collection))
                 }
             }
         }
@@ -494,9 +512,14 @@ struct LibraryCollectionsView: View {
 
 private struct LibraryCollectionCard: View {
     let collection: LibraryCollection
+    @State private var uiCustomization = UICustomizationPreferences.shared
 
-    private var cardWidth: CGFloat { ContinuumTheme.posterCardWidth }
-    private var cardHeight: CGFloat { ContinuumTheme.posterCardHeight }
+    private var cardWidth: CGFloat {
+        ContinuumTheme.posterCardWidth * uiCustomization.cardPresentation.posterSize.scale
+    }
+    private var cardHeight: CGFloat {
+        cardWidth * (ContinuumTheme.posterCardHeight / ContinuumTheme.posterCardWidth)
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -515,15 +538,19 @@ private struct LibraryCollectionCard: View {
             .frame(width: cardWidth, height: cardHeight)
             .clipShape(RoundedRectangle(cornerRadius: ContinuumTheme.smallCornerRadius))
 
-            Text(collection.name)
-                .font(.continuumCaption)
-                .foregroundColor(.continuumOnSurface)
-                .lineLimit(2, reservesSpace: true)
+            if uiCustomization.cardPresentation.caption.showsTitle {
+                Text(collection.name)
+                    .font(.continuumCaption)
+                    .foregroundStyle(Color.continuumOnSurface)
+                    .lineLimit(2, reservesSpace: true)
+            }
 
-            Text(typeLabel)
-                .font(.continuumSmall)
-                .foregroundColor(.continuumSecondaryText)
-                .lineLimit(1)
+            if uiCustomization.cardPresentation.caption.showsMetadata {
+                Text(typeLabel)
+                    .font(.continuumSmall)
+                    .foregroundStyle(Color.continuumSecondaryText)
+                    .lineLimit(1)
+            }
         }
         .frame(width: cardWidth, alignment: .leading)
     }
@@ -551,7 +578,7 @@ private struct LibraryCollectionCard: View {
     }
 
     private var countLabel: String {
-        if let itemCount = collection.itemCount, itemCount > 0 {
+        if let itemCount = collection.itemCount {
             return "\(itemCount)"
         }
         return "Smart"

--- a/iosApp/iosApp/Screens/Detail/AudiobookDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/AudiobookDetailContent.swift
@@ -1,10 +1,22 @@
 import SwiftUI
 
+func audiobookRelatedItemAccessibilityLabel(_ item: AudiobookRelatedItem) -> String {
+    var components = [item.title]
+    if let seriesIndex = item.seriesIndex {
+        components.append("Book \(seriesIndex)")
+    }
+    if let year = item.year {
+        components.append(String(year))
+    }
+    return components.joined(separator: ", ")
+}
+
 struct AudiobookDetailContent: View {
     let detail: ItemDetail
     let onNavigateToItem: (String) -> Void
 
     @Environment(AudioPlaybackStore.self) private var audioStore
+    @State private var uiCustomization = UICustomizationPreferences.shared
 
     #if !os(tvOS)
     @State private var showAllChapters = false
@@ -530,24 +542,30 @@ struct AudiobookDetailContent: View {
                     } label: {
                         VStack(alignment: .leading, spacing: 8) {
                             relatedPoster(item)
-                            Text(item.title)
-                                .font(.subheadline)
-                                .fontWeight(.semibold)
-                                .foregroundColor(.continuumOnSurface)
-                                .lineLimit(2, reservesSpace: true)
-                            if let seriesIndex = item.seriesIndex {
-                                Text("Book \(seriesIndex)")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            } else if let year = item.year {
-                                Text(String(year))
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
+                            if uiCustomization.cardPresentation.caption.showsTitle {
+                                Text(item.title)
+                                    .font(.subheadline)
+                                    .fontWeight(.semibold)
+                                    .foregroundStyle(Color.continuumOnSurface)
+                                    .lineLimit(2, reservesSpace: true)
+                                if uiCustomization.cardPresentation.caption.showsMetadata {
+                                    if let seriesIndex = item.seriesIndex {
+                                        Text("Book \(seriesIndex)")
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                    } else if let year = item.year {
+                                        Text(String(year))
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                }
                             }
                         }
                         .frame(width: relatedPosterWidth, alignment: .leading)
                     }
                     .buttonStyle(.plain)
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel(audiobookRelatedItemAccessibilityLabel(item))
                 }
             }
             .padding(.vertical, 4)
@@ -801,7 +819,9 @@ struct AudiobookDetailContent: View {
 
     private var aboutFont: Font { .system(size: 15) }
 
-    private var relatedPosterWidth: CGFloat { 110 }
+    private var relatedPosterWidth: CGFloat {
+        110 * uiCustomization.cardPresentation.posterSize.scale
+    }
 
     private var relatedPosterHeight: CGFloat {
         // Audiobook covers are square — don't stretch them into the
@@ -876,4 +896,3 @@ private struct AudiobookResumePill: View {
     }
 }
 #endif
-

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeRail.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeRail.swift
@@ -10,8 +10,12 @@ struct PhoneEpisodeRail: View {
     let onSelect: (String) -> Void
     var currentContentId: String? = nil
 
-    private let cardWidth: CGFloat = 240
-    private let stillHeight: CGFloat = 135   // 16:9 of 240
+    @State private var uiCustomization = UICustomizationPreferences.shared
+
+    private var cardWidth: CGFloat {
+        240 * uiCustomization.cardPresentation.posterSize.scale
+    }
+    private var stillHeight: CGFloat { cardWidth * 9 / 16 }
     private let cardSpacing: CGFloat = 14
     private let stillCornerRadius: CGFloat = 8
 
@@ -26,6 +30,7 @@ struct PhoneEpisodeRail: View {
                             cardWidth: cardWidth,
                             stillHeight: stillHeight,
                             stillCornerRadius: stillCornerRadius,
+                            captionStyle: uiCustomization.cardPresentation.caption,
                             onSelect: { onSelect(episode.contentId) }
                         )
                         .id(episode.contentId)
@@ -52,6 +57,7 @@ private struct PhoneEpisodeCard: View {
     let cardWidth: CGFloat
     let stillHeight: CGFloat
     let stillCornerRadius: CGFloat
+    let captionStyle: CardCaptionStyle
     let onSelect: () -> Void
 
     var body: some View {
@@ -62,39 +68,43 @@ private struct PhoneEpisodeCard: View {
         Button(action: onSelect) {
             VStack(alignment: .leading, spacing: 8) {
                 still
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack(spacing: 6) {
-                        Text(episodeNumberLabel)
-                            .font(.system(size: 10, weight: .bold))
-                            .tracking(1.0)
-                            .foregroundColor(.continuumOnSurface.opacity(0.55))
-                        if isCurrent {
-                            nowViewingTag
+                if captionStyle.showsTitle {
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack(spacing: 6) {
+                            Text(episodeNumberLabel)
+                                .font(.system(size: 10, weight: .bold))
+                                .tracking(1.0)
+                                .foregroundStyle(Color.continuumOnSurface.opacity(0.55))
+                            if isCurrent {
+                                nowViewingTag
+                            }
                         }
-                    }
 
-                    Text(episode.title ?? "Episode \(episode.episodeNumber)")
-                        .font(.system(size: 14, weight: .semibold))
-                        .foregroundColor(titleColor)
-                        .lineLimit(1)
-                        .multilineTextAlignment(.leading)
-
-                    if let metadataLine = episodeMetadataLine {
-                        Text(metadataLine)
-                            .font(.system(size: 12, weight: .medium))
-                            .foregroundColor(.continuumSecondaryText)
+                        Text(episode.title ?? "Episode \(episode.episodeNumber)")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundStyle(titleColor)
                             .lineLimit(1)
-                            .minimumScaleFactor(0.85)
                             .multilineTextAlignment(.leading)
-                    }
 
-                    if let overview = episode.overview, !overview.isEmpty {
-                        Text(overview)
-                            .font(.system(size: 12, weight: .regular))
-                            .foregroundColor(.continuumSecondaryText)
-                            .lineLimit(3, reservesSpace: true)
-                            .lineSpacing(2)
-                            .multilineTextAlignment(.leading)
+                        if captionStyle.showsMetadata {
+                            if let metadataLine = episodeMetadataLine {
+                                Text(metadataLine)
+                                    .font(.system(size: 12, weight: .medium))
+                                    .foregroundStyle(Color.continuumSecondaryText)
+                                    .lineLimit(1)
+                                    .minimumScaleFactor(0.85)
+                                    .multilineTextAlignment(.leading)
+                            }
+
+                            if let overview = episode.overview, !overview.isEmpty {
+                                Text(overview)
+                                    .font(.system(size: 12, weight: .regular))
+                                    .foregroundStyle(Color.continuumSecondaryText)
+                                    .lineLimit(3, reservesSpace: true)
+                                    .lineSpacing(2)
+                                    .multilineTextAlignment(.leading)
+                            }
+                        }
                     }
                 }
             }
@@ -102,6 +112,8 @@ private struct PhoneEpisodeCard: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityDescription)
     }
 
     private var titleColor: Color {
@@ -131,6 +143,17 @@ private struct PhoneEpisodeCard: View {
             parts.append(formatRuntime(runtime))
         }
         return parts.isEmpty ? nil : parts.joined(separator: "  ·  ")
+    }
+
+    private var accessibilityDescription: String {
+        episodeRailAccessibilityLabel(
+            seasonNumber: episode.seasonNumber,
+            episodeNumber: episode.episodeNumber,
+            title: episode.title,
+            metadata: episodeMetadataLine,
+            isCurrent: isCurrent,
+            isPlayed: episode.userData?.played == true
+        )
     }
 
     private var still: some View {

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneSimilarRail.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneSimilarRail.swift
@@ -21,6 +21,7 @@ struct PhoneSimilarRail: View {
     @State private var items: [SimilarPosterItem] = []
     @State private var isLoading = true
     @State private var loadedFor: String? = nil
+    @State private var uiCustomization = UICustomizationPreferences.shared
 
     var body: some View {
         Group {
@@ -55,6 +56,8 @@ struct PhoneSimilarRail: View {
                         PhoneSimilarCard(item: item)
                     }
                     .buttonStyle(.plain)
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel(item.accessibilityDescription)
                 }
             }
             .padding(.horizontal, ContinuumTheme.safePadding)
@@ -70,7 +73,12 @@ struct PhoneSimilarRail: View {
                 ForEach(0..<4, id: \.self) { _ in
                     RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius)
                         .fill(Color.continuumSurfaceElevated)
-                        .frame(width: ContinuumTheme.posterCardWidth, height: ContinuumTheme.posterCardHeight)
+                        .frame(
+                            width: ContinuumTheme.posterCardWidth
+                                * uiCustomization.cardPresentation.posterSize.scale,
+                            height: ContinuumTheme.posterCardHeight
+                                * uiCustomization.cardPresentation.posterSize.scale
+                        )
                 }
             }
             .padding(.horizontal, ContinuumTheme.safePadding)
@@ -132,6 +140,10 @@ struct SimilarPosterItem: Identifiable, Hashable {
     let year: Int?
     var id: String { contentId }
 
+    var accessibilityDescription: String {
+        [title, year.map(String.init)].compactMap { $0 }.joined(separator: ", ")
+    }
+
     init(detail: ItemDetail) {
         self.contentId = detail.contentId
         self.title = detail.title
@@ -145,19 +157,26 @@ struct SimilarPosterItem: Identifiable, Hashable {
 
 private struct PhoneSimilarCard: View {
     let item: SimilarPosterItem
+    @State private var uiCustomization = UICustomizationPreferences.shared
 
-    private var cardWidth: CGFloat { ContinuumTheme.posterCardWidth }
-    private var cardHeight: CGFloat { ContinuumTheme.posterCardHeight }
+    private var cardWidth: CGFloat {
+        ContinuumTheme.posterCardWidth * uiCustomization.cardPresentation.posterSize.scale
+    }
+    private var cardHeight: CGFloat {
+        cardWidth * (ContinuumTheme.posterCardHeight / ContinuumTheme.posterCardWidth)
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             poster
-            Text(item.title)
-                .font(.continuumSubheadline)
-                .foregroundColor(.continuumOnSurface)
-                .lineLimit(2, reservesSpace: true)
-                .multilineTextAlignment(.leading)
-            if let year = item.year {
+            if uiCustomization.cardPresentation.caption.showsTitle {
+                Text(item.title)
+                    .font(.continuumSubheadline)
+                    .foregroundStyle(Color.continuumOnSurface)
+                    .lineLimit(2, reservesSpace: true)
+                    .multilineTextAlignment(.leading)
+            }
+            if uiCustomization.cardPresentation.caption.showsMetadata, let year = item.year {
                 Text(String(year))
                     .font(.continuumCaption)
                     .foregroundColor(.continuumSecondaryText)

--- a/iosApp/iosApp/Screens/Home/Feed/HomeFeedKit.swift
+++ b/iosApp/iosApp/Screens/Home/Feed/HomeFeedKit.swift
@@ -130,6 +130,7 @@ enum HomeFeedMeta {
 /// including the iOS 26 zoom transition the shipping `MediaCard` uses.
 private struct HomeCardTap<Label: View>: View {
     let contentId: String
+    let accessibilityLabel: String
     @ViewBuilder var label: () -> Label
 
     @Environment(AppRouter.self) private var router
@@ -145,6 +146,8 @@ private struct HomeCardTap<Label: View>: View {
                 .zoomTransitionSource(id: zoomInstanceID.uuidString, in: zoomNamespace)
         }
         .buttonStyle(.plain)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
     }
 }
 
@@ -279,6 +282,7 @@ struct HomePosterCard: View {
     let item: SectionItem
     var width: CGFloat = HomeFeedMetrics.posterWidth
     var showsCaption: Bool = true
+    var showsMetadata: Bool = true
     /// Draws the resume rail across the bottom of the artwork.
     var showsProgress: Bool = false
     /// Audiobook covers are square; stretching one into a 2:3 poster crops
@@ -307,7 +311,10 @@ struct HomePosterCard: View {
     }
 
     var body: some View {
-        HomeCardTap(contentId: item.contentId) {
+        HomeCardTap(
+            contentId: item.contentId,
+            accessibilityLabel: accessibilityDescription
+        ) {
             VStack(alignment: .leading, spacing: 7) {
                 artwork
                 if showsCaption { caption }
@@ -399,7 +406,7 @@ struct HomePosterCard: View {
                 .lineLimit(1)
                 .truncationMode(.tail)
 
-            if let year = item.year {
+            if showsMetadata, let year = item.year {
                 Text(String(year))
                     .font(.system(size: 11, weight: .regular))
                     .foregroundStyle(Color.continuumOnSurface.opacity(0.5))
@@ -407,6 +414,15 @@ struct HomePosterCard: View {
             }
         }
         .frame(width: width, alignment: .leading)
+    }
+
+    private var accessibilityDescription: String {
+        var components = [HomeFeedMeta.cardTitle(for: item)]
+        components.append(contentsOf: [episodeBadge, item.year.map(String.init)].compactMap { $0 })
+        if isPlayed {
+            components.append("Watched")
+        }
+        return components.joined(separator: ", ")
     }
 }
 
@@ -418,6 +434,8 @@ struct HomePosterCard: View {
 struct HomeStillCard: View {
     let item: SectionItem
     var width: CGFloat = HomeFeedMetrics.stillWidth
+    var showsCaption: Bool = true
+    var showsMetadata: Bool = true
     var onRemoveFromContinueWatching: (() -> Void)? = nil
     var onSetWatched: ((Bool) async -> Bool)? = nil
 
@@ -441,10 +459,13 @@ struct HomeStillCard: View {
     }
 
     var body: some View {
-        HomeCardTap(contentId: item.contentId) {
+        HomeCardTap(
+            contentId: item.contentId,
+            accessibilityLabel: accessibilityDescription
+        ) {
             VStack(alignment: .leading, spacing: 8) {
                 artwork
-                caption
+                if showsCaption { caption }
             }
             .frame(width: width, alignment: .leading)
         }
@@ -538,7 +559,7 @@ struct HomeStillCard: View {
                 .foregroundStyle(Color.continuumOnSurface)
                 .lineLimit(1)
 
-            if let subtitle = HomeFeedMeta.resumeCaption(for: item) {
+            if showsMetadata, let subtitle = HomeFeedMeta.resumeCaption(for: item) {
                 Text(subtitle)
                     .font(.system(size: 11, weight: .regular))
                     .foregroundStyle(Color.continuumOnSurface.opacity(0.55))
@@ -546,6 +567,17 @@ struct HomeStillCard: View {
             }
         }
         .frame(width: width, alignment: .leading)
+    }
+
+    private var accessibilityDescription: String {
+        var components = [HomeFeedMeta.cardTitle(for: item)]
+        if let resumeCaption = HomeFeedMeta.resumeCaption(for: item) {
+            components.append(resumeCaption)
+        }
+        if isPlayed {
+            components.append("Watched")
+        }
+        return components.joined(separator: ", ")
     }
 }
 

--- a/iosApp/iosApp/Screens/Home/Feed/HomeFeedRow.swift
+++ b/iosApp/iosApp/Screens/Home/Feed/HomeFeedRow.swift
@@ -13,6 +13,7 @@ struct HomeFeedRow: View {
     /// Long-press actions, forwarded to every card in the row.
     var onRemoveFromContinueWatching: ((SectionItem) -> Void)? = nil
     var onSetWatched: ((SectionItem, Bool) async -> Bool)? = nil
+    @State private var uiCustomization = UICustomizationPreferences.shared
 
     private var isResume: Bool { HomeFeed.isResume(section) }
 
@@ -50,13 +51,19 @@ struct HomeFeedRow: View {
                         if usesStills {
                             HomeStillCard(
                                 item: item,
+                                width: HomeFeedMetrics.stillWidth
+                                    * uiCustomization.cardPresentation.posterSize.scale,
+                                showsCaption: uiCustomization.cardPresentation.caption.showsTitle,
+                                showsMetadata: uiCustomization.cardPresentation.caption.showsMetadata,
                                 onRemoveFromContinueWatching: removalAction(for: item),
                                 onSetWatched: watchedAction(for: item)
                             )
                         } else {
                             HomePosterCard(
                                 item: item,
-                                width: posterWidth,
+                                width: posterWidth * uiCustomization.cardPresentation.posterSize.scale,
+                                showsCaption: uiCustomization.cardPresentation.caption.showsTitle,
+                                showsMetadata: uiCustomization.cardPresentation.caption.showsMetadata,
                                 showsProgress: isResume,
                                 aspect: isAudiobookRow ? .square : .poster,
                                 episodeBadge: episodeBadge(for: item),

--- a/iosApp/iosApp/Screens/Personal/FavoritesView.swift
+++ b/iosApp/iosApp/Screens/Personal/FavoritesView.swift
@@ -7,11 +7,15 @@ struct FavoritesView: View {
     @State private var items: [BrowseItem] = []
     @State private var isLoading = false
     @State private var error: ErrorState?
+    @State private var uiCustomization = UICustomizationPreferences.shared
     @Environment(AppRouter.self) private var router
     @Environment(\.horizontalSizeClass) private var hSize
 
     private var columns: [GridItem] {
-        AdaptiveColumns.posters(for: hSize)
+        AdaptiveColumns.posters(
+            for: hSize,
+            posterSize: uiCustomization.cardPresentation.posterSize
+        )
     }
 
     init(showsNavigationTitle: Bool = true) {

--- a/iosApp/iosApp/Screens/Personal/WatchlistView.swift
+++ b/iosApp/iosApp/Screens/Personal/WatchlistView.swift
@@ -7,11 +7,15 @@ struct WatchlistView: View {
     @State private var items: [BrowseItem] = []
     @State private var isLoading = false
     @State private var error: ErrorState?
+    @State private var uiCustomization = UICustomizationPreferences.shared
     @Environment(AppRouter.self) private var router
     @Environment(\.horizontalSizeClass) private var hSize
 
     private var columns: [GridItem] {
-        AdaptiveColumns.posters(for: hSize)
+        AdaptiveColumns.posters(
+            for: hSize,
+            posterSize: uiCustomization.cardPresentation.posterSize
+        )
     }
 
     init(showsNavigationTitle: Bool = true) {

--- a/iosApp/iosApp/Screens/Requests/Components/RequestMediaCard.swift
+++ b/iosApp/iosApp/Screens/Requests/Components/RequestMediaCard.swift
@@ -17,6 +17,7 @@ struct RequestMediaCard: View {
     let posterPath: String?
     let state: RequestDisplayState?
     let onTap: () -> Void
+    @State private var uiCustomization = UICustomizationPreferences.shared
 
     init(result: RequestMediaResult, onTap: @escaping () -> Void) {
         self.title = result.title
@@ -45,7 +46,9 @@ struct RequestMediaCard: View {
         return label
     }
 
-    private var width: CGFloat { RequestsUI.cardWidth }
+    private var width: CGFloat {
+        RequestsUI.cardWidth * uiCustomization.cardPresentation.posterSize.scale
+    }
 
     private var height: CGFloat {
         width * (ContinuumTheme.posterCardHeight / ContinuumTheme.posterCardWidth)
@@ -63,18 +66,24 @@ struct RequestMediaCard: View {
             // would announce an image-only "Button".
             .accessibilityLabel(accessibilityTitle)
 
-            caption
+            if uiCustomization.cardPresentation.caption.showsTitle {
+                caption
+            }
         }
         .frame(width: width)
         #else
         Button(action: onTap) {
             VStack(alignment: .leading, spacing: 4) {
                 posterImage
-                caption
+                if uiCustomization.cardPresentation.caption.showsTitle {
+                    caption
+                }
             }
         }
         .buttonStyle(.plain)
         .frame(width: width)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityTitle)
         #endif
     }
 
@@ -126,7 +135,7 @@ struct RequestMediaCard: View {
                 .lineLimit(2, reservesSpace: true)
                 #endif
 
-            if let year, year > 0 {
+            if uiCustomization.cardPresentation.caption.showsMetadata, let year, year > 0 {
                 Text(String(year))
                     .font(.continuumCaption)
                     .foregroundColor(.continuumSecondaryText)

--- a/iosApp/iosApp/Screens/Requests/Hub/RequestsHubView.swift
+++ b/iosApp/iosApp/Screens/Requests/Hub/RequestsHubView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 /// reports `requests_enabled`.
 struct RequestsHubView: View {
     @State private var viewModel = RequestsHubViewModel()
+    @State private var uiCustomization = UICustomizationPreferences.shared
     @Environment(AppRouter.self) private var router
 
     var body: some View {
@@ -97,7 +98,14 @@ struct RequestsHubView: View {
             .frame(maxWidth: .infinity)
         } else {
             LazyVGrid(
-                columns: [GridItem(.adaptive(minimum: RequestsUI.cardWidth), spacing: RequestsUI.railSpacing, alignment: .top)],
+                columns: [GridItem(
+                    .adaptive(
+                        minimum: RequestsUI.cardWidth
+                            * uiCustomization.cardPresentation.posterSize.scale
+                    ),
+                    spacing: RequestsUI.railSpacing,
+                    alignment: .top
+                )],
                 alignment: .leading,
                 spacing: RequestsUI.railSpacing
             ) {

--- a/iosApp/iosApp/Screens/Settings/InterfaceCustomizationView.swift
+++ b/iosApp/iosApp/Screens/Settings/InterfaceCustomizationView.swift
@@ -1,0 +1,369 @@
+#if !os(tvOS)
+import SwiftUI
+
+func availablePrimaryMenuLibraryShortcuts(
+    _ shortcuts: [PrimaryMenuItem],
+    visibleIds: Set<String>,
+    availableLibraryIds: Set<Int>
+) -> [PrimaryMenuItem] {
+    shortcuts.filter { item in
+        guard case .library(let libraryId, _) = item else { return false }
+        return availableLibraryIds.contains(libraryId) && !visibleIds.contains(item.id)
+    }
+}
+
+/// Family-synced navigation and card presets for iPhone, iPad, and Mac.
+/// Downloads, Search, and Profile are automatic shell utilities and stay
+/// outside the reorderable list, matching the cross-client contract.
+struct InterfaceCustomizationView: View {
+    @State private var preferences = UICustomizationPreferences.shared
+    @State private var registry = ServerRegistry.shared
+    @State private var librarySnapshot = MainTabLibrarySnapshot.cachedForCurrentAuthority()
+    @Environment(\.scenePhase) private var scenePhase
+
+    var body: some View {
+        List {
+            if let message = preferences.capabilityMessage {
+                Section {
+                    Label(message, systemImage: "server.rack")
+                        .foregroundStyle(Color.continuumSecondaryText)
+                }
+            }
+
+            if preferences.hasDeviceOverrides {
+                Section {
+                    Label(
+                        "This device has older device-specific interface settings that override family sync.",
+                        systemImage: "iphone.and.arrow.forward"
+                    )
+                    Button("Use Synced \(familySettingsName) Settings") {
+                        preferences.useFamilySettings()
+                    }
+                    .disabled(preferences.isSaving || !preferences.allowsEditing)
+                } footer: {
+                    Text("Clearing the device override makes the controls below apply to all like-family devices on this profile.")
+                }
+            }
+
+            Section {
+                Picker("Preset", selection: presetSelection) {
+                    ForEach(CardPresentationPreset.allCases) { preset in
+                        Text(preset.title).tag(preset.rawValue)
+                    }
+                    if preferences.cardPresentation.preset == nil {
+                        Text("Custom").tag(Self.customPresetId)
+                    }
+                }
+
+                Picker("Poster Size", selection: posterSize) {
+                    ForEach(CardPosterSize.allCases) { size in
+                        Text(size.title).tag(size)
+                    }
+                }
+
+                Picker("Captions", selection: captionStyle) {
+                    ForEach(CardCaptionStyle.allCases) { style in
+                        Text(style.title).tag(style)
+                    }
+                }
+
+                if preferences.cardPresentationUsesFamilyOverride {
+                    Button("Use Profile Default") {
+                        preferences.resetCardPresentationToInherited()
+                    }
+                    .disabled(preferences.isSaving)
+                }
+            } header: {
+                Text("Cards & Posters")
+            } footer: {
+                Text("Start with Balanced, Compact, Cinema, or Artwork Only, then fine-tune size and captions. These choices sync with other \(familyLabel) devices on this profile.")
+            }
+            .disabled(
+                !preferences.allowsEditing
+                    || preferences.cardPresentationUsesDeviceOverride
+            )
+
+            Section {
+                ForEach(visibleDestinations) { item in
+                    HStack(spacing: 12) {
+                        Image(systemName: item.isHome ? "lock.fill" : "line.3.horizontal")
+                            .foregroundStyle(Color.continuumSecondaryText)
+                            .frame(width: 22)
+                        Text(displayTitle(for: item))
+                        Spacer()
+#if os(macOS)
+                        Button {
+                            move(item, by: -1)
+                        } label: {
+                            Image(systemName: "arrow.up")
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(visibleDestinations.first?.id == item.id)
+                        .accessibilityLabel("Move \(displayTitle(for: item)) up")
+
+                        Button {
+                            move(item, by: 1)
+                        } label: {
+                            Image(systemName: "arrow.down")
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(visibleDestinations.last?.id == item.id)
+                        .accessibilityLabel("Move \(displayTitle(for: item)) down")
+#endif
+                        if !item.isHome {
+                            Button {
+                                hide(item)
+                            } label: {
+                                Image(systemName: "minus.circle.fill")
+                                    .foregroundStyle(.red)
+                                    .frame(width: 44, height: 44)
+                                    .contentShape(Rectangle())
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("Hide \(displayTitle(for: item))")
+                        }
+                    }
+                }
+                .onMove(perform: move)
+            } header: {
+                Text("Primary Menu")
+            } footer: {
+                Text("Home is required. Downloads (when available), Search, and Profile stay automatic. Media categories share Libraries; pinned libraries open directly. Unsupported section and collection rows stay synced for clients that can show them.")
+            }
+            .disabled(
+                !preferences.allowsEditing
+                    || preferences.primaryMenuUsesDeviceOverride
+            )
+
+            if !hiddenDestinations.isEmpty {
+                Section("Hidden") {
+                    ForEach(hiddenDestinations) { item in
+                        Button {
+                            show(item)
+                        } label: {
+                            Label("Show \(displayTitle(for: item))", systemImage: "plus.circle.fill")
+                        }
+                    }
+                }
+                .disabled(
+                    !preferences.allowsEditing
+                        || preferences.primaryMenuUsesDeviceOverride
+                )
+            }
+
+            if !availableShortcuts.isEmpty {
+                Section("Available Shortcuts") {
+                    ForEach(availableShortcuts) { item in
+                        Button {
+                            show(item)
+                        } label: {
+                            Label("Show \(item.title)", systemImage: "pin.circle.fill")
+                        }
+                    }
+                }
+                .disabled(
+                    !preferences.allowsEditing
+                        || preferences.primaryMenuUsesDeviceOverride
+                )
+            }
+
+            if !libraries.isEmpty {
+                Section("Pinned Libraries") {
+                    ForEach(libraries.sorted(by: librarySort)) { library in
+                        Toggle(
+                            library.name,
+                            isOn: Binding(
+                                get: { preferences.isLibraryPinned(library.id) },
+                                set: { preferences.setLibraryPinned(library, isPinned: $0) }
+                            )
+                        )
+                    }
+                }
+                .disabled(!preferences.allowsEditing)
+            }
+
+            if let message = preferences.syncErrorMessage,
+               message != preferences.capabilityMessage {
+                Section {
+                    Label(message, systemImage: "icloud.slash")
+                        .font(.footnote)
+                        .foregroundStyle(Color.continuumSecondaryText)
+                }
+            }
+        }
+        .continuumGroupedListStyle()
+        .navigationTitle("Interface")
+#if os(iOS)
+        .toolbar { EditButton() }
+#endif
+        .task {
+            await preferences.refresh()
+        }
+        .task(id: currentLibraryAuthority) {
+            await refreshLibraries(for: currentLibraryAuthority)
+        }
+        .onChange(of: scenePhase) { _, phase in
+            guard phase == .active else { return }
+            let authority = currentLibraryAuthority
+            Task {
+                async let preferencesRefresh: Void = preferences.refresh()
+                async let librariesRefresh: Void = refreshLibraries(for: authority)
+                _ = await (preferencesRefresh, librariesRefresh)
+            }
+        }
+    }
+
+    private var posterSize: Binding<CardPosterSize> {
+        Binding(
+            get: { preferences.cardPresentation.posterSize },
+            set: { preferences.setPosterSize($0) }
+        )
+    }
+
+    private var presetSelection: Binding<String> {
+        Binding(
+            get: { preferences.cardPresentation.preset?.rawValue ?? Self.customPresetId },
+            set: { rawValue in
+                guard let preset = CardPresentationPreset(rawValue: rawValue) else { return }
+                preferences.setCardPresentation(preset.presentation)
+            }
+        )
+    }
+
+    private var captionStyle: Binding<CardCaptionStyle> {
+        Binding(
+            get: { preferences.cardPresentation.caption },
+            set: { preferences.setCaptionStyle($0) }
+        )
+    }
+
+    private static let candidates: [PrimaryMenuItem] = [
+        .builtin(.home),
+        .builtin(.movies),
+        .builtin(.series),
+        .builtin(.music),
+        .builtin(.audiobooks),
+        .builtin(.forYou),
+        .builtin(.calendar),
+    ]
+    private static let customPresetId = "custom"
+
+    private var currentLibraryAuthority: MainTabLibraryAuthority? {
+        MainTabLibraryAuthority(
+            serverId: registry.activeServerId,
+            profileId: registry.activeProfileId
+        )
+    }
+
+    private var libraries: [Library] {
+        librarySnapshot.availableLibraries(for: currentLibraryAuthority)
+    }
+
+    private func refreshLibraries(for authority: MainTabLibraryAuthority?) async {
+        let retained = librarySnapshot.authority == authority ? librarySnapshot.libraries : []
+        librarySnapshot = .init(authority: authority, libraries: retained)
+        guard let authority else { return }
+        do {
+            let response = try await StartupContentPrefetcher.fetchUserLibraries()
+            guard !Task.isCancelled, currentLibraryAuthority == authority else { return }
+            librarySnapshot = .init(authority: authority, libraries: response.libraries)
+        } catch {
+            // Keep the same-authority cache; a different authority already
+            // failed closed above.
+        }
+    }
+
+    private var visibleDestinations: [PrimaryMenuItem] {
+        preferences.resolvedPrimaryMenuItems().filter {
+            mainTabSupportsDestination($0, availableLibraries: libraries)
+        }
+    }
+
+    private var hiddenDestinations: [PrimaryMenuItem] {
+        let visible = Set(visibleDestinations.map(\.id))
+        return Self.candidates.filter {
+            mainTabSupportsDestination($0, availableLibraries: libraries)
+                && !visible.contains($0.id)
+        }
+    }
+
+    private var availableShortcuts: [PrimaryMenuItem] {
+        let visible = Set(visibleDestinations.map(\.id))
+        return availablePrimaryMenuLibraryShortcuts(
+            preferences.shortcuts.items,
+            visibleIds: visible,
+            availableLibraryIds: Set(libraries.map(\.id))
+        )
+    }
+
+    private func displayTitle(for item: PrimaryMenuItem) -> String {
+        item.title
+    }
+
+    private func move(from source: IndexSet, to destination: Int) {
+        var items = visibleDestinations
+        items.move(fromOffsets: source, toOffset: destination)
+        persistVisibleDestinations(items)
+    }
+
+    private func move(_ item: PrimaryMenuItem, by offset: Int) {
+        var items = visibleDestinations
+        guard let source = items.firstIndex(where: { $0.id == item.id }) else { return }
+        let destination = source + offset
+        guard items.indices.contains(destination) else { return }
+        items.swapAt(source, destination)
+        persistVisibleDestinations(items)
+    }
+
+    private func hide(_ item: PrimaryMenuItem) {
+        guard !item.isHome else { return }
+        persistVisibleDestinations(visibleDestinations.filter { $0.id != item.id })
+    }
+
+    private func show(_ item: PrimaryMenuItem) {
+        persistVisibleDestinations(visibleDestinations + [item])
+    }
+
+    private func persistVisibleDestinations(_ destinations: [PrimaryMenuItem]) {
+        let currentlyVisibleIds = Set(visibleDestinations.map(\.id))
+        var replacements = destinations.makeIterator()
+        var result: [PrimaryMenuItem] = []
+
+        for item in preferences.resolvedPrimaryMenuItems() {
+            if currentlyVisibleIds.contains(item.id) {
+                if let replacement = replacements.next() {
+                    result.append(replacement)
+                }
+            } else {
+                result.append(item)
+            }
+        }
+        while let remaining = replacements.next() {
+            result.append(remaining)
+        }
+        preferences.setPrimaryMenuItems(result)
+    }
+
+    private func librarySort(_ lhs: Library, _ rhs: Library) -> Bool {
+        (lhs.sortOrder ?? Int.max, lhs.id) < (rhs.sortOrder ?? Int.max, rhs.id)
+    }
+
+    private var familyLabel: String {
+        switch AppleDeviceIdentity.current.clientFamily {
+        case "mobile": return "iPhone-like"
+        case "tablet": return "tablet-like"
+        case "desktop": return "desktop-like"
+        default: return "similar"
+        }
+    }
+
+    private var familySettingsName: String {
+        switch AppleDeviceIdentity.current.clientFamily {
+        case "mobile": return "Mobile"
+        case "tablet": return "Tablet"
+        case "desktop": return "Desktop"
+        default: return "Family"
+        }
+    }
+}
+#endif

--- a/iosApp/iosApp/Screens/Settings/ProfilePrefsEditor.swift
+++ b/iosApp/iosApp/Screens/Settings/ProfilePrefsEditor.swift
@@ -76,6 +76,8 @@ final class ProfilePrefsEditor {
             return "More specific device, library, or series subtitle settings override this profile default. Changes here are saved for the profile, but those overrides still apply where configured."
         }
         switch scope {
+        case .profileClient:
+            return "This device family has a more specific subtitle setting. Changes here update the profile default, but the family override still applies."
         case .profileDevice:
             return "This device, for this profile, has a more specific subtitle setting. Changes here update the profile default, but the device override still applies."
         case .profileLibrary:
@@ -513,7 +515,7 @@ final class ProfilePrefsEditor {
     private static func profileWriteMayBeShadowed(by source: SettingSource?) -> Bool {
         guard case .scope(let scope) = source else { return false }
         switch scope {
-        case .profileDevice, .profileLibrary, .profileSeries, .other:
+        case .profileClient, .profileDevice, .profileLibrary, .profileSeries, .other:
             return true
         case .account, .profile:
             return false

--- a/iosApp/iosApp/Screens/Settings/SettingsView.swift
+++ b/iosApp/iosApp/Screens/Settings/SettingsView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 /// with drill-in sub-screens tuned for the 10-foot experience.
 struct SettingsView: View {
     @State private var viewModel = SettingsViewModel()
+    @State private var uiCustomization = UICustomizationPreferences.shared
     @Environment(AppRouter.self) private var router
     @State private var showSignOutConfirm = false
     #if os(iOS)
@@ -153,6 +154,17 @@ struct SettingsView: View {
 
     private var preferencesSection: some View {
         Section {
+            NavigationLink {
+                InterfaceCustomizationView()
+            } label: {
+                SettingsRowLabel(
+                    title: "Interface",
+                    systemImage: "rectangle.3.group.fill",
+                    color: .indigo,
+                    value: uiCustomization.cardPresentation.preset?.title ?? "Custom"
+                )
+            }
+
             NavigationLink {
                 PlaybackSettingsView(viewModel: viewModel)
             } label: {

--- a/iosApp/iosApp/Shared/AppleDeviceIdentity.swift
+++ b/iosApp/iosApp/Shared/AppleDeviceIdentity.swift
@@ -16,11 +16,11 @@ struct AppleDeviceIdentity: Sendable {
     /// interchangeable form factors across operating systems.
     let clientFamily: String
 
-    init(id: String, name: String, platform: String, clientFamily: String? = nil) {
+    init(id: String, name: String, platform: String, clientFamily: String) {
         self.id = id
         self.name = name
         self.platform = platform
-        self.clientFamily = clientFamily ?? Self.defaultClientFamily(for: platform)
+        self.clientFamily = clientFamily
     }
 
     static let current = AppleDeviceIdentity(
@@ -74,14 +74,5 @@ struct AppleDeviceIdentity: Sendable {
         #else
         return "desktop"
         #endif
-    }
-
-    private static func defaultClientFamily(for platform: String) -> String {
-        switch platform.lowercased() {
-        case "tvos": return "tv"
-        case "ios": return "mobile"
-        case "macos": return "desktop"
-        default: return "desktop"
-        }
     }
 }

--- a/iosApp/iosApp/Shared/AppleDeviceIdentity.swift
+++ b/iosApp/iosApp/Shared/AppleDeviceIdentity.swift
@@ -10,11 +10,24 @@ struct AppleDeviceIdentity: Sendable {
     let id: String
     let name: String
     let platform: String
+    /// Canonical settings family used by `profile_client` resolution.
+    /// Kept separate from `platform`: the latter is diagnostic/device
+    /// metadata (`iOS`, `tvOS`, `macOS`), while this intentionally groups
+    /// interchangeable form factors across operating systems.
+    let clientFamily: String
+
+    init(id: String, name: String, platform: String, clientFamily: String? = nil) {
+        self.id = id
+        self.name = name
+        self.platform = platform
+        self.clientFamily = clientFamily ?? Self.defaultClientFamily(for: platform)
+    }
 
     static let current = AppleDeviceIdentity(
         id: AppleDeviceIdentity.loadOrCreateID(),
         name: AppleDeviceIdentity.currentName(),
-        platform: AppleDeviceIdentity.currentPlatform()
+        platform: AppleDeviceIdentity.currentPlatform(),
+        clientFamily: AppleDeviceIdentity.currentClientFamily()
     )
 
     private static let keychainAccount = "com.continuum.device.identity"
@@ -49,5 +62,26 @@ struct AppleDeviceIdentity: Sendable {
         #else
         return "Apple"
         #endif
+    }
+
+    private static func currentClientFamily() -> String {
+        #if os(tvOS)
+        return "tv"
+        #elseif os(macOS)
+        return "desktop"
+        #elseif os(iOS)
+        return UIDevice.current.userInterfaceIdiom == .pad ? "tablet" : "mobile"
+        #else
+        return "desktop"
+        #endif
+    }
+
+    private static func defaultClientFamily(for platform: String) -> String {
+        switch platform.lowercased() {
+        case "tvos": return "tv"
+        case "ios": return "mobile"
+        case "macos": return "desktop"
+        default: return "desktop"
+        }
     }
 }

--- a/iosApp/iosApp/Shared/Diagnostics/DiagnosticsCoordinator.swift
+++ b/iosApp/iosApp/Shared/Diagnostics/DiagnosticsCoordinator.swift
@@ -973,7 +973,7 @@ actor DiagnosticsCoordinator {
             case .http(let statusCode, _):
                 return (500...599).contains(statusCode)
             case .serverUrlNotConfigured, .invalidURL, .invalidResponse,
-                 .encodingFailed, .decodingFailed:
+                 .requestIdentityChanged, .encodingFailed, .decodingFailed:
                 return false
             }
         }

--- a/iosApp/iosApp/tvOS/Navigation/TVCascadeSelector.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVCascadeSelector.swift
@@ -21,7 +21,7 @@ import SwiftUI
 /// Focus contract (the hard part — see §5.3/§7):
 /// - The host (`TVMainTabView`) keeps focus on the *tab* while dwell only
 ///   previews the panel. D-pad **down** flips `entersPanel` true and bumps
-///   `focusEntryToken`, landing on the current-scope library row.
+///   `focusEntryGeneration`, landing on the current-scope library row.
 /// - **Up/down** rolls libraries; the flyout follows. **Right** enters the
 ///   flyout (first section); **left** returns to the library row.
 /// - **Press** on a library row commits that scope → Browse landing.
@@ -41,7 +41,7 @@ struct TVCascadeSelector: View {
     let entersPanel: Bool
     /// Bumped by the host the moment focus should enter the panel — lands
     /// on the current-scope library row.
-    let focusEntryToken: Int
+    let focusEntryGeneration: Int
     /// Commit a library scope → its Browse landing.
     let onCommitLibrary: (Library) -> Void
     /// Commit a library scope + land on a specific section (pill).
@@ -69,7 +69,7 @@ struct TVCascadeSelector: View {
     @State private var flyoutAnchorId: Int?
     /// Debounce task for the flyout follow (§5.3).
     @State private var flyoutFollowTask: Task<Void, Never>?
-    @State private var lastAppliedEntryToken = 0
+    @State private var lastAppliedEntryGeneration = 0
     /// Each library row's vertical center in the level-1 HStack's coordinate
     /// space. The flyout offsets to align its first section with the anchored
     /// row, so the composite highlight does not visually jump on Right.
@@ -104,7 +104,9 @@ struct TVCascadeSelector: View {
         // The cascade is a composite tvOS control. Rows are rendered labels in
         // both preview and entered modes; only the panel container itself is
         // focusable, and D-pad movement updates the internal highlighted row.
-        .onChange(of: focusEntryToken) { _, token in applyEntryToken(token) }
+        .onChange(of: focusEntryGeneration) { _, generation in
+            applyEntryGeneration(generation)
+        }
         .onChange(of: focus) { _, newValue in handleFocusChange(newValue) }
         .onChange(of: panelFocused) { _, isFocused in handlePanelFocusedChange(isFocused) }
         .onChange(of: entersPanel) { _, entered in
@@ -115,7 +117,7 @@ struct TVCascadeSelector: View {
         }
         .onAppear {
             flyoutAnchorId = currentScopeId ?? libraries.first?.id
-            if entersPanel { applyEntryToken(focusEntryToken) }
+            if entersPanel { applyEntryGeneration(focusEntryGeneration) }
         }
         .onDisappear { flyoutFollowTask?.cancel() }
         .contentShape(Rectangle())
@@ -393,9 +395,11 @@ struct TVCascadeSelector: View {
 
     // MARK: - Focus plumbing
 
-    private func applyEntryToken(_ token: Int) {
-        guard entersPanel, token > 0, token != lastAppliedEntryToken else { return }
-        lastAppliedEntryToken = token
+    private func applyEntryGeneration(_ generation: Int) {
+        guard entersPanel,
+              generation > 0,
+              generation != lastAppliedEntryGeneration else { return }
+        lastAppliedEntryGeneration = generation
         if isSingleLibrary, let library = libraries.first {
             // Single-level: land on the first section (§5.3).
             focus = .section(library.id, pills.first ?? .recommended)

--- a/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
@@ -27,6 +27,7 @@ struct TVMainTabView: View {
     /// tab is opted in). Observed so the bar re-derives `visibleRoots` the
     /// instant a toggle flips in Settings.
     @State private var navPrefs = TVNavPreferences.shared
+    @State private var uiCustomization = UICustomizationPreferences.shared
     /// Visible libraries for the active profile; drives which type tabs
     /// exist and which library each type tab scopes to. Seeded from the
     /// startup prefetch so all type tabs are in the bar's first frame —
@@ -34,9 +35,20 @@ struct TVMainTabView: View {
     /// splash lifted.
     @State private var libraries: [Library] =
         ResponseCache.shared.get(CacheKey.userLibraries, as: LibrariesResponse.self)?.libraries ?? []
+    @State private var loadedLibraryAuthority: MainTabLibraryAuthority? = {
+        let registry = ServerRegistry.shared
+        return MainTabLibraryAuthority(
+            serverId: registry.activeServerId,
+            profileId: registry.activeProfileId
+        )
+    }()
     /// Per-type pill selection, session-only (§8): it survives tab
-    /// switches but cold start always lands on Browse.
+    /// switches but cold start always lands on Recommended.
     @State private var pillSelections: [TVLibraryTabType: TVLibraryPill] = [:]
+    /// Direct pins own section state by exact library identity. They must not
+    /// inherit Movies/Series state, and each pin's one-library cascade remains
+    /// independently usable even when its category root is hidden.
+    @State private var shortcutPillSelections: [Int: TVLibraryPill] = [:]
     /// Per-type library scope: which single library each multi-library type
     /// is scoped to (§3.1). Seeded from the persisted choice (or the first
     /// library on cold start) via `TVLibraryScopeStore`, and updated +
@@ -49,7 +61,7 @@ struct TVMainTabView: View {
     /// route or full-screen modal.
     @State private var openPanel: TVTopMenuPanel?
     @State private var panelEntersFocus = false
-    @State private var panelFocusEntryToken = 0
+    @State private var panelFocusEntryGeneration = 0
     @State private var panelHasFocus = false
     @State private var panelFocusExitTask: Task<Void, Never>?
     @State private var controlReceiver = TVControlReceiver.shared
@@ -66,7 +78,7 @@ struct TVMainTabView: View {
     /// this, so their pops keep the engine's restore-to-card behavior.
     @State private var barOwnsFocusOnPopToRoot = false
     @State private var topMenuFocusRequest = 0
-    /// Active focus hand-down token. Incremented whenever a root is
+    /// Active focus hand-down generation. Incremented whenever a root is
     /// selected so the freshly-swapped-in content imperatively claims
     /// focus, instead of relying on `prefersDefaultFocus` (which can lose
     /// to geometric proximity, per CLAUDE.md's "tvOS default focus on
@@ -189,10 +201,12 @@ struct TVMainTabView: View {
             // Re-read tab-visibility prefs for the now-known profile (the
             // singleton may hold the previous profile's value after a switch).
             navPrefs.refresh()
+            await uiCustomization.refresh()
             controlReceiver.start(router: router)
-            async let profileTask: Void = loadCurrentProfile()
-            async let librariesTask: Void = loadLibraries()
-            _ = await (profileTask, librariesTask)
+            await loadCurrentProfile()
+        }
+        .task(id: currentLibraryAuthority) {
+            await loadLibraries(for: currentLibraryAuthority)
         }
         .onChange(of: router.path.isEmpty) { _, isEmpty in
             // Returning from a pushed route (Search, detail, settings)
@@ -233,6 +247,12 @@ struct TVMainTabView: View {
             // page with no matching tab in the bar; snap back to Home.
             ensureSelectedRootIsVisible()
         }
+        .onChange(of: uiCustomization.primaryMenu) { _, _ in
+            ensureSelectedRootIsVisible()
+        }
+        .onChange(of: uiCustomization.shortcuts) { _, _ in
+            ensureSelectedRootIsVisible()
+        }
         .onDisappear {
             controlReceiver.stop()
         }
@@ -245,6 +265,8 @@ struct TVMainTabView: View {
             // find this TV. No-op when the listener is healthy.
             if newPhase == .active {
                 controlReceiver.start(router: router)
+                let authority = currentLibraryAuthority
+                Task { await loadLibraries(for: authority) }
             }
         }
     }
@@ -308,6 +330,27 @@ struct TVMainTabView: View {
             // section fetches reset cleanly (pill selection survives in
             // pillSelections).
             .id(type)
+        case .libraryShortcut(let libraryId, _):
+            if let library = libraries.first(where: { $0.id == libraryId }),
+               let type = tabType(for: library) {
+                TVLibraryTypeTabView(
+                    type: type,
+                    libraries: [library],
+                    activeLibrary: library,
+                    selectedPill: shortcutPillSelection(for: libraryId, categoryType: type),
+                    focusRequest: contentFocusRequest,
+                    isTopMenuFocused: isTopMenuFocused,
+                    onTopMenuFocusRequest: { focusTopMenuIfVisible() }
+                )
+                .id(library.id)
+            } else {
+                EmptyStateView(
+                    icon: "square.stack.3d.up",
+                    title: "Library unavailable",
+                    subtitle: "This pinned library is no longer visible to the active profile."
+                )
+                .padding(.top, TVTopMenuLayout.contentTopInset)
+            }
         case .calendar:
             CalendarView(
                 focusRequest: contentFocusRequest,
@@ -355,7 +398,7 @@ struct TVMainTabView: View {
     private var persistentPanels: [TVTopMenuPanel] {
         var panels = visibleRoots.compactMap { root -> TVTopMenuPanel? in
             switch root {
-            case .libraryType, .recommendations:
+            case .libraryType, .libraryShortcut, .recommendations:
                 return .root(root)
             case .home, .calendar:
                 return nil
@@ -367,7 +410,7 @@ struct TVMainTabView: View {
 
     private func panelIntrinsicWidth(for panel: TVTopMenuPanel) -> CGFloat {
         switch panel {
-        case .profile, .root(.recommendations):
+        case .profile, .root(.recommendations), .root(.libraryShortcut):
             return ContinuumTheme.Skyline.dropdownWidth
         case .root:
             return ContinuumTheme.Skyline.dropdownWidth
@@ -428,7 +471,7 @@ struct TVMainTabView: View {
         case .profile:
             // Right-aligned to safeArea.x (§5.8).
             return max(safe, screenWidth - safe - level1Width)
-        case .root(.recommendations):
+        case .root(.recommendations), .root(.libraryShortcut):
             guard let anchor = anchors[panel] else {
                 return safe
             }
@@ -476,6 +519,11 @@ struct TVMainTabView: View {
             switch root {
             case .libraryType(let type):
                 cascadePanel(for: type, isActive: isActive)
+            case .libraryShortcut(let libraryId, let label):
+                shortcutCascadePanel(
+                    for: .libraryShortcut(libraryId: libraryId, label: label),
+                    isActive: isActive
+                )
             case .recommendations:
                 forYouPanel(isActive: isActive)
             case .home, .calendar:
@@ -492,7 +540,7 @@ struct TVMainTabView: View {
             libraries: libraries(of: type),
             currentScopeId: activeLibrary(for: type)?.id,
             entersPanel: isActive && panelEntersFocus,
-            focusEntryToken: panelFocusEntryToken,
+            focusEntryGeneration: panelFocusEntryGeneration,
             onCommitLibrary: { commitScope(type: type, library: $0, pill: nil) },
             onCommitSection: { commitScope(type: type, library: $0, pill: $1) },
             onClose: { closePanel() },
@@ -501,10 +549,33 @@ struct TVMainTabView: View {
         )
     }
 
+    @ViewBuilder
+    private func shortcutCascadePanel(
+        for root: TVRootDestination,
+        isActive: Bool
+    ) -> some View {
+        if case .libraryShortcut(let libraryId, _) = root,
+           let library = libraries.first(where: { $0.id == libraryId }),
+           let type = tabType(for: library) {
+            TVCascadeSelector(
+                type: type,
+                libraries: [library],
+                currentScopeId: library.id,
+                entersPanel: isActive && panelEntersFocus,
+                focusEntryGeneration: panelFocusEntryGeneration,
+                onCommitLibrary: { commitShortcut(root: root, library: $0, pill: nil) },
+                onCommitSection: { commitShortcut(root: root, library: $0, pill: $1) },
+                onClose: { closePanel() },
+                onPanelFocusChanged: { handlePanelFocusChanged($0) },
+                onExitToContent: { exitPanelToContent() }
+            )
+        }
+    }
+
     private func forYouPanel(isActive: Bool) -> some View {
         TVForYouDropdown(
             entersPanel: isActive && panelEntersFocus,
-            focusEntryToken: panelFocusEntryToken,
+            focusEntryGeneration: panelFocusEntryGeneration,
             onPanelFocusChanged: { handlePanelFocusChanged($0) },
             onClose: { closePanel() },
             onExitToContent: { exitPanelToContent() },
@@ -520,7 +591,7 @@ struct TVMainTabView: View {
             avatar: currentProfile?.avatarEmoji,
             serverHost: ServerRegistry.shared.activeServer?.displayName,
             entersPanel: isActive && panelEntersFocus,
-            focusEntryToken: panelFocusEntryToken,
+            focusEntryGeneration: panelFocusEntryGeneration,
             onPanelFocusChanged: { handlePanelFocusChanged($0) },
             onSwitchProfile: { closePanel(then: switchProfile) },
             onWatchlist: { closePanel(then: { navigateFromBar(.watchlist) }) },
@@ -591,7 +662,7 @@ struct TVMainTabView: View {
         panelFocusExitTask = nil
         panelEntersFocus = true
         panelHasFocus = true
-        panelFocusEntryToken += 1
+        panelFocusEntryGeneration += 1
     }
 
     /// Route a d-pad-down on a panel-bearing bar element (§5.3): open its
@@ -622,7 +693,7 @@ struct TVMainTabView: View {
         panelFocusExitTask = nil
         panelEntersFocus = true
         panelHasFocus = true
-        panelFocusEntryToken += 1
+        panelFocusEntryGeneration += 1
         withAnimation(reduceMotion ? nil : .easeOut(duration: ContinuumTheme.Skyline.cascadeScrimDuration)) {
             openPanel = panel
         }
@@ -719,7 +790,7 @@ struct TVMainTabView: View {
 
         // Tear down the panel first, then select the tab + hand focus to the
         // swapped-in content. Selecting the root bumps contentFocusRequest,
-        // which the new page consumes as its entry token.
+        // which the new page consumes as its entry generation.
         withAnimation(reduceMotion ? nil : .easeOut(duration: ContinuumTheme.Skyline.cascadeScrimDuration)) {
             openPanel = nil
         }
@@ -728,30 +799,64 @@ struct TVMainTabView: View {
         selectRoot(.libraryType(type))
     }
 
+    private func commitShortcut(
+        root: TVRootDestination,
+        library: Library,
+        pill: TVLibraryPill?
+    ) {
+        guard case .libraryShortcut(let libraryId, _) = root,
+              library.id == libraryId else { return }
+        panelFocusExitTask?.cancel()
+        panelFocusExitTask = nil
+        shortcutPillSelections[libraryId] = pill ?? .recommended
+
+        withAnimation(reduceMotion ? nil : .easeOut(duration: ContinuumTheme.Skyline.cascadeScrimDuration)) {
+            openPanel = nil
+        }
+        panelEntersFocus = false
+        panelHasFocus = false
+        selectRoot(root)
+    }
+
     // MARK: - Tab derivation
 
-    /// Fixed root order (Skyline §3.1): Home, then one tab per library type
-    /// the profile can see, then For You and Calendar.
+    /// Contract-ordered roots for this TV family. Search and Profile remain
+    /// fixed outside this list, which keeps their focus anchors stable while
+    /// the user rearranges content tabs.
     private var visibleRoots: [TVRootDestination] {
-        var roots: [TVRootDestination] = [.home]
-        for type in TVLibraryTabType.allCases
-        where libraries.contains(where: { type.matches($0) }) && isTypeVisible(type) {
-            roots.append(.libraryType(type))
+        var roots: [TVRootDestination] = []
+        for item in uiCustomization.resolvedPrimaryMenuItems(availableLibraries: libraries) {
+            let root: TVRootDestination?
+            switch item {
+            case .builtin(.home): root = .home
+            case .builtin(.movies): root = availableRoot(for: .movies)
+            case .builtin(.series): root = availableRoot(for: .series)
+            case .builtin(.music): root = availableRoot(for: .music)
+            case .builtin(.audiobooks): root = availableRoot(for: .audiobooks)
+            case .builtin(.forYou): root = .recommendations
+            case .builtin(.calendar): root = .calendar
+            case .library(let libraryId, let label):
+                root = libraries.contains(where: { $0.id == libraryId })
+                    ? .libraryShortcut(libraryId: libraryId, label: label)
+                    : nil
+            case .section, .collection:
+                // The contract can carry these for web and future clients.
+                // Apple TV currently has a stable root route only for whole
+                // libraries, so unsupported shortcuts stay stored but hidden.
+                root = nil
+            }
+            if let root, !roots.contains(root) { roots.append(root) }
         }
-        roots.append(.recommendations)
-        roots.append(.calendar)
+        if !roots.contains(.home) { roots.insert(.home, at: 0) }
         return roots
     }
 
-    /// Whether a library type the profile can see should surface as a tab.
-    /// Most types are always shown; Audiobooks is opt-in (hidden by default)
-    /// because most users don't want it on their TV. This is the seam a
-    /// fuller "customize the header" feature would extend.
-    private func isTypeVisible(_ type: TVLibraryTabType) -> Bool {
-        switch type {
-        case .audiobooks: return navPrefs.showAudiobooks
-        default: return true
-        }
+    private func availableRoot(for type: TVLibraryTabType) -> TVRootDestination? {
+        libraries.contains(where: { type.matches($0) }) ? .libraryType(type) : nil
+    }
+
+    private func tabType(for library: Library) -> TVLibraryTabType? {
+        TVLibraryTabType.allCases.first(where: { $0.matches(library) })
     }
 
     private func libraries(of type: TVLibraryTabType) -> [Library] {
@@ -777,20 +882,65 @@ struct TVMainTabView: View {
 
     private func pillSelection(for type: TVLibraryTabType) -> Binding<TVLibraryPill> {
         Binding(
-            get: { pillSelections[type] ?? .recommended },
+            get: {
+                resolvedLibraryRootPill(
+                    categorySelection: pillSelections[type] ?? .recommended,
+                    directSelection: nil,
+                    isDirectLibraryShortcut: false
+                )
+            },
             set: { pillSelections[type] = $0 }
         )
     }
 
-    private func loadLibraries() async {
+    private func shortcutPillSelection(
+        for libraryId: Int,
+        categoryType: TVLibraryTabType
+    ) -> Binding<TVLibraryPill> {
+        Binding(
+            get: {
+                resolvedLibraryRootPill(
+                    categorySelection: pillSelections[categoryType] ?? .recommended,
+                    directSelection: shortcutPillSelections[libraryId],
+                    isDirectLibraryShortcut: true
+                )
+            },
+            set: { shortcutPillSelections[libraryId] = $0 }
+        )
+    }
+
+    private var currentLibraryAuthority: MainTabLibraryAuthority? {
+        MainTabLibraryAuthority(
+            serverId: registry.activeServerId,
+            profileId: registry.activeProfileId
+        )
+    }
+
+    private func loadLibraries(for authority: MainTabLibraryAuthority?) async {
+        if loadedLibraryAuthority != authority {
+            loadedLibraryAuthority = authority
+            libraries = []
+            scopeSelections = [:]
+            pillSelections = [:]
+            shortcutPillSelections = [:]
+            ensureSelectedRootIsVisible()
+        }
+        guard let authority else { return }
+
         if libraries.isEmpty,
            let cached: LibrariesResponse = ResponseCache.shared.get(CacheKey.userLibraries) {
             libraries = cached.libraries
+            ensureSelectedRootIsVisible()
         }
 
         do {
             let response = try await StartupContentPrefetcher.fetchUserLibraries()
+            guard !Task.isCancelled, currentLibraryAuthority == authority else { return }
+            loadedLibraryAuthority = authority
             libraries = response.libraries
+            shortcutPillSelections = shortcutPillSelections.filter { libraryId, _ in
+                response.libraries.contains { $0.id == libraryId }
+            }
             ensureSelectedRootIsVisible()
         } catch {
             // Keep whatever tabs we already have (cached or none) — Home
@@ -947,8 +1097,10 @@ struct TVMainTabView: View {
                 selectedRoot = .home
                 currentProfile = nil
                 libraries = []
+                loadedLibraryAuthority = nil
                 ResponseCache.shared.remove(CacheKey.userLibraries)
                 pillSelections = [:]
+                shortcutPillSelections = [:]
                 // Re-read tab-visibility prefs under the new server+profile
                 // key: this path switches in place without rebuilding the
                 // shell, so `.task` (the only other caller of refresh) won't
@@ -958,7 +1110,7 @@ struct TVMainTabView: View {
             }
             if AuthService.shared.hasProfile {
                 async let profileTask: Void = loadCurrentProfile()
-                async let librariesTask: Void = loadLibraries()
+                async let librariesTask: Void = loadLibraries(for: currentLibraryAuthority)
                 _ = await (profileTask, librariesTask)
             }
         }

--- a/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
@@ -1,3 +1,19 @@
+enum TVVisibleRootsFocusRearm: Equatable {
+    case none
+    case topMenu
+    case content
+}
+
+func tvVisibleRootsFocusRearm(
+    menuOwnedFocus: Bool,
+    isShowingRoot: Bool,
+    selectedRootWasRemoved: Bool
+) -> TVVisibleRootsFocusRearm {
+    guard isShowingRoot else { return .none }
+    if menuOwnedFocus { return .topMenu }
+    return selectedRootWasRemoved ? .content : .none
+}
+
 #if os(tvOS)
 import SwiftUI
 
@@ -242,16 +258,8 @@ struct TVMainTabView: View {
                 selectRoot(.home)
             }
         }
-        .onChange(of: navPrefs.showAudiobooks) {
-            // Turning a tab off while parked on it would otherwise orphan the
-            // page with no matching tab in the bar; snap back to Home.
-            ensureSelectedRootIsVisible()
-        }
-        .onChange(of: uiCustomization.primaryMenu) { _, _ in
-            ensureSelectedRootIsVisible()
-        }
-        .onChange(of: uiCustomization.shortcuts) { _, _ in
-            ensureSelectedRootIsVisible()
+        .onChange(of: visibleRoots) { _, _ in
+            reconcileVisibleRootsChange()
         }
         .onDisappear {
             controlReceiver.stop()
@@ -952,11 +960,41 @@ struct TVMainTabView: View {
     /// The selected root can stop being visible — a library refresh removes
     /// its type (e.g. profile permissions changed), or the user hides its tab
     /// from Settings. Snap back to Home rather than leaving a tab-less content
-    /// view on screen. Home / For You / Calendar are always in `visibleRoots`,
-    /// so this never strands the user.
-    private func ensureSelectedRootIsVisible() {
+    /// view on screen. Home is always injected into `visibleRoots`, so this
+    /// never strands the user.
+    private func ensureSelectedRootIsVisible(requestContentFocus: Bool = true) {
         if !visibleRoots.contains(selectedRoot) {
             selectedRoot = .home
+            if requestContentFocus {
+                contentFocusRequest += 1
+            }
+        }
+    }
+
+    /// A synced menu edit can remove the bar button that currently owns focus
+    /// even when the selected page remains visible. Capture the owner before
+    /// closing any panel, then explicitly re-arm that same focus zone after the
+    /// graph changes so tvOS never has to repair from an ownerless state.
+    private func reconcileVisibleRootsChange() {
+        let menuOwnedFocus = !isTopMenuFocusSuppressed || panelEntersFocus
+        let isShowingRoot = router.path.isEmpty
+        let selectedRootWasRemoved = !visibleRoots.contains(selectedRoot)
+        let focusRearm = tvVisibleRootsFocusRearm(
+            menuOwnedFocus: menuOwnedFocus,
+            isShowingRoot: isShowingRoot,
+            selectedRootWasRemoved: selectedRootWasRemoved
+        )
+
+        closePanel()
+        ensureSelectedRootIsVisible(requestContentFocus: false)
+
+        switch focusRearm {
+        case .none:
+            break
+        case .topMenu:
+            focusTopMenuIfVisible()
+        case .content:
+            suppressTopMenuFocusForContentHandoff()
             contentFocusRequest += 1
         }
     }

--- a/iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift
@@ -82,13 +82,45 @@ enum TVRootDestination: Hashable {
     case home
     case recommendations
     case libraryType(TVLibraryTabType)
+    case libraryShortcut(libraryId: Int, label: String)
     case calendar
+
+    static func == (lhs: TVRootDestination, rhs: TVRootDestination) -> Bool {
+        switch (lhs, rhs) {
+        case (.home, .home), (.recommendations, .recommendations), (.calendar, .calendar):
+            return true
+        case (.libraryType(let lhsType), .libraryType(let rhsType)):
+            return lhsType == rhsType
+        case (.libraryShortcut(let lhsId, _), .libraryShortcut(let rhsId, _)):
+            return lhsId == rhsId
+        default:
+            return false
+        }
+    }
+
+    func hash(into hasher: inout Hasher) {
+        switch self {
+        case .home:
+            hasher.combine(0)
+        case .recommendations:
+            hasher.combine(1)
+        case .libraryType(let type):
+            hasher.combine(2)
+            hasher.combine(type)
+        case .libraryShortcut(let libraryId, _):
+            hasher.combine(3)
+            hasher.combine(libraryId)
+        case .calendar:
+            hasher.combine(4)
+        }
+    }
 
     var title: String {
         switch self {
         case .home: return "Home"
         case .recommendations: return "For You"
         case .libraryType(let type): return type.title
+        case .libraryShortcut(_, let label): return label
         case .calendar: return "Calendar"
         }
     }
@@ -298,18 +330,31 @@ struct TVTopMenuBar: View {
         HStack(spacing: ContinuumTheme.Skyline.tabSpacing) {
             searchButton
 
-            ForEach(Array(roots.enumerated()), id: \.element) { index, root in
-                rootButton(root, index: index, count: roots.count)
+            ScrollViewReader { proxy in
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: ContinuumTheme.Skyline.tabSpacing) {
+                        ForEach(Array(roots.enumerated()), id: \.element) { index, root in
+                            rootButton(root, index: index, count: roots.count)
+                                .id(TVTopMenuFocus.root(root))
+                        }
+                    }
+                    .scrollTargetLayout()
+                }
+                .scrollClipDisabled()
+                .onChange(of: focusedItem) { _, item in
+                    guard let item, case .root = item else { return }
+                    withAnimation(reduceMotion ? nil : .easeOut(duration: ContinuumTheme.fastDuration)) {
+                        proxy.scrollTo(item, anchor: .center)
+                    }
+                }
+                .onChange(of: selectedRoot) { _, root in
+                    proxy.scrollTo(TVTopMenuFocus.root(root), anchor: .center)
+                }
             }
-
-            // Invisible twin of the search button so the tab group itself
-            // stays centered on screen with search sitting to its left.
-            Color.clear
-                .frame(
-                    width: ContinuumTheme.Skyline.barIconSize,
-                    height: ContinuumTheme.Skyline.barIconSize
-                )
         }
+        // Search and Profile stay fixed while only the customizable roots
+        // scroll through the center lane.
+        .padding(.horizontal, 150)
         .frame(maxWidth: .infinity, alignment: .center)
         .frame(height: ContinuumTheme.Skyline.barHeight)
     }
@@ -335,6 +380,8 @@ struct TVTopMenuBar: View {
                 .font(.system(size: ContinuumTheme.Skyline.tabLabelSize, weight: .semibold))
                 .foregroundStyle(tabForeground(isSelected: isSelected, isFocused: isFocused))
                 .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: 260)
                 .padding(.horizontal, ContinuumTheme.Skyline.tabPaddingHorizontal)
                 .padding(.vertical, ContinuumTheme.Skyline.tabPaddingVertical)
                 .modifier(TVTopMenuCapsuleChrome(isSelected: isSelected, isFocused: isFocused))
@@ -370,7 +417,11 @@ struct TVTopMenuBar: View {
 
     private func rootPanel(_ root: TVRootDestination) -> TVTopMenuPanel? {
         switch root {
-        case .libraryType, .recommendations:
+        case .libraryType:
+            return TVLibraryMenuRootKind.category.hasSectionCascade ? .root(root) : nil
+        case .libraryShortcut:
+            return TVLibraryMenuRootKind.directShortcut.hasSectionCascade ? .root(root) : nil
+        case .recommendations:
             return .root(root)
         case .home, .calendar:
             return nil
@@ -381,6 +432,8 @@ struct TVTopMenuBar: View {
         switch root {
         case .libraryType:
             return "Rest to choose a library"
+        case .libraryShortcut:
+            return "Rest to choose a section"
         case .recommendations:
             return "Rest to choose Watchlist, Favorites, or Recommendations"
         case .home, .calendar:
@@ -807,7 +860,7 @@ private enum TVForYouAction: Hashable {
 /// cascades.
 struct TVForYouDropdown: View {
     let entersPanel: Bool
-    let focusEntryToken: Int
+    let focusEntryGeneration: Int
     let onPanelFocusChanged: (Bool) -> Void
     let onClose: () -> Void
     let onExitToContent: () -> Void
@@ -816,11 +869,13 @@ struct TVForYouDropdown: View {
     let onRecommendations: () -> Void
 
     @FocusState private var focusedAction: TVForYouAction?
-    @State private var lastAppliedEntryToken = 0
+    @State private var lastAppliedEntryGeneration = 0
 
     var body: some View {
         panel
-            .onChange(of: focusEntryToken) { _, token in applyEntryToken(token) }
+            .onChange(of: focusEntryGeneration) { _, generation in
+                applyEntryGeneration(generation)
+            }
             .onChange(of: focusedAction) { _, newValue in
                 onPanelFocusChanged(newValue != nil)
             }
@@ -828,13 +883,15 @@ struct TVForYouDropdown: View {
                 if !entered { focusedAction = nil }
             }
             .onAppear {
-                if entersPanel { applyEntryToken(focusEntryToken) }
+                if entersPanel { applyEntryGeneration(focusEntryGeneration) }
             }
     }
 
-    private func applyEntryToken(_ token: Int) {
-        guard entersPanel, token > 0, token != lastAppliedEntryToken else { return }
-        lastAppliedEntryToken = token
+    private func applyEntryGeneration(_ generation: Int) {
+        guard entersPanel,
+              generation > 0,
+              generation != lastAppliedEntryGeneration else { return }
+        lastAppliedEntryGeneration = generation
         focusedAction = .watchlist
     }
 
@@ -964,7 +1021,7 @@ private enum TVProfileAction: Hashable {
 /// Anchored profile dropdown panel (§5.8): the same `glass.strong` level-1
 /// panel as the cascade, hosted by the shell under the avatar. The shell
 /// owns the scrim and Menu-to-close; this view owns only its rows and the
-/// focus hand-off when the host bumps `focusEntryToken`.
+/// focus hand-off when the host bumps `focusEntryGeneration`.
 struct TVProfileDropdown: View {
     let profileName: String
     let avatar: String?
@@ -974,7 +1031,7 @@ struct TVProfileDropdown: View {
     /// Whether focus has entered the panel.
     let entersPanel: Bool
     /// Bumped by the host when focus should enter — lands on the first row.
-    let focusEntryToken: Int
+    let focusEntryGeneration: Int
     /// Reports whether any row currently holds focus, so the host can drop
     /// the avatar's focus ring once focus descends (§5.8).
     let onPanelFocusChanged: (Bool) -> Void
@@ -988,7 +1045,7 @@ struct TVProfileDropdown: View {
     let onSignOut: () -> Void
 
     @FocusState private var focusedAction: TVProfileAction?
-    @State private var lastAppliedEntryToken = 0
+    @State private var lastAppliedEntryGeneration = 0
 
     /// Capability-gated: the Requests row only exists (and only takes a
     /// focus slot) when the server reports `requests_enabled`.
@@ -1000,7 +1057,9 @@ struct TVProfileDropdown: View {
         panel
             // Dwell previews render passive labels; rows become focusable
             // only after the host explicitly hands focus into the panel.
-            .onChange(of: focusEntryToken) { _, token in applyEntryToken(token) }
+            .onChange(of: focusEntryGeneration) { _, generation in
+                applyEntryGeneration(generation)
+            }
             .onChange(of: focusedAction) { _, newValue in
                 onPanelFocusChanged(newValue != nil)
             }
@@ -1008,13 +1067,15 @@ struct TVProfileDropdown: View {
                 if !entered { focusedAction = nil }
             }
             .onAppear {
-                if entersPanel { applyEntryToken(focusEntryToken) }
+                if entersPanel { applyEntryGeneration(focusEntryGeneration) }
             }
     }
 
-    private func applyEntryToken(_ token: Int) {
-        guard entersPanel, token > 0, token != lastAppliedEntryToken else { return }
-        lastAppliedEntryToken = token
+    private func applyEntryGeneration(_ generation: Int) {
+        guard entersPanel,
+              generation > 0,
+              generation != lastAppliedEntryGeneration else { return }
+        lastAppliedEntryGeneration = generation
         focusedAction = .switchProfile
     }
 

--- a/iosApp/iosApp/tvOS/Screens/Components/TVCatalogGrid.swift
+++ b/iosApp/iosApp/tvOS/Screens/Components/TVCatalogGrid.swift
@@ -31,6 +31,7 @@ struct TVCatalogGrid: View {
     @Namespace private var gridFocusNamespace
     @FocusState private var focusedItemId: String?
     @State private var lastAppliedFocusRequest = 0
+    @State private var uiCustomization = UICustomizationPreferences.shared
     @Environment(AppRouter.self) private var router
 
     private let columnSpacing: CGFloat = 40
@@ -42,8 +43,15 @@ struct TVCatalogGrid: View {
     /// before the user reaches the bottom.
     private let prefetchRowsRemaining: Int = 8
 
+    private var resolvedColumnCount: Int {
+        AdaptiveColumns.tvPosterCount(
+            standardCount: columnCount,
+            posterSize: uiCustomization.cardPresentation.posterSize
+        )
+    }
+
     private var rowStartIndices: [Int] {
-        stride(from: 0, to: items.count, by: columnCount).map { $0 }
+        stride(from: 0, to: items.count, by: resolvedColumnCount).map { $0 }
     }
 
     var body: some View {
@@ -107,16 +115,16 @@ struct TVCatalogGrid: View {
     }
 
     private func rowItems(from rowStart: Int) -> [BrowseItem] {
-        Array(items[rowStart..<min(rowStart + columnCount, items.count)])
+        Array(items[rowStart..<min(rowStart + resolvedColumnCount, items.count)])
     }
 
     private func emptySlotCount(from rowStart: Int) -> Int {
-        columnCount - rowItems(from: rowStart).count
+        resolvedColumnCount - rowItems(from: rowStart).count
     }
 
     private func onCellAppear(index: Int) {
         guard hasMore else { return }
-        let threshold = items.count - (prefetchRowsRemaining * columnCount)
+        let threshold = items.count - (prefetchRowsRemaining * resolvedColumnCount)
         if index >= threshold {
             onNearEnd(index)
         }

--- a/iosApp/iosApp/tvOS/Screens/Components/TVCollectionPosterCard.swift
+++ b/iosApp/iosApp/tvOS/Screens/Components/TVCollectionPosterCard.swift
@@ -27,16 +27,22 @@ struct TVCollectionPosterCard: View {
     var focusContentId: String? = nil
 
     @FocusState private var isFocused: Bool
+    @State private var uiCustomization = UICustomizationPreferences.shared
 
     // Standard 2:3 movie-poster aspect ratio — height tracks width.
-    private var cardHeight: CGFloat { cardWidth * 1.5 }
+    private var resolvedCardWidth: CGFloat {
+        cardWidth * uiCustomization.cardPresentation.posterSize.scale
+    }
+    private var cardHeight: CGFloat { resolvedCardWidth * 1.5 }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             posterButton
-            caption
+            if uiCustomization.cardPresentation.caption.showsTitle {
+                caption
+            }
         }
-        .frame(width: cardWidth)
+        .frame(width: resolvedCardWidth)
     }
 
     private var posterButton: some View {
@@ -58,7 +64,7 @@ struct TVCollectionPosterCard: View {
             if let url = collection.posterUrl, !url.isEmpty {
                 CachedAsyncImage(
                     url: url,
-                    targetSize: CGSize(width: cardWidth, height: cardHeight),
+                    targetSize: CGSize(width: resolvedCardWidth, height: cardHeight),
                     thumbhash: collection.posterThumbhash,
                     contentMode: .fill
                 )
@@ -66,7 +72,7 @@ struct TVCollectionPosterCard: View {
                 placeholder
             }
         }
-        .frame(width: cardWidth, height: cardHeight)
+        .frame(width: resolvedCardWidth, height: cardHeight)
         .clipShape(RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius))
     }
 
@@ -102,7 +108,7 @@ struct TVCollectionPosterCard: View {
                 .truncationMode(.tail)
                 .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: isFocused)
 
-            if let countText {
+            if uiCustomization.cardPresentation.caption.showsMetadata, let countText {
                 Text(countText)
                     .font(.system(size: 18, weight: .regular))
                     .foregroundColor(.continuumSecondaryText)
@@ -110,7 +116,7 @@ struct TVCollectionPosterCard: View {
             }
         }
         .multilineTextAlignment(.center)
-        .frame(width: cardWidth, alignment: .center)
+        .frame(width: resolvedCardWidth, alignment: .center)
     }
 
     // MARK: - Derived

--- a/iosApp/iosApp/tvOS/Screens/Components/TVMediaCard.swift
+++ b/iosApp/iosApp/tvOS/Screens/Components/TVMediaCard.swift
@@ -53,14 +53,19 @@ struct TVMediaCard: View {
     @FocusState private var isFocused: Bool
     @State private var favoriteOverride: Bool?
     @State private var watchlistOverride: Bool?
+    @State private var uiCustomization = UICustomizationPreferences.shared
     @EnvironmentObject private var overlayStore: OverlayPrefsStore
+
+    private var resolvedCardWidth: CGFloat {
+        cardWidth * uiCustomization.cardPresentation.posterSize.scale
+    }
 
     private var cardHeight: CGFloat {
         switch aspect {
         case .poster:
-            cardWidth * 1.5
+            resolvedCardWidth * 1.5
         case .square:
-            cardWidth
+            resolvedCardWidth
         }
     }
 
@@ -68,9 +73,11 @@ struct TVMediaCard: View {
         VStack(alignment: .leading, spacing: 16) {
             posterButton
                 .personalListContextMenu(hasPersonalActions ? personalMenuItems : nil)
-            caption
+            if uiCustomization.cardPresentation.caption.showsTitle {
+                caption
+            }
         }
-        .frame(width: cardWidth)
+        .frame(width: resolvedCardWidth)
         .onChange(of: userState) { _, _ in
             favoriteOverride = nil
             watchlistOverride = nil
@@ -138,6 +145,8 @@ struct TVMediaCard: View {
                 .applyDefaultFocusIfNeeded(prefersDefaultFocus, namespace: defaultFocusNamespace)
                 .applyRailFocus(focusBinding, contentId: focusContentId)
                 .applyTVCardPlayPauseAction(playAction)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(accessibilityDescription)
         case .ring:
             Button(action: action) { posterImage }
                 .buttonStyle(TVPosterRingButtonStyle())
@@ -145,6 +154,8 @@ struct TVMediaCard: View {
                 .applyDefaultFocusIfNeeded(prefersDefaultFocus, namespace: defaultFocusNamespace)
                 .applyRailFocus(focusBinding, contentId: focusContentId)
                 .applyTVCardPlayPauseAction(playAction)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(accessibilityDescription)
         }
     }
 
@@ -154,15 +165,15 @@ struct TVMediaCard: View {
         ZStack(alignment: .topTrailing) {
             CachedAsyncImage(
                 url: posterUrl,
-                targetSize: CGSize(width: cardWidth, height: cardHeight),
+                targetSize: CGSize(width: resolvedCardWidth, height: cardHeight),
                 contentMode: .fill
             )
-            .frame(width: cardWidth, height: cardHeight)
+            .frame(width: resolvedCardWidth, height: cardHeight)
             .clipShape(RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius))
 
             if let overlayData, overlayStore.enabled {
                 CardOverlays(data: overlayData, prefs: overlayStore.prefs, variant: .poster)
-                    .frame(width: cardWidth, height: cardHeight)
+                    .frame(width: resolvedCardWidth, height: cardHeight)
                     .clipShape(RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius))
             }
 
@@ -171,7 +182,7 @@ struct TVMediaCard: View {
                     .padding(12)
             }
         }
-        .frame(width: cardWidth, height: cardHeight)
+        .frame(width: resolvedCardWidth, height: cardHeight)
         .overlay {
             // The `.ring` treatment supplies its own focus cue (the native
             // halo is suppressed in TVPosterRingButtonStyle), matching the
@@ -196,14 +207,15 @@ struct TVMediaCard: View {
                 .truncationMode(.tail)
                 .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: isFocused)
 
-            if let secondLine = subtitle ?? year.map(String.init) {
+            if uiCustomization.cardPresentation.caption.showsMetadata,
+               let secondLine = subtitle ?? year.map(String.init) {
                 Text(secondLine)
                     .font(.system(size: 18, weight: .regular))
                     .foregroundColor(.continuumSecondaryText)
             }
         }
         .multilineTextAlignment(.center)
-        .frame(width: cardWidth, alignment: .center)
+        .frame(width: resolvedCardWidth, alignment: .center)
     }
 
     private var watchedBadge: some View {
@@ -216,6 +228,18 @@ struct TVMediaCard: View {
                 .font(.system(size: 20, weight: .bold))
                 .foregroundColor(Color.continuumBackground)
         }
+    }
+
+    private var accessibilityDescription: String {
+        let secondLine = subtitle ?? year.map(String.init)
+        var components = [title]
+        if let secondLine {
+            components.append(secondLine)
+        }
+        if userState?.played == true {
+            components.append("Watched")
+        }
+        return components.joined(separator: ", ")
     }
 }
 

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
@@ -26,6 +26,7 @@ struct TVEpisodeRail: View {
 
     private let cardSpacing: CGFloat = 36
     @FocusState private var focusedCardId: String?
+    @State private var uiCustomization = UICustomizationPreferences.shared
 
     var body: some View {
         ScrollViewReader { proxy in
@@ -35,6 +36,8 @@ struct TVEpisodeRail: View {
                         TVEpisodeCard(
                             episode: episode,
                             isCurrent: currentContentId == episode.contentId,
+                            posterSize: uiCustomization.cardPresentation.posterSize,
+                            captionStyle: uiCustomization.cardPresentation.caption,
                             onSelect: { onSelect(episode.contentId) },
                             onSetWatched: onSetWatched,
                             initialIsFavorite: currentContentId == episode.contentId
@@ -92,6 +95,8 @@ private extension View {
 struct TVEpisodeCard: View {
     let episode: EpisodeListItem
     var isCurrent: Bool = false
+    var posterSize: CardPosterSize = .standard
+    var captionStyle: CardCaptionStyle = .titleMetadata
     let onSelect: () -> Void
     var onSetWatched: ((_ contentId: String, _ played: Bool) async -> Bool)? = nil
     var initialIsFavorite = false
@@ -100,8 +105,8 @@ struct TVEpisodeCard: View {
     @State private var playedOverride: Bool?
     @State private var favoriteOverride: Bool?
 
-    private let cardWidth: CGFloat = 460
-    private let stillHeight: CGFloat = 260
+    private var cardWidth: CGFloat { 460 * posterSize.scale }
+    private var stillHeight: CGFloat { cardWidth * 9 / 16 }
     private let stillCornerRadius: CGFloat = 10
 
     var body: some View {
@@ -112,10 +117,13 @@ struct TVEpisodeCard: View {
                 isCurrent: isCurrent,
                 cardWidth: cardWidth,
                 stillHeight: stillHeight,
-                stillCornerRadius: stillCornerRadius
+                stillCornerRadius: stillCornerRadius,
+                captionStyle: captionStyle
             )
         }
         .buttonStyle(EpisodeCardStyle())
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityDescription)
 
         Group {
             if onSetWatched != nil || onSetFavorite != nil {
@@ -140,6 +148,32 @@ struct TVEpisodeCard: View {
 
     private var isFavorite: Bool {
         favoriteOverride ?? initialIsFavorite
+    }
+
+    private var accessibilityDescription: String {
+        episodeRailAccessibilityLabel(
+            seasonNumber: episode.seasonNumber,
+            episodeNumber: episode.episodeNumber,
+            title: episode.title,
+            metadata: episodeMetadataLine,
+            isCurrent: isCurrent,
+            isPlayed: isPlayed
+        )
+    }
+
+    private var episodeMetadataLine: String? {
+        var parts: [String] = []
+        if let airDate = DetailDateFormatting.abbreviatedDate(episode.airDate) {
+            parts.append(airDate)
+        }
+        if let runtime = episode.runtime, runtime > 0 {
+            if runtime >= 60 {
+                parts.append("\(runtime / 60)h \(runtime % 60)m")
+            } else {
+                parts.append("\(runtime)m")
+            }
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: "  ·  ")
     }
 
     @ViewBuilder
@@ -187,49 +221,54 @@ private struct EpisodeCardLabel: View {
     let cardWidth: CGFloat
     let stillHeight: CGFloat
     let stillCornerRadius: CGFloat
+    let captionStyle: CardCaptionStyle
 
     @Environment(\.isFocused) private var isFocused
 
     var body: some View {
         VStack(alignment: .leading, spacing: 18) {
             still
-            VStack(alignment: .leading, spacing: 6) {
-                HStack(spacing: 10) {
-                    Text(episodeNumberLabel)
-                        .font(.system(size: 18, weight: .bold))
-                        .tracking(2.0)
-                        .foregroundColor(.continuumOnSurface.opacity(0.55))
-                    if isCurrent {
-                        nowViewingTag
+            if captionStyle.showsTitle {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 10) {
+                            Text(episodeNumberLabel)
+                                .font(.system(size: 18, weight: .bold))
+                                .tracking(2.0)
+                                .foregroundStyle(Color.continuumOnSurface.opacity(0.55))
+                        if isCurrent {
+                            nowViewingTag
+                        }
+                    }
+
+                    Text(episode.title ?? "Episode \(episode.episodeNumber)")
+                        .font(.system(size: 26, weight: .semibold))
+                        .foregroundStyle(titleColor)
+                        // Allow up to two lines for long titles, but don't reserve
+                        // the second line — a single-line title (the common case)
+                        // was leaving a full empty line of dead space above the
+                        // description.
+                        .lineLimit(2)
+
+                    if captionStyle.showsMetadata {
+                        if let metadataLine = episodeMetadataLine {
+                            Text(metadataLine)
+                                .font(.system(size: 20, weight: .medium))
+                                .foregroundStyle(Color.continuumSecondaryText)
+                                .lineLimit(1)
+                        }
+
+                        if let overview = episode.overview, !overview.isEmpty {
+                            Text(overview)
+                                .font(.system(size: 20, weight: .regular))
+                                .foregroundStyle(Color.continuumSecondaryText)
+                                .lineLimit(3, reservesSpace: true)
+                                .lineSpacing(3)
+                                .padding(.top, 4)
+                        }
                     }
                 }
-
-                Text(episode.title ?? "Episode \(episode.episodeNumber)")
-                    .font(.system(size: 26, weight: .semibold))
-                    .foregroundColor(titleColor)
-                    // Allow up to two lines for long titles, but don't reserve
-                    // the second line — a single-line title (the common case)
-                    // was leaving a full empty line of dead space above the
-                    // description.
-                    .lineLimit(2)
-
-                if let metadataLine = episodeMetadataLine {
-                    Text(metadataLine)
-                        .font(.system(size: 20, weight: .medium))
-                        .foregroundColor(.continuumSecondaryText)
-                        .lineLimit(1)
-                }
-
-                if let overview = episode.overview, !overview.isEmpty {
-                    Text(overview)
-                        .font(.system(size: 20, weight: .regular))
-                        .foregroundColor(.continuumSecondaryText)
-                        .lineLimit(3, reservesSpace: true)
-                        .lineSpacing(3)
-                        .padding(.top, 4)
-                }
+                .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: isFocused)
             }
-            .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: isFocused)
         }
         .frame(width: cardWidth, alignment: .leading)
     }

--- a/iosApp/iosApp/tvOS/Screens/Libraries/TVLibraryCollectionsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Libraries/TVLibraryCollectionsView.swift
@@ -17,6 +17,7 @@ struct TVLibraryCollectionsView: View {
 
     @State private var collectionSections: [LibraryCollectionSection] = []
     @State private var isLoadingCollections = true
+    @State private var uiCustomization = UICustomizationPreferences.shared
 
     @State private var hasPendingFocusClaim = false
     @State private var lastShellFocusRequest = 0
@@ -89,7 +90,7 @@ struct TVLibraryCollectionsView: View {
                                     spacing: ContinuumTheme.Skyline.collectionGridColumnSpacing,
                                     alignment: .top
                                 ),
-                                count: ContinuumTheme.Skyline.collectionGridColumnCount
+                                count: resolvedColumnCount
                             ),
                             alignment: .leading,
                             spacing: ContinuumTheme.Skyline.collectionGridRowSpacing
@@ -187,6 +188,15 @@ struct TVLibraryCollectionsView: View {
             collectionSections = []
         }
         isLoadingCollections = false
+    }
+
+    private var resolvedColumnCount: Int {
+        let standard = ContinuumTheme.Skyline.collectionGridColumnCount
+        switch uiCustomization.cardPresentation.posterSize {
+        case .compact: return standard + 1
+        case .standard: return standard
+        case .large: return max(3, standard - 1)
+        }
     }
 }
 

--- a/iosApp/iosApp/tvOS/Screens/Libraries/TVLibraryPillRow.swift
+++ b/iosApp/iosApp/tvOS/Screens/Libraries/TVLibraryPillRow.swift
@@ -1,5 +1,8 @@
+import Foundation
+
 #if os(tvOS)
 import SwiftUI
+#endif
 
 /// Sub-destinations of a Skyline library-type tab (§3). The on-page pill
 /// row was removed, so these are now reached only through the top-bar
@@ -31,8 +34,43 @@ enum TVLibraryPill: String, Hashable, CaseIterable {
 
     /// Sections offered for every library type (§3): Recommended (the
     /// landing default, always first) · Collections · Browse.
+    #if os(tvOS)
     static func set(for type: TVLibraryTabType) -> [TVLibraryPill] {
         allCases
     }
+    #endif
 }
-#endif
+
+enum TVLibraryMenuRootKind {
+    case category
+    case directShortcut
+    case staticRoot
+
+    var hasSectionCascade: Bool {
+        switch self {
+        case .category, .directShortcut: return true
+        case .staticRoot: return false
+        }
+    }
+}
+
+func tvCustomizationMutationIsEnabled(
+    allowsEditing: Bool,
+    usesDeviceMenuOverride: Bool,
+    changesFamilyMenu: Bool
+) -> Bool {
+    allowsEditing && (!changesFamilyMenu || !usesDeviceMenuOverride)
+}
+
+/// Direct-library roots own a separate sub-destination value, so changing a
+/// Movies/Series cascade cannot alter a pinned library's landing. The direct
+/// value defaults to Recommended but remains writable by its one-library
+/// cascade. Keeping this policy pure makes the isolation contract testable by
+/// the cross-platform unit-test target.
+func resolvedLibraryRootPill(
+    categorySelection: TVLibraryPill,
+    directSelection: TVLibraryPill?,
+    isDirectLibraryShortcut: Bool
+) -> TVLibraryPill {
+    isDirectLibraryShortcut ? (directSelection ?? .recommended) : categorySelection
+}

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVGeneralSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVGeneralSettingsView.swift
@@ -126,7 +126,10 @@ struct TVGeneralSettingsPane: View {
     }
 
     private var visibleMenuCount: Int {
-        preferences.resolvedPrimaryMenuItems(availableLibraries: libraries).count
+        TVMenuCustomizationSheet.visibleItems(
+            in: preferences.resolvedPrimaryMenuItems(),
+            libraries: libraries
+        ).count
     }
 
     @ViewBuilder
@@ -349,8 +352,21 @@ private struct TVMenuCustomizationSheet: View {
     }
 
     private var visibleItems: [PrimaryMenuItem] {
+        Self.visibleItems(
+            in: preferences.resolvedPrimaryMenuItems(),
+            libraries: libraries
+        )
+    }
+
+    static func visibleItems(
+        in items: [PrimaryMenuItem],
+        libraries: [Library]
+    ) -> [PrimaryMenuItem] {
         let availableIds = Set(libraries.map(\.id))
-        return preferences.resolvedPrimaryMenuItems(availableLibraries: libraries).filter { item in
+        func hasLibrary(_ type: TVLibraryTabType) -> Bool {
+            libraries.contains(where: { type.matches($0) })
+        }
+        return items.filter { item in
             switch item {
             case .builtin(.movies): return hasLibrary(.movies)
             case .builtin(.series): return hasLibrary(.series)

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVGeneralSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVGeneralSettingsView.swift
@@ -1,33 +1,519 @@
 #if os(tvOS)
 import SwiftUI
 
-/// General pane of tvOS Settings, rendered inline in the right pane of
-/// the two-pane `TVSettingsView`.
-///
-/// Home for app-level preferences that aren't playback or subtitles. Today
-/// that's the opt-in Audiobooks tab, and it's the natural place any future
-/// top-menu / header customization would live.
+/// Family-synced tvOS interface preferences. Every control is a native focus
+/// target; the menu editor changes data only on Select and never intercepts
+/// directional movement, preserving the stable focus graph described in
+/// `docs/tvos-focus.md`.
 struct TVGeneralSettingsPane: View {
+    @State private var preferences = UICustomizationPreferences.shared
     @State private var navPrefs = TVNavPreferences.shared
+    @State private var activePicker: PickerKind?
+    @State private var showsMenuEditor = false
+    @State private var registry = ServerRegistry.shared
+    @State private var librarySnapshot = MainTabLibrarySnapshot.cachedForCurrentAuthority()
     let detailFocus: FocusState<TVSettingsDetailFocus?>.Binding
+    @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
+            if let message = preferences.capabilityMessage {
+                TVSettingsSectionHeader("SERVER SUPPORT")
+                TVSettingsFooter(message)
+            }
+
+            if preferences.hasDeviceOverrides {
+                TVSettingsSectionHeader("SYNC SOURCE")
+                if preferences.cardPresentationUsesDeviceOverride {
+                    familySettingsButton
+                        .focused(detailFocus, equals: .top)
+                } else {
+                    familySettingsButton
+                }
+                TVSettingsFooter("This Apple TV has older device-specific settings. Clear them to use the TV-family choices shared by this profile.")
+            }
+
+            TVSettingsSectionHeader("CARDS & POSTERS")
+
+            presetRow
+
+            TVSettingsPickerRow(
+                title: "Poster Size",
+                value: preferences.cardPresentation.posterSize.title
+            ) { activePicker = .posterSize }
+            .disabled(
+                !preferences.allowsEditing
+                    || preferences.cardPresentationUsesDeviceOverride
+            )
+
+            TVSettingsPickerRow(
+                title: "Captions",
+                value: preferences.cardPresentation.caption.title
+            ) { activePicker = .caption }
+            .disabled(
+                !preferences.allowsEditing
+                    || preferences.cardPresentationUsesDeviceOverride
+            )
+
+            if preferences.cardPresentationUsesFamilyOverride {
+                Button("Use Profile Default") {
+                    preferences.resetCardPresentationToInherited()
+                }
+                .buttonStyle(TVSettingsPaneRowStyle())
+                .disabled(preferences.isSaving || !preferences.allowsEditing)
+            }
+
+            TVSettingsFooter("Start with Balanced, Compact, Cinema, or Artwork Only, then fine-tune size and captions. These choices sync with other TV-family devices on this profile.")
+
             TVSettingsSectionHeader("TOP MENU")
 
-            // Bound straight to the local store (not the settings view model):
-            // this is a device-local, per-profile preference, not one of the
-            // server-synced device settings the view model owns.
-            TVSettingsToggleRow(
-                title: "Show Audiobooks",
-                isOn: navPrefs.showAudiobooks
-            ) {
-                navPrefs.setShowAudiobooks(!navPrefs.showAudiobooks)
-            }
-            .focused(detailFocus, equals: .top)
+            if preferences.supportProjection == .knownUnsupported {
+                TVSettingsToggleRow(
+                    title: "Show Audiobooks",
+                    isOn: navPrefs.showAudiobooks
+                ) {
+                    navPrefs.setShowAudiobooks(!navPrefs.showAudiobooks)
+                }
+                .focused(detailFocus, equals: .top)
 
-            TVSettingsFooter("Adds an Audiobooks tab to the top menu when your server has an audiobook library. Hidden by default.")
+                TVSettingsFooter("This server uses the legacy device-local menu preference. Adds an Audiobooks tab when an audiobook library is available.")
+            } else {
+                Button { showsMenuEditor = true } label: {
+                    HStack(spacing: 16) {
+                        Text("Customize Top Menu")
+                            .font(.system(size: 26))
+                        Spacer(minLength: 16)
+                        Text("\(visibleMenuCount) items")
+                            .font(.system(size: 24))
+                            .opacity(0.68)
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 18, weight: .semibold))
+                            .opacity(0.55)
+                    }
+                }
+                .buttonStyle(TVSettingsPaneRowStyle())
+                .disabled(!preferences.allowsEditing)
+
+                TVSettingsFooter("Reorder or hide destinations and pin individual libraries. Search and Profile stay fixed so remote navigation always has stable anchors.")
+            }
+
+            if let message = preferences.syncErrorMessage,
+               message != preferences.capabilityMessage {
+                TVSettingsFooter(message)
+            }
         }
+        .fullScreenCover(item: $activePicker) { picker in
+            pickerSheet(for: picker)
+        }
+        .fullScreenCover(isPresented: $showsMenuEditor) {
+            TVMenuCustomizationSheet(libraries: libraries)
+        }
+        .task {
+            await preferences.refresh()
+        }
+        .task(id: currentLibraryAuthority) {
+            await refreshLibraries(for: currentLibraryAuthority)
+        }
+        .onChange(of: scenePhase) { _, phase in
+            guard phase == .active else { return }
+            let authority = currentLibraryAuthority
+            Task {
+                async let preferencesRefresh: Void = preferences.refresh()
+                async let librariesRefresh: Void = refreshLibraries(for: authority)
+                _ = await (preferencesRefresh, librariesRefresh)
+            }
+        }
+    }
+
+    private var visibleMenuCount: Int {
+        preferences.resolvedPrimaryMenuItems(availableLibraries: libraries).count
+    }
+
+    @ViewBuilder
+    private var presetRow: some View {
+        let row = TVSettingsPickerRow(
+            title: "Preset",
+            value: preferences.cardPresentation.preset?.title ?? "Custom"
+        ) { activePicker = .preset }
+
+        if preferences.cardPresentationUsesDeviceOverride || !preferences.allowsEditing {
+            row.disabled(true)
+        } else {
+            row.focused(detailFocus, equals: .top)
+        }
+    }
+
+    private var familySettingsButton: some View {
+        Button("Use Synced TV Settings") {
+            preferences.useFamilySettings()
+        }
+        .buttonStyle(TVSettingsPaneRowStyle())
+        .disabled(preferences.isSaving || !preferences.allowsEditing)
+    }
+
+    @ViewBuilder
+    private func pickerSheet(for picker: PickerKind) -> some View {
+        switch picker {
+        case .preset:
+            TVSettingsPickerSheet(
+                title: "Card Preset",
+                options: CardPresentationPreset.allCases.map {
+                    TVSettingsOption(id: $0.rawValue, label: $0.title)
+                } + (preferences.cardPresentation.preset == nil
+                    ? [TVSettingsOption(id: Self.customPresetId, label: "Custom")]
+                    : []),
+                selection: Binding(
+                    get: {
+                        preferences.cardPresentation.preset?.rawValue ?? Self.customPresetId
+                    },
+                    set: { value in
+                        guard let preset = CardPresentationPreset(rawValue: value) else { return }
+                        preferences.setCardPresentation(preset.presentation)
+                    }
+                ),
+                allowsSelection: preferences.allowsEditing,
+                disabledMessage: preferences.capabilityMessage
+            )
+        case .posterSize:
+            TVSettingsPickerSheet(
+                title: "Poster Size",
+                options: CardPosterSize.allCases.map {
+                    TVSettingsOption(id: $0.rawValue, label: $0.title)
+                },
+                selection: Binding(
+                    get: { preferences.cardPresentation.posterSize.rawValue },
+                    set: { value in
+                        guard let size = CardPosterSize(rawValue: value) else { return }
+                        preferences.setPosterSize(size)
+                    }
+                ),
+                allowsSelection: preferences.allowsEditing,
+                disabledMessage: preferences.capabilityMessage
+            )
+        case .caption:
+            TVSettingsPickerSheet(
+                title: "Card Captions",
+                options: CardCaptionStyle.allCases.map {
+                    TVSettingsOption(id: $0.rawValue, label: $0.title)
+                },
+                selection: Binding(
+                    get: { preferences.cardPresentation.caption.rawValue },
+                    set: { value in
+                        guard let style = CardCaptionStyle(rawValue: value) else { return }
+                        preferences.setCaptionStyle(style)
+                    }
+                ),
+                allowsSelection: preferences.allowsEditing,
+                disabledMessage: preferences.capabilityMessage
+            )
+        }
+    }
+
+    private enum PickerKind: String, Identifiable {
+        case preset
+        case posterSize
+        case caption
+        var id: String { rawValue }
+    }
+
+    private var currentLibraryAuthority: MainTabLibraryAuthority? {
+        MainTabLibraryAuthority(
+            serverId: registry.activeServerId,
+            profileId: registry.activeProfileId
+        )
+    }
+
+    private var libraries: [Library] {
+        librarySnapshot.availableLibraries(for: currentLibraryAuthority)
+    }
+
+    private func refreshLibraries(for authority: MainTabLibraryAuthority?) async {
+        let retained = librarySnapshot.authority == authority ? librarySnapshot.libraries : []
+        librarySnapshot = .init(authority: authority, libraries: retained)
+        guard let authority else { return }
+        do {
+            let response = try await StartupContentPrefetcher.fetchUserLibraries()
+            guard !Task.isCancelled, currentLibraryAuthority == authority else { return }
+            librarySnapshot = .init(authority: authority, libraries: response.libraries)
+        } catch {
+            // Keep the same-authority cache; a different authority already
+            // failed closed above.
+        }
+    }
+
+    private static let customPresetId = "custom"
+}
+
+private struct TVMenuCustomizationSheet: View {
+    let libraries: [Library]
+    @State private var preferences = UICustomizationPreferences.shared
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 28) {
+                    if let message = preferences.capabilityMessage {
+                        TVSettingsFooter(message)
+                    }
+
+                    if preferences.primaryMenuUsesDeviceOverride {
+                        TVSettingsFooter("This Apple TV's older device-specific menu is read-only. You can still update profile library pins below, or clear the override from General settings.")
+                    }
+
+                    sectionHeader("VISIBLE DESTINATIONS")
+
+                    VStack(spacing: 10) {
+                        ForEach(visibleItems) { item in
+                            visibleRow(item)
+                        }
+                    }
+                    .focusSection()
+                    .disabled(!familyMenuMutationsEnabled)
+
+                    if !hiddenBuiltins.isEmpty {
+                        sectionHeader("HIDDEN DESTINATIONS")
+                        VStack(spacing: 10) {
+                            ForEach(hiddenBuiltins) { item in
+                                Button {
+                                    persistVisibleItems(visibleItems + [item])
+                                } label: {
+                                    HStack(spacing: 18) {
+                                        Image(systemName: "plus.circle.fill")
+                                        Text("Show \(item.title)")
+                                        Spacer()
+                                    }
+                                    .font(.system(size: 26, weight: .medium))
+                                }
+                                .buttonStyle(TVSettingsPaneRowStyle())
+                            }
+                        }
+                        .focusSection()
+                        .disabled(!familyMenuMutationsEnabled)
+                    }
+
+                    if !availableLibraryShortcuts.isEmpty {
+                        sectionHeader("AVAILABLE LIBRARY SHORTCUTS")
+                        VStack(spacing: 10) {
+                            ForEach(availableLibraryShortcuts) { item in
+                                Button {
+                                    persistVisibleItems(visibleItems + [item])
+                                } label: {
+                                    HStack(spacing: 18) {
+                                        Image(systemName: "plus.circle.fill")
+                                        Text("Show \(item.title)")
+                                        Spacer()
+                                    }
+                                    .font(.system(size: 26, weight: .medium))
+                                }
+                                .buttonStyle(TVSettingsPaneRowStyle())
+                            }
+                        }
+                        .focusSection()
+                        .disabled(!familyMenuMutationsEnabled)
+                    }
+
+                    if !libraries.isEmpty {
+                        sectionHeader("PIN LIBRARIES")
+                        VStack(spacing: 10) {
+                            ForEach(libraries.sorted(by: librarySort)) { library in
+                                TVSettingsToggleRow(
+                                    title: library.name,
+                                    isOn: preferences.isLibraryPinned(library.id)
+                                ) {
+                                    preferences.setLibraryPinned(
+                                        library,
+                                        isPinned: !preferences.isLibraryPinned(library.id)
+                                    )
+                                }
+                            }
+                        }
+                        .focusSection()
+                        .disabled(!profilePinMutationsEnabled)
+                    }
+
+                    TVSettingsFooter("Home cannot be hidden. Pinned libraries also enter your profile shortcut catalog; their top-menu placement stays specific to TV-family devices.")
+                }
+                .frame(maxWidth: 1120, alignment: .leading)
+                .padding(.horizontal, 72)
+                .padding(.vertical, 36)
+            }
+            .navigationTitle("Customize Top Menu")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .background(Color.continuumBackground.ignoresSafeArea())
+        }
+    }
+
+    private var visibleItems: [PrimaryMenuItem] {
+        let availableIds = Set(libraries.map(\.id))
+        return preferences.resolvedPrimaryMenuItems(availableLibraries: libraries).filter { item in
+            switch item {
+            case .builtin(.movies): return hasLibrary(.movies)
+            case .builtin(.series): return hasLibrary(.series)
+            case .builtin(.music): return hasLibrary(.music)
+            case .builtin(.audiobooks): return hasLibrary(.audiobooks)
+            case .library(let id, _): return availableIds.contains(id)
+            case .section, .collection: return false
+            case .builtin(.home), .builtin(.forYou), .builtin(.calendar): return true
+            }
+        }
+    }
+
+    private var familyMenuMutationsEnabled: Bool {
+        tvCustomizationMutationIsEnabled(
+            allowsEditing: preferences.allowsEditing,
+            usesDeviceMenuOverride: preferences.primaryMenuUsesDeviceOverride,
+            changesFamilyMenu: true
+        )
+    }
+
+    private var profilePinMutationsEnabled: Bool {
+        tvCustomizationMutationIsEnabled(
+            allowsEditing: preferences.allowsEditing,
+            usesDeviceMenuOverride: preferences.primaryMenuUsesDeviceOverride,
+            changesFamilyMenu: false
+        )
+    }
+
+    private var hiddenBuiltins: [PrimaryMenuItem] {
+        let visibleIds = Set(visibleItems.map(\.id))
+        return builtinCandidates.filter { !visibleIds.contains($0.id) }
+    }
+
+    /// A profile shortcut and a TV-family menu row are separate pieces of
+    /// state. Keep a hidden pinned library pinned, while still offering an
+    /// explicit way to restore it to this TV's top menu.
+    private var availableLibraryShortcuts: [PrimaryMenuItem] {
+        let visibleIds = Set(visibleItems.map(\.id))
+        let availableLibraryIds = Set(libraries.map(\.id))
+        return preferences.shortcuts.items.filter { item in
+            guard case .library(let libraryId, _) = item else { return false }
+            return availableLibraryIds.contains(libraryId) && !visibleIds.contains(item.id)
+        }
+    }
+
+    private var builtinCandidates: [PrimaryMenuItem] {
+        var items: [PrimaryMenuItem] = [.builtin(.home)]
+        for type in TVLibraryTabType.allCases where hasLibrary(type) {
+            let builtin: PrimaryMenuBuiltin
+            switch type {
+            case .movies: builtin = .movies
+            case .series: builtin = .series
+            case .music: builtin = .music
+            case .audiobooks: builtin = .audiobooks
+            }
+            items.append(.builtin(builtin))
+        }
+        items.append(contentsOf: [.builtin(.forYou), .builtin(.calendar)])
+        return items
+    }
+
+    private func visibleRow(_ item: PrimaryMenuItem) -> some View {
+        let index = visibleItems.firstIndex(where: { $0.id == item.id }) ?? 0
+        return HStack(spacing: 12) {
+            Text(item.title)
+                .font(.system(size: 26, weight: .medium))
+                .lineLimit(1)
+            Spacer(minLength: 12)
+
+            Button {
+                move(item, by: -1)
+            } label: {
+                Image(systemName: "arrow.up")
+                    .frame(width: 44, height: 44)
+            }
+            .buttonStyle(.bordered)
+            .disabled(index == 0)
+            .accessibilityLabel("Move \(item.title) earlier")
+
+            Button {
+                move(item, by: 1)
+            } label: {
+                Image(systemName: "arrow.down")
+                    .frame(width: 44, height: 44)
+            }
+            .buttonStyle(.bordered)
+            .disabled(index == visibleItems.count - 1)
+            .accessibilityLabel("Move \(item.title) later")
+
+            if !item.isHome {
+                Button {
+                    hide(item)
+                } label: {
+                    Image(systemName: "eye.slash")
+                        .frame(width: 44, height: 44)
+                }
+                .buttonStyle(.bordered)
+                .accessibilityLabel("Hide \(item.title)")
+            }
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(Color.continuumChromeRestingFill)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .strokeBorder(Color.continuumChromeRestingBorder, lineWidth: 1)
+        }
+    }
+
+    private func move(_ item: PrimaryMenuItem, by offset: Int) {
+        var items = visibleItems
+        guard let index = items.firstIndex(where: { $0.id == item.id }) else { return }
+        let target = index + offset
+        guard items.indices.contains(target) else { return }
+        items.swapAt(index, target)
+        persistVisibleItems(items)
+    }
+
+    private func hide(_ item: PrimaryMenuItem) {
+        guard !item.isHome else { return }
+        persistVisibleItems(visibleItems.filter { $0.id != item.id })
+    }
+
+    /// Weave the edited, focus-visible rows back through the complete synced
+    /// menu. Section/collection targets and temporarily unavailable libraries
+    /// are not renderable roots on Apple TV yet, but must survive an unrelated
+    /// reorder so another TV-family client does not lose them.
+    private func persistVisibleItems(_ updatedVisibleItems: [PrimaryMenuItem]) {
+        let currentlyVisibleIds = Set(visibleItems.map(\.id))
+        var replacements = updatedVisibleItems.makeIterator()
+        var result: [PrimaryMenuItem] = []
+
+        for item in preferences.resolvedPrimaryMenuItems() {
+            if currentlyVisibleIds.contains(item.id) {
+                if let replacement = replacements.next() {
+                    result.append(replacement)
+                }
+            } else {
+                result.append(item)
+            }
+        }
+        while let remaining = replacements.next() {
+            result.append(remaining)
+        }
+        preferences.setPrimaryMenuItems(result)
+    }
+
+    private func hasLibrary(_ type: TVLibraryTabType) -> Bool {
+        libraries.contains(where: { type.matches($0) })
+    }
+
+    private func librarySort(_ lhs: Library, _ rhs: Library) -> Bool {
+        (lhs.sortOrder ?? Int.max, lhs.id) < (rhs.sortOrder ?? Int.max, rhs.id)
+    }
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(.system(size: 15, weight: .semibold, design: .monospaced))
+            .tracking(2)
+            .foregroundStyle(Color.continuumSecondaryText)
     }
 }
 #endif

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsComponents.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsComponents.swift
@@ -513,6 +513,8 @@ struct TVSettingsPickerSheet: View {
     let options: [TVSettingsOption]
     @Binding var selection: String
     var subtitlePreviewAppearance: SubtitleAppearance? = nil
+    var allowsSelection = true
+    var disabledMessage: String? = nil
 
     @Environment(\.dismiss) private var dismiss
     @FocusState private var focusedOptionID: String?
@@ -520,6 +522,10 @@ struct TVSettingsPickerSheet: View {
     var body: some View {
         NavigationStack {
             VStack(spacing: 18) {
+                if let disabledMessage {
+                    TVSettingsFooter(disabledMessage)
+                }
+
                 if let subtitlePreviewAppearance {
                     TVSettingsSubtitlePreview(
                         appearance: previewAppearance(from: subtitlePreviewAppearance)
@@ -545,6 +551,18 @@ struct TVSettingsPickerSheet: View {
                     }
                     .scrollIndicators(options.count > 8 ? .automatic : .hidden)
                     .onAppear {
+                        guard allowsSelection else {
+                            focusedOptionID = nil
+                            return
+                        }
+                        focusSelection()
+                        scrollToFocusedOption(with: proxy, animated: false)
+                    }
+                    .onChange(of: allowsSelection) { _, enabled in
+                        guard enabled else {
+                            focusedOptionID = nil
+                            return
+                        }
                         focusSelection()
                         scrollToFocusedOption(with: proxy, animated: false)
                     }
@@ -555,6 +573,7 @@ struct TVSettingsPickerSheet: View {
                         scrollToFocusedOption(with: proxy)
                     }
                 }
+                .disabled(!allowsSelection)
             }
             .frame(maxWidth: 960)
             .navigationTitle(title)
@@ -563,7 +582,7 @@ struct TVSettingsPickerSheet: View {
         }
         .focusSection()
         .onChange(of: focusedOptionID) { _, value in
-            if value == nil {
+            if allowsSelection, value == nil {
                 focusSelection()
             }
         }
@@ -584,6 +603,7 @@ struct TVSettingsPickerSheet: View {
     }
 
     private func scrollToFocusedOption(with proxy: ScrollViewProxy, animated: Bool = true) {
+        guard allowsSelection else { return }
         let targetID = focusedOptionID ?? options.first { $0.id == selection }?.id ?? options.first?.id
         guard let targetID else { return }
         if animated {


### PR DESCRIPTION
## Problem

Part of [Silo-Server/silo-server#376](https://github.com/Silo-Server/silo-server/issues/376).

Apple clients had fixed navigation and card presentation, and their preferences could not follow a profile across like devices.

Depends on [Silo-Server/silo-server#538](https://github.com/Silo-Server/silo-server/pull/538).

## Approach

- Add revision-5 settings support for client-family navigation, profile-wide shortcuts, and card presentation.
- Add Balanced, Compact, Cinema, and Artwork Only presets plus title/metadata visibility and poster sizing across shared card/grid surfaces.
- Add a customization editor for iOS/macOS and a focus-safe tvOS editor/top menu with reorder, visibility, library, section, and collection destinations.
- Bind durable settings/outbox work to captured server, account, profile, PIN, and client-family authority across refreshes and identity transitions.
- Serialize server, sign-in, sign-out, pairing, remote-control, and refresh transitions so requests and persisted credentials cannot cross account or server generations.
- Preserve backward-compatible legacy behavior when the connected server does not advertise revision-5/atomic shortcut capabilities.

## Validation

- Settings-contract fixtures are byte-identical to server commit `5e185e6e592613fb84529e192ce13c7551374ff1`.
- XCTest passes 150/150 combined customization, settings-contract, auth-transition, pairing, diagnostics, and persistence tests with no failures or skips.
- iOS Simulator, tvOS Simulator, and macOS builds pass with task-scoped NVMe DerivedData.
- `git diff --check` passes.
- The required external autoreview ran successfully during review closeout; its two accepted refresh/reachability findings were fixed and covered by regression tests. A later scoped rerun returned clean. The final aggregate rerun failed closed before engine invocation because the added XCTest fixtures exercise `accessToken`/`refreshToken` fields and match its secret-like-content scanner; no exclusion or bypass was used. Independent fixed-point reviews found no remaining in-scope P1/P2 issues after the final teardown and sign-out fixes.

Build success is not physical Apple TV remote proof. The tvOS implementation uses the documented stable focus graph, but no physical D-pad runtime session was available for this PR.

### AI Disclosure

- Tool(s): OpenAI Codex
- Model(s): gpt-5.6-sol
- Involvement: fully AI-generated
- Adversarial review: findings were verified and resolved across authority capture, temporary/persistent refresh routing, durable outbox reconciliation, capability downgrade behavior, collision-free shortcut identity, per-destination routing, item limits, tvOS focus/navigation state, generation-safe temporary teardown, and refusal-aware sign-out navigation.

## Checklist

- [x] I ran focused tests and all affected Apple platform builds.
- [x] I verified the vendored contract against the exact server commit.
- [x] I ran the required adversarial autoreview closeout and documented its fail-closed scanner disposition above.
