### PR TITLE
Redesign iOS and tvOS settings

### DIFF
--- a/.claude/skills/mac-builder/SKILL.md
+++ b/.claude/skills/mac-builder/SKILL.md
@@ -99,8 +99,11 @@ Schemes: `Silo` (iOS), `SiloTV` (tvOS), `SiloMac` (macOS).
 
 ### Simulator — the default
 
-Needs no signing, so it never hits the keychain trap. Use it for any "does this compile / do the
-tests pass" question.
+Needs no developer signing identity, so it never hits the login-keychain trap. Normal simulator
+build/run tools still apply Xcode's local ad-hoc signature and simulated entitlements. Keep that
+signature for any flow that signs in: Silo stores its session in the Keychain, and an installed
+`CODE_SIGNING_ALLOWED=NO` product has no Keychain entitlement, so authentication exists only in
+memory and disappears on the next launch.
 
 | Intent | Tool |
 |---|---|
@@ -124,6 +127,12 @@ ssh mac-builder 'cd ~/silo-apple-deploy/iosApp && \
 ```
 
 `-scheme SiloMac -destination "platform=macOS"` for the Mac app.
+
+This is **compile-only**. Never install or launch this unsigned product for authenticated UI
+validation. Use `build_run_sim` or a normal simulator `xcodebuild` without
+`CODE_SIGNING_ALLOWED=NO`, reuse the same simulator, and verify the built app contains simulated
+`application-identifier` / `keychain-access-groups` entitlements before asking the user to sign
+in. Once authenticated, prefer stop/launch over reinstalling when the binary has not changed.
 
 ### Physical device
 
@@ -159,8 +168,10 @@ allowed`) is in the raw log.
 
 Rules:
 
-- **Simulator and `CODE_SIGNING_ALLOWED=NO` builds are unaffected.** Prefer them whenever the
-  question doesn't actually require a device.
+- **Normally signed simulator builds are unaffected.** Xcode uses "Sign to Run Locally" and does
+  not need the developer login keychain.
+- **`CODE_SIGNING_ALLOWED=NO` is compile-only.** It is safe for build checks, but an installed Silo
+  product cannot persist its Keychain-backed login across relaunches.
 - **Device builds:** unlock inside the *same* `ssh` command as `xcodebuild`:
 
 ```bash
@@ -238,6 +249,7 @@ mid-test; if you do, you caused the `App terminated due to signal 15` and must r
 - [ ] `xcodegen generate` run after the sync
 - [ ] Errors read from the full log, not the truncated tool output
 - [ ] Destination matches the claim (simulator build ≠ device verification)
+- [ ] Authenticated simulator runs use a normally signed product, not `CODE_SIGNING_ALLOWED=NO`
 - [ ] Nothing committed or edited on the Mac
 
 ## When the simulator misbehaves, check the disk first

--- a/docs/mac-builder.md
+++ b/docs/mac-builder.md
@@ -219,8 +219,11 @@ Use the MCP tools; they parse errors and return structured results.
 
 `build_run_sim` in one call beats `build_sim` then `launch_app_sim` — fewer round trips over SSH.
 
-Simulator builds need no signing at all, which is why they are the default for verifying a change
-compiles and its tests pass.
+Simulator builds need no developer signing identity, which is why they are the default for
+verifying a change. Xcode still signs normal simulator products locally and embeds simulated
+entitlements. Preserve that local signature for authenticated runs: Silo's tokens live in the
+Keychain, and installing a `CODE_SIGNING_ALLOWED=NO` product removes the entitlement needed to
+persist them across process launches.
 
 ### Compile-only check without signing
 
@@ -234,6 +237,12 @@ ssh mac-builder 'cd ~/silo-apple-deploy/iosApp && \
 ```
 
 Swap `-scheme SiloMac -destination "platform=macOS"` for the Mac app.
+
+Treat the output above as **compile-only**. Do not install or launch it for authenticated UI
+testing. Use `build_run_sim` or normal simulator `xcodebuild` without
+`CODE_SIGNING_ALLOWED=NO`, keep the existing simulator, and confirm the product's simulated
+entitlements include `application-identifier` and `keychain-access-groups` before the user signs
+in. After login, use stop/launch for repeat checks when no new binary needs installation.
 
 ### Physical device
 
@@ -296,7 +305,10 @@ cause (`User interaction is not allowed`) is buried in the raw log.
 
 Consequences:
 
-- **Simulator and `CODE_SIGNING_ALLOWED=NO` builds** — unaffected. Use MCP tools freely.
+- **Normally signed simulator builds** — unaffected. Xcode's "Sign to Run Locally" path does not
+  need the developer login keychain and preserves Silo's Keychain-backed session.
+- **`CODE_SIGNING_ALLOWED=NO` builds** — compile-only. Installing one makes authentication
+  process-local because the product has no Keychain entitlement.
 - **Device builds** — either unlock inside the same `ssh` command as `xcodebuild` (the recipe
   above), or unlock the keychain out-of-band and keep it unlocked for the MCP server's session.
 
@@ -359,6 +371,8 @@ buried under thousands of lines of Swift toolchain noise.
 - **Simulator versus device destinations produce different product directories**
   (`Debug-appletvsimulator` versus `Debug-appletvos`). `devicectl install` silently rejects a
   simulator bundle.
+- **Do not install `CODE_SIGNING_ALLOWED=NO` products for authenticated simulator work.** Reuse a
+  normally signed build and the existing simulator so Keychain login survives relaunches.
 - **Run `xcodegen generate` after syncing.** `Silo.xcodeproj` is generated; a stale one omits new
   files and the build fails with confusing "cannot find type" errors.
 - **SourceKit "No such module" errors are IDE index artifacts.** If `xcodebuild` says

