### PR TITLE
fix(player): stop same-owner origin retarget churn

### DIFF
--- a/iosApp/Tests/PlaybackOriginStreamPolicyTests.swift
+++ b/iosApp/Tests/PlaybackOriginStreamPolicyTests.swift
@@ -129,18 +129,69 @@ final class PlaybackWindowClaimPolicyTests: XCTestCase {
 
     func testUnownedWindowGrantsAnyClaim() {
         XCTAssertEqual(
-            PlaybackWindowClaimPolicy.arbitrate(claimant: rival, owner: nil, ownerIsAlive: false),
+            PlaybackWindowClaimPolicy.arbitrate(
+                claimant: rival,
+                owner: nil,
+                ownerIsAlive: false,
+                demandOffset: 10,
+                windowCursor: 20
+            ),
             .retarget
         )
         XCTAssertEqual(
-            PlaybackWindowClaimPolicy.arbitrate(claimant: nil, owner: nil, ownerIsAlive: false),
+            PlaybackWindowClaimPolicy.arbitrate(
+                claimant: nil,
+                owner: nil,
+                ownerIsAlive: false,
+                demandOffset: 10,
+                windowCursor: 20
+            ),
             .retarget
         )
     }
 
-    func testOwnerReclaimsItsOwnWindow() {
+    func testOwnerMayAdvanceItsOwnWindow() {
         XCTAssertEqual(
-            PlaybackWindowClaimPolicy.arbitrate(claimant: owner, owner: owner, ownerIsAlive: true),
+            PlaybackWindowClaimPolicy.arbitrate(
+                claimant: owner,
+                owner: owner,
+                ownerIsAlive: true,
+                demandOffset: 100,
+                windowCursor: 20
+            ),
+            .retarget
+        )
+    }
+
+    func testOwnerUsesChunkForNearbyBehindWindowMiss() {
+        // Origin bytes can land between the response's cache check and its
+        // window claim. Re-anchoring for this tiny behind-cursor race caused
+        // the production 1-2 second cancellation loop.
+        XCTAssertEqual(
+            PlaybackWindowClaimPolicy.arbitrate(
+                claimant: owner,
+                owner: owner,
+                ownerIsAlive: true,
+                demandOffset: 10,
+                windowCursor: 50
+            ),
+            .chunk(.sameOwnerBehindWindow)
+        )
+    }
+
+    func testOwnerReanchorsWhenFarBehindProductiveWindow() {
+        // A sequential reader can lag after finite-cache eviction. Discrete
+        // fallback is deliberately bounded to one chunk so that reader can
+        // reclaim the streaming connection instead of becoming RTT-bound.
+        let cursor = PlaybackWindowClaimPolicy.sameOwnerChunkBehindBytes + 100
+        XCTAssertEqual(
+            PlaybackWindowClaimPolicy.arbitrate(
+                claimant: owner,
+                owner: owner,
+                ownerIsAlive: true,
+                demandOffset: 0,
+                windowCursor: cursor
+            ),
             .retarget
         )
     }
@@ -150,12 +201,24 @@ final class PlaybackWindowClaimPolicyTests: XCTestCase {
         // retargeting the window, cancelling each other's origin connection
         // every 1-2s. The rival must be served by a chunk instead.
         XCTAssertEqual(
-            PlaybackWindowClaimPolicy.arbitrate(claimant: rival, owner: owner, ownerIsAlive: true),
-            .chunk
+            PlaybackWindowClaimPolicy.arbitrate(
+                claimant: rival,
+                owner: owner,
+                ownerIsAlive: true,
+                demandOffset: 100,
+                windowCursor: 20
+            ),
+            .chunk(.liveOwnerConflict)
         )
         XCTAssertEqual(
-            PlaybackWindowClaimPolicy.arbitrate(claimant: nil, owner: owner, ownerIsAlive: true),
-            .chunk
+            PlaybackWindowClaimPolicy.arbitrate(
+                claimant: nil,
+                owner: owner,
+                ownerIsAlive: true,
+                demandOffset: 100,
+                windowCursor: 20
+            ),
+            .chunk(.liveOwnerConflict)
         )
     }
 
@@ -163,9 +226,54 @@ final class PlaybackWindowClaimPolicyTests: XCTestCase {
         // A seek closes the old serve connection and opens a new one; the
         // new consumer must be able to re-anchor immediately.
         XCTAssertEqual(
-            PlaybackWindowClaimPolicy.arbitrate(claimant: rival, owner: owner, ownerIsAlive: false),
+            PlaybackWindowClaimPolicy.arbitrate(
+                claimant: rival,
+                owner: owner,
+                ownerIsAlive: false,
+                demandOffset: 10,
+                windowCursor: 50
+            ),
             .retarget
         )
+    }
+
+    func testRepeatedBehindMissesDoNotRetargetTheLiveOwner() {
+        // Model the live simulator trace: the origin advances productively
+        // while a cache-check/storage race leaves the same response only
+        // kilobytes behind it. Those nearby misses must never cancel the
+        // warm request.
+        var windowCursor: Int64 = 64 * 1024 * 1024
+        var retargetCount = 0
+        var chunkCount = 0
+        let deliveredPerInterval: [Int64] = [
+            23_709_456,
+            16_391_800,
+            14_292_744,
+        ]
+
+        for cycle in 0..<48 {
+            let delivered = deliveredPerInterval[cycle % deliveredPerInterval.count]
+            windowCursor += delivered
+            let demandOffset = windowCursor - 64 * 1024
+            let verdict = PlaybackWindowClaimPolicy.arbitrate(
+                claimant: owner,
+                owner: owner,
+                ownerIsAlive: true,
+                demandOffset: demandOffset,
+                windowCursor: windowCursor
+            )
+            switch verdict {
+            case .retarget:
+                retargetCount += 1
+                windowCursor = demandOffset
+            case .chunk(let reason):
+                XCTAssertEqual(reason, .sameOwnerBehindWindow)
+                chunkCount += 1
+            }
+        }
+
+        XCTAssertEqual(retargetCount, 0)
+        XCTAssertEqual(chunkCount, 48)
     }
 }
 

--- a/iosApp/Tests/PlaybackSourceProxyThroughputTests.swift
+++ b/iosApp/Tests/PlaybackSourceProxyThroughputTests.swift
@@ -18,15 +18,19 @@ final class PlaybackSourceProxyThroughputTests: XCTestCase {
     private final class StubOrigin {
         let listener: NWListener
         let totalBytes: Int64
+        let responseDelay: TimeInterval
         private(set) var port: UInt16 = 0
         private let queue = DispatchQueue(label: "stub-origin")
         private var connections: [ObjectIdentifier: NWConnection] = [:]
         private let lock = NSLock()
         /// Range request offsets observed, in arrival order.
         private(set) var requestedOffsets: [Int64] = []
+        /// Raw byte-range specs (for example `0-4194303` or `8388608-`).
+        private var requestedRanges: [String] = []
 
-        init(totalBytes: Int64) throws {
+        init(totalBytes: Int64, responseDelay: TimeInterval = 0) throws {
             self.totalBytes = totalBytes
+            self.responseDelay = responseDelay
             let params = NWParameters.tcp
             params.allowLocalEndpointReuse = true
             params.requiredLocalEndpoint = NWEndpoint.hostPort(host: .ipv4(.loopback), port: .any)
@@ -70,6 +74,12 @@ final class PlaybackSourceProxyThroughputTests: XCTestCase {
             open.forEach { $0.cancel() }
         }
 
+        func observedRanges() -> [String] {
+            lock.lock()
+            defer { lock.unlock() }
+            return requestedRanges
+        }
+
         private func accept(_ connection: NWConnection) {
             lock.lock()
             connections[ObjectIdentifier(connection)] = connection
@@ -97,10 +107,12 @@ final class PlaybackSourceProxyThroughputTests: XCTestCase {
         private func respond(_ connection: NWConnection, request: String) {
             var offset: Int64 = 0
             var end: Int64 = totalBytes - 1
+            var requestedRange = "0-"
             for line in request.split(separator: "\r\n") {
                 let lower = line.lowercased()
                 if lower.hasPrefix("range:"), let eq = line.range(of: "bytes=") {
                     let spec = line[eq.upperBound...]
+                    requestedRange = String(spec)
                     let parts = spec.split(separator: "-", omittingEmptySubsequences: false)
                     offset = parts.first.flatMap { Int64($0) } ?? 0
                     if parts.count > 1, let bounded = Int64(parts[1]) {
@@ -110,12 +122,21 @@ final class PlaybackSourceProxyThroughputTests: XCTestCase {
             }
             lock.lock()
             requestedOffsets.append(offset)
+            requestedRanges.append(requestedRange)
             lock.unlock()
             let remaining = end - offset + 1
             let header = "HTTP/1.1 206 Partial Content\r\nContent-Range: bytes \(offset)-\(end)/\(totalBytes)\r\nContent-Length: \(remaining)\r\nContent-Type: application/octet-stream\r\nConnection: close\r\n\r\n"
-            connection.send(content: Data(header.utf8), completion: .contentProcessed { [weak self] _ in
-                self?.sendBody(connection, remaining: remaining)
-            })
+            let sendResponse = { [weak self] in
+                connection.send(content: Data(header.utf8), completion: .contentProcessed { [weak self] error in
+                    guard error == nil else { return }
+                    self?.sendBody(connection, remaining: remaining)
+                })
+            }
+            if responseDelay > 0 {
+                queue.asyncAfter(deadline: .now() + responseDelay, execute: sendResponse)
+            } else {
+                sendResponse()
+            }
         }
 
         private static let bodyChunk = Data(count: 256 * 1024)
@@ -233,6 +254,46 @@ final class PlaybackSourceProxyThroughputTests: XCTestCase {
         // loopback should clear that by an order of magnitude. This is a
         // diagnostic floor, not a performance target.
         XCTAssertGreaterThan(rate, 100, "proxy sequential serve path is the ingest bottleneck")
+    }
+
+    func testProxyKeepsStreamingAfter150MillisecondOriginDelay() async throws {
+        let origin = try StubOrigin(
+            totalBytes: Self.fileSize,
+            responseDelay: 0.150
+        )
+        try await origin.start()
+        defer { origin.stop() }
+
+        let proxy = PlaybackSourceProxy(originURL: origin.url, originHeaders: [:])
+        try await proxy.start()
+        defer { proxy.stop() }
+        proxy.startPrefetch(at: 0)
+        let localURL = try XCTUnwrap(proxy.localURL)
+
+        let target: Int64 = 64 * 1024 * 1024
+        let reader = ThroughputReader(target: target, deadline: Self.readDeadline)
+        let (bytes, seconds) = reader.measure(url: localURL, testCase: self)
+        let rate = mbps(bytes, seconds)
+        let ranges = origin.observedRanges()
+        let openEndedWindows = ranges.filter { $0.hasSuffix("-") }
+        print(
+            "[THROUGHPUT] delayed-origin latency=150ms bytes=\(bytes) "
+                + "seconds=\(String(format: "%.2f", seconds)) "
+                + "rate=\(String(format: "%.1f", rate))Mbps ranges=\(ranges)"
+        )
+
+        XCTAssertGreaterThanOrEqual(bytes, target, "delayed origin starved the sequential reader")
+        XCTAssertEqual(
+            openEndedWindows.count,
+            1,
+            "sequential delivery reopened its streaming window under latency: \(ranges)"
+        )
+        XCTAssertLessThanOrEqual(
+            ranges.count,
+            4,
+            "sequential delivery fell back to RTT-bound discrete reads: \(ranges)"
+        )
+        XCTAssertGreaterThan(rate, 80, "150 ms request latency collapsed steady-state throughput")
     }
 
     /// AE-parity churn regression: random-access probe reads (mkv head,

--- a/iosApp/iosApp/Screens/Player/PlaybackSourceOriginStream.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSourceOriginStream.swift
@@ -62,21 +62,50 @@ enum PlaybackOriginRoutingPolicy {
 /// 2026-07-29: an origin cancel + fresh range request every 1–2 s, each
 /// discarding 10–30 MB of delivered bytes). The window belongs to one serve
 /// connection at a time; a contested claim is served by a discrete chunk,
-/// which never disturbs the window. Ownership frees when the owning serve
-/// connection ends, so an ordinary seek (close + new connection) still
-/// re-anchors immediately.
+/// which never disturbs the window. A live owner's miss just behind the
+/// productive cursor is also served discretely: this is commonly the race
+/// where origin storage lands between the response's cache check and claim.
+/// That diversion is bounded to one chunk's distance. A farther-behind owner
+/// may re-anchor so cache eviction or reader lag cannot strand sequential
+/// playback on RTT-bound chunks. Ownership frees when the owning serve
+/// connection ends, so a new response created by an ordinary seek can still
+/// re-anchor immediately.
 enum PlaybackWindowClaimPolicy {
+    /// A nearby miss costs at most one discrete fetch. Beyond this distance,
+    /// preserving the ahead window would make a lagging sequential reader
+    /// issue an unbounded series of RTT-bound chunk requests.
+    static let sameOwnerChunkBehindBytes = PlaybackOriginRoutingPolicy.chunkBytes
+
+    enum ChunkReason: String, Equatable {
+        /// Another live response owns the streaming window.
+        case liveOwnerConflict = "live_owner_conflict"
+        /// The owning response missed just behind the productive cursor.
+        case sameOwnerBehindWindow = "same_owner_behind_window"
+    }
+
     enum Verdict: Equatable {
         /// The claimant may re-anchor (or spawn) the window.
         case retarget
-        /// A live owner holds the window; serve this demand with a chunk.
-        case chunk
+        /// Preserve the productive window and serve this demand discretely.
+        case chunk(ChunkReason)
     }
 
-    static func arbitrate(claimant: UUID?, owner: UUID?, ownerIsAlive: Bool) -> Verdict {
+    static func arbitrate(
+        claimant: UUID?,
+        owner: UUID?,
+        ownerIsAlive: Bool,
+        demandOffset: Int64,
+        windowCursor: Int64?
+    ) -> Verdict {
         guard let owner, ownerIsAlive else { return .retarget }
-        guard let claimant else { return .chunk }
-        return claimant == owner ? .retarget : .chunk
+        guard let claimant else { return .chunk(.liveOwnerConflict) }
+        guard claimant == owner else { return .chunk(.liveOwnerConflict) }
+        if let windowCursor,
+           demandOffset < windowCursor,
+           windowCursor - demandOffset <= sameOwnerChunkBehindBytes {
+            return .chunk(.sameOwnerBehindWindow)
+        }
+        return .retarget
     }
 }
 

--- a/iosApp/iosApp/Screens/Player/PlaybackSourceProxy.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSourceProxy.swift
@@ -745,6 +745,11 @@ private final class PlaybackSourceResource {
     /// completion fires. Guarded by `stateLock`.
     private var serveTasks: [UUID: Task<Void, Never>] = [:]
     private var completedServeTaskIDs: Set<UUID> = []
+    /// A peer may close after `handle` publishes its serve id but before the
+    /// newly-created task reaches `registerServeTask`. Remember that close so
+    /// registration cancels the task instead of installing a dead reader that
+    /// can retain window ownership indefinitely.
+    private var closedServeTaskIDs: Set<UUID> = []
     /// Serve connections currently inside their response loop, keyed by the
     /// same id as `serveTasks`. Inserted before the task body can run so
     /// window-claim arbitration always sees a live claimant.
@@ -808,6 +813,7 @@ private final class PlaybackSourceResource {
         let serving = serveTasks
         serveTasks.removeAll()
         completedServeTaskIDs.removeAll()
+        closedServeTaskIDs.removeAll()
         activeServeIDs.removeAll()
         serveIDsByConnection.removeAll()
         windowOwnerServeID = nil
@@ -1056,8 +1062,17 @@ private final class PlaybackSourceResource {
     private func registerServeTask(_ task: Task<Void, Never>, id: UUID) {
         var cancelNow = false
         stateLock.lock()
-        if completedServeTaskIDs.remove(id) != nil {
+        let completedBeforeRegistration = completedServeTaskIDs.remove(id) != nil
+        let closedBeforeRegistration = closedServeTaskIDs.remove(id) != nil
+        if completedBeforeRegistration {
             // Finished before registration — nothing to track.
+        } else if closedBeforeRegistration {
+            // Track before cancelling so serveTaskFinished removes this id
+            // through the ordinary registered-task path. Cancelling an
+            // untracked task here would make completion publish a tombstone
+            // after registration had already consumed its only reader.
+            serveTasks[id] = task
+            cancelNow = true
         } else if cancelled || sourceEntityInvalidated {
             cancelNow = true
         } else {
@@ -1094,7 +1109,11 @@ private final class PlaybackSourceResource {
         var toCancel: Task<Void, Never>?
         stateLock.lock()
         if let id = serveIDsByConnection.removeValue(forKey: key) {
-            toCancel = serveTasks[id]
+            if let task = serveTasks[id] {
+                toCancel = task
+            } else if !completedServeTaskIDs.contains(id) {
+                closedServeTaskIDs.insert(id)
+            }
         }
         stateLock.unlock()
         toCancel?.cancel()
@@ -1299,7 +1318,9 @@ private final class PlaybackSourceResource {
             switch PlaybackWindowClaimPolicy.arbitrate(
                 claimant: serveID,
                 owner: windowOwnerServeID,
-                ownerIsAlive: ownerIsAlive
+                ownerIsAlive: ownerIsAlive,
+                demandOffset: offset,
+                windowCursor: cursor
             ) {
             case .retarget:
                 windowOwnerServeID = serveID
@@ -1315,9 +1336,9 @@ private final class PlaybackSourceResource {
                     cache.beginOriginRequest()
                     toStart = stream
                 }
-            case .chunk:
+            case .chunk(let reason):
                 Self.logger.info(
-                    "[CMP-SOURCE-CACHE] window claim contested offset=\(offset, privacy: .public) served=\(servedSequentialBytes, privacy: .public) routed=chunk"
+                    "[CMP-SOURCE-CACHE] window claim diverted reason=\(reason.rawValue, privacy: .public) offset=\(offset, privacy: .public) cursor=\(cursor ?? -1, privacy: .public) served=\(servedSequentialBytes, privacy: .public) routed=chunk"
                 )
                 chunk = true
                 deferChunkUntilEntityKnown = resumeCapable && sourceEntityETag == nil


### PR DESCRIPTION
## Summary

- Prevent a live window owner from re-anchoring the origin for a cache miss that is only one 4 MiB chunk behind the productive cursor.
- Keep the fallback bounded: a farther-lagging sequential owner may still re-anchor, so cache eviction cannot strand playback on RTT-bound chunk reads.
- Reconcile the connection-close-before-task-registration race so a dead serve response cannot retain window ownership.
- Add focused ownership, repeated-miss, lifecycle-race, and 150 ms delayed-origin coverage.

Follow-up to #115.

## Root cause

#115 stopped different live serve connections from stealing the streaming window, but the current owner could still retarget it on every qualified cache miss.

During direct-original 1080p playback in the tvOS simulator, the cache check repeatedly lost a small race with the productive origin write: eight same-owner claims arrived only 4-16 KiB behind the sampled window cursor. Before this change, each claim was permitted to cancel and reopen the warm origin request.

Nearby behind-window misses now use one bounded discrete chunk instead. The limit is intentionally one chunk (4 MiB); if the owner falls farther behind, it can reclaim the streaming window rather than degrading into an unbounded sequence of request-latency-bound reads.

## Validation

- 34 focused XCTest cases passed on the iPhone 17 Pro simulator (0 failures).
- The 150 ms delayed-origin test transferred 67,371,008 bytes through one open-ended origin range (`0-`) with no window reopen.
- In live tvOS Simulator playback, the direct-original 1080p MKV advanced for about 50 seconds without a playback stall after the near-behind claims were diverted.
- Final autoreview: clean, with no accepted/actionable findings. An initial review finding about unbounded lag was accepted and fixed by adding the one-chunk bound plus far-lag re-anchor coverage.

## Follow-up validation

- [ ] Test a high-bitrate direct-original 1080p source on physical Apple TV hardware.
- [ ] Repeat with a real 150 ms+ network path and confirm the server no longer sees the 1-2 second `client_gone` cancellation cadence.

The high-bitrate 1080p files available in the simulator session were selected for server HLS compatibility delivery, so they did not exercise this loopback source-proxy path and are not claimed as validation here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback recovery when streaming windows fall slightly behind, reducing unnecessary cancellations and retargeting.
  * Added smarter re-anchoring for readers that fall significantly behind the available content.
  * Prevented closed connections from leaving playback tasks active indefinitely.
  * Improved handling of delayed streaming responses and bounded range requests.

* **Reliability**
  * Added coverage for extended playback scenarios, including variable delivery rates and repeated behind-window misses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->