### PR TITLE
fix(auth): use native branding for server names

### DIFF
--- a/iosApp/Tests/ServerIdentityResolverTests.swift
+++ b/iosApp/Tests/ServerIdentityResolverTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+@testable import Silo
+
+final class ServerIdentityResolverTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        ServerIdentityStubProtocol.reset()
+    }
+
+    func testPrefersNativeBrandingName() async {
+        ServerIdentityStubProtocol.configure([
+            "/api/v1/theme/branding": (200, #"{"server_name":"  Home Silo  "}"#),
+            "/api/v1/health": (200, #"{"status":"ok","server_name":"StreamApp"}"#),
+        ])
+
+        let name = await resolver().fetchServerName(serverURL: "https://silo.example")
+
+        XCTAssertEqual(name, "Home Silo")
+        XCTAssertEqual(ServerIdentityStubProtocol.requestedPaths(), ["/api/v1/theme/branding"])
+    }
+
+    func testFallsBackToHealthForOlderServer() async {
+        ServerIdentityStubProtocol.configure([
+            "/api/v1/theme/branding": (404, #"{"error":"not_found"}"#),
+            "/api/v1/health": (200, #"{"status":"ok","server_name":"Legacy Home"}"#),
+        ])
+
+        let name = await resolver().fetchServerName(serverURL: "https://silo.example")
+
+        XCTAssertEqual(name, "Legacy Home")
+        XCTAssertEqual(
+            ServerIdentityStubProtocol.requestedPaths(),
+            ["/api/v1/theme/branding", "/api/v1/health"]
+        )
+    }
+
+    func testBlankBrandingNameFallsBackToHealth() async {
+        ServerIdentityStubProtocol.configure([
+            "/api/v1/theme/branding": (200, #"{"server_name":"  "}"#),
+            "/api/v1/health": (200, #"{"status":"ok","server_name":"Fallback"}"#),
+        ])
+
+        let name = await resolver().fetchServerName(serverURL: "https://silo.example")
+
+        XCTAssertEqual(name, "Fallback")
+    }
+
+    private func resolver() -> ServerIdentityResolver {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ServerIdentityStubProtocol.self]
+        return ServerIdentityResolver(
+            httpClient: HTTPClient(session: URLSession(configuration: configuration))
+        )
+    }
+}
+
+private final class ServerIdentityStubProtocol: URLProtocol {
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var responses: [String: (status: Int, body: String)] = [:]
+    nonisolated(unsafe) private static var paths: [String] = []
+
+    static func configure(_ configuredResponses: [String: (status: Int, body: String)]) {
+        lock.withLock {
+            responses = configuredResponses
+            paths = []
+        }
+    }
+
+    static func requestedPaths() -> [String] {
+        lock.withLock { paths }
+    }
+
+    static func reset() {
+        lock.withLock {
+            responses = [:]
+            paths = []
+        }
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let url = request.url else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+        let response = Self.lock.withLock {
+            Self.paths.append(url.path)
+            return Self.responses[url.path] ?? (500, #"{"error":"unexpected"}"#)
+        }
+
+        guard let httpResponse = HTTPURLResponse(
+            url: url,
+            statusCode: response.status,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        ) else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        client?.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(response.body.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}

--- a/iosApp/Tests/ServerIdentityResolverTests.swift
+++ b/iosApp/Tests/ServerIdentityResolverTests.swift
@@ -45,6 +45,83 @@ final class ServerIdentityResolverTests: XCTestCase {
         XCTAssertEqual(name, "Fallback")
     }
 
+    func testBrandingFailureDoesNotFallBackToHealth() async {
+        ServerIdentityStubProtocol.configure([
+            "/api/v1/theme/branding": (500, #"{"error":"unavailable"}"#),
+            "/api/v1/health": (200, #"{"status":"ok","server_name":"Compat Name"}"#),
+        ])
+
+        let name = await resolver().fetchServerName(serverURL: "https://silo.example")
+
+        XCTAssertNil(name)
+        XCTAssertEqual(ServerIdentityStubProtocol.requestedPaths(), ["/api/v1/theme/branding"])
+    }
+
+    func testBrandingDecodeFailureDoesNotFallBackToHealth() async {
+        ServerIdentityStubProtocol.configure([
+            "/api/v1/theme/branding": (200, #"{"server_name":42}"#),
+            "/api/v1/health": (200, #"{"status":"ok","server_name":"Compat Name"}"#),
+        ])
+
+        let name = await resolver().fetchServerName(serverURL: "https://silo.example")
+
+        XCTAssertNil(name)
+        XCTAssertEqual(ServerIdentityStubProtocol.requestedPaths(), ["/api/v1/theme/branding"])
+    }
+
+    func testStaleActiveServerResponseDoesNotRenameRegistryEntries() async {
+        let previousTokenServerId = await TokenStore.shared.getActiveServerId()
+        let suiteName = "ServerIdentityResolverTests.\(UUID().uuidString)"
+        guard let suite = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create isolated defaults suite")
+            return
+        }
+        defer { suite.removePersistentDomain(forName: suiteName) }
+
+        let registry = ServerRegistry(
+            defaults: SharedDefaults(suite: suite, standard: suite),
+            keychain: SharedKeychain(service: suiteName)
+        )
+        let serverA = ServerEntry(
+            id: ServerRegistry.serverId(for: "https://a.example"),
+            url: "https://a.example",
+            fetchedName: "Server A",
+            profileId: nil,
+            lastUsedAt: .now
+        )
+        let serverB = ServerEntry(
+            id: ServerRegistry.serverId(for: "https://b.example"),
+            url: "https://b.example",
+            fetchedName: "Server B",
+            profileId: nil,
+            lastUsedAt: .now
+        )
+        registry.addOrUpdate(serverA)
+        registry.addOrUpdate(serverB)
+        await registry.switchTo(serverId: serverA.id)
+
+        ServerIdentityStubProtocol.configure([
+            "/api/v1/theme/branding": (200, #"{"server_name":"Updated A"}"#),
+        ], blockedPaths: ["/api/v1/theme/branding"])
+        defer { ServerIdentityStubProtocol.release(path: "/api/v1/theme/branding") }
+
+        let service = AuthService(
+            serverIdentityResolver: resolver(),
+            serverRegistry: registry
+        )
+        let refresh = Task { await service.refreshActiveServerName() }
+        await waitForRequest(path: "/api/v1/theme/branding")
+
+        await registry.switchTo(serverId: serverB.id)
+        ServerIdentityStubProtocol.release(path: "/api/v1/theme/branding")
+        await refresh.value
+
+        XCTAssertEqual(registry.activeServerId, serverB.id)
+        XCTAssertEqual(registry.entry(with: serverA.id)?.fetchedName, "Server A")
+        XCTAssertEqual(registry.entry(with: serverB.id)?.fetchedName, "Server B")
+        await TokenStore.shared.switchActiveServer(serverId: previousTokenServerId)
+    }
+
     private func resolver() -> ServerIdentityResolver {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [ServerIdentityStubProtocol.self]
@@ -52,17 +129,37 @@ final class ServerIdentityResolverTests: XCTestCase {
             httpClient: HTTPClient(session: URLSession(configuration: configuration))
         )
     }
+
+    private func waitForRequest(path: String) async {
+        for _ in 0..<100 {
+            if ServerIdentityStubProtocol.requestedPaths().contains(path) {
+                return
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        XCTFail("Timed out waiting for request: \(path)")
+    }
 }
 
 private final class ServerIdentityStubProtocol: URLProtocol {
     private static let lock = NSLock()
+    private static let responseCondition = NSCondition()
     nonisolated(unsafe) private static var responses: [String: (status: Int, body: String)] = [:]
     nonisolated(unsafe) private static var paths: [String] = []
+    nonisolated(unsafe) private static var blockedPaths: Set<String> = []
+    nonisolated(unsafe) private static var releasedPaths: Set<String> = []
 
-    static func configure(_ configuredResponses: [String: (status: Int, body: String)]) {
+    static func configure(
+        _ configuredResponses: [String: (status: Int, body: String)],
+        blockedPaths configuredBlockedPaths: Set<String> = []
+    ) {
         lock.withLock {
             responses = configuredResponses
             paths = []
+        }
+        responseCondition.withLock {
+            blockedPaths = configuredBlockedPaths
+            releasedPaths = []
         }
     }
 
@@ -74,6 +171,18 @@ private final class ServerIdentityStubProtocol: URLProtocol {
         lock.withLock {
             responses = [:]
             paths = []
+        }
+        responseCondition.withLock {
+            blockedPaths = []
+            releasedPaths = []
+            responseCondition.broadcast()
+        }
+    }
+
+    static func release(path: String) {
+        responseCondition.withLock {
+            releasedPaths.insert(path)
+            responseCondition.broadcast()
         }
     }
 
@@ -89,6 +198,12 @@ private final class ServerIdentityStubProtocol: URLProtocol {
         let response = Self.lock.withLock {
             Self.paths.append(url.path)
             return Self.responses[url.path] ?? (500, #"{"error":"unexpected"}"#)
+        }
+        Self.responseCondition.withLock {
+            while Self.blockedPaths.contains(url.path),
+                  !Self.releasedPaths.contains(url.path) {
+                Self.responseCondition.wait()
+            }
         }
 
         guard let httpResponse = HTTPURLResponse(

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -185,6 +185,8 @@ struct ContentView: View {
             // queued and must perform no work for the stale destination.
             guard await HTTPClient.shared.waitForRequestDispatchOpen() else { return }
             guard !Task.isCancelled else { return }
+            await AuthService.shared.refreshActiveServerName()
+            guard !Task.isCancelled else { return }
             #if os(iOS) || os(tvOS)
             diagnosticsModel.reset()
             #endif

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -185,8 +185,6 @@ struct ContentView: View {
             // queued and must perform no work for the stale destination.
             guard await HTTPClient.shared.waitForRequestDispatchOpen() else { return }
             guard !Task.isCancelled else { return }
-            await AuthService.shared.refreshActiveServerName()
-            guard !Task.isCancelled else { return }
             #if os(iOS) || os(tvOS)
             diagnosticsModel.reset()
             #endif
@@ -198,6 +196,8 @@ struct ContentView: View {
                 serverId: serverRegistry.activeServerId ?? ""
             )
             overlayPrefs.clear()
+            guard !Task.isCancelled else { return }
+            Task { await AuthService.shared.refreshActiveServerName() }
             if router.authState == .authenticated {
                 await uiCustomization.refresh()
                 await overlayPrefs.hydrateIfNeeded()

--- a/iosApp/iosApp/Control/tvOS/TVControlReceiver.swift
+++ b/iosApp/iosApp/Control/tvOS/TVControlReceiver.swift
@@ -10,6 +10,7 @@ final class TVControlReceiver {
 
     private var listener: NWListener?
     private var advertisedServerId: String?
+    private var advertisedServerName: String?
     /// Bumped whenever we intentionally cancel/replace the listener, so its
     /// state handler can tell a system-initiated failure (restart) from our
     /// own teardown (ignore).
@@ -65,7 +66,9 @@ final class TVControlReceiver {
         }
         let serverId = RemotePlaybackIdentityManager.shared.effectiveServerId ?? server.id
         let serverName = RemotePlaybackIdentityManager.shared.effectiveServerName ?? server.displayName
-        if listener != nil, advertisedServerId == serverId {
+        if listener != nil,
+           advertisedServerId == serverId,
+           advertisedServerName == serverName {
             return
         }
 
@@ -119,6 +122,7 @@ final class TVControlReceiver {
             listener.start(queue: .main)
             self.listener = listener
             advertisedServerId = serverId
+            advertisedServerName = serverName
         } catch {
             Self.logger.error("failed to start control listener: \(String(describing: error), privacy: .public)")
         }
@@ -127,6 +131,7 @@ final class TVControlReceiver {
     private func scheduleListenerRestart() {
         listener = nil
         advertisedServerId = nil
+        advertisedServerName = nil
         Task { @MainActor [weak self] in
             try? await Task.sleep(for: .seconds(2))
             guard let self, self.listener == nil, let router = self.router else { return }
@@ -157,6 +162,7 @@ final class TVControlReceiver {
         listener?.cancel()
         listener = nil
         advertisedServerId = nil
+        advertisedServerName = nil
         closeActiveSession(sendClose: false)
     }
 

--- a/iosApp/iosApp/Networking/HTTPClient.swift
+++ b/iosApp/iosApp/Networking/HTTPClient.swift
@@ -239,7 +239,8 @@ actor HTTPClient {
     /// attaching credentials from the currently active server.
     func getUnauthenticated<T: Decodable>(
         serverURL: String,
-        path: String
+        path: String,
+        quietStatuses: Set<Int> = []
     ) async throws -> T {
         let dispatchRevision = try captureRequestDispatchRevision()
         let request = try buildRequest(
@@ -254,7 +255,7 @@ actor HTTPClient {
             dispatchRevision: dispatchRevision,
             reportReachability: false
         )
-        try ensureSuccess(data, response, method: "GET")
+        try ensureSuccess(data, response, method: "GET", quietStatuses: quietStatuses)
         do {
             return try decoder.decode(T.self, from: data)
         } catch {

--- a/iosApp/iosApp/Networking/ServerIdentityResolver.swift
+++ b/iosApp/iosApp/Networking/ServerIdentityResolver.swift
@@ -3,7 +3,9 @@ import Foundation
 /// Resolves the native display name advertised by a Silo server.
 ///
 /// Branding owns the native product identity. Health remains a compatibility
-/// fallback for servers that predate the public branding endpoint.
+/// fallback when branding is blank or the endpoint returns 404, indicating a
+/// server that predates the public branding endpoint. Other failures leave the
+/// previously stored identity unchanged.
 struct ServerIdentityResolver {
     private let httpClient: HTTPClient
 
@@ -12,11 +14,19 @@ struct ServerIdentityResolver {
     }
 
     func fetchServerName(serverURL: String) async -> String? {
-        if let branding: ServerBrandingStatus = try? await httpClient.getUnauthenticated(
-            serverURL: serverURL,
-            path: "/api/v1/theme/branding"
-        ), let name = Self.usableName(branding.serverName) {
-            return name
+        do {
+            let branding: ServerBrandingStatus = try await httpClient.getUnauthenticated(
+                serverURL: serverURL,
+                path: "/api/v1/theme/branding",
+                quietStatuses: [404]
+            )
+            if let name = Self.usableName(branding.serverName) {
+                return name
+            }
+        } catch HTTPError.http(let statusCode, _) where statusCode == 404 {
+            // Older servers do not expose native branding.
+        } catch {
+            return nil
         }
 
         if let health: HealthStatus = try? await httpClient.getUnauthenticated(

--- a/iosApp/iosApp/Networking/ServerIdentityResolver.swift
+++ b/iosApp/iosApp/Networking/ServerIdentityResolver.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Resolves the native display name advertised by a Silo server.
+///
+/// Branding owns the native product identity. Health remains a compatibility
+/// fallback for servers that predate the public branding endpoint.
+struct ServerIdentityResolver {
+    private let httpClient: HTTPClient
+
+    init(httpClient: HTTPClient = .shared) {
+        self.httpClient = httpClient
+    }
+
+    func fetchServerName(serverURL: String) async -> String? {
+        if let branding: ServerBrandingStatus = try? await httpClient.getUnauthenticated(
+            serverURL: serverURL,
+            path: "/api/v1/theme/branding"
+        ), let name = Self.usableName(branding.serverName) {
+            return name
+        }
+
+        if let health: HealthStatus = try? await httpClient.getUnauthenticated(
+            serverURL: serverURL,
+            path: "/api/v1/health"
+        ) {
+            return Self.usableName(health.serverName)
+        }
+        return nil
+    }
+
+    private static func usableName(_ value: String?) -> String? {
+        guard let name = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !name.isEmpty else {
+            return nil
+        }
+        return name
+    }
+}

--- a/iosApp/iosApp/Networking/ServerRegistry.swift
+++ b/iosApp/iosApp/Networking/ServerRegistry.swift
@@ -14,8 +14,8 @@ struct ServerEntry: Codable, Identifiable, Equatable, Hashable {
     /// Normalized base URL (trailing slash stripped, whitespace trimmed).
     var url: String
 
-    /// Advertised by the server at `GET /api/v1/health` (`server_name`).
-    /// Filled on first successful connect and refreshed opportunistically.
+    /// Advertised by native branding, with a legacy health-name fallback.
+    /// Filled on first successful connect and refreshed on server activation.
     var fetchedName: String?
 
     /// Remembered profile for this server. Set after `selectProfile`.

--- a/iosApp/iosApp/Screens/Auth/AuthModels.swift
+++ b/iosApp/iosApp/Screens/Auth/AuthModels.swift
@@ -22,3 +22,11 @@ struct HealthStatus: Codable {
     let serverName: String?
     let serverId: String?
 }
+
+/// Public native identity from GET /api/v1/theme/branding.
+///
+/// The endpoint predates native multi-server clients, so only the server name
+/// is required here. Additional white-label fields remain forward-compatible.
+struct ServerBrandingStatus: Codable {
+    let serverName: String?
+}

--- a/iosApp/iosApp/Screens/Auth/AuthService.swift
+++ b/iosApp/iosApp/Screens/Auth/AuthService.swift
@@ -11,6 +11,7 @@ import Foundation
 final class AuthService: @unchecked Sendable {
     static let shared = AuthService()
     private let defaults = SharedDefaults.shared
+    private let serverIdentityResolver = ServerIdentityResolver()
 
     enum SignOutAuthorization: Equatable, Sendable {
         case allowed(account: RefreshAccountIdentity?)
@@ -77,14 +78,15 @@ final class AuthService: @unchecked Sendable {
     // MARK: - Server Check
 
     /// Probe a candidate server: set it as the active server URL,
-    /// identify it via `GET /api/v1/health`, register the entry, and
+    /// identify it via native branding (with a legacy health fallback),
+    /// register the entry, and
     /// return the setup status so the caller can decide between initial
     /// setup and login.
     ///
     /// Candidate probes use their explicit URL and no active credentials.
     /// Global registry/default/token routing changes only after setup status
-    /// succeeds. If the optional health probe fails, the display name falls
-    /// back to the URL.
+    /// succeeds. If both optional identity probes fail, the display name
+    /// falls back to the URL.
     func checkServer(url: String) async throws -> SetupStatus {
         let normalized = ServerRegistry.normalize(url: url)
         let id = ServerRegistry.serverId(for: normalized)
@@ -92,13 +94,7 @@ final class AuthService: @unchecked Sendable {
         // Probe the candidate by explicit URL without touching the active
         // defaults or credential slot. This prevents candidate discovery from
         // exposing a global A/B routing mixture to unrelated requests.
-        var fetchedName: String?
-        if let health: HealthStatus = try? await HTTPClient.shared.getUnauthenticated(
-            serverURL: normalized,
-            path: "/api/v1/health"
-        ) {
-            fetchedName = health.serverName
-        }
+        let fetchedName = await serverIdentityResolver.fetchServerName(serverURL: normalized)
 
         // Commit only after the candidate proves it can serve setup status.
         let status: SetupStatus = try await HTTPClient.shared.getUnauthenticated(
@@ -120,6 +116,19 @@ final class AuthService: @unchecked Sendable {
         }
 
         return status
+    }
+
+    /// Refreshes the active registry entry from the server's native branding.
+    /// The identity check prevents a slow response from one server renaming a
+    /// different server after the user switches destinations.
+    func refreshActiveServerName() async {
+        guard let server = ServerRegistry.shared.activeServer else { return }
+        let serverId = server.id
+        guard let name = await serverIdentityResolver.fetchServerName(serverURL: server.url),
+              ServerRegistry.shared.activeServerId == serverId else {
+            return
+        }
+        ServerRegistry.shared.updateFetchedName(for: serverId, fetchedName: name)
     }
 
     // MARK: - Authentication

--- a/iosApp/iosApp/Screens/Auth/AuthService.swift
+++ b/iosApp/iosApp/Screens/Auth/AuthService.swift
@@ -11,14 +11,21 @@ import Foundation
 final class AuthService: @unchecked Sendable {
     static let shared = AuthService()
     private let defaults = SharedDefaults.shared
-    private let serverIdentityResolver = ServerIdentityResolver()
+    private let serverIdentityResolver: ServerIdentityResolver
+    private let serverRegistry: ServerRegistry
 
     enum SignOutAuthorization: Equatable, Sendable {
         case allowed(account: RefreshAccountIdentity?)
         case refused
     }
 
-    private init() {}
+    init(
+        serverIdentityResolver: ServerIdentityResolver = ServerIdentityResolver(),
+        serverRegistry: ServerRegistry = .shared
+    ) {
+        self.serverIdentityResolver = serverIdentityResolver
+        self.serverRegistry = serverRegistry
+    }
 
     // MARK: - Stored State Accessors
 
@@ -122,13 +129,13 @@ final class AuthService: @unchecked Sendable {
     /// The identity check prevents a slow response from one server renaming a
     /// different server after the user switches destinations.
     func refreshActiveServerName() async {
-        guard let server = ServerRegistry.shared.activeServer else { return }
+        guard let server = serverRegistry.activeServer else { return }
         let serverId = server.id
         guard let name = await serverIdentityResolver.fetchServerName(serverURL: server.url),
-              ServerRegistry.shared.activeServerId == serverId else {
+              serverRegistry.activeServerId == serverId else {
             return
         }
-        ServerRegistry.shared.updateFetchedName(for: serverId, fetchedName: name)
+        serverRegistry.updateFetchedName(for: serverId, fetchedName: name)
     }
 
     // MARK: - Authentication

--- a/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
@@ -267,6 +267,9 @@ struct TVMainTabView: View {
         .onChange(of: ServerRegistry.shared.activeServerId) {
             controlReceiver.start(router: router)
         }
+        .onChange(of: ServerRegistry.shared.activeServer?.displayName) {
+            controlReceiver.start(router: router)
+        }
         .onChange(of: scenePhase) { _, newPhase in
             // Returning from a suspension can leave the Bonjour listener dead
             // (its state handler nils it out); restart so phones can still


### PR DESCRIPTION
## Problem

The Apple client saves and displays `GET /api/v1/health.server_name`. That field is currently backed by the Jellyfin compatibility setting, so an iOS or tvOS client can show “StreamApp” even when Jellyfin compatibility is disabled.

Fixes #125.
Related to Silo-Server/silo-server#553.

## Approach

- Resolve native server identity from the public `GET /api/v1/theme/branding` endpoint.
- Fall back to `GET /api/v1/health` for older servers.
- Refresh saved names when the active server changes, with an identity guard so a delayed response cannot rename a different server.
- Preserve the existing URL fallback when neither endpoint returns a usable name.

## Validation

- `xcodegen generate`
- iOS simulator: `ServerIdentityResolverTests` — 3 tests passed
- tvOS simulator: `SiloTV` build succeeded
- Reviewed the shared SwiftUI boundary with the repository's SwiftUI guidance; no view-level changes were needed.

## Risk

Low. Both identity requests are public, best-effort reads. Existing servers remain compatible through the health fallback, and failures retain the existing URL display name.

## AI use

Implemented and validated with Codex on behalf of the repository maintainer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server names now load from native branding information when available.
  * Older servers continue to display their name through a health-check fallback.
  * Active server names refresh automatically when switching or reactivating servers.
  * TV controls now update when the active server’s display name changes.

* **Bug Fixes**
  * Improved handling of blank, unavailable, or outdated server-name responses.
  * Prevented stale responses from overwriting the currently active server’s name.
  * Reduced unnecessary logging for expected unavailable-server responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->