### PR TITLE
fix(downloads): give offline playback a working loopback route and Do…

### DIFF
--- a/iosApp/Tests/OfflinePlaybackMappingTests.swift
+++ b/iosApp/Tests/OfflinePlaybackMappingTests.swift
@@ -1,0 +1,290 @@
+import XCTest
+import Foundation
+@testable import Silo
+
+/// Contract coverage for the offline manifest → player metadata mapping in
+/// `OfflinePlaybackBuilder`.
+///
+/// The manifest's `index` is the ordinal within its own audio list, while
+/// `AudioTrack.index` means the ffmpeg stream index — it becomes the
+/// `ffIndex` the loopback muxer selects a source stream by. Forwarding one as
+/// the other named the video stream, so the demuxer discarded the audio the
+/// muxer then waited forever to receive, and playback died with a
+/// `vodMoovBlocked` error that named nothing about audio. These lock the
+/// mapping down, and decode through the same `.convertFromSnakeCase` strategy
+/// the API client uses so the wire keys are covered too.
+final class OfflinePlaybackMappingTests: XCTestCase {
+
+    // MARK: - Factories
+
+    private func manifest(
+        audioTracksJSON: String? = nil,
+        selectedAudioTrackIndex: Int? = nil,
+        targetBitrateKbps: Int? = nil,
+        fileSize: Int64? = 1_000_000_000,
+        durationSeconds: Double? = 1358.176
+    ) throws -> OfflineManifest {
+        var fields = [
+            "\"download_id\": \"d1\"",
+            "\"content_id\": \"c1\"",
+            "\"type\": \"episode\"",
+            "\"title\": \"Test Episode\"",
+            "\"quality\": \"original\"",
+            "\"media_file_id\": 42",
+            "\"container\": \"mkv\"",
+            "\"codec_video\": \"hevc\"",
+            "\"codec_audio\": \"eac3\""
+        ]
+        if let fileSize { fields.append("\"file_size\": \(fileSize)") }
+        if let durationSeconds { fields.append("\"duration_seconds\": \(durationSeconds)") }
+        if let audioTracksJSON { fields.append("\"audio_tracks\": \(audioTracksJSON)") }
+        if let selectedAudioTrackIndex {
+            fields.append("\"selected_audio_track_index\": \(selectedAudioTrackIndex)")
+        }
+        if let targetBitrateKbps {
+            fields.append("\"target_bitrate_kbps\": \(targetBitrateKbps)")
+        }
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(
+            OfflineManifest.self,
+            from: Data("{\(fields.joined(separator: ","))}".utf8)
+        )
+    }
+
+    private func prepared(
+        _ manifest: OfflineManifest,
+        videoTracks: [VideoTrack] = []
+    ) -> PreparedPlayback {
+        OfflinePlaybackBuilder.makePreparedPlayback(
+            leafContentId: "leaf",
+            manifest: manifest,
+            mediaURL: URL(fileURLWithPath: "/tmp/media.mkv"),
+            videoTracks: videoTracks,
+            subtitleURLs: [],
+            resumePosition: nil
+        )
+    }
+
+    /// A video track shaped the way `LocalMediaProbe` emits one: a bare DV
+    /// profile number, and `color_transfer` in FFmpeg's spelling.
+    private func probedVideoTrack(
+        dolbyVisionProfile: Int?,
+        colorTransfer: String = "smpte2084"
+    ) -> VideoTrack {
+        VideoTrack(
+            index: 0,
+            codec: "hevc",
+            width: 3840,
+            height: 2160,
+            frameRate: "23.976",
+            bitrate: nil,
+            profile: nil,
+            level: 153,
+            bitDepth: 10,
+            colorRange: "tv",
+            colorSpace: "bt2020nc",
+            colorPrimaries: "bt2020",
+            colorTransfer: colorTransfer,
+            videoRange: nil,
+            dolbyVision: dolbyVisionProfile.map(String.init),
+            title: nil,
+            language: nil
+        )
+    }
+
+    /// One 5.1 EAC-3 track, shaped exactly as the server writes it: `index` is
+    /// the loop counter over the audio list, not the probed stream index.
+    private let singleEAC3Track = """
+    [{
+      "index": 0,
+      "title": "Surround 5.1",
+      "language": "eng",
+      "codec": "eac3",
+      "layout": "5.1(side)",
+      "channels": 6,
+      "bitrate": 640000,
+      "sample_rate": 48000,
+      "default": true
+    }]
+    """
+
+    // MARK: - Audio track identity
+
+    func testManifestOrdinalIsNotForwardedAsAStreamIndex() throws {
+        let version = prepared(try manifest(audioTracksJSON: singleEAC3Track)).selectedVersion
+        let track = try XCTUnwrap(version.audioTracks?.first)
+
+        // The manifest said `index: 0`. Forwarding it would claim the audio
+        // lives on stream 0, which on any normal file is the video stream.
+        XCTAssertNil(track.index)
+    }
+
+    func testAudioTrackDetailSurvivesTheWire() throws {
+        let version = prepared(try manifest(audioTracksJSON: singleEAC3Track)).selectedVersion
+        let track = try XCTUnwrap(version.audioTracks?.first)
+
+        XCTAssertEqual(track.codec, "eac3")
+        XCTAssertEqual(track.language, "eng")
+        XCTAssertEqual(track.channels, 6)
+        XCTAssertEqual(track.title, "Surround 5.1")
+        // `layout` feeds the detail badge and the loopback's channel handling;
+        // `sample_rate` only survives `.convertFromSnakeCase` if the coding key
+        // is spelled in its converted camelCase form.
+        XCTAssertEqual(track.channelLayout, "5.1(side)")
+        XCTAssertEqual(track.bitrate, 640_000)
+        XCTAssertEqual(track.sampleRate, 48_000)
+        XCTAssertEqual(track.isDefault, true)
+    }
+
+    func testEmbeddedTitleIsNotFabricated() throws {
+        let version = prepared(try manifest(audioTracksJSON: singleEAC3Track)).selectedVersion
+        let track = try XCTUnwrap(version.audioTracks?.first)
+
+        // The server collapsed title and embedded title into one field. Echoing
+        // the same string back as both would corrupt the audio-pref signature,
+        // which compares them separately.
+        XCTAssertNil(track.embeddedTitle)
+    }
+
+    func testAbsentAudioTracksStayAbsent() throws {
+        let version = prepared(try manifest()).selectedVersion
+
+        // Manifests written before the client decoded these fields carry no
+        // audio list at all; they must degrade to nil rather than an empty
+        // array that would claim the file has no audio.
+        XCTAssertNil(version.audioTracks)
+    }
+
+    // MARK: - Selected track
+
+    func testSelectedAudioTrackIndexReachesTheSession() throws {
+        let session = prepared(try manifest(
+            audioTracksJSON: singleEAC3Track,
+            selectedAudioTrackIndex: 0
+        )).session
+
+        // Ordinal into `version.audioTracks` — the same space the server's
+        // `audio_track_index` uses.
+        XCTAssertEqual(session.audioTrackIndex, 0)
+    }
+
+    // MARK: - Bitrate
+
+    func testBitrateIsDerivedFromTheDeliveredFile() throws {
+        let version = prepared(try manifest()).selectedVersion
+
+        // 1_000_000_000 bytes * 8 / 1358.176s / 1000 ≈ 5890 kbps.
+        XCTAssertEqual(version.bitrate, 5890)
+    }
+
+    func testBitrateFallsBackToTargetWhenDurationIsUnusable() throws {
+        let version = prepared(try manifest(
+            targetBitrateKbps: 4000,
+            durationSeconds: 0
+        )).selectedVersion
+
+        XCTAssertEqual(version.bitrate, 4000)
+    }
+
+    func testUnusableDurationDoesNotTrapOnConversion() throws {
+        // A sub-second duration divides into a value `Int(_:)` traps on.
+        // Nothing to assert beyond "this returned at all", plus that it did
+        // not invent a bitrate from the corrupt pair.
+        let version = prepared(try manifest(durationSeconds: 0.000_001)).selectedVersion
+
+        XCTAssertNil(version.bitrate)
+    }
+
+    func testBitrateIsAbsentWhenTheManifestCannotSupportIt() throws {
+        let version = prepared(try manifest(fileSize: nil, durationSeconds: nil)).selectedVersion
+
+        XCTAssertNil(version.bitrate)
+    }
+
+    // MARK: - Dolby Vision parity
+
+    /// Route the offline playback through the real planner. The DV helpers are
+    /// fileprivate to the planner, so asserting on the plan it produces both
+    /// exercises them and pins the contract that actually matters.
+    private func plan(
+        dolbyVisionProfile: Int,
+        colorTransfer: String = "smpte2084"
+    ) throws -> PlaybackExecutionPlan {
+        try plan(videoTracks: [probedVideoTrack(
+            dolbyVisionProfile: dolbyVisionProfile,
+            colorTransfer: colorTransfer
+        )])
+    }
+
+    private func plan(videoTracks: [VideoTrack]) throws -> PlaybackExecutionPlan {
+        let playback = prepared(
+            try manifest(audioTracksJSON: singleEAC3Track, selectedAudioTrackIndex: 0),
+            videoTracks: videoTracks
+        )
+        return ApplePlaybackRoutePlanner().makeExecutionPlan(
+            input: ApplePlaybackPlannerInput(
+                session: playback.session,
+                selectedVersion: playback.selectedVersion,
+                streamRequest: StreamRequest(
+                    url: URL(fileURLWithPath: "/tmp/media.mkv"),
+                    headers: [:],
+                    serverUrl: ""
+                ),
+                routeRequirements: .baseline,
+                selectedAudioTrackId: nil,
+                pendingAudioFfIndex: nil,
+                preferredAudioTrackIndex: 0,
+                selectedPrimarySubtitleTrackId: nil,
+                selectedSecondarySubtitleTrackId: nil,
+                hlsRouteFeatureEnabled: true,
+                siloPlayerPrimaryEnabled: true,
+                dolbyVisionPolicy: .default
+            )
+        )
+    }
+
+    func testProbedDolbyVisionRoutesToTheDolbyVisionEngine() throws {
+        for profile in [5, 7, 8] {
+            let plan = try plan(dolbyVisionProfile: profile)
+
+            // The end state asked for: a downloaded DV file reaches the
+            // DV-capable engine with a resolved loopback session, exactly as
+            // the same file does when streamed.
+            XCTAssertEqual(plan.engine, .siloPlayerLoopback, "profile \(profile)")
+            XCTAssertNotNil(plan.loopbackSession, "profile \(profile)")
+            XCTAssertEqual(plan.sourceMetadata.dolbyVisionProfile, profile)
+            XCTAssertTrue(
+                plan.reason.contains("dolby_vision"),
+                "profile \(profile) expected a Dolby Vision reason, got \(plan.reason)"
+            )
+        }
+    }
+
+    func testWithoutAProbedTrackDolbyVisionIsInvisible() throws {
+        // The state this change exists to fix: the manifest describes no video
+        // stream, so with nothing probed off the file a DV download planned as
+        // plain HEVC and lost DV silently.
+        let plan = try plan(videoTracks: [])
+
+        XCTAssertNil(plan.sourceMetadata.dolbyVisionProfile)
+        XCTAssertFalse(plan.reason.contains("dolby_vision"), plan.reason)
+    }
+
+    func testProbedTransferSplitsProfile8BaseLayers() throws {
+        // 8.1 (PQ base) and 8.4 (HLG base) are only distinguishable by
+        // color_transfer, which is exactly what a video track carries.
+        let pq = try plan(dolbyVisionProfile: 8, colorTransfer: "smpte2084")
+        let hlg = try plan(dolbyVisionProfile: 8, colorTransfer: "arib-std-b67")
+
+        XCTAssertEqual(pq.loopbackSession?.manifestMetadata.videoRange, "PQ")
+        XCTAssertEqual(hlg.loopbackSession?.manifestMetadata.videoRange, "HLG")
+    }
+
+    func testProbedColourRangeAndFrameRateReachThePlan() throws {
+        let plan = try plan(dolbyVisionProfile: 8)
+
+        XCTAssertEqual(plan.sourceMetadata.colorRange, "tv")
+        XCTAssertEqual(plan.loopbackSession?.sourceVideoFrameRate, 23.976)
+    }
+}

