### PR TITLE
fix(diagnostics): store diagnostics under Caches on tvOS

### DIFF
--- a/iosApp/Tests/DiagnosticsStorageRootTests.swift
+++ b/iosApp/Tests/DiagnosticsStorageRootTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import Silo
+
+final class DiagnosticsStorageRootTests: XCTestCase {
+    func testBaseDirectoryMatchesPlatformStorageDirectory() {
+        let fileManager = FileManager.default
+#if os(tvOS)
+        let platformDirectory = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first
+#else
+        let platformDirectory = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+#endif
+        let expected = platformDirectory
+            ?? URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+
+        XCTAssertEqual(DiagnosticsStorageRoot.baseDirectory(fileManager: fileManager), expected)
+    }
+}

--- a/iosApp/iosApp/Shared/Diagnostics/DiagnosticsStorageRoot.swift
+++ b/iosApp/iosApp/Shared/Diagnostics/DiagnosticsStorageRoot.swift
@@ -1,0 +1,17 @@
+#if os(iOS) || os(tvOS)
+import Foundation
+
+/// tvOS devices only permit writes under Caches; the simulator does not enforce
+/// this constraint, so simulator testing cannot catch storage-root regressions.
+enum DiagnosticsStorageRoot {
+    static func baseDirectory(fileManager: FileManager) -> URL {
+#if os(tvOS)
+        let searchPathDirectory: FileManager.SearchPathDirectory = .cachesDirectory
+#else
+        let searchPathDirectory: FileManager.SearchPathDirectory = .applicationSupportDirectory
+#endif
+        return fileManager.urls(for: searchPathDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+    }
+}
+#endif

--- a/iosApp/iosApp/Shared/Diagnostics/ExitSentinel.swift
+++ b/iosApp/iosApp/Shared/Diagnostics/ExitSentinel.swift
@@ -204,9 +204,7 @@ final class ExitSentinel {
     }
 
     init(markerURL: URL? = nil, fileManager: FileManager = .default) {
-        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
-            ?? URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
-        let resolvedMarkerURL = markerURL ?? appSupport
+        let resolvedMarkerURL = markerURL ?? DiagnosticsStorageRoot.baseDirectory(fileManager: fileManager)
             .appendingPathComponent("Diagnostics", isDirectory: true)
             .appendingPathComponent("exit-sentinel.json", isDirectory: false)
         self.store = ExitSentinelMarkerStore(currentURL: resolvedMarkerURL, fileManager: fileManager)

--- a/iosApp/iosApp/Shared/Diagnostics/Logging/BreadcrumbJournal.swift
+++ b/iosApp/iosApp/Shared/Diagnostics/Logging/BreadcrumbJournal.swift
@@ -215,9 +215,7 @@ final class BreadcrumbJournal {
     }
 
     private static func defaultDirectory(fileManager: FileManager) -> URL {
-        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
-            ?? URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
-        return appSupport
+        DiagnosticsStorageRoot.baseDirectory(fileManager: fileManager)
             .appendingPathComponent("Diagnostics", isDirectory: true)
             .appendingPathComponent("breadcrumbs", isDirectory: true)
     }

--- a/iosApp/iosApp/Shared/Diagnostics/PendingReportStore.swift
+++ b/iosApp/iosApp/Shared/Diagnostics/PendingReportStore.swift
@@ -218,9 +218,8 @@ final class PendingReportStore {
 
     init(rootDirectory: URL? = nil, fileManager: FileManager = .default) {
         self.fileManager = fileManager
-        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
-            ?? URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
-        self.rootDirectory = rootDirectory ?? appSupport.appendingPathComponent("Diagnostics", isDirectory: true)
+        self.rootDirectory = rootDirectory ?? DiagnosticsStorageRoot.baseDirectory(fileManager: fileManager)
+            .appendingPathComponent("Diagnostics", isDirectory: true)
     }
 
     var pendingDirectory: URL {


### PR DESCRIPTION
## Problem

A user reported that **Send Diagnostics Now** on the tvOS app always fails with *"The report could not be created. Please try again."* even though Status shows Available.

Root cause: on physical Apple TV hardware, tvOS sandboxing forbids writes under `Library/Application Support` — only `Library/Caches` (and tmp) are writable. Three diagnostics components rooted their on-disk storage in Application Support:

- `PendingReportStore` — pending report persistence; the first write (`ensureDirectory`) throws, so `createManualReport()` always fails → the user-visible error.
- `ExitSentinel` (tvOS-only) — the abnormal-exit marker could never be written, so crash/abnormal-exit detection never fired on device.
- `BreadcrumbJournal` — breadcrumb segments never persisted.

The tvOS **simulator does not enforce this restriction**, which is why the feature validated clean in simulator testing and only broke for real users.

## Fix

New shared `DiagnosticsStorageRoot.baseDirectory(fileManager:)` helper picks `.cachesDirectory` on tvOS and keeps `.applicationSupportDirectory` on iOS (where crash evidence should survive cache purges). All three components route through it; subpaths (`Diagnostics/`, `Diagnostics/breadcrumbs`, `Diagnostics/exit-sentinel.json`) and the injected-URL test seams are unchanged.

Caches' eviction semantics are an acceptable trade-off on tvOS — it's the only writable persistent location, and the store is already purge-tolerant (7-day expiry, 3-report cap per binding, backup-excluded). No migration: nothing on a tvOS device ever successfully wrote to the old path; the iOS path is unchanged.

## Validation

- `xcodegen generate` clean
- tvOS build (`SiloTV`, tvOS simulator): **succeeded**
- iOS build (`Silo`, iPhone 17 Pro simulator): **succeeded**
- Focused tests (`DiagnosticsStorageRootTests`, `PendingReportStoreTests`, `BreadcrumbJournalTests`): **12 passed, 0 failed**
- Not yet validated on physical Apple TV hardware — needs an on-device pass to confirm the end-to-end send succeeds.

## AI disclosure

Implementation drafted by OpenAI Codex (gpt-5.6-sol) from a brief; reviewed, verified, and committed by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics storage location handling across iOS and tvOS.
  * Diagnostics data now uses the appropriate platform storage directory, with a temporary-directory fallback when needed.
  * Updated exit markers, breadcrumb logs, and pending reports to use the consistent storage location.

* **Tests**
  * Added coverage verifying diagnostics storage paths on supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->