### PR TITLE
Improve iPad detail layouts and selectors

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -1187,7 +1187,7 @@ struct MainTabView: View {
         NavigationSplitView(columnVisibility: $columnVisibility) {
             List(selection: Binding<MainTabDestinationID?>(
                 get: { selectedDestinationID },
-                set: { if let value = $0 { selectedDestinationID = value } }
+                set: { if let value = $0 { selectSidebarDestination(value) } }
             )) {
                 ForEach(visibleDestinations) { destination in
                     Label(
@@ -1223,6 +1223,14 @@ struct MainTabView: View {
         withAnimation(.easeInOut(duration: 0.25)) {
             columnVisibility = columnVisibility == .detailOnly ? .all : .detailOnly
         }
+    }
+
+    /// Sidebar rows are root destinations, even when the same row is already
+    /// selected beneath a pushed screen. Clear the detail stack first so, for
+    /// example, tapping Home while Search is open actually returns to Home.
+    private func selectSidebarDestination(_ destinationID: MainTabDestinationID) {
+        router.popToRoot()
+        selectedDestinationID = destinationID
     }
 
     @ViewBuilder

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -1200,6 +1200,7 @@ struct MainTabView: View {
                 }
             }
             .navigationTitle("Silo")
+            .navigationSplitViewColumnWidth(min: 240, ideal: 260, max: 280)
         } detail: {
             NavigationStack(path: $router.path) {
                 destinationContent(for: selectedDestination)

--- a/iosApp/iosApp/Screens/Detail/ItemDetailView.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailView.swift
@@ -284,6 +284,7 @@ private struct ItemDetailPhoneContent: View {
                 seasons: viewModel.seasons,
                 selectedSeason: viewModel.selectedSeason,
                 episodes: viewModel.episodes,
+                episodesBySeason: viewModel.episodesBySeason,
                 isLoadingEpisodes: viewModel.isLoadingEpisodes,
                 selectedNextUpFileId: preferredNextUpFileId,
                 selectedNextUpAudioTrackIndex: preferredNextUpAudioTrackIndex,
@@ -389,6 +390,7 @@ private struct ItemDetailPhoneContent: View {
                 seasons: viewModel.seasons,
                 selectedSeason: viewModel.selectedSeason,
                 episodes: viewModel.episodes,
+                episodesBySeason: viewModel.episodesBySeason,
                 isLoadingEpisodes: viewModel.isLoadingEpisodes,
                 selectedNextUpFileId: preferredNextUpFileId,
                 selectedNextUpAudioTrackIndex: preferredNextUpAudioTrackIndex,
@@ -497,7 +499,10 @@ private struct ItemDetailPhoneContent: View {
                 seasons: viewModel.seasons,
                 selectedSeason: viewModel.selectedSeason,
                 seasonEpisodes: viewModel.episodes,
+                seasonEpisodesBySeason: viewModel.episodesBySeason,
                 isLoadingEpisodes: viewModel.isLoadingEpisodes,
+                episodeSeriesPosterUrl: viewModel.episodeSeriesPosterUrl,
+                episodeSeriesPosterThumbhash: viewModel.episodeSeriesPosterThumbhash,
                 onPlay: { startFromBeginning in
                     let resumePosition = startFromBeginning ? nil : playableResumePosition(for: detail)
                     if let fileId = playbackFileId(for: detail) {
@@ -559,8 +564,7 @@ private struct ItemDetailPhoneContent: View {
                     )
                 },
                 onSelectSeason: { season in
-                    guard season.id != detail.contentId else { return }
-                    router.navigate(to: .itemDetail(contentId: season.contentId))
+                    Task { await viewModel.selectSeason(season) }
                 },
                 onToggleFavorite: { Task { await viewModel.toggleFavorite() } },
                 onToggleWatchlist: { Task { await viewModel.toggleWatchlist() } },

--- a/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
@@ -15,6 +15,15 @@ class ItemDetailViewModel {
     var seasons: [Season] = []
     var selectedSeason: Season?
     var episodes: [EpisodeListItem] = []
+    /// Parent-series portrait artwork used only when an episode's season has
+    /// no poster of its own. Episode artwork is normally a landscape still,
+    /// so it must not be stretched into the iPad hero's portrait slot.
+    var episodeSeriesPosterUrl: String?
+    var episodeSeriesPosterThumbhash: String?
+    /// Route-scoped pages already loaded while browsing seasons. This keeps
+    /// chip taps and iPad page swipes instant when the user comes back to a
+    /// season, while `ResponseCache` remains the longer-lived cold-start tier.
+    var episodesBySeason: [Int: [EpisodeListItem]] = [:]
     var episodeFavoriteStates: [String: Bool] = [:]
     var isLoadingEpisodes = false
 
@@ -22,6 +31,12 @@ class ItemDetailViewModel {
     /// finish after the user has already changed an episode's state.
     private var episodeFavoriteMutationVersions: [String: Int] = [:]
     private var episodeFavoriteRefreshGeneration = 0
+    /// Cancels publication from an older season request after the user has
+    /// already moved to another page.
+    private var episodeLoadGeneration = 0
+    /// Season whose episodes are actually painted. Used to roll back an
+    /// optimistic chip/page selection if its request fails.
+    private var loadedSeasonNumber: Int?
 
     /// Bumped by every writer of `detail` + `CacheKey.itemDetail`, so a load
     /// that started earlier but finishes later cannot publish over a newer
@@ -66,6 +81,11 @@ class ItemDetailViewModel {
     ///   the user — under focus, on tvOS. Entry loads and the player-dismiss
     ///   reload leave it false: there, re-picking the season is the point.
     func loadDetail(contentId: String, preserveSeasonSelection: Bool = false) async {
+        if detail?.contentId != contentId {
+            episodeSeriesPosterUrl = nil
+            episodeSeriesPosterThumbhash = nil
+        }
+
         // Stage 1 — hydrate from cache synchronously so the view paints
         // the last-known detail immediately. Anything missing (e.g.
         // first-ever visit) leaves the corresponding fields nil and the
@@ -202,10 +222,35 @@ class ItemDetailViewModel {
             // detail page can render the horizontal episode rail with
             // the current episode highlighted + scrolled into view.
             seriesContentId = seriesId
-            await loadEpisodes(seriesId: seriesId, seasonNumber: seasonNumber)
+            async let episodeLoad: Void = loadEpisodes(
+                seriesId: seriesId,
+                seasonNumber: seasonNumber
+            )
             await loadSeasons(seriesId: seriesId, autoSelectInitial: false)
             selectedSeason = seasons.first(where: { $0.seasonNumber == seasonNumber })
+            // Resolve the season first so its more-specific poster paints
+            // immediately. The series detail is an optional fallback only.
+            await loadEpisodeSeriesArtwork(seriesId: seriesId)
+            await episodeLoad
         }
+    }
+
+    private func loadEpisodeSeriesArtwork(seriesId: String) async {
+        let seriesDetail: ItemDetail
+        if let cached: ItemDetail = ResponseCache.shared.get(CacheKey.itemDetail(seriesId)) {
+            seriesDetail = cached
+        } else {
+            do {
+                seriesDetail = try await ContinuumAPI.shared.itemDetail(contentId: seriesId)
+                ResponseCache.shared.set(seriesDetail, for: CacheKey.itemDetail(seriesId))
+            } catch {
+                return
+            }
+        }
+
+        guard detail?.type == "episode", detail?.seriesId == seriesId else { return }
+        episodeSeriesPosterUrl = seriesDetail.posterUrl
+        episodeSeriesPosterThumbhash = seriesDetail.posterThumbhash
     }
 
     /// Adopt a detail payload the caller already has in hand, taking the
@@ -274,7 +319,10 @@ class ItemDetailViewModel {
            let cached: EpisodesResponse = ResponseCache.shared.get(
                CacheKey.itemEpisodes(seriesId: seriesId, seasonNumber: seasonNumber)
            ) {
-            episodes = cached.episodes.sorted(by: { $0.episodeNumber < $1.episodeNumber })
+            let sorted = cached.episodes.sorted(by: { $0.episodeNumber < $1.episodeNumber })
+            episodes = sorted
+            episodesBySeason[seasonNumber] = sorted
+            loadedSeasonNumber = seasonNumber
         }
     }
 
@@ -469,7 +517,7 @@ class ItemDetailViewModel {
             ResponseCache.shared.set(response, for: CacheKey.itemSeasons(seriesId))
             seasons = response.seasons.sortedForDisplay()
             if autoSelectInitial, let target = preferredInitialSeason(seasons: seasons) {
-                await selectSeason(target)
+                await selectSeason(target, forceRefresh: true)
             }
         } catch {
             // Seasons loading failure is non-fatal — keep whatever
@@ -498,40 +546,93 @@ class ItemDetailViewModel {
         return seasons.first
     }
 
-    func selectSeason(_ season: Season) async {
+    func selectSeason(_ season: Season, forceRefresh: Bool = false) async {
+        let fallbackSeasonNumber = loadedSeasonNumber ?? selectedSeason?.seasonNumber
         selectedSeason = season
         guard let seriesId = seriesContentId else { return }
-        await loadEpisodes(seriesId: seriesId, seasonNumber: season.seasonNumber)
+
+        if !forceRefresh, let cached = episodesBySeason[season.seasonNumber] {
+            // Invalidate any older in-flight request before publishing the
+            // cached page. Otherwise it could finish later and replace this
+            // selection with stale content.
+            episodeLoadGeneration += 1
+            episodes = cached
+            loadedSeasonNumber = season.seasonNumber
+            isLoadingEpisodes = false
+            return
+        }
+
+        await loadEpisodes(
+            seriesId: seriesId,
+            seasonNumber: season.seasonNumber,
+            fallbackSeasonNumber: fallbackSeasonNumber
+        )
     }
 
     func loadEpisodes(
         seriesId: String,
         seasonNumber: Int,
-        refreshFavoriteStates: Bool = true
+        refreshFavoriteStates: Bool = true,
+        fallbackSeasonNumber: Int? = nil
     ) async {
+        episodeLoadGeneration += 1
+        let generation = episodeLoadGeneration
         let key = CacheKey.itemEpisodes(seriesId: seriesId, seasonNumber: seasonNumber)
-        // Hydrate from cache so the rail paints immediately, then
-        // refresh silently in the background.
-        if episodes.isEmpty,
+
+        // Hydrate this page from either route memory or ResponseCache, then
+        // refresh silently. Never leave the previous season's rows under a
+        // newly-selected chip.
+        var cachedEpisodes = episodesBySeason[seasonNumber]
+        if cachedEpisodes == nil,
            let cached: EpisodesResponse = ResponseCache.shared.get(key) {
-            episodes = cached.episodes.sorted(by: { $0.episodeNumber < $1.episodeNumber })
+            let sorted = cached.episodes.sorted(by: { $0.episodeNumber < $1.episodeNumber })
+            episodesBySeason[seasonNumber] = sorted
+            cachedEpisodes = sorted
         }
-        if episodes.isEmpty {
+
+        let shouldPublish = selectedSeason == nil || selectedSeason?.seasonNumber == seasonNumber
+        if shouldPublish, let cachedEpisodes {
+            episodes = cachedEpisodes
+            loadedSeasonNumber = seasonNumber
+        } else if shouldPublish {
+            episodes = []
             isLoadingEpisodes = true
         }
+
         do {
             let response: EpisodesResponse = try await ContinuumAPI.shared.get(
                 "/api/v1/catalog/series/\(seriesId)/seasons/\(seasonNumber)/episodes"
             )
             ResponseCache.shared.set(response, for: key)
-            episodes = response.episodes.sorted(by: { $0.episodeNumber < $1.episodeNumber })
+            let sorted = response.episodes.sorted(by: { $0.episodeNumber < $1.episodeNumber })
+            guard generation == episodeLoadGeneration else { return }
+            episodesBySeason[seasonNumber] = sorted
+            if selectedSeason == nil || selectedSeason?.seasonNumber == seasonNumber {
+                episodes = sorted
+                loadedSeasonNumber = seasonNumber
+                isLoadingEpisodes = false
+            }
         } catch {
-            // Episode loading failure is non-fatal — keep whatever
-            // we hydrated from cache.
+            guard generation == episodeLoadGeneration else { return }
+            if selectedSeason == nil || selectedSeason?.seasonNumber == seasonNumber {
+                if cachedEpisodes == nil,
+                   let fallbackSeasonNumber,
+                   let fallbackEpisodes = episodesBySeason[fallbackSeasonNumber],
+                   let fallbackSeason = seasons.first(where: {
+                       $0.seasonNumber == fallbackSeasonNumber
+                   }) {
+                    selectedSeason = fallbackSeason
+                    episodes = fallbackEpisodes
+                    loadedSeasonNumber = fallbackSeasonNumber
+                }
+                isLoadingEpisodes = false
+            }
         }
-        isLoadingEpisodes = false
-        if refreshFavoriteStates {
-            await refreshEpisodeFavoriteStates(for: episodes)
+
+        if refreshFavoriteStates,
+           generation == episodeLoadGeneration,
+           (selectedSeason?.seasonNumber == seasonNumber || selectedSeason == nil) {
+            await refreshEpisodeFavoriteStates(for: episodesBySeason[seasonNumber] ?? episodes)
         }
     }
 

--- a/iosApp/iosApp/Screens/Detail/MovieDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/MovieDetailContent.swift
@@ -20,7 +20,10 @@ struct MovieDetailContent<BelowOverview: View>: View {
     let seasons: [Season]
     let selectedSeason: Season?
     let seasonEpisodes: [EpisodeListItem]
+    let seasonEpisodesBySeason: [Int: [EpisodeListItem]]
     let isLoadingEpisodes: Bool
+    let episodeSeriesPosterUrl: String?
+    let episodeSeriesPosterThumbhash: String?
     let onPlay: (_ startFromBeginning: Bool) -> Void
     let onSelectVersion: (Int?) -> Void
     let onSelectAudioTrack: (Int?) -> Void
@@ -49,6 +52,7 @@ struct MovieDetailContent<BelowOverview: View>: View {
     /// site (which owns the view model) and rendered under the overview.
     @ViewBuilder let belowOverview: () -> BelowOverview
 
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var showResumeDialog = false
     /// Presents the DownloadActionButton's options sheet; lives here so the
     /// overflow menu can open it now that a plain tap downloads directly.
@@ -56,7 +60,7 @@ struct MovieDetailContent<BelowOverview: View>: View {
 
     var body: some View {
         ScrollView(.vertical, showsIndicators: false) {
-            VStack(alignment: .leading, spacing: 32) {
+            VStack(alignment: .leading, spacing: heroToContentSpacing) {
                 hero
                 belowFold
             }
@@ -73,15 +77,20 @@ struct MovieDetailContent<BelowOverview: View>: View {
         }
     }
 
+    private var heroToContentSpacing: CGFloat {
+        horizontalSizeClass == .regular ? 16 : 32
+    }
+
     // MARK: - Hero
 
     private var hero: some View {
-        PhoneDetailHero(
+        let posterArtwork = heroPosterArtwork
+        return PhoneDetailHero(
             title: detail.title,
             seriesTitle: detail.type == "episode" ? detail.seriesTitle : nil,
             logoUrl: detail.logoUrl,
-            posterUrl: detail.posterUrl,
-            posterThumbhash: detail.posterThumbhash,
+            posterUrl: posterArtwork.url,
+            posterThumbhash: posterArtwork.thumbhash,
             backdropUrl: detail.backdropUrl,
             backdropThumbhash: detail.backdropThumbhash,
             eyebrow: detail.type == "episode" ? nil : PhoneHeroMetadata.eyebrow(from: detail),
@@ -93,6 +102,35 @@ struct MovieDetailContent<BelowOverview: View>: View {
             actions: { actionStack },
             belowOverview: belowOverview
         )
+    }
+
+    /// Episodes carry wide stills as their own artwork. The portrait slot
+    /// instead follows the episode hierarchy: its season poster, then the
+    /// parent series poster. Browsing another season below the hero does not
+    /// change this because the lookup stays anchored to `detail.seasonNumber`.
+    private var heroPosterArtwork: (url: String?, thumbhash: String?) {
+        guard detail.type == "episode" else {
+            return (detail.posterUrl, detail.posterThumbhash)
+        }
+
+        if let seasonNumber = detail.seasonNumber,
+           let season = seasons.first(where: { $0.seasonNumber == seasonNumber }),
+           let url = nonEmptyArtworkURL(season.posterUrl) {
+            return (url, season.posterThumbhash)
+        }
+
+        if let url = nonEmptyArtworkURL(episodeSeriesPosterUrl) {
+            return (url, episodeSeriesPosterThumbhash)
+        }
+
+        return (nil, nil)
+    }
+
+    private func nonEmptyArtworkURL(_ value: String?) -> String? {
+        guard let value, !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+        return value
     }
 
     /// Play, then the named secondary actions, then the playback
@@ -288,7 +326,8 @@ struct MovieDetailContent<BelowOverview: View>: View {
     // MARK: - Episode rail (episode detail page)
 
     private var showsEpisodeRail: Bool {
-        detail.type == "episode" && !seasonEpisodes.isEmpty
+        detail.type == "episode"
+            && (!seasons.isEmpty || !seasonEpisodes.isEmpty || isLoadingEpisodes)
     }
 
     @ViewBuilder
@@ -297,27 +336,16 @@ struct MovieDetailContent<BelowOverview: View>: View {
             PhoneSectionHeader(label: episodeRailEyebrow, title: "Episodes")
                 .padding(.horizontal, ContinuumTheme.safePadding)
 
-            if seasons.count > 1 {
-                PhoneSeasonChips(
-                    seasons: seasons,
-                    selected: selectedSeason,
-                    onSelect: onSelectSeason
-                )
-            }
-
-            if isLoadingEpisodes {
-                HStack {
-                    Spacer()
-                    ProgressView().tint(.continuumOnSurface).padding()
-                    Spacer()
-                }
-            } else {
-                PhoneEpisodeRail(
-                    episodes: seasonEpisodes,
-                    onSelect: onEpisodeTap,
-                    currentContentId: detail.contentId
-                )
-            }
+            PhoneSeasonEpisodeBrowser(
+                seasons: seasons,
+                selectedSeason: selectedSeason,
+                episodes: seasonEpisodes,
+                episodesBySeason: seasonEpisodesBySeason,
+                isLoadingEpisodes: isLoadingEpisodes,
+                onSelectSeason: onSelectSeason,
+                onSelectEpisode: onEpisodeTap,
+                currentContentId: detail.contentId
+            )
         }
     }
 

--- a/iosApp/iosApp/Screens/Detail/MovieDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/MovieDetailContent.swift
@@ -80,6 +80,8 @@ struct MovieDetailContent<BelowOverview: View>: View {
             title: detail.title,
             seriesTitle: detail.type == "episode" ? detail.seriesTitle : nil,
             logoUrl: detail.logoUrl,
+            posterUrl: detail.posterUrl,
+            posterThumbhash: detail.posterThumbhash,
             backdropUrl: detail.backdropUrl,
             backdropThumbhash: detail.backdropThumbhash,
             eyebrow: detail.type == "episode" ? nil : PhoneHeroMetadata.eyebrow(from: detail),

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneDetailHero.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneDetailHero.swift
@@ -98,8 +98,11 @@ struct PhoneDetailHero<Actions: View, BelowOverview: View>: View {
         }
         .padding(.horizontal, expandedHorizontalPadding)
         .padding(.top, 92)
-        .padding(.bottom, 44)
-        .frame(maxWidth: .infinity, minHeight: 620, alignment: .topLeading)
+        // The page adds its own hero-to-section spacing. A smaller trailing
+        // inset keeps the first detail section within reach on iPad without
+        // changing the more generous compact-phone composition.
+        .padding(.bottom, 24)
+        .frame(maxWidth: .infinity, minHeight: 560, alignment: .topLeading)
         .background {
             expandedBackdrop
         }

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneDetailHero.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneDetailHero.swift
@@ -1,20 +1,19 @@
 #if !os(tvOS)
 import SwiftUI
 
-/// Phone detail hero, Apple-TV-style. The backdrop occupies the upper
-/// portion of the viewport and is intentionally clean — no overlay
-/// chrome — fading softly into the background. Below the fade sits a
-/// centered editorial column (eyebrow → title → source → actions →
-/// overview → facts) on the dark surface.
+/// Adaptive iOS detail hero. Compact containers retain the phone's
+/// backdrop-first, centered editorial composition. At regular iPad detail
+/// widths, poster art and a left-aligned editorial column share a single
+/// backdrop-backed stage so actions and context stay above the fold.
 ///
-/// Why this composition: leaving the backdrop unobstructed lets the
-/// artwork breathe; centering the metadata column matches the Apple TV
-/// app's identity-first layout and gives every CTA a strong horizontal
-/// anchor (especially the full-width Play button).
+/// The breakpoint is based on this view's actual container rather than the
+/// device size class, so split view and resizable windows fall back cleanly.
 struct PhoneDetailHero<Actions: View, BelowOverview: View>: View {
     let title: String
     let seriesTitle: String?
     let logoUrl: String?
+    let posterUrl: String?
+    let posterThumbhash: String?
     let backdropUrl: String?
     let backdropThumbhash: String?
     let eyebrow: String?
@@ -32,21 +31,161 @@ struct PhoneDetailHero<Actions: View, BelowOverview: View>: View {
     @ViewBuilder let belowOverview: () -> BelowOverview
 
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @State private var availableWidth: CGFloat = 0
     @State private var showFullOverview = false
     @EnvironmentObject private var overlayStore: OverlayPrefsStore
+
+    private let expandedLayoutBreakpoint: CGFloat = 640
 
     private var backdropHeight: CGFloat {
         horizontalSizeClass == .regular ? 420 : 360
     }
 
     var body: some View {
+        Group {
+            if usesExpandedLayout {
+                expandedHero
+            } else {
+                compactHero
+            }
+        }
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.width
+        } action: { width in
+            guard abs(width - availableWidth) > 1 else { return }
+            availableWidth = width
+        }
+    }
+
+    private var usesExpandedLayout: Bool {
+        if availableWidth > 0 {
+            return availableWidth >= expandedLayoutBreakpoint
+        }
+        return horizontalSizeClass == .regular
+    }
+
+    private var compactHero: some View {
         VStack(spacing: 0) {
             backdropBlock
-            editorialColumn
-                .padding(.horizontal, ContinuumTheme.safePadding)
-                .padding(.top, 4)
-                .padding(.bottom, 8)
+            editorialColumn(
+                alignment: .center,
+                textAlignment: .center,
+                factsAlignment: .center,
+                logoHeight: compactLogoHeight
+            )
+            .padding(.horizontal, ContinuumTheme.safePadding)
+            .padding(.top, 4)
+            .padding(.bottom, 8)
         }
+    }
+
+    // MARK: - Expanded iPad hero
+
+    private var expandedHero: some View {
+        HStack(alignment: .top, spacing: expandedColumnSpacing) {
+            poster
+                .padding(.top, 8)
+
+            editorialColumn(
+                alignment: .leading,
+                textAlignment: .leading,
+                factsAlignment: .leading,
+                logoHeight: 144
+            )
+            .frame(maxWidth: 620, alignment: .leading)
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, expandedHorizontalPadding)
+        .padding(.top, 92)
+        .padding(.bottom, 44)
+        .frame(maxWidth: .infinity, minHeight: 620, alignment: .topLeading)
+        .background {
+            expandedBackdrop
+        }
+    }
+
+    @ViewBuilder
+    private var poster: some View {
+        if let posterUrl, !posterUrl.isEmpty {
+            AsyncImageView(
+                url: posterUrl,
+                thumbhash: posterThumbhash,
+                targetSize: CGSize(width: posterWidth, height: posterHeight),
+                contentMode: .fill
+            )
+            .frame(width: posterWidth, height: posterHeight)
+            .clipShape(RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius))
+            .shadow(color: .black.opacity(0.4), radius: 18, y: 10)
+            .accessibilityHidden(true)
+        }
+    }
+
+    private var expandedBackdrop: some View {
+        ZStack {
+            Group {
+                if let url = backdropUrl, !url.isEmpty {
+                    AsyncImageView(
+                        url: url,
+                        thumbhash: backdropThumbhash,
+                        contentMode: .fill
+                    )
+                } else {
+                    Color.continuumSurface
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .clipped()
+
+            Color.black.opacity(0.18)
+
+            LinearGradient(
+                stops: [
+                    .init(color: Color.continuumBackground.opacity(0.78), location: 0),
+                    .init(color: Color.continuumBackground.opacity(0.38), location: 0.48),
+                    .init(color: Color.continuumBackground.opacity(0.62), location: 1),
+                ],
+                startPoint: .leading,
+                endPoint: .trailing
+            )
+
+            LinearGradient(
+                stops: [
+                    .init(color: Color.continuumBackground.opacity(0.18), location: 0),
+                    .init(color: Color.continuumBackground.opacity(0.28), location: 0.52),
+                    .init(color: Color.continuumBackground, location: 1),
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+
+            if let overlayData, overlayStore.enabled {
+                CardOverlays(
+                    data: overlayData,
+                    prefs: overlayStore.prefs,
+                    variant: .hero
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .backgroundExtensionEffect()
+        .allowsHitTesting(false)
+    }
+
+    private var expandedHorizontalPadding: CGFloat {
+        availableWidth >= 840 ? 48 : 32
+    }
+
+    private var expandedColumnSpacing: CGFloat {
+        availableWidth >= 840 ? 36 : 28
+    }
+
+    private var posterWidth: CGFloat {
+        min(max(availableWidth * 0.25, 164), 224)
+    }
+
+    private var posterHeight: CGFloat {
+        posterWidth / ContinuumTheme.posterAspectRatio
     }
 
     // MARK: - Backdrop
@@ -109,33 +248,45 @@ struct PhoneDetailHero<Actions: View, BelowOverview: View>: View {
 
     // MARK: - Editorial column
 
-    private var editorialColumn: some View {
-        VStack(spacing: 14) {
+    private func editorialColumn(
+        alignment: HorizontalAlignment,
+        textAlignment: TextAlignment,
+        factsAlignment: HorizontalAlignment,
+        logoHeight: CGFloat
+    ) -> some View {
+        VStack(alignment: alignment, spacing: 14) {
             if let eyebrow, !eyebrow.isEmpty {
                 PhoneHeroEyebrow(text: eyebrow)
             }
-            titleBlock
-            sourceRow
+            titleBlock(textAlignment: textAlignment, logoHeight: logoHeight)
+            sourceRow(textAlignment: textAlignment)
             actions()
                 .padding(.top, 6)
             overviewBlock
             belowOverview()
-            factsRow
+            factsRow(alignment: factsAlignment)
         }
         .frame(maxWidth: .infinity)
     }
 
     @ViewBuilder
-    private var titleBlock: some View {
+    private func titleBlock(textAlignment: TextAlignment, logoHeight: CGFloat) -> some View {
         if let episodeSeriesTitle {
-            PhoneEpisodeHierarchyTitle(seriesTitle: episodeSeriesTitle, episodeTitle: title)
+            PhoneEpisodeHierarchyTitle(
+                seriesTitle: episodeSeriesTitle,
+                episodeTitle: title,
+                textAlignment: textAlignment
+            )
         } else if let logoUrl, !logoUrl.isEmpty {
             AsyncImageView(url: logoUrl, contentMode: .fit, placeholderStyle: .clear)
-                .frame(height: logoHeight)
-                .frame(maxWidth: .infinity)
+                .frame(
+                    width: textAlignment == .leading ? expandedLogoWidth : nil,
+                    height: logoHeight
+                )
+                .frame(maxWidth: .infinity, alignment: frameAlignment(for: textAlignment))
                 .accessibilityLabel(title)
         } else {
-            PhoneHeroTitle(title: title)
+            PhoneHeroTitle(title: title, textAlignment: textAlignment)
         }
     }
 
@@ -151,12 +302,12 @@ struct PhoneDetailHero<Actions: View, BelowOverview: View>: View {
     /// wordmark like "SCARY MOVIE" claimed a third of the editorial column
     /// and pushed Play toward the fold. This keeps the logo dominant without
     /// crowding out the actions it exists to introduce.
-    private var logoHeight: CGFloat {
+    private var compactLogoHeight: CGFloat {
         horizontalSizeClass == .regular ? 168 : 132
     }
 
     @ViewBuilder
-    private var sourceRow: some View {
+    private func sourceRow(textAlignment: TextAlignment) -> some View {
         if !sourceTokens.isEmpty || ratingChip != nil {
             HStack(spacing: 8) {
                 ForEach(Array(sourceTokens.enumerated()), id: \.offset) { index, token in
@@ -184,8 +335,21 @@ struct PhoneDetailHero<Actions: View, BelowOverview: View>: View {
                         .padding(.leading, 2)
                 }
             }
-            .multilineTextAlignment(.center)
+            .multilineTextAlignment(textAlignment)
+            .frame(maxWidth: .infinity, alignment: frameAlignment(for: textAlignment))
         }
+    }
+
+    private var expandedLogoWidth: CGFloat {
+        let editorialWidth = availableWidth
+            - (expandedHorizontalPadding * 2)
+            - posterWidth
+            - expandedColumnSpacing
+        return min(max(editorialWidth, 220), 360)
+    }
+
+    private func frameAlignment(for textAlignment: TextAlignment) -> Alignment {
+        textAlignment == .leading ? .leading : .center
     }
 
     // MARK: - Overview with inline MORE pill
@@ -243,9 +407,9 @@ struct PhoneDetailHero<Actions: View, BelowOverview: View>: View {
     // MARK: - Facts row
 
     @ViewBuilder
-    private var factsRow: some View {
+    private func factsRow(alignment: HorizontalAlignment) -> some View {
         if !factsLine.isEmpty {
-            FlowingFactsRow(tokens: factsLine)
+            FlowingFactsRow(tokens: factsLine, alignment: alignment)
                 .padding(.top, 4)
         }
     }
@@ -255,6 +419,7 @@ struct PhoneDetailHero<Actions: View, BelowOverview: View>: View {
 
 private struct PhoneHeroTitle: View {
     let title: String
+    let textAlignment: TextAlignment
 
     var body: some View {
         let parts = PhoneHeroMetadata.splitTitle(title)
@@ -263,7 +428,7 @@ private struct PhoneHeroTitle: View {
                 .font(.system(size: 30, weight: .heavy))
                 .foregroundColor(.continuumOnSurface)
                 .lineLimit(2)
-                .multilineTextAlignment(.center)
+                .multilineTextAlignment(textAlignment)
                 .fixedSize(horizontal: false, vertical: true)
             if let subtitle = parts.subtitle {
                 Text(subtitle.uppercased())
@@ -271,16 +436,21 @@ private struct PhoneHeroTitle: View {
                     .tracking(1.2)
                     .foregroundColor(.continuumOnSurface.opacity(0.8))
                     .lineLimit(2)
-                    .multilineTextAlignment(.center)
+                    .multilineTextAlignment(textAlignment)
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
+        .frame(
+            maxWidth: .infinity,
+            alignment: textAlignment == .leading ? .leading : .center
+        )
     }
 }
 
 private struct PhoneEpisodeHierarchyTitle: View {
     let seriesTitle: String
     let episodeTitle: String
+    let textAlignment: TextAlignment
 
     var body: some View {
         let parts = PhoneHeroMetadata.splitTitle(episodeTitle)
@@ -289,13 +459,13 @@ private struct PhoneEpisodeHierarchyTitle: View {
                 .font(.system(size: 34, weight: .heavy))
                 .foregroundColor(.continuumOnSurface)
                 .lineLimit(2)
-                .multilineTextAlignment(.center)
+                .multilineTextAlignment(textAlignment)
                 .fixedSize(horizontal: false, vertical: true)
             Text(parts.primary)
                 .font(.system(size: 22, weight: .semibold))
                 .foregroundColor(.continuumOnSurface.opacity(0.9))
                 .lineLimit(2)
-                .multilineTextAlignment(.center)
+                .multilineTextAlignment(textAlignment)
                 .fixedSize(horizontal: false, vertical: true)
             if let subtitle = parts.subtitle {
                 Text(subtitle.uppercased())
@@ -303,10 +473,14 @@ private struct PhoneEpisodeHierarchyTitle: View {
                     .tracking(1.0)
                     .foregroundColor(.continuumOnSurface.opacity(0.76))
                     .lineLimit(2)
-                    .multilineTextAlignment(.center)
+                    .multilineTextAlignment(textAlignment)
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
+        .frame(
+            maxWidth: .infinity,
+            alignment: textAlignment == .leading ? .leading : .center
+        )
     }
 }
 
@@ -337,9 +511,10 @@ private struct PhoneHeroEyebrow: View {
 /// quality-badge row beneath the overview.
 private struct FlowingFactsRow: View {
     let tokens: [PhoneHeroFactToken]
+    let alignment: HorizontalAlignment
 
     var body: some View {
-        PhoneFactsFlowLayout(spacing: 8, lineSpacing: 6, alignment: .center) {
+        PhoneFactsFlowLayout(spacing: 8, lineSpacing: 6, alignment: alignment) {
             ForEach(Array(tokens.enumerated()), id: \.offset) { index, token in
                 if index > 0,
                    case .text = token,

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeFormatting.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeFormatting.swift
@@ -1,0 +1,63 @@
+#if !os(tvOS)
+import Foundation
+
+/// Shared display formatting for the compact episode rail and expanded iPad
+/// rows. Keeping these labels in one seam prevents the two adaptive layouts
+/// from drifting as metadata rules evolve.
+enum PhoneEpisodeFormatting {
+    static func title(for episode: EpisodeListItem) -> String {
+        episode.title ?? "Episode \(episode.episodeNumber)"
+    }
+
+    static func cardNumberLabel(for episode: EpisodeListItem) -> String {
+        "EPISODE \(episode.episodeNumber)"
+    }
+
+    static func compactNumberLabel(for episode: EpisodeListItem) -> String {
+        String(format: "S%02dE%02d", episode.seasonNumber, episode.episodeNumber)
+    }
+
+    static func metadataLine(for episode: EpisodeListItem) -> String? {
+        var parts: [String] = []
+        if let airDate = DetailDateFormatting.abbreviatedDate(episode.airDate) {
+            parts.append(airDate)
+        }
+        if let runtime = episode.runtime, runtime > 0 {
+            parts.append(formatRuntime(runtime))
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: "  ·  ")
+    }
+
+    static func progressFraction(for episode: EpisodeListItem) -> Double? {
+        guard let userData = episode.userData,
+              let position = userData.positionSeconds,
+              let duration = userData.durationSeconds,
+              duration > 0,
+              position > 0,
+              position < duration
+        else { return nil }
+        return position / duration
+    }
+
+    static func accessibilityDescription(
+        for episode: EpisodeListItem,
+        isCurrent: Bool
+    ) -> String {
+        episodeRailAccessibilityLabel(
+            seasonNumber: episode.seasonNumber,
+            episodeNumber: episode.episodeNumber,
+            title: episode.title,
+            metadata: metadataLine(for: episode),
+            isCurrent: isCurrent,
+            isPlayed: episode.userData?.played == true
+        )
+    }
+
+    private static func formatRuntime(_ minutes: Int) -> String {
+        if minutes >= 60 {
+            return "\(minutes / 60)h \(minutes % 60)m"
+        }
+        return "\(minutes)m"
+    }
+}
+#endif

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeList.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeList.swift
@@ -1,0 +1,81 @@
+#if !os(tvOS)
+import SwiftUI
+
+enum PhoneEpisodeListLayout {
+    static let columnBreakpoint: CGFloat = 900
+    static let rowSpacing: CGFloat = 16
+    static let verticalPadding: CGFloat = 8
+
+    static func columnCount(for availableWidth: CGFloat) -> Int {
+        availableWidth >= columnBreakpoint ? 2 : 1
+    }
+
+    static func estimatedHeight(
+        episodeCount: Int,
+        availableWidth: CGFloat,
+        rowHeight: CGFloat
+    ) -> CGFloat {
+        guard episodeCount > 0 else { return 72 }
+        let columns = columnCount(for: availableWidth)
+        let rows = Int(ceil(Double(episodeCount) / Double(columns)))
+        return CGFloat(rows) * rowHeight
+            + CGFloat(max(0, rows - 1)) * rowSpacing
+            + verticalPadding
+    }
+}
+
+/// Expanded episode presentation for regular-width detail containers.
+/// Portrait uses one readable row per episode; wider landscape panes use two
+/// columns so the browser gains density without shrinking the copy.
+struct PhoneEpisodeList: View {
+    let episodes: [EpisodeListItem]
+    let onSelect: (String) -> Void
+    var currentContentId: String? = nil
+
+    @State private var availableWidth: CGFloat = 0
+
+    private var columnCount: Int {
+        PhoneEpisodeListLayout.columnCount(for: availableWidth)
+    }
+
+    private var rowStarts: [Int] {
+        Array(stride(from: 0, to: episodes.count, by: columnCount))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: PhoneEpisodeListLayout.rowSpacing) {
+            ForEach(rowStarts, id: \.self) { rowStart in
+                HStack(alignment: .top, spacing: 16) {
+                    ForEach(0..<columnCount, id: \.self) { column in
+                        let episodeIndex = rowStart + column
+                        if episodes.indices.contains(episodeIndex) {
+                            episodeRow(episodes[episodeIndex])
+                        } else {
+                            Color.clear
+                                .frame(maxWidth: .infinity)
+                                .accessibilityHidden(true)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, ContinuumTheme.safePadding)
+        .padding(.vertical, 4)
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.width
+        } action: { width in
+            guard abs(width - availableWidth) > 1 else { return }
+            availableWidth = width
+        }
+    }
+
+    private func episodeRow(_ episode: EpisodeListItem) -> some View {
+        PhoneEpisodeListRow(
+            episode: episode,
+            isCurrent: currentContentId == episode.contentId,
+            onSelect: { onSelect(episode.contentId) }
+        )
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+#endif

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeListRow.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeListRow.swift
@@ -1,0 +1,128 @@
+#if !os(tvOS)
+import SwiftUI
+
+/// One regular-width episode row. The entire row keeps the existing Apple
+/// behavior—opening episode detail—while exposing enough title, date,
+/// runtime, progress, and overview context to make that choice useful.
+struct PhoneEpisodeListRow: View {
+    let episode: EpisodeListItem
+    let isCurrent: Bool
+    let onSelect: () -> Void
+
+    private let thumbnailWidth: CGFloat = 168
+    private var thumbnailHeight: CGFloat { thumbnailWidth * 9 / 16 }
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack(alignment: .top, spacing: 14) {
+                thumbnail
+                metadata
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(
+            PhoneEpisodeFormatting.accessibilityDescription(
+                for: episode,
+                isCurrent: isCurrent
+            )
+        )
+    }
+
+    private var thumbnail: some View {
+        ZStack(alignment: .bottom) {
+            AsyncImageView(
+                url: episode.stillUrl ?? "",
+                thumbhash: episode.stillThumbhash,
+                targetSize: CGSize(width: thumbnailWidth, height: thumbnailHeight),
+                contentMode: .fill
+            )
+            .frame(width: thumbnailWidth, height: thumbnailHeight)
+            .clipped()
+            .accessibilityHidden(true)
+
+            if episode.userData?.played == true {
+                Color.black.opacity(0.3)
+            }
+
+            if isCurrent {
+                Text("NOW VIEWING")
+                    .font(.system(size: 9, weight: .heavy))
+                    .tracking(0.8)
+                    .foregroundStyle(.black)
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 2)
+                    .background(.white, in: Capsule())
+                    .padding(7)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            }
+
+            if episode.userData?.played == true {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundStyle(.black)
+                    .frame(width: 21, height: 21)
+                    .background(.white, in: Circle())
+                    .padding(7)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+            }
+
+            if let progress = PhoneEpisodeFormatting.progressFraction(for: episode) {
+                progressBar(fraction: progress)
+            }
+        }
+        .frame(width: thumbnailWidth, height: thumbnailHeight)
+        .clipShape(RoundedRectangle(cornerRadius: ContinuumTheme.smallCornerRadius))
+        .overlay {
+            RoundedRectangle(cornerRadius: ContinuumTheme.smallCornerRadius)
+                .stroke(isCurrent ? Color.white.opacity(0.8) : .clear, lineWidth: 2)
+        }
+    }
+
+    private var metadata: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                Text(PhoneEpisodeFormatting.compactNumberLabel(for: episode))
+                    .font(.caption.bold())
+                    .foregroundStyle(.secondary)
+
+                if let metadataLine = PhoneEpisodeFormatting.metadataLine(for: episode) {
+                    Text(metadataLine)
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                }
+            }
+
+            Text(PhoneEpisodeFormatting.title(for: episode))
+                .font(.headline)
+                .foregroundStyle(Color.continuumOnSurface)
+                .lineLimit(1)
+
+            if let overview = episode.overview, !overview.isEmpty {
+                Text(overview)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+            }
+        }
+        .padding(.vertical, 2)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func progressBar(fraction: Double) -> some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                Rectangle().fill(.black.opacity(0.6))
+                Rectangle()
+                    .fill(.white)
+                    .frame(width: proxy.size.width * CGFloat(fraction))
+            }
+        }
+        .frame(height: 3)
+    }
+}
+#endif

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodePage.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodePage.swift
@@ -1,0 +1,44 @@
+#if !os(tvOS)
+import SwiftUI
+
+/// Loading, empty, compact-rail, and expanded-list states for one season.
+struct PhoneEpisodePage: View {
+    let episodes: [EpisodeListItem]
+    let isLoading: Bool
+    let usesExpandedList: Bool
+    let onSelect: (String) -> Void
+    var currentContentId: String? = nil
+
+    var body: some View {
+        Group {
+            if isLoading, episodes.isEmpty {
+                HStack {
+                    Spacer()
+                    ProgressView()
+                        .tint(.continuumOnSurface)
+                        .padding(32)
+                    Spacer()
+                }
+            } else if episodes.isEmpty {
+                Text("No episodes available")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, ContinuumTheme.safePadding)
+                    .padding(.vertical, 12)
+            } else if usesExpandedList {
+                PhoneEpisodeList(
+                    episodes: episodes,
+                    onSelect: onSelect,
+                    currentContentId: currentContentId
+                )
+            } else {
+                PhoneEpisodeRail(
+                    episodes: episodes,
+                    onSelect: onSelect,
+                    currentContentId: currentContentId
+                )
+            }
+        }
+    }
+}
+#endif

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeRail.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeRail.swift
@@ -71,7 +71,7 @@ private struct PhoneEpisodeCard: View {
                 if captionStyle.showsTitle {
                     VStack(alignment: .leading, spacing: 4) {
                         HStack(spacing: 6) {
-                            Text(episodeNumberLabel)
+                            Text(PhoneEpisodeFormatting.cardNumberLabel(for: episode))
                                 .font(.system(size: 10, weight: .bold))
                                 .tracking(1.0)
                                 .foregroundStyle(Color.continuumOnSurface.opacity(0.55))
@@ -80,14 +80,14 @@ private struct PhoneEpisodeCard: View {
                             }
                         }
 
-                        Text(episode.title ?? "Episode \(episode.episodeNumber)")
+                        Text(PhoneEpisodeFormatting.title(for: episode))
                             .font(.system(size: 14, weight: .semibold))
                             .foregroundStyle(titleColor)
                             .lineLimit(1)
                             .multilineTextAlignment(.leading)
 
                         if captionStyle.showsMetadata {
-                            if let metadataLine = episodeMetadataLine {
+                            if let metadataLine = PhoneEpisodeFormatting.metadataLine(for: episode) {
                                 Text(metadataLine)
                                     .font(.system(size: 12, weight: .medium))
                                     .foregroundStyle(Color.continuumSecondaryText)
@@ -130,30 +130,8 @@ private struct PhoneEpisodeCard: View {
             .background(Capsule().fill(Color.white))
     }
 
-    private var episodeNumberLabel: String {
-        "EPISODE \(episode.episodeNumber)"
-    }
-
-    private var episodeMetadataLine: String? {
-        var parts: [String] = []
-        if let airDate = DetailDateFormatting.abbreviatedDate(episode.airDate) {
-            parts.append(airDate)
-        }
-        if let runtime = episode.runtime, runtime > 0 {
-            parts.append(formatRuntime(runtime))
-        }
-        return parts.isEmpty ? nil : parts.joined(separator: "  ·  ")
-    }
-
     private var accessibilityDescription: String {
-        episodeRailAccessibilityLabel(
-            seasonNumber: episode.seasonNumber,
-            episodeNumber: episode.episodeNumber,
-            title: episode.title,
-            metadata: episodeMetadataLine,
-            isCurrent: isCurrent,
-            isPlayed: episode.userData?.played == true
-        )
+        PhoneEpisodeFormatting.accessibilityDescription(for: episode, isCurrent: isCurrent)
     }
 
     private var still: some View {
@@ -229,17 +207,7 @@ private struct PhoneEpisodeCard: View {
     }
 
     private var progressFraction: Double? {
-        guard let userData = episode.userData,
-              let pos = userData.positionSeconds,
-              let dur = userData.durationSeconds,
-              dur > 0, pos > 0, pos < dur
-        else { return nil }
-        return pos / dur
-    }
-
-    private func formatRuntime(_ minutes: Int) -> String {
-        if minutes >= 60 { return "\(minutes / 60)h \(minutes % 60)m" }
-        return "\(minutes)m"
+        PhoneEpisodeFormatting.progressFraction(for: episode)
     }
 }
 #endif

--- a/iosApp/iosApp/Screens/Detail/Phone/PhonePlaybackSelectorRow.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhonePlaybackSelectorRow.swift
@@ -38,6 +38,9 @@ struct PhonePlaybackSelectorRow: View {
     let onSelectAudioTrack: (Int?) -> Void
     let onSelectSubtitleTrack: (Int?) -> Void
 
+    #if os(iOS)
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    #endif
     @State private var activeSelector: PhonePlaybackSelectorKind?
 
     private var editions: [PlaybackEditions.Edition] {
@@ -46,21 +49,47 @@ struct PhonePlaybackSelectorRow: View {
 
     var body: some View {
         if currentVersion != nil, !selectorKinds.isEmpty {
+            #if os(iOS)
+            selectorCard
+                .popover(
+                    item: $activeSelector,
+                    attachmentAnchor: .rect(.bounds),
+                    arrowEdge: .top
+                ) { kind in
+                    selectorPresentation(for: kind)
+                }
+            #else
             selectorCard
                 .sheet(item: $activeSelector) { kind in
-                    PhonePlaybackSelectorSheet(
-                        kinds: [kind],
-                        versions: versions,
-                        currentVersion: currentVersion,
-                        selectedVersionFileId: selectedVersionFileId,
-                        selectedAudioTrackIndex: selectedAudioTrackIndex,
-                        selectedSubtitleTrackIndex: selectedSubtitleTrackIndex,
-                        onSelectVersion: onSelectVersion,
-                        onSelectAudioTrack: onSelectAudioTrack,
-                        onSelectSubtitleTrack: onSelectSubtitleTrack
-                    )
+                    selectorPresentation(for: kind)
                 }
+            #endif
         }
+    }
+
+    private func selectorPresentation(
+        for kind: PhonePlaybackSelectorKind
+    ) -> PhonePlaybackSelectorSheet {
+        PhonePlaybackSelectorSheet(
+            kinds: [kind],
+            versions: versions,
+            currentVersion: currentVersion,
+            selectedVersionFileId: selectedVersionFileId,
+            selectedAudioTrackIndex: selectedAudioTrackIndex,
+            selectedSubtitleTrackIndex: selectedSubtitleTrackIndex,
+            usesPopoverLayout: usesPopoverLayout,
+            onSelectVersion: onSelectVersion,
+            onSelectAudioTrack: onSelectAudioTrack,
+            onSelectSubtitleTrack: onSelectSubtitleTrack
+        )
+    }
+
+    private var usesPopoverLayout: Bool {
+        #if os(iOS)
+        horizontalSizeClass == .regular
+        #else
+        false
+        #endif
     }
 
     /// Settings-style rows: icon and label lead, value trails, chevron last.
@@ -233,6 +262,7 @@ private struct PhonePlaybackSelectorSheet: View {
     let selectedVersionFileId: Int?
     let selectedAudioTrackIndex: Int?
     let selectedSubtitleTrackIndex: Int?
+    let usesPopoverLayout: Bool
     let onSelectVersion: (Int?) -> Void
     let onSelectAudioTrack: (Int?) -> Void
     let onSelectSubtitleTrack: (Int?) -> Void
@@ -285,6 +315,15 @@ private struct PhonePlaybackSelectorSheet: View {
                 #endif
             }
         }
+        #if os(iOS)
+        // Regular-width iPad uses this view as an anchored popover instead
+        // of forcing a phone detent into the split-view detail column.
+        .frame(
+            width: usesPopoverLayout ? 440 : nil,
+            height: usesPopoverLayout ? 480 : nil
+        )
+        .presentationCompactAdaptation(.sheet)
+        #endif
         #if !os(macOS)
         .presentationDetents([.medium, .large])
         .presentationDragIndicator(.visible)

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneSeasonChips.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneSeasonChips.swift
@@ -10,6 +10,8 @@ struct PhoneSeasonChips: View {
     let selected: Season?
     let onSelect: (Season) -> Void
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView(.horizontal, showsIndicators: false) {
@@ -22,12 +24,27 @@ struct PhoneSeasonChips: View {
                 .padding(.horizontal, ContinuumTheme.safePadding)
                 .padding(.vertical, 4)
             }
-            .onChange(of: selected?.id) { _, newId in
-                guard let newId else { return }
-                withAnimation(.easeOut(duration: ContinuumTheme.fastDuration)) {
-                    proxy.scrollTo(newId, anchor: .center)
-                }
+            .onAppear {
+                scrollToSelection(selected?.id, using: proxy, animated: false)
             }
+            .onChange(of: selected?.id) { _, newId in
+                scrollToSelection(newId, using: proxy, animated: !reduceMotion)
+            }
+        }
+    }
+
+    private func scrollToSelection(
+        _ id: String?,
+        using proxy: ScrollViewProxy,
+        animated: Bool
+    ) {
+        guard let id else { return }
+        if animated {
+            withAnimation(.easeOut(duration: ContinuumTheme.fastDuration)) {
+                proxy.scrollTo(id, anchor: .center)
+            }
+        } else {
+            proxy.scrollTo(id, anchor: .center)
         }
     }
 

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneSeasonEpisodeBrowser.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneSeasonEpisodeBrowser.swift
@@ -1,0 +1,74 @@
+#if !os(tvOS)
+import SwiftUI
+
+/// Shared season and episode browser for series, season, and episode detail.
+/// It follows the real detail-column width: compact containers retain the
+/// phone carousel, while regular-width panes use readable episode rows.
+struct PhoneSeasonEpisodeBrowser: View {
+    let seasons: [Season]
+    let selectedSeason: Season?
+    let episodes: [EpisodeListItem]
+    let episodesBySeason: [Int: [EpisodeListItem]]
+    let isLoadingEpisodes: Bool
+    let onSelectSeason: (Season) -> Void
+    let onSelectEpisode: (String) -> Void
+    var currentContentId: String? = nil
+    /// Series and episode pages browse seasons in place. A dedicated season
+    /// page instead navigates when a chip is picked, so horizontal paging is
+    /// intentionally disabled there to keep its hero identity coherent.
+    var allowsSeasonPaging = true
+
+    @State private var availableWidth: CGFloat = 0
+
+    private var usesExpandedList: Bool {
+        availableWidth >= 640
+    }
+
+    var body: some View {
+        Group {
+            if selectedSeason == nil,
+               seasons.isEmpty,
+               episodes.isEmpty,
+               !isLoadingEpisodes {
+                EmptyView()
+            } else if usesExpandedList, allowsSeasonPaging, seasons.count > 1 {
+                PhoneSeasonEpisodePager(
+                    seasons: seasons,
+                    selectedSeason: selectedSeason,
+                    episodes: episodes,
+                    episodesBySeason: episodesBySeason,
+                    isLoadingEpisodes: isLoadingEpisodes,
+                    onSelectSeason: onSelectSeason,
+                    onSelectEpisode: onSelectEpisode,
+                    currentContentId: currentContentId,
+                    availableWidth: availableWidth
+                )
+            } else {
+                VStack(alignment: .leading, spacing: 14) {
+                    if seasons.count > 1 {
+                        PhoneSeasonChips(
+                            seasons: seasons,
+                            selected: selectedSeason,
+                            onSelect: onSelectSeason
+                        )
+                    }
+
+                    PhoneEpisodePage(
+                        episodes: episodes,
+                        isLoading: isLoadingEpisodes,
+                        usesExpandedList: usesExpandedList,
+                        onSelect: onSelectEpisode,
+                        currentContentId: currentContentId
+                    )
+                }
+            }
+        }
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.width
+        } action: { width in
+            guard abs(width - availableWidth) > 1 else { return }
+            availableWidth = width
+        }
+    }
+}
+#endif

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneSeasonEpisodePager.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneSeasonEpisodePager.swift
@@ -1,0 +1,131 @@
+#if !os(tvOS)
+import SwiftUI
+
+/// Regular-width season pager. Chip taps and settled page swipes share one
+/// selection, and previously loaded pages render from the view model cache.
+struct PhoneSeasonEpisodePager: View {
+    let seasons: [Season]
+    let selectedSeason: Season?
+    let episodes: [EpisodeListItem]
+    let episodesBySeason: [Int: [EpisodeListItem]]
+    let isLoadingEpisodes: Bool
+    let onSelectSeason: (Season) -> Void
+    let onSelectEpisode: (String) -> Void
+    var currentContentId: String? = nil
+    let availableWidth: CGFloat
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @ScaledMetric(relativeTo: .body) private var estimatedRowHeight: CGFloat = 96
+    @State private var visibleSeasonId: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            PhoneSeasonChips(
+                seasons: seasons,
+                selected: selectedSeason,
+                onSelect: onSelectSeason
+            )
+
+            ScrollView(.horizontal) {
+                LazyHStack(alignment: .top, spacing: 0) {
+                    ForEach(seasons) { season in
+                        PhoneEpisodePage(
+                            episodes: episodes(for: season),
+                            isLoading: isLoading(season),
+                            usesExpandedList: true,
+                            onSelect: onSelectEpisode,
+                            currentContentId: currentContentId
+                        )
+                        // A horizontal ScrollView otherwise proposes only a
+                        // single-row height to this page when it is nested in
+                        // the detail screen's vertical ScrollView.
+                        .fixedSize(horizontal: false, vertical: true)
+                        .containerRelativeFrame(.horizontal)
+                        .id(season.id)
+                    }
+                }
+                .scrollTargetLayout()
+            }
+            .scrollIndicators(.hidden)
+            .scrollTargetBehavior(.paging)
+            .scrollPosition(id: $visibleSeasonId)
+            .frame(height: visiblePageHeight)
+            // NavigationSplitView does not reliably mask horizontally
+            // translated SwiftUI scroll content to the detail column during
+            // paging and rubber-banding. Keep adjacent season pages from
+            // appearing beneath the iPad sidebar.
+            .scrollClipDisabled(false)
+            .clipped()
+            .onAppear {
+                visibleSeasonId = selectedSeason?.id ?? seasons.first?.id
+            }
+            .onChange(of: selectedSeason?.id) { _, newId in
+                guard let newId, visibleSeasonId != newId else { return }
+                if reduceMotion {
+                    visibleSeasonId = newId
+                } else {
+                    withAnimation(.easeInOut(duration: ContinuumTheme.normalDuration)) {
+                        visibleSeasonId = newId
+                    }
+                }
+            }
+            .onScrollPhaseChange { _, newPhase in
+                guard newPhase == .idle else { return }
+                selectVisibleSeasonIfNeeded()
+            }
+        }
+    }
+
+    private func episodes(for season: Season) -> [EpisodeListItem] {
+        if let cached = episodesBySeason[season.seasonNumber] {
+            return cached
+        }
+        if selectedSeason?.id == season.id {
+            return episodes
+        }
+        return []
+    }
+
+    private func isLoading(_ season: Season) -> Bool {
+        if selectedSeason?.id == season.id {
+            return isLoadingEpisodes
+        }
+        return episodesBySeason[season.seasonNumber] == nil
+    }
+
+    private var visiblePageHeight: CGFloat {
+        guard let season = visibleSeason else { return 72 }
+        return PhoneEpisodeListLayout.estimatedHeight(
+            episodeCount: episodeCount(for: season),
+            availableWidth: availableWidth,
+            rowHeight: estimatedRowHeight
+        )
+    }
+
+    private var visibleSeason: Season? {
+        if let visibleSeasonId,
+           let season = seasons.first(where: { $0.id == visibleSeasonId }) {
+            return season
+        }
+        return selectedSeason ?? seasons.first
+    }
+
+    private func episodeCount(for season: Season) -> Int {
+        if let cached = episodesBySeason[season.seasonNumber] {
+            return cached.count
+        }
+        if selectedSeason?.id == season.id, !episodes.isEmpty {
+            return episodes.count
+        }
+        return season.episodeCount
+    }
+
+    private func selectVisibleSeasonIfNeeded() {
+        guard let visibleSeasonId,
+              visibleSeasonId != selectedSeason?.id,
+              let season = seasons.first(where: { $0.id == visibleSeasonId })
+        else { return }
+        onSelectSeason(season)
+    }
+}
+#endif

--- a/iosApp/iosApp/Screens/Detail/SeasonDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/SeasonDetailContent.swift
@@ -17,6 +17,7 @@ struct SeasonDetailContent<BelowOverview: View>: View {
     let seasons: [Season]
     let selectedSeason: Season?
     let episodes: [EpisodeListItem]
+    let episodesBySeason: [Int: [EpisodeListItem]]
     let isLoadingEpisodes: Bool
     let selectedNextUpFileId: Int?
     let selectedNextUpAudioTrackIndex: Int?
@@ -37,11 +38,12 @@ struct SeasonDetailContent<BelowOverview: View>: View {
     /// site (which owns the view model) and rendered under the overview.
     @ViewBuilder let belowOverview: () -> BelowOverview
 
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var showResumeDialog = false
 
     var body: some View {
         ScrollView(.vertical, showsIndicators: false) {
-            VStack(alignment: .leading, spacing: 32) {
+            VStack(alignment: .leading, spacing: heroToContentSpacing) {
                 hero
                 belowFold
             }
@@ -58,6 +60,10 @@ struct SeasonDetailContent<BelowOverview: View>: View {
             guard let nextUp = nextUpEpisode else { return }
             onPlayEpisode(nextUp.contentId, selectedNextUpFileId, true)
         }
+    }
+
+    private var heroToContentSpacing: CGFloat {
+        horizontalSizeClass == .regular ? 16 : 32
     }
 
     // MARK: - Hero
@@ -227,31 +233,16 @@ struct SeasonDetailContent<BelowOverview: View>: View {
             PhoneSectionHeader(label: "This Season", title: "Episodes")
                 .padding(.horizontal, ContinuumTheme.safePadding)
 
-            if seasons.count > 1 {
-                PhoneSeasonChips(
-                    seasons: seasons,
-                    selected: selectedSeason,
-                    onSelect: onSelectSeason
-                )
-            }
-
-            if isLoadingEpisodes {
-                HStack {
-                    Spacer()
-                    ProgressView().tint(.continuumOnSurface).padding()
-                    Spacer()
-                }
-            } else if episodes.isEmpty {
-                Text("No episodes available")
-                    .font(.continuumCaption)
-                    .foregroundColor(.continuumSecondaryText)
-                    .padding(.horizontal, ContinuumTheme.safePadding)
-            } else {
-                PhoneEpisodeRail(
-                    episodes: episodes,
-                    onSelect: onEpisodeTap
-                )
-            }
+            PhoneSeasonEpisodeBrowser(
+                seasons: seasons,
+                selectedSeason: selectedSeason,
+                episodes: episodes,
+                episodesBySeason: episodesBySeason,
+                isLoadingEpisodes: isLoadingEpisodes,
+                onSelectSeason: onSelectSeason,
+                onSelectEpisode: onEpisodeTap,
+                allowsSeasonPaging: false
+            )
         }
     }
 

--- a/iosApp/iosApp/Screens/Detail/SeasonDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/SeasonDetailContent.swift
@@ -67,6 +67,8 @@ struct SeasonDetailContent<BelowOverview: View>: View {
             title: detail.title,
             seriesTitle: nil,
             logoUrl: nil,
+            posterUrl: detail.posterUrl,
+            posterThumbhash: detail.posterThumbhash,
             backdropUrl: detail.backdropUrl,
             backdropThumbhash: detail.backdropThumbhash,
             eyebrow: detail.seriesTitle,

--- a/iosApp/iosApp/Screens/Detail/SeriesDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/SeriesDetailContent.swift
@@ -79,6 +79,8 @@ struct SeriesDetailContent<BelowOverview: View>: View {
             title: detail.title,
             seriesTitle: nil,
             logoUrl: detail.logoUrl,
+            posterUrl: detail.posterUrl,
+            posterThumbhash: detail.posterThumbhash,
             backdropUrl: detail.backdropUrl,
             backdropThumbhash: detail.backdropThumbhash,
             eyebrow: PhoneHeroMetadata.eyebrow(from: detail),

--- a/iosApp/iosApp/Screens/Detail/SeriesDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/SeriesDetailContent.swift
@@ -15,6 +15,7 @@ struct SeriesDetailContent<BelowOverview: View>: View {
     let seasons: [Season]
     let selectedSeason: Season?
     let episodes: [EpisodeListItem]
+    let episodesBySeason: [Int: [EpisodeListItem]]
     let isLoadingEpisodes: Bool
     let selectedNextUpFileId: Int?
     let selectedNextUpAudioTrackIndex: Int?
@@ -49,11 +50,12 @@ struct SeriesDetailContent<BelowOverview: View>: View {
     /// site (which owns the view model) and rendered under the overview.
     @ViewBuilder let belowOverview: () -> BelowOverview
 
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var showResumeDialog = false
 
     var body: some View {
         ScrollView(.vertical, showsIndicators: false) {
-            VStack(alignment: .leading, spacing: 32) {
+            VStack(alignment: .leading, spacing: heroToContentSpacing) {
                 hero
                 belowFold
             }
@@ -70,6 +72,10 @@ struct SeriesDetailContent<BelowOverview: View>: View {
             guard let nextUp = nextUpEpisode else { return }
             onPlayEpisode(nextUp.contentId, selectedFileId(for: nextUp), true)
         }
+    }
+
+    private var heroToContentSpacing: CGFloat {
+        horizontalSizeClass == .regular ? 16 : 32
     }
 
     // MARK: - Hero
@@ -312,44 +318,21 @@ struct SeriesDetailContent<BelowOverview: View>: View {
             )
             .padding(.horizontal, ContinuumTheme.safePadding)
 
-            if seasons.count > 1 {
-                PhoneSeasonChips(
-                    seasons: seasons,
-                    selected: selectedSeason,
-                    onSelect: onSelectSeason
-                )
-            }
-
-            episodeBody
+            PhoneSeasonEpisodeBrowser(
+                seasons: seasons,
+                selectedSeason: selectedSeason,
+                episodes: episodes,
+                episodesBySeason: episodesBySeason,
+                isLoadingEpisodes: isLoadingEpisodes,
+                onSelectSeason: onSelectSeason,
+                onSelectEpisode: onEpisodeTap
+            )
         }
     }
 
     private var episodeCountSubtitle: String? {
         guard let count = selectedSeason?.episodeCount, count > 0 else { return nil }
         return "\(count) episode\(count == 1 ? "" : "s")"
-    }
-
-    @ViewBuilder
-    private var episodeBody: some View {
-        if selectedSeason == nil && seasons.isEmpty {
-            EmptyView()
-        } else if isLoadingEpisodes {
-            HStack {
-                Spacer()
-                ProgressView().tint(.continuumOnSurface).padding()
-                Spacer()
-            }
-        } else if episodes.isEmpty {
-            Text("No episodes available")
-                .font(.continuumCaption)
-                .foregroundColor(.continuumSecondaryText)
-                .padding(.horizontal, ContinuumTheme.safePadding)
-        } else {
-            PhoneEpisodeRail(
-                episodes: episodes,
-                onSelect: onEpisodeTap
-            )
-        }
     }
 
     // MARK: - Cast


### PR DESCRIPTION
## Summary

- adapt movie, series, season, and episode detail layouts for regular-width iPad screens
- add an in-place season browser with readable episode rows, page swiping, cached season data, and clipping at the detail-column boundary
- tighten hero-to-content spacing and use season or series portrait artwork for episode heroes
- make sidebar root selections dismiss pushed Search and detail screens
- present Edition, Version, Audio, and Subtitles as anchored iPad popovers while retaining sheets on compact iPhone layouts

## Why

The phone-oriented detail layout left excessive vertical space on iPad, showed narrow episode cards, allowed adjacent season pages to appear beneath the sidebar, and presented playback choices in an awkward partial sheet. Episode stills were also being placed in a portrait poster slot.

## Validation

- built, signed, installed, and launched on an iPad Pro 13-inch (M5) simulator running iOS 26.4
- verified authenticated movie, series, season, and episode detail flows against the development server
- exercised season chip selection and paging, sidebar Home from Search, episode poster fallback, and Version, Audio, and Subtitles popovers
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added responsive season and episode browsing for phones and iPads, including paged seasons and one- or two-column episode lists.
  * Episode rows now show thumbnails, watch progress, watched status, metadata, and current-episode indicators.
  * Detail pages adapt hero layouts, artwork, spacing, and playback controls to screen size.
  * Added cached season navigation for faster switching between seasons.
* **Bug Fixes**
  * Prevented outdated episode-loading results from replacing newer selections.
  * Improved artwork fallbacks and restored the previous season when loading fails.
  * Improved sidebar navigation by clearing stale navigation state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->