--- a/iosApp/iosApp/Downloads/DownloadModels.swift
+++ b/iosApp/iosApp/Downloads/DownloadModels.swift
@@ -435,18 +435,37 @@ struct OfflineManifest: Codable, Hashable, Sendable {
     }
 }
 
+/// An audio track described by an offline manifest.
+///
+/// `index` is the ordinal within this list, not the ffmpeg stream index — the
+/// server writes the loop counter and drops the probed index, so it must never
+/// be handed to code that means "stream index" by it.
+///
+/// `title` is already the server's collapse of the cleaned title and the raw
+/// embedded title, so the two cannot be told apart again on this side.
 struct OfflineAudioTrack: Codable, Hashable, Sendable {
     let index: Int?
+    let title: String?
     let language: String?
     let codec: String?
+    let layout: String?
     let channels: Int?
+    let bitrate: Int?
+    let sampleRate: Int?
     let isDefault: Bool?
 
     private enum CodingKeys: String, CodingKey {
         case index
+        case title
         case language
         case codec
+        case layout
         case channels
+        case bitrate
+        // Wire key is `sample_rate`; the API decoder's `.convertFromSnakeCase`
+        // has already rewritten it by the time these keys are matched, and the
+        // bare on-disk coder round-trips this camelCase form unchanged.
+        case sampleRate
         case isDefault = "default"
     }
 }

