### PR TITLE
Fix system subtitle appearance matching

### DIFF
--- a/iosApp/Tests/SystemCaptionAppearanceTests.swift
+++ b/iosApp/Tests/SystemCaptionAppearanceTests.swift
@@ -91,4 +91,14 @@ final class SystemCaptionAppearanceTests: XCTestCase {
             XCTFail("grayscale conversion failed")
         }
     }
+
+    func testContentFallbackBehaviorStillUsesSystemValueWhenMatchingDeviceSettings() {
+        XCTAssertEqual(
+            SystemCaptionAppearance.valueForMatchingDeviceSettings(
+                MACaptionAppearanceTextEdgeStyle.uniform,
+                behavior: .useContentIfAvailable
+            ),
+            .uniform
+        )
+    }
 }

--- a/iosApp/Tests/SystemCaptionAppearanceTests.swift
+++ b/iosApp/Tests/SystemCaptionAppearanceTests.swift
@@ -24,6 +24,29 @@ final class SystemCaptionAppearanceTests: XCTestCase {
         XCTAssertEqual(mapped.backgroundColor, "#123456")
     }
 
+    func testWindowOpacityMapsToBox() {
+        var snapshot = SystemCaptionAppearance.Snapshot()
+        snapshot.windowOpacity = 0.5
+        snapshot.windowColorHex = "#ff00ff"
+
+        let mapped = SystemCaptionAppearance.appearance(from: snapshot)
+        XCTAssertEqual(mapped.backgroundStyle, .box)
+        XCTAssertEqual(mapped.backgroundOpacity, 50)
+        XCTAssertEqual(mapped.backgroundColor, "#ff00ff")
+    }
+
+    func testWindowTakesPrecedenceOverGlyphBackground() {
+        var snapshot = SystemCaptionAppearance.Snapshot()
+        snapshot.backgroundOpacity = 0.8
+        snapshot.backgroundColorHex = "#000000"
+        snapshot.windowOpacity = 0.5
+        snapshot.windowColorHex = "#ff00ff"
+
+        let mapped = SystemCaptionAppearance.appearance(from: snapshot)
+        XCTAssertEqual(mapped.backgroundOpacity, 50)
+        XCTAssertEqual(mapped.backgroundColor, "#ff00ff")
+    }
+
     func testZeroBackgroundOpacityRemovesBackground() {
         var snapshot = SystemCaptionAppearance.Snapshot()
         snapshot.backgroundOpacity = 0

--- a/iosApp/iosApp/Screens/Player/Subtitles/SystemCaptionAppearance.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SystemCaptionAppearance.swift
@@ -6,9 +6,12 @@
 //  Accessibility → Subtitles & Captioning) onto `SubtitleAppearance` so
 //  the player can offer a "match device settings" appearance source.
 //
-//  Only fields the user actually customized (behavior == .useValue) are
-//  taken from the system; everything else keeps the Silo default, which
-//  mirrors how AVPlayer applies these preferences to its own captions.
+//  Every value returned by MediaAccessibility participates in the mapped
+//  appearance. Apple's `.useContentIfAvailable` behavior still requires the
+//  returned value when content does not supply one. Silo-controlled text
+//  tracks intentionally have no competing authored style while "Match Device
+//  Settings" is enabled, so dropping those fallback values would replace the
+//  selected system profile with Silo's defaults.
 //
 
 import CoreGraphics
@@ -18,10 +21,9 @@ import MediaAccessibility
 
 enum SystemCaptionAppearance {
 
-    /// Raw values read from MediaAccessibility. `nil` means the user did
-    /// not customize that field (behavior was `.useContentIfAvailable`).
-    /// Split from the mapping so tests can exercise the mapping without
-    /// touching the process-wide accessibility state.
+    /// Raw values read from MediaAccessibility. `nil` means the framework did
+    /// not provide a value Silo can map. Split from the mapping so tests can
+    /// exercise the mapping without touching process-wide accessibility state.
     struct Snapshot: Equatable {
         var foregroundColorHex: String?
         var backgroundColorHex: String?
@@ -48,45 +50,70 @@ enum SystemCaptionAppearance {
         var behavior = MACaptionAppearanceBehavior.useValue
 
         let foreground = MACaptionAppearanceCopyForegroundColor(.user, &behavior).takeRetainedValue()
-        if behavior == .useValue {
-            result.foregroundColorHex = hexString(from: foreground)
+        if let foregroundHex = hexString(from: foreground) {
+            result.foregroundColorHex = valueForMatchingDeviceSettings(
+                foregroundHex,
+                behavior: behavior
+            )
         }
 
         behavior = .useValue
         let background = MACaptionAppearanceCopyBackgroundColor(.user, &behavior).takeRetainedValue()
-        if behavior == .useValue {
-            result.backgroundColorHex = hexString(from: background)
+        if let backgroundHex = hexString(from: background) {
+            result.backgroundColorHex = valueForMatchingDeviceSettings(
+                backgroundHex,
+                behavior: behavior
+            )
         }
 
         behavior = .useValue
         let backgroundOpacity = MACaptionAppearanceGetBackgroundOpacity(.user, &behavior)
-        if behavior == .useValue {
-            result.backgroundOpacity = Double(backgroundOpacity)
-        }
+        result.backgroundOpacity = valueForMatchingDeviceSettings(
+            Double(backgroundOpacity),
+            behavior: behavior
+        )
 
         behavior = .useValue
         let edge = MACaptionAppearanceGetTextEdgeStyle(.user, &behavior)
-        if behavior == .useValue {
-            result.edgeStyle = edge
-        }
+        result.edgeStyle = valueForMatchingDeviceSettings(edge, behavior: behavior)
 
         behavior = .useValue
         let size = MACaptionAppearanceGetRelativeCharacterSize(.user, &behavior)
-        if behavior == .useValue {
-            result.relativeCharacterSize = Double(size)
-        }
+        result.relativeCharacterSize = valueForMatchingDeviceSettings(
+            Double(size),
+            behavior: behavior
+        )
 
         behavior = .useValue
         let descriptor = MACaptionAppearanceCopyFontDescriptorForStyle(
             .user, &behavior, .default
         ).takeRetainedValue()
-        if behavior == .useValue,
-           let family = CTFontDescriptorCopyAttribute(descriptor, kCTFontFamilyNameAttribute) as? String,
+        if let family = CTFontDescriptorCopyAttribute(descriptor, kCTFontFamilyNameAttribute) as? String,
            !family.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            result.fontFamilyName = family
+            result.fontFamilyName = valueForMatchingDeviceSettings(family, behavior: behavior)
         }
 
         return result
+    }
+
+    /// Resolve a value for Silo's explicit "Match Device Settings" mode.
+    ///
+    /// `.useContentIfAvailable` is a precedence rule, not an absent value:
+    /// Apple's contract says to use the returned preference when the content
+    /// has no competing style. Plain SRT/VTT and other controlled text tracks
+    /// have no authored appearance, so both known behaviors resolve to the
+    /// system value. Native ASS continues to preserve its authored styling in
+    /// `SubtitleStylingOverride`, downstream from this mapper.
+    static func valueForMatchingDeviceSettings<Value>(
+        _ value: Value,
+        behavior: MACaptionAppearanceBehavior
+    ) -> Value? {
+        switch behavior {
+        case .useValue, .useContentIfAvailable:
+            return value
+        @unknown default:
+            return nil
+        }
     }
 
     // MARK: - Mapping

--- a/iosApp/iosApp/Screens/Player/Subtitles/SystemCaptionAppearance.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SystemCaptionAppearance.swift
@@ -29,6 +29,9 @@ enum SystemCaptionAppearance {
         var backgroundColorHex: String?
         /// 0.0–1.0.
         var backgroundOpacity: Double?
+        var windowColorHex: String?
+        /// 0.0–1.0.
+        var windowOpacity: Double?
         var edgeStyle: MACaptionAppearanceTextEdgeStyle?
         /// Multiplier around 1.0 (system slider spans roughly 0.5–2.0).
         var relativeCharacterSize: Double?
@@ -70,6 +73,22 @@ enum SystemCaptionAppearance {
         let backgroundOpacity = MACaptionAppearanceGetBackgroundOpacity(.user, &behavior)
         result.backgroundOpacity = valueForMatchingDeviceSettings(
             Double(backgroundOpacity),
+            behavior: behavior
+        )
+
+        behavior = .useValue
+        let window = MACaptionAppearanceCopyWindowColor(.user, &behavior).takeRetainedValue()
+        if let windowHex = hexString(from: window) {
+            result.windowColorHex = valueForMatchingDeviceSettings(
+                windowHex,
+                behavior: behavior
+            )
+        }
+
+        behavior = .useValue
+        let windowOpacity = MACaptionAppearanceGetWindowOpacity(.user, &behavior)
+        result.windowOpacity = valueForMatchingDeviceSettings(
+            Double(windowOpacity),
             behavior: behavior
         )
 
@@ -130,16 +149,24 @@ enum SystemCaptionAppearance {
     ) -> SubtitleAppearance {
         var result = base
 
-        if let opacity = snapshot.backgroundOpacity {
-            if opacity > 0.01 {
-                result.backgroundStyle = .box
-                result.backgroundOpacity = Int((opacity * 100).rounded())
-            } else {
-                result.backgroundStyle = SubtitleBackgroundStylePreset.none
+        // Apple's background is behind each glyph, while its window is the
+        // box behind the whole caption. Silo has one box layer, so a visible
+        // window is the closest match and takes precedence; the glyph
+        // background remains the fallback when the window is transparent.
+        if let opacity = snapshot.windowOpacity, opacity > 0.01 {
+            result.backgroundStyle = .box
+            result.backgroundOpacity = Int((opacity * 100).rounded())
+            if let window = snapshot.windowColorHex {
+                result.backgroundColor = window
             }
-        }
-        if let background = snapshot.backgroundColorHex {
-            result.backgroundColor = background
+        } else if let opacity = snapshot.backgroundOpacity, opacity > 0.01 {
+            result.backgroundStyle = .box
+            result.backgroundOpacity = Int((opacity * 100).rounded())
+            if let background = snapshot.backgroundColorHex {
+                result.backgroundColor = background
+            }
+        } else if snapshot.windowOpacity != nil || snapshot.backgroundOpacity != nil {
+            result.backgroundStyle = SubtitleBackgroundStylePreset.none
         }
 
         if let edge = snapshot.edgeStyle {


### PR DESCRIPTION
## Summary

- treat MediaAccessibility's `useContentIfAvailable` behavior as a usable system fallback when Match Device Settings is enabled
- map Apple's caption-window color and opacity to Silo's full-caption background box, while retaining glyph background as the fallback
- preserve authored native ASS styling at the existing downstream boundary
- add regression coverage for fallback behavior and caption-window precedence

## Root cause

Apple returns caption preferences with either `useValue` or `useContentIfAvailable`. The latter still supplies the value to use when content has no competing appearance. Silo discarded every `useContentIfAvailable` result, so common device profiles such as Outline Text collapsed back to Silo defaults for plain text subtitles.

Apple also exposes two distinct background layers: a background behind each glyph and a window behind the full caption. Silo only read the glyph background. A tvOS profile with a transparent glyph background and a visible magenta window therefore rendered no background at all.

## Validation

- Before the fallback fix, an iOS simulator probe with the system Outline Text profile failed: MediaAccessibility returned `.uniform` with `useContentIfAvailable`, while Silo's snapshot stored `nil`.
- After the fallback fix, the same iOS simulator probe passed and stored `.uniform`.
- The active tvOS simulator profile was reproduced with green foreground, glyph background opacity `0`, and magenta caption window opacity `0.5`; the pre-fix preview showed green text with no magenta box.
- After the caption-window fix, the same normally signed tvOS simulator build visibly rendered green text over the magenta box in the live Settings preview.
- Focused iOS `SystemCaptionAppearanceTests`: 12 passed, 0 failed.
- Normal simulator-signed `SiloTV` build and launch succeeded on tvOS 26.4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system caption preference handling when content-provided settings are available.
  * Ensured caption colors, opacity, edge styles, sizes, and fonts consistently respect device preferences and content fallback behavior.
  * Caption window settings now take precedence over glyph background settings, with transparent backgrounds handled correctly.
  * Unknown caption behaviors safely produce no preference value.

* **Documentation**
  * Clarified caption preference precedence and snapshot behavior.

* **Tests**
  * Added coverage for caption color, opacity, and preference precedence mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->