### PR TITLE
Honor complete Apple subtitle preferences

### DIFF
--- a/iosApp/Tests/DetailVersionSelectionTests.swift
+++ b/iosApp/Tests/DetailVersionSelectionTests.swift
@@ -3,6 +3,22 @@ import Foundation
 @testable import Silo
 
 final class DetailVersionSelectionTests: XCTestCase {
+
+    func testDeviceSettingsDoNotForwardServerSubtitleSeedAsManualChoice() {
+        XCTAssertNil(DetailPlaybackFormatting.launchPreferredSubtitleIndex(
+            version: nil,
+            signature: nil,
+            mode: SubtitleMode.off.rawValue,
+            usesDeviceSettings: true
+        ))
+        XCTAssertEqual(DetailPlaybackFormatting.launchPreferredSubtitleIndex(
+            version: nil,
+            signature: nil,
+            mode: SubtitleMode.off.rawValue,
+            usesDeviceSettings: false
+        ), -1)
+    }
+
     func testAutoDisplayPrefersBestVersionOverFirstReturnedVersion() {
         let versions = [
             version(fileId: 10, resolution: "1080p"),

--- a/iosApp/Tests/SubtitleAutoResolverTests.swift
+++ b/iosApp/Tests/SubtitleAutoResolverTests.swift
@@ -250,6 +250,18 @@ final class SubtitleAutoResolverTests: XCTestCase {
         XCTAssertEqual(result, .disable)
     }
 
+    func testSystemPolicyDisablesWhenNoSubtitleTracksAreAvailable() {
+        let result = SubtitleAutoResolver.resolve(inputs(
+            preferredLanguage: "en",
+            mode: .always,
+            showForced: false,
+            tracks: [],
+            audioLanguage: "eng",
+            disableWhenNoLanguageMatch: true
+        ))
+        XCTAssertEqual(result, .disable)
+    }
+
     func testSystemForcedOnlyDoesNotSelectUnrequestedLanguage() {
         let frenchForced = track(id: 11, lang: "fra", forced: true)
         let result = SubtitleAutoResolver.resolve(inputs(

--- a/iosApp/Tests/SubtitleAutoResolverTests.swift
+++ b/iosApp/Tests/SubtitleAutoResolverTests.swift
@@ -34,12 +34,18 @@ final class SubtitleAutoResolverTests: XCTestCase {
         mode: SubtitleMode?,
         showForced: Bool,
         tracks: [PlayerTrack],
-        audioLanguage: String?
+        audioLanguage: String?,
+        additionalLanguages: [String] = [],
+        forcedOnly: Bool = false,
+        preferAccessibility: Bool = false
     ) -> SubtitleAutoResolver.Inputs {
         SubtitleAutoResolver.Inputs(
             preferredLanguage: preferredLanguage,
+            additionalPreferredLanguages: additionalLanguages,
             mode: mode,
             showForced: showForced,
+            forcedOnly: forcedOnly,
+            preferAccessibilityTracks: preferAccessibility,
             trackSignature: nil,
             availableSubtitles: tracks,
             currentAudioLanguage: audioLanguage
@@ -132,5 +138,60 @@ final class SubtitleAutoResolverTests: XCTestCase {
         XCTAssertTrue(SubtitleAutoResolver.titleIndicatesHearingImpaired("English [SDH]"))
         XCTAssertTrue(SubtitleAutoResolver.titleIndicatesHearingImpaired("Closed Captions"))
         XCTAssertFalse(SubtitleAutoResolver.titleIndicatesHearingImpaired(nil))
+    }
+
+    func testSystemLanguageStackFallsBackInOrder() {
+        let french = track(id: 10, lang: "fra")
+        let spanish = track(id: 11, lang: "spa")
+        let result = SubtitleAutoResolver.resolve(inputs(
+            preferredLanguage: "de-DE",
+            mode: .always,
+            showForced: false,
+            tracks: [spanish, french],
+            audioLanguage: "eng",
+            additionalLanguages: ["es-ES", "fr-FR"]
+        ))
+        XCTAssertEqual(result, .select(spanish))
+    }
+
+    func testSystemAccessibilityCharacteristicPrefersSDH() {
+        let plain = track(id: 10, lang: "eng", title: "English")
+        let sdh = track(id: 11, lang: "eng", hearingImpaired: true, title: "English SDH")
+        let result = SubtitleAutoResolver.resolve(inputs(
+            preferredLanguage: "en",
+            mode: .always,
+            showForced: false,
+            tracks: [plain, sdh],
+            audioLanguage: "eng",
+            preferAccessibility: true
+        ))
+        XCTAssertEqual(result, .select(sdh))
+    }
+
+    func testSystemForcedOnlyNeverSelectsFullDialogueTrack() {
+        let full = track(id: 10, lang: "eng")
+        let forcedSpanish = track(id: 11, lang: "spa", forced: true)
+        let result = SubtitleAutoResolver.resolve(inputs(
+            preferredLanguage: "en",
+            mode: .auto,
+            showForced: true,
+            tracks: [full, forcedSpanish],
+            audioLanguage: "eng",
+            additionalLanguages: ["es"],
+            forcedOnly: true
+        ))
+        XCTAssertEqual(result, .select(forcedSpanish))
+    }
+
+    func testSystemForcedOnlyDisablesWhenNoForcedTrackExists() {
+        let result = SubtitleAutoResolver.resolve(inputs(
+            preferredLanguage: "en",
+            mode: .auto,
+            showForced: true,
+            tracks: [track(id: 10, lang: "eng")],
+            audioLanguage: "eng",
+            forcedOnly: true
+        ))
+        XCTAssertEqual(result, .disable)
     }
 }

--- a/iosApp/Tests/SubtitleAutoResolverTests.swift
+++ b/iosApp/Tests/SubtitleAutoResolverTests.swift
@@ -37,7 +37,8 @@ final class SubtitleAutoResolverTests: XCTestCase {
         audioLanguage: String?,
         additionalLanguages: [String] = [],
         forcedOnly: Bool = false,
-        preferAccessibility: Bool = false
+        preferAccessibility: Bool = false,
+        disableWhenNoLanguageMatch: Bool = false
     ) -> SubtitleAutoResolver.Inputs {
         SubtitleAutoResolver.Inputs(
             preferredLanguage: preferredLanguage,
@@ -46,6 +47,7 @@ final class SubtitleAutoResolverTests: XCTestCase {
             showForced: showForced,
             forcedOnly: forcedOnly,
             preferAccessibilityTracks: preferAccessibility,
+            disableWhenNoLanguageMatch: disableWhenNoLanguageMatch,
             trackSignature: nil,
             availableSubtitles: tracks,
             currentAudioLanguage: audioLanguage
@@ -193,5 +195,44 @@ final class SubtitleAutoResolverTests: XCTestCase {
             forcedOnly: true
         ))
         XCTAssertEqual(result, .disable)
+    }
+
+    func testSystemForcedOnlyDoesNotSelectUnrequestedLanguage() {
+        let frenchForced = track(id: 11, lang: "fra", forced: true)
+        let result = SubtitleAutoResolver.resolve(inputs(
+            preferredLanguage: "en",
+            mode: .auto,
+            showForced: true,
+            tracks: [frenchForced],
+            audioLanguage: "eng",
+            forcedOnly: true,
+            disableWhenNoLanguageMatch: true
+        ))
+        XCTAssertEqual(result, .disable)
+    }
+
+    func testSystemLanguageMissClearsExistingServerSelection() {
+        let english = track(id: 10, lang: "eng")
+        let result = SubtitleAutoResolver.resolve(inputs(
+            preferredLanguage: "es",
+            mode: .always,
+            showForced: false,
+            tracks: [english],
+            audioLanguage: "eng",
+            disableWhenNoLanguageMatch: true
+        ))
+        XCTAssertEqual(result, .disable)
+    }
+
+    func testServerLanguageMissStillLeavesExistingSelectionAlone() {
+        let english = track(id: 10, lang: "eng")
+        let result = SubtitleAutoResolver.resolve(inputs(
+            preferredLanguage: "es",
+            mode: .always,
+            showForced: false,
+            tracks: [english],
+            audioLanguage: "eng"
+        ))
+        XCTAssertEqual(result, .noChange)
     }
 }

--- a/iosApp/Tests/SubtitleAutoResolverTests.swift
+++ b/iosApp/Tests/SubtitleAutoResolverTests.swift
@@ -169,6 +169,19 @@ final class SubtitleAutoResolverTests: XCTestCase {
         XCTAssertEqual(result, .select(portugalPortuguese))
     }
 
+    func testSystemLanguageMatchesArbitraryISOThreeLetterMetadata() {
+        let dutch = track(id: 10, lang: "nld")
+        let result = SubtitleAutoResolver.resolve(inputs(
+            preferredLanguage: "nl-NL",
+            mode: .always,
+            showForced: false,
+            tracks: [dutch],
+            audioLanguage: "eng"
+        ))
+        XCTAssertEqual(result, .select(dutch))
+        XCTAssertTrue(SubtitleAutoResolver.languagesMatch("dut", "nl-NL"))
+    }
+
     func testSystemAccessibilityCharacteristicPrefersSDH() {
         let plain = track(id: 10, lang: "eng", title: "English")
         let sdh = track(id: 11, lang: "eng", hearingImpaired: true, title: "English SDH")

--- a/iosApp/Tests/SubtitleAutoResolverTests.swift
+++ b/iosApp/Tests/SubtitleAutoResolverTests.swift
@@ -169,6 +169,33 @@ final class SubtitleAutoResolverTests: XCTestCase {
         XCTAssertEqual(result, .select(portugalPortuguese))
     }
 
+    func testFullDialogueTrackBeatsExactRegionalForcedTrack() {
+        let exactForced = track(id: 10, lang: "pt-PT", forced: true)
+        let genericFull = track(id: 11, lang: "pt")
+        let result = SubtitleAutoResolver.resolve(inputs(
+            preferredLanguage: "pt-PT",
+            mode: .always,
+            showForced: true,
+            tracks: [exactForced, genericFull],
+            audioLanguage: "eng"
+        ))
+        XCTAssertEqual(result, .select(genericFull))
+    }
+
+    func testRegionalLanguageStackExhaustsExactMatchesBeforeFallback() {
+        let arbitraryFallback = track(id: 10, lang: "pt-AO")
+        let exactSecondPreference = track(id: 11, lang: "pt-PT")
+        let result = SubtitleAutoResolver.resolve(inputs(
+            preferredLanguage: "pt-BR",
+            mode: .always,
+            showForced: false,
+            tracks: [arbitraryFallback, exactSecondPreference],
+            audioLanguage: "eng",
+            additionalLanguages: ["pt-PT"]
+        ))
+        XCTAssertEqual(result, .select(exactSecondPreference))
+    }
+
     func testSystemLanguageMatchesArbitraryISOThreeLetterMetadata() {
         let dutch = track(id: 10, lang: "nld")
         let result = SubtitleAutoResolver.resolve(inputs(

--- a/iosApp/Tests/SubtitleAutoResolverTests.swift
+++ b/iosApp/Tests/SubtitleAutoResolverTests.swift
@@ -156,6 +156,19 @@ final class SubtitleAutoResolverTests: XCTestCase {
         XCTAssertEqual(result, .select(spanish))
     }
 
+    func testExactRegionalLanguageWinsBeforePrimarySubtagFallback() {
+        let brazilianPortuguese = track(id: 10, lang: "pt-BR")
+        let portugalPortuguese = track(id: 11, lang: "pt-PT")
+        let result = SubtitleAutoResolver.resolve(inputs(
+            preferredLanguage: "pt-PT",
+            mode: .always,
+            showForced: false,
+            tracks: [brazilianPortuguese, portugalPortuguese],
+            audioLanguage: "eng"
+        ))
+        XCTAssertEqual(result, .select(portugalPortuguese))
+    }
+
     func testSystemAccessibilityCharacteristicPrefersSDH() {
         let plain = track(id: 10, lang: "eng", title: "English")
         let sdh = track(id: 11, lang: "eng", hearingImpaired: true, title: "English SDH")

--- a/iosApp/Tests/SubtitleStylingOverrideTests.swift
+++ b/iosApp/Tests/SubtitleStylingOverrideTests.swift
@@ -145,6 +145,8 @@ final class SubtitleStylingOverrideTests: XCTestCase {
         XCTAssertEqual(params.nativeForegroundColorOverride?.1, 0xC5)
         XCTAssertEqual(params.nativeForegroundColorOverride?.2, 0x5E)
         XCTAssertNil(params.nativeForegroundAlphaOverride)
+        XCTAssertNil(params.nativeBackgroundColorOverride)
+        XCTAssertEqual(params.nativeBackgroundAlphaOverride, 127)
     }
 
     func testDropShadowWithGlyphBoxUsesIndependentCompositorEdge() {
@@ -209,18 +211,50 @@ final class SubtitleStylingOverrideTests: XCTestCase {
         XCTAssertTrue(SubtitleRenderer.shouldSynthesizeGlyphBackground(
             isNativeASS: true,
             opacityPercent: 50,
-            overrides: [.backgroundColor]
+            overrides: [.backgroundColor],
+            hasAuthoredBackground: false
         ))
         XCTAssertTrue(SubtitleRenderer.shouldSynthesizeGlyphBackground(
             isNativeASS: true,
             opacityPercent: 50,
-            overrides: [.backgroundOpacity]
+            overrides: [.backgroundOpacity],
+            hasAuthoredBackground: false
+        ))
+        XCTAssertFalse(SubtitleRenderer.shouldSynthesizeGlyphBackground(
+            isNativeASS: true,
+            opacityPercent: 50,
+            overrides: [.backgroundColor],
+            hasAuthoredBackground: true
         ))
         XCTAssertFalse(SubtitleRenderer.shouldSynthesizeGlyphBackground(
             isNativeASS: false,
             opacityPercent: 50,
-            overrides: [.backgroundOpacity]
+            overrides: [.backgroundOpacity],
+            hasAuthoredBackground: false
         ))
+    }
+
+    func testSolidBackgroundMaskDetectionRejectsGlyphMasks() {
+        let solid = [UInt8](repeating: 0xFF, count: 12)
+        var glyph = solid
+        glyph[5] = 0
+
+        solid.withUnsafeBufferPointer {
+            XCTAssertTrue(SubtitleRenderer.isSolidBackgroundMask(
+                $0.baseAddress,
+                width: 4,
+                height: 3,
+                stride: 4
+            ))
+        }
+        glyph.withUnsafeBufferPointer {
+            XCTAssertFalse(SubtitleRenderer.isSolidBackgroundMask(
+                $0.baseAddress,
+                width: 4,
+                height: 3,
+                stride: 4
+            ))
+        }
     }
 
     // MARK: - Struct color packing (libass internal RRGGBBAA)

--- a/iosApp/Tests/SubtitleStylingOverrideTests.swift
+++ b/iosApp/Tests/SubtitleStylingOverrideTests.swift
@@ -132,6 +132,64 @@ final class SubtitleStylingOverrideTests: XCTestCase {
         XCTAssertFalse(json.contains("systemContentOverrides"))
     }
 
+    func testNativeColorOverridesRemainPerProperty() {
+        var appearance = SubtitleAppearance.default
+        appearance.fontColor = "#22c55e"
+        appearance.fontOpacity = 40
+        appearance.backgroundColor = "#ff00ff"
+        appearance.backgroundOpacity = 50
+        appearance.systemContentOverrides = [.foregroundColor, .backgroundOpacity]
+
+        let params = SubtitleStylingOverride.Parameters.from(appearance: appearance, syncOffsetMs: 0)
+        XCTAssertEqual(params.nativeForegroundColorOverride?.0, 0x22)
+        XCTAssertEqual(params.nativeForegroundColorOverride?.1, 0xC5)
+        XCTAssertEqual(params.nativeForegroundColorOverride?.2, 0x5E)
+        XCTAssertNil(params.nativeForegroundAlphaOverride)
+        XCTAssertNil(params.nativeBackgroundColorOverride)
+        XCTAssertEqual(params.nativeBackgroundAlphaOverride, 127)
+    }
+
+    func testDropShadowWithGlyphBoxUsesIndependentCompositorEdge() {
+        var params = SubtitleStylingOverride.Parameters.default
+        params.backgroundStyle = .box
+        params.backgroundOpacityPercent = 80
+        params.systemTextEdgeStyle = .dropShadow
+
+        XCTAssertEqual(params.assBorderStyle, 4)
+        XCTAssertEqual(params.assShadow, params.boxPadding)
+        XCTAssertNotNil(params.compositedEdgeShadow)
+    }
+
+    func testRaisedAndDepressedEdgesUseVisibleBackColours() {
+        var raised = SubtitleStylingOverride.Parameters.default
+        raised.backgroundStyle = SubtitleBackgroundStylePreset.none
+        raised.systemTextEdgeStyle = .raised
+        XCTAssertEqual(raised.effectiveBackColorHex, "#FFFFFF")
+        XCTAssertNotEqual(raised.backgroundAlphaByte, 0xFF)
+
+        var depressed = raised
+        depressed.systemTextEdgeStyle = .depressed
+        XCTAssertEqual(depressed.effectiveBackColorHex, "#000000")
+        XCTAssertNotEqual(depressed.backgroundAlphaByte, 0xFF)
+    }
+
+    func testCaptionWindowGroupingSeparatesDistantSimultaneousCues() {
+        let leftCue = [
+            CGRect(x: 20, y: 400, width: 80, height: 30),
+            CGRect(x: 110, y: 400, width: 70, height: 30),
+        ]
+        let positionedSign = CGRect(x: 700, y: 80, width: 120, height: 40)
+
+        let groups = SubtitleRenderer.groupedPaintedBounds(
+            leftCue + [positionedSign],
+            joiningDistance: 20
+        )
+
+        XCTAssertEqual(groups.count, 2)
+        XCTAssertTrue(groups.contains(where: { $0.contains(CGPoint(x: 50, y: 410)) }))
+        XCTAssertTrue(groups.contains(where: { $0.contains(CGPoint(x: 750, y: 90)) }))
+    }
+
     // MARK: - Struct color packing (libass internal RRGGBBAA)
 
     func testStructColorPackingIsInternalRGBA() {

--- a/iosApp/Tests/SubtitleStylingOverrideTests.swift
+++ b/iosApp/Tests/SubtitleStylingOverrideTests.swift
@@ -145,8 +145,6 @@ final class SubtitleStylingOverrideTests: XCTestCase {
         XCTAssertEqual(params.nativeForegroundColorOverride?.1, 0xC5)
         XCTAssertEqual(params.nativeForegroundColorOverride?.2, 0x5E)
         XCTAssertNil(params.nativeForegroundAlphaOverride)
-        XCTAssertNil(params.nativeBackgroundColorOverride)
-        XCTAssertEqual(params.nativeBackgroundAlphaOverride, 127)
     }
 
     func testDropShadowWithGlyphBoxUsesIndependentCompositorEdge() {
@@ -166,11 +164,13 @@ final class SubtitleStylingOverrideTests: XCTestCase {
         raised.systemTextEdgeStyle = .raised
         XCTAssertEqual(raised.effectiveBackColorHex, "#FFFFFF")
         XCTAssertNotEqual(raised.backgroundAlphaByte, 0xFF)
+        XCTAssertLessThan(raised.assShadow, 0)
 
         var depressed = raised
         depressed.systemTextEdgeStyle = .depressed
         XCTAssertEqual(depressed.effectiveBackColorHex, "#000000")
         XCTAssertNotEqual(depressed.backgroundAlphaByte, 0xFF)
+        XCTAssertGreaterThan(depressed.assShadow, 0)
     }
 
     func testCaptionWindowGroupingSeparatesDistantSimultaneousCues() {
@@ -188,6 +188,37 @@ final class SubtitleStylingOverrideTests: XCTestCase {
         XCTAssertEqual(groups.count, 2)
         XCTAssertTrue(groups.contains(where: { $0.contains(CGPoint(x: 50, y: 410)) }))
         XCTAssertTrue(groups.contains(where: { $0.contains(CGPoint(x: 750, y: 90)) }))
+    }
+
+    func testNativeCaptionWindowRequiresItsOwnOpacityOverride() {
+        XCTAssertFalse(SubtitleRenderer.shouldDrawCaptionWindow(
+            isNativeASS: true,
+            opacityPercent: 50,
+            overrides: [.windowCornerRadius]
+        ))
+        XCTAssertTrue(SubtitleRenderer.shouldDrawCaptionWindow(
+            isNativeASS: true,
+            opacityPercent: 50,
+            overrides: [.windowOpacity]
+        ))
+    }
+
+    func testNativeBackgroundIsSynthesizedWhenEitherPropertyOverridesContent() {
+        XCTAssertTrue(SubtitleRenderer.shouldSynthesizeGlyphBackground(
+            isNativeASS: true,
+            opacityPercent: 50,
+            overrides: [.backgroundColor]
+        ))
+        XCTAssertTrue(SubtitleRenderer.shouldSynthesizeGlyphBackground(
+            isNativeASS: true,
+            opacityPercent: 50,
+            overrides: [.backgroundOpacity]
+        ))
+        XCTAssertFalse(SubtitleRenderer.shouldSynthesizeGlyphBackground(
+            isNativeASS: false,
+            opacityPercent: 50,
+            overrides: [.backgroundOpacity]
+        ))
     }
 
     // MARK: - Struct color packing (libass internal RRGGBBAA)

--- a/iosApp/Tests/SubtitleStylingOverrideTests.swift
+++ b/iosApp/Tests/SubtitleStylingOverrideTests.swift
@@ -164,7 +164,9 @@ final class SubtitleStylingOverrideTests: XCTestCase {
         raised.systemTextEdgeStyle = .raised
         XCTAssertEqual(raised.effectiveBackColorHex, "#FFFFFF")
         XCTAssertNotEqual(raised.backgroundAlphaByte, 0xFF)
-        XCTAssertLessThan(raised.assShadow, 0)
+        XCTAssertEqual(raised.assShadow, 0)
+        XCTAssertEqual(raised.compositedEdgeShadow?.offsetX, -1)
+        XCTAssertEqual(raised.compositedEdgeShadow?.offsetY, -1)
 
         var depressed = raised
         depressed.systemTextEdgeStyle = .depressed

--- a/iosApp/Tests/SubtitleStylingOverrideTests.swift
+++ b/iosApp/Tests/SubtitleStylingOverrideTests.swift
@@ -69,6 +69,69 @@ final class SubtitleStylingOverrideTests: XCTestCase {
         XCTAssertEqual(fields[6], "&H80000000")
     }
 
+    func testSystemForegroundOpacityReachesASSPrimaryColour() {
+        var appearance = SubtitleAppearance.default
+        appearance.fontColor = "#ffffff"
+        appearance.fontOpacity = 40
+        let params = SubtitleStylingOverride.Parameters.from(appearance: appearance, syncOffsetMs: 0)
+
+        XCTAssertEqual(styleFields(params: params)[3], "&H99FFFFFF")
+        XCTAssertEqual(
+            SubtitleStylingOverride.assColor(
+                hexRGBUInt: params.textColorHex,
+                alphaByte: params.textAlphaByte
+            ),
+            0xFFFFFF99
+        )
+    }
+
+    func testSystemRelativeSizeDoesNotQuantizeToPresetLadder() {
+        var appearance = SubtitleAppearance.default
+        appearance.systemRelativeFontScale = 1.75
+        let params = SubtitleStylingOverride.Parameters.from(appearance: appearance, syncOffsetMs: 0)
+
+        XCTAssertEqual(
+            params.fontSize,
+            SubtitleStylingOverride.Parameters.referenceFontSize * 1.75,
+            accuracy: 0.001
+        )
+    }
+
+    func testSystemWindowParametersRemainSeparateFromGlyphBackground() {
+        var appearance = SubtitleAppearance.default
+        appearance.backgroundColor = "#000000"
+        appearance.backgroundOpacity = 80
+        appearance.captionWindowColor = "#ff00ff"
+        appearance.captionWindowOpacity = 50
+        appearance.captionWindowCornerRadius = 8
+        appearance.systemContentOverrides = [.font, .window]
+        let params = SubtitleStylingOverride.Parameters.from(appearance: appearance, syncOffsetMs: 0)
+
+        XCTAssertEqual(params.backgroundColorHex, "#000000")
+        XCTAssertEqual(params.backgroundOpacityPercent, 80)
+        XCTAssertEqual(params.captionWindowColorHex, "#ff00ff")
+        XCTAssertEqual(params.captionWindowOpacityPercent, 50)
+        XCTAssertEqual(params.captionWindowCornerRadius, 8)
+        XCTAssertEqual(params.systemContentOverrides, [.font, .window])
+    }
+
+    func testSystemOnlyAppearanceFieldsAreNotServerEncoded() {
+        var appearance = SubtitleAppearance.default
+        appearance.fontOpacity = 25
+        appearance.systemRelativeFontScale = 1.75
+        appearance.systemTextEdgeStyle = .raised
+        appearance.captionWindowColor = "#ff00ff"
+        appearance.captionWindowOpacity = 50
+        appearance.captionWindowCornerRadius = 8
+        appearance.systemContentOverrides = [.font, .window]
+
+        let json = appearance.jsonString
+        XCTAssertFalse(json.contains("fontOpacity"))
+        XCTAssertFalse(json.contains("systemRelativeFontScale"))
+        XCTAssertFalse(json.contains("captionWindow"))
+        XCTAssertFalse(json.contains("systemContentOverrides"))
+    }
+
     // MARK: - Struct color packing (libass internal RRGGBBAA)
 
     func testStructColorPackingIsInternalRGBA() {

--- a/iosApp/Tests/SystemCaptionAppearanceTests.swift
+++ b/iosApp/Tests/SystemCaptionAppearanceTests.swift
@@ -28,14 +28,15 @@ final class SystemCaptionAppearanceTests: XCTestCase {
         var snapshot = SystemCaptionAppearance.Snapshot()
         snapshot.windowOpacity = 0.5
         snapshot.windowColorHex = "#ff00ff"
+        snapshot.windowCornerRadius = 8
 
         let mapped = SystemCaptionAppearance.appearance(from: snapshot)
-        XCTAssertEqual(mapped.backgroundStyle, .box)
-        XCTAssertEqual(mapped.backgroundOpacity, 50)
-        XCTAssertEqual(mapped.backgroundColor, "#ff00ff")
+        XCTAssertEqual(mapped.captionWindowOpacity, 50)
+        XCTAssertEqual(mapped.captionWindowColor, "#ff00ff")
+        XCTAssertEqual(mapped.captionWindowCornerRadius, 8)
     }
 
-    func testWindowTakesPrecedenceOverGlyphBackground() {
+    func testWindowAndGlyphBackgroundRemainIndependent() {
         var snapshot = SystemCaptionAppearance.Snapshot()
         snapshot.backgroundOpacity = 0.8
         snapshot.backgroundColorHex = "#000000"
@@ -43,8 +44,10 @@ final class SystemCaptionAppearanceTests: XCTestCase {
         snapshot.windowColorHex = "#ff00ff"
 
         let mapped = SystemCaptionAppearance.appearance(from: snapshot)
-        XCTAssertEqual(mapped.backgroundOpacity, 50)
-        XCTAssertEqual(mapped.backgroundColor, "#ff00ff")
+        XCTAssertEqual(mapped.backgroundOpacity, 80)
+        XCTAssertEqual(mapped.backgroundColor, "#000000")
+        XCTAssertEqual(mapped.captionWindowOpacity, 50)
+        XCTAssertEqual(mapped.captionWindowColor, "#ff00ff")
     }
 
     func testZeroBackgroundOpacityRemovesBackground() {
@@ -69,8 +72,9 @@ final class SystemCaptionAppearanceTests: XCTestCase {
         snapshot.edgeStyle = .dropShadow
 
         let mapped = SystemCaptionAppearance.appearance(from: snapshot)
-        XCTAssertEqual(mapped.backgroundStyle, .shadow)
+        XCTAssertEqual(mapped.backgroundStyle, SubtitleBackgroundStylePreset.none)
         XCTAssertFalse(mapped.textOutline)
+        XCTAssertEqual(mapped.systemTextEdgeStyle, .dropShadow)
     }
 
     func testDropShadowEdgeYieldsToBoxBackground() {
@@ -83,6 +87,7 @@ final class SystemCaptionAppearanceTests: XCTestCase {
         let mapped = SystemCaptionAppearance.appearance(from: snapshot)
         XCTAssertEqual(mapped.backgroundStyle, .box)
         XCTAssertEqual(mapped.backgroundOpacity, 80)
+        XCTAssertEqual(mapped.systemTextEdgeStyle, .dropShadow)
     }
 
     func testForegroundColorMaps() {
@@ -91,6 +96,46 @@ final class SystemCaptionAppearanceTests: XCTestCase {
 
         let mapped = SystemCaptionAppearance.appearance(from: snapshot)
         XCTAssertEqual(mapped.fontColor, "#facc15")
+    }
+
+    func testForegroundOpacityMapsWithoutChangingColor() {
+        var snapshot = SystemCaptionAppearance.Snapshot()
+        snapshot.foregroundOpacity = 0.4
+
+        let mapped = SystemCaptionAppearance.appearance(from: snapshot)
+        XCTAssertEqual(mapped.fontOpacity, 40)
+    }
+
+    func testRelativeSizePreservesExactSystemScale() {
+        var snapshot = SystemCaptionAppearance.Snapshot()
+        snapshot.relativeCharacterSize = 1.75
+
+        let mapped = SystemCaptionAppearance.appearance(from: snapshot)
+        XCTAssertEqual(mapped.systemRelativeFontScale, 1.75)
+    }
+
+    func testRaisedAndDepressedEdgesStayDistinct() {
+        var raised = SystemCaptionAppearance.Snapshot()
+        raised.edgeStyle = .raised
+        var depressed = SystemCaptionAppearance.Snapshot()
+        depressed.edgeStyle = .depressed
+
+        XCTAssertEqual(
+            SystemCaptionAppearance.appearance(from: raised).systemTextEdgeStyle,
+            .raised
+        )
+        XCTAssertEqual(
+            SystemCaptionAppearance.appearance(from: depressed).systemTextEdgeStyle,
+            .depressed
+        )
+    }
+
+    func testVideoOverridePrecedenceSurvivesMapping() {
+        var snapshot = SystemCaptionAppearance.Snapshot()
+        snapshot.contentOverrides = [.font, .size, .colors, .edge, .window]
+
+        let mapped = SystemCaptionAppearance.appearance(from: snapshot)
+        XCTAssertEqual(mapped.systemContentOverrides, snapshot.contentOverrides)
     }
 
     func testRelativeSizeAnchorsDefaultAtSiloDefaultPreset() {

--- a/iosApp/Tests/SystemCaptionAppearanceTests.swift
+++ b/iosApp/Tests/SystemCaptionAppearanceTests.swift
@@ -24,7 +24,7 @@ final class SystemCaptionAppearanceTests: XCTestCase {
         XCTAssertEqual(mapped.backgroundColor, "#123456")
     }
 
-    func testWindowOpacityMapsToBox() {
+    func testWindowPropertiesMapToCaptionWindow() {
         var snapshot = SystemCaptionAppearance.Snapshot()
         snapshot.windowOpacity = 0.5
         snapshot.windowColorHex = "#ff00ff"

--- a/iosApp/Tests/SystemCaptionAppearanceTests.swift
+++ b/iosApp/Tests/SystemCaptionAppearanceTests.swift
@@ -138,6 +138,17 @@ final class SystemCaptionAppearanceTests: XCTestCase {
         XCTAssertEqual(mapped.systemContentOverrides, snapshot.contentOverrides)
     }
 
+    func testColorOverridePrecedenceRemainsPerProperty() {
+        var snapshot = SystemCaptionAppearance.Snapshot()
+        snapshot.contentOverrides = [.foregroundColor, .backgroundOpacity]
+
+        let overrides = SystemCaptionAppearance.appearance(from: snapshot).systemContentOverrides
+        XCTAssertTrue(overrides.contains(.foregroundColor))
+        XCTAssertFalse(overrides.contains(.foregroundOpacity))
+        XCTAssertFalse(overrides.contains(.backgroundColor))
+        XCTAssertTrue(overrides.contains(.backgroundOpacity))
+    }
+
     func testRelativeSizeAnchorsDefaultAtSiloDefaultPreset() {
         XCTAssertEqual(SystemCaptionAppearance.fontSizePreset(forRelativeSize: 1.0), .large)
         XCTAssertEqual(SystemCaptionAppearance.fontSizePreset(forRelativeSize: 0.5), .small)

--- a/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
+++ b/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
@@ -244,6 +244,24 @@ enum DetailPlaybackFormatting {
         return nil
     }
 
+    /// A server-remembered track is useful for reflecting the server policy
+    /// in the pre-play selector, but it is not a manual choice made during
+    /// this visit. Device-settings mode must start on Apple's caption policy
+    /// instead of forwarding that seed as an explicit player override.
+    static func launchPreferredSubtitleIndex(
+        version: FileVersion?,
+        signature: SubtitleTrackSignature?,
+        mode: String?,
+        usesDeviceSettings: Bool
+    ) -> Int? {
+        guard !usesDeviceSettings else { return nil }
+        return serverPreferredSubtitleIndex(
+            version: version,
+            signature: signature,
+            mode: mode
+        )
+    }
+
     /// Mirrors `SubtitleAutoResolver.bestSignatureMatch` scoring, applied
     /// to the detail payload's `SubtitleTrack` metadata, so the selector
     /// shows the same track the player would restore on its own.

--- a/iosApp/iosApp/Screens/Detail/ItemDetailView.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailView.swift
@@ -68,6 +68,7 @@ private struct ItemDetailPhoneContent: View {
     @State private var preferredVersionFileId: Int?
     @State private var preferredAudioTrackIndex: Int?
     @State private var preferredSubtitleTrackIndex: Int?
+    @State private var preferredSubtitleTrackWasManuallySelected = false
     @State private var preferredNextUpFileId: Int?
     @State private var preferredNextUpAudioTrackIndex: Int?
     @State private var preferredNextUpSubtitleTrackIndex: Int?
@@ -98,6 +99,7 @@ private struct ItemDetailPhoneContent: View {
             preferredVersionFileId = nil
             preferredAudioTrackIndex = nil
             preferredSubtitleTrackIndex = nil
+            preferredSubtitleTrackWasManuallySelected = false
             preferredNextUpFileId = nil
             preferredNextUpAudioTrackIndex = nil
             preferredNextUpSubtitleTrackIndex = nil
@@ -112,6 +114,7 @@ private struct ItemDetailPhoneContent: View {
             // already spent the item's weekly slot. Precedent:
             // `PersonDetailView.resumeMetadataRefreshIfNeeded`.
             viewModel.resumeTrailerFetchIfNeeded()
+            seedSubtitleOverrideIfNeeded()
         }
         .onDisappear {
             // The trailer poll isn't owned by `.task`, so it would otherwise
@@ -128,6 +131,7 @@ private struct ItemDetailPhoneContent: View {
                 // drop the pre-play selector state so the reloaded pref
                 // re-seeds and the selector reflects the latest pick.
                 preferredSubtitleTrackIndex = nil
+                preferredSubtitleTrackWasManuallySelected = false
                 seedSubtitleOverrideIfNeeded()
             }
         }
@@ -540,6 +544,7 @@ private struct ItemDetailPhoneContent: View {
                     )
                 },
                 onSelectSubtitleTrack: { index in
+                    preferredSubtitleTrackWasManuallySelected = true
                     preferredSubtitleTrackIndex = sanitizedSubtitleTrackIndex(
                         for: detail,
                         versionFileId: preferredVersionFileId,
@@ -760,7 +765,15 @@ private struct ItemDetailPhoneContent: View {
     /// the pick was persisted; audio doesn't need an equivalent because
     /// `resolvedAudioOrdinal` falls back to `effectiveAudioTrackIndex`.
     private func seedSubtitleOverrideIfNeeded() {
-        guard preferredSubtitleTrackIndex == nil, let detail = viewModel.detail else { return }
+        if PlayerSettings.shared.subtitleMatchesSystemAppearance {
+            if !preferredSubtitleTrackWasManuallySelected {
+                preferredSubtitleTrackIndex = nil
+            }
+            return
+        }
+        guard !preferredSubtitleTrackWasManuallySelected,
+              preferredSubtitleTrackIndex == nil,
+              let detail = viewModel.detail else { return }
         preferredSubtitleTrackIndex = DetailPlaybackFormatting.launchPreferredSubtitleIndex(
             version: effectiveVersion(for: detail, versionFileId: preferredVersionFileId),
             signature: detail.effectiveSubtitleTrackSignature,

--- a/iosApp/iosApp/Screens/Detail/ItemDetailView.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailView.swift
@@ -761,10 +761,11 @@ private struct ItemDetailPhoneContent: View {
     /// `resolvedAudioOrdinal` falls back to `effectiveAudioTrackIndex`.
     private func seedSubtitleOverrideIfNeeded() {
         guard preferredSubtitleTrackIndex == nil, let detail = viewModel.detail else { return }
-        preferredSubtitleTrackIndex = DetailPlaybackFormatting.serverPreferredSubtitleIndex(
+        preferredSubtitleTrackIndex = DetailPlaybackFormatting.launchPreferredSubtitleIndex(
             version: effectiveVersion(for: detail, versionFileId: preferredVersionFileId),
             signature: detail.effectiveSubtitleTrackSignature,
-            mode: detail.effectiveSubtitleMode
+            mode: detail.effectiveSubtitleMode,
+            usesDeviceSettings: PlayerSettings.shared.subtitleMatchesSystemAppearance
         )
     }
 
@@ -849,10 +850,11 @@ private struct ItemDetailPhoneContent: View {
             let watchDetail = try await ContinuumAPI.shared.watchDetail(contentId: nextUp.contentId)
             guard !Task.isCancelled else { return }
             nextUpWatchDetail = watchDetail
-            preferredNextUpSubtitleTrackIndex = DetailPlaybackFormatting.serverPreferredSubtitleIndex(
+            preferredNextUpSubtitleTrackIndex = DetailPlaybackFormatting.launchPreferredSubtitleIndex(
                 version: effectiveVersion(for: watchDetail, versionFileId: nil),
                 signature: watchDetail.effectiveSubtitleTrackSignature,
-                mode: watchDetail.effectiveSubtitleMode
+                mode: watchDetail.effectiveSubtitleMode,
+                usesDeviceSettings: PlayerSettings.shared.subtitleMatchesSystemAppearance
             )
         } catch {
             guard !Task.isCancelled else { return }

--- a/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
@@ -48,6 +48,9 @@ class ItemDetailViewModel {
     var preferredVersionFileId: Int?
     var preferredAudioTrackIndex: Int?
     var preferredSubtitleTrackIndex: Int?
+    /// Distinguishes a selector choice from a server-derived launch seed so
+    /// enabling device caption settings can discard only the latter.
+    var preferredSubtitleTrackWasManuallySelected = false
     var preferredNextUpFileId: Int?
     var preferredNextUpAudioTrackIndex: Int?
     var preferredNextUpSubtitleTrackIndex: Int?

--- a/iosApp/iosApp/Screens/Player/PlaybackPrefsResolver.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackPrefsResolver.swift
@@ -47,6 +47,10 @@ struct SubtitleAutoResolver {
         /// Prefer CC/SDH over plain subtitles when Apple requests the
         /// accessibility media characteristics.
         let preferAccessibilityTracks: Bool
+        /// An explicit device language stack is authoritative. If none of
+        /// those languages exists, clear any server-selected subtitle rather
+        /// than leaking the server profile back into device-settings mode.
+        let disableWhenNoLanguageMatch: Bool
         /// Per-series sticky pick. Highest priority signal — if a track
         /// matches the signature, select it regardless of language /
         /// mode.
@@ -67,6 +71,7 @@ struct SubtitleAutoResolver {
             showForced: Bool,
             forcedOnly: Bool = false,
             preferAccessibilityTracks: Bool = false,
+            disableWhenNoLanguageMatch: Bool = false,
             trackSignature: SubtitleTrackSignature?,
             availableSubtitles: [PlayerTrack],
             currentAudioLanguage: String?
@@ -77,6 +82,7 @@ struct SubtitleAutoResolver {
             self.showForced = showForced
             self.forcedOnly = forcedOnly
             self.preferAccessibilityTracks = preferAccessibilityTracks
+            self.disableWhenNoLanguageMatch = disableWhenNoLanguageMatch
             self.trackSignature = trackSignature
             self.availableSubtitles = availableSubtitles
             self.currentAudioLanguage = currentAudioLanguage
@@ -88,7 +94,7 @@ struct SubtitleAutoResolver {
     /// arguments) — the resolver is for the "no override" case.
     static func resolve(_ inputs: Inputs) -> SubtitleAutoSelection {
         if inputs.availableSubtitles.isEmpty {
-            return .noChange
+            return inputs.disableWhenNoLanguageMatch ? .disable : .noChange
         }
 
         let mode = inputs.mode ?? .auto
@@ -109,14 +115,6 @@ struct SubtitleAutoResolver {
                 ) {
                     return .select(forced)
                 }
-            }
-            if let forced = bestLanguageMatch(
-                nil,
-                in: inputs.availableSubtitles.filter(\.isForced),
-                preferForced: true,
-                preferAccessibility: inputs.preferAccessibilityTracks
-            ) {
-                return .select(forced)
             }
             return .disable
         }
@@ -183,10 +181,12 @@ struct SubtitleAutoResolver {
         // No matching language. `always` could fall back to anything,
         // but unless forced subs are wanted we'd rather show nothing
         // than a random language the user can't read.
-        if inputs.showForced, let forced = inputs.availableSubtitles.first(where: { $0.isForced }) {
+        if !inputs.disableWhenNoLanguageMatch,
+           inputs.showForced,
+           let forced = inputs.availableSubtitles.first(where: { $0.isForced }) {
             return .select(forced)
         }
-        return .noChange
+        return inputs.disableWhenNoLanguageMatch ? .disable : .noChange
     }
 
     // MARK: - Matching helpers

--- a/iosApp/iosApp/Screens/Player/PlaybackPrefsResolver.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackPrefsResolver.swift
@@ -106,15 +106,13 @@ struct SubtitleAutoResolver {
         let preferredLanguages = orderedLanguages(from: inputs)
 
         if inputs.forcedOnly {
-            for language in preferredLanguages {
-                if let forced = bestLanguageMatch(
-                    language,
-                    in: inputs.availableSubtitles.filter(\.isForced),
-                    preferForced: true,
-                    preferAccessibility: inputs.preferAccessibilityTracks
-                ) {
-                    return .select(forced)
-                }
+            if let forced = bestLanguageMatch(
+                preferredLanguages,
+                in: inputs.availableSubtitles.filter(\.isForced),
+                preferForced: true,
+                preferAccessibility: inputs.preferAccessibilityTracks
+            ) {
+                return .select(forced)
             }
             return .disable
         }
@@ -151,7 +149,9 @@ struct SubtitleAutoResolver {
         if mode == .auto, let audio = inputs.currentAudioLanguage,
            preferredLanguages.contains(where: { languagesMatch(audio, $0) }) {
             if inputs.showForced,
-               let matchingLanguage = preferredLanguages.first(where: { languagesMatch(audio, $0) }),
+               let matchingLanguage = preferredLanguages.first(where: {
+                   normalizedLanguageIdentifier(audio) == normalizedLanguageIdentifier($0)
+               }) ?? preferredLanguages.first(where: { languagesMatch(audio, $0) }),
                let forced = bestLanguageMatch(
                    matchingLanguage,
                    in: inputs.availableSubtitles.filter(\.isForced),
@@ -167,15 +167,13 @@ struct SubtitleAutoResolver {
         // full-dialogue track. `showForced` must NOT steal this pick —
         // a forced track is signs-only and reads as "subtitles stopped
         // working" minutes into any dialogue scene.
-        for language in preferredLanguages {
-            if let pick = bestLanguageMatch(
-                language,
-                in: inputs.availableSubtitles,
-                preferForced: false,
-                preferAccessibility: inputs.preferAccessibilityTracks
-            ) {
-                return .select(pick)
-            }
+        if let pick = bestLanguageMatch(
+            preferredLanguages,
+            in: inputs.availableSubtitles,
+            preferForced: false,
+            preferAccessibility: inputs.preferAccessibilityTracks
+        ) {
+            return .select(pick)
         }
 
         // No matching language. `always` could fall back to anything,
@@ -242,47 +240,94 @@ struct SubtitleAutoResolver {
         preferForced: Bool,
         preferAccessibility: Bool = false
     ) -> PlayerTrack? {
-        let pool: [PlayerTrack]
-        if let lang = language {
-            let exactMatches = tracks.filter {
-                guard let trackLanguage = $0.lang else { return false }
-                return normalizedLanguageIdentifier(trackLanguage)
-                    == normalizedLanguageIdentifier(lang)
-            }
-            pool = exactMatches.isEmpty
-                ? tracks.filter {
-                    guard let trackLang = $0.lang else { return false }
-                    return languagesMatch(trackLang, lang)
+        guard let language else {
+            return bestTrackClass(in: tracks, preferForced: preferForced,
+                                  preferAccessibility: preferAccessibility)
+        }
+        return bestLanguageMatch(
+            [language],
+            in: tracks,
+            preferForced: preferForced,
+            preferAccessibility: preferAccessibility
+        )
+    }
+
+    /// Apply track-class priority before regional exactness: a full-dialogue
+    /// generic-language track must beat an exact signs-only track. Within the
+    /// same class, exhaust Apple's ordered exact locale matches before falling
+    /// back to primary-language equivalence.
+    private static func bestLanguageMatch(
+        _ languages: [String],
+        in tracks: [PlayerTrack],
+        preferForced: Bool,
+        preferAccessibility: Bool
+    ) -> PlayerTrack? {
+        let predicates = trackClassPredicates(
+            preferForced: preferForced,
+            preferAccessibility: preferAccessibility
+        )
+        for predicate in predicates {
+            for language in languages {
+                let normalized = normalizedLanguageIdentifier(language)
+                if let exact = tracks.first(where: { track in
+                    predicate(track)
+                        && track.lang.map(normalizedLanguageIdentifier) == normalized
+                }) {
+                    return exact
                 }
-                : exactMatches
-        } else {
-            pool = tracks
+            }
+            for language in languages {
+                if let fallback = tracks.first(where: { track in
+                    predicate(track)
+                        && track.lang.map { languagesMatch($0, language) } == true
+                }) {
+                    return fallback
+                }
+            }
         }
-        guard !pool.isEmpty else { return nil }
-        if preferForced, let forced = pool.first(where: { $0.isForced }) {
-            return forced
+        return nil
+    }
+
+    private static func bestTrackClass(
+        in tracks: [PlayerTrack],
+        preferForced: Bool,
+        preferAccessibility: Bool
+    ) -> PlayerTrack? {
+        for predicate in trackClassPredicates(
+            preferForced: preferForced,
+            preferAccessibility: preferAccessibility
+        ) {
+            if let track = tracks.first(where: predicate) { return track }
         }
-        if preferAccessibility, let accessible = pool.first(where: {
+        return nil
+    }
+
+    private static func trackClassPredicates(
+        preferForced: Bool,
+        preferAccessibility: Bool
+    ) -> [(PlayerTrack) -> Bool] {
+        let accessible: (PlayerTrack) -> Bool = {
             !$0.isForced && ($0.isHearingImpaired || titleIndicatesHearingImpaired($0.title))
-        }) {
-            return accessible
         }
-        if let nonForced = pool.first(where: {
+        let plain: (PlayerTrack) -> Bool = {
             !$0.isForced && !$0.isHearingImpaired && !titleIndicatesHearingImpaired($0.title)
-        }) {
-            return nonForced
         }
-        if let nonForced = pool.first(where: { !$0.isForced }) {
-            return nonForced
-        }
-        return pool.first
+        let nonForced: (PlayerTrack) -> Bool = { !$0.isForced }
+        let forced: (PlayerTrack) -> Bool = { $0.isForced }
+
+        if preferForced { return [forced, accessible, plain, nonForced, { _ in true }] }
+        if preferAccessibility { return [accessible, plain, nonForced, forced, { _ in true }] }
+        return [plain, nonForced, forced, { _ in true }]
     }
 
     private static func orderedLanguages(from inputs: Inputs) -> [String] {
         guard let first = inputs.preferredLanguage, !first.isEmpty else { return [] }
         var result: [String] = []
         for language in [first] + inputs.additionalPreferredLanguages where !language.isEmpty {
-            if !result.contains(where: { languagesMatch($0, language) }) {
+            let normalized = normalizedLanguageIdentifier(language)
+            if !result.contains(where: {
+                normalizedLanguageIdentifier($0) == normalized
+            }) {
                 result.append(language)
             }
         }

--- a/iosApp/iosApp/Screens/Player/PlaybackPrefsResolver.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackPrefsResolver.swift
@@ -245,7 +245,9 @@ struct SubtitleAutoResolver {
         let pool: [PlayerTrack]
         if let lang = language {
             let exactMatches = tracks.filter {
-                $0.lang?.caseInsensitiveCompare(lang) == .orderedSame
+                guard let trackLanguage = $0.lang else { return false }
+                return normalizedLanguageIdentifier(trackLanguage)
+                    == normalizedLanguageIdentifier(lang)
             }
             pool = exactMatches.isEmpty
                 ? tracks.filter {
@@ -301,41 +303,30 @@ struct SubtitleAutoResolver {
         return tokens.contains("cc") || tokens.contains("sdh")
     }
 
-    /// Loose ISO 639 comparison. Accepts mixed 2-letter / 3-letter
-    /// codes by mapping known pairs ("en"↔"eng", "es"↔"spa", etc.).
-    /// Falls back to case-insensitive prefix match for codes outside
-    /// the table.
+    /// Loose ISO 639 comparison. Foundation canonicalizes arbitrary alpha-2,
+    /// alpha-3 terminology, and alpha-3 bibliographic spellings before the
+    /// primary language subtags are compared. This keeps Apple locale tags
+    /// such as `nl-NL` equivalent to mux metadata such as `nld` without a
+    /// hand-maintained language allowlist.
     static func languagesMatch(_ a: String, _ b: String) -> Bool {
-        let la = a.lowercased()
-        let lb = b.lowercased()
+        let la = normalizedLanguageIdentifier(a)
+        let lb = normalizedLanguageIdentifier(b)
         if la == lb { return true }
-        if let alt = isoEquivalent[la], alt == lb { return true }
-        if let alt = isoEquivalent[lb], alt == la { return true }
-        // Some mux tools emit hyphenated forms like "en-us"; compare on
-        // the primary subtag.
-        let primaryA = la.split(separator: "-").first.map(String.init) ?? la
-        let primaryB = lb.split(separator: "-").first.map(String.init) ?? lb
-        if primaryA == primaryB { return true }
-        if let alt = isoEquivalent[primaryA], alt == primaryB { return true }
-        if let alt = isoEquivalent[primaryB], alt == primaryA { return true }
-        return false
+        return canonicalPrimaryLanguage(la) == canonicalPrimaryLanguage(lb)
     }
 
-    /// 2-letter ↔ 3-letter ISO 639 mapping for the languages our prefs
-    /// editor exposes. Server uses both forms interchangeably depending
-    /// on the source codec metadata, so the client has to match either.
-    private static let isoEquivalent: [String: String] = [
-        "en": "eng", "eng": "en",
-        "es": "spa", "spa": "es",
-        "fr": "fre", "fre": "fr", "fra": "fr",
-        "de": "ger", "ger": "de", "deu": "de",
-        "it": "ita", "ita": "it",
-        "pt": "por", "por": "pt",
-        "ja": "jpn", "jpn": "ja",
-        "ko": "kor", "kor": "ko",
-        "zh": "chi", "chi": "zh", "zho": "zh",
-        "ru": "rus", "rus": "ru",
-        "ar": "ara", "ara": "ar",
-        "hi": "hin", "hin": "hi",
-    ]
+    private static func normalizedLanguageIdentifier(_ identifier: String) -> String {
+        identifier
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "_", with: "-")
+    }
+
+    private static func canonicalPrimaryLanguage(_ identifier: String) -> String {
+        let primary = identifier.split(separator: "-").first.map(String.init) ?? identifier
+        let languageCode = Locale(identifier: primary).language.languageCode
+        return languageCode?.identifier(.alpha2)
+            ?? languageCode?.identifier(.alpha3)
+            ?? primary
+    }
 }

--- a/iosApp/iosApp/Screens/Player/PlaybackPrefsResolver.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackPrefsResolver.swift
@@ -244,10 +244,15 @@ struct SubtitleAutoResolver {
     ) -> PlayerTrack? {
         let pool: [PlayerTrack]
         if let lang = language {
-            pool = tracks.filter {
-                guard let trackLang = $0.lang else { return false }
-                return languagesMatch(trackLang, lang)
+            let exactMatches = tracks.filter {
+                $0.lang?.caseInsensitiveCompare(lang) == .orderedSame
             }
+            pool = exactMatches.isEmpty
+                ? tracks.filter {
+                    guard let trackLang = $0.lang else { return false }
+                    return languagesMatch(trackLang, lang)
+                }
+                : exactMatches
         } else {
             pool = tracks
         }

--- a/iosApp/iosApp/Screens/Player/PlaybackPrefsResolver.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackPrefsResolver.swift
@@ -35,10 +35,18 @@ struct SubtitleAutoResolver {
         /// means the user has no preference at any level. Empty
         /// string means "no subs" — distinct from no preference.
         let preferredLanguage: String?
+        /// Additional ordered language fallbacks. Used by Apple's caption
+        /// profile, which exposes a stack rather than one server value.
+        let additionalPreferredLanguages: [String]
         /// `subtitle_mode` from the cascade. `nil` → fall back to "auto".
         let mode: SubtitleMode?
         /// Whether forced subs should be auto-selected when available.
         let showForced: Bool
+        /// Apple's Forced Only display mode.
+        let forcedOnly: Bool
+        /// Prefer CC/SDH over plain subtitles when Apple requests the
+        /// accessibility media characteristics.
+        let preferAccessibilityTracks: Bool
         /// Per-series sticky pick. Highest priority signal — if a track
         /// matches the signature, select it regardless of language /
         /// mode.
@@ -51,6 +59,28 @@ struct SubtitleAutoResolver {
         /// preferred subtitle language (e.g. English audio + English
         /// sub preference → no subs).
         let currentAudioLanguage: String?
+
+        init(
+            preferredLanguage: String?,
+            additionalPreferredLanguages: [String] = [],
+            mode: SubtitleMode?,
+            showForced: Bool,
+            forcedOnly: Bool = false,
+            preferAccessibilityTracks: Bool = false,
+            trackSignature: SubtitleTrackSignature?,
+            availableSubtitles: [PlayerTrack],
+            currentAudioLanguage: String?
+        ) {
+            self.preferredLanguage = preferredLanguage
+            self.additionalPreferredLanguages = additionalPreferredLanguages
+            self.mode = mode
+            self.showForced = showForced
+            self.forcedOnly = forcedOnly
+            self.preferAccessibilityTracks = preferAccessibilityTracks
+            self.trackSignature = trackSignature
+            self.availableSubtitles = availableSubtitles
+            self.currentAudioLanguage = currentAudioLanguage
+        }
     }
 
     /// Resolve a subtitle pick. Caller is expected to skip this when
@@ -67,6 +97,30 @@ struct SubtitleAutoResolver {
             return .disable
         }
 
+        let preferredLanguages = orderedLanguages(from: inputs)
+
+        if inputs.forcedOnly {
+            for language in preferredLanguages {
+                if let forced = bestLanguageMatch(
+                    language,
+                    in: inputs.availableSubtitles.filter(\.isForced),
+                    preferForced: true,
+                    preferAccessibility: inputs.preferAccessibilityTracks
+                ) {
+                    return .select(forced)
+                }
+            }
+            if let forced = bestLanguageMatch(
+                nil,
+                in: inputs.availableSubtitles.filter(\.isForced),
+                preferForced: true,
+                preferAccessibility: inputs.preferAccessibilityTracks
+            ) {
+                return .select(forced)
+            }
+            return .disable
+        }
+
         if let signature = inputs.trackSignature,
            let match = bestSignatureMatch(signature, in: inputs.availableSubtitles) {
             return .select(match)
@@ -74,9 +128,14 @@ struct SubtitleAutoResolver {
 
         guard let rawLang = inputs.preferredLanguage else {
             // No language preference recorded anywhere. Honour `always`
-            // by trying any default forced track but otherwise leave
+            // by choosing the best available track, but otherwise leave
             // alone — auto-enabling a random language would surprise.
-            if mode == .always, let any = bestLanguageMatch(nil, in: inputs.availableSubtitles, preferForced: inputs.showForced) {
+            if mode == .always, let any = bestLanguageMatch(
+                nil,
+                in: inputs.availableSubtitles,
+                preferForced: inputs.showForced,
+                preferAccessibility: inputs.preferAccessibilityTracks
+            ) {
                 return .select(any)
             }
             return .noChange
@@ -92,12 +151,15 @@ struct SubtitleAutoResolver {
         // (signs/foreign-dialogue-only) track is what "show forced
         // subtitles" is FOR. Mirrors the Android resolver.
         if mode == .auto, let audio = inputs.currentAudioLanguage,
-           languagesMatch(audio, rawLang) {
+           preferredLanguages.contains(where: { languagesMatch(audio, $0) }) {
             if inputs.showForced,
-               let forced = inputs.availableSubtitles.first(where: { track in
-                   track.isForced
-                       && track.lang.map { languagesMatch($0, rawLang) } == true
-               }) {
+               let matchingLanguage = preferredLanguages.first(where: { languagesMatch(audio, $0) }),
+               let forced = bestLanguageMatch(
+                   matchingLanguage,
+                   in: inputs.availableSubtitles.filter(\.isForced),
+                   preferForced: true,
+                   preferAccessibility: inputs.preferAccessibilityTracks
+               ) {
                 return .select(forced)
             }
             return .disable
@@ -107,8 +169,15 @@ struct SubtitleAutoResolver {
         // full-dialogue track. `showForced` must NOT steal this pick —
         // a forced track is signs-only and reads as "subtitles stopped
         // working" minutes into any dialogue scene.
-        if let pick = bestLanguageMatch(rawLang, in: inputs.availableSubtitles, preferForced: false) {
-            return .select(pick)
+        for language in preferredLanguages {
+            if let pick = bestLanguageMatch(
+                language,
+                in: inputs.availableSubtitles,
+                preferForced: false,
+                preferAccessibility: inputs.preferAccessibilityTracks
+            ) {
+                return .select(pick)
+            }
         }
 
         // No matching language. `always` could fall back to anything,
@@ -170,7 +239,8 @@ struct SubtitleAutoResolver {
     private static func bestLanguageMatch(
         _ language: String?,
         in tracks: [PlayerTrack],
-        preferForced: Bool
+        preferForced: Bool,
+        preferAccessibility: Bool = false
     ) -> PlayerTrack? {
         let pool: [PlayerTrack]
         if let lang = language {
@@ -185,6 +255,11 @@ struct SubtitleAutoResolver {
         if preferForced, let forced = pool.first(where: { $0.isForced }) {
             return forced
         }
+        if preferAccessibility, let accessible = pool.first(where: {
+            !$0.isForced && ($0.isHearingImpaired || titleIndicatesHearingImpaired($0.title))
+        }) {
+            return accessible
+        }
         if let nonForced = pool.first(where: {
             !$0.isForced && !$0.isHearingImpaired && !titleIndicatesHearingImpaired($0.title)
         }) {
@@ -194,6 +269,17 @@ struct SubtitleAutoResolver {
             return nonForced
         }
         return pool.first
+    }
+
+    private static func orderedLanguages(from inputs: Inputs) -> [String] {
+        guard let first = inputs.preferredLanguage, !first.isEmpty else { return [] }
+        var result: [String] = []
+        for language in [first] + inputs.additionalPreferredLanguages where !language.isEmpty {
+            if !result.contains(where: { languagesMatch($0, language) }) {
+                result.append(language)
+            }
+        }
+        return result
     }
 
     /// CC/SDH detection from the track title, for files that label the

--- a/iosApp/iosApp/Screens/Player/PlayerSettings.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerSettings.swift
@@ -269,6 +269,7 @@ final class PlayerSettings {
     /// Latest mapping of the system caption preferences. Refreshed when
     /// MediaAccessibility posts its settings-changed notification.
     var subtitleSystemAppearance: SubtitleAppearance = SystemCaptionAppearance.current()
+    var subtitleSystemSelectionPreferences = SystemCaptionSelectionPreferences.current()
 
     /// The appearance the player should actually render with.
     var effectiveSubtitleAppearance: SubtitleAppearance {
@@ -452,6 +453,7 @@ final class PlayerSettings {
     /// re-application never races this class's own observer.
     func refreshSubtitleSystemAppearance() {
         subtitleSystemAppearance = SystemCaptionAppearance.current()
+        subtitleSystemSelectionPreferences = SystemCaptionSelectionPreferences.current()
     }
 
     var subtitleBackgroundColorHex: String {
@@ -642,6 +644,7 @@ final class PlayerSettings {
         guard enabled != subtitleMatchesSystemAppearance else { return }
         if enabled {
             subtitleSystemAppearance = SystemCaptionAppearance.current()
+            subtitleSystemSelectionPreferences = SystemCaptionSelectionPreferences.current()
         }
         subtitleMatchesSystemAppearance = enabled
     }

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -1176,6 +1176,8 @@ class PlayerViewModel {
             guard let self, self.settings.subtitleMatchesSystemAppearance else { return }
             self.settings.refreshSubtitleSystemAppearance()
             self.applySubtitleAppearanceToPlayer()
+            self.subtitleOrderingLanguage = self.settings
+                .subtitleSystemSelectionPreferences.preferredLanguages.first
             guard !self.hasExplicitSubtitleChoice else { return }
             self.prefsForCurrentItem = self.systemCaptionPrefsSnapshot()
             self.prefsResolvedForCurrentItem = false
@@ -2859,6 +2861,9 @@ class PlayerViewModel {
     func setSubtitleMatchesSystemAppearance(_ enabled: Bool) {
         settings.setSubtitleMatchesSystemAppearance(enabled)
         applySubtitleAppearanceToPlayer()
+        subtitleOrderingLanguage = enabled
+            ? settings.subtitleSystemSelectionPreferences.preferredLanguages.first
+            : currentWatchDetail?.effectiveSubtitleLanguage
         hasExplicitSubtitleChoice = false
         prefsForCurrentItem = enabled
             ? systemCaptionPrefsSnapshot()
@@ -3397,7 +3402,9 @@ class PlayerViewModel {
                 // Snapshot the preferred language for track-list ordering
                 // unconditionally (even with an explicit choice) so the
                 // displayed groups float the user's language to the top.
-                self.subtitleOrderingLanguage = prepared.watchDetail.effectiveSubtitleLanguage
+                self.subtitleOrderingLanguage = self.settings.subtitleMatchesSystemAppearance
+                    ? self.settings.subtitleSystemSelectionPreferences.preferredLanguages.first
+                    : prepared.watchDetail.effectiveSubtitleLanguage
 
                 // Snapshot the server-resolved subtitle policy so the
                 // track-list callback (which fires post-FFmpeg-open)
@@ -7435,6 +7442,8 @@ class PlayerViewModel {
 
     private func reapplySystemSubtitlePolicy() {
         guard settings.subtitleMatchesSystemAppearance, !hasExplicitSubtitleChoice else { return }
+        subtitleOrderingLanguage = settings.subtitleSystemSelectionPreferences
+            .preferredLanguages.first
         prefsForCurrentItem = systemCaptionPrefsSnapshot()
         prefsResolvedForCurrentItem = false
         applyAutoSubtitlePreferencesIfNeeded(forceReevaluation: true)

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -954,6 +954,7 @@ class PlayerViewModel {
         let showForced: Bool
         let forcedOnly: Bool
         let preferAccessibilityTracks: Bool
+        let disableWhenNoLanguageMatch: Bool
         let trackSignature: SubtitleTrackSignature?
     }
     /// Set after the resolver has fired once for the current item so we
@@ -7414,6 +7415,7 @@ class PlayerViewModel {
             showForced: prefs.showForced,
             forcedOnly: prefs.forcedOnly,
             preferAccessibilityTracks: prefs.preferAccessibilityTracks,
+            disableWhenNoLanguageMatch: prefs.disableWhenNoLanguageMatch,
             trackSignature: prefs.trackSignature,
             availableSubtitles: allSubs,
             currentAudioLanguage: audioLang
@@ -7435,6 +7437,7 @@ class PlayerViewModel {
                 showForced: true,
                 forcedOnly: true,
                 preferAccessibilityTracks: system.prefersAccessibilityTracks,
+                disableWhenNoLanguageMatch: true,
                 trackSignature: nil
             )
         case .automatic:
@@ -7445,6 +7448,7 @@ class PlayerViewModel {
                 showForced: true,
                 forcedOnly: false,
                 preferAccessibilityTracks: system.prefersAccessibilityTracks,
+                disableWhenNoLanguageMatch: true,
                 trackSignature: nil
             )
         case .alwaysOn:
@@ -7455,6 +7459,7 @@ class PlayerViewModel {
                 showForced: false,
                 forcedOnly: false,
                 preferAccessibilityTracks: system.prefersAccessibilityTracks,
+                disableWhenNoLanguageMatch: true,
                 trackSignature: nil
             )
         }
@@ -7468,6 +7473,7 @@ class PlayerViewModel {
             showForced: watchDetail.effectiveShowForcedSubtitles ?? false,
             forcedOnly: false,
             preferAccessibilityTracks: false,
+            disableWhenNoLanguageMatch: false,
             trackSignature: watchDetail.effectiveSubtitleTrackSignature
         )
     }

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -1179,7 +1179,7 @@ class PlayerViewModel {
             guard !self.hasExplicitSubtitleChoice else { return }
             self.prefsForCurrentItem = self.systemCaptionPrefsSnapshot()
             self.prefsResolvedForCurrentItem = false
-            self.applyAutoSubtitlePreferencesIfNeeded(forceWhenNoSelection: true)
+            self.applyAutoSubtitlePreferencesIfNeeded(forceReevaluation: true)
         }
         #if !os(macOS)
         outputRouteObserverToken = NotificationCenter.default.addObserver(
@@ -2172,6 +2172,7 @@ class PlayerViewModel {
                 SubtitleTrackIdSpace.isSyntheticNonEmbedded(track.trackId) ? nil : TrackSelectionSnapshot(track: track)
             }
         let secondarySubtitleSelectionSnapshot = selectedSecondarySubtitleId
+        let explicitSubtitleChoiceSnapshot = hasExplicitSubtitleChoice
         resetPublishedLoadState(
             preferredAudioTrackIndex: preferredAudioTrackIndex,
             preferredSubtitleTrackIndex: preferredSubtitleTrackIndex,
@@ -2187,9 +2188,7 @@ class PlayerViewModel {
         pendingRecoveredAudioSelection = audioSelectionSnapshot
         pendingRecoveredSubtitleSelection = subtitleSelectionSnapshot
         pendingRecoveredSecondarySubtitleId = secondarySubtitleSelectionSnapshot
-        if subtitleSelectionSnapshot != nil {
-            hasExplicitSubtitleChoice = true
-        }
+        hasExplicitSubtitleChoice = explicitSubtitleChoiceSnapshot
         activePlayer.dispose()
         logExecutionPlan(fallbackPlan)
         Task { @MainActor [weak self] in
@@ -2865,7 +2864,7 @@ class PlayerViewModel {
             ? systemCaptionPrefsSnapshot()
             : currentWatchDetail.map(serverSubtitlePrefsSnapshot)
         prefsResolvedForCurrentItem = false
-        applyAutoSubtitlePreferencesIfNeeded(forceWhenNoSelection: true)
+        applyAutoSubtitlePreferencesIfNeeded(forceReevaluation: true)
     }
 
     func setPlaybackSpeed(_ rate: Double) {
@@ -4858,6 +4857,7 @@ class PlayerViewModel {
         let externalSubtitleSnapshot = knownExternalSubtitles
         let selectedSubtitleSnapshot = selectedSubtitleId
         let selectedSecondarySubtitleSnapshot = selectedSecondarySubtitleId
+        let explicitSubtitleChoiceSnapshot = hasExplicitSubtitleChoice
         // An embedded selection can't be re-established by trackId across
         // the backend rebuild (ids aren't stable), and after a switch to
         // transcode the same stream may resurface as a sidecar instead.
@@ -4946,9 +4946,7 @@ class PlayerViewModel {
                     self.pendingSidecarSubtitleTrackId = selectedSubtitleSnapshot
                 }
                 self.pendingRecoveredSubtitleSelection = embeddedSubtitleSelectionSnapshot
-                if embeddedSubtitleSelectionSnapshot != nil {
-                    self.hasExplicitSubtitleChoice = true
-                }
+                self.hasExplicitSubtitleChoice = explicitSubtitleChoiceSnapshot
                 self.pendingRecoveredSecondarySubtitleId = selectedSecondarySubtitleSnapshot
                 self.duration = session.durationSeconds ?? selectedVersion.duration ?? self.duration
                 self.currentTime = self.movieTime(for: session)
@@ -5246,6 +5244,7 @@ class PlayerViewModel {
         pendingAudioFfIndex = nil
         selectedAudioId = track.trackId
         persistAudioSelection(track)
+        reapplySystemSubtitlePolicy()
         if activePreparedProtocolV3 != nil {
             attemptProtocolV3Replan(
                 position: currentTime,
@@ -7254,7 +7253,10 @@ class PlayerViewModel {
             }
         }
 
-        if restoredPrimarySidecar { return }
+        if restoredPrimarySidecar,
+           !settings.subtitleMatchesSystemAppearance || hasExplicitSubtitleChoice {
+            return
+        }
 
         // A pre-restart embedded selection can resurface as a sidecar when
         // the new route has the server extract embedded streams into
@@ -7271,13 +7273,18 @@ class PlayerViewModel {
                 selectedSubtitleId = match.trackId
                 applySubtitleTrackSelection(match.trackId)
             }
-            return
+            if !settings.subtitleMatchesSystemAppearance || hasExplicitSubtitleChoice {
+                return
+            }
         }
 
         // If a forced sidecar is present, auto-select it. Forced tracks
         // (for non-native dialogue or song lyrics in anime) are meant
-        // to display regardless of the user's subtitle preference.
-        if selectedSubtitleId == nil,
+        // to display regardless of the Silo subtitle preference. Device
+        // settings mode instead routes every sidecar through Apple's ordered
+        // language policy, including Forced Only.
+        if !settings.subtitleMatchesSystemAppearance,
+           selectedSubtitleId == nil,
            let forced = descriptors.first(where: { $0.forced == true }) {
             let trackId = SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: forced.index)
             selectedSubtitleId = trackId
@@ -7285,7 +7292,9 @@ class PlayerViewModel {
             return
         }
 
-        applyAutoSubtitlePreferencesIfNeeded(forceWhenNoSelection: true)
+        applyAutoSubtitlePreferencesIfNeeded(
+            forceReevaluation: settings.subtitleMatchesSystemAppearance || selectedSubtitleId == nil
+        )
     }
 
     /// Called on every `track-list` change. Updates the published track lists,
@@ -7396,9 +7405,9 @@ class PlayerViewModel {
         return best.track
     }
 
-    private func applyAutoSubtitlePreferencesIfNeeded(forceWhenNoSelection: Bool = false) {
+    private func applyAutoSubtitlePreferencesIfNeeded(forceReevaluation: Bool = false) {
         guard !hasExplicitSubtitleChoice, let prefs = prefsForCurrentItem else { return }
-        if prefsResolvedForCurrentItem && !(forceWhenNoSelection && selectedSubtitleId == nil) {
+        if prefsResolvedForCurrentItem && !forceReevaluation {
             return
         }
 
@@ -7422,6 +7431,13 @@ class PlayerViewModel {
         ))
         prefsResolvedForCurrentItem = true
         applyAutoSubtitle(pick)
+    }
+
+    private func reapplySystemSubtitlePolicy() {
+        guard settings.subtitleMatchesSystemAppearance, !hasExplicitSubtitleChoice else { return }
+        prefsForCurrentItem = systemCaptionPrefsSnapshot()
+        prefsResolvedForCurrentItem = false
+        applyAutoSubtitlePreferencesIfNeeded(forceReevaluation: true)
     }
 
     private func systemCaptionPrefsSnapshot() -> PrefsSnapshot {

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -7419,7 +7419,6 @@ class PlayerViewModel {
         }
 
         let allSubs = subtitleTracks
-        guard !allSubs.isEmpty else { return }
 
         let audioLang = audioTracks
             .first(where: { $0.trackId == selectedAudioId })?
@@ -7436,7 +7435,10 @@ class PlayerViewModel {
             availableSubtitles: allSubs,
             currentAudioLanguage: audioLang
         ))
-        prefsResolvedForCurrentItem = true
+        // An empty callback still has to clear a server-seeded automatic
+        // selection in device-settings mode, but it must not latch the
+        // resolver: embedded or sidecar tracks can arrive in a later update.
+        prefsResolvedForCurrentItem = !allSubs.isEmpty
         applyAutoSubtitle(pick)
     }
 

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -949,8 +949,11 @@ class PlayerViewModel {
     private var prefsForCurrentItem: PrefsSnapshot?
     private struct PrefsSnapshot {
         let preferredLanguage: String?
+        let additionalPreferredLanguages: [String]
         let mode: SubtitleMode?
         let showForced: Bool
+        let forcedOnly: Bool
+        let preferAccessibilityTracks: Bool
         let trackSignature: SubtitleTrackSignature?
     }
     /// Set after the resolver has fired once for the current item so we
@@ -1172,6 +1175,10 @@ class PlayerViewModel {
             guard let self, self.settings.subtitleMatchesSystemAppearance else { return }
             self.settings.refreshSubtitleSystemAppearance()
             self.applySubtitleAppearanceToPlayer()
+            guard !self.hasExplicitSubtitleChoice else { return }
+            self.prefsForCurrentItem = self.systemCaptionPrefsSnapshot()
+            self.prefsResolvedForCurrentItem = false
+            self.applyAutoSubtitlePreferencesIfNeeded(forceWhenNoSelection: true)
         }
         #if !os(macOS)
         outputRouteObserverToken = NotificationCenter.default.addObserver(
@@ -2852,6 +2859,12 @@ class PlayerViewModel {
     func setSubtitleMatchesSystemAppearance(_ enabled: Bool) {
         settings.setSubtitleMatchesSystemAppearance(enabled)
         applySubtitleAppearanceToPlayer()
+        hasExplicitSubtitleChoice = false
+        prefsForCurrentItem = enabled
+            ? systemCaptionPrefsSnapshot()
+            : currentWatchDetail.map(serverSubtitlePrefsSnapshot)
+        prefsResolvedForCurrentItem = false
+        applyAutoSubtitlePreferencesIfNeeded(forceWhenNoSelection: true)
     }
 
     func setPlaybackSpeed(_ rate: Double) {
@@ -3392,13 +3405,9 @@ class PlayerViewModel {
                 // entirely if the caller already passed an explicit
                 // subtitle index — manual override always wins.
                 if !self.hasExplicitSubtitleChoice {
-                    let modeRaw = prepared.watchDetail.effectiveSubtitleMode ?? ""
-                    self.prefsForCurrentItem = PrefsSnapshot(
-                        preferredLanguage: prepared.watchDetail.effectiveSubtitleLanguage,
-                        mode: SubtitleMode(rawValue: modeRaw),
-                        showForced: prepared.watchDetail.effectiveShowForcedSubtitles ?? false,
-                        trackSignature: prepared.watchDetail.effectiveSubtitleTrackSignature
-                    )
+                    self.prefsForCurrentItem = self.settings.subtitleMatchesSystemAppearance
+                        ? self.systemCaptionPrefsSnapshot()
+                        : self.serverSubtitlePrefsSnapshot(prepared.watchDetail)
                 }
 
                 self.title = prepared.displayTitle
@@ -5251,6 +5260,7 @@ class PlayerViewModel {
 
     func selectSubtitle(_ track: PlayerTrack) {
         guard !isBackgroundSuspended else { return }
+        hasExplicitSubtitleChoice = true
         pendingSubtitleFfIndex = nil
         if selectedSecondarySubtitleId == track.trackId {
             selectedSecondarySubtitleId = nil
@@ -5277,6 +5287,7 @@ class PlayerViewModel {
 
     func disableSubtitles() {
         guard !isBackgroundSuspended else { return }
+        hasExplicitSubtitleChoice = true
         pendingSubtitleFfIndex = nil
         if selectedSecondarySubtitleId != nil {
             selectedSecondarySubtitleId = nil
@@ -7398,14 +7409,67 @@ class PlayerViewModel {
             .lang
         let pick = SubtitleAutoResolver.resolve(.init(
             preferredLanguage: prefs.preferredLanguage,
+            additionalPreferredLanguages: prefs.additionalPreferredLanguages,
             mode: prefs.mode,
             showForced: prefs.showForced,
+            forcedOnly: prefs.forcedOnly,
+            preferAccessibilityTracks: prefs.preferAccessibilityTracks,
             trackSignature: prefs.trackSignature,
             availableSubtitles: allSubs,
             currentAudioLanguage: audioLang
         ))
         prefsResolvedForCurrentItem = true
         applyAutoSubtitle(pick)
+    }
+
+    private func systemCaptionPrefsSnapshot() -> PrefsSnapshot {
+        let system = settings.subtitleSystemSelectionPreferences
+        let firstLanguage = system.preferredLanguages.first
+        let remainingLanguages = Array(system.preferredLanguages.dropFirst())
+        switch system.displayMode {
+        case .forcedOnly:
+            return PrefsSnapshot(
+                preferredLanguage: firstLanguage,
+                additionalPreferredLanguages: remainingLanguages,
+                mode: .auto,
+                showForced: true,
+                forcedOnly: true,
+                preferAccessibilityTracks: system.prefersAccessibilityTracks,
+                trackSignature: nil
+            )
+        case .automatic:
+            return PrefsSnapshot(
+                preferredLanguage: firstLanguage,
+                additionalPreferredLanguages: remainingLanguages,
+                mode: .auto,
+                showForced: true,
+                forcedOnly: false,
+                preferAccessibilityTracks: system.prefersAccessibilityTracks,
+                trackSignature: nil
+            )
+        case .alwaysOn:
+            return PrefsSnapshot(
+                preferredLanguage: firstLanguage,
+                additionalPreferredLanguages: remainingLanguages,
+                mode: .always,
+                showForced: false,
+                forcedOnly: false,
+                preferAccessibilityTracks: system.prefersAccessibilityTracks,
+                trackSignature: nil
+            )
+        }
+    }
+
+    private func serverSubtitlePrefsSnapshot(_ watchDetail: WatchDetail) -> PrefsSnapshot {
+        PrefsSnapshot(
+            preferredLanguage: watchDetail.effectiveSubtitleLanguage,
+            additionalPreferredLanguages: [],
+            mode: SubtitleMode(rawValue: watchDetail.effectiveSubtitleMode ?? ""),
+            showForced: watchDetail.effectiveShowForcedSubtitles ?? false,
+            forcedOnly: false,
+            preferAccessibilityTracks: false,
+            trackSignature: watchDetail.effectiveSubtitleTrackSignature
+        )
     }
 
     /// Apply a resolver verdict. `noChange` is the "leave the player

--- a/iosApp/iosApp/Screens/Player/Sheets/PlayerSettingsSheet.swift
+++ b/iosApp/iosApp/Screens/Player/Sheets/PlayerSettingsSheet.swift
@@ -298,7 +298,7 @@ struct PlayerSettingsSheet: View {
     /// "Large · Box · Bottom"-style value label for the Appearance row.
     private var appearanceSummary: String {
         if viewModel.settings.subtitleMatchesSystemAppearance {
-            return "Matching Device"
+            return "Using Device"
         }
         let appearance = viewModel.settings.subtitleAppearance
         return [
@@ -321,7 +321,7 @@ struct PlayerSettingsSheet: View {
             }
 
             Section {
-                Toggle("Match device settings", isOn: Binding(
+                Toggle("Use device settings", isOn: Binding(
                     get: { viewModel.settings.subtitleMatchesSystemAppearance },
                     set: { enabled in
                         viewModel.setSubtitleMatchesSystemAppearance(enabled)
@@ -339,7 +339,7 @@ struct PlayerSettingsSheet: View {
                 .disabled(matchesSystem)
             } footer: {
                 Text(matchesSystem
-                     ? "Following this device's caption style from Accessibility settings. Editing any option below switches back to Silo styling."
+                     ? "Following this device's caption language, behavior, CC/SDH preference, and complete style from Accessibility settings."
                      : "Subtitles with their own built-in styling keep their original appearance; image-based subtitles keep their authored fonts and colors but follow the size, position, and background settings.")
             }
 
@@ -728,7 +728,7 @@ struct PlayerSettingsSheet: View {
                     SubtitleAppearancePreview(appearance: viewModel.settings.effectiveSubtitleAppearance)
                         .listRowInsets(EdgeInsets())
 
-                    Toggle("Match device settings", isOn: Binding(
+                    Toggle("Use device settings", isOn: Binding(
                         get: { viewModel.settings.subtitleMatchesSystemAppearance },
                         set: { enabled in
                             viewModel.setSubtitleMatchesSystemAppearance(enabled)
@@ -805,7 +805,7 @@ struct PlayerSettingsSheet: View {
                     Text("Subtitle appearance")
                 } footer: {
                     Text(matchesSystem
-                         ? "Following this device's caption style from Accessibility settings. Editing any option switches back to Silo styling."
+                         ? "Following this device's caption language, behavior, CC/SDH preference, and complete style from Accessibility settings."
                          : "Subtitles with their own built-in styling keep their original appearance; image-based subtitles keep their authored fonts and colors but follow the size, position, and background settings.")
                 }
             }

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleAppearance.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleAppearance.swift
@@ -178,6 +178,27 @@ enum SubtitlePositionPreset: String, Codable, CaseIterable, Identifiable {
     }
 }
 
+/// Apple exposes five distinct caption edge treatments. This value is
+/// runtime-only: it is populated from MediaAccessibility and deliberately
+/// excluded from the server-backed Silo appearance JSON.
+enum SystemCaptionTextEdgeStyle: Equatable {
+    case none
+    case raised
+    case depressed
+    case uniform
+    case dropShadow
+}
+
+struct SystemCaptionContentOverrides: OptionSet, Equatable {
+    let rawValue: Int
+
+    static let font = SystemCaptionContentOverrides(rawValue: 1 << 0)
+    static let size = SystemCaptionContentOverrides(rawValue: 1 << 1)
+    static let colors = SystemCaptionContentOverrides(rawValue: 1 << 2)
+    static let edge = SystemCaptionContentOverrides(rawValue: 1 << 3)
+    static let window = SystemCaptionContentOverrides(rawValue: 1 << 4)
+}
+
 struct SubtitleAppearance: Codable, Equatable {
     var fontSize: SubtitleFontSizePreset
     var fontFamily: SubtitleFontFamilyPreset
@@ -189,6 +210,17 @@ struct SubtitleAppearance: Codable, Equatable {
     var textOutlineColor: String
     var position: SubtitlePositionPreset
 
+    // Runtime-only MediaAccessibility details. These are intentionally not
+    // CodingKeys: a device caption profile must never leak into the user's
+    // server-synced Silo appearance or another platform.
+    var fontOpacity: Int
+    var systemRelativeFontScale: Double?
+    var systemTextEdgeStyle: SystemCaptionTextEdgeStyle?
+    var captionWindowColor: String
+    var captionWindowOpacity: Int
+    var captionWindowCornerRadius: Double
+    var systemContentOverrides: SystemCaptionContentOverrides
+
     init(
         fontSize: SubtitleFontSizePreset,
         fontFamily: SubtitleFontFamilyPreset,
@@ -198,7 +230,14 @@ struct SubtitleAppearance: Codable, Equatable {
         backgroundOpacity: Int,
         textOutline: Bool,
         textOutlineColor: String,
-        position: SubtitlePositionPreset
+        position: SubtitlePositionPreset,
+        fontOpacity: Int = 100,
+        systemRelativeFontScale: Double? = nil,
+        systemTextEdgeStyle: SystemCaptionTextEdgeStyle? = nil,
+        captionWindowColor: String = "#000000",
+        captionWindowOpacity: Int = 0,
+        captionWindowCornerRadius: Double = 0,
+        systemContentOverrides: SystemCaptionContentOverrides = []
     ) {
         self.fontSize = fontSize
         self.fontFamily = fontFamily
@@ -209,6 +248,13 @@ struct SubtitleAppearance: Codable, Equatable {
         self.textOutline = textOutline
         self.textOutlineColor = textOutlineColor
         self.position = position
+        self.fontOpacity = fontOpacity
+        self.systemRelativeFontScale = systemRelativeFontScale
+        self.systemTextEdgeStyle = systemTextEdgeStyle
+        self.captionWindowColor = captionWindowColor
+        self.captionWindowOpacity = captionWindowOpacity
+        self.captionWindowCornerRadius = captionWindowCornerRadius
+        self.systemContentOverrides = systemContentOverrides
     }
 
     static let `default` = SubtitleAppearance(
@@ -267,6 +313,13 @@ struct SubtitleAppearance: Codable, Equatable {
         self.textOutline = try container.decodeIfPresent(Bool.self, forKey: .textOutline) ?? Self.default.textOutline
         self.textOutlineColor = try container.decodeIfPresent(String.self, forKey: .textOutlineColor) ?? Self.default.textOutlineColor
         self.position = try container.decodeIfPresent(SubtitlePositionPreset.self, forKey: .position) ?? Self.default.position
+        self.fontOpacity = 100
+        self.systemRelativeFontScale = nil
+        self.systemTextEdgeStyle = nil
+        self.captionWindowColor = "#000000"
+        self.captionWindowOpacity = 0
+        self.captionWindowCornerRadius = 0
+        self.systemContentOverrides = []
     }
 
     static func decode(from json: String?) -> SubtitleAppearance {
@@ -293,7 +346,16 @@ struct SubtitleAppearance: Codable, Equatable {
         if !Self.isValidHex(copy.fontColor) { copy.fontColor = Self.default.fontColor }
         if !Self.isValidHex(copy.backgroundColor) { copy.backgroundColor = Self.default.backgroundColor }
         if !Self.isValidHex(copy.textOutlineColor) { copy.textOutlineColor = Self.default.textOutlineColor }
+        if !Self.isValidHex(copy.captionWindowColor) { copy.captionWindowColor = "#000000" }
         copy.backgroundOpacity = max(0, min(100, copy.backgroundOpacity))
+        copy.fontOpacity = max(0, min(100, copy.fontOpacity))
+        copy.captionWindowOpacity = max(0, min(100, copy.captionWindowOpacity))
+        if let scale = copy.systemRelativeFontScale {
+            copy.systemRelativeFontScale = scale.isFinite ? max(0.1, min(5, scale)) : nil
+        }
+        copy.captionWindowCornerRadius = copy.captionWindowCornerRadius.isFinite
+            ? max(0, min(200, copy.captionWindowCornerRadius))
+            : 0
         // Legacy "outline" background style folds into the text-edge axis
         // so the UI has a single outline concept. Rendering is identical:
         // both paths draw a 2px border in the outline color.
@@ -362,4 +424,3 @@ struct EffectiveSettingResponse: Codable {
 struct EffectiveSettingsResponse: Codable {
     let settings: [EffectiveSettingResponse]
 }
-

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleAppearance.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleAppearance.swift
@@ -194,9 +194,26 @@ struct SystemCaptionContentOverrides: OptionSet, Equatable {
 
     static let font = SystemCaptionContentOverrides(rawValue: 1 << 0)
     static let size = SystemCaptionContentOverrides(rawValue: 1 << 1)
-    static let colors = SystemCaptionContentOverrides(rawValue: 1 << 2)
-    static let edge = SystemCaptionContentOverrides(rawValue: 1 << 3)
-    static let window = SystemCaptionContentOverrides(rawValue: 1 << 4)
+    static let foregroundColor = SystemCaptionContentOverrides(rawValue: 1 << 2)
+    static let foregroundOpacity = SystemCaptionContentOverrides(rawValue: 1 << 3)
+    static let backgroundColor = SystemCaptionContentOverrides(rawValue: 1 << 4)
+    static let backgroundOpacity = SystemCaptionContentOverrides(rawValue: 1 << 5)
+    static let edge = SystemCaptionContentOverrides(rawValue: 1 << 6)
+    static let windowColor = SystemCaptionContentOverrides(rawValue: 1 << 7)
+    static let windowOpacity = SystemCaptionContentOverrides(rawValue: 1 << 8)
+    static let windowCornerRadius = SystemCaptionContentOverrides(rawValue: 1 << 9)
+
+    static let colors: SystemCaptionContentOverrides = [
+        .foregroundColor,
+        .foregroundOpacity,
+        .backgroundColor,
+        .backgroundOpacity,
+    ]
+    static let window: SystemCaptionContentOverrides = [
+        .windowColor,
+        .windowOpacity,
+        .windowCornerRadius,
+    ]
 }
 
 struct SubtitleAppearance: Codable, Equatable {

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleAppearancePreview.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleAppearancePreview.swift
@@ -54,33 +54,40 @@ struct SubtitleAppearancePreview: View {
     }
 
     private var sampleText: some View {
-        let size = appearance.fontSize.pointSize * Self.fontScale
-        let font: Font = {
-            switch appearance.fontFamily {
-            case .serif: return .system(size: size, weight: .semibold, design: .serif)
-            case .monospace: return .system(size: size, weight: .semibold, design: .monospaced)
-            case .sansSerif: return .system(size: size, weight: .semibold)
-            default: return .custom(appearance.fontFamily.assFontName, size: size)
-            }
-        }()
+        glyphText
+            .padding(.horizontal, appearance.captionWindowOpacity > 0 ? 6 : 0)
+            .padding(.vertical, appearance.captionWindowOpacity > 0 ? 4 : 0)
+            .background { captionWindowBackground }
+    }
+
+    private var glyphText: some View {
+        let systemEdge = appearance.systemTextEdgeStyle
         let hasOutline = appearance.textOutline || appearance.backgroundStyle == .outline
+            || systemEdge == .uniform
         let outlineColor = hasOutline ? Color(hex: appearance.textOutlineColor) : .clear
         // Four hard directional shadows fake libass's uniform glyph
         // outline; a soft radius reads as a glow instead.
-        let outlineOffset: CGFloat = max(1, size * 0.04)
+        let outlineOffset: CGFloat = max(1, sampleFontSize * 0.04)
+
+        let raisedColor = systemEdge == .raised ? Color.white.opacity(0.8) : .clear
+        let depressedColor = systemEdge == .depressed ? Color.black.opacity(0.9) : .clear
+        let dropShadowColor = systemEdge == .dropShadow
+            || appearance.backgroundStyle == .shadow ? Color.black.opacity(0.85) : .clear
 
         return Text(Self.sampleLine)
-            .font(font)
+            .font(sampleFont)
             .multilineTextAlignment(.center)
-            .foregroundStyle(Color(hex: appearance.fontColor))
+            .foregroundStyle(
+                Color(hex: appearance.fontColor)
+                    .opacity(Double(appearance.fontOpacity) / 100)
+            )
             .shadow(color: outlineColor, radius: 0, x: outlineOffset, y: outlineOffset)
             .shadow(color: outlineColor, radius: 0, x: -outlineOffset, y: outlineOffset)
             .shadow(color: outlineColor, radius: 0, x: outlineOffset, y: -outlineOffset)
             .shadow(color: outlineColor, radius: 0, x: -outlineOffset, y: -outlineOffset)
-            .shadow(
-                color: appearance.backgroundStyle == .shadow ? .black.opacity(0.85) : .clear,
-                radius: 3, y: 2
-            )
+            .shadow(color: raisedColor, radius: 0, x: -outlineOffset, y: -outlineOffset)
+            .shadow(color: depressedColor, radius: 0, x: outlineOffset, y: outlineOffset)
+            .shadow(color: dropShadowColor, radius: 3, y: 2)
             .padding(.horizontal, appearance.backgroundStyle == .box ? 10 : 0)
             .padding(.vertical, appearance.backgroundStyle == .box ? 4 : 0)
             .background {
@@ -90,5 +97,34 @@ struct SubtitleAppearancePreview: View {
                             .opacity(Double(appearance.backgroundOpacity) / 100))
                 }
             }
+    }
+
+    @ViewBuilder
+    private var captionWindowBackground: some View {
+        if appearance.captionWindowOpacity > 0 {
+            RoundedRectangle(
+                cornerRadius: appearance.captionWindowCornerRadius * Self.fontScale,
+                style: .continuous
+            )
+            .fill(
+                Color(hex: appearance.captionWindowColor)
+                    .opacity(Double(appearance.captionWindowOpacity) / 100)
+            )
+        }
+    }
+
+    private var sampleFontSize: CGFloat {
+        (appearance.systemRelativeFontScale.map {
+            SubtitleStylingOverride.Parameters.referenceFontSize * $0
+        } ?? appearance.fontSize.pointSize) * Self.fontScale
+    }
+
+    private var sampleFont: Font {
+        switch appearance.fontFamily {
+        case .serif: return .system(size: sampleFontSize, weight: .semibold, design: .serif)
+        case .monospace: return .system(size: sampleFontSize, weight: .semibold, design: .monospaced)
+        case .sansSerif: return .system(size: sampleFontSize, weight: .semibold)
+        default: return .custom(appearance.fontFamily.assFontName, size: sampleFontSize)
+        }
     }
 }

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleRenderer.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleRenderer.swift
@@ -543,6 +543,29 @@ final class SubtitleRenderer {
         }
     }
 
+    static func shouldDrawCaptionWindow(
+        isNativeASS: Bool,
+        opacityPercent: Int,
+        overrides: SystemCaptionContentOverrides
+    ) -> Bool {
+        guard opacityPercent > 0 else { return false }
+        return !isNativeASS || overrides.contains(.windowOpacity)
+    }
+
+    static func shouldSynthesizeGlyphBackground(
+        isNativeASS: Bool,
+        opacityPercent: Int,
+        overrides: SystemCaptionContentOverrides
+    ) -> Bool {
+        let backgroundOverrides: SystemCaptionContentOverrides = [
+            .backgroundColor,
+            .backgroundOpacity,
+        ]
+        return isNativeASS
+            && opacityPercent > 0
+            && !overrides.intersection(backgroundOverrides).isEmpty
+    }
+
     /// Render the current frame. Callable only from `sessionQueue`. The
     /// caller is responsible for hopping back to main to assign the
     /// returned image to the overlay layer's `contents`.
@@ -705,15 +728,24 @@ final class SubtitleRenderer {
             secondaryRects,
             joiningDistance: cueJoiningDistance
         )
+        let primaryCharacterGroups = Self.groupedPaintedBounds(
+            paintedRects(imgPrimary, charactersOnly: true),
+            joiningDistance: cueJoiningDistance
+        )
+        let secondaryCharacterGroups = Self.groupedPaintedBounds(
+            paintedRects(imgSecondary, charactersOnly: true),
+            joiningDistance: cueJoiningDistance
+        )
         func captionWindowBounds(
             _ groups: [CGRect],
             for handle: ASSTrackHandle?
         ) -> [CGRect] {
-            guard currentParams.captionWindowEnabled,
-                  let handle,
-                  !handle.isNativeASS
-                    || !currentParams.systemContentOverrides.intersection(.window).isEmpty
-                    else { return [] }
+            guard let handle,
+                  Self.shouldDrawCaptionWindow(
+                      isNativeASS: handle.isNativeASS,
+                      opacityPercent: currentParams.captionWindowOpacityPercent,
+                      overrides: currentParams.systemContentOverrides
+                  ) else { return [] }
             return groups.map { bounds in
                 CGRect(
                     x: max(0, Int(bounds.minX) - windowPadding),
@@ -727,6 +759,41 @@ final class SubtitleRenderer {
         }
         let primaryWindowBounds = captionWindowBounds(primaryGroups, for: primaryHandle)
         let secondaryWindowBounds = captionWindowBounds(secondaryGroups, for: secondaryHandle)
+
+        let glyphBackgroundPadding = max(
+            1,
+            Int((currentParams.boxPadding * playfieldScale).rounded())
+        )
+        func nativeGlyphBackgroundBounds(
+            _ groups: [CGRect],
+            for handle: ASSTrackHandle?
+        ) -> [CGRect] {
+            guard let handle,
+                  Self.shouldSynthesizeGlyphBackground(
+                      isNativeASS: handle.isNativeASS,
+                      opacityPercent: currentParams.backgroundOpacityPercent,
+                      overrides: currentParams.systemContentOverrides
+                  )
+                    else { return [] }
+            return groups.map { bounds in
+                CGRect(
+                    x: max(0, Int(bounds.minX) - glyphBackgroundPadding),
+                    y: max(0, Int(bounds.minY) - glyphBackgroundPadding),
+                    width: min(widthPx, Int(bounds.maxX) + glyphBackgroundPadding)
+                        - max(0, Int(bounds.minX) - glyphBackgroundPadding),
+                    height: min(heightPx, Int(bounds.maxY) + glyphBackgroundPadding)
+                        - max(0, Int(bounds.minY) - glyphBackgroundPadding)
+                )
+            }
+        }
+        let primaryGlyphBackgroundBounds = nativeGlyphBackgroundBounds(
+            primaryCharacterGroups,
+            for: primaryHandle
+        )
+        let secondaryGlyphBackgroundBounds = nativeGlyphBackgroundBounds(
+            secondaryCharacterGroups,
+            for: secondaryHandle
+        )
 
         func compositedEdgeShadow(
             for handle: ASSTrackHandle?
@@ -758,6 +825,7 @@ final class SubtitleRenderer {
 
         let allBounds = primaryRects + secondaryRects
             + primaryWindowBounds + secondaryWindowBounds
+            + primaryGlyphBackgroundBounds + secondaryGlyphBackgroundBounds
             + primaryShadowBounds + secondaryShadowBounds
         let minX = max(0, Int(allBounds.map(\.minX).min() ?? CGFloat(widthPx)))
         let minY = max(0, Int(allBounds.map(\.minY).min() ?? CGFloat(heightPx)))
@@ -791,8 +859,6 @@ final class SubtitleRenderer {
             let isNativeASS = handle?.isNativeASS == true
             let characterColor = isNativeASS ? currentParams.nativeForegroundColorOverride : nil
             let characterAlpha = isNativeASS ? currentParams.nativeForegroundAlphaOverride : nil
-            let backgroundColor = isNativeASS ? currentParams.nativeBackgroundColorOverride : nil
-            let backgroundAlpha = isNativeASS ? currentParams.nativeBackgroundAlphaOverride : nil
 
             if let edgeShadow {
                 // BorderStyle 4 emits the box through the non-character image
@@ -802,9 +868,7 @@ final class SubtitleRenderer {
                     imageList: imageList,
                     offsetX: frameOffsetX,
                     offsetY: frameOffsetY,
-                    selection: .excludingCharacters,
-                    backgroundColorOverride: backgroundColor,
-                    backgroundAlphaOverride: backgroundAlpha
+                    selection: .excludingCharacters
                 )
                 canvas.draw(
                     imageList: imageList,
@@ -830,9 +894,7 @@ final class SubtitleRenderer {
                     offsetX: frameOffsetX,
                     offsetY: frameOffsetY,
                     characterColorOverride: characterColor,
-                    characterAlphaOverride: characterAlpha,
-                    backgroundColorOverride: backgroundColor,
-                    backgroundAlphaOverride: backgroundAlpha
+                    characterAlphaOverride: characterAlpha
                 )
             }
         }
@@ -843,20 +905,49 @@ final class SubtitleRenderer {
         // authored content.
         let canvas = ensureCanvas(widthPx: maxX - minX, heightPx: maxY - minY)
         canvas.clear()
-        let windowColor = SubtitleStylingOverride.rgbBytes(fromHex: currentParams.captionWindowColorHex)
-        let windowAlpha = UInt8(
-            max(0, min(255, currentParams.captionWindowOpacityPercent * 255 / 100))
-        )
-        let windowRadius = currentParams.captionWindowCornerRadius * playfieldScale
+        func captionWindowStyle(
+            for handle: ASSTrackHandle?
+        ) -> (color: (UInt8, UInt8, UInt8), alpha: UInt8, radius: Double) {
+            let isNativeASS = handle?.isNativeASS == true
+            let usesSystemColor = !isNativeASS
+                || currentParams.systemContentOverrides.contains(.windowColor)
+            let usesSystemRadius = !isNativeASS
+                || currentParams.systemContentOverrides.contains(.windowCornerRadius)
+            return (
+                SubtitleStylingOverride.rgbBytes(
+                    fromHex: usesSystemColor ? currentParams.captionWindowColorHex : "#000000"
+                ),
+                UInt8(max(0, min(255, currentParams.captionWindowOpacityPercent * 255 / 100))),
+                (usesSystemRadius ? currentParams.captionWindowCornerRadius : 0) * playfieldScale
+            )
+        }
+        let secondaryWindowStyle = captionWindowStyle(for: secondaryHandle)
         for bounds in secondaryWindowBounds {
             canvas.drawRoundedRect(
                 x: Int(bounds.minX) - minX,
                 y: Int(bounds.minY) - minY,
                 width: Int(bounds.width),
                 height: Int(bounds.height),
-                radius: windowRadius,
-                color: windowColor,
-                alpha: windowAlpha
+                radius: secondaryWindowStyle.radius,
+                color: secondaryWindowStyle.color,
+                alpha: secondaryWindowStyle.alpha
+            )
+        }
+        let glyphBackgroundColor = SubtitleStylingOverride.rgbBytes(
+            fromHex: currentParams.backgroundColorHex
+        )
+        let glyphBackgroundAlpha = UInt8(
+            max(0, min(255, currentParams.backgroundOpacityPercent * 255 / 100))
+        )
+        for bounds in secondaryGlyphBackgroundBounds {
+            canvas.drawRoundedRect(
+                x: Int(bounds.minX) - minX,
+                y: Int(bounds.minY) - minY,
+                width: Int(bounds.width),
+                height: Int(bounds.height),
+                radius: 0,
+                color: glyphBackgroundColor,
+                alpha: glyphBackgroundAlpha
             )
         }
         if let imgSecondary {
@@ -869,15 +960,27 @@ final class SubtitleRenderer {
                 edgeShadow: secondaryEdgeShadow
             )
         }
+        let primaryWindowStyle = captionWindowStyle(for: primaryHandle)
         for bounds in primaryWindowBounds {
             canvas.drawRoundedRect(
                 x: Int(bounds.minX) - minX,
                 y: Int(bounds.minY) - minY,
                 width: Int(bounds.width),
                 height: Int(bounds.height),
-                radius: windowRadius,
-                color: windowColor,
-                alpha: windowAlpha
+                radius: primaryWindowStyle.radius,
+                color: primaryWindowStyle.color,
+                alpha: primaryWindowStyle.alpha
+            )
+        }
+        for bounds in primaryGlyphBackgroundBounds {
+            canvas.drawRoundedRect(
+                x: Int(bounds.minX) - minX,
+                y: Int(bounds.minY) - minY,
+                width: Int(bounds.width),
+                height: Int(bounds.height),
+                radius: 0,
+                color: glyphBackgroundColor,
+                alpha: glyphBackgroundAlpha
             )
         }
         if let imgPrimary {
@@ -1175,9 +1278,7 @@ private final class CompositorCanvas {
         translationY: Int = 0,
         selection: ImageSelection = .all,
         characterColorOverride: (UInt8, UInt8, UInt8)? = nil,
-        characterAlphaOverride: UInt8? = nil,
-        backgroundColorOverride: (UInt8, UInt8, UInt8)? = nil,
-        backgroundAlphaOverride: UInt8? = nil
+        characterAlphaOverride: UInt8? = nil
     ) {
         var current: UnsafeMutablePointer<ASS_Image>? = head
         while let node = current {
@@ -1218,15 +1319,6 @@ private final class CompositorCanvas {
                 }
                 if let characterAlphaOverride {
                     rgba.alpha = characterAlphaOverride
-                }
-            } else if img.type == IMAGE_TYPE_SHADOW {
-                if let backgroundColorOverride {
-                    rgba.r = backgroundColorOverride.0
-                    rgba.g = backgroundColorOverride.1
-                    rgba.b = backgroundColorOverride.2
-                }
-                if let backgroundAlphaOverride {
-                    rgba.alpha = backgroundAlphaOverride
                 }
             }
             if rgba.alpha == 0 {

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleRenderer.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleRenderer.swift
@@ -543,6 +543,8 @@ final class SubtitleRenderer {
         }
     }
 
+    /// Native ASS receives a compositor window only when Apple says the
+    /// window opacity itself overrides authored content.
     static func shouldDrawCaptionWindow(
         isNativeASS: Bool,
         opacityPercent: Int,
@@ -552,6 +554,8 @@ final class SubtitleRenderer {
         return !isNativeASS || overrides.contains(.windowOpacity)
     }
 
+    /// Native ASS needs an explicit compositor box because changing a libass
+    /// shadow bitmap cannot create a background when the track authored none.
     static func shouldSynthesizeGlyphBackground(
         isNativeASS: Bool,
         opacityPercent: Int,
@@ -563,7 +567,7 @@ final class SubtitleRenderer {
         ]
         return isNativeASS
             && opacityPercent > 0
-            && !overrides.intersection(backgroundOverrides).isEmpty
+            && !overrides.isDisjoint(with: backgroundOverrides)
     }
 
     /// Render the current frame. Callable only from `sessionQueue`. The

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleRenderer.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleRenderer.swift
@@ -714,6 +714,26 @@ final class SubtitleRenderer {
         frameSizeDirty = false
         lastCompositedImageFingerprint = imageFingerprint
 
+        // BorderStyle 4 backgrounds are the largest libass masks in a cue.
+        // Classify each bitmap once for this dirty frame and pass the identity
+        // set through every grouping and compositor pass; uniform edges alone
+        // redraw the image list eight times.
+        var glyphBackgroundBitmaps: Set<UInt> = []
+        for head in [imgPrimary, imgSecondary] {
+            var node = head
+            while let current = node {
+                let image = current.pointee
+                if Self.isGlyphBackgroundImage(image), let bitmap = image.bitmap {
+                    glyphBackgroundBitmaps.insert(UInt(bitPattern: UnsafeRawPointer(bitmap)))
+                }
+                node = image.next
+            }
+        }
+        func isGlyphBackground(_ image: ASS_Image) -> Bool {
+            guard let bitmap = image.bitmap else { return false }
+            return glyphBackgroundBitmaps.contains(UInt(bitPattern: UnsafeRawPointer(bitmap)))
+        }
+
         // Composite only the union of the rects libass painted. The
         // full-frame canvas was the dominant render cost on tvOS: at 4K
         // (scale 2) every cue change cleared, copied (`makeImage`), and
@@ -727,7 +747,7 @@ final class SubtitleRenderer {
             var node = head
             while let cur = node {
                 let img = cur.pointee
-                let isCharacter = !Self.isGlyphBackgroundImage(img)
+                let isCharacter = !isGlyphBackground(img)
                     && img.type == IMAGE_TYPE_CHARACTER
                 if (!charactersOnly || isCharacter),
                    img.w > 0, img.h > 0, img.bitmap != nil {
@@ -776,7 +796,7 @@ final class SubtitleRenderer {
         func hasAuthoredGlyphBackground(_ head: UnsafeMutablePointer<ASS_Image>?) -> Bool {
             var node = head
             while let current = node {
-                if Self.isGlyphBackgroundImage(current.pointee) { return true }
+                if isGlyphBackground(current.pointee) { return true }
                 node = current.pointee.next
             }
             return false
@@ -963,7 +983,8 @@ final class SubtitleRenderer {
                     selection: .excludingCharacters,
                     suppressAuthoredEdges: replacesAuthoredEdge,
                     glyphBackgroundColorOverride: backgroundColor,
-                    glyphBackgroundAlphaOverride: backgroundAlpha
+                    glyphBackgroundAlphaOverride: backgroundAlpha,
+                    glyphBackgroundBitmaps: glyphBackgroundBitmaps
                 )
                 for edge in edgeLayers {
                     canvas.draw(
@@ -974,7 +995,8 @@ final class SubtitleRenderer {
                         translationY: edge.offsetY,
                         selection: .charactersOnly,
                         characterColorOverride: edge.color,
-                        characterAlphaOverride: edge.alpha
+                        characterAlphaOverride: edge.alpha,
+                        glyphBackgroundBitmaps: glyphBackgroundBitmaps
                     )
                 }
                 canvas.draw(
@@ -983,7 +1005,8 @@ final class SubtitleRenderer {
                     offsetY: frameOffsetY,
                     selection: .charactersOnly,
                     characterColorOverride: characterColor,
-                    characterAlphaOverride: characterAlpha
+                    characterAlphaOverride: characterAlpha,
+                    glyphBackgroundBitmaps: glyphBackgroundBitmaps
                 )
             } else {
                 canvas.draw(
@@ -993,7 +1016,8 @@ final class SubtitleRenderer {
                     characterColorOverride: characterColor,
                     characterAlphaOverride: characterAlpha,
                     glyphBackgroundColorOverride: backgroundColor,
-                    glyphBackgroundAlphaOverride: backgroundAlpha
+                    glyphBackgroundAlphaOverride: backgroundAlpha,
+                    glyphBackgroundBitmaps: glyphBackgroundBitmaps
                 )
             }
         }
@@ -1380,12 +1404,15 @@ private final class CompositorCanvas {
         characterAlphaOverride: UInt8? = nil,
         suppressAuthoredEdges: Bool = false,
         glyphBackgroundColorOverride: (UInt8, UInt8, UInt8)? = nil,
-        glyphBackgroundAlphaOverride: UInt8? = nil
+        glyphBackgroundAlphaOverride: UInt8? = nil,
+        glyphBackgroundBitmaps: Set<UInt> = []
     ) {
         var current: UnsafeMutablePointer<ASS_Image>? = head
         while let node = current {
             let img = node.pointee
-            let isGlyphBackground = SubtitleRenderer.isGlyphBackgroundImage(img)
+            let isGlyphBackground = img.bitmap.map {
+                glyphBackgroundBitmaps.contains(UInt(bitPattern: UnsafeRawPointer($0)))
+            } ?? false
             let isCharacter = !isGlyphBackground && img.type == IMAGE_TYPE_CHARACTER
             let shouldDraw = switch selection {
             case .all: true

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleRenderer.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleRenderer.swift
@@ -510,6 +510,39 @@ final class SubtitleRenderer {
 
     // MARK: - Render + composite
 
+    /// Merge nearby libass image rectangles into cue-sized regions. libass
+    /// does not expose an event identifier on `ASS_Image`, but images for one
+    /// cue are spatially adjacent while simultaneous dialogue/sign events at
+    /// different positions are not. Connected-component merging preserves
+    /// those independent regions instead of spanning the empty space between
+    /// them with one caption window.
+    static func groupedPaintedBounds(
+        _ rects: [CGRect],
+        joiningDistance: CGFloat
+    ) -> [CGRect] {
+        let distance = max(0, joiningDistance)
+        var groups: [CGRect] = []
+
+        for rect in rects where !rect.isNull && !rect.isEmpty {
+            var merged = rect
+            var index = 0
+            while index < groups.count {
+                let mergeRegion = merged.insetBy(dx: -distance, dy: -distance)
+                if mergeRegion.intersects(groups[index]) {
+                    merged = merged.union(groups.remove(at: index))
+                    index = 0
+                } else {
+                    index += 1
+                }
+            }
+            groups.append(merged)
+        }
+
+        return groups.sorted {
+            $0.minY == $1.minY ? $0.minX < $1.minX : $0.minY < $1.minY
+        }
+    }
+
     /// Render the current frame. Callable only from `sessionQueue`. The
     /// caller is responsible for hopping back to main to assign the
     /// returned image to the overlay layer's `contents`.
@@ -628,53 +661,108 @@ final class SubtitleRenderer {
         // (scale 2) every cue change cleared, copied (`makeImage`), and
         // re-uploaded a 33 MiB buffer when the painted region is
         // typically 1-2 MiB. Clipped to the frame like `draw` does.
-        func paintedBounds(
-            _ head: UnsafeMutablePointer<ASS_Image>?
-        ) -> (minX: Int, minY: Int, maxX: Int, maxY: Int)? {
-            var result = (minX: widthPx, minY: heightPx, maxX: 0, maxY: 0)
+        func paintedRects(
+            _ head: UnsafeMutablePointer<ASS_Image>?,
+            charactersOnly: Bool = false
+        ) -> [CGRect] {
+            var result: [CGRect] = []
             var node = head
             while let cur = node {
                 let img = cur.pointee
-                if img.w > 0, img.h > 0, img.bitmap != nil {
-                    result.minX = min(result.minX, max(0, Int(img.dst_x)))
-                    result.minY = min(result.minY, max(0, Int(img.dst_y)))
-                    result.maxX = max(result.maxX, min(widthPx, Int(img.dst_x) + Int(img.w)))
-                    result.maxY = max(result.maxY, min(heightPx, Int(img.dst_y) + Int(img.h)))
+                if (!charactersOnly || img.type == IMAGE_TYPE_CHARACTER),
+                   img.w > 0, img.h > 0, img.bitmap != nil {
+                    let minX = max(0, Int(img.dst_x))
+                    let minY = max(0, Int(img.dst_y))
+                    let maxX = min(widthPx, Int(img.dst_x) + Int(img.w))
+                    let maxY = min(heightPx, Int(img.dst_y) + Int(img.h))
+                    if maxX > minX, maxY > minY {
+                        result.append(CGRect(
+                            x: minX,
+                            y: minY,
+                            width: maxX - minX,
+                            height: maxY - minY
+                        ))
+                    }
                 }
                 node = img.next
             }
-            return result.maxX > result.minX && result.maxY > result.minY ? result : nil
+            return result
         }
 
-        let primaryBounds = paintedBounds(imgPrimary)
-        let secondaryBounds = paintedBounds(imgSecondary)
         let playfieldScale = Double(heightPx) / 1080.0
         let windowPadding = max(2, Int((currentParams.fontSize * 0.12 * playfieldScale).rounded()))
+        let cueJoiningDistance = max(
+            CGFloat(windowPadding * 2),
+            CGFloat(currentParams.fontSize * 0.35 * playfieldScale)
+        )
+        let primaryRects = paintedRects(imgPrimary)
+        let secondaryRects = paintedRects(imgSecondary)
+        let primaryGroups = Self.groupedPaintedBounds(
+            primaryRects,
+            joiningDistance: cueJoiningDistance
+        )
+        let secondaryGroups = Self.groupedPaintedBounds(
+            secondaryRects,
+            joiningDistance: cueJoiningDistance
+        )
         func captionWindowBounds(
-            _ bounds: (minX: Int, minY: Int, maxX: Int, maxY: Int)?,
+            _ groups: [CGRect],
             for handle: ASSTrackHandle?
-        ) -> (minX: Int, minY: Int, maxX: Int, maxY: Int)? {
+        ) -> [CGRect] {
             guard currentParams.captionWindowEnabled,
                   let handle,
                   !handle.isNativeASS
-                    || currentParams.systemContentOverrides.contains(.window),
-                  let bounds else { return nil }
+                    || !currentParams.systemContentOverrides.intersection(.window).isEmpty
+                    else { return [] }
+            return groups.map { bounds in
+                CGRect(
+                    x: max(0, Int(bounds.minX) - windowPadding),
+                    y: max(0, Int(bounds.minY) - windowPadding),
+                    width: min(widthPx, Int(bounds.maxX) + windowPadding)
+                        - max(0, Int(bounds.minX) - windowPadding),
+                    height: min(heightPx, Int(bounds.maxY) + windowPadding)
+                        - max(0, Int(bounds.minY) - windowPadding)
+                )
+            }
+        }
+        let primaryWindowBounds = captionWindowBounds(primaryGroups, for: primaryHandle)
+        let secondaryWindowBounds = captionWindowBounds(secondaryGroups, for: secondaryHandle)
+
+        func compositedEdgeShadow(
+            for handle: ASSTrackHandle?
+        ) -> (offsetX: Int, offsetY: Int, color: (UInt8, UInt8, UInt8), alpha: UInt8)? {
+            guard let shadow = currentParams.compositedEdgeShadow,
+                  let handle,
+                  !handle.isNativeASS || currentParams.systemContentOverrides.contains(.edge)
+                    else { return nil }
             return (
-                max(0, bounds.minX - windowPadding),
-                max(0, bounds.minY - windowPadding),
-                min(widthPx, bounds.maxX + windowPadding),
-                min(heightPx, bounds.maxY + windowPadding)
+                Int((shadow.offsetX * playfieldScale).rounded()),
+                Int((shadow.offsetY * playfieldScale).rounded()),
+                SubtitleStylingOverride.rgbBytes(fromHex: shadow.colorHex),
+                UInt8(max(0, min(255, shadow.opacityPercent * 255 / 100)))
             )
         }
-        let primaryWindowBounds = captionWindowBounds(primaryBounds, for: primaryHandle)
-        let secondaryWindowBounds = captionWindowBounds(secondaryBounds, for: secondaryHandle)
+        let primaryEdgeShadow = compositedEdgeShadow(for: primaryHandle)
+        let secondaryEdgeShadow = compositedEdgeShadow(for: secondaryHandle)
+        func shadowBounds(
+            _ head: UnsafeMutablePointer<ASS_Image>?,
+            shadow: (offsetX: Int, offsetY: Int, color: (UInt8, UInt8, UInt8), alpha: UInt8)?
+        ) -> [CGRect] {
+            guard let shadow else { return [] }
+            return paintedRects(head, charactersOnly: true).map {
+                $0.offsetBy(dx: CGFloat(shadow.offsetX), dy: CGFloat(shadow.offsetY))
+            }
+        }
+        let primaryShadowBounds = shadowBounds(imgPrimary, shadow: primaryEdgeShadow)
+        let secondaryShadowBounds = shadowBounds(imgSecondary, shadow: secondaryEdgeShadow)
 
-        let allBounds = [primaryBounds, secondaryBounds, primaryWindowBounds, secondaryWindowBounds]
-            .compactMap { $0 }
-        let minX = allBounds.map { $0.minX }.min() ?? widthPx
-        let minY = allBounds.map { $0.minY }.min() ?? heightPx
-        let maxX = allBounds.map { $0.maxX }.max() ?? 0
-        let maxY = allBounds.map { $0.maxY }.max() ?? 0
+        let allBounds = primaryRects + secondaryRects
+            + primaryWindowBounds + secondaryWindowBounds
+            + primaryShadowBounds + secondaryShadowBounds
+        let minX = max(0, Int(allBounds.map(\.minX).min() ?? CGFloat(widthPx)))
+        let minY = max(0, Int(allBounds.map(\.minY).min() ?? CGFloat(heightPx)))
+        let maxX = min(widthPx, Int(ceil(allBounds.map(\.maxX).max() ?? 0)))
+        let maxY = min(heightPx, Int(ceil(allBounds.map(\.maxY).max() ?? 0)))
         guard maxX > minX, maxY > minY else {
             // Cue ended (or everything rasterized off-frame): dirty with a
             // nil image so the overlay clears without a full-frame pass.
@@ -685,6 +773,68 @@ final class SubtitleRenderer {
                 diagImageCount: diagImageCount, diagImageBytes: diagImageBytes,
                 diagTrackEvents: diagTrackEvents
             )
+        }
+
+        func draw(
+            _ imageList: UnsafeMutablePointer<ASS_Image>,
+            on canvas: CompositorCanvas,
+            frameOffsetX: Int,
+            frameOffsetY: Int,
+            handle: ASSTrackHandle?,
+            edgeShadow: (
+                offsetX: Int,
+                offsetY: Int,
+                color: (UInt8, UInt8, UInt8),
+                alpha: UInt8
+            )?
+        ) {
+            let isNativeASS = handle?.isNativeASS == true
+            let characterColor = isNativeASS ? currentParams.nativeForegroundColorOverride : nil
+            let characterAlpha = isNativeASS ? currentParams.nativeForegroundAlphaOverride : nil
+            let backgroundColor = isNativeASS ? currentParams.nativeBackgroundColorOverride : nil
+            let backgroundAlpha = isNativeASS ? currentParams.nativeBackgroundAlphaOverride : nil
+
+            if let edgeShadow {
+                // BorderStyle 4 emits the box through the non-character image
+                // layers. Draw those first, then the independent system edge,
+                // then the foreground glyphs so neither layer hides another.
+                canvas.draw(
+                    imageList: imageList,
+                    offsetX: frameOffsetX,
+                    offsetY: frameOffsetY,
+                    selection: .excludingCharacters,
+                    backgroundColorOverride: backgroundColor,
+                    backgroundAlphaOverride: backgroundAlpha
+                )
+                canvas.draw(
+                    imageList: imageList,
+                    offsetX: frameOffsetX,
+                    offsetY: frameOffsetY,
+                    translationX: edgeShadow.offsetX,
+                    translationY: edgeShadow.offsetY,
+                    selection: .charactersOnly,
+                    characterColorOverride: edgeShadow.color,
+                    characterAlphaOverride: edgeShadow.alpha
+                )
+                canvas.draw(
+                    imageList: imageList,
+                    offsetX: frameOffsetX,
+                    offsetY: frameOffsetY,
+                    selection: .charactersOnly,
+                    characterColorOverride: characterColor,
+                    characterAlphaOverride: characterAlpha
+                )
+            } else {
+                canvas.draw(
+                    imageList: imageList,
+                    offsetX: frameOffsetX,
+                    offsetY: frameOffsetY,
+                    characterColorOverride: characterColor,
+                    characterAlphaOverride: characterAlpha,
+                    backgroundColorOverride: backgroundColor,
+                    backgroundAlphaOverride: backgroundAlpha
+                )
+            }
         }
 
         // Secondary first so primary draws on top if they overlap. Apple's
@@ -698,30 +848,48 @@ final class SubtitleRenderer {
             max(0, min(255, currentParams.captionWindowOpacityPercent * 255 / 100))
         )
         let windowRadius = currentParams.captionWindowCornerRadius * playfieldScale
-        if let secondaryWindowBounds {
+        for bounds in secondaryWindowBounds {
             canvas.drawRoundedRect(
-                x: secondaryWindowBounds.minX - minX,
-                y: secondaryWindowBounds.minY - minY,
-                width: secondaryWindowBounds.maxX - secondaryWindowBounds.minX,
-                height: secondaryWindowBounds.maxY - secondaryWindowBounds.minY,
+                x: Int(bounds.minX) - minX,
+                y: Int(bounds.minY) - minY,
+                width: Int(bounds.width),
+                height: Int(bounds.height),
                 radius: windowRadius,
                 color: windowColor,
                 alpha: windowAlpha
             )
         }
-        if let imgSecondary { canvas.draw(imageList: imgSecondary, offsetX: minX, offsetY: minY) }
-        if let primaryWindowBounds {
+        if let imgSecondary {
+            draw(
+                imgSecondary,
+                on: canvas,
+                frameOffsetX: minX,
+                frameOffsetY: minY,
+                handle: secondaryHandle,
+                edgeShadow: secondaryEdgeShadow
+            )
+        }
+        for bounds in primaryWindowBounds {
             canvas.drawRoundedRect(
-                x: primaryWindowBounds.minX - minX,
-                y: primaryWindowBounds.minY - minY,
-                width: primaryWindowBounds.maxX - primaryWindowBounds.minX,
-                height: primaryWindowBounds.maxY - primaryWindowBounds.minY,
+                x: Int(bounds.minX) - minX,
+                y: Int(bounds.minY) - minY,
+                width: Int(bounds.width),
+                height: Int(bounds.height),
                 radius: windowRadius,
                 color: windowColor,
                 alpha: windowAlpha
             )
         }
-        if let imgPrimary { canvas.draw(imageList: imgPrimary, offsetX: minX, offsetY: minY) }
+        if let imgPrimary {
+            draw(
+                imgPrimary,
+                on: canvas,
+                frameOffsetX: minX,
+                frameOffsetY: minY,
+                handle: primaryHandle,
+                edgeShadow: primaryEdgeShadow
+            )
+        }
 
         let cgImage = canvas.snapshot(scale: scale)
         // Canvas pixels map to points through the (possibly capped) render
@@ -881,6 +1049,12 @@ final class SubtitleRenderer {
 /// `clear()`), and produce a fresh `CGImage` per dirty frame so
 /// CoreAnimation can retain the image while we write the next one.
 private final class CompositorCanvas {
+    enum ImageSelection {
+        case all
+        case charactersOnly
+        case excludingCharacters
+    }
+
     let widthPx: Int
     let heightPx: Int
 
@@ -993,15 +1167,36 @@ private final class CompositorCanvas {
     /// channels are premultiplied by that effective alpha and blended
     /// over the existing canvas contents using straightforward `over`
     /// compositing.
-    func draw(imageList head: UnsafeMutablePointer<ASS_Image>, offsetX: Int = 0, offsetY: Int = 0) {
+    func draw(
+        imageList head: UnsafeMutablePointer<ASS_Image>,
+        offsetX: Int = 0,
+        offsetY: Int = 0,
+        translationX: Int = 0,
+        translationY: Int = 0,
+        selection: ImageSelection = .all,
+        characterColorOverride: (UInt8, UInt8, UInt8)? = nil,
+        characterAlphaOverride: UInt8? = nil,
+        backgroundColorOverride: (UInt8, UInt8, UInt8)? = nil,
+        backgroundAlphaOverride: UInt8? = nil
+    ) {
         var current: UnsafeMutablePointer<ASS_Image>? = head
         while let node = current {
             let img = node.pointee
+            let isCharacter = img.type == IMAGE_TYPE_CHARACTER
+            let shouldDraw = switch selection {
+            case .all: true
+            case .charactersOnly: isCharacter
+            case .excludingCharacters: !isCharacter
+            }
+            if !shouldDraw {
+                current = img.next
+                continue
+            }
             let w = Int(img.w)
             let h = Int(img.h)
             let stride = Int(img.stride)
-            let dstX = Int(img.dst_x) - offsetX
-            let dstY = Int(img.dst_y) - offsetY
+            let dstX = Int(img.dst_x) - offsetX + translationX
+            let dstY = Int(img.dst_y) - offsetY + translationY
             guard w > 0, h > 0, let bitmap = img.bitmap else {
                 current = img.next
                 continue
@@ -1014,7 +1209,26 @@ private final class CompositorCanvas {
             // from SubtitleStylingOverride, and it resurrected genuinely
             // faded-out glyphs as opaque. Both are fixed; trust the
             // documented order.)
-            let rgba = unpackDocumentedRenderColor(img.color)
+            var rgba = unpackDocumentedRenderColor(img.color)
+            if isCharacter {
+                if let characterColorOverride {
+                    rgba.r = characterColorOverride.0
+                    rgba.g = characterColorOverride.1
+                    rgba.b = characterColorOverride.2
+                }
+                if let characterAlphaOverride {
+                    rgba.alpha = characterAlphaOverride
+                }
+            } else if img.type == IMAGE_TYPE_SHADOW {
+                if let backgroundColorOverride {
+                    rgba.r = backgroundColorOverride.0
+                    rgba.g = backgroundColorOverride.1
+                    rgba.b = backgroundColorOverride.2
+                }
+                if let backgroundAlphaOverride {
+                    rgba.alpha = backgroundAlphaOverride
+                }
+            }
             if rgba.alpha == 0 {
                 current = img.next
                 continue

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleRenderer.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleRenderer.swift
@@ -559,7 +559,8 @@ final class SubtitleRenderer {
     static func shouldSynthesizeGlyphBackground(
         isNativeASS: Bool,
         opacityPercent: Int,
-        overrides: SystemCaptionContentOverrides
+        overrides: SystemCaptionContentOverrides,
+        hasAuthoredBackground: Bool = false
     ) -> Bool {
         let backgroundOverrides: SystemCaptionContentOverrides = [
             .backgroundColor,
@@ -567,7 +568,37 @@ final class SubtitleRenderer {
         ]
         return isNativeASS
             && opacityPercent > 0
+            && !hasAuthoredBackground
             && !overrides.isDisjoint(with: backgroundOverrides)
+    }
+
+    /// libass represents a BorderStyle 4 caption background as an entirely
+    /// filled bitmap but does not assign it a distinct image type. Detect the
+    /// exact mask so background and edge precedence can be applied
+    /// independently for native ASS cues.
+    static func isSolidBackgroundMask(
+        _ bitmap: UnsafePointer<UInt8>?,
+        width: Int,
+        height: Int,
+        stride: Int
+    ) -> Bool {
+        guard let bitmap, width > 0, height > 0, stride >= width else { return false }
+        for y in 0..<height {
+            let row = bitmap.advanced(by: y * stride)
+            for x in 0..<width where row[x] != 0xFF {
+                return false
+            }
+        }
+        return true
+    }
+
+    fileprivate static func isGlyphBackgroundImage(_ image: ASS_Image) -> Bool {
+        isSolidBackgroundMask(
+            image.bitmap,
+            width: Int(image.w),
+            height: Int(image.h),
+            stride: Int(image.stride)
+        )
     }
 
     /// Render the current frame. Callable only from `sessionQueue`. The
@@ -696,7 +727,9 @@ final class SubtitleRenderer {
             var node = head
             while let cur = node {
                 let img = cur.pointee
-                if (!charactersOnly || img.type == IMAGE_TYPE_CHARACTER),
+                let isCharacter = !Self.isGlyphBackgroundImage(img)
+                    && img.type == IMAGE_TYPE_CHARACTER
+                if (!charactersOnly || isCharacter),
                    img.w > 0, img.h > 0, img.bitmap != nil {
                     let minX = max(0, Int(img.dst_x))
                     let minY = max(0, Int(img.dst_y))
@@ -740,6 +773,14 @@ final class SubtitleRenderer {
             paintedRects(imgSecondary, charactersOnly: true),
             joiningDistance: cueJoiningDistance
         )
+        func hasAuthoredGlyphBackground(_ head: UnsafeMutablePointer<ASS_Image>?) -> Bool {
+            var node = head
+            while let current = node {
+                if Self.isGlyphBackgroundImage(current.pointee) { return true }
+                node = current.pointee.next
+            }
+            return false
+        }
         func captionWindowBounds(
             _ groups: [CGRect],
             for handle: ASSTrackHandle?
@@ -770,13 +811,15 @@ final class SubtitleRenderer {
         )
         func nativeGlyphBackgroundBounds(
             _ groups: [CGRect],
+            imageList: UnsafeMutablePointer<ASS_Image>?,
             for handle: ASSTrackHandle?
         ) -> [CGRect] {
             guard let handle,
                   Self.shouldSynthesizeGlyphBackground(
                       isNativeASS: handle.isNativeASS,
                       opacityPercent: currentParams.backgroundOpacityPercent,
-                      overrides: currentParams.systemContentOverrides
+                      overrides: currentParams.systemContentOverrides,
+                      hasAuthoredBackground: hasAuthoredGlyphBackground(imageList)
                   )
                     else { return [] }
             return groups.map { bounds in
@@ -792,40 +835,86 @@ final class SubtitleRenderer {
         }
         let primaryGlyphBackgroundBounds = nativeGlyphBackgroundBounds(
             primaryCharacterGroups,
+            imageList: imgPrimary,
             for: primaryHandle
         )
         let secondaryGlyphBackgroundBounds = nativeGlyphBackgroundBounds(
             secondaryCharacterGroups,
+            imageList: imgSecondary,
             for: secondaryHandle
         )
 
-        func compositedEdgeShadow(
+        typealias EdgeLayer = (
+            offsetX: Int,
+            offsetY: Int,
+            color: (UInt8, UInt8, UInt8),
+            alpha: UInt8
+        )
+        func compositedEdgeLayers(
             for handle: ASSTrackHandle?
-        ) -> (offsetX: Int, offsetY: Int, color: (UInt8, UInt8, UInt8), alpha: UInt8)? {
-            guard let shadow = currentParams.compositedEdgeShadow,
-                  let handle,
-                  !handle.isNativeASS || currentParams.systemContentOverrides.contains(.edge)
-                    else { return nil }
-            return (
+        ) -> [EdgeLayer] {
+            guard let handle else { return [] }
+            if handle.isNativeASS,
+               currentParams.systemContentOverrides.contains(.edge) {
+                let single: (Double, Double, String, Int)?
+                switch currentParams.systemTextEdgeStyle {
+                case .some(.none), nil:
+                    return []
+                case .some(.raised):
+                    single = (-1, -1, "#FFFFFF", 80)
+                case .some(.depressed):
+                    single = (1, 1, "#000000", 90)
+                case .some(.dropShadow):
+                    single = (1.5, 1.5, "#000000", 50)
+                case .some(.uniform):
+                    let radius = max(
+                        1,
+                        Int((currentParams.effectiveBorderSize * playfieldScale).rounded())
+                    )
+                    let color = SubtitleStylingOverride.rgbBytes(
+                        fromHex: currentParams.effectiveOutlineColorHex
+                    )
+                    return [
+                        (-radius, -radius, color, 255),
+                        (0, -radius, color, 255),
+                        (radius, -radius, color, 255),
+                        (-radius, 0, color, 255),
+                        (radius, 0, color, 255),
+                        (-radius, radius, color, 255),
+                        (0, radius, color, 255),
+                        (radius, radius, color, 255),
+                    ]
+                }
+                guard let single else { return [] }
+                return [(
+                    Int((single.0 * playfieldScale).rounded()),
+                    Int((single.1 * playfieldScale).rounded()),
+                    SubtitleStylingOverride.rgbBytes(fromHex: single.2),
+                    UInt8(max(0, min(255, single.3 * 255 / 100)))
+                )]
+            }
+            guard let shadow = currentParams.compositedEdgeShadow else { return [] }
+            return [(
                 Int((shadow.offsetX * playfieldScale).rounded()),
                 Int((shadow.offsetY * playfieldScale).rounded()),
                 SubtitleStylingOverride.rgbBytes(fromHex: shadow.colorHex),
                 UInt8(max(0, min(255, shadow.opacityPercent * 255 / 100)))
-            )
+            )]
         }
-        let primaryEdgeShadow = compositedEdgeShadow(for: primaryHandle)
-        let secondaryEdgeShadow = compositedEdgeShadow(for: secondaryHandle)
+        let primaryEdgeLayers = compositedEdgeLayers(for: primaryHandle)
+        let secondaryEdgeLayers = compositedEdgeLayers(for: secondaryHandle)
         func shadowBounds(
             _ head: UnsafeMutablePointer<ASS_Image>?,
-            shadow: (offsetX: Int, offsetY: Int, color: (UInt8, UInt8, UInt8), alpha: UInt8)?
+            edges: [EdgeLayer]
         ) -> [CGRect] {
-            guard let shadow else { return [] }
-            return paintedRects(head, charactersOnly: true).map {
-                $0.offsetBy(dx: CGFloat(shadow.offsetX), dy: CGFloat(shadow.offsetY))
+            paintedRects(head, charactersOnly: true).flatMap { bounds in
+                edges.map {
+                    bounds.offsetBy(dx: CGFloat($0.offsetX), dy: CGFloat($0.offsetY))
+                }
             }
         }
-        let primaryShadowBounds = shadowBounds(imgPrimary, shadow: primaryEdgeShadow)
-        let secondaryShadowBounds = shadowBounds(imgSecondary, shadow: secondaryEdgeShadow)
+        let primaryShadowBounds = shadowBounds(imgPrimary, edges: primaryEdgeLayers)
+        let secondaryShadowBounds = shadowBounds(imgSecondary, edges: secondaryEdgeLayers)
 
         let allBounds = primaryRects + secondaryRects
             + primaryWindowBounds + secondaryWindowBounds
@@ -853,18 +942,17 @@ final class SubtitleRenderer {
             frameOffsetX: Int,
             frameOffsetY: Int,
             handle: ASSTrackHandle?,
-            edgeShadow: (
-                offsetX: Int,
-                offsetY: Int,
-                color: (UInt8, UInt8, UInt8),
-                alpha: UInt8
-            )?
+            edgeLayers: [EdgeLayer]
         ) {
             let isNativeASS = handle?.isNativeASS == true
             let characterColor = isNativeASS ? currentParams.nativeForegroundColorOverride : nil
             let characterAlpha = isNativeASS ? currentParams.nativeForegroundAlphaOverride : nil
+            let backgroundColor = isNativeASS ? currentParams.nativeBackgroundColorOverride : nil
+            let backgroundAlpha = isNativeASS ? currentParams.nativeBackgroundAlphaOverride : nil
+            let replacesAuthoredEdge = isNativeASS
+                && currentParams.systemContentOverrides.contains(.edge)
 
-            if let edgeShadow {
+            if !edgeLayers.isEmpty || replacesAuthoredEdge {
                 // BorderStyle 4 emits the box through the non-character image
                 // layers. Draw those first, then the independent system edge,
                 // then the foreground glyphs so neither layer hides another.
@@ -872,18 +960,23 @@ final class SubtitleRenderer {
                     imageList: imageList,
                     offsetX: frameOffsetX,
                     offsetY: frameOffsetY,
-                    selection: .excludingCharacters
+                    selection: .excludingCharacters,
+                    suppressAuthoredEdges: replacesAuthoredEdge,
+                    glyphBackgroundColorOverride: backgroundColor,
+                    glyphBackgroundAlphaOverride: backgroundAlpha
                 )
-                canvas.draw(
-                    imageList: imageList,
-                    offsetX: frameOffsetX,
-                    offsetY: frameOffsetY,
-                    translationX: edgeShadow.offsetX,
-                    translationY: edgeShadow.offsetY,
-                    selection: .charactersOnly,
-                    characterColorOverride: edgeShadow.color,
-                    characterAlphaOverride: edgeShadow.alpha
-                )
+                for edge in edgeLayers {
+                    canvas.draw(
+                        imageList: imageList,
+                        offsetX: frameOffsetX,
+                        offsetY: frameOffsetY,
+                        translationX: edge.offsetX,
+                        translationY: edge.offsetY,
+                        selection: .charactersOnly,
+                        characterColorOverride: edge.color,
+                        characterAlphaOverride: edge.alpha
+                    )
+                }
                 canvas.draw(
                     imageList: imageList,
                     offsetX: frameOffsetX,
@@ -898,7 +991,9 @@ final class SubtitleRenderer {
                     offsetX: frameOffsetX,
                     offsetY: frameOffsetY,
                     characterColorOverride: characterColor,
-                    characterAlphaOverride: characterAlpha
+                    characterAlphaOverride: characterAlpha,
+                    glyphBackgroundColorOverride: backgroundColor,
+                    glyphBackgroundAlphaOverride: backgroundAlpha
                 )
             }
         }
@@ -961,7 +1056,7 @@ final class SubtitleRenderer {
                 frameOffsetX: minX,
                 frameOffsetY: minY,
                 handle: secondaryHandle,
-                edgeShadow: secondaryEdgeShadow
+                edgeLayers: secondaryEdgeLayers
             )
         }
         let primaryWindowStyle = captionWindowStyle(for: primaryHandle)
@@ -994,7 +1089,7 @@ final class SubtitleRenderer {
                 frameOffsetX: minX,
                 frameOffsetY: minY,
                 handle: primaryHandle,
-                edgeShadow: primaryEdgeShadow
+                edgeLayers: primaryEdgeLayers
             )
         }
 
@@ -1282,18 +1377,26 @@ private final class CompositorCanvas {
         translationY: Int = 0,
         selection: ImageSelection = .all,
         characterColorOverride: (UInt8, UInt8, UInt8)? = nil,
-        characterAlphaOverride: UInt8? = nil
+        characterAlphaOverride: UInt8? = nil,
+        suppressAuthoredEdges: Bool = false,
+        glyphBackgroundColorOverride: (UInt8, UInt8, UInt8)? = nil,
+        glyphBackgroundAlphaOverride: UInt8? = nil
     ) {
         var current: UnsafeMutablePointer<ASS_Image>? = head
         while let node = current {
             let img = node.pointee
-            let isCharacter = img.type == IMAGE_TYPE_CHARACTER
+            let isGlyphBackground = SubtitleRenderer.isGlyphBackgroundImage(img)
+            let isCharacter = !isGlyphBackground && img.type == IMAGE_TYPE_CHARACTER
             let shouldDraw = switch selection {
             case .all: true
             case .charactersOnly: isCharacter
             case .excludingCharacters: !isCharacter
             }
             if !shouldDraw {
+                current = img.next
+                continue
+            }
+            if suppressAuthoredEdges && !isCharacter && !isGlyphBackground {
                 current = img.next
                 continue
             }
@@ -1323,6 +1426,15 @@ private final class CompositorCanvas {
                 }
                 if let characterAlphaOverride {
                     rgba.alpha = characterAlphaOverride
+                }
+            } else if isGlyphBackground {
+                if let glyphBackgroundColorOverride {
+                    rgba.r = glyphBackgroundColorOverride.0
+                    rgba.g = glyphBackgroundColorOverride.1
+                    rgba.b = glyphBackgroundColorOverride.2
+                }
+                if let glyphBackgroundAlphaOverride {
+                    rgba.alpha = glyphBackgroundAlphaOverride
                 }
             }
             if rgba.alpha == 0 {

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleRenderer.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleRenderer.swift
@@ -628,20 +628,53 @@ final class SubtitleRenderer {
         // (scale 2) every cue change cleared, copied (`makeImage`), and
         // re-uploaded a 33 MiB buffer when the painted region is
         // typically 1-2 MiB. Clipped to the frame like `draw` does.
-        var minX = widthPx, minY = heightPx, maxX = 0, maxY = 0
-        for head in [imgSecondary, imgPrimary] {
+        func paintedBounds(
+            _ head: UnsafeMutablePointer<ASS_Image>?
+        ) -> (minX: Int, minY: Int, maxX: Int, maxY: Int)? {
+            var result = (minX: widthPx, minY: heightPx, maxX: 0, maxY: 0)
             var node = head
             while let cur = node {
                 let img = cur.pointee
                 if img.w > 0, img.h > 0, img.bitmap != nil {
-                    minX = min(minX, max(0, Int(img.dst_x)))
-                    minY = min(minY, max(0, Int(img.dst_y)))
-                    maxX = max(maxX, min(widthPx, Int(img.dst_x) + Int(img.w)))
-                    maxY = max(maxY, min(heightPx, Int(img.dst_y) + Int(img.h)))
+                    result.minX = min(result.minX, max(0, Int(img.dst_x)))
+                    result.minY = min(result.minY, max(0, Int(img.dst_y)))
+                    result.maxX = max(result.maxX, min(widthPx, Int(img.dst_x) + Int(img.w)))
+                    result.maxY = max(result.maxY, min(heightPx, Int(img.dst_y) + Int(img.h)))
                 }
                 node = img.next
             }
+            return result.maxX > result.minX && result.maxY > result.minY ? result : nil
         }
+
+        let primaryBounds = paintedBounds(imgPrimary)
+        let secondaryBounds = paintedBounds(imgSecondary)
+        let playfieldScale = Double(heightPx) / 1080.0
+        let windowPadding = max(2, Int((currentParams.fontSize * 0.12 * playfieldScale).rounded()))
+        func captionWindowBounds(
+            _ bounds: (minX: Int, minY: Int, maxX: Int, maxY: Int)?,
+            for handle: ASSTrackHandle?
+        ) -> (minX: Int, minY: Int, maxX: Int, maxY: Int)? {
+            guard currentParams.captionWindowEnabled,
+                  let handle,
+                  !handle.isNativeASS
+                    || currentParams.systemContentOverrides.contains(.window),
+                  let bounds else { return nil }
+            return (
+                max(0, bounds.minX - windowPadding),
+                max(0, bounds.minY - windowPadding),
+                min(widthPx, bounds.maxX + windowPadding),
+                min(heightPx, bounds.maxY + windowPadding)
+            )
+        }
+        let primaryWindowBounds = captionWindowBounds(primaryBounds, for: primaryHandle)
+        let secondaryWindowBounds = captionWindowBounds(secondaryBounds, for: secondaryHandle)
+
+        let allBounds = [primaryBounds, secondaryBounds, primaryWindowBounds, secondaryWindowBounds]
+            .compactMap { $0 }
+        let minX = allBounds.map { $0.minX }.min() ?? widthPx
+        let minY = allBounds.map { $0.minY }.min() ?? heightPx
+        let maxX = allBounds.map { $0.maxX }.max() ?? 0
+        let maxY = allBounds.map { $0.maxY }.max() ?? 0
         guard maxX > minX, maxY > minY else {
             // Cue ended (or everything rasterized off-frame): dirty with a
             // nil image so the overlay clears without a full-frame pass.
@@ -654,11 +687,41 @@ final class SubtitleRenderer {
             )
         }
 
-        // Secondary first so primary draws on top if they overlap.
+        // Secondary first so primary draws on top if they overlap. Apple's
+        // caption window is a separate layer behind the complete cue; native
+        // ASS receives it only when Apple says the system value overrides
+        // authored content.
         let canvas = ensureCanvas(widthPx: maxX - minX, heightPx: maxY - minY)
         canvas.clear()
+        let windowColor = SubtitleStylingOverride.rgbBytes(fromHex: currentParams.captionWindowColorHex)
+        let windowAlpha = UInt8(
+            max(0, min(255, currentParams.captionWindowOpacityPercent * 255 / 100))
+        )
+        let windowRadius = currentParams.captionWindowCornerRadius * playfieldScale
+        if let secondaryWindowBounds {
+            canvas.drawRoundedRect(
+                x: secondaryWindowBounds.minX - minX,
+                y: secondaryWindowBounds.minY - minY,
+                width: secondaryWindowBounds.maxX - secondaryWindowBounds.minX,
+                height: secondaryWindowBounds.maxY - secondaryWindowBounds.minY,
+                radius: windowRadius,
+                color: windowColor,
+                alpha: windowAlpha
+            )
+        }
         if let imgSecondary { canvas.draw(imageList: imgSecondary, offsetX: minX, offsetY: minY) }
-        if let imgPrimary   { canvas.draw(imageList: imgPrimary, offsetX: minX, offsetY: minY) }
+        if let primaryWindowBounds {
+            canvas.drawRoundedRect(
+                x: primaryWindowBounds.minX - minX,
+                y: primaryWindowBounds.minY - minY,
+                width: primaryWindowBounds.maxX - primaryWindowBounds.minX,
+                height: primaryWindowBounds.maxY - primaryWindowBounds.minY,
+                radius: windowRadius,
+                color: windowColor,
+                alpha: windowAlpha
+            )
+        }
+        if let imgPrimary { canvas.draw(imageList: imgPrimary, offsetX: minX, offsetY: minY) }
 
         let cgImage = canvas.snapshot(scale: scale)
         // Canvas pixels map to points through the (possibly capped) render
@@ -861,6 +924,62 @@ private final class CompositorCanvas {
 
     func clear() {
         buffer.initialize(repeating: 0, count: bufferLength)
+    }
+
+    /// Draw Apple's caption-window layer behind a complete cue. Coordinates
+    /// are in this cropped canvas's top-left pixel space.
+    func drawRoundedRect(
+        x: Int,
+        y: Int,
+        width: Int,
+        height: Int,
+        radius: Double,
+        color: (UInt8, UInt8, UInt8),
+        alpha: UInt8
+    ) {
+        guard width > 0, height > 0, alpha > 0 else { return }
+        let startX = max(0, x)
+        let startY = max(0, y)
+        let endX = min(widthPx, x + width)
+        let endY = min(heightPx, y + height)
+        guard startX < endX, startY < endY else { return }
+
+        let r = max(0, min(radius, Double(min(width, height)) / 2))
+        let rSquared = r * r
+        let leftCenter = Double(x) + r
+        let rightCenter = Double(x + width) - r
+        let topCenter = Double(y) + r
+        let bottomCenter = Double(y + height) - r
+        let srcAlpha = UInt32(alpha)
+        let srcR = (UInt32(color.0) * srcAlpha) / 255
+        let srcG = (UInt32(color.1) * srcAlpha) / 255
+        let srcB = (UInt32(color.2) * srcAlpha) / 255
+        let invA = 255 - srcAlpha
+
+        for py in startY..<endY {
+            let canvasRow = buffer.advanced(by: py * bytesPerRow)
+            for px in startX..<endX {
+                if r > 0 {
+                    let sampleX = Double(px) + 0.5
+                    let sampleY = Double(py) + 0.5
+                    let centerX = min(max(sampleX, leftCenter), rightCenter)
+                    let centerY = min(max(sampleY, topCenter), bottomCenter)
+                    let dx = sampleX - centerX
+                    let dy = sampleY - centerY
+                    if (dx * dx) + (dy * dy) > rSquared { continue }
+                }
+
+                let offset = px * 4
+                let dstB = UInt32(canvasRow[offset])
+                let dstG = UInt32(canvasRow[offset + 1])
+                let dstR = UInt32(canvasRow[offset + 2])
+                let dstA = UInt32(canvasRow[offset + 3])
+                canvasRow[offset] = UInt8(min(255, srcB + (dstB * invA) / 255))
+                canvasRow[offset + 1] = UInt8(min(255, srcG + (dstG * invA) / 255))
+                canvasRow[offset + 2] = UInt8(min(255, srcR + (dstR * invA) / 255))
+                canvasRow[offset + 3] = UInt8(min(255, srcAlpha + (dstA * invA) / 255))
+            }
+        }
     }
 
     /// Walk a libass `ASS_Image*` linked list and composite each rect's

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleStylingOverride.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleStylingOverride.swift
@@ -103,28 +103,101 @@ enum SubtitleStylingOverride {
         /// Value for the ASS `Shadow` field: drop-shadow depth for the
         /// shadow style, box padding for the box style (see `boxPadding`).
         var assShadow: Double {
+            // BorderStyle 4 consumes Shadow as box padding and never draws
+            // the shadow. The compositor adds Apple's requested edge behind
+            // the glyphs separately in this combination.
+            if boxEnabled { return boxPadding }
             if systemTextEdgeStyle == .dropShadow { return 1.5 }
             if systemTextEdgeStyle == .raised { return 1.0 }
             if systemTextEdgeStyle == .depressed { return -1.0 }
-            return backgroundStyle == .shadow ? 1.5 : boxPadding
+            return backgroundStyle == .shadow ? 1.5 : 0
         }
 
         var textAlphaByte: UInt8 {
             UInt8(max(0, min(255, (100 - textOpacityPercent) * 255 / 100)))
         }
 
-        /// Inverted ASS alpha byte for `BackColour` (0x00 opaque … 0xFF
-        /// transparent). Box: user opacity. Shadow: 50% black so the drop
-        /// shadow is actually visible. Otherwise fully transparent.
-        var backgroundAlphaByte: UInt8 {
-            switch backgroundStyle {
-            case .box:
-                return UInt8(max(0, min(255, (100 - backgroundOpacityPercent) * 255 / 100)))
-            case .shadow:
-                return 0x80
-            case .outline, .none:
-                return systemTextEdgeStyle == .dropShadow ? 0x80 : 0xFF
+        /// BackColour is the glyph box under BorderStyle 4 and the edge
+        /// shadow under BorderStyle 1. Keep those meanings separate so every
+        /// Apple edge remains visible when no glyph box is active.
+        var effectiveBackColorHex: String {
+            if boxEnabled { return backgroundColorHex }
+            switch systemTextEdgeStyle {
+            case .some(.raised):
+                return "#FFFFFF"
+            case .some(.depressed), .some(.dropShadow):
+                return "#000000"
+            case .some(.none), .some(.uniform), nil:
+                return backgroundColorHex
             }
+        }
+
+        /// Inverted ASS alpha byte for `BackColour` (0x00 opaque … 0xFF
+        /// transparent).
+        var backgroundAlphaByte: UInt8 {
+            if boxEnabled {
+                return UInt8(max(0, min(255, (100 - backgroundOpacityPercent) * 255 / 100)))
+            }
+            switch systemTextEdgeStyle {
+            case .some(.raised):
+                return 0x33
+            case .some(.depressed):
+                return 0x1A
+            case .some(.dropShadow):
+                return 0x80
+            case .some(.none), .some(.uniform), nil:
+                break
+            }
+            if backgroundStyle == .shadow {
+                return 0x80
+            }
+            return 0xFF
+        }
+
+        /// BorderStyle 4 cannot combine its glyph box with a libass shadow.
+        /// The compositor draws this edge from the character masks before it
+        /// composites the regular libass image list.
+        var compositedEdgeShadow: (
+            offsetX: Double,
+            offsetY: Double,
+            colorHex: String,
+            opacityPercent: Int
+        )? {
+            guard boxEnabled else { return nil }
+            switch systemTextEdgeStyle {
+            case .some(.raised):
+                return (-1, -1, "#FFFFFF", 80)
+            case .some(.depressed):
+                return (1, 1, "#000000", 90)
+            case .some(.dropShadow):
+                return (1.5, 1.5, "#000000", 50)
+            case .some(.none), .some(.uniform), nil:
+                return nil
+            }
+        }
+
+        var nativeForegroundColorOverride: (UInt8, UInt8, UInt8)? {
+            systemContentOverrides.contains(.foregroundColor)
+                ? SubtitleStylingOverride.rgbBytes(fromHex: textColorHex)
+                : nil
+        }
+
+        var nativeForegroundAlphaOverride: UInt8? {
+            systemContentOverrides.contains(.foregroundOpacity)
+                ? UInt8(max(0, min(255, textOpacityPercent * 255 / 100)))
+                : nil
+        }
+
+        var nativeBackgroundColorOverride: (UInt8, UInt8, UInt8)? {
+            systemContentOverrides.contains(.backgroundColor)
+                ? SubtitleStylingOverride.rgbBytes(fromHex: backgroundColorHex)
+                : nil
+        }
+
+        var nativeBackgroundAlphaOverride: UInt8? {
+            systemContentOverrides.contains(.backgroundOpacity)
+                ? UInt8(max(0, min(255, backgroundOpacityPercent * 255 / 100)))
+                : nil
         }
 
         var captionWindowEnabled: Bool {
@@ -196,7 +269,7 @@ enum SubtitleStylingOverride {
     ) -> String {
         let primary = assColor(hexRGB: params.textColorHex, alphaByte: params.textAlphaByte)
         let outline = assColor(hexRGB: params.effectiveOutlineColorHex, alphaByte: 0x00)
-        let back = assColor(hexRGB: params.backgroundColorHex, alphaByte: params.backgroundAlphaByte)
+        let back = assColor(hexRGB: params.effectiveBackColorHex, alphaByte: params.backgroundAlphaByte)
         let alignment = (slot == .secondary) ? 8 : primaryHeaderAlignment(for: params)
 
         // BorderStyle 1 = outline + shadow; BorderStyle 4 = per-event
@@ -335,7 +408,7 @@ enum SubtitleStylingOverride {
         style.SecondaryColour = 0xFFFFFF00 // opaque white, internal RRGGBBAA
         style.OutlineColour = assColor(hexRGBUInt: params.effectiveOutlineColorHex, alphaByte: 0x00)
         style.BackColour = assColor(
-            hexRGBUInt: params.backgroundColorHex,
+            hexRGBUInt: params.effectiveBackColorHex,
             alphaByte: params.backgroundAlphaByte
         )
         // ScaleX/Y are doubles where 1.0 = 100%. The integer 100 here
@@ -372,9 +445,11 @@ enum SubtitleStylingOverride {
             if params.systemContentOverrides.contains(.size) {
                 systemBits |= Int32(ASS_OVERRIDE_BIT_SELECTIVE_FONT_SCALE.rawValue)
             }
-            if params.systemContentOverrides.contains(.colors) {
-                systemBits |= Int32(ASS_OVERRIDE_BIT_COLORS.rawValue)
-            }
+            // libass exposes color override as one atomic bit spanning
+            // Primary, Secondary, Outline, and BackColour. Apple exposes
+            // foreground/background color and opacity precedence separately,
+            // so native ASS colors are transformed per image type by the
+            // compositor instead of enabling the lossy category-wide bit.
             if params.systemContentOverrides.contains(.edge) {
                 systemBits |= Int32(ASS_OVERRIDE_BIT_BORDER.rawValue)
             }

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleStylingOverride.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleStylingOverride.swift
@@ -189,6 +189,18 @@ enum SubtitleStylingOverride {
                 : nil
         }
 
+        var nativeBackgroundColorOverride: (UInt8, UInt8, UInt8)? {
+            systemContentOverrides.contains(.backgroundColor)
+                ? SubtitleStylingOverride.rgbBytes(fromHex: backgroundColorHex)
+                : nil
+        }
+
+        var nativeBackgroundAlphaOverride: UInt8? {
+            systemContentOverrides.contains(.backgroundOpacity)
+                ? UInt8(max(0, min(255, backgroundOpacityPercent * 255 / 100)))
+                : nil
+        }
+
         static let referenceFontSize: Double = SubtitleAppearance.default.fontSize.pointSize
 
         static let `default` = Parameters(
@@ -435,9 +447,11 @@ enum SubtitleStylingOverride {
             // foreground/background color and opacity precedence separately,
             // so native ASS colors are transformed per image type by the
             // compositor instead of enabling the lossy category-wide bit.
-            if params.systemContentOverrides.contains(.edge) {
-                systemBits |= Int32(ASS_OVERRIDE_BIT_BORDER.rawValue)
-            }
+            // Border is another atomic libass category: BorderStyle,
+            // Outline, and Shadow are replaced together. Apple gives the
+            // edge its own precedence, independent of the caption
+            // background. Native ASS edge overrides are therefore composed
+            // from glyph masks after rendering instead of enabling this bit.
             bits = systemBits
         } else {
             bits =

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleStylingOverride.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleStylingOverride.swift
@@ -108,7 +108,9 @@ enum SubtitleStylingOverride {
             // the glyphs separately in this combination.
             if boxEnabled { return boxPadding }
             if systemTextEdgeStyle == .dropShadow { return 1.5 }
-            if systemTextEdgeStyle == .raised { return -1.0 }
+            // Parsed V4+ Style Shadow is a non-negative depth. Raised needs
+            // an up/left offset, so the compositor supplies that direction.
+            if systemTextEdgeStyle == .raised { return 0 }
             if systemTextEdgeStyle == .depressed { return 1.0 }
             return backgroundStyle == .shadow ? 1.5 : 0
         }
@@ -163,14 +165,13 @@ enum SubtitleStylingOverride {
             colorHex: String,
             opacityPercent: Int
         )? {
-            guard boxEnabled else { return nil }
             switch systemTextEdgeStyle {
             case .some(.raised):
                 return (-1, -1, "#FFFFFF", 80)
             case .some(.depressed):
-                return (1, 1, "#000000", 90)
+                return boxEnabled ? (1, 1, "#000000", 90) : nil
             case .some(.dropShadow):
-                return (1.5, 1.5, "#000000", 50)
+                return boxEnabled ? (1.5, 1.5, "#000000", 50) : nil
             case .some(.none), .some(.uniform), nil:
                 return nil
             }

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleStylingOverride.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleStylingOverride.swift
@@ -32,6 +32,8 @@ enum SubtitleStylingOverride {
         var fontFamilyName: String
         /// `#RRGGBB` hex.
         var textColorHex: String
+        /// 0-100.
+        var textOpacityPercent: Int
         var borderSize: Double
         /// `#RRGGBB` hex.
         var borderColorHex: String
@@ -41,6 +43,12 @@ enum SubtitleStylingOverride {
         /// 0-100 (opaque if >0).
         var backgroundOpacityPercent: Int
         var textOutline: Bool
+        var systemTextEdgeStyle: SystemCaptionTextEdgeStyle?
+        /// Apple's separate box behind the complete caption cue.
+        var captionWindowColorHex: String
+        var captionWindowOpacityPercent: Int
+        var captionWindowCornerRadius: Double
+        var systemContentOverrides: SystemCaptionContentOverrides
         /// User position 0 (top) to 150 (bottom). Centered around 100.
         var verticalPosition: Int
         /// Subtitle sync offset in milliseconds. Positive = subs appear
@@ -48,7 +56,8 @@ enum SubtitleStylingOverride {
         var syncOffsetMs: Int
 
         var effectiveBorderSize: Double {
-            if borderSize > 0 {
+            if borderSize > 0 || systemTextEdgeStyle == .uniform
+                || systemTextEdgeStyle == .raised || systemTextEdgeStyle == .depressed {
                 return max(2, min(4, fontSize * 0.08))
             }
             return 0
@@ -94,7 +103,14 @@ enum SubtitleStylingOverride {
         /// Value for the ASS `Shadow` field: drop-shadow depth for the
         /// shadow style, box padding for the box style (see `boxPadding`).
         var assShadow: Double {
-            backgroundStyle == .shadow ? 1.5 : boxPadding
+            if systemTextEdgeStyle == .dropShadow { return 1.5 }
+            if systemTextEdgeStyle == .raised { return 1.0 }
+            if systemTextEdgeStyle == .depressed { return -1.0 }
+            return backgroundStyle == .shadow ? 1.5 : boxPadding
+        }
+
+        var textAlphaByte: UInt8 {
+            UInt8(max(0, min(255, (100 - textOpacityPercent) * 255 / 100)))
         }
 
         /// Inverted ASS alpha byte for `BackColour` (0x00 opaque … 0xFF
@@ -107,8 +123,12 @@ enum SubtitleStylingOverride {
             case .shadow:
                 return 0x80
             case .outline, .none:
-                return 0xFF
+                return systemTextEdgeStyle == .dropShadow ? 0x80 : 0xFF
             }
+        }
+
+        var captionWindowEnabled: Bool {
+            captionWindowOpacityPercent > 0
         }
 
         static let referenceFontSize: Double = SubtitleAppearance.default.fontSize.pointSize
@@ -117,12 +137,18 @@ enum SubtitleStylingOverride {
             fontSize: referenceFontSize,
             fontFamilyName: "Arial",
             textColorHex: "#FFFFFF",
+            textOpacityPercent: 100,
             borderSize: 0,
             borderColorHex: "#000000",
             backgroundColorHex: "#000000",
             backgroundStyle: .shadow,
             backgroundOpacityPercent: 0,
             textOutline: false,
+            systemTextEdgeStyle: nil,
+            captionWindowColorHex: "#000000",
+            captionWindowOpacityPercent: 0,
+            captionWindowCornerRadius: 0,
+            systemContentOverrides: [],
             verticalPosition: 100,
             syncOffsetMs: 0
         )
@@ -131,15 +157,23 @@ enum SubtitleStylingOverride {
             let sanitized = appearance.sanitized()
             let outlineEnabled = sanitized.backgroundStyle == .outline || sanitized.textOutline
             return Parameters(
-                fontSize: sanitized.fontSize.pointSize,
+                fontSize: sanitized.systemRelativeFontScale.map {
+                    referenceFontSize * $0
+                } ?? sanitized.fontSize.pointSize,
                 fontFamilyName: sanitized.fontFamily.assFontName,
                 textColorHex: sanitized.fontColor,
+                textOpacityPercent: sanitized.fontOpacity,
                 borderSize: outlineEnabled ? 2 : 0,
                 borderColorHex: sanitized.textOutlineColor,
                 backgroundColorHex: sanitized.backgroundColor,
                 backgroundStyle: sanitized.backgroundStyle,
                 backgroundOpacityPercent: sanitized.backgroundStyle == .box ? sanitized.backgroundOpacity : 0,
                 textOutline: sanitized.textOutline,
+                systemTextEdgeStyle: sanitized.systemTextEdgeStyle,
+                captionWindowColorHex: sanitized.captionWindowColor,
+                captionWindowOpacityPercent: sanitized.captionWindowOpacity,
+                captionWindowCornerRadius: sanitized.captionWindowCornerRadius,
+                systemContentOverrides: sanitized.systemContentOverrides,
                 verticalPosition: sanitized.position.legacyPosition,
                 syncOffsetMs: syncOffsetMs
             )
@@ -160,7 +194,7 @@ enum SubtitleStylingOverride {
         params: Parameters,
         slot: SubtitleSlot
     ) -> String {
-        let primary = assColor(hexRGB: params.textColorHex, alphaByte: 0x00)
+        let primary = assColor(hexRGB: params.textColorHex, alphaByte: params.textAlphaByte)
         let outline = assColor(hexRGB: params.effectiveOutlineColorHex, alphaByte: 0x00)
         let back = assColor(hexRGB: params.backgroundColorHex, alphaByte: params.backgroundAlphaByte)
         let alignment = (slot == .secondary) ? 8 : primaryHeaderAlignment(for: params)
@@ -231,9 +265,8 @@ enum SubtitleStylingOverride {
     /// - Parameter params: user preferences snapshot.
     /// - Parameter isNativeASS: true iff the active track was authored
     ///   as ASS/SSA (codec == AV_CODEC_ID_ASS / _SSA). For native ASS we
-    ///   skip color/font/border overrides so the creative work renders
-    ///   as the author intended. Sync offset still applies in the overlay
-    ///   pump, outside libass style overrides.
+    ///   preserve authored styling unless Apple's active caption profile marks
+    ///   a category as `useValue` (the user disabled Video Overrides Style).
     /// - Parameter slot: which subtitle slot this renderer draws. Only the
     ///   primary slot participates in `use_margins` placement below.
     /// - Parameter fontScaleCompensation: multiplier that re-keys libass's
@@ -264,7 +297,7 @@ enum SubtitleStylingOverride {
         let useMargins = !isNativeASS && slot == .primary && params.verticalPosition >= 100
         ass_set_use_margins(renderer, useMargins ? 1 : 0)
 
-        if isNativeASS {
+        if isNativeASS && params.systemContentOverrides.isEmpty {
             ass_set_font_scale(renderer, 1.0)
             ass_set_selective_style_override_enabled(renderer, 0)
             return
@@ -274,11 +307,12 @@ enum SubtitleStylingOverride {
         // source. Use renderer font scale for live size changes, but do not
         // use FONT_SIZE_FIELDS below: that path also overrides ScaleX/Y and
         // scales FontSize against each source track's PlayRes.
-        let compensation = fontScaleCompensation.isFinite && fontScaleCompensation > 0
+        let compensation = !isNativeASS && fontScaleCompensation.isFinite && fontScaleCompensation > 0
             ? fontScaleCompensation
             : 1.0
         let scale = (params.fontSize / Parameters.referenceFontSize) * compensation
-        ass_set_font_scale(renderer, scale.isFinite && scale > 0 ? scale : 1.0)
+        let shouldScaleFont = !isNativeASS || params.systemContentOverrides.contains(.size)
+        ass_set_font_scale(renderer, shouldScaleFont && scale.isFinite && scale > 0 ? scale : 1.0)
 
         // Swift's `ASS_Style()` already zero-initialises the struct.
         // Pointer fields (`Name`, `FontName`) are nil which violates the
@@ -297,7 +331,7 @@ enum SubtitleStylingOverride {
         style.Name = nameCString
         style.FontName = fontCString
         style.FontSize = params.fontSize
-        style.PrimaryColour = assColor(hexRGBUInt: params.textColorHex, alphaByte: 0x00)
+        style.PrimaryColour = assColor(hexRGBUInt: params.textColorHex, alphaByte: params.textAlphaByte)
         style.SecondaryColour = 0xFFFFFF00 // opaque white, internal RRGGBBAA
         style.OutlineColour = assColor(hexRGBUInt: params.effectiveOutlineColorHex, alphaByte: 0x00)
         style.BackColour = assColor(
@@ -329,14 +363,32 @@ enum SubtitleStylingOverride {
         // FONT_SIZE_FIELDS: it also overrides ScaleX/Y/Blur/Spacing and
         // scales FontSize against the source track's PlayRes, which makes
         // identical user sizes render differently across subtitle sources.
-        let bits: Int32 =
-            Int32(ASS_OVERRIDE_BIT_FONT_NAME.rawValue) |
-            Int32(ASS_OVERRIDE_BIT_SELECTIVE_FONT_SCALE.rawValue) |
-            Int32(ASS_OVERRIDE_BIT_COLORS.rawValue) |
-            Int32(ASS_OVERRIDE_BIT_ATTRIBUTES.rawValue) |
-            Int32(ASS_OVERRIDE_BIT_BORDER.rawValue) |
-            Int32(ASS_OVERRIDE_BIT_ALIGNMENT.rawValue) |
-            Int32(ASS_OVERRIDE_BIT_MARGINS.rawValue)
+        let bits: Int32
+        if isNativeASS {
+            var systemBits: Int32 = 0
+            if params.systemContentOverrides.contains(.font) {
+                systemBits |= Int32(ASS_OVERRIDE_BIT_FONT_NAME.rawValue)
+            }
+            if params.systemContentOverrides.contains(.size) {
+                systemBits |= Int32(ASS_OVERRIDE_BIT_SELECTIVE_FONT_SCALE.rawValue)
+            }
+            if params.systemContentOverrides.contains(.colors) {
+                systemBits |= Int32(ASS_OVERRIDE_BIT_COLORS.rawValue)
+            }
+            if params.systemContentOverrides.contains(.edge) {
+                systemBits |= Int32(ASS_OVERRIDE_BIT_BORDER.rawValue)
+            }
+            bits = systemBits
+        } else {
+            bits =
+                Int32(ASS_OVERRIDE_BIT_FONT_NAME.rawValue) |
+                Int32(ASS_OVERRIDE_BIT_SELECTIVE_FONT_SCALE.rawValue) |
+                Int32(ASS_OVERRIDE_BIT_COLORS.rawValue) |
+                Int32(ASS_OVERRIDE_BIT_ATTRIBUTES.rawValue) |
+                Int32(ASS_OVERRIDE_BIT_BORDER.rawValue) |
+                Int32(ASS_OVERRIDE_BIT_ALIGNMENT.rawValue) |
+                Int32(ASS_OVERRIDE_BIT_MARGINS.rawValue)
+        }
         ass_set_selective_style_override_enabled(renderer, bits)
     }
 

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleStylingOverride.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleStylingOverride.swift
@@ -108,8 +108,8 @@ enum SubtitleStylingOverride {
             // the glyphs separately in this combination.
             if boxEnabled { return boxPadding }
             if systemTextEdgeStyle == .dropShadow { return 1.5 }
-            if systemTextEdgeStyle == .raised { return 1.0 }
-            if systemTextEdgeStyle == .depressed { return -1.0 }
+            if systemTextEdgeStyle == .raised { return -1.0 }
+            if systemTextEdgeStyle == .depressed { return 1.0 }
             return backgroundStyle == .shadow ? 1.5 : 0
         }
 
@@ -186,22 +186,6 @@ enum SubtitleStylingOverride {
             systemContentOverrides.contains(.foregroundOpacity)
                 ? UInt8(max(0, min(255, textOpacityPercent * 255 / 100)))
                 : nil
-        }
-
-        var nativeBackgroundColorOverride: (UInt8, UInt8, UInt8)? {
-            systemContentOverrides.contains(.backgroundColor)
-                ? SubtitleStylingOverride.rgbBytes(fromHex: backgroundColorHex)
-                : nil
-        }
-
-        var nativeBackgroundAlphaOverride: UInt8? {
-            systemContentOverrides.contains(.backgroundOpacity)
-                ? UInt8(max(0, min(255, backgroundOpacityPercent * 255 / 100)))
-                : nil
-        }
-
-        var captionWindowEnabled: Bool {
-            captionWindowOpacityPercent > 0
         }
 
         static let referenceFontSize: Double = SubtitleAppearance.default.fontSize.pointSize

--- a/iosApp/iosApp/Screens/Player/Subtitles/SystemCaptionAppearance.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SystemCaptionAppearance.swift
@@ -63,7 +63,7 @@ enum SystemCaptionAppearance {
                 behavior: behavior
             )
         }
-        if behavior == .useValue { result.contentOverrides.insert(.colors) }
+        if behavior == .useValue { result.contentOverrides.insert(.foregroundColor) }
 
         behavior = .useValue
         let foregroundOpacity = MACaptionAppearanceGetForegroundOpacity(.user, &behavior)
@@ -71,7 +71,7 @@ enum SystemCaptionAppearance {
             Double(foregroundOpacity),
             behavior: behavior
         )
-        if behavior == .useValue { result.contentOverrides.insert(.colors) }
+        if behavior == .useValue { result.contentOverrides.insert(.foregroundOpacity) }
 
         behavior = .useValue
         let background = MACaptionAppearanceCopyBackgroundColor(.user, &behavior).takeRetainedValue()
@@ -81,7 +81,7 @@ enum SystemCaptionAppearance {
                 behavior: behavior
             )
         }
-        if behavior == .useValue { result.contentOverrides.insert(.colors) }
+        if behavior == .useValue { result.contentOverrides.insert(.backgroundColor) }
 
         behavior = .useValue
         let backgroundOpacity = MACaptionAppearanceGetBackgroundOpacity(.user, &behavior)
@@ -89,7 +89,7 @@ enum SystemCaptionAppearance {
             Double(backgroundOpacity),
             behavior: behavior
         )
-        if behavior == .useValue { result.contentOverrides.insert(.colors) }
+        if behavior == .useValue { result.contentOverrides.insert(.backgroundOpacity) }
 
         behavior = .useValue
         let window = MACaptionAppearanceCopyWindowColor(.user, &behavior).takeRetainedValue()
@@ -99,7 +99,7 @@ enum SystemCaptionAppearance {
                 behavior: behavior
             )
         }
-        if behavior == .useValue { result.contentOverrides.insert(.window) }
+        if behavior == .useValue { result.contentOverrides.insert(.windowColor) }
 
         behavior = .useValue
         let windowOpacity = MACaptionAppearanceGetWindowOpacity(.user, &behavior)
@@ -107,7 +107,7 @@ enum SystemCaptionAppearance {
             Double(windowOpacity),
             behavior: behavior
         )
-        if behavior == .useValue { result.contentOverrides.insert(.window) }
+        if behavior == .useValue { result.contentOverrides.insert(.windowOpacity) }
 
         behavior = .useValue
         let windowCornerRadius = MACaptionAppearanceGetWindowRoundedCornerRadius(.user, &behavior)
@@ -115,7 +115,7 @@ enum SystemCaptionAppearance {
             Double(windowCornerRadius),
             behavior: behavior
         )
-        if behavior == .useValue { result.contentOverrides.insert(.window) }
+        if behavior == .useValue { result.contentOverrides.insert(.windowCornerRadius) }
 
         behavior = .useValue
         let edge = MACaptionAppearanceGetTextEdgeStyle(.user, &behavior)

--- a/iosApp/iosApp/Screens/Player/Subtitles/SystemCaptionAppearance.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SystemCaptionAppearance.swift
@@ -4,12 +4,12 @@
 //
 //  Maps Apple's Media Accessibility caption preferences (Settings →
 //  Accessibility → Subtitles & Captioning) onto `SubtitleAppearance` so
-//  the player can offer a "match device settings" appearance source.
+//  the player can offer a "use device settings" appearance source.
 //
 //  Every value returned by MediaAccessibility participates in the mapped
 //  appearance. Apple's `.useContentIfAvailable` behavior still requires the
 //  returned value when content does not supply one. Silo-controlled text
-//  tracks intentionally have no competing authored style while "Match Device
+//  tracks intentionally have no competing authored style while "Use Device
 //  Settings" is enabled, so dropping those fallback values would replace the
 //  selected system profile with Silo's defaults.
 //
@@ -26,16 +26,20 @@ enum SystemCaptionAppearance {
     /// exercise the mapping without touching process-wide accessibility state.
     struct Snapshot: Equatable {
         var foregroundColorHex: String?
+        /// 0.0–1.0.
+        var foregroundOpacity: Double?
         var backgroundColorHex: String?
         /// 0.0–1.0.
         var backgroundOpacity: Double?
         var windowColorHex: String?
         /// 0.0–1.0.
         var windowOpacity: Double?
+        var windowCornerRadius: Double?
         var edgeStyle: MACaptionAppearanceTextEdgeStyle?
         /// Multiplier around 1.0 (system slider spans roughly 0.5–2.0).
         var relativeCharacterSize: Double?
         var fontFamilyName: String?
+        var contentOverrides: SystemCaptionContentOverrides = []
     }
 
     static let settingsChangedNotification =
@@ -59,6 +63,15 @@ enum SystemCaptionAppearance {
                 behavior: behavior
             )
         }
+        if behavior == .useValue { result.contentOverrides.insert(.colors) }
+
+        behavior = .useValue
+        let foregroundOpacity = MACaptionAppearanceGetForegroundOpacity(.user, &behavior)
+        result.foregroundOpacity = valueForMatchingDeviceSettings(
+            Double(foregroundOpacity),
+            behavior: behavior
+        )
+        if behavior == .useValue { result.contentOverrides.insert(.colors) }
 
         behavior = .useValue
         let background = MACaptionAppearanceCopyBackgroundColor(.user, &behavior).takeRetainedValue()
@@ -68,6 +81,7 @@ enum SystemCaptionAppearance {
                 behavior: behavior
             )
         }
+        if behavior == .useValue { result.contentOverrides.insert(.colors) }
 
         behavior = .useValue
         let backgroundOpacity = MACaptionAppearanceGetBackgroundOpacity(.user, &behavior)
@@ -75,6 +89,7 @@ enum SystemCaptionAppearance {
             Double(backgroundOpacity),
             behavior: behavior
         )
+        if behavior == .useValue { result.contentOverrides.insert(.colors) }
 
         behavior = .useValue
         let window = MACaptionAppearanceCopyWindowColor(.user, &behavior).takeRetainedValue()
@@ -84,6 +99,7 @@ enum SystemCaptionAppearance {
                 behavior: behavior
             )
         }
+        if behavior == .useValue { result.contentOverrides.insert(.window) }
 
         behavior = .useValue
         let windowOpacity = MACaptionAppearanceGetWindowOpacity(.user, &behavior)
@@ -91,10 +107,20 @@ enum SystemCaptionAppearance {
             Double(windowOpacity),
             behavior: behavior
         )
+        if behavior == .useValue { result.contentOverrides.insert(.window) }
+
+        behavior = .useValue
+        let windowCornerRadius = MACaptionAppearanceGetWindowRoundedCornerRadius(.user, &behavior)
+        result.windowCornerRadius = valueForMatchingDeviceSettings(
+            Double(windowCornerRadius),
+            behavior: behavior
+        )
+        if behavior == .useValue { result.contentOverrides.insert(.window) }
 
         behavior = .useValue
         let edge = MACaptionAppearanceGetTextEdgeStyle(.user, &behavior)
         result.edgeStyle = valueForMatchingDeviceSettings(edge, behavior: behavior)
+        if behavior == .useValue { result.contentOverrides.insert(.edge) }
 
         behavior = .useValue
         let size = MACaptionAppearanceGetRelativeCharacterSize(.user, &behavior)
@@ -102,6 +128,7 @@ enum SystemCaptionAppearance {
             Double(size),
             behavior: behavior
         )
+        if behavior == .useValue { result.contentOverrides.insert(.size) }
 
         behavior = .useValue
         let descriptor = MACaptionAppearanceCopyFontDescriptorForStyle(
@@ -111,18 +138,19 @@ enum SystemCaptionAppearance {
            !family.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             result.fontFamilyName = valueForMatchingDeviceSettings(family, behavior: behavior)
         }
+        if behavior == .useValue { result.contentOverrides.insert(.font) }
 
         return result
     }
 
-    /// Resolve a value for Silo's explicit "Match Device Settings" mode.
+    /// Resolve a value for Silo's explicit "Use Device Settings" mode.
     ///
     /// `.useContentIfAvailable` is a precedence rule, not an absent value:
     /// Apple's contract says to use the returned preference when the content
     /// has no competing style. Plain SRT/VTT and other controlled text tracks
     /// have no authored appearance, so both known behaviors resolve to the
-    /// system value. Native ASS continues to preserve its authored styling in
-    /// `SubtitleStylingOverride`, downstream from this mapper.
+    /// system value. Native ASS uses each returned behavior downstream to
+    /// preserve authored styling or apply the system category as requested.
     static func valueForMatchingDeviceSettings<Value>(
         _ value: Value,
         behavior: MACaptionAppearanceBehavior
@@ -140,59 +168,72 @@ enum SystemCaptionAppearance {
     /// Fold a system snapshot over a base appearance. Field-by-field:
     /// customized values win, everything else keeps the base.
     ///
-    /// The system model has no combined shadow-plus-box: a drop-shadow
-    /// edge maps to our Drop Shadow style only when the user has no
-    /// background, since Box occupies the same `backgroundStyle` slot.
     static func appearance(
         from snapshot: Snapshot,
         base: SubtitleAppearance = .default
     ) -> SubtitleAppearance {
         var result = base
 
-        // Apple's background is behind each glyph, while its window is the
-        // box behind the whole caption. Silo has one box layer, so a visible
-        // window is the closest match and takes precedence; the glyph
-        // background remains the fallback when the window is transparent.
-        if let opacity = snapshot.windowOpacity, opacity > 0.01 {
-            result.backgroundStyle = .box
-            result.backgroundOpacity = Int((opacity * 100).rounded())
-            if let window = snapshot.windowColorHex {
-                result.backgroundColor = window
-            }
-        } else if let opacity = snapshot.backgroundOpacity, opacity > 0.01 {
+        // Apple's glyph background and caption window are independent
+        // layers. Keep both rather than folding the window over the glyph
+        // background (which previously lost one of the user's colors).
+        if let opacity = snapshot.backgroundOpacity, opacity > 0.01 {
             result.backgroundStyle = .box
             result.backgroundOpacity = Int((opacity * 100).rounded())
             if let background = snapshot.backgroundColorHex {
                 result.backgroundColor = background
             }
-        } else if snapshot.windowOpacity != nil || snapshot.backgroundOpacity != nil {
+        } else if snapshot.backgroundOpacity != nil {
             result.backgroundStyle = SubtitleBackgroundStylePreset.none
+        }
+
+        if let window = snapshot.windowColorHex {
+            result.captionWindowColor = window
+        }
+        if let opacity = snapshot.windowOpacity {
+            result.captionWindowOpacity = Int((opacity * 100).rounded())
+        }
+        if let radius = snapshot.windowCornerRadius {
+            result.captionWindowCornerRadius = radius
         }
 
         if let edge = snapshot.edgeStyle {
             switch edge {
-            case .uniform, .raised, .depressed:
+            case .uniform:
+                result.systemTextEdgeStyle = .uniform
+                result.textOutline = true
+            case .raised:
+                result.systemTextEdgeStyle = .raised
+                result.textOutline = true
+            case .depressed:
+                result.systemTextEdgeStyle = .depressed
                 result.textOutline = true
             case .dropShadow:
+                result.systemTextEdgeStyle = .dropShadow
                 result.textOutline = false
-                if result.backgroundStyle != .box {
-                    result.backgroundStyle = .shadow
-                }
-            default:
+            case .none, .undefined:
+                result.systemTextEdgeStyle = SystemCaptionTextEdgeStyle.none
                 result.textOutline = false
+            @unknown default:
+                result.systemTextEdgeStyle = nil
             }
         }
 
         if let foreground = snapshot.foregroundColorHex {
             result.fontColor = foreground
         }
+        if let opacity = snapshot.foregroundOpacity {
+            result.fontOpacity = Int((opacity * 100).rounded())
+        }
         if let relativeSize = snapshot.relativeCharacterSize {
+            result.systemRelativeFontScale = relativeSize
             result.fontSize = fontSizePreset(forRelativeSize: relativeSize)
         }
         if let family = snapshot.fontFamilyName,
            let preset = SubtitleFontFamilyPreset(rawValue: family) {
             result.fontFamily = preset
         }
+        result.systemContentOverrides = snapshot.contentOverrides
 
         return result.sanitized()
     }

--- a/iosApp/iosApp/Screens/Player/Subtitles/SystemCaptionSelectionPreferences.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SystemCaptionSelectionPreferences.swift
@@ -1,0 +1,55 @@
+//
+//  SystemCaptionSelectionPreferences.swift
+//  Continuum (iOS + tvOS + macOS)
+//
+//  Read-only bridge for the non-visual half of Apple's Subtitles &
+//  Captioning preferences. Silo never writes these values: the active
+//  system profile remains the single source of truth.
+//
+
+import Foundation
+import MediaAccessibility
+
+struct SystemCaptionSelectionPreferences: Equatable {
+    enum DisplayMode: Equatable {
+        case forcedOnly
+        case automatic
+        case alwaysOn
+    }
+
+    var displayMode: DisplayMode
+    /// Ordered canonical language identifiers from the active Apple profile.
+    var preferredLanguages: [String]
+    /// True when Apple asks players to prefer CC/SDH accessibility tracks.
+    var prefersAccessibilityTracks: Bool
+
+    static func current() -> SystemCaptionSelectionPreferences {
+        let displayMode: DisplayMode
+        switch MACaptionAppearanceGetDisplayType(.user) {
+        case .forcedOnly:
+            displayMode = .forcedOnly
+        case .alwaysOn:
+            displayMode = .alwaysOn
+        case .automatic:
+            displayMode = .automatic
+        @unknown default:
+            displayMode = .automatic
+        }
+
+        let selectedLanguages = MACaptionAppearanceCopySelectedLanguages(.user)
+            .takeRetainedValue() as? [String] ?? []
+        let languages = selectedLanguages.isEmpty ? Locale.preferredLanguages : selectedLanguages
+        let characteristics = MACaptionAppearanceCopyPreferredCaptioningMediaCharacteristics(.user)
+            .takeRetainedValue() as? [String] ?? []
+        let accessibilityCharacteristics = Set([
+            MAMediaCharacteristicDescribesMusicAndSoundForAccessibility as String,
+            MAMediaCharacteristicTranscribesSpokenDialogForAccessibility as String,
+        ])
+
+        return SystemCaptionSelectionPreferences(
+            displayMode: displayMode,
+            preferredLanguages: languages,
+            prefersAccessibilityTracks: !accessibilityCharacteristics.isDisjoint(with: characteristics)
+        )
+    }
+}

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPlayerInfoHUD.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPlayerInfoHUD.swift
@@ -1125,7 +1125,7 @@ private struct SubtitleAppearanceDialog: View {
                 ScrollView(showsIndicators: true) {
                     VStack(spacing: 2) {
                         HUDToggleRow(
-                            label: "Match device style",
+                            label: "Use device settings",
                             isOn: viewModel.settings.subtitleMatchesSystemAppearance
                         ) { enabled in
                             viewModel.setSubtitleMatchesSystemAppearance(enabled)

--- a/iosApp/iosApp/Screens/Settings/SubtitleSettingsView.swift
+++ b/iosApp/iosApp/Screens/Settings/SubtitleSettingsView.swift
@@ -123,7 +123,9 @@ struct SubtitleSettingsView: View {
                 .foregroundStyle(Color.continuumSecondaryText)
         } footer: {
             VStack(alignment: .leading, spacing: 6) {
-                if viewModel.settingsServerUpgradeRequired {
+                if viewModel.subtitleMatchesSystemAppearance {
+                    Text("Language, display behavior, forced captions, and CC/SDH preference follow this device's Accessibility settings.")
+                } else if viewModel.settingsServerUpgradeRequired {
                     Text(ProfilePrefsEditor.serverUpgradeMessage)
                         .foregroundStyle(Color.continuumError)
                 } else {
@@ -140,7 +142,7 @@ struct SubtitleSettingsView: View {
             }
             .foregroundStyle(Color.continuumSecondaryText)
         }
-        .disabled(viewModel.settingsServerUpgradeRequired)
+        .disabled(viewModel.settingsServerUpgradeRequired || viewModel.subtitleMatchesSystemAppearance)
         .listRowBackground(Color.continuumSurfaceElevated)
     }
 
@@ -168,7 +170,7 @@ struct SubtitleSettingsView: View {
 
         Section {
             Toggle(
-                "Match Device Settings",
+                "Use Device Settings",
                 isOn: Binding(
                     get: { viewModel.subtitleMatchesSystemAppearance },
                     set: { enabled in
@@ -194,13 +196,17 @@ struct SubtitleSettingsView: View {
         } footer: {
             VStack(alignment: .leading, spacing: 6) {
                 if viewModel.subtitleMatchesSystemAppearance {
-                    Text("Following this device's caption style from Accessibility settings (Subtitles & Captioning). Editing any option below switches back to Silo styling.")
+                    Text("Following this device's caption language, display behavior, CC/SDH preference, font, colors, opacity, edges, size, and caption window from Accessibility → Subtitles & Captioning.")
                 } else if viewModel.subtitleUsesDeviceAppearanceOverride {
                     Text("Saved on the server for this profile on this device. An admin can reset it.")
                 } else {
                     Text("Using the server fallback for this profile on this device. Turn on Custom Appearance to save your own here.")
                 }
-                Text("Subtitles with their own built-in styling keep their original appearance; image-based subtitles keep their authored fonts and colors but follow the size, position, and background settings.")
+                if viewModel.subtitleMatchesSystemAppearance {
+                    Text("Subtitles with built-in styling follow each device caption option's Video Overrides Style choice.")
+                } else {
+                    Text("Subtitles with their own built-in styling keep their original appearance; image-based subtitles keep their authored fonts and colors but follow the size, position, and background settings.")
+                }
             }
             .foregroundStyle(Color.continuumSecondaryText)
         }

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
@@ -666,10 +666,11 @@ struct TVItemDetailView: View {
     /// `resolvedAudioOrdinal` falls back to `effectiveAudioTrackIndex`.
     private func seedSubtitleOverrideIfNeeded() {
         guard preferredSubtitleTrackIndex == nil, let detail = viewModel.detail else { return }
-        preferredSubtitleTrackIndex = DetailPlaybackFormatting.serverPreferredSubtitleIndex(
+        preferredSubtitleTrackIndex = DetailPlaybackFormatting.launchPreferredSubtitleIndex(
             version: effectiveVersion(for: detail, versionFileId: preferredVersionFileId),
             signature: detail.effectiveSubtitleTrackSignature,
-            mode: detail.effectiveSubtitleMode
+            mode: detail.effectiveSubtitleMode,
+            usesDeviceSettings: PlayerSettings.shared.subtitleMatchesSystemAppearance
         )
     }
 
@@ -758,10 +759,11 @@ struct TVItemDetailView: View {
             let enriched = await enrichPlaybackMetadata(for: item, contentId: nextUp.contentId)
             guard !Task.isCancelled else { return }
             nextUpPlaybackDetail = enriched
-            preferredNextUpSubtitleTrackIndex = DetailPlaybackFormatting.serverPreferredSubtitleIndex(
+            preferredNextUpSubtitleTrackIndex = DetailPlaybackFormatting.launchPreferredSubtitleIndex(
                 version: effectiveVersion(for: enriched, versionFileId: nil),
                 signature: enriched.effectiveSubtitleTrackSignature,
-                mode: enriched.effectiveSubtitleMode
+                mode: enriched.effectiveSubtitleMode,
+                usesDeviceSettings: PlayerSettings.shared.subtitleMatchesSystemAppearance
             )
             didLoadNextUpPlaybackDetail = true
         } catch {
@@ -813,10 +815,11 @@ struct TVItemDetailView: View {
             let enriched = await enrichPlaybackMetadata(for: item, contentId: nextUp.contentId)
             guard !Task.isCancelled else { return }
             nextUpPlaybackDetail = enriched
-            preferredNextUpSubtitleTrackIndex = DetailPlaybackFormatting.serverPreferredSubtitleIndex(
+            preferredNextUpSubtitleTrackIndex = DetailPlaybackFormatting.launchPreferredSubtitleIndex(
                 version: effectiveVersion(for: enriched, versionFileId: nil),
                 signature: enriched.effectiveSubtitleTrackSignature,
-                mode: enriched.effectiveSubtitleMode
+                mode: enriched.effectiveSubtitleMode,
+                usesDeviceSettings: PlayerSettings.shared.subtitleMatchesSystemAppearance
             )
             didLoadNextUpPlaybackDetail = true
         } catch {

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
@@ -61,6 +61,7 @@ struct TVItemDetailView: View {
         .onAppear {
             Self.focusLogger.debug("itemDetail.appear contentId=\(contentId, privacy: .public) pathDepth=\(router.path.count, privacy: .public)")
             allowRemoteTrailers = TVTrailerLaunch.isYouTubeAppInstalled()
+            seedSubtitleOverrideIfNeeded()
             // Returning from the player (or an extra) resumes a poll that
             // `onDisappear` cancelled — without re-POSTing, since the server
             // already spent the item's weekly slot. Precedent:
@@ -483,6 +484,7 @@ struct TVItemDetailView: View {
                 },
                 onSelectSubtitleTrack: { index in
                     didClearSubtitleOverride = (index == nil)
+                    viewModel.preferredSubtitleTrackWasManuallySelected = true
                     preferredSubtitleTrackIndex = sanitizedSubtitleTrackIndex(
                         for: detail,
                         versionFileId: preferredVersionFileId,
@@ -665,7 +667,15 @@ struct TVItemDetailView: View {
     /// the pick was persisted; audio doesn't need an equivalent because
     /// `resolvedAudioOrdinal` falls back to `effectiveAudioTrackIndex`.
     private func seedSubtitleOverrideIfNeeded() {
-        guard preferredSubtitleTrackIndex == nil, let detail = viewModel.detail else { return }
+        if PlayerSettings.shared.subtitleMatchesSystemAppearance {
+            if !viewModel.preferredSubtitleTrackWasManuallySelected {
+                preferredSubtitleTrackIndex = nil
+            }
+            return
+        }
+        guard !viewModel.preferredSubtitleTrackWasManuallySelected,
+              preferredSubtitleTrackIndex == nil,
+              let detail = viewModel.detail else { return }
         preferredSubtitleTrackIndex = DetailPlaybackFormatting.launchPreferredSubtitleIndex(
             version: effectiveVersion(for: detail, versionFileId: preferredVersionFileId),
             signature: detail.effectiveSubtitleTrackSignature,

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsView.swift
@@ -83,7 +83,7 @@ struct TVSettingsView: View {
             // The pane previews whatever category the rail focus rests on.
             // Profile / Sign Out keep the last category visible.
             if case .category(let category) = focus {
-                preferredDetailFocus = .top
+                preferredDetailFocus = initialDetailFocus(for: category)
                 if category != selectedCategory {
                     withAnimation(.easeOut(duration: ContinuumTheme.normalDuration)) {
                         selectedCategory = category
@@ -288,18 +288,27 @@ struct TVSettingsView: View {
     private func enterDetailPane(for category: TVSettingsCategory) {
         selectedCategory = category
         preferredFocusOwner = .detail
-        preferredDetailFocus = .top
+        let initialFocus = initialDetailFocus(for: category)
+        preferredDetailFocus = initialFocus
         isRestoringDetailFocus = true
         railFocus = nil
-        detailFocus = .top
+        detailFocus = initialFocus
         Task { @MainActor in
             await Task.yield()
             resetFocus(in: settingsFocusScope)
             resetFocus(in: detailFocusScope)
-            detailFocus = .top
+            detailFocus = initialFocus
             try? await Task.sleep(for: .milliseconds(120))
             isRestoringDetailFocus = false
         }
+    }
+
+    private func initialDetailFocus(for category: TVSettingsCategory) -> TVSettingsDetailFocus {
+        if category == .subtitles,
+           viewModel.settingsServerUpgradeRequired || viewModel.subtitleMatchesSystemAppearance {
+            return .subtitleUseDeviceSettings
+        }
+        return .top
     }
 
     private func returnFocusToRail() {
@@ -533,6 +542,7 @@ enum TVSettingsDetailFocus: Hashable {
     case playbackAudioLanguage
     case playbackNextUpPrompt
     case subtitleBehavior
+    case subtitleUseDeviceSettings
     case subtitleMetadataLanguage
     case subtitleFontSize
     case subtitleFontFamily

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSubtitleSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSubtitleSettingsView.swift
@@ -35,25 +35,15 @@ struct TVSubtitleSettingsPane: View {
     private var profileSection: some View {
         TVSettingsSectionHeader("PROFILE")
 
-        if viewModel.settingsServerUpgradeRequired || viewModel.subtitleMatchesSystemAppearance {
-            TVSettingsPickerRow(
-                title: "Language",
-                value: TVSettingsOptions.label(
-                    for: viewModel.editorSubtitleLanguage,
-                    in: TVSettingsOptions.subtitleLanguage(viewModel.subtitleLanguageOptions)
-                )
-            ) { showPicker(.language) }
-            .disabled(true)
-        } else {
-            TVSettingsPickerRow(
-                title: "Language",
-                value: TVSettingsOptions.label(
-                    for: viewModel.editorSubtitleLanguage,
-                    in: TVSettingsOptions.subtitleLanguage(viewModel.subtitleLanguageOptions)
-                )
-            ) { showPicker(.language) }
-            .focused(detailFocus, equals: .top)
-        }
+        TVSettingsPickerRow(
+            title: "Language",
+            value: TVSettingsOptions.label(
+                for: viewModel.editorSubtitleLanguage,
+                in: TVSettingsOptions.subtitleLanguage(viewModel.subtitleLanguageOptions)
+            )
+        ) { showPicker(.language) }
+        .focused(detailFocus, equals: .top)
+        .disabled(viewModel.settingsServerUpgradeRequired || viewModel.subtitleMatchesSystemAppearance)
 
         TVSettingsPickerRow(
             title: "Behavior",
@@ -114,24 +104,14 @@ struct TVSubtitleSettingsPane: View {
             TVSettingsFooter("Low contrast — dark text without a box or outline can be hard to read.")
         }
 
-        if viewModel.settingsServerUpgradeRequired || viewModel.subtitleMatchesSystemAppearance {
-            TVSettingsToggleRow(
-                title: "Use Device Settings",
-                isOn: viewModel.subtitleMatchesSystemAppearance
-            ) {
-                let enabled = !viewModel.subtitleMatchesSystemAppearance
-                Task { await viewModel.setSubtitleMatchesSystemAppearance(enabled) }
-            }
-            .focused(detailFocus, equals: .top)
-        } else {
-            TVSettingsToggleRow(
-                title: "Use Device Settings",
-                isOn: viewModel.subtitleMatchesSystemAppearance
-            ) {
-                let enabled = !viewModel.subtitleMatchesSystemAppearance
-                Task { await viewModel.setSubtitleMatchesSystemAppearance(enabled) }
-            }
+        TVSettingsToggleRow(
+            title: "Use Device Settings",
+            isOn: viewModel.subtitleMatchesSystemAppearance
+        ) {
+            let enabled = !viewModel.subtitleMatchesSystemAppearance
+            Task { await viewModel.setSubtitleMatchesSystemAppearance(enabled) }
         }
+        .focused(detailFocus, equals: .subtitleUseDeviceSettings)
 
         TVSettingsToggleRow(
             title: "Custom Subtitle Appearance",

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSubtitleSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSubtitleSettingsView.swift
@@ -35,7 +35,7 @@ struct TVSubtitleSettingsPane: View {
     private var profileSection: some View {
         TVSettingsSectionHeader("PROFILE")
 
-        if viewModel.settingsServerUpgradeRequired {
+        if viewModel.settingsServerUpgradeRequired || viewModel.subtitleMatchesSystemAppearance {
             TVSettingsPickerRow(
                 title: "Language",
                 value: TVSettingsOptions.label(
@@ -60,7 +60,7 @@ struct TVSubtitleSettingsPane: View {
             value: TVSettingsOptions.label(for: viewModel.editorSubtitleMode, in: TVSettingsOptions.subtitleMode)
         ) { showPicker(.mode) }
         .focused(detailFocus, equals: .subtitleBehavior)
-        .disabled(viewModel.settingsServerUpgradeRequired)
+        .disabled(viewModel.settingsServerUpgradeRequired || viewModel.subtitleMatchesSystemAppearance)
 
         TVSettingsToggleRow(
             title: "Show Forced Subtitles",
@@ -69,9 +69,11 @@ struct TVSubtitleSettingsPane: View {
             viewModel.editorShowForcedSubtitles =
                 viewModel.editorShowForcedSubtitles == "on" ? "off" : "on"
         }
-        .disabled(viewModel.settingsServerUpgradeRequired)
+        .disabled(viewModel.settingsServerUpgradeRequired || viewModel.subtitleMatchesSystemAppearance)
 
-        if viewModel.settingsServerUpgradeRequired {
+        if viewModel.subtitleMatchesSystemAppearance {
+            TVSettingsFooter("Language, display behavior, forced captions, and CC/SDH preference follow this Apple TV's Accessibility settings.")
+        } else if viewModel.settingsServerUpgradeRequired {
             TVSettingsWarningFooter(ProfilePrefsEditor.serverUpgradeMessage)
         } else {
             TVSettingsFooter("Used to pick a matching track when one is available. Forced subtitles cover foreign-language dialogue even when subtitles are off or set to auto.")
@@ -112,9 +114,9 @@ struct TVSubtitleSettingsPane: View {
             TVSettingsFooter("Low contrast — dark text without a box or outline can be hard to read.")
         }
 
-        if viewModel.settingsServerUpgradeRequired {
+        if viewModel.settingsServerUpgradeRequired || viewModel.subtitleMatchesSystemAppearance {
             TVSettingsToggleRow(
-                title: "Match Device Settings",
+                title: "Use Device Settings",
                 isOn: viewModel.subtitleMatchesSystemAppearance
             ) {
                 let enabled = !viewModel.subtitleMatchesSystemAppearance
@@ -123,7 +125,7 @@ struct TVSubtitleSettingsPane: View {
             .focused(detailFocus, equals: .top)
         } else {
             TVSettingsToggleRow(
-                title: "Match Device Settings",
+                title: "Use Device Settings",
                 isOn: viewModel.subtitleMatchesSystemAppearance
             ) {
                 let enabled = !viewModel.subtitleMatchesSystemAppearance
@@ -216,13 +218,16 @@ struct TVSubtitleSettingsPane: View {
     private var appearanceFooterText: String {
         let source: String
         if viewModel.subtitleMatchesSystemAppearance {
-            source = "Following this Apple TV's caption style from Settings → Accessibility. Editing any option switches back to Silo styling."
+            source = "Following this Apple TV's caption language, display behavior, CC/SDH preference, font, colors, opacity, edges, size, and caption window from Settings → Accessibility."
         } else if viewModel.subtitleUsesDeviceAppearanceOverride {
             source = "Appearance is saved on the server for this profile on this Apple TV."
         } else {
             source = "Appearance is using the server fallback for this profile on this Apple TV."
         }
-        return source + " Subtitles with their own built-in styling keep their original appearance; image-based subtitles keep their authored fonts and colors but follow the size, position, and background settings."
+        let authoredStyleBehavior = viewModel.subtitleMatchesSystemAppearance
+            ? " Subtitles with built-in styling follow each device caption option's Video Overrides Style choice."
+            : " Subtitles with their own built-in styling keep their original appearance; image-based subtitles keep their authored fonts and colors but follow the size, position, and background settings."
+        return source + authoredStyleBehavior
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

- make **Use Device Settings** control subtitle selection as well as appearance
- honor Apple's ordered caption languages, Forced Only / Automatic / Always On display modes, and CC/SDH media-characteristic preference
- map the remaining visual preferences: foreground opacity, exact relative size, all edge styles, and the separate rounded caption window
- keep Apple-only detail runtime-local so the server subtitle appearance contract and other clients do not change
- refresh selection and appearance when MediaAccessibility reports a settings change, while preserving a manual in-player track choice
- respect Apple's per-category Video Overrides Style precedence for authored ASS content

## Root cause

The existing bridge only mapped a subset of MediaAccessibility into Silo's persistent appearance model. It quantized the system font scale, omitted foreground opacity and window radius, collapsed Apple's glyph background and caption window into one layer, and treated raised/depressed/uniform edges as the same outline.

The toggle also never participated in subtitle track selection, so Apple's language order, display mode, and CC/SDH preference were ignored in favor of the Silo profile settings.

## User impact

When Use Device Settings is enabled, iPhone and Apple TV users now get one coherent system-driven experience: track choice, font, color, alpha, scale, edge, glyph background, caption window, and authored-style precedence all follow the active Apple accessibility profile. The Silo profile controls are disabled while the system source is active so the UI reflects the actual source of truth.

## Validation

- rebased onto `main` at `671d4f1`
- focused iOS simulator tests: **43 passed, 0 failed**
  - system appearance mapping
  - renderer parameter mapping and server-encoding isolation
  - ordered language fallback, CC/SDH preference, and forced-only selection
- normally signed iOS simulator build and launch succeeded; authenticated Settings UI visually confirmed system-driven preview and disabled Silo profile/appearance controls
- normally signed tvOS 26.4 simulator build and launch succeeded after the rebase
- read the active tvOS MediaAccessibility profile without modifying it and confirmed the signed app preview matches its green foreground, 1.75x scale, transparent glyph background, 50% magenta window, and 8-point rounded corners


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved automatic subtitle selection with language fallbacks, forced-subtitle mode, accessibility-track preference, and configurable no-match behavior.
  - Added broader support for device caption settings, including opacity, font scaling, caption windows, colors, corner radius, and text-edge styles.
  - Subtitle previews and playback rendering now better reflect system caption appearance.

- **Improvements**
  - “Use Device Settings” wording clarifies how Accessibility preferences control subtitle appearance.
  - Profile appearance controls are disabled when device settings are active.
  - Manual subtitle selections are preserved without automatic reselection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->