--- a/iosApp/iosApp/Downloads/DownloadsSettingsView.swift
+++ b/iosApp/iosApp/Downloads/DownloadsSettingsView.swift
@@ -16,6 +16,13 @@ struct DownloadsSettingsView: View {
 
     var body: some View {
         Form {
+            SettingsPageHeader(
+                title: "Downloads",
+                subtitle: "Offline quality, cleanup, and storage preferences.",
+                systemImage: "arrow.down.circle.fill"
+            )
+            .settingsPageHeaderRow()
+
             Section {
                 Toggle("Download over Wi-Fi only", isOn: $settings.wifiOnly)
                     .tint(.continuumAccent)
@@ -36,6 +43,7 @@ struct DownloadsSettingsView: View {
                     Text("Original prefers source quality and may prepare a compatibility file if this device needs one. Bitrate presets are prepared on the server before download starts.")
                 }
             }
+            .listRowBackground(Color.continuumSurfaceElevated.opacity(0.92))
 
             Section("Series Monitoring Defaults") {
                 Toggle("Delete watched episodes", isOn: $settings.defaultDeleteWatched)
@@ -49,6 +57,7 @@ struct DownloadsSettingsView: View {
                     step: 5
                 )
             }
+            .listRowBackground(Color.continuumSurfaceElevated.opacity(0.92))
 
             Section {
                 Toggle("Keep watched downloads", isOn: $settings.keepWatchedDownloads)
@@ -58,6 +67,7 @@ struct DownloadsSettingsView: View {
             } footer: {
                 Text("When off, the Downloads tab suggests freeing up space by removing items you've finished watching.")
             }
+            .listRowBackground(Color.continuumSurfaceElevated.opacity(0.92))
 
             Section("Storage") {
                 HStack {
@@ -74,8 +84,9 @@ struct DownloadsSettingsView: View {
                     }
                 }
             }
+            .listRowBackground(Color.continuumSurfaceElevated.opacity(0.92))
         }
-        .navigationTitle("Downloads")
+        .navigationTitle("")
         .task {
             // The quality picker is hidden when the cached capability only
             // offers one preset; re-fetch so permission changes show up here
@@ -85,8 +96,7 @@ struct DownloadsSettingsView: View {
         #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
         #endif
-        .continuumScrollContentBackgroundHidden()
-        .background(Color.continuumBackground)
+        .settingsListChrome()
         .continuumToolbarColorSchemeDark()
         .confirmationDialog(
             "Remove all downloaded files?",

--- a/iosApp/iosApp/Screens/Servers/ServerListView.swift
+++ b/iosApp/iosApp/Screens/Servers/ServerListView.swift
@@ -35,14 +35,12 @@ struct ServerListView: View {
                 .zIndex(1)
             }
         }
-        .continuumBackground()
+        .background(SettingsBackdrop())
         .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: removeTarget)
         #else
         contentList
-            .navigationTitle("Servers")
+            .navigationTitle("")
             .continuumNavigationTitleDisplayMode(.inline)
-            .continuumBackground()
-            .continuumScrollContentBackgroundHidden()
             .alert(
                 "Remove this server?",
                 isPresented: Binding(
@@ -173,8 +171,17 @@ struct ServerListView: View {
     }
     #endif
 
+    #if !os(tvOS)
     private var contentList: some View {
         List {
+            SettingsPageHeader(
+                title: "Servers",
+                subtitle: "Manage saved Silo connections for this device.",
+                systemImage: "server.rack",
+                tint: .teal
+            )
+            .settingsPageHeaderRow()
+
             Section {
                 ForEach(registry.sortedEntries) { entry in
                     row(for: entry)
@@ -195,7 +202,7 @@ struct ServerListView: View {
             }
             .listRowBackground(Color.continuumSurfaceElevated)
         }
-        .continuumGroupedListStyle()
+        .settingsListChrome()
     }
 
     @ViewBuilder
@@ -226,7 +233,6 @@ struct ServerListView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        #if !os(tvOS)
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
             Button(role: .destructive) {
                 removeTarget = entry
@@ -234,8 +240,8 @@ struct ServerListView: View {
                 Label("Remove", systemImage: "trash")
             }
         }
-        #endif
     }
+    #endif
 
     private func switchTo(_ entry: ServerEntry) {
         guard entry.id != registry.activeServerId else {

--- a/iosApp/iosApp/Screens/Settings/DiagnosticsSettingsView.swift
+++ b/iosApp/iosApp/Screens/Settings/DiagnosticsSettingsView.swift
@@ -11,15 +11,23 @@ struct DiagnosticsSettingsView: View {
 
     var body: some View {
         List {
+            SettingsPageHeader(
+                title: "Diagnostics",
+                subtitle: "Capture, review, and send reports to your Silo server.",
+                systemImage: "stethoscope",
+                tint: .orange
+            )
+            .settingsPageHeaderRow()
+
             availabilitySection
             preferencesSection
             pendingSection
             manualSection
             sentHistorySection
         }
-        .continuumGroupedListStyle()
-        .navigationTitle("Diagnostics")
-        .continuumNavigationTitleDisplayMode(.large)
+        .settingsListChrome()
+        .navigationTitle("")
+        .continuumNavigationTitleDisplayMode(.inline)
         .continuumToolbarColorSchemeDark()
         .task {
             await model.load(profile: profile)
@@ -41,6 +49,7 @@ struct DiagnosticsSettingsView: View {
                 Text("Showing the last known diagnostics state. Reports stay on this device while the server is offline.")
             }
         }
+        .listRowBackground(Color.continuumSurfaceElevated.opacity(0.92))
     }
 
     private var preferencesSection: some View {
@@ -83,6 +92,7 @@ struct DiagnosticsSettingsView: View {
         } footer: {
             Text("Crash report consent is tied to this server account. Debug logging is a setting for this device.")
         }
+        .listRowBackground(Color.continuumSurfaceElevated.opacity(0.92))
     }
 
     private var pendingSection: some View {
@@ -107,6 +117,7 @@ struct DiagnosticsSettingsView: View {
         } header: {
             Text("Pending Reports (\(model.pendingReports.count))")
         }
+        .listRowBackground(Color.continuumSurfaceElevated.opacity(0.92))
     }
 
     private var manualSection: some View {
@@ -138,6 +149,7 @@ struct DiagnosticsSettingsView: View {
         } footer: {
             Text("A manual report includes device capability details, recent playback session identifiers, and recent diagnostic logs for this server.")
         }
+        .listRowBackground(Color.continuumSurfaceElevated.opacity(0.92))
     }
 
     private var sentHistorySection: some View {
@@ -162,6 +174,7 @@ struct DiagnosticsSettingsView: View {
                 }
             }
         }
+        .listRowBackground(Color.continuumSurfaceElevated.opacity(0.92))
     }
 
     private func requestModeChange(_ mode: DiagnosticsConsentChoice) {

--- a/iosApp/iosApp/Screens/Settings/IOSSettingsOverview.swift
+++ b/iosApp/iosApp/Screens/Settings/IOSSettingsOverview.swift
@@ -1,0 +1,458 @@
+#if os(iOS)
+import SwiftUI
+
+/// Searchable, card-based iOS Settings overview. Its information hierarchy
+/// intentionally mirrors the web client while navigation and controls remain
+/// native SwiftUI for Dynamic Type, VoiceOver, and predictable gestures.
+struct IOSSettingsOverview: View {
+    @Bindable var viewModel: SettingsViewModel
+    @Bindable var diagnosticsModel: DiagnosticsViewModel
+    @Bindable var uiCustomization: UICustomizationPreferences
+    @Binding var showSignOutConfirm: Bool
+
+    @Environment(AppRouter.self) private var router
+    @State private var navPrefs = AppNavPreferences.shared
+    @State private var searchText = ""
+
+    var body: some View {
+        ZStack {
+            SettingsBackdrop()
+
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 24) {
+                    pageHeader
+
+                    SettingsAccountCard(
+                        avatar: viewModel.activeProfile?.avatarEmoji,
+                        name: displayName,
+                        subtitle: subtitleLine,
+                        isAdministrator: viewModel.userInfo?.isAdmin == true,
+                        action: switchProfile
+                    )
+
+                    SettingsSearchField(text: $searchText)
+
+                    if hasSearchResults {
+                        interfaceSection
+                        playbackSection
+
+                        if diagnosticsModel.shouldShowSettings && matchesDiagnostics {
+                            diagnosticsSection
+                        }
+
+                        if matchesLibrarySection {
+                            librarySection
+                        }
+
+                        if matchesConnectionSection {
+                            connectionSection
+                        }
+
+                        if matchesAboutSection {
+                            aboutSection
+                        }
+
+                        if matchesSignOut {
+                            signOutButton
+                        }
+                    } else {
+                        ContentUnavailableView.search
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 36)
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 8)
+                .padding(.bottom, 36)
+                .frame(maxWidth: 760, alignment: .leading)
+                .frame(maxWidth: .infinity)
+            }
+            .scrollDismissesKeyboard(.interactively)
+        }
+        .navigationTitle("")
+        .continuumNavigationTitleDisplayMode(.inline)
+        .continuumNavigationBarBackgroundHidden()
+        .continuumToolbarColorSchemeDark()
+        .onAppear(perform: navPrefs.refresh)
+    }
+
+    private var pageHeader: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text("Settings")
+                .font(.largeTitle)
+                .bold()
+                .foregroundStyle(Color.continuumOnSurface)
+
+            Text("Make Silo work the way you like.")
+                .font(.subheadline)
+                .foregroundStyle(Color.continuumSecondaryText)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    @ViewBuilder
+    private var interfaceSection: some View {
+        if matchesInterface {
+            SettingsOverviewSection("Interface") {
+                NavigationLink {
+                    InterfaceCustomizationView()
+                } label: {
+                    SettingsOverviewRow(
+                        title: "Interface",
+                        subtitle: "Navigation, cards, and poster presentation",
+                        systemImage: "rectangle.3.group.fill",
+                        tint: .indigo,
+                        value: uiCustomization.cardPresentation.preset?.title ?? "Custom"
+                    )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var playbackSection: some View {
+        if matchesPlaybackSection {
+            SettingsOverviewSection("Playback") {
+                if matches("playback", "quality", "audio", "dolby vision", "episodes", "skipping") {
+                    NavigationLink {
+                        PlaybackSettingsView(viewModel: viewModel)
+                    } label: {
+                        SettingsOverviewRow(
+                            title: "Playback",
+                            subtitle: "Quality, language, and episode behavior",
+                            systemImage: "play.fill",
+                            value: viewModel.preferredQualityLabel
+                        )
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                if matchesPlayback && matchesSubtitles {
+                    SettingsOverviewDivider()
+                }
+
+                if matchesSubtitles {
+                    NavigationLink {
+                        SubtitleSettingsView(viewModel: viewModel)
+                    } label: {
+                        SettingsOverviewRow(
+                            title: "Subtitles",
+                            subtitle: "Language, behavior, and appearance",
+                            systemImage: "captions.bubble.fill",
+                            tint: .pink,
+                            value: subtitleLanguageName(viewModel.editorSubtitleLanguage)
+                        )
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                if matchesDownloads {
+                    if matchesPlayback || matchesSubtitles {
+                        SettingsOverviewDivider()
+                    }
+
+                    NavigationLink {
+                        DownloadsSettingsView()
+                    } label: {
+                        SettingsOverviewRow(
+                            title: "Downloads",
+                            subtitle: "Quality, cleanup, and storage",
+                            systemImage: "arrow.down.circle.fill"
+                        )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    private var diagnosticsSection: some View {
+        SettingsOverviewSection("Support") {
+            NavigationLink {
+                DiagnosticsSettingsView(
+                    model: diagnosticsModel,
+                    profile: viewModel.activeProfile
+                )
+            } label: {
+                SettingsOverviewRow(
+                    title: "Diagnostics",
+                    subtitle: "Capture, review, and send support reports",
+                    systemImage: "stethoscope",
+                    tint: .orange,
+                    value: diagnosticsModel.featureState.title
+                )
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private var librarySection: some View {
+        SettingsOverviewSection("Library & Data") {
+            if matchesAudiobooks {
+                SettingsOverviewToggleRow(
+                    title: "Show Audiobooks",
+                    subtitle: "Add Audiobooks to the main navigation",
+                    systemImage: "book.closed.fill",
+                    tint: .indigo,
+                    isOn: Binding(
+                        get: { navPrefs.showAudiobooks },
+                        set: { navPrefs.setShowAudiobooks($0) }
+                    )
+                )
+            }
+
+            if matchesAudiobooks && matchesWatchlist {
+                SettingsOverviewDivider()
+            }
+
+            if matchesWatchlist {
+                NavigationLink {
+                    WatchlistView()
+                } label: {
+                    SettingsOverviewRow(
+                        title: "Watchlist",
+                        subtitle: "Titles you plan to watch",
+                        systemImage: "bookmark.fill",
+                        tint: .orange
+                    )
+                }
+                .buttonStyle(.plain)
+            }
+
+            if (matchesAudiobooks || matchesWatchlist) && matchesFavorites {
+                SettingsOverviewDivider()
+            }
+
+            if matchesFavorites {
+                NavigationLink {
+                    FavoritesView()
+                } label: {
+                    SettingsOverviewRow(
+                        title: "Favorites",
+                        subtitle: "Your saved movies and shows",
+                        systemImage: "heart.fill",
+                        tint: .red
+                    )
+                }
+                .buttonStyle(.plain)
+            }
+
+            if (matchesAudiobooks || matchesWatchlist || matchesFavorites) && matchesHistory {
+                SettingsOverviewDivider()
+            }
+
+            if matchesHistory {
+                NavigationLink {
+                    HistoryView()
+                } label: {
+                    SettingsOverviewRow(
+                        title: "Watch History",
+                        subtitle: "Review recently watched titles",
+                        systemImage: "clock.fill",
+                        tint: .gray
+                    )
+                }
+                .buttonStyle(.plain)
+            }
+
+            if (matchesAudiobooks || matchesWatchlist || matchesFavorites || matchesHistory)
+                && matchesCollections {
+                SettingsOverviewDivider()
+            }
+
+            if matchesCollections {
+                NavigationLink {
+                    CollectionsView()
+                } label: {
+                    SettingsOverviewRow(
+                        title: "Collections",
+                        subtitle: "Browse grouped movies and shows",
+                        systemImage: "square.stack.fill",
+                        tint: .purple
+                    )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private var connectionSection: some View {
+        SettingsOverviewSection("Connection") {
+            Button {
+                router.navigate(to: .serverList)
+            } label: {
+                SettingsOverviewRow(
+                    title: "Server",
+                    subtitle: "Manage this device's Silo connection",
+                    systemImage: "server.rack",
+                    tint: .teal,
+                    value: viewModel.serverDisplayName
+                )
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private var aboutSection: some View {
+        SettingsOverviewSection("About") {
+            SettingsOverviewRow(
+                title: "Version",
+                subtitle: "Installed Silo app version",
+                systemImage: "info.circle.fill",
+                tint: .gray,
+                value: versionString,
+                showsChevron: false
+            )
+        }
+    }
+
+    private var signOutButton: some View {
+        Button(role: .destructive) {
+            showSignOutConfirm = true
+        } label: {
+            Label("Sign Out", systemImage: "rectangle.portrait.and.arrow.right")
+                .font(.headline)
+                .frame(maxWidth: .infinity, minHeight: 50)
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(Color.red)
+        .background(Color.red.opacity(0.09))
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .overlay {
+            RoundedRectangle(cornerRadius: 16)
+                .strokeBorder(Color.red.opacity(0.18), lineWidth: 1)
+        }
+    }
+
+    private var displayName: String {
+        if let name = viewModel.activeProfile?.name, !name.isEmpty {
+            return name
+        }
+        if let username = viewModel.userInfo?.username, !username.isEmpty {
+            return username
+        }
+        return "Switch Profile"
+    }
+
+    private var subtitleLine: String {
+        let host = serverHost
+        let username = viewModel.userInfo?.username
+        switch (username, host) {
+        case let (user?, host?) where !user.isEmpty && user != displayName:
+            return "\(user) · \(host)"
+        case let (_, host?):
+            return host
+        case let (user?, _) where !user.isEmpty && user != displayName:
+            return user
+        default:
+            return "Tap to switch profile"
+        }
+    }
+
+    private var serverHost: String? {
+        guard let url = URL(string: viewModel.serverUrl), let host = url.host else {
+            return viewModel.serverUrl.isEmpty ? nil : viewModel.serverUrl
+        }
+        return host
+    }
+
+    private func switchProfile() {
+        AuthService.shared.profileId = nil
+        router.showProfileSelection()
+    }
+
+    private func subtitleLanguageName(_ tag: String) -> String {
+        if tag == PlaybackPrefSentinel.none || tag.isEmpty { return "None" }
+        return PlaybackLanguageOption.label(forCode: tag)
+    }
+
+    private var versionString: String {
+        let info = Bundle.main.infoDictionary
+        let version = info?["CFBundleShortVersionString"] as? String ?? "1.0"
+        guard let build = info?["CFBundleVersion"] as? String,
+              !build.isEmpty,
+              build != version else {
+            return version
+        }
+        return "\(version) (\(build))"
+    }
+
+    private var matchesPlayback: Bool {
+        matches("playback", "quality", "audio", "dolby vision", "episodes", "skipping")
+    }
+
+    private var matchesInterface: Bool {
+        matches("interface", "appearance", "navigation", "menu", "cards", "posters", "captions")
+    }
+
+    private var matchesSubtitles: Bool {
+        matches("subtitles", "captions", "language", "behavior", "appearance")
+    }
+
+    private var matchesDownloads: Bool {
+        DownloadManager.shared.downloadsEnabled
+            && matches("downloads", "offline", "quality", "cleanup", "storage")
+    }
+
+    private var matchesDiagnostics: Bool {
+        matches("diagnostics", "support", "reports", "debug", "crash")
+    }
+
+    private var matchesAudiobooks: Bool {
+        matches("audiobooks", "navigation", "library")
+    }
+
+    private var matchesWatchlist: Bool {
+        matches("watchlist", "saved", "library")
+    }
+
+    private var matchesFavorites: Bool {
+        matches("favorites", "saved", "library")
+    }
+
+    private var matchesHistory: Bool {
+        matches("watch history", "recently watched", "history", "library")
+    }
+
+    private var matchesCollections: Bool {
+        matches("collections", "groups", "library")
+    }
+
+    private var matchesConnectionSection: Bool {
+        matches("server", "connection", viewModel.serverDisplayName)
+    }
+
+    private var matchesAboutSection: Bool {
+        matches("about", "version", versionString)
+    }
+
+    private var matchesSignOut: Bool {
+        matches("sign out", "account")
+    }
+
+    private var matchesPlaybackSection: Bool {
+        matchesPlayback || matchesSubtitles || matchesDownloads
+    }
+
+    private var matchesLibrarySection: Bool {
+        matchesAudiobooks || matchesWatchlist || matchesFavorites || matchesHistory || matchesCollections
+    }
+
+    private var hasSearchResults: Bool {
+        matchesInterface
+            || matchesPlaybackSection
+            || (diagnosticsModel.shouldShowSettings && matchesDiagnostics)
+            || matchesLibrarySection
+            || matchesConnectionSection
+            || matchesAboutSection
+            || matchesSignOut
+    }
+
+    private func matches(_ terms: String...) -> Bool {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return true }
+        return terms.contains { $0.localizedCaseInsensitiveContains(query) }
+    }
+}
+#endif

--- a/iosApp/iosApp/Screens/Settings/PlaybackSettingsView.swift
+++ b/iosApp/iosApp/Screens/Settings/PlaybackSettingsView.swift
@@ -9,14 +9,19 @@ struct PlaybackSettingsView: View {
 
     var body: some View {
         List {
+            SettingsPageHeader(
+                title: "Playback",
+                subtitle: "Quality, language, and episode behavior for this device.",
+                systemImage: "play.fill"
+            )
+            .settingsPageHeaderRow()
+
             streamingSection
             behaviorSection
             resetSection
         }
-        .continuumGroupedListStyle()
-        .continuumScrollContentBackgroundHidden()
-        .background(Color.continuumBackground.ignoresSafeArea())
-        .navigationTitle("Playback")
+        .settingsListChrome()
+        .navigationTitle("")
         .continuumNavigationTitleDisplayMode(.inline)
         .continuumToolbarColorSchemeDark()
     }

--- a/iosApp/iosApp/Screens/Settings/SettingsAccountCard.swift
+++ b/iosApp/iosApp/Screens/Settings/SettingsAccountCard.swift
@@ -1,0 +1,64 @@
+#if os(iOS)
+import SwiftUI
+
+struct SettingsAccountCard: View {
+    let avatar: String?
+    let name: String
+    let subtitle: String
+    let isAdministrator: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 14) {
+                ProfileAvatarView(avatar: avatar, name: name, size: 54)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Current profile")
+                        .font(.caption)
+                        .foregroundStyle(Color.continuumSecondaryText)
+
+                    Text(name)
+                        .font(.headline)
+                        .foregroundStyle(Color.continuumOnSurface)
+                        .lineLimit(1)
+
+                    Text(subtitle)
+                        .font(.footnote)
+                        .foregroundStyle(Color.continuumSecondaryText)
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 8)
+
+                if isAdministrator {
+                    Text("Admin")
+                        .font(.caption)
+                        .bold()
+                        .foregroundStyle(Color.continuumAccent)
+                        .padding(.horizontal, 9)
+                        .padding(.vertical, 5)
+                        .background(Color.continuumAccent.opacity(0.12), in: Capsule())
+                }
+
+                Image(systemName: "chevron.right")
+                    .font(.footnote)
+                    .bold()
+                    .foregroundStyle(Color.continuumSecondaryText)
+                    .accessibilityHidden(true)
+            }
+            .padding(15)
+            .frame(maxWidth: .infinity, minHeight: 80, alignment: .leading)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .background(Color.continuumSurfaceElevated.opacity(0.9))
+        .clipShape(RoundedRectangle(cornerRadius: 18))
+        .overlay {
+            RoundedRectangle(cornerRadius: 18)
+                .strokeBorder(Color.continuumOutline, lineWidth: 1)
+        }
+        .accessibilityHint("Switches to a different profile")
+    }
+}
+#endif

--- a/iosApp/iosApp/Screens/Settings/SettingsBackdrop.swift
+++ b/iosApp/iosApp/Screens/Settings/SettingsBackdrop.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+/// Quiet atmospheric backdrop shared by the native Settings experiences.
+/// It mirrors the web app's dark canvas and restrained blue signal glow
+/// without competing with controls or reducing text contrast.
+struct SettingsBackdrop: View {
+    var body: some View {
+        ZStack {
+            Color.continuumBackground
+
+            RadialGradient(
+                colors: [
+                    Color.continuumAccent.opacity(0.14),
+                    Color(hex: "#162235").opacity(0.07),
+                    .clear,
+                ],
+                center: UnitPoint(x: 0.82, y: 0.04),
+                startRadius: 0,
+                endRadius: 620
+            )
+
+            RadialGradient(
+                colors: [
+                    Color.continuumBrandOrange.opacity(0.045),
+                    .clear,
+                ],
+                center: UnitPoint(x: 0.08, y: 0.72),
+                startRadius: 0,
+                endRadius: 440
+            )
+
+            LinearGradient(
+                colors: [.clear, Color.black.opacity(0.4)],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        }
+        .ignoresSafeArea()
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+    }
+}

--- a/iosApp/iosApp/Screens/Settings/SettingsOverviewDivider.swift
+++ b/iosApp/iosApp/Screens/Settings/SettingsOverviewDivider.swift
@@ -1,0 +1,11 @@
+#if os(iOS)
+import SwiftUI
+
+struct SettingsOverviewDivider: View {
+    var body: some View {
+        Divider()
+            .overlay(Color.continuumDivider)
+            .padding(.leading, 66)
+    }
+}
+#endif

--- a/iosApp/iosApp/Screens/Settings/SettingsOverviewRow.swift
+++ b/iosApp/iosApp/Screens/Settings/SettingsOverviewRow.swift
@@ -1,0 +1,64 @@
+#if os(iOS)
+import SwiftUI
+
+/// Web-style Settings destination row with a descriptive second line and an
+/// optional current value. The containing NavigationLink or Button owns the
+/// interaction so the full row remains a native 44-point target.
+struct SettingsOverviewRow: View {
+    let title: String
+    let subtitle: String
+    let systemImage: String
+    var tint: Color = .continuumAccent
+    var value: String? = nil
+    var showsChevron = true
+
+    var body: some View {
+        HStack(spacing: 13) {
+            Image(systemName: systemImage)
+                .font(.body)
+                .foregroundStyle(tint)
+                .frame(width: 38, height: 38)
+                .background(tint.opacity(0.12), in: Circle())
+                .overlay {
+                    Circle()
+                        .strokeBorder(tint.opacity(0.18), lineWidth: 1)
+                }
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.headline)
+                    .foregroundStyle(Color.continuumOnSurface)
+
+                Text(subtitle)
+                    .font(.footnote)
+                    .foregroundStyle(Color.continuumSecondaryText)
+                    .lineLimit(2)
+            }
+
+            Spacer(minLength: 8)
+
+            if let value {
+                Text(value)
+                    .font(.subheadline)
+                    .foregroundStyle(Color.continuumSecondaryText)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
+
+            if showsChevron {
+                Image(systemName: "chevron.right")
+                    .font(.footnote)
+                    .bold()
+                    .foregroundStyle(Color.continuumSecondaryText)
+                    .accessibilityHidden(true)
+            }
+        }
+        .padding(.horizontal, 15)
+        .padding(.vertical, 13)
+        .frame(maxWidth: .infinity, minHeight: 64, alignment: .leading)
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .combine)
+    }
+}
+#endif

--- a/iosApp/iosApp/Screens/Settings/SettingsOverviewSection.swift
+++ b/iosApp/iosApp/Screens/Settings/SettingsOverviewSection.swift
@@ -1,0 +1,36 @@
+#if os(iOS)
+import SwiftUI
+
+/// Labeled card grouping related Settings destinations, matching the web
+/// app's section hierarchy while keeping native controls inside the card.
+struct SettingsOverviewSection<Content: View>: View {
+    let title: String
+    @ViewBuilder let content: Content
+
+    init(_ title: String, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            Text(title.uppercased())
+                .font(.caption)
+                .bold()
+                .tracking(1.5)
+                .foregroundStyle(Color.continuumSecondaryText)
+                .padding(.horizontal, 4)
+
+            VStack(spacing: 0) {
+                content
+            }
+            .background(Color.continuumSurfaceElevated.opacity(0.88))
+            .clipShape(RoundedRectangle(cornerRadius: 18))
+            .overlay {
+                RoundedRectangle(cornerRadius: 18)
+                    .strokeBorder(Color.continuumOutline, lineWidth: 1)
+            }
+        }
+    }
+}
+#endif

--- a/iosApp/iosApp/Screens/Settings/SettingsOverviewToggleRow.swift
+++ b/iosApp/iosApp/Screens/Settings/SettingsOverviewToggleRow.swift
@@ -1,0 +1,44 @@
+#if os(iOS)
+import SwiftUI
+
+struct SettingsOverviewToggleRow: View {
+    let title: String
+    let subtitle: String
+    let systemImage: String
+    var tint: Color = .continuumAccent
+    @Binding var isOn: Bool
+
+    var body: some View {
+        Toggle(isOn: $isOn) {
+            HStack(spacing: 13) {
+                Image(systemName: systemImage)
+                    .font(.body)
+                    .foregroundStyle(tint)
+                    .frame(width: 38, height: 38)
+                    .background(tint.opacity(0.12), in: Circle())
+                    .overlay {
+                        Circle()
+                            .strokeBorder(tint.opacity(0.18), lineWidth: 1)
+                    }
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.headline)
+                        .foregroundStyle(Color.continuumOnSurface)
+
+                    Text(subtitle)
+                        .font(.footnote)
+                        .foregroundStyle(Color.continuumSecondaryText)
+                }
+            }
+        }
+        .tint(.continuumAccent)
+        .padding(.horizontal, 15)
+        .padding(.vertical, 13)
+        .frame(maxWidth: .infinity, minHeight: 64, alignment: .leading)
+        .accessibilityLabel(title)
+        .accessibilityHint(subtitle)
+    }
+}
+#endif

--- a/iosApp/iosApp/Screens/Settings/SettingsPageHeader.swift
+++ b/iosApp/iosApp/Screens/Settings/SettingsPageHeader.swift
@@ -1,0 +1,55 @@
+#if !os(tvOS)
+import SwiftUI
+
+/// Consistent introduction for Settings detail pages, matching the web
+/// client's icon, title, and concise explanatory copy.
+struct SettingsPageHeader: View {
+    let title: String
+    let subtitle: String
+    let systemImage: String
+    var tint: Color = .continuumAccent
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 14) {
+            Image(systemName: systemImage)
+                .font(.title3)
+                .foregroundStyle(tint)
+                .frame(width: 44, height: 44)
+                .background(tint.opacity(0.13), in: Circle())
+                .overlay {
+                    Circle()
+                        .strokeBorder(tint.opacity(0.2), lineWidth: 1)
+                }
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(.title2)
+                    .bold()
+                    .foregroundStyle(Color.continuumOnSurface)
+
+                Text(subtitle)
+                    .font(.subheadline)
+                    .foregroundStyle(Color.continuumSecondaryText)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+extension View {
+    func settingsPageHeaderRow() -> some View {
+        listRowInsets(EdgeInsets(top: 14, leading: 20, bottom: 10, trailing: 20))
+            .listRowBackground(Color.clear)
+            .listRowSeparator(.hidden)
+    }
+
+    func settingsListChrome() -> some View {
+        continuumGroupedListStyle()
+            .continuumScrollContentBackgroundHidden()
+            .background(SettingsBackdrop())
+    }
+}
+#endif

--- a/iosApp/iosApp/Screens/Settings/SettingsSearchField.swift
+++ b/iosApp/iosApp/Screens/Settings/SettingsSearchField.swift
@@ -1,0 +1,37 @@
+#if os(iOS)
+import SwiftUI
+
+struct SettingsSearchField: View {
+    @Binding var text: String
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(Color.continuumSecondaryText)
+                .accessibilityHidden(true)
+
+            TextField("Search settings", text: $text)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .foregroundStyle(Color.continuumOnSurface)
+
+            if !text.isEmpty {
+                Button("Clear search", systemImage: "xmark.circle.fill") {
+                    text = ""
+                }
+                .labelStyle(.iconOnly)
+                .foregroundStyle(Color.continuumSecondaryText)
+                .frame(width: 44, height: 44)
+            }
+        }
+        .padding(.horizontal, 15)
+        .frame(minHeight: 48)
+        .background(Color.continuumSurfaceElevated.opacity(0.78))
+        .clipShape(RoundedRectangle(cornerRadius: 15))
+        .overlay {
+            RoundedRectangle(cornerRadius: 15)
+                .strokeBorder(Color.continuumOutline, lineWidth: 1)
+        }
+    }
+}
+#endif

--- a/iosApp/iosApp/Screens/Settings/SettingsView.swift
+++ b/iosApp/iosApp/Screens/Settings/SettingsView.swift
@@ -2,10 +2,8 @@ import SwiftUI
 
 /// App settings screen.
 ///
-/// iOS/macOS: a native Settings-style inset-grouped `List` — account
-/// header up top, icon-badged rows grouped into sections, and
-/// drilldowns to dedicated sub-screens for compound preferences like
-/// Playback and Subtitles.
+/// iOS: a searchable, card-based overview aligned with the web app's
+/// information hierarchy. macOS retains the compact native Settings list.
 ///
 /// On tvOS this view delegates to ``TVSettingsView``, a root-menu Form
 /// with drill-in sub-screens tuned for the 10-foot experience.
@@ -15,50 +13,58 @@ struct SettingsView: View {
     @Environment(AppRouter.self) private var router
     @State private var showSignOutConfirm = false
     #if os(iOS)
-    @State private var navPrefs = AppNavPreferences.shared
     @State private var diagnosticsModel = DiagnosticsViewModel()
     #endif
 
     var body: some View {
         #if os(tvOS)
         TVSettingsView()
+        #elseif os(iOS)
+        iOSOverview
         #else
-        iosBody
+        macOSBody
         #endif
     }
 
-    #if !os(tvOS)
-    private var iosBody: some View {
+    #if os(iOS)
+    private var iOSOverview: some View {
+        IOSSettingsOverview(
+            viewModel: viewModel,
+            diagnosticsModel: diagnosticsModel,
+            uiCustomization: uiCustomization,
+            showSignOutConfirm: $showSignOutConfirm
+        )
+        .task {
+            await viewModel.loadSettings()
+            await diagnosticsModel.load(profile: viewModel.activeProfile)
+        }
+        .alert("Sign Out", isPresented: $showSignOutConfirm) {
+            Button("Sign Out", role: .destructive) {
+                router.signOutAndReset()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Are you sure you want to sign out?")
+        }
+    }
+    #endif
+
+    #if os(macOS)
+    private var macOSBody: some View {
         List {
             accountSection
             preferencesSection
-            #if os(iOS)
-            if diagnosticsModel.shouldShowSettings {
-                diagnosticsSection
-            }
-            #endif
             librarySection
             connectionSection
             aboutSection
             signOutSection
         }
-        // iOS-26 restyle (plan 010, PENDING REVIEW): let the native grouped-list
-        // glass show through instead of forcing flat OLED black. The previous
-        // `.continuumScrollContentBackgroundHidden()` + `Color.continuumBackground`
-        // page override and per-section `.listRowBackground(Color.continuumSurfaceElevated)`
-        // were intentionally dropped here. If brand-black must win, restore those.
         .continuumGroupedListStyle()
         .navigationTitle("Settings")
         .continuumNavigationTitleDisplayMode(.large)
         .continuumToolbarColorSchemeDark()
         .task {
-            #if os(iOS)
-            navPrefs.refresh()
-            #endif
             await viewModel.loadSettings()
-            #if os(iOS)
-            await diagnosticsModel.load(profile: viewModel.activeProfile)
-            #endif
         }
         .alert("Sign Out", isPresented: $showSignOutConfirm) {
             Button("Sign Out", role: .destructive) {
@@ -206,40 +212,10 @@ struct SettingsView: View {
         return PlaybackLanguageOption.label(forCode: tag)
     }
 
-    #if os(iOS)
-    private var diagnosticsSection: some View {
-        Section("Diagnostics") {
-            NavigationLink {
-                DiagnosticsSettingsView(
-                    model: diagnosticsModel,
-                    profile: viewModel.activeProfile
-                )
-            } label: {
-                SettingsRowLabel(
-                    title: "Diagnostics",
-                    systemImage: "stethoscope",
-                    color: .orange,
-                    value: diagnosticsModel.featureState.title
-                )
-            }
-        }
-    }
-    #endif
-
     // MARK: - Library
 
     private var librarySection: some View {
         Section("Library") {
-            #if os(iOS)
-            Toggle(isOn: Binding(
-                get: { navPrefs.showAudiobooks },
-                set: { navPrefs.setShowAudiobooks($0) }
-            )) {
-                SettingsRowLabel(title: "Show Audiobooks", systemImage: "book.closed.fill", color: .indigo)
-            }
-            .tint(.continuumAccent)
-            #endif
-
             NavigationLink {
                 WatchlistView()
             } label: {
@@ -325,7 +301,7 @@ struct SettingsView: View {
     #endif
 }
 
-#if !os(tvOS)
+#if os(macOS)
 
 // MARK: - Row primitives
 

--- a/iosApp/iosApp/Screens/Settings/SubtitleSettingsView.swift
+++ b/iosApp/iosApp/Screens/Settings/SubtitleSettingsView.swift
@@ -13,16 +13,22 @@ struct SubtitleSettingsView: View {
 
     var body: some View {
         List {
+            SettingsPageHeader(
+                title: "Subtitles",
+                subtitle: "Language, behavior, and on-screen appearance.",
+                systemImage: "captions.bubble.fill",
+                tint: .pink
+            )
+            .settingsPageHeaderRow()
+
             profileBackedSection
             if AICapabilities.shared.metadataEnabled {
                 metadataLanguageSection
             }
             appearanceSection
         }
-        .continuumGroupedListStyle()
-        .continuumScrollContentBackgroundHidden()
-        .background(Color.continuumBackground.ignoresSafeArea())
-        .navigationTitle("Subtitles")
+        .settingsListChrome()
+        .navigationTitle("")
         .continuumNavigationTitleDisplayMode(.inline)
         .continuumToolbarColorSchemeDark()
         .onChange(of: viewModel.editorSubtitleLanguage) { _, _ in

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVDiagnosticsConsentScreen.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVDiagnosticsConsentScreen.swift
@@ -10,7 +10,7 @@ struct TVDiagnosticsConsentScreen: View {
 
     var body: some View {
         ZStack {
-            Color.continuumBackground.ignoresSafeArea()
+            SettingsBackdrop()
 
             VStack(alignment: .leading, spacing: 24) {
                 Text("Crash Reports")

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVDiagnosticsPendingReportScreen.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVDiagnosticsPendingReportScreen.swift
@@ -12,7 +12,7 @@ struct TVDiagnosticsPendingReportScreen: View {
 
     var body: some View {
         ZStack {
-            Color.continuumBackground.ignoresSafeArea()
+            SettingsBackdrop()
 
             VStack(alignment: .leading, spacing: 28) {
                 Text("Report Details")

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVDiagnosticsPromptScreen.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVDiagnosticsPromptScreen.swift
@@ -11,7 +11,7 @@ struct TVDiagnosticsPromptScreen: View {
 
     var body: some View {
         ZStack {
-            Color.continuumBackground.ignoresSafeArea()
+            SettingsBackdrop()
 
             VStack(alignment: .leading, spacing: 28) {
                 Text(isReviewing ? "Report Summary" : prompt.title)

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVPlaybackSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVPlaybackSettingsView.swift
@@ -2,21 +2,18 @@
 import SwiftUI
 
 /// Playback pane of tvOS Settings, rendered inline in the right pane of
-/// the two-pane `TVSettingsView`. Option pickers present as full-screen
-/// covers (plain sheets render as narrow clipped cards on tvOS 26).
+/// the two-pane `TVSettingsView`. The root view owns modal picker
+/// presentation so only one focus graph is active at a time.
 struct TVPlaybackSettingsPane: View {
     @Bindable var viewModel: TVSettingsViewModel
     let detailFocus: FocusState<TVSettingsDetailFocus?>.Binding
-    @State private var activePicker: PickerKind?
+    let presentPicker: (TVSettingsPickerRequest) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             streamingSection
             episodesSection
             resetSection
-        }
-        .fullScreenCover(item: $activePicker) { kind in
-            pickerSheet(for: kind)
         }
     }
 
@@ -29,7 +26,7 @@ struct TVPlaybackSettingsPane: View {
         TVSettingsPickerRow(
             title: "Quality",
             value: viewModel.preferredQualityLabel
-        ) { activePicker = .quality }
+        ) { showPicker(.quality) }
         .focused(detailFocus, equals: .top)
 
         TVSettingsPickerRow(
@@ -38,7 +35,8 @@ struct TVPlaybackSettingsPane: View {
                 for: viewModel.preferredAudioLanguage,
                 in: TVSettingsOptions.audioLanguage(viewModel.audioLanguageOptions)
             )
-        ) { activePicker = .audioLanguage }
+        ) { showPicker(.audioLanguage) }
+        .focused(detailFocus, equals: .playbackAudioLanguage)
 
         TVSettingsToggleRow(
             title: "Dolby Vision",
@@ -103,7 +101,8 @@ struct TVPlaybackSettingsPane: View {
         TVSettingsPickerRow(
             title: "Show Next Up",
             value: TVSettingsOptions.label(for: String(viewModel.nextUpPromptSeconds), in: TVSettingsOptions.nextUpPrompt)
-        ) { activePicker = .nextUpPrompt }
+        ) { showPicker(.nextUpPrompt) }
+        .focused(detailFocus, equals: .playbackNextUpPrompt)
 
         TVSettingsToggleRow(
             title: "Skip Intros",
@@ -146,11 +145,15 @@ struct TVPlaybackSettingsPane: View {
 
     // MARK: - Pickers
 
-    @ViewBuilder
-    private func pickerSheet(for kind: PickerKind) -> some View {
+    private func showPicker(_ kind: PickerKind) {
+        presentPicker(pickerRequest(for: kind))
+    }
+
+    private func pickerRequest(for kind: PickerKind) -> TVSettingsPickerRequest {
         switch kind {
         case .quality:
-            TVSettingsPickerSheet(
+            TVSettingsPickerRequest(
+                id: kind.id,
                 title: "Quality",
                 options: TVSettingsOptions.quality(
                     // A stored pair no preset covers gets its own entry
@@ -166,10 +169,12 @@ struct TVPlaybackSettingsPane: View {
                         guard value != TVSettingsOptions.customQualityId else { return }
                         Task { await viewModel.setQualityPreset(value) }
                     }
-                )
+                ),
+                returnFocus: .top
             )
         case .audioLanguage:
-            TVSettingsPickerSheet(
+            TVSettingsPickerRequest(
+                id: kind.id,
                 title: "Audio Language",
                 options: TVSettingsOptions.audioLanguage(viewModel.audioLanguageOptions),
                 selection: Binding(
@@ -178,10 +183,12 @@ struct TVPlaybackSettingsPane: View {
                         viewModel.preferredAudioLanguage = value
                         Task { await viewModel.setPreferredAudioLanguage(value) }
                     }
-                )
+                ),
+                returnFocus: .playbackAudioLanguage
             )
         case .nextUpPrompt:
-            TVSettingsPickerSheet(
+            TVSettingsPickerRequest(
+                id: kind.id,
                 title: "Show Next Up",
                 options: TVSettingsOptions.nextUpPrompt,
                 selection: Binding(
@@ -191,7 +198,8 @@ struct TVPlaybackSettingsPane: View {
                         viewModel.nextUpPromptSeconds = seconds
                         Task { await viewModel.setNextUpPromptSeconds(seconds) }
                     }
-                )
+                ),
+                returnFocus: .playbackNextUpPrompt
             )
         }
     }

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsComponents.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsComponents.swift
@@ -160,7 +160,18 @@ private struct TVSettingsRailRowBody: View {
                         lineWidth: 1
                     )
             )
-            .scaleEffect(configuration.isPressed ? 0.98 : 1)
+            .overlay(alignment: .leading) {
+                Capsule()
+                    .fill(Color.continuumAccent)
+                    .frame(width: 4)
+                    .padding(.vertical, 12)
+                    .opacity(isSelected && !isFocused ? 1 : 0)
+            }
+            .scaleEffect(configuration.isPressed ? 0.98 : (isFocused ? 1.012 : 1))
+            .shadow(
+                color: isFocused ? Color.continuumAccent.opacity(0.14) : .clear,
+                radius: 18
+            )
             .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: isFocused)
     }
 
@@ -174,7 +185,7 @@ private struct TVSettingsRailRowBody: View {
     private var fill: Color {
         if isDestructive && isFocused { return .continuumError }
         if isFocused { return .continuumOnSurface }
-        if isSelected { return .continuumChromeSelectedFill }
+        if isSelected { return .continuumSurfaceElevated.opacity(0.92) }
         return .clear
     }
 }
@@ -185,15 +196,21 @@ private struct TVSettingsRailRowBody: View {
 /// platter with dark content on focus.
 struct TVSettingsPaneRowStyle: ButtonStyle {
     var isDestructive: Bool = false
+    var isSelected: Bool = false
 
     func makeBody(configuration: Configuration) -> some View {
-        TVSettingsPaneRowBody(configuration: configuration, isDestructive: isDestructive)
+        TVSettingsPaneRowBody(
+            configuration: configuration,
+            isDestructive: isDestructive,
+            isSelected: isSelected
+        )
     }
 }
 
 private struct TVSettingsPaneRowBody: View {
     let configuration: ButtonStyleConfiguration
     let isDestructive: Bool
+    let isSelected: Bool
     @Environment(\.isFocused) private var isFocused
 
     var body: some View {
@@ -204,16 +221,21 @@ private struct TVSettingsPaneRowBody: View {
             .foregroundColor(foreground)
             .background(
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .fill(isFocused ? Color.continuumOnSurface : Color.continuumChromeRestingFill)
+                    .fill(backgroundFill)
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
                     .strokeBorder(
-                        isFocused ? Color.clear : Color.continuumChromeRestingBorder,
+                        borderColor,
                         lineWidth: 1
                     )
             )
-            .scaleEffect(configuration.isPressed ? 0.98 : 1)
+            .scaleEffect(configuration.isPressed ? 0.98 : (isFocused ? 1.012 : 1))
+            .shadow(
+                color: isFocused ? Color.continuumAccent.opacity(0.16) : .clear,
+                radius: 18
+            )
+            .focusEffectDisabled()
             .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: isFocused)
     }
 
@@ -222,6 +244,18 @@ private struct TVSettingsPaneRowBody: View {
             return isFocused ? Color(hex: "#D22F3F") : .continuumError
         }
         return isFocused ? .continuumBackground : .continuumOnSurface
+    }
+
+    private var backgroundFill: Color {
+        if isFocused { return .continuumOnSurface }
+        if isSelected { return .continuumChromeSelectedFill }
+        return .continuumSurfaceElevated.opacity(0.84)
+    }
+
+    private var borderColor: Color {
+        if isFocused { return .clear }
+        if isSelected { return .continuumChromeSelectedBorder }
+        return .continuumChromeRestingBorder
     }
 }
 
@@ -336,7 +370,7 @@ struct TVSettingsInfoRow: View {
         .foregroundColor(.continuumOnSurface)
         .background(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(Color.continuumChromeRestingFill)
+                .fill(Color.continuumSurfaceElevated.opacity(0.84))
         )
         .overlay(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
@@ -359,7 +393,7 @@ struct TVSettingsSectionHeader: View {
         Text(title)
             .font(.system(size: 15, weight: .semibold, design: .monospaced))
             .tracking(2)
-            .foregroundColor(.continuumSecondaryText)
+            .foregroundStyle(Color.continuumAccent.opacity(0.86))
             .padding(.horizontal, 24)
             .padding(.top, 26)
             .padding(.bottom, 6)
@@ -503,11 +537,10 @@ struct TVSettingsConfirmationOverlay: View {
 
 // MARK: - Picker sheet
 
-/// Modal option picker presented by `.fullScreenCover(item:)` (tvOS 26
-/// renders plain sheets as narrow centered cards that clip content).
-/// Contains its own `NavigationStack` so it has a title regardless of
-/// where it was presented from. Selecting an option updates the
-/// binding and dismisses.
+/// Compact modal option menu mounted by the root Settings view.
+/// The menu stays compact while a full-screen scrim cleanly separates it
+/// from the disabled two-pane settings focus graph beneath it.
+/// Selecting an option updates the binding and dismisses; Menu cancels.
 struct TVSettingsPickerSheet: View {
     let title: String
     let options: [TVSettingsOption]
@@ -515,81 +548,194 @@ struct TVSettingsPickerSheet: View {
     var subtitlePreviewAppearance: SubtitleAppearance? = nil
     var allowsSelection = true
     var disabledMessage: String? = nil
+    var onDismiss: (() -> Void)? = nil
 
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.resetFocus) private var resetFocus
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Namespace private var pickerFocusScope
     @FocusState private var focusedOptionID: String?
+    @State private var isClosing = false
 
     var body: some View {
-        NavigationStack {
-            VStack(spacing: 18) {
-                if let disabledMessage {
-                    TVSettingsFooter(disabledMessage)
-                }
+        GeometryReader { geometry in
+            ZStack {
+                Color.continuumBackground.opacity(0.88)
+                    .ignoresSafeArea()
 
-                if let subtitlePreviewAppearance {
-                    TVSettingsSubtitlePreview(
-                        appearance: previewAppearance(from: subtitlePreviewAppearance)
+                RadialGradient(
+                    colors: [
+                        Color.continuumAccent.opacity(0.08),
+                        Color.clear,
+                    ],
+                    center: .center,
+                    startRadius: 40,
+                    endRadius: 680
+                )
+                .ignoresSafeArea()
+
+                pickerCard(
+                    width: min(760, geometry.size.width - 240),
+                    height: min(
+                        max(preferredCardHeight, 390),
+                        min(760, geometry.size.height - 160)
                     )
-                }
-
-                ScrollViewReader { proxy in
-                    ScrollView {
-                        LazyVStack(spacing: 10) {
-                            ForEach(options) { option in
-                                TVSettingsPickerOptionRow(
-                                    option: option,
-                                    isSelected: option.id == selection,
-                                    focusedOptionID: $focusedOptionID
-                                ) {
-                                    selection = option.id
-                                    dismiss()
-                                }
-                                .id(option.id)
-                            }
-                        }
-                        .padding(.vertical, 16)
-                    }
-                    .scrollIndicators(options.count > 8 ? .automatic : .hidden)
-                    .onAppear {
-                        guard allowsSelection else {
-                            focusedOptionID = nil
-                            return
-                        }
-                        focusSelection()
-                        scrollToFocusedOption(with: proxy, animated: false)
-                    }
-                    .onChange(of: allowsSelection) { _, enabled in
-                        guard enabled else {
-                            focusedOptionID = nil
-                            return
-                        }
-                        focusSelection()
-                        scrollToFocusedOption(with: proxy, animated: false)
-                    }
-                    .onChange(of: focusedOptionID) { _, _ in
-                        scrollToFocusedOption(with: proxy)
-                    }
-                    .onChange(of: selection) { _, _ in
-                        scrollToFocusedOption(with: proxy)
-                    }
-                }
-                .disabled(!allowsSelection)
+                )
             }
-            .frame(maxWidth: 960)
-            .navigationTitle(title)
-            .safeAreaPadding(.vertical, ContinuumTheme.safePadding / 2)
-            .background(Color.continuumBackground.ignoresSafeArea())
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+        .preferredColorScheme(.dark)
+        .focusScope(pickerFocusScope)
         .focusSection()
+        .onExitCommand(perform: close)
+        .onDisappear { isClosing = true }
         .onChange(of: focusedOptionID) { _, value in
-            if allowsSelection, value == nil {
-                focusSelection()
+            if allowsSelection, value == nil, !isClosing {
+                claimFocus()
             }
         }
     }
 
+    private func pickerCard(width: CGFloat, height: CGFloat) -> some View {
+        let cardShape = RoundedRectangle(cornerRadius: 30, style: .continuous)
+
+        return VStack(alignment: .leading, spacing: 18) {
+            HStack(alignment: .top, spacing: 24) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(title)
+                        .font(.system(size: 42, weight: .bold))
+                        .foregroundStyle(Color.continuumOnSurface)
+                        .accessibilityAddTraits(.isHeader)
+
+                    Text("Choose an option")
+                        .font(.system(size: 19))
+                        .foregroundStyle(Color.continuumSecondaryText)
+                }
+
+                Spacer(minLength: 12)
+
+                Label("Menu to close", systemImage: "arrow.uturn.backward")
+                    .font(.system(size: 17, weight: .medium))
+                    .foregroundStyle(Color.continuumSecondaryText)
+                    .padding(.horizontal, 15)
+                    .padding(.vertical, 10)
+                    .background(Color.white.opacity(0.055), in: Capsule())
+                    .overlay {
+                        Capsule()
+                            .strokeBorder(Color.continuumChromeRestingBorder, lineWidth: 1)
+                }
+            }
+
+            if let disabledMessage {
+                TVSettingsFooter(disabledMessage)
+            }
+
+            if let subtitlePreviewAppearance {
+                TVSettingsSubtitlePreview(
+                    appearance: previewAppearance(from: subtitlePreviewAppearance)
+                )
+            }
+
+            Rectangle()
+                .fill(Color.continuumChromeRestingBorder)
+                .frame(height: 1)
+
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(spacing: 10) {
+                        ForEach(options) { option in
+                            TVSettingsPickerOptionRow(
+                                option: option,
+                                isSelected: option.id == selection,
+                                focusedOptionID: $focusedOptionID
+                            ) {
+                                selection = option.id
+                                close()
+                            }
+                            .id(option.id)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                    .padding(.horizontal, 8)
+                }
+                .contentMargins(.vertical, 8, for: .scrollContent)
+                .scrollIndicators(options.count > 7 ? .automatic : .hidden)
+                // Picker rows scale and cast a small shadow on focus. Keep
+                // those layers inside the list viewport so scrolling cannot
+                // paint over the header or beyond the card.
+                .clipped()
+                .onAppear {
+                    guard allowsSelection else {
+                        focusedOptionID = nil
+                        return
+                    }
+                    claimFocus()
+                    scrollToFocusedOption(with: proxy, animated: false)
+                }
+                .onChange(of: allowsSelection) { _, enabled in
+                    guard enabled else {
+                        focusedOptionID = nil
+                        return
+                    }
+                    claimFocus()
+                    scrollToFocusedOption(with: proxy, animated: false)
+                }
+                .onChange(of: focusedOptionID) { _, _ in
+                    scrollToFocusedOption(with: proxy)
+                }
+                .onChange(of: selection) { _, _ in
+                    scrollToFocusedOption(with: proxy)
+                }
+            }
+            .disabled(!allowsSelection)
+        }
+        .padding(30)
+        .frame(width: width, height: height, alignment: .top)
+        .background(cardShape.fill(Color.continuumSurfaceElevated.opacity(0.98)))
+        // Clip child layers first, then add the border and outer card shadow.
+        // This preserves the floating dialog while containing scroll content.
+        .clipShape(cardShape)
+        .overlay {
+            cardShape.strokeBorder(
+                Color.continuumChromeSelectedBorder.opacity(0.9),
+                lineWidth: 1
+            )
+        }
+        .shadow(color: .black.opacity(0.58), radius: 48, y: 22)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("\(title) options")
+    }
+
+    private var preferredCardHeight: CGFloat {
+        let rowHeight: CGFloat = options.contains { $0.previewFontName != nil } ? 88 : 72
+        let chromeHeight: CGFloat = subtitlePreviewAppearance == nil ? 158 : 344
+        let disabledMessageHeight: CGFloat = disabledMessage == nil ? 0 : 72
+        return chromeHeight + disabledMessageHeight + CGFloat(options.count) * rowHeight
+    }
+
     private func focusSelection() {
         focusedOptionID = options.first { $0.id == selection }?.id ?? options.first?.id
+    }
+
+    private func claimFocus() {
+        guard allowsSelection, !isClosing else { return }
+        focusSelection()
+        Task { @MainActor in
+            await Task.yield()
+            guard allowsSelection, !isClosing else { return }
+            resetFocus(in: pickerFocusScope)
+            focusSelection()
+        }
+    }
+
+    private func close() {
+        guard !isClosing else { return }
+        isClosing = true
+        if let onDismiss {
+            onDismiss()
+        } else {
+            dismiss()
+        }
     }
 
     private func previewAppearance(from base: SubtitleAppearance) -> SubtitleAppearance {
@@ -606,7 +752,7 @@ struct TVSettingsPickerSheet: View {
         guard allowsSelection else { return }
         let targetID = focusedOptionID ?? options.first { $0.id == selection }?.id ?? options.first?.id
         guard let targetID else { return }
-        if animated {
+        if animated, !reduceMotion {
             withAnimation(.easeOut(duration: ContinuumTheme.fastDuration)) {
                 proxy.scrollTo(targetID, anchor: .center)
             }
@@ -622,63 +768,33 @@ private struct TVSettingsPickerOptionRow: View {
     @FocusState.Binding var focusedOptionID: String?
     let onSelect: () -> Void
 
-    private var isFocused: Bool { focusedOptionID == option.id }
-
     var body: some View {
-        HStack(spacing: 16) {
-            VStack(alignment: .leading, spacing: 3) {
-                Text(option.label)
-                    .font(.system(size: 28, weight: isSelected ? .semibold : .medium))
-                    .lineLimit(1)
-
-                if let previewFontName = option.previewFontName {
-                    Text("Subtitle sample")
-                        .font(.custom(previewFontName, size: 22))
+        Button(action: onSelect) {
+            HStack(spacing: 16) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(option.label)
+                        .font(.system(size: 27, weight: isSelected ? .semibold : .medium))
                         .lineLimit(1)
-                        .opacity(0.72)
+
+                    if let previewFontName = option.previewFontName {
+                        Text("Subtitle sample")
+                            .font(.custom(previewFontName, size: 22))
+                            .lineLimit(1)
+                            .opacity(0.72)
+                    }
                 }
+
+                Spacer(minLength: 0)
+
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 24, weight: .semibold))
+                    .opacity(isSelected ? 1 : 0)
             }
-
-            Spacer(minLength: 0)
-
-            Image(systemName: "checkmark.circle.fill")
-                .font(.system(size: 24, weight: .semibold))
-                .opacity(isSelected ? 1 : 0)
         }
-        .foregroundStyle(isFocused ? Color.continuumBackground : .continuumOnSurface)
-        .padding(.horizontal, 24)
-        .padding(.vertical, 15)
-        .background(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(backgroundFill)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .strokeBorder(
-                    borderColor,
-                    lineWidth: 1
-                )
-        )
-        .contentShape(RoundedRectangle(cornerRadius: 14))
-        .focusable(true)
+        .buttonStyle(TVSettingsPaneRowStyle(isSelected: isSelected))
         .focused($focusedOptionID, equals: option.id)
-        .onTapGesture(perform: onSelect)
-        .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: isFocused)
-        .accessibilityAddTraits(.isButton)
         .accessibilityLabel(option.label)
         .accessibilityValue(isSelected ? "Selected" : "")
-    }
-
-    private var backgroundFill: Color {
-        if isFocused { return .continuumOnSurface }
-        if isSelected { return .continuumChromeSelectedFill }
-        return .continuumChromeRestingFill
-    }
-
-    private var borderColor: Color {
-        if isFocused { return .clear }
-        if isSelected { return .continuumChromeSelectedBorder }
-        return .continuumChromeRestingBorder
     }
 }
 

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsPickerRequest.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsPickerRequest.swift
@@ -1,0 +1,14 @@
+#if os(tvOS)
+import SwiftUI
+
+/// Everything the root Settings view needs to present one modal picker while
+/// preserving the exact detail row that should regain focus on dismissal.
+struct TVSettingsPickerRequest: Identifiable {
+    let id: String
+    let title: String
+    let options: [TVSettingsOption]
+    let selection: Binding<String>
+    var subtitlePreviewAppearance: SubtitleAppearance? = nil
+    let returnFocus: TVSettingsDetailFocus
+}
+#endif

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsView.swift
@@ -7,27 +7,38 @@ import SwiftUI
 /// controls inline. The pane follows rail focus live (like the system
 /// Settings app's split screens), so there is no drill-in navigation —
 /// which also sidesteps the tvOS 26 push-from-tab-Form problem that used
-/// to force every sub-screen through a `fullScreenCover`. Only option
-/// pickers still present as covers (`TVSettingsPickerSheet`).
+/// to force every sub-screen through a `fullScreenCover`. Option pickers
+/// mount as root overlays so their focus graph is fully isolated.
 ///
-/// Focus model: one native graph. Each pane is a `.focusSection()`;
-/// vertical movement stays in-pane and Left/Right bridges panes
-/// geometrically. User-initiated default focus makes each pane's anchor
-/// win during that native resolution; Select/Menu use the same anchors
-/// explicitly (see docs/tvos-focus.md).
+/// Focus model: one native graph with one preferred owner. Each pane is a
+/// `.focusSection()`; vertical movement stays in-pane and Left/Right bridges
+/// panes natively. The detail pane gives its preferred row user-initiated
+/// default priority so it wins the initial cross-pane focus resolution before
+/// geometric proximity can select a lower row. The outer scope still chooses
+/// the active pane for page entry and modal restoration (see docs/tvos-focus.md).
 struct TVSettingsView: View {
     @State private var viewModel = TVSettingsViewModel()
     @State private var diagnosticsModel = DiagnosticsViewModel()
     @State private var showSignOutConfirm = false
     @State private var selectedCategory: TVSettingsCategory = .general
+    @State private var activePicker: TVSettingsPickerRequest?
+    @State private var pendingPickerFocus: TVSettingsDetailFocus?
+    @State private var isRestoringDetailFocus = false
+    @State private var preferredFocusOwner: FocusOwner = .rail
+    @State private var preferredDetailFocus: TVSettingsDetailFocus = .top
     @FocusState private var railFocus: RailItem?
     @FocusState private var detailFocus: TVSettingsDetailFocus?
+    @Environment(\.resetFocus) private var resetFocus
+    @Namespace private var settingsFocusScope
+    @Namespace private var railFocusScope
+    @Namespace private var detailFocusScope
     @Environment(AppRouter.self) private var router
 
     var body: some View {
         ZStack {
+            SettingsBackdrop()
+
             settingsContent
-                .disabled(showSignOutConfirm)
 
             if showSignOutConfirm {
                 TVSettingsConfirmationOverlay(
@@ -42,21 +53,51 @@ struct TVSettingsView: View {
                 .transition(.opacity)
                 .zIndex(1)
             }
+
+            if let activePicker {
+                TVSettingsPickerSheet(
+                    title: activePicker.title,
+                    options: activePicker.options,
+                    selection: activePicker.selection,
+                    subtitlePreviewAppearance: activePicker.subtitlePreviewAppearance,
+                    onDismiss: dismissPicker
+                )
+                .onDisappear(perform: restorePickerFocus)
+                .zIndex(2)
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: showSignOutConfirm)
-        .defaultFocus($railFocus, .category(selectedCategory))
         .task {
             await viewModel.load()
             await diagnosticsModel.load(profile: viewModel.activeProfile)
         }
         .onChange(of: railFocus) { _, focus in
+            if focus != nil,
+               activePicker == nil,
+               !showSignOutConfirm,
+               !isRestoringDetailFocus {
+                preferredFocusOwner = .rail
+            }
+
             // The pane previews whatever category the rail focus rests on.
             // Profile / Sign Out keep the last category visible.
-            if case .category(let category) = focus, category != selectedCategory {
-                withAnimation(.easeOut(duration: ContinuumTheme.normalDuration)) {
-                    selectedCategory = category
+            if case .category(let category) = focus {
+                preferredDetailFocus = .top
+                if category != selectedCategory {
+                    withAnimation(.easeOut(duration: ContinuumTheme.normalDuration)) {
+                        selectedCategory = category
+                    }
                 }
+            }
+        }
+        .onChange(of: detailFocus) { _, focus in
+            if let focus,
+               activePicker == nil,
+               !showSignOutConfirm,
+               !isRestoringDetailFocus {
+                preferredDetailFocus = focus
+                preferredFocusOwner = .detail
             }
         }
         .onChange(of: viewModel.editorSubtitleLanguage) { _, _ in
@@ -79,37 +120,68 @@ struct TVSettingsView: View {
     }
 
     private var settingsContent: some View {
-        HStack(alignment: .top, spacing: 64) {
+        HStack(alignment: .top, spacing: 52) {
             rail
-                .frame(width: 430)
-                .focusSection()
+                .padding(24)
+                .background(
+                    RoundedRectangle(cornerRadius: 26)
+                        .fill(Color.continuumSurface.opacity(0.74))
+                )
+                .overlay {
+                    RoundedRectangle(cornerRadius: 26)
+                        .strokeBorder(Color.continuumOutline, lineWidth: 1)
+                }
+                .frame(width: 490)
+                .disabled(
+                    showSignOutConfirm
+                        || activePicker != nil
+                        || isRestoringDetailFocus
+                )
                 .defaultFocus(
                     $railFocus,
                     .category(selectedCategory),
-                    priority: .userInitiated
+                    priority: preferredFocusOwner == .rail ? .userInitiated : .automatic
                 )
+                .prefersDefaultFocus(preferredFocusOwner == .rail, in: settingsFocusScope)
+                .focusSection()
+                .focusScope(railFocusScope)
                 .onExitCommand(perform: exitSettingsToHome)
 
             detailPane
                 .frame(maxWidth: .infinity, alignment: .topLeading)
+                .disabled(showSignOutConfirm || activePicker != nil)
+                .defaultFocus(
+                    $detailFocus,
+                    preferredDetailFocus,
+                    priority: .userInitiated
+                )
+                .prefersDefaultFocus(preferredFocusOwner == .detail, in: settingsFocusScope)
                 .focusSection()
-                .defaultFocus($detailFocus, .top, priority: .userInitiated)
+                .focusScope(detailFocusScope)
                 .onExitCommand(perform: returnFocusToRail)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .focusScope(settingsFocusScope)
         .safeAreaPadding(.horizontal, ContinuumTheme.Skyline.safeAreaX)
-        .safeAreaPadding(.top, 64)
+        .safeAreaPadding(.top, 48)
+        .safeAreaPadding(.bottom, 44)
     }
 
     // MARK: - Left rail
 
     private var rail: some View {
         VStack(alignment: .leading, spacing: 6) {
-            Text("Settings")
-                .font(.system(size: 44, weight: .bold))
-                .foregroundColor(.continuumOnSurface)
-                .padding(.leading, 20)
-                .padding(.bottom, 26)
+            VStack(alignment: .leading, spacing: 5) {
+                Text("Settings")
+                    .font(.system(size: 42, weight: .bold))
+                    .foregroundStyle(Color.continuumOnSurface)
+
+                Text("Make Silo work the way you like.")
+                    .font(.system(size: 18))
+                    .foregroundStyle(Color.continuumSecondaryText)
+            }
+            .padding(.horizontal, 20)
+            .padding(.bottom, 20)
 
             profileRow
                 .padding(.bottom, 22)
@@ -171,8 +243,17 @@ struct TVSettingsView: View {
                 Image(systemName: category.icon)
                     .font(.system(size: 22, weight: .medium))
                     .frame(width: 34)
-                Text(category.title)
-                    .font(.system(size: 27, weight: .medium))
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(category.title)
+                        .font(.system(size: 25, weight: .medium))
+
+                    Text(category.railDescription)
+                        .font(.system(size: 16))
+                        .opacity(0.62)
+                        .lineLimit(1)
+                }
+
                 Spacer(minLength: 0)
             }
         }
@@ -206,19 +287,89 @@ struct TVSettingsView: View {
 
     private func enterDetailPane(for category: TVSettingsCategory) {
         selectedCategory = category
+        preferredFocusOwner = .detail
+        preferredDetailFocus = .top
+        isRestoringDetailFocus = true
+        railFocus = nil
         detailFocus = .top
+        Task { @MainActor in
+            await Task.yield()
+            resetFocus(in: settingsFocusScope)
+            resetFocus(in: detailFocusScope)
+            detailFocus = .top
+            try? await Task.sleep(for: .milliseconds(120))
+            isRestoringDetailFocus = false
+        }
     }
 
     private func returnFocusToRail() {
+        guard activePicker == nil,
+              !showSignOutConfirm,
+              !isRestoringDetailFocus else {
+            return
+        }
+        preferredFocusOwner = .rail
         detailFocus = nil
         railFocus = .category(selectedCategory)
+        resetFocus(in: railFocusScope)
     }
 
     private func dismissSignOutConfirmation() {
         showSignOutConfirm = false
+        preferredFocusOwner = .rail
+        railFocus = .signOut
         Task { @MainActor in
             await Task.yield()
+            resetFocus(in: railFocusScope)
             railFocus = .signOut
+        }
+    }
+
+    private func presentPicker(_ request: TVSettingsPickerRequest) {
+        // Remove every underlying focus candidate in the same update that
+        // mounts the modal. The picker then becomes the sole focus owner.
+        preferredFocusOwner = .detail
+        preferredDetailFocus = request.returnFocus
+        railFocus = nil
+        detailFocus = nil
+        activePicker = request
+    }
+
+    private func dismissPicker() {
+        guard let target = activePicker?.returnFocus else {
+            activePicker = nil
+            return
+        }
+
+        // Keep the rail out of the graph while SwiftUI removes the modal.
+        // The exact row is restored from the overlay's onDisappear callback,
+        // after its focus subtree has actually left the hierarchy.
+        preferredFocusOwner = .detail
+        preferredDetailFocus = target
+        pendingPickerFocus = target
+        isRestoringDetailFocus = true
+        activePicker = nil
+    }
+
+    private func restorePickerFocus() {
+        guard let target = pendingPickerFocus else { return }
+
+        preferredFocusOwner = .detail
+        preferredDetailFocus = target
+        railFocus = nil
+        detailFocus = nil
+        resetFocus(in: settingsFocusScope)
+        Task { @MainActor in
+            await Task.yield()
+            railFocus = nil
+            resetFocus(in: settingsFocusScope)
+            await Task.yield()
+            detailFocus = nil
+            await Task.yield()
+            detailFocus = target
+            try? await Task.sleep(for: .milliseconds(120))
+            pendingPickerFocus = nil
+            isRestoringDetailFocus = false
         }
     }
 
@@ -240,6 +391,10 @@ struct TVSettingsView: View {
             .frame(maxWidth: 1080, alignment: .leading)
             .padding(.bottom, 64)
         }
+        // Keep focused row scaling and shadows inside a deliberate gutter
+        // instead of letting the scroll view trim their rounded edges.
+        .contentMargins(.horizontal, 18, for: .scrollContent)
+        .scrollClipDisabled()
         // Rebuild the scroll view per category so it opens at the top.
         // Safe: selection only changes while focus is in the rail.
         .id(selectedCategory)
@@ -247,21 +402,35 @@ struct TVSettingsView: View {
     }
 
     private var paneHeader: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(selectedCategory.eyebrow)
-                .font(.system(size: 15, weight: .semibold, design: .monospaced))
-                .tracking(2)
-                .foregroundColor(.continuumSecondaryText)
+        HStack(alignment: .center, spacing: 20) {
+            Image(systemName: selectedCategory.icon)
+                .font(.system(size: 27, weight: .medium))
+                .foregroundStyle(selectedCategory.tint)
+                .frame(width: 62, height: 62)
+                .background(selectedCategory.tint.opacity(0.13), in: Circle())
+                .overlay {
+                    Circle()
+                        .strokeBorder(selectedCategory.tint.opacity(0.22), lineWidth: 1)
+                }
+                .accessibilityHidden(true)
 
-            Text(selectedCategory.title)
-                .font(.system(size: 38, weight: .semibold))
-                .foregroundColor(.continuumOnSurface)
+            VStack(alignment: .leading, spacing: 7) {
+                Text(selectedCategory.eyebrow)
+                    .font(.system(size: 15, weight: .semibold, design: .monospaced))
+                    .tracking(2)
+                    .foregroundStyle(selectedCategory.tint)
 
-            Text(selectedCategory.blurb)
-                .font(.system(size: 20))
-                .foregroundColor(.continuumSecondaryText)
+                Text(selectedCategory.title)
+                    .font(.system(size: 38, weight: .semibold))
+                    .foregroundStyle(Color.continuumOnSurface)
+
+                Text(selectedCategory.blurb)
+                    .font(.system(size: 20))
+                    .foregroundStyle(Color.continuumSecondaryText)
+            }
         }
         .padding(.horizontal, 24)
+        .accessibilityElement(children: .combine)
     }
 
     @ViewBuilder
@@ -270,9 +439,17 @@ struct TVSettingsView: View {
         case .general:
             TVGeneralSettingsPane(detailFocus: $detailFocus)
         case .playback:
-            TVPlaybackSettingsPane(viewModel: viewModel, detailFocus: $detailFocus)
+            TVPlaybackSettingsPane(
+                viewModel: viewModel,
+                detailFocus: $detailFocus,
+                presentPicker: presentPicker
+            )
         case .subtitles:
-            TVSubtitleSettingsPane(viewModel: viewModel, detailFocus: $detailFocus)
+            TVSubtitleSettingsPane(
+                viewModel: viewModel,
+                detailFocus: $detailFocus,
+                presentPicker: presentPicker
+            )
         case .diagnostics:
             TVDiagnosticsSettingsPane(model: diagnosticsModel, detailFocus: $detailFocus)
         case .server:
@@ -328,6 +505,11 @@ struct TVSettingsView: View {
         case signOut
     }
 
+    private enum FocusOwner {
+        case rail
+        case detail
+    }
+
     private var visibleCategories: [TVSettingsCategory] {
         TVSettingsCategory.allCases.filter { category in
             category != .diagnostics || diagnosticsModel.shouldShowSettings
@@ -348,6 +530,18 @@ struct TVSettingsView: View {
 
 enum TVSettingsDetailFocus: Hashable {
     case top
+    case playbackAudioLanguage
+    case playbackNextUpPrompt
+    case subtitleBehavior
+    case subtitleMetadataLanguage
+    case subtitleFontSize
+    case subtitleFontFamily
+    case subtitleFontColor
+    case subtitleOutlineColor
+    case subtitleBackgroundStyle
+    case subtitleBackgroundOpacity
+    case subtitleBackgroundColor
+    case subtitlePosition
 }
 
 // MARK: - Categories
@@ -401,6 +595,27 @@ enum TVSettingsCategory: String, CaseIterable, Identifiable {
             return "Review and send diagnostics to this Silo server."
         case .server:
             return "The Silo server this Apple TV is connected to."
+        }
+    }
+
+    var railDescription: String {
+        switch self {
+        case .general: return "App and navigation"
+        case .playback: return "Quality and episodes"
+        case .subtitles: return "Language and appearance"
+        case .diagnostics: return "Reports and support"
+        case .server: return "Connection and version"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .general, .playback, .subtitles:
+            return .continuumAccent
+        case .diagnostics:
+            return .orange
+        case .server:
+            return .teal
         }
     }
 }

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSubtitleSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSubtitleSettingsView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 struct TVSubtitleSettingsPane: View {
     @Bindable var viewModel: TVSettingsViewModel
     let detailFocus: FocusState<TVSettingsDetailFocus?>.Binding
-    @State private var activePicker: PickerKind?
+    let presentPicker: (TVSettingsPickerRequest) -> Void
     @State private var showResetConfirmation = false
 
     var body: some View {
@@ -18,9 +18,6 @@ struct TVSubtitleSettingsPane: View {
                 metadataLanguageSection
             }
             appearanceSection
-        }
-        .fullScreenCover(item: $activePicker) { kind in
-            pickerSheet(for: kind)
         }
         .alert("Reset Custom Appearance?", isPresented: $showResetConfirmation) {
             Button("Reset", role: .destructive) {
@@ -45,7 +42,7 @@ struct TVSubtitleSettingsPane: View {
                     for: viewModel.editorSubtitleLanguage,
                     in: TVSettingsOptions.subtitleLanguage(viewModel.subtitleLanguageOptions)
                 )
-            ) { activePicker = .language }
+            ) { showPicker(.language) }
             .disabled(true)
         } else {
             TVSettingsPickerRow(
@@ -54,14 +51,15 @@ struct TVSubtitleSettingsPane: View {
                     for: viewModel.editorSubtitleLanguage,
                     in: TVSettingsOptions.subtitleLanguage(viewModel.subtitleLanguageOptions)
                 )
-            ) { activePicker = .language }
+            ) { showPicker(.language) }
             .focused(detailFocus, equals: .top)
         }
 
         TVSettingsPickerRow(
             title: "Behavior",
             value: TVSettingsOptions.label(for: viewModel.editorSubtitleMode, in: TVSettingsOptions.subtitleMode)
-        ) { activePicker = .mode }
+        ) { showPicker(.mode) }
+        .focused(detailFocus, equals: .subtitleBehavior)
         .disabled(viewModel.settingsServerUpgradeRequired)
 
         TVSettingsToggleRow(
@@ -94,7 +92,8 @@ struct TVSubtitleSettingsPane: View {
                 for: viewModel.editorPreferredMetadataLanguage,
                 in: TVSettingsOptions.metadataLanguage(viewModel.metadataLanguageOptions)
             )
-        ) { activePicker = .metadataLanguage }
+        ) { showPicker(.metadataLanguage) }
+        .focused(detailFocus, equals: .subtitleMetadataLanguage)
         .disabled(viewModel.settingsServerUpgradeRequired)
 
         TVSettingsFooter("Translates descriptions and taglines into your preferred language when available. Titles are never translated.")
@@ -169,8 +168,9 @@ struct TVSubtitleSettingsPane: View {
                     : "—"
             ) {
                 guard viewModel.subtitleUsesDeviceAppearanceOverride else { return }
-                activePicker = .outlineColor
+                showPicker(.outlineColor)
             }
+            .focused(detailFocus, equals: .subtitleOutlineColor)
 
             pickerRow("Background Style", options: TVSettingsOptions.backgroundStyle,
                       selection: viewModel.subtitleAppearance.backgroundStyle.rawValue, kind: .backgroundStyle)
@@ -182,8 +182,9 @@ struct TVSubtitleSettingsPane: View {
                     : "—"
             ) {
                 guard viewModel.subtitleUsesDeviceAppearanceOverride else { return }
-                activePicker = .backgroundOpacity
+                showPicker(.backgroundOpacity)
             }
+            .focused(detailFocus, equals: .subtitleBackgroundOpacity)
 
             TVSettingsPickerRow(
                 title: "Background Color",
@@ -195,8 +196,9 @@ struct TVSubtitleSettingsPane: View {
                     : "—"
             ) {
                 guard viewModel.subtitleUsesDeviceAppearanceOverride else { return }
-                activePicker = .backgroundColor
+                showPicker(.backgroundColor)
             }
+            .focused(detailFocus, equals: .subtitleBackgroundColor)
 
             pickerRow("Position", options: TVSettingsOptions.position,
                       selection: viewModel.subtitleAppearance.position.rawValue, kind: .position)
@@ -253,81 +255,107 @@ struct TVSubtitleSettingsPane: View {
             value: TVSettingsOptions.label(for: selection, in: options)
         ) {
             guard viewModel.subtitleUsesDeviceAppearanceOverride else { return }
-            activePicker = kind
+            showPicker(kind)
         }
+        .focused(detailFocus, equals: kind.returnFocus)
     }
 
     // MARK: - Pickers
 
-    @ViewBuilder
-    private func pickerSheet(for kind: PickerKind) -> some View {
+    private func showPicker(_ kind: PickerKind) {
+        presentPicker(pickerRequest(for: kind))
+    }
+
+    private func pickerRequest(for kind: PickerKind) -> TVSettingsPickerRequest {
         switch kind {
         case .language:
-            TVSettingsPickerSheet(
+            TVSettingsPickerRequest(
+                id: kind.id,
                 title: "Language",
                 options: TVSettingsOptions.subtitleLanguage(viewModel.subtitleLanguageOptions),
-                selection: $viewModel.editorSubtitleLanguage
+                selection: $viewModel.editorSubtitleLanguage,
+                returnFocus: kind.returnFocus
             )
         case .mode:
-            TVSettingsPickerSheet(
+            TVSettingsPickerRequest(
+                id: kind.id,
                 title: "Behavior",
                 options: TVSettingsOptions.subtitleMode,
-                selection: $viewModel.editorSubtitleMode
+                selection: $viewModel.editorSubtitleMode,
+                returnFocus: kind.returnFocus
             )
         case .metadataLanguage:
-            TVSettingsPickerSheet(
+            TVSettingsPickerRequest(
+                id: kind.id,
                 title: "Metadata Language",
                 options: TVSettingsOptions.metadataLanguage(viewModel.metadataLanguageOptions),
-                selection: $viewModel.editorPreferredMetadataLanguage
+                selection: $viewModel.editorPreferredMetadataLanguage,
+                returnFocus: kind.returnFocus
             )
         case .fontSize:
-            TVSettingsPickerSheet(
+            TVSettingsPickerRequest(
+                id: kind.id,
                 title: "Font Size",
                 options: TVSettingsOptions.subtitleSize,
-                selection: appearanceEnumBinding(\.fontSize, SubtitleFontSizePreset.self)
+                selection: appearanceEnumBinding(\.fontSize, SubtitleFontSizePreset.self),
+                returnFocus: kind.returnFocus
             )
         case .fontFamily:
-            TVSettingsPickerSheet(
+            TVSettingsPickerRequest(
+                id: kind.id,
                 title: "Font Family",
                 options: TVSettingsOptions.fontFamily,
                 selection: appearanceEnumBinding(\.fontFamily, SubtitleFontFamilyPreset.self),
-                subtitlePreviewAppearance: viewModel.subtitleAppearance
+                subtitlePreviewAppearance: viewModel.subtitleAppearance,
+                returnFocus: kind.returnFocus
             )
         case .fontColor:
-            TVSettingsPickerSheet(
+            TVSettingsPickerRequest(
+                id: kind.id,
                 title: "Font Color",
                 options: TVSettingsOptions.fontColor,
-                selection: appearanceStringBinding(\.fontColor)
+                selection: appearanceStringBinding(\.fontColor),
+                returnFocus: kind.returnFocus
             )
         case .outlineColor:
-            TVSettingsPickerSheet(
+            TVSettingsPickerRequest(
+                id: kind.id,
                 title: "Outline Color",
                 options: TVSettingsOptions.outlineColor,
-                selection: outlineColorBinding
+                selection: outlineColorBinding,
+                returnFocus: kind.returnFocus
             )
         case .backgroundStyle:
-            TVSettingsPickerSheet(
+            TVSettingsPickerRequest(
+                id: kind.id,
                 title: "Background Style",
                 options: TVSettingsOptions.backgroundStyle,
-                selection: backgroundStyleBinding
+                selection: backgroundStyleBinding,
+                returnFocus: kind.returnFocus
             )
         case .backgroundOpacity:
-            TVSettingsPickerSheet(
+            TVSettingsPickerRequest(
+                id: kind.id,
                 title: "Background Opacity",
                 options: TVSettingsOptions.backgroundOpacity,
-                selection: backgroundOpacityBinding
+                selection: backgroundOpacityBinding,
+                returnFocus: kind.returnFocus
             )
         case .backgroundColor:
-            TVSettingsPickerSheet(
+            TVSettingsPickerRequest(
+                id: kind.id,
                 title: "Background Color",
                 options: TVSettingsOptions.backgroundColor,
-                selection: backgroundColorBinding
+                selection: backgroundColorBinding,
+                returnFocus: kind.returnFocus
             )
         case .position:
-            TVSettingsPickerSheet(
+            TVSettingsPickerRequest(
+                id: kind.id,
                 title: "Position",
                 options: TVSettingsOptions.position,
-                selection: appearanceEnumBinding(\.position, SubtitlePositionPreset.self)
+                selection: appearanceEnumBinding(\.position, SubtitlePositionPreset.self),
+                returnFocus: kind.returnFocus
             )
         }
     }
@@ -346,6 +374,22 @@ struct TVSubtitleSettingsPane: View {
         case position
 
         var id: String { rawValue }
+
+        var returnFocus: TVSettingsDetailFocus {
+            switch self {
+            case .language: .top
+            case .mode: .subtitleBehavior
+            case .metadataLanguage: .subtitleMetadataLanguage
+            case .fontSize: .subtitleFontSize
+            case .fontFamily: .subtitleFontFamily
+            case .fontColor: .subtitleFontColor
+            case .outlineColor: .subtitleOutlineColor
+            case .backgroundStyle: .subtitleBackgroundStyle
+            case .backgroundOpacity: .subtitleBackgroundOpacity
+            case .backgroundColor: .subtitleBackgroundColor
+            case .position: .subtitlePosition
+            }
+        }
     }
 
     // MARK: - Appearance bindings


### PR DESCRIPTION
## Summary

- redesign the iOS Settings overview around the web app's hierarchy, with search, grouped cards, account context, and a first-class Interface customization destination
- give iOS Settings subpages consistent headers, surfaces, spacing, and backdrop treatment
- polish the tvOS two-pane Settings layout and every category pane
- replace oversized/clipped tvOS option covers with a compact root overlay whose scroll content stays inside the dialog
- isolate modal focus ownership, restore the originating row after dismissal, and make native Right entry select the top row before geometric proximity can choose a lower control
- preserve current `main` behavior for synced interface/card customization and capability-disabled pickers
- document why authenticated simulator validation must use a normally signed product and reuse the same simulator

## Why

The Apple Settings surfaces had drifted from the web app's information hierarchy and visual language. On tvOS, full-screen picker presentation also produced clipped dialogs and competing focus subtrees. Directional entry could initially select the geometrically nearest detail row, then be corrected afterward, causing a visible focus jump.

This change gives each modal a single focus owner and uses a user-initiated default focus on the destination section, matching the existing cast/similar/trailer rail pattern so the intended top row wins the first native focus resolution.

## Validation

- regenerated `iosApp/Silo.xcodeproj` with XcodeGen
- iOS Simulator Debug build: `Silo` — succeeded
- tvOS Simulator Debug build: `SiloTV` — succeeded
- live walkthrough on the existing signed/authenticated Apple TV simulator:
  - compact picker presentation and clipped scrolling
  - picker dismissal restores its originating detail row
  - Back restores the matching Settings category
  - Right from Diagnostics lands directly on Debug Logging
  - Right from Playback lands directly on Quality
- recorded and inspected the tvOS Right transition frames to confirm there is no intermediate lower-row focus
- `git diff --check origin/main...HEAD` — passed

The compiler warnings emitted by the final builds are pre-existing and outside this diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a searchable, card-based iOS Settings overview with account, playback, diagnostics, library, connection, and app information.
  * Introduced consistent settings headers, sections, rows, toggles, search, and account profile presentation.
  * Redesigned tvOS Settings with a two-pane layout, improved focus management, clearer category descriptions, and custom picker dialogs.

* **Style**
  * Refreshed iOS, tvOS, server, downloads, diagnostics, playback, subtitle, and consent screens with cohesive backgrounds, elevated surfaces, and accent styling.

* **Documentation**
  * Clarified simulator signing requirements for authenticated testing and Keychain-backed sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->