### PR TITLE
feat(player): show playback stats on iOS as an inert overlay

### DIFF
--- a/iosApp/iosApp/Screens/Player/PlaybackStats.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackStats.swift
@@ -99,6 +99,46 @@ struct PlaybackStats: Equatable {
 }
 
 extension PlaybackStats {
+    /// Every section's rows in display order — the full set the tvOS HUD
+    /// pane pages through.
+    var allRows: [(String, String)] {
+        sourceRows + mediaRows + bufferRows + networkRows + deviceRows
+    }
+
+    /// The subset the iOS overlay draws. The full set runs to ~45 rows on
+    /// the loopback route, which is a wall of text over the picture and
+    /// mostly cache/segment internals you'd go to the tvOS pane (or the
+    /// Advanced page) for. This keeps what identifies the file and tells
+    /// you whether playback is healthy, in the same order.
+    ///
+    /// Filtered by label against `allRows` rather than rebuilt from the
+    /// stored properties, so the formatting can never drift from the pane.
+    var compactRows: [(String, String)] {
+        let wanted = [
+            "Route", "Source", "Container", "Created by",
+            "Video", "Audio", "Dynamic range", "Subtitles",
+            "Buffer status", "Buffered ahead", "Dropped frames",
+            // Indicated/Observed are the fallbacks `networkRows` emits when
+            // the average/download pair is unavailable on the active route,
+            // so both spellings have to be listed or the bitrate line just
+            // vanishes there.
+            "Average file bitrate", "Current download bitrate",
+            "Indicated bitrate", "Observed bitrate",
+            "Network throughput", "Stream speed",
+            "Device", "Free disk space"
+        ]
+        let rows = allRows
+        return wanted.compactMap { label in
+            rows.first { $0.0 == label }
+        }
+    }
+
+    /// True once any section has something to show. Every row accessor drops
+    /// nil/empty values, so a snapshot taken before the engine has reported
+    /// anything renders as a blank panel; callers use this to show a
+    /// placeholder instead.
+    var hasRows: Bool { !allRows.isEmpty }
+
     var sourceRows: [(String, String)] {
         [
             ("Route", route),

--- a/iosApp/iosApp/Screens/Player/PlaybackStatsPanel.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackStatsPanel.swift
@@ -1,7 +1,20 @@
 import SwiftUI
 
 struct PlaybackStatsPanel: View {
+    /// How the same row set is dressed. The rows themselves always come from
+    /// `PlaybackStats`, so the platforms can't drift on *what* is reported —
+    /// only on how much chrome is drawn around it.
+    enum Layout {
+        /// tvOS Info HUD pane: uppercase section headers, trailing-aligned
+        /// label column, monospaced values. Reads as a panel.
+        case sectioned
+        /// iOS overlay: one flat `Label:  value` list, no section headers,
+        /// drawn straight onto the picture. Reads as annotation.
+        case plain
+    }
+
     let stats: PlaybackStats
+    var layout: Layout = .sectioned
     var usesTVTypography = false
     var usesTwoColumnLayout = false
 
@@ -13,17 +26,43 @@ struct PlaybackStatsPanel: View {
 
     var body: some View {
         Group {
-            if usesTwoColumnLayout {
+            switch layout {
+            case .plain:
+                plainList
+            case .sectioned where usesTwoColumnLayout:
                 HStack(alignment: .top, spacing: 34) {
                     column(leftSections)
                     divider
                     column(rightSections)
                 }
-            } else {
+            case .sectioned:
                 column(allSections)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - Plain layout
+
+    /// Flat `Label:` / value grid over `compactRows`. Draws no background of
+    /// its own — the overlay owns that, so this stays reusable as bare
+    /// annotation. Single column by design: the compact set is short enough
+    /// to fit a phone in landscape, which is what lets the overlay stay
+    /// inert (no scrolling) without clipping anything.
+    private var plainList: some View {
+        Grid(alignment: .leadingFirstTextBaseline, horizontalSpacing: 12, verticalSpacing: 4) {
+            ForEach(stats.compactRows, id: \.0) { row in
+                GridRow {
+                    Text("\(row.0):")
+                        .foregroundStyle(.white.opacity(0.58))
+                        .gridColumnAlignment(.leading)
+                    Text(row.1)
+                        .foregroundStyle(.white.opacity(0.95))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+        .font(.system(size: 11))
     }
 
     private var leftSections: [StatsSection] {

--- a/iosApp/iosApp/Screens/Player/Sheets/PlayerSettingsSheet.swift
+++ b/iosApp/iosApp/Screens/Player/Sheets/PlayerSettingsSheet.swift
@@ -114,6 +114,11 @@ private struct DoubleRangeSpinner: View {
 struct PlayerSettingsSheet: View {
     let viewModel: PlayerViewModel
     let sleepTimer: SleepTimer
+    /// Visibility of the iOS stats annotation. A binding rather than a
+    /// one-shot action because the overlay itself has no dismiss affordance
+    /// — this row is both the on and the off switch. Nil on platforms with
+    /// no such overlay, which hides the row.
+    var statsOverlayVisible: Binding<Bool>?
 
     #if os(iOS)
     @Environment(\.dismiss) private var dismiss
@@ -473,6 +478,18 @@ struct PlayerSettingsSheet: View {
 
     private var advancedSection: some View {
         Section {
+            if let statsOverlayVisible {
+                Toggle(isOn: statsOverlayVisible) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Stats")
+                        Text("Live overlay on the player")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .tint(.continuumAccent)
+            }
+
             NavigationLink {
                 advancedPage
             } label: {

--- a/iosApp/iosApp/Screens/Player/iOS/MobilePlaybackStatsOverlay.swift
+++ b/iosApp/iosApp/Screens/Player/iOS/MobilePlaybackStatsOverlay.swift
@@ -1,0 +1,65 @@
+#if os(iOS)
+import SwiftUI
+
+/// Infuse-style stats annotation: `PlaybackStats.compactRows` drawn over the
+/// picture on a low-contrast dark plate, with no header, close button or
+/// scroll affordance.
+///
+/// Two properties matter and are easy to break:
+///
+/// - It is inert. `allowsHitTesting(false)` means a tap in its footprint
+///   still reaches the transport and the gesture layer underneath — the
+///   overlay must never cost the user a play/pause. That rules out
+///   scrolling, which is why it renders the compact row set and not the
+///   full one the tvOS pane pages through.
+/// - It outlives the controls. It sits outside the `showControls` gate in
+///   `MobilePlayerControls`, so the 3 s auto-hide takes the transport away
+///   and leaves the stats up. Toggled off from where it was toggled on
+///   (settings sheet → Stats), which is why there is no dismiss control.
+struct MobilePlaybackStatsOverlay: View {
+    let stats: PlaybackStats
+
+    /// Clears the control overlay's top strip so the two never collide.
+    private static let topInset: CGFloat = 60
+
+    var body: some View {
+        plate
+            .padding(.leading, 16)
+            .padding(.top, Self.topInset)
+            .frame(
+                maxWidth: .infinity,
+                maxHeight: .infinity,
+                alignment: .topLeading
+            )
+            .allowsHitTesting(false)
+    }
+
+    private var plate: some View {
+        content
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            // Flat translucent black rather than a material: a blur reads as
+            // a window, which is exactly what this shouldn't look like. Just
+            // enough to hold white text over a bright scene.
+            .background(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(Color.black.opacity(0.38))
+            )
+            // Hug the rows so the plate never spans the player.
+            .fixedSize()
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        // Gated on the compact set, not `hasRows`: early snapshots can carry
+        // only rows this overlay filters out, which would draw a blank plate.
+        if !stats.compactRows.isEmpty {
+            PlaybackStatsPanel(stats: stats, layout: .plain)
+        } else {
+            Text("Stats appear once playback starts.")
+                .font(.system(size: 11))
+                .foregroundStyle(.white.opacity(0.6))
+        }
+    }
+}
+#endif

--- a/iosApp/iosApp/Screens/Player/iOS/MobilePlayerControls.swift
+++ b/iosApp/iosApp/Screens/Player/iOS/MobilePlayerControls.swift
@@ -25,6 +25,10 @@ struct MobilePlayerControls: View {
     /// duration otherwise. Tap the label to flip — the native player idiom.
     @State private var showsRemainingTime = true
     @State private var pictureInPicture = PictureInPictureCoordinator.shared
+    /// Floating stats card. Kept here rather than on the view model because
+    /// it is purely presentation, and kept outside the `showControls` gate
+    /// below so the auto-hide takes the transport away without it.
+    @State private var showsStats = false
 
 
     var body: some View {
@@ -72,7 +76,12 @@ struct MobilePlayerControls: View {
             if viewModel.showIntroSkip {
                 introSkipPill
             }
+            if showsStats {
+                MobilePlaybackStatsOverlay(stats: viewModel.playbackStats)
+                    .transition(.opacity)
+            }
         }
+        .animation(.easeOut(duration: 0.18), value: showsStats)
         .sheet(item: $activeSheet) { sheet in
             switch sheet {
             case .aiSubtitles:
@@ -94,8 +103,20 @@ struct MobilePlayerControls: View {
                 )
                 .presentationDetents([.large])
             case .settings:
-                PlayerSettingsSheet(viewModel: viewModel, sleepTimer: viewModel.sleepTimer)
-                    .presentationDetents([.large])
+                PlayerSettingsSheet(
+                    viewModel: viewModel,
+                    sleepTimer: viewModel.sleepTimer,
+                    statsOverlayVisible: Binding(
+                        get: { showsStats },
+                        set: { newValue in
+                            showsStats = newValue
+                            // Switching it on closes the sheet: the stats are
+                            // only useful over the picture they describe.
+                            if newValue { activeSheet = nil }
+                        }
+                    )
+                )
+                .presentationDetents([.large])
             }
         }
         .onChange(of: activeSheet) { _, newValue in


### PR DESCRIPTION
The stats pipeline was already platform-agnostic — PlaybackStats, the ~1s emission from AVPlayerBackend/PlayerCore, and the enrichment in PlayerViewModel all ran on iOS with nothing rendering them. Only the entry point was tvOS-only.

Adds an Infuse-style annotation over the picture rather than a sheet or a card: a compact Label: value list on a translucent black plate, top left, toggled from the playback settings sheet. It sits outside the showControls gate so the 3s auto-hide takes the transport away and leaves the stats up, and it is allowsHitTesting(false) so it can never cost the user a play/pause tap.

Being inert rules out scrolling, so it renders PlaybackStats.compactRows — what identifies the file plus the bitrate/buffer lines that say whether playback is healthy — instead of the ~45 rows the tvOS pane pages through. The subset is filtered by label out of the full row set, so formatting cannot drift from the pane, and the deep cache/segment internals stay reachable there.

PlaybackStatsPanel gains a Layout:
 tvOS keeps .sectioned unchanged, iOS gets .plain.
 
 <img width="2868" height="1320" alt="IMG_7074-2" src="https://github.com/user-attachments/assets/0f3e1c5d-014f-4aa7-bef1-12cdbaf06dfb" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an iOS playback statistics overlay displaying compact playback health and device information.
  - Added a Stats toggle in the iOS Advanced settings.
  - Statistics remain visible independently of auto-hidden player controls.
  - Added a fallback message when playback statistics are unavailable.
  - Added flexible statistics layouts for sectioned or compact single-column presentation.
- **UI Improvements**
  - Added translucent, non-interactive overlay styling positioned at the top-left of the player.
  - Enabling the Stats option closes the settings sheet automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->