--- a/iosApp/iosApp/Downloads/LocalMediaProbe.swift
+++ b/iosApp/iosApp/Downloads/LocalMediaProbe.swift
@@ -1,0 +1,123 @@
+import Foundation
+import Libavcodec
+import Libavformat
+import Libavutil
+
+/// Reads the video parameters route planning needs straight out of a
+/// downloaded file.
+///
+/// Online these arrive on the catalog's `FileVersion`: the server probed the
+/// file and shipped `video_tracks`. The offline manifest carries no video
+/// track at all, so without this a downloaded Dolby Vision file plans as plain
+/// HEVC and silently loses DV, and the loopback route cannot work out its HLS
+/// `VIDEO-RANGE` because `transferKind` has no `color_transfer` to read.
+///
+/// Probing the delivered file is also the more truthful source offline. A
+/// transcoded download is a *different file* from the one the catalog
+/// describes — it may have had its DV RPU stripped or been re-encoded — so
+/// catalog metadata would over-claim. This reports what is actually on disk,
+/// which makes the transcode case correct by construction rather than by
+/// special-casing it.
+enum LocalMediaProbe {
+    /// Probe cost is on the path to first frame, and routing only needs the
+    /// stream header, so keep the scan short. Matches the caps
+    /// `LoopbackSegmentWriter` uses when it opens the same file moments later.
+    private static let analyzeDurationMicroseconds = "500000"
+    private static let probeSizeBytes = "1000000"
+
+    /// Every video stream in the file, in stream order. Empty when the file
+    /// cannot be opened or has no video — callers treat that as "no metadata",
+    /// which lands on exactly the behavior that existed before probing.
+    ///
+    /// Synchronous and blocking: it opens a file and runs a header scan. Call
+    /// it off the main actor.
+    static func videoTracks(at url: URL) -> [VideoTrack] {
+        var options: OpaquePointer?
+        av_dict_set(&options, "analyzeduration", analyzeDurationMicroseconds, 0)
+        av_dict_set(&options, "probesize", probeSizeBytes, 0)
+
+        // FFmpeg's `file` protocol takes a raw filesystem path and does NOT
+        // percent-decode, so a downloads directory under "Application Support"
+        // only resolves via `path`, never `absoluteString`.
+        var ctx: UnsafeMutablePointer<AVFormatContext>?
+        let opened = avformat_open_input(&ctx, url.path, nil, &options)
+        av_dict_free(&options)
+        guard opened == 0, let ctx else { return [] }
+        defer {
+            var closing: UnsafeMutablePointer<AVFormatContext>? = ctx
+            avformat_close_input(&closing)
+        }
+
+        // The Dolby Vision configuration record reaches `coded_side_data` only
+        // once the stream info scan has run, so this is not optional here.
+        guard avformat_find_stream_info(ctx, nil) >= 0 else { return [] }
+
+        var tracks: [VideoTrack] = []
+        for index in 0..<Int(ctx.pointee.nb_streams) {
+            guard let stream = ctx.pointee.streams?[index] else { continue }
+            let codecpar = stream.pointee.codecpar.pointee
+            guard codecpar.codec_type == AVMEDIA_TYPE_VIDEO else { continue }
+            // Cover art and thumbnails ride in video streams; they are not the
+            // presentation video and must not be mistaken for it.
+            guard stream.pointee.disposition & AV_DISPOSITION_ATTACHED_PIC == 0 else { continue }
+
+            let dolbyVision = DolbyVisionFormat.readConfig(stream: stream, codecpar: codecpar)
+            tracks.append(VideoTrack(
+                index: index,
+                codec: codecName(codecpar.codec_id),
+                width: codecpar.width > 0 ? Int(codecpar.width) : nil,
+                height: codecpar.height > 0 ? Int(codecpar.height) : nil,
+                frameRate: frameRateToken(stream.pointee.avg_frame_rate),
+                bitrate: codecpar.bit_rate > 0 ? Int(codecpar.bit_rate) : nil,
+                profile: nil,
+                level: codecpar.level > 0 ? Int(codecpar.level) : nil,
+                bitDepth: bitDepth(of: codecpar),
+                colorRange: VideoColorMetadata.colorRangeName(codecpar.color_range),
+                colorSpace: enumName(av_color_space_name(codecpar.color_space)),
+                colorPrimaries: enumName(av_color_primaries_name(codecpar.color_primaries)),
+                colorTransfer: enumName(av_color_transfer_name(codecpar.color_trc)),
+                // Deliberately nil. `video_range` is the server's higher-level
+                // roll-up, and `transferKind` only falls back to it when
+                // `color_transfer` is missing — which it is not here. Deriving
+                // our own would risk disagreeing with the server's vocabulary.
+                videoRange: nil,
+                // A bare profile number: `dolbyVisionProfile(from:)` parses
+                // that first, and leaving it nil when no configuration record
+                // is present is what keeps `versionHasDolbyVision` honest.
+                dolbyVision: dolbyVision.map { String($0.profile) },
+                title: nil,
+                language: nil
+            ))
+        }
+        return tracks
+    }
+
+    private static func codecName(_ id: AVCodecID) -> String? {
+        enumName(avcodec_get_name(id))
+    }
+
+    private static func enumName(_ raw: UnsafePointer<CChar>?) -> String? {
+        guard let raw else { return nil }
+        let name = String(cString: raw)
+        // FFmpeg returns these sentinels rather than null for unset values.
+        guard !name.isEmpty, name != "unknown", name != "none", name != "reserved" else {
+            return nil
+        }
+        return name
+    }
+
+    private static func bitDepth(of codecpar: AVCodecParameters) -> Int? {
+        let format = AVPixelFormat(rawValue: codecpar.format)
+        guard format != AV_PIX_FMT_NONE else { return nil }
+        return Int(VideoColorMetadata.sourceBitDepth(format))
+    }
+
+    /// Decimal token matching the server's `frame_rate` spelling ("23.976"), so
+    /// a probed track and a catalog track render identically.
+    private static func frameRateToken(_ rate: AVRational) -> String? {
+        guard rate.den > 0, rate.num > 0 else { return nil }
+        let value = Double(rate.num) / Double(rate.den)
+        guard value.isFinite, value > 0 else { return nil }
+        return String(format: "%g", (value * 1000).rounded() / 1000)
+    }
+}

--- a/iosApp/iosApp/Downloads/OfflinePlayback.swift
+++ b/iosApp/iosApp/Downloads/OfflinePlayback.swift
@@ -36,9 +36,11 @@ struct OfflinePreparedPlayback {
 
 /// Synthesizes the same `PreparedPlayback` the online path produces, but
 /// from a stored offline manifest + local media file, so the player loads
-/// with no server session. The local file plays via the existing engines
-/// (FFmpeg `PlayerCore` for MKV/etc., `AVPlayer` for MP4) and the manifest
-/// drives chapters, intro/credits markers, and subtitles unchanged.
+/// with no server session. Routing is left to the standard planner — the
+/// synthesized version carries the manifest's real track metadata so a
+/// `file://` source can reach the loopback route, not just `PlayerCore` —
+/// and the manifest drives chapters, intro/credits markers, and subtitles
+/// unchanged.
 enum OfflinePlaybackBuilder {
     /// Near-end resume points restart from zero, mirroring the session
     /// bridge's suppression window so offline resume feels identical to
@@ -66,11 +68,21 @@ enum OfflinePlaybackBuilder {
             throw OfflinePlaybackError.mediaFileMissing
         }
 
+        // The manifest describes the catalog's file, never its video streams,
+        // so Dolby Vision and colour signalling have to come off the download
+        // itself. Off the MainActor: this opens the file and runs a header
+        // scan. Failures come back empty and simply leave the version without
+        // video tracks, which is where offline was before probing.
+        let videoTracks = await Task.detached(priority: .userInitiated) {
+            LocalMediaProbe.videoTracks(at: mediaURL)
+        }.value
+
         let leafId = record.leafMediaItemId
         let prepared = makePreparedPlayback(
             leafContentId: leafId,
             manifest: manifest,
             mediaURL: mediaURL,
+            videoTracks: videoTracks,
             subtitleURLs: localSubtitleUrls(record: record, manifest: manifest, manager: manager),
             resumePosition: resolvedResumePosition(
                 startFromBeginning: startFromBeginning,
@@ -144,10 +156,70 @@ enum OfflinePlaybackBuilder {
         return candidate >= max(0, duration - nearEndResumeSuppressionSeconds) ? 0 : candidate
     }
 
+    /// Map the manifest's audio tracks into the catalog `AudioTrack` shape the
+    /// route planner, loopback session spec, and detail views all read.
+    ///
+    /// `index` is deliberately dropped rather than forwarded. `AudioTrack.index`
+    /// means the ffmpeg stream index — it becomes `PlayerTrack.ffIndex`, which
+    /// selects the stream to mux — while the manifest's `index` is only the
+    /// ordinal within this list. On a typical file the ordinal names the video
+    /// stream, and the audio the muxer is waiting for gets discarded. Nil sends
+    /// selection down the ordinal path, which is what the manifest describes.
+    ///
+    /// `embeddedTitle` stays nil because the server already collapsed the
+    /// cleaned and embedded titles into one field; echoing the same string back
+    /// as both would corrupt the audio-pref signature that compares them
+    /// separately.
+    private static func audioTracks(from manifest: OfflineManifest) -> [AudioTrack]? {
+        manifest.audioTracks.map { tracks in
+            tracks.map { track in
+                AudioTrack(
+                    index: nil,
+                    codec: track.codec,
+                    channels: track.channels,
+                    channelLayout: track.layout,
+                    bitrate: track.bitrate,
+                    sampleRate: track.sampleRate,
+                    language: track.language,
+                    title: track.title,
+                    embeddedTitle: nil,
+                    isDefault: track.isDefault
+                )
+            }
+        }
+    }
+
+    /// Overall bitrate in kbps, matching the probed value the server puts on an
+    /// online `FileVersion`. Without it the loopback advertises a placeholder
+    /// `BANDWIDTH` in its master playlist and logs `source_bitrate_unknown`,
+    /// so offline sessions ramp differently from the same file streamed.
+    ///
+    /// The manifest carries no probed bitrate, so derive the real average from
+    /// the delivered file. `targetBitrateKbps` is only a transcode target and
+    /// is absent for original downloads, so it is the fallback, not the source.
+    /// A sub-second duration would be a corrupt manifest, not real content, and
+    /// dividing by it produces a value `Int(_:)` traps on. Both bounds below
+    /// keep a bad manifest falling back rather than crashing playback.
+    private static func averageBitrateKbps(from manifest: OfflineManifest) -> Int? {
+        guard let fileSize = manifest.fileSize, fileSize > 0,
+              let duration = manifest.durationSeconds, duration >= 1 else {
+            return manifest.targetBitrateKbps
+        }
+        let kbps = Double(fileSize) * 8 / duration / 1_000
+        guard kbps.isFinite, kbps >= 1, kbps < Double(Int32.max) else {
+            return manifest.targetBitrateKbps
+        }
+        return Int(kbps)
+    }
+
+    /// `videoTracks` comes from `LocalMediaProbe` reading the delivered file.
+    /// Defaulted so tests and any caller with no file to probe still get the
+    /// manifest-only version.
     static func makePreparedPlayback(
         leafContentId: String,
         manifest: OfflineManifest,
         mediaURL: URL,
+        videoTracks: [VideoTrack] = [],
         subtitleURLs: [SubtitleUrl],
         resumePosition: Double?
     ) -> PreparedPlayback {
@@ -161,9 +233,9 @@ enum OfflinePlaybackBuilder {
             container: manifest.container,
             fileSize: manifest.fileSize,
             duration: manifest.durationSeconds,
-            bitrate: nil,
-            videoTracks: nil,
-            audioTracks: nil,
+            bitrate: averageBitrateKbps(from: manifest),
+            videoTracks: videoTracks.isEmpty ? nil : videoTracks,
+            audioTracks: audioTracks(from: manifest),
             subtitleTracks: nil,
             chapters: manifest.chapters,
             intro: manifest.intro,
@@ -185,7 +257,7 @@ enum OfflinePlaybackBuilder {
             position: resumePosition ?? 0,
             isPaused: false,
             streamUrl: mediaURL.absoluteString,
-            audioTrackIndex: nil,
+            audioTrackIndex: manifest.selectedAudioTrackIndex,
             durationSeconds: manifest.durationSeconds,
             timelineOffsetSeconds: 0,
             subtitleUrls: subtitleURLs.isEmpty ? nil : subtitleURLs,

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/LoopbackSegmentWriter.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/LoopbackSegmentWriter.swift
@@ -2359,12 +2359,46 @@ final class LoopbackSegmentWriter {
         // source on every producer restart.
     }
 
+    /// Which input stream supplies the selected audio track, or nil when the
+    /// selection names no audio stream in this context.
+    ///
+    /// An explicit `ffIndex` wins only when it actually points at an audio
+    /// stream here. A stale index — or an ordinal-shaped one, as offline
+    /// manifests carry (the server writes the audio-list ordinal and drops the
+    /// real ffmpeg stream index) — falls through to the ordinal scan instead
+    /// of naming a video stream or nothing at all.
+    ///
+    /// Both the demuxer discard pass and the mux setup resolve through this so
+    /// they cannot disagree: when they did, the discard pass dropped the audio
+    /// the muxer then waited forever to receive, surfacing as `vodMoovBlocked`
+    /// with nothing naming the real cause.
+    private static func audioStreamIndex(
+        in ctx: UnsafeMutablePointer<AVFormatContext>,
+        ffIndex: Int?,
+        ordinal: Int
+    ) -> Int? {
+        let nb = Int(ctx.pointee.nb_streams)
+        func isAudio(_ index: Int) -> Bool {
+            guard index >= 0, index < nb,
+                  let stream = ctx.pointee.streams?[index] else { return false }
+            return stream.pointee.codecpar.pointee.codec_type == AVMEDIA_TYPE_AUDIO
+        }
+        if let ffIndex, isAudio(ffIndex) { return ffIndex }
+        guard ordinal >= 0 else { return nil }
+        var audioOrdinal = 0
+        for i in 0..<nb where isAudio(i) {
+            if audioOrdinal == ordinal { return i }
+            audioOrdinal += 1
+        }
+        return nil
+    }
+
     /// Marks every stream we won't mux as `AVDISCARD_ALL` so libavformat
     /// skips them during `find_stream_info` and `av_read_frame`. Discards
     /// (a) all non-audio / non-video streams unconditionally and (b) every
-    /// audio stream other than the one selected by ordinal `keepAudioOrdinal`
-    /// or explicit `keepAudioFfIndex`. Pass `keepAudioOrdinal=-1` to drop
-    /// audio entirely.
+    /// audio stream other than the one `audioStreamIndex` resolves
+    /// from `keepAudioFfIndex`/`keepAudioOrdinal`. Pass `keepAudioOrdinal=-1`
+    /// with no `keepAudioFfIndex` to drop audio entirely.
     private static func discardUnusedStreamsForMux(
         in ctx: UnsafeMutablePointer<AVFormatContext>,
         keepVideoIndex: Int,
@@ -2373,6 +2407,11 @@ final class LoopbackSegmentWriter {
         keepSubtitleIndices: Set<Int>
     ) {
         let nb = Int(ctx.pointee.nb_streams)
+        let keepAudioIndex = audioStreamIndex(
+            in: ctx,
+            ffIndex: keepAudioFfIndex,
+            ordinal: keepAudioOrdinal
+        )
         var discardedSubtitles = 0
         var discardedOther = 0
         var discardedExtraVideo = 0
@@ -2380,7 +2419,6 @@ final class LoopbackSegmentWriter {
         var keptVideo = 0
         var keptAudio = 0
         var keptSubtitles = 0
-        var audioOrdinal = 0
         if let streams = ctx.pointee.streams {
             for i in 0..<nb {
                 guard let stream = streams[i] else { continue }
@@ -2395,16 +2433,7 @@ final class LoopbackSegmentWriter {
                     continue
                 }
                 if mediaType == AVMEDIA_TYPE_AUDIO {
-                    let isSelected: Bool
-                    if let ff = keepAudioFfIndex, ff >= 0 {
-                        isSelected = (i == ff)
-                    } else if keepAudioOrdinal >= 0 {
-                        isSelected = (audioOrdinal == keepAudioOrdinal)
-                    } else {
-                        isSelected = false
-                    }
-                    audioOrdinal += 1
-                    if isSelected {
+                    if i == keepAudioIndex {
                         keptAudio += 1
                     } else {
                         stream.pointee.discard = AVDISCARD_ALL
@@ -3126,27 +3155,16 @@ final class LoopbackSegmentWriter {
     private func resolveSelectedAudioStreamIndex(
         in inputCtx: UnsafeMutablePointer<AVFormatContext>
     ) throws -> Int {
-        if let explicitStreamIndex = sessionSpec.selectedAudio.ffIndex,
-           explicitStreamIndex >= 0,
-           explicitStreamIndex < Int(inputCtx.pointee.nb_streams),
-           let stream = inputCtx.pointee.streams?[explicitStreamIndex],
-           stream.pointee.codecpar.pointee.codec_type == AVMEDIA_TYPE_AUDIO {
-            return explicitStreamIndex
+        guard let index = Self.audioStreamIndex(
+            in: inputCtx,
+            ffIndex: sessionSpec.selectedAudio.ffIndex,
+            ordinal: selectedAudioTrackIndex
+        ) else {
+            throw LoopbackWriterError.audioTranscodeSetup(
+                "selected audio track \(selectedAudioTrackIndex) was not found in source stream map"
+            )
         }
-
-        var audioOrdinal = 0
-        for i in 0 ..< Int(inputCtx.pointee.nb_streams) {
-            guard let stream = inputCtx.pointee.streams?[i] else { continue }
-            guard stream.pointee.codecpar.pointee.codec_type == AVMEDIA_TYPE_AUDIO else { continue }
-            if audioOrdinal == selectedAudioTrackIndex {
-                return i
-            }
-            audioOrdinal += 1
-        }
-
-        throw LoopbackWriterError.audioTranscodeSetup(
-            "selected audio track \(selectedAudioTrackIndex) was not found in source stream map"
-        )
+        return index
     }
 
     /// Drain a queue of prefetched packets to the muxer. Each packet's

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -2478,7 +2478,6 @@ class PlayerViewModel {
     private enum SourceProxyPreparationError: LocalizedError {
         case missingLocalURL
         case missingLoopbackSession
-        case unsupportedSourceURL
 
         var errorDescription: String? {
             switch self {
@@ -2486,8 +2485,6 @@ class PlayerViewModel {
                 return "local proxy URL was unavailable"
             case .missingLoopbackSession:
                 return "loopback session was unavailable"
-            case .unsupportedSourceURL:
-                return "loopback source URL is not HTTP(S)"
             }
         }
     }
@@ -2502,10 +2499,13 @@ class PlayerViewModel {
             // This load runs without a proxy, so any stashed cache has no
             // adopter — release it rather than hold its disk spans for the
             // rest of playback.
+            //
+            // Loopback included: the proxy exists to give the segment writer a
+            // cached, resumable HTTP origin, and a local `file://` source
+            // (offline downloads) needs neither — it is already seekable on
+            // disk and `LoopbackSegmentWriter` opens the path directly. The
+            // plan travels through unproxied, still pointing at the file.
             discardSourceCacheHandoff()
-            if plan.engine == .siloPlayerLoopback {
-                throw SourceProxyPreparationError.unsupportedSourceURL
-            }
             return SourceProxyPreparation(plan: plan, proxy: nil)
         }
         let cacheBudget = sourceCacheBudget(for: plan)


### PR DESCRIPTION
…lby Vision

A downloaded MKV could only ever play through playerCoreDirect. When VideoToolbox rejected the stream, the recovery planner routed to siloPlayerLoopback, whose proxy guard rejected the file:// source and failed the load with "loopback source URL is not HTTP(S)" — so a decode failure surfaced as an unrelated proxy error with no working fallback. Fixing the routing then exposed two more offline-only gaps behind it.

Let file:// sources skip the source proxy rather than fail the load. The proxy exists to give the segment writer a cached, resumable HTTP origin; a local file needs neither, and LoopbackSegmentWriter already opens the path directly. A nil loopback session is still caught downstream by PlaybackEngine, so no coverage is lost with the throw removed.

Resolve the selected audio stream through a single helper in LoopbackSegmentWriter. The demuxer discard pass trusted an explicit ffIndex without checking it named an audio stream, while the mux setup validated it and fell back to an ordinal scan. When they disagreed the discard pass dropped the audio the muxer then waited forever to receive, which surfaced as vodMoovBlocked naming nothing about audio.

Carry the manifest's audio track detail — title, layout, bitrate, sample rate — into the synthesized FileVersion, and derive the overall bitrate from the delivered file so the loopback stops advertising a placeholder BANDWIDTH and logging source_bitrate_unknown. The manifest's per-track index is an ordinal within its own list, not an ffmpeg stream index, so it is deliberately not forwarded: doing so named the video stream.

Probe the downloaded file for its video parameters. The manifest describes no video stream at all, so Dolby Vision, colour transfer, colour range and frame rate had nowhere to come from and DV downloads planned as plain HEVC. Reading the delivered file rather than catalog metadata also keeps transcoded downloads honest, since a stripped RPU reports no DV instead of inheriting the source's claim.

Verified on iOS; tvOS and macOS were not built (no tvOS simulator runtime installed, and the macOS scheme fails at HEAD on unrelated FFmpeg framework errors).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Offline playback now reads downloaded video metadata, including bitrate, frame rate, color settings, Dolby Vision details, and audio-track information.
  - Selected audio tracks and richer media metadata are preserved during offline playback.
  - Local offline media can play without being routed through the source proxy.

- **Bug Fixes**
  - Improved audio stream selection when manifest indexes are stale or use ordinal values.
  - Added safer handling for missing or invalid media metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->