### PR TITLE
feat(playback): adopt platform-neutral protocol v3

### DIFF
--- a/iosApp/Tests/AppleDecodeCapabilitiesTests.swift
+++ b/iosApp/Tests/AppleDecodeCapabilitiesTests.swift
@@ -38,6 +38,20 @@ final class AppleDecodeCapabilitiesTests: XCTestCase {
         XCTAssertEqual(v3, Set(AppleDecodeCapabilities.audioCodecs))
     }
 
+    func testBareAudioContainersReachTheFlatAndOriginalHTTPClaims() throws {
+        let expected = Set(["mp3", "m4a", "m4b", "aac", "flac", "wav"])
+        XCTAssertEqual(Set(AppleDecodeCapabilities.audioContainers), expected)
+        XCTAssertTrue(expected.isSubset(of: Set(AppleDecodeCapabilities.containers)))
+
+        let originalHTTP = try XCTUnwrap(
+            ApplePlaybackV3Capabilities.snapshot().context.deliveries[
+                PlaybackProtocolV3.DeliveryClass.originalHTTP
+            ]
+        )
+        XCTAssertTrue(expected.isSubset(of: Set(originalHTTP.containers)))
+        XCTAssertFalse(originalHTTP.containers.contains("ogg"))
+    }
+
     // MARK: - The vocabulary itself
 
     func testDeviceListsCoverTheFormatsTheStackDecodes() {
@@ -47,6 +61,9 @@ final class AppleDecodeCapabilitiesTests: XCTestCase {
         let containers = AppleDecodeCapabilities.containers
         XCTAssertTrue(containers.contains("mkv"))
         XCTAssertTrue(containers.contains("mp4"))
+        XCTAssertTrue(containers.contains("mp3"))
+        XCTAssertTrue(containers.contains("flac"))
+        XCTAssertTrue(containers.contains("wav"))
         // Both spellings of the aliased containers, or a server that recorded
         // the other one reads as unsupported.
         XCTAssertEqual(containers.contains("mkv"), containers.contains("matroska"))

--- a/iosApp/Tests/DetailVersionSelectionTests.swift
+++ b/iosApp/Tests/DetailVersionSelectionTests.swift
@@ -655,6 +655,7 @@ final class DetailVersionSelectionTests: XCTestCase {
                 index: 0,
                 fileId: 7,
                 fileName: nil,
+                version: version(fileId: 7, resolution: nil),
                 durationSeconds: 120,
                 startOffsetSeconds: 0
             ),
@@ -662,6 +663,7 @@ final class DetailVersionSelectionTests: XCTestCase {
                 index: 1,
                 fileId: 8,
                 fileName: nil,
+                version: version(fileId: 8, resolution: nil),
                 durationSeconds: 180,
                 startOffsetSeconds: 120
             ),

--- a/iosApp/Tests/Fixtures/PlaybackV3/SOURCE
+++ b/iosApp/Tests/Fixtures/PlaybackV3/SOURCE
@@ -1,6 +1,6 @@
-Source: silo-server internal/playback/testdata/protocol_v3
+Source: silo-server docs/design/schemas/playback-v3/v3/fixtures/valid and internal/playback/testdata/protocol_v3
 Server ref: codex/playback-v3-neutral-server
-Server commit: 30ddc0d09255816e44cd9874ff79a785d8a6fd8e
-Vendored: 2026-08-09
+Server commit: ce2f3e6df084f52c62595db8e3011f55c3a925ef
+Vendored: 2026-08-10
 
 Refresh these files from the exact server commit above, then regenerate Silo.xcodeproj with cd iosApp && xcodegen generate.

--- a/iosApp/Tests/Fixtures/PlaybackV3/SOURCE
+++ b/iosApp/Tests/Fixtures/PlaybackV3/SOURCE
@@ -1,6 +1,6 @@
 Source: silo-server internal/playback/testdata/protocol_v3
 Server ref: codex/playback-v3-neutral-server
-Server commit: 81f6dcc257d4f6590e1b62285377e59318ce733f
+Server commit: 63247a36a3dcb4462cd6c6145b090025578dbbf9
 Vendored: 2026-08-08
 
 Refresh these files from the exact server commit above, then regenerate Silo.xcodeproj with xcodegen generate.

--- a/iosApp/Tests/Fixtures/PlaybackV3/SOURCE
+++ b/iosApp/Tests/Fixtures/PlaybackV3/SOURCE
@@ -1,6 +1,6 @@
 Source: silo-server internal/playback/testdata/protocol_v3
 Server ref: codex/playback-v3-neutral-server
-Server commit: c133f0cf0e752bba9b1fa13097644674639f4889
-Vendored: 2026-08-06
+Server commit: 81f6dcc257d4f6590e1b62285377e59318ce733f
+Vendored: 2026-08-08
 
 Refresh these files from the exact server commit above, then regenerate Silo.xcodeproj with xcodegen generate.

--- a/iosApp/Tests/Fixtures/PlaybackV3/SOURCE
+++ b/iosApp/Tests/Fixtures/PlaybackV3/SOURCE
@@ -1,0 +1,6 @@
+Source: silo-server internal/playback/testdata/protocol_v3
+Server ref: codex/playback-v3-neutral-server
+Server commit: c133f0cf0e752bba9b1fa13097644674639f4889
+Vendored: 2026-08-06
+
+Refresh these files from the exact server commit above, then regenerate Silo.xcodeproj with xcodegen generate.

--- a/iosApp/Tests/Fixtures/PlaybackV3/SOURCE
+++ b/iosApp/Tests/Fixtures/PlaybackV3/SOURCE
@@ -1,6 +1,6 @@
 Source: silo-server internal/playback/testdata/protocol_v3
 Server ref: codex/playback-v3-neutral-server
-Server commit: 63247a36a3dcb4462cd6c6145b090025578dbbf9
-Vendored: 2026-08-08
+Server commit: 30ddc0d09255816e44cd9874ff79a785d8a6fd8e
+Vendored: 2026-08-09
 
 Refresh these files from the exact server commit above, then regenerate Silo.xcodeproj with xcodegen generate.

--- a/iosApp/Tests/Fixtures/PlaybackV3/SOURCE
+++ b/iosApp/Tests/Fixtures/PlaybackV3/SOURCE
@@ -3,4 +3,4 @@ Server ref: codex/playback-v3-neutral-server
 Server commit: 30ddc0d09255816e44cd9874ff79a785d8a6fd8e
 Vendored: 2026-08-09
 
-Refresh these files from the exact server commit above, then regenerate Silo.xcodeproj with xcodegen generate.
+Refresh these files from the exact server commit above, then regenerate Silo.xcodeproj with cd iosApp && xcodegen generate.

--- a/iosApp/Tests/Fixtures/PlaybackV3/attempt_keys.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/attempt_keys.json
@@ -1,89 +1,29 @@
 [
   {
     "name": "hls_burn_in_sorted_transformations_and_pcm_mutations",
-    "plan_id": "plan:fixture",
-    "delivery": "server_remux_hls",
-    "stream_protocol": "hls",
-    "container": "hls",
-    "video_codec": "hevc",
-    "audio_codec": "aac",
-    "width": 3840,
-    "height": 2160,
-    "bitrate_kbps": 20000,
-    "dynamic_range": "hdr10",
-    "subtitle_mode": "burn_in",
-    "transformations": [
-      {
-        "name": "hdr_to_sdr_tonemap",
-        "executor": "server",
-        "recipe_version": "1",
-        "validated_claims": []
-      },
-      {
-        "name": "audio_to_aac",
-        "executor": "server",
-        "recipe_version": "1",
-        "validated_claims": []
-      }
+    "server_plan_attempt_key": "v3:a90828494166fe72",
+    "replan_echo": "v3:a90828494166fe72",
+    "attempted_plan_keys": [
+      "v3:a90828494166fe72"
     ],
-    "output_context_id": "7",
-    "local_mutations": [
-      "transport_reopen",
-      "pcm:truehd:8"
-    ],
-    "expected": "v3:a90828494166fe72"
+    "expected_server_action": "reject_already_attempted_plan"
   },
   {
     "name": "direct_client_dv81_executor_and_version",
-    "plan_id": "plan:dv81-fixture",
-    "delivery": "original_http",
-    "stream_protocol": "http_progressive",
-    "container": "mkv",
-    "video_codec": "hevc",
-    "audio_codec": "truehd",
-    "width": 3840,
-    "height": 2160,
-    "bitrate_kbps": 65000,
-    "dynamic_range": "dolby_vision",
-    "subtitle_mode": "off",
-    "transformations": [
-      {
-        "name": "client_dv7_to_dv81",
-        "executor": "client",
-        "recipe_version": "1",
-        "validated_claims": []
-      }
+    "server_plan_attempt_key": "v3:9f82315867a70b80",
+    "replan_echo": "v3:9f82315867a70b80",
+    "attempted_plan_keys": [
+      "v3:9f82315867a70b80"
     ],
-    "output_context_id": "9",
-    "local_mutations": [],
-    "expected": "v3:9f82315867a70b80"
+    "expected_server_action": "reject_already_attempted_plan"
   },
   {
     "name": "direct_device_quirk_and_runtime_correction_identity",
-    "plan_id": "plan:quirk",
-    "delivery": "original_http",
-    "stream_protocol": "http_progressive",
-    "container": "mkv",
-    "video_codec": "hevc",
-    "audio_codec": "eac3",
-    "width": 3840,
-    "height": 2160,
-    "bitrate_kbps": 60000,
-    "dynamic_range": "dolby_vision",
-    "subtitle_mode": "off",
-    "transformations": [],
-    "applied_quirks": [
-      {
-        "id": "android.fire_tv.dv8_hdr10plus_sei_v1",
-        "registry_revision": "2026-07-13.1",
-        "action": "client_runtime_correction"
-      }
+    "server_plan_attempt_key": "v3:32a3a37d71bc4f43",
+    "replan_echo": "v3:32a3a37d71bc4f43",
+    "attempted_plan_keys": [
+      "v3:32a3a37d71bc4f43"
     ],
-    "runtime_corrections": [
-      "client_dv8_hdr10plus_sanitizer_v1"
-    ],
-    "output_context_id": "9",
-    "local_mutations": [],
-    "expected": "v3:32a3a37d71bc4f43"
+    "expected_server_action": "reject_already_attempted_plan"
   }
 ]

--- a/iosApp/Tests/Fixtures/PlaybackV3/attempt_keys.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/attempt_keys.json
@@ -1,0 +1,89 @@
+[
+  {
+    "name": "hls_burn_in_sorted_transformations_and_pcm_mutations",
+    "plan_id": "plan:fixture",
+    "delivery": "server_remux_hls",
+    "stream_protocol": "hls",
+    "container": "hls",
+    "video_codec": "hevc",
+    "audio_codec": "aac",
+    "width": 3840,
+    "height": 2160,
+    "bitrate_kbps": 20000,
+    "dynamic_range": "hdr10",
+    "subtitle_mode": "burn_in",
+    "transformations": [
+      {
+        "name": "hdr_to_sdr_tonemap",
+        "executor": "server",
+        "recipe_version": "1",
+        "validated_claims": []
+      },
+      {
+        "name": "audio_to_aac",
+        "executor": "server",
+        "recipe_version": "1",
+        "validated_claims": []
+      }
+    ],
+    "output_context_id": "7",
+    "local_mutations": [
+      "transport_reopen",
+      "pcm:truehd:8"
+    ],
+    "expected": "v3:a90828494166fe72"
+  },
+  {
+    "name": "direct_client_dv81_executor_and_version",
+    "plan_id": "plan:dv81-fixture",
+    "delivery": "original_http",
+    "stream_protocol": "http_progressive",
+    "container": "mkv",
+    "video_codec": "hevc",
+    "audio_codec": "truehd",
+    "width": 3840,
+    "height": 2160,
+    "bitrate_kbps": 65000,
+    "dynamic_range": "dolby_vision",
+    "subtitle_mode": "off",
+    "transformations": [
+      {
+        "name": "client_dv7_to_dv81",
+        "executor": "client",
+        "recipe_version": "1",
+        "validated_claims": []
+      }
+    ],
+    "output_context_id": "9",
+    "local_mutations": [],
+    "expected": "v3:9f82315867a70b80"
+  },
+  {
+    "name": "direct_device_quirk_and_runtime_correction_identity",
+    "plan_id": "plan:quirk",
+    "delivery": "original_http",
+    "stream_protocol": "http_progressive",
+    "container": "mkv",
+    "video_codec": "hevc",
+    "audio_codec": "eac3",
+    "width": 3840,
+    "height": 2160,
+    "bitrate_kbps": 60000,
+    "dynamic_range": "dolby_vision",
+    "subtitle_mode": "off",
+    "transformations": [],
+    "applied_quirks": [
+      {
+        "id": "android.fire_tv.dv8_hdr10plus_sei_v1",
+        "registry_revision": "2026-07-13.1",
+        "action": "client_runtime_correction"
+      }
+    ],
+    "runtime_corrections": [
+      "client_dv8_hdr10plus_sanitizer_v1"
+    ],
+    "output_context_id": "9",
+    "local_mutations": [],
+    "expected": "v3:32a3a37d71bc4f43"
+  }
+]

--- a/iosApp/Tests/Fixtures/PlaybackV3/capability_response.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/capability_response.json
@@ -41,7 +41,7 @@
     {
       "name": "video_to_h264",
       "executor": "server",
-      "recipe_version": "1",
+      "recipe_version": "2",
       "validated_claims": [
         "h264_decode"
       ]

--- a/iosApp/Tests/Fixtures/PlaybackV3/capability_response.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/capability_response.json
@@ -5,6 +5,7 @@
   ],
   "features": [
     "playback_plan_v3",
+    "neutral_playback_v3_contract_v1",
     "layout_aware_passthrough",
     "playback_route_diagnostics",
     "device_quirks_v1",

--- a/iosApp/Tests/Fixtures/PlaybackV3/capability_response.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/capability_response.json
@@ -1,0 +1,49 @@
+{
+  "enabled": true,
+  "protocol_versions": [
+    3
+  ],
+  "features": [
+    "playback_plan_v3",
+    "layout_aware_passthrough",
+    "playback_route_diagnostics",
+    "device_quirks_v1",
+    "seek_reanchor_v1",
+    "direct_stream_resume_v1",
+    "plan_source_duration_v1"
+  ],
+  "deliveries": [
+    "original_http",
+    "server_remux_progressive",
+    "server_remux_hls",
+    "server_transcode_hls"
+  ],
+  "transformations": [
+    {
+      "name": "audio_to_aac",
+      "executor": "server",
+      "recipe_version": "1",
+      "validated_claims": [
+        "audio_decode"
+      ]
+    },
+    {
+      "name": "server_dv7_to_hdr10",
+      "executor": "server",
+      "recipe_version": "1",
+      "validated_claims": [
+        "dolby_vision_metadata_removed",
+        "hdr10_base_layer_preserved",
+        "enhancement_layer_discarded"
+      ]
+    },
+    {
+      "name": "video_to_h264",
+      "executor": "server",
+      "recipe_version": "1",
+      "validated_claims": [
+        "h264_decode"
+      ]
+    }
+  ]
+}

--- a/iosApp/Tests/Fixtures/PlaybackV3/conformance_matrix.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/conformance_matrix.json
@@ -15,6 +15,7 @@
         "quality_preference": "original",
         "subtitle_fidelity_preference": "compatible",
         "start_position": 12.5,
+        "progress_persistence": "client",
         "audio_track_id": "file:42:audio:0",
         "audio_track_index": 0,
         "metered": false,
@@ -259,6 +260,7 @@
         "quality_preference": "original",
         "subtitle_fidelity_preference": "compatible",
         "start_position": 12.5,
+        "progress_persistence": "client",
         "audio_track_id": "file:42:audio:0",
         "audio_track_index": 0,
         "metered": false,
@@ -485,6 +487,7 @@
         "quality_preference": "original",
         "subtitle_fidelity_preference": "compatible",
         "start_position": 12.5,
+        "progress_persistence": "client",
         "audio_track_id": "file:42:audio:0",
         "audio_track_index": 0,
         "metered": false,
@@ -692,6 +695,7 @@
         "quality_preference": "original",
         "subtitle_fidelity_preference": "compatible",
         "start_position": 12.5,
+        "progress_persistence": "client",
         "audio_track_id": "file:42:audio:0",
         "audio_track_index": 0,
         "metered": false,
@@ -899,6 +903,7 @@
         "quality_preference": "original",
         "subtitle_fidelity_preference": "compatible",
         "start_position": 12.5,
+        "progress_persistence": "client",
         "audio_track_id": "file:42:audio:0",
         "audio_track_index": 0,
         "metered": false,
@@ -1109,6 +1114,7 @@
         "quality_preference": "original",
         "subtitle_fidelity_preference": "compatible",
         "start_position": 12.5,
+        "progress_persistence": "client",
         "audio_track_id": "file:42:audio:0",
         "audio_track_index": 0,
         "metered": false,
@@ -1320,6 +1326,7 @@
         "quality_preference": "720p",
         "subtitle_fidelity_preference": "compatible",
         "start_position": 12.5,
+        "progress_persistence": "client",
         "audio_track_id": "file:42:audio:0",
         "audio_track_index": 0,
         "metered": false,
@@ -1545,6 +1552,7 @@
         "quality_preference": "original",
         "subtitle_fidelity_preference": "compatible",
         "start_position": 12.5,
+        "progress_persistence": "client",
         "audio_track_id": "file:42:audio:0",
         "audio_track_index": 0,
         "metered": false,
@@ -1751,6 +1759,7 @@
         "quality_preference": "original",
         "subtitle_fidelity_preference": "compatible",
         "start_position": 12.5,
+        "progress_persistence": "client",
         "audio_track_id": "file:42:audio:0",
         "audio_track_index": 0,
         "metered": false,
@@ -1978,6 +1987,7 @@
         "quality_preference": "original",
         "subtitle_fidelity_preference": "compatible",
         "start_position": 12.5,
+        "progress_persistence": "client",
         "audio_track_id": "file:42:audio:0",
         "audio_track_index": 0,
         "metered": false,
@@ -2212,6 +2222,7 @@
         "quality_preference": "original",
         "subtitle_fidelity_preference": "compatible",
         "start_position": 12.5,
+        "progress_persistence": "client",
         "audio_track_id": "file:42:audio:0",
         "audio_track_index": 0,
         "metered": false,
@@ -2453,6 +2464,7 @@
         "quality_preference": "original",
         "subtitle_fidelity_preference": "compatible",
         "start_position": 12.5,
+        "progress_persistence": "client",
         "audio_track_id": "file:42:audio:0",
         "audio_track_index": 0,
         "metered": false,
@@ -2691,6 +2703,7 @@
         "quality_preference": "original",
         "subtitle_fidelity_preference": "compatible",
         "start_position": 12.5,
+        "progress_persistence": "client",
         "audio_track_id": "file:42:audio:0",
         "audio_track_index": 0,
         "metered": false,
@@ -2936,6 +2949,7 @@
         "quality_preference": "original",
         "subtitle_fidelity_preference": "compatible",
         "start_position": 12.5,
+        "progress_persistence": "client",
         "audio_track_id": "file:42:audio:0",
         "audio_track_index": 0,
         "subtitle_track_id": "file:42:subtitle:0",
@@ -3184,6 +3198,7 @@
         "quality_preference": "original",
         "subtitle_fidelity_preference": "preserve",
         "start_position": 12.5,
+        "progress_persistence": "client",
         "audio_track_id": "file:42:audio:0",
         "audio_track_index": 0,
         "subtitle_track_id": "file:42:subtitle:0",
@@ -3432,6 +3447,7 @@
         "quality_preference": "original",
         "subtitle_fidelity_preference": "compatible",
         "start_position": 12.5,
+        "progress_persistence": "client",
         "audio_track_id": "file:42:audio:0",
         "audio_track_index": 0,
         "subtitle_track_id": "file:42:subtitle:0",
@@ -3697,6 +3713,7 @@
         "quality_preference": "original",
         "subtitle_fidelity_preference": "compatible",
         "start_position": 12.5,
+        "progress_persistence": "client",
         "audio_track_id": "file:42:audio:0",
         "audio_track_index": 0,
         "metered": false,
@@ -4981,6 +4998,25 @@
       }
     },
     {
+      "name": "draft_v3_start_requires_upgrade",
+      "category": "draft_v3_426",
+      "input": {
+        "body": {
+          "protocol_version": 3,
+          "file_id": 42,
+          "client_capabilities": {
+            "codecs_video": [
+              "h264"
+            ]
+          }
+        }
+      },
+      "expected": {
+        "http_status": 426,
+        "error": "client_upgrade_required"
+      }
+    },
+    {
       "name": "output_context_change_invalidates_attempt",
       "category": "output_context_invalidation",
       "input": {
@@ -5153,6 +5189,7 @@
           "quality_preference": "original",
           "subtitle_fidelity_preference": "compatible",
           "start_position": 12.5,
+          "progress_persistence": "client",
           "audio_track_id": "file:42:audio:0",
           "audio_track_index": 0,
           "metered": false,
@@ -5244,6 +5281,7 @@
           "protocol_version": 3,
           "server_features": [
             "playback_plan_v3",
+            "neutral_playback_v3_contract_v1",
             "layout_aware_passthrough",
             "playback_route_diagnostics",
             "device_quirks_v1",
@@ -5283,6 +5321,7 @@
           "quality_preference": "original",
           "subtitle_fidelity_preference": "compatible",
           "start_position": 12.5,
+          "progress_persistence": "client",
           "audio_track_id": "file:42:audio:0",
           "audio_track_index": 0,
           "metered": false,

--- a/iosApp/Tests/Fixtures/PlaybackV3/conformance_matrix.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/conformance_matrix.json
@@ -175,8 +175,8 @@
         "outcome": "playable",
         "delivery": "server_transcode_hls",
         "decision_reason": "quality_original",
-        "plan_id": "plan:a7f5c7091b7a5ce1cd4fc43b2a6b327c",
-        "plan_attempt_key": "v3:8da9bae216075de8",
+        "plan_id": "plan:7b3b4cdf37a1a1084395bc810c9ac179",
+        "plan_attempt_key": "v3:5f2c9f8566a979cc",
         "selected_tracks": {
           "audio": {
             "id": "file:42:audio:0",
@@ -210,7 +210,7 @@
           {
             "name": "video_to_h264",
             "executor": "server",
-            "recipe_version": "1",
+            "recipe_version": "2",
             "validated_claims": [
               "h264_decode"
             ]
@@ -1467,8 +1467,8 @@
         "outcome": "playable",
         "delivery": "server_transcode_hls",
         "decision_reason": "quality_fixed_rung",
-        "plan_id": "plan:85ff00dd716863e27555e38202a9cefb",
-        "plan_attempt_key": "v3:cc8428ba187f6470",
+        "plan_id": "plan:36db80a93b9d295f44c2c3be6a7cb0ce",
+        "plan_attempt_key": "v3:aad5ccea009fea2a",
         "selected_tracks": {
           "audio": {
             "id": "file:42:audio:0",
@@ -1502,7 +1502,7 @@
           {
             "name": "video_to_h264",
             "executor": "server",
-            "recipe_version": "1",
+            "recipe_version": "2",
             "validated_claims": [
               "h264_decode"
             ]
@@ -2826,7 +2826,9 @@
               "audio_decode_codecs": [
                 "aac"
               ],
-              "audio_passthrough_codecs": [],
+              "audio_passthrough_codecs": [
+                "truehd"
+              ],
               "subtitles": {
                 "embedded_text": false,
                 "sidecar_text": false,
@@ -3609,8 +3611,8 @@
         "outcome": "playable",
         "delivery": "server_transcode_hls",
         "decision_reason": "subtitle_burn_in_required",
-        "plan_id": "plan:d7b6522ee3cef9299cdb650f339848c6",
-        "plan_attempt_key": "v3:624c543b8e5e7f44",
+        "plan_id": "plan:67e9593ed921a129645e41427a081943",
+        "plan_attempt_key": "v3:4d2de636abf938b1",
         "selected_tracks": {
           "audio": {
             "id": "file:42:audio:0",
@@ -3663,7 +3665,7 @@
           {
             "name": "video_to_h264",
             "executor": "server",
-            "recipe_version": "1",
+            "recipe_version": "2",
             "validated_claims": [
               "h264_decode"
             ]

--- a/iosApp/Tests/Fixtures/PlaybackV3/conformance_matrix.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/conformance_matrix.json
@@ -1,0 +1,5440 @@
+{
+  "schema_version": 1,
+  "planner_scenarios": [
+    {
+      "name": "evidence_exact",
+      "category": "evidence_tier_gating",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "file_id": 42,
+        "profile_id": "profile-1",
+        "playback_attempt_id": "attempt-evidence-exact",
+        "quality_preference": "original",
+        "subtitle_fidelity_preference": "compatible",
+        "start_position": 12.5,
+        "audio_track_id": "file:42:audio:0",
+        "audio_track_index": 0,
+        "metered": false,
+        "client_capabilities": {
+          "video_evidence": "exact",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "hevc"
+          ],
+          "codecs_video_hardware": [
+            "hevc"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mkv"
+          ],
+          "max_resolution": "1080p",
+          "hdr": false,
+          "video_decode": [
+            {
+              "codec": "hevc",
+              "profiles": [
+                "main 10"
+              ],
+              "levels": [
+                41
+              ],
+              "bit_depths": [
+                8
+              ],
+              "max_width": 1920,
+              "max_height": 1080,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 20000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "fixture"
+          },
+          "output": {
+            "output_context_id": "output-a"
+          },
+          "deliveries": {
+            "hls": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "hls"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mkv",
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "progressive": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "source": {
+        "media_file_id": 42,
+        "duration_seconds": 7200,
+        "container": "mkv",
+        "video_codec": "hevc",
+        "video_profile": "main",
+        "video_level": 41,
+        "bit_depth": 8,
+        "width": 1920,
+        "height": 1080,
+        "frame_rate": 23.976023976023978,
+        "bitrate_kbps": 8000,
+        "dynamic_range": "sdr",
+        "hdr10_plus": false,
+        "dv_enhancement_layer": "none",
+        "audio_codec": "aac",
+        "audio_channels": 2,
+        "audio_layout": "stereo"
+      },
+      "expected": {
+        "outcome": "playable",
+        "delivery": "server_transcode_hls",
+        "decision_reason": "quality_original",
+        "plan_id": "plan:a7f5c7091b7a5ce1cd4fc43b2a6b327c",
+        "plan_attempt_key": "v3:8da9bae216075de8",
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:0",
+            "index": 0
+          }
+        },
+        "subtitle": {
+          "mode": "off",
+          "inventory": []
+        },
+        "claims": {
+          "video": {
+            "hdr10": false,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision": false
+          },
+          "audio": {
+            "codec": "aac",
+            "passthrough": false,
+            "atmos_preserved": false,
+            "reason": "server_audio_adaptation"
+          },
+          "subtitles": {
+            "ass_styling_preserved": false,
+            "bitmap_overlay": false,
+            "bitmap_sidecar": false
+          }
+        },
+        "transformations": [
+          {
+            "name": "video_to_h264",
+            "executor": "server",
+            "recipe_version": "1",
+            "validated_claims": [
+              "h264_decode"
+            ]
+          },
+          {
+            "name": "audio_to_aac",
+            "executor": "server",
+            "recipe_version": "1",
+            "validated_claims": [
+              "audio_decode"
+            ]
+          }
+        ],
+        "available_qualities": [
+          {
+            "label": "original",
+            "height": 1080,
+            "bitrate_kbps": 8000,
+            "preserves_source": true
+          },
+          {
+            "label": "720p",
+            "height": 720,
+            "bitrate_kbps": 2000,
+            "preserves_source": false
+          },
+          {
+            "label": "480p",
+            "height": 480,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "evidence_platform_attested",
+      "category": "evidence_tier_gating",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "file_id": 42,
+        "profile_id": "profile-1",
+        "playback_attempt_id": "attempt-evidence-platform_attested",
+        "quality_preference": "original",
+        "subtitle_fidelity_preference": "compatible",
+        "start_position": 12.5,
+        "audio_track_id": "file:42:audio:0",
+        "audio_track_index": 0,
+        "metered": false,
+        "client_capabilities": {
+          "video_evidence": "platform_attested",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "hevc"
+          ],
+          "codecs_video_hardware": [
+            "hevc"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mkv"
+          ],
+          "max_resolution": "1080p",
+          "hdr": false,
+          "video_decode": [
+            {
+              "codec": "hevc",
+              "profiles": [
+                "main 10"
+              ],
+              "levels": [
+                41
+              ],
+              "bit_depths": [
+                8
+              ],
+              "max_width": 1920,
+              "max_height": 1080,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 20000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "fixture"
+          },
+          "output": {
+            "output_context_id": "output-a"
+          },
+          "deliveries": {
+            "hls": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "hls"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mkv",
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "progressive": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "source": {
+        "media_file_id": 42,
+        "duration_seconds": 7200,
+        "container": "mkv",
+        "video_codec": "hevc",
+        "video_profile": "main",
+        "video_level": 41,
+        "bit_depth": 8,
+        "width": 1920,
+        "height": 1080,
+        "frame_rate": 23.976023976023978,
+        "bitrate_kbps": 8000,
+        "dynamic_range": "sdr",
+        "hdr10_plus": false,
+        "dv_enhancement_layer": "none",
+        "audio_codec": "aac",
+        "audio_channels": 2,
+        "audio_layout": "stereo"
+      },
+      "expected": {
+        "outcome": "playable",
+        "delivery": "original_http",
+        "decision_reason": "validated_original_playback",
+        "plan_id": "plan:af10638f68c79ddc3e228cb93259e4cc",
+        "plan_attempt_key": "v3:0c345038da67f548",
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:0",
+            "index": 0
+          }
+        },
+        "subtitle": {
+          "mode": "off",
+          "inventory": []
+        },
+        "claims": {
+          "video": {
+            "hdr10": false,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision": false
+          },
+          "audio": {
+            "codec": "aac",
+            "passthrough": false,
+            "atmos_preserved": false,
+            "reason": "client_decode_supported"
+          },
+          "subtitles": {
+            "ass_styling_preserved": false,
+            "bitmap_overlay": false,
+            "bitmap_sidecar": false
+          }
+        },
+        "available_qualities": [
+          {
+            "label": "original",
+            "height": 1080,
+            "bitrate_kbps": 8000,
+            "preserves_source": true
+          },
+          {
+            "label": "720p",
+            "height": 720,
+            "bitrate_kbps": 2000,
+            "preserves_source": false
+          },
+          {
+            "label": "480p",
+            "height": 480,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "evidence_declared",
+      "category": "evidence_tier_gating",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "file_id": 42,
+        "profile_id": "profile-1",
+        "playback_attempt_id": "attempt-evidence-declared",
+        "quality_preference": "original",
+        "subtitle_fidelity_preference": "compatible",
+        "start_position": 12.5,
+        "audio_track_id": "file:42:audio:0",
+        "audio_track_index": 0,
+        "metered": false,
+        "client_capabilities": {
+          "video_evidence": "declared",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "hevc"
+          ],
+          "codecs_video_hardware": [
+            "hevc"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mkv"
+          ],
+          "max_resolution": "1080p",
+          "hdr": false
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "fixture"
+          },
+          "output": {
+            "output_context_id": "output-a"
+          },
+          "deliveries": {
+            "hls": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "hls"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mkv",
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "progressive": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "source": {
+        "media_file_id": 42,
+        "duration_seconds": 7200,
+        "container": "mkv",
+        "video_codec": "hevc",
+        "video_profile": "main",
+        "video_level": 41,
+        "bit_depth": 8,
+        "width": 1920,
+        "height": 1080,
+        "frame_rate": 23.976023976023978,
+        "bitrate_kbps": 8000,
+        "dynamic_range": "sdr",
+        "hdr10_plus": false,
+        "dv_enhancement_layer": "none",
+        "audio_codec": "aac",
+        "audio_channels": 2,
+        "audio_layout": "stereo"
+      },
+      "expected": {
+        "outcome": "playable",
+        "delivery": "original_http",
+        "decision_reason": "validated_original_playback",
+        "plan_id": "plan:112292a396dba70825480f538c5e1ab3",
+        "plan_attempt_key": "v3:407f095ab06f0d06",
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:0",
+            "index": 0
+          }
+        },
+        "subtitle": {
+          "mode": "off",
+          "inventory": []
+        },
+        "claims": {
+          "video": {
+            "hdr10": false,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision": false
+          },
+          "audio": {
+            "codec": "aac",
+            "passthrough": false,
+            "atmos_preserved": false,
+            "reason": "client_decode_supported"
+          },
+          "subtitles": {
+            "ass_styling_preserved": false,
+            "bitmap_overlay": false,
+            "bitmap_sidecar": false
+          }
+        },
+        "available_qualities": [
+          {
+            "label": "original",
+            "height": 1080,
+            "bitrate_kbps": 8000,
+            "preserves_source": true
+          },
+          {
+            "label": "720p",
+            "height": 720,
+            "bitrate_kbps": 2000,
+            "preserves_source": false
+          },
+          {
+            "label": "480p",
+            "height": 480,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "delivery_original",
+      "category": "deliveries_negotiation",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "file_id": 42,
+        "profile_id": "profile-1",
+        "playback_attempt_id": "attempt-delivery-chain",
+        "quality_preference": "original",
+        "subtitle_fidelity_preference": "compatible",
+        "start_position": 12.5,
+        "audio_track_id": "file:42:audio:0",
+        "audio_track_index": 0,
+        "metered": false,
+        "client_capabilities": {
+          "video_evidence": "declared",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "h264"
+          ],
+          "codecs_video_hardware": [
+            "h264"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mp4"
+          ],
+          "max_resolution": "1080p",
+          "hdr": false
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "fixture"
+          },
+          "output": {
+            "output_context_id": "output-a"
+          },
+          "deliveries": {
+            "hls": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "hls"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mkv",
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "progressive": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "source": {
+        "media_file_id": 42,
+        "duration_seconds": 7200,
+        "container": "mp4",
+        "video_codec": "h264",
+        "video_profile": "high",
+        "video_level": 41,
+        "bit_depth": 8,
+        "width": 1920,
+        "height": 1080,
+        "frame_rate": 23.976023976023978,
+        "bitrate_kbps": 8000,
+        "dynamic_range": "sdr",
+        "hdr10_plus": false,
+        "dv_enhancement_layer": "none",
+        "audio_codec": "aac",
+        "audio_channels": 2,
+        "audio_layout": "stereo"
+      },
+      "expected": {
+        "outcome": "playable",
+        "delivery": "original_http",
+        "decision_reason": "validated_original_playback",
+        "plan_id": "plan:11cf586f0837878a8bd7fb56aad2b114",
+        "plan_attempt_key": "v3:aea14da7eb994836",
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:0",
+            "index": 0
+          }
+        },
+        "subtitle": {
+          "mode": "off",
+          "inventory": []
+        },
+        "claims": {
+          "video": {
+            "hdr10": false,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision": false
+          },
+          "audio": {
+            "codec": "aac",
+            "passthrough": false,
+            "atmos_preserved": false,
+            "reason": "client_decode_supported"
+          },
+          "subtitles": {
+            "ass_styling_preserved": false,
+            "bitmap_overlay": false,
+            "bitmap_sidecar": false
+          }
+        },
+        "available_qualities": [
+          {
+            "label": "original",
+            "height": 1080,
+            "bitrate_kbps": 8000,
+            "preserves_source": true
+          },
+          {
+            "label": "720p",
+            "height": 720,
+            "bitrate_kbps": 2000,
+            "preserves_source": false
+          },
+          {
+            "label": "480p",
+            "height": 480,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "delivery_progressive",
+      "category": "deliveries_negotiation",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "file_id": 42,
+        "profile_id": "profile-1",
+        "playback_attempt_id": "attempt-delivery-chain",
+        "quality_preference": "original",
+        "subtitle_fidelity_preference": "compatible",
+        "start_position": 12.5,
+        "audio_track_id": "file:42:audio:0",
+        "audio_track_index": 0,
+        "metered": false,
+        "client_capabilities": {
+          "video_evidence": "declared",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "h264"
+          ],
+          "codecs_video_hardware": [
+            "h264"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mp4"
+          ],
+          "max_resolution": "1080p",
+          "hdr": false
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "fixture"
+          },
+          "output": {
+            "output_context_id": "output-a"
+          },
+          "deliveries": {
+            "hls": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "hls"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mkv",
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "progressive": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "source": {
+        "media_file_id": 42,
+        "duration_seconds": 7200,
+        "container": "mp4",
+        "video_codec": "h264",
+        "video_profile": "high",
+        "video_level": 41,
+        "bit_depth": 8,
+        "width": 1920,
+        "height": 1080,
+        "frame_rate": 23.976023976023978,
+        "bitrate_kbps": 8000,
+        "dynamic_range": "sdr",
+        "hdr10_plus": false,
+        "dv_enhancement_layer": "none",
+        "audio_codec": "aac",
+        "audio_channels": 2,
+        "audio_layout": "stereo"
+      },
+      "attempted_plan_keys": [
+        "v3:aea14da7eb994836"
+      ],
+      "expected": {
+        "outcome": "playable",
+        "delivery": "server_remux_progressive",
+        "decision_reason": "container_normalization",
+        "plan_id": "plan:56abab9075fd926b4a2901fdeac7f7bb",
+        "plan_attempt_key": "v3:e02a401930e003f8",
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:0",
+            "index": 0
+          }
+        },
+        "subtitle": {
+          "mode": "off",
+          "inventory": []
+        },
+        "claims": {
+          "video": {
+            "hdr10": false,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision": false
+          },
+          "audio": {
+            "codec": "aac",
+            "passthrough": false,
+            "atmos_preserved": false,
+            "reason": "client_decode_supported"
+          },
+          "subtitles": {
+            "ass_styling_preserved": false,
+            "bitmap_overlay": false,
+            "bitmap_sidecar": false
+          }
+        },
+        "available_qualities": [
+          {
+            "label": "original",
+            "height": 1080,
+            "bitrate_kbps": 8000,
+            "preserves_source": true
+          },
+          {
+            "label": "720p",
+            "height": 720,
+            "bitrate_kbps": 2000,
+            "preserves_source": false
+          },
+          {
+            "label": "480p",
+            "height": 480,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "delivery_hls",
+      "category": "deliveries_negotiation",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "file_id": 42,
+        "profile_id": "profile-1",
+        "playback_attempt_id": "attempt-delivery-chain",
+        "quality_preference": "original",
+        "subtitle_fidelity_preference": "compatible",
+        "start_position": 12.5,
+        "audio_track_id": "file:42:audio:0",
+        "audio_track_index": 0,
+        "metered": false,
+        "client_capabilities": {
+          "video_evidence": "declared",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "h264"
+          ],
+          "codecs_video_hardware": [
+            "h264"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mp4"
+          ],
+          "max_resolution": "1080p",
+          "hdr": false
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "fixture"
+          },
+          "output": {
+            "output_context_id": "output-a"
+          },
+          "deliveries": {
+            "hls": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "hls"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mkv",
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "progressive": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "source": {
+        "media_file_id": 42,
+        "duration_seconds": 7200,
+        "container": "mp4",
+        "video_codec": "h264",
+        "video_profile": "high",
+        "video_level": 41,
+        "bit_depth": 8,
+        "width": 1920,
+        "height": 1080,
+        "frame_rate": 23.976023976023978,
+        "bitrate_kbps": 8000,
+        "dynamic_range": "sdr",
+        "hdr10_plus": false,
+        "dv_enhancement_layer": "none",
+        "audio_codec": "aac",
+        "audio_channels": 2,
+        "audio_layout": "stereo"
+      },
+      "attempted_plan_keys": [
+        "v3:aea14da7eb994836",
+        "v3:e02a401930e003f8"
+      ],
+      "expected": {
+        "outcome": "playable",
+        "delivery": "server_remux_hls",
+        "decision_reason": "hls_packaging_required",
+        "plan_id": "plan:2dc0d6fc38a49b49d17ac9a60d8beba2",
+        "plan_attempt_key": "v3:464f01a4d6ecc0e8",
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:0",
+            "index": 0
+          }
+        },
+        "subtitle": {
+          "mode": "off",
+          "inventory": []
+        },
+        "claims": {
+          "video": {
+            "hdr10": false,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision": false
+          },
+          "audio": {
+            "codec": "aac",
+            "passthrough": false,
+            "atmos_preserved": false,
+            "reason": "client_decode_supported"
+          },
+          "subtitles": {
+            "ass_styling_preserved": false,
+            "bitmap_overlay": false,
+            "bitmap_sidecar": false
+          }
+        },
+        "available_qualities": [
+          {
+            "label": "original",
+            "height": 1080,
+            "bitrate_kbps": 8000,
+            "preserves_source": true
+          },
+          {
+            "label": "720p",
+            "height": 720,
+            "bitrate_kbps": 2000,
+            "preserves_source": false
+          },
+          {
+            "label": "480p",
+            "height": 480,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "delivery_transcode",
+      "category": "deliveries_negotiation",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "file_id": 42,
+        "profile_id": "profile-1",
+        "playback_attempt_id": "attempt-delivery-transcode",
+        "quality_preference": "720p",
+        "subtitle_fidelity_preference": "compatible",
+        "start_position": 12.5,
+        "audio_track_id": "file:42:audio:0",
+        "audio_track_index": 0,
+        "metered": false,
+        "client_capabilities": {
+          "video_evidence": "declared",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "h264"
+          ],
+          "codecs_video_hardware": [
+            "h264"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mp4"
+          ],
+          "max_resolution": "1080p",
+          "hdr": false
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "fixture"
+          },
+          "output": {
+            "output_context_id": "output-a"
+          },
+          "deliveries": {
+            "hls": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "hls"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mkv",
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "progressive": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "source": {
+        "media_file_id": 42,
+        "duration_seconds": 7200,
+        "container": "mp4",
+        "video_codec": "h264",
+        "video_profile": "high",
+        "video_level": 41,
+        "bit_depth": 8,
+        "width": 1920,
+        "height": 1080,
+        "frame_rate": 23.976023976023978,
+        "bitrate_kbps": 8000,
+        "dynamic_range": "sdr",
+        "hdr10_plus": false,
+        "dv_enhancement_layer": "none",
+        "audio_codec": "aac",
+        "audio_channels": 2,
+        "audio_layout": "stereo"
+      },
+      "expected": {
+        "outcome": "playable",
+        "delivery": "server_transcode_hls",
+        "decision_reason": "quality_fixed_rung",
+        "plan_id": "plan:85ff00dd716863e27555e38202a9cefb",
+        "plan_attempt_key": "v3:cc8428ba187f6470",
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:0",
+            "index": 0
+          }
+        },
+        "subtitle": {
+          "mode": "off",
+          "inventory": []
+        },
+        "claims": {
+          "video": {
+            "hdr10": false,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision": false
+          },
+          "audio": {
+            "codec": "aac",
+            "passthrough": false,
+            "atmos_preserved": false,
+            "reason": "server_audio_adaptation"
+          },
+          "subtitles": {
+            "ass_styling_preserved": false,
+            "bitmap_overlay": false,
+            "bitmap_sidecar": false
+          }
+        },
+        "transformations": [
+          {
+            "name": "video_to_h264",
+            "executor": "server",
+            "recipe_version": "1",
+            "validated_claims": [
+              "h264_decode"
+            ]
+          },
+          {
+            "name": "audio_to_aac",
+            "executor": "server",
+            "recipe_version": "1",
+            "validated_claims": [
+              "audio_decode"
+            ]
+          }
+        ],
+        "available_qualities": [
+          {
+            "label": "original",
+            "height": 1080,
+            "bitrate_kbps": 8000,
+            "preserves_source": true
+          },
+          {
+            "label": "720p",
+            "height": 720,
+            "bitrate_kbps": 2000,
+            "preserves_source": false
+          },
+          {
+            "label": "480p",
+            "height": 480,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "audio_only_original",
+      "category": "audio_only_planning",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "file_id": 77,
+        "profile_id": "profile-1",
+        "playback_attempt_id": "attempt-audio-only",
+        "quality_preference": "original",
+        "subtitle_fidelity_preference": "compatible",
+        "start_position": 12.5,
+        "audio_track_id": "file:42:audio:0",
+        "audio_track_index": 0,
+        "metered": false,
+        "client_capabilities": {
+          "video_evidence": "exact",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "hevc"
+          ],
+          "codecs_video_hardware": [
+            "hevc"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mp4"
+          ],
+          "max_resolution": "1080p",
+          "hdr": false,
+          "video_decode": [
+            {
+              "codec": "hevc",
+              "profiles": [
+                "main 10"
+              ],
+              "levels": [
+                41
+              ],
+              "bit_depths": [
+                8
+              ],
+              "max_width": 1920,
+              "max_height": 1080,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 20000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "fixture"
+          },
+          "output": {
+            "output_context_id": "output-a"
+          },
+          "deliveries": {
+            "hls": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "hls"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mkv",
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "progressive": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "source": {
+        "media_file_id": 77,
+        "duration_seconds": 39600,
+        "container": "mp4",
+        "bitrate_kbps": 128,
+        "dynamic_range": "sdr",
+        "hdr10_plus": false,
+        "dv_enhancement_layer": "none",
+        "audio_codec": "aac",
+        "audio_channels": 2,
+        "audio_layout": "stereo"
+      },
+      "expected": {
+        "outcome": "playable",
+        "delivery": "original_http",
+        "decision_reason": "validated_original_playback",
+        "plan_id": "plan:603b26dbc39763a3f935467f56e6902a",
+        "plan_attempt_key": "v3:e6a9fa3fb77cea40",
+        "selected_tracks": {
+          "audio": {
+            "id": "file:77:audio:0",
+            "index": 0
+          }
+        },
+        "subtitle": {
+          "mode": "off",
+          "inventory": []
+        },
+        "claims": {
+          "video": {
+            "hdr10": false,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision": false
+          },
+          "audio": {
+            "codec": "aac",
+            "passthrough": false,
+            "atmos_preserved": false,
+            "reason": "client_decode_supported"
+          },
+          "subtitles": {
+            "ass_styling_preserved": false,
+            "bitmap_overlay": false,
+            "bitmap_sidecar": false
+          }
+        },
+        "available_qualities": [
+          {
+            "label": "original",
+            "bitrate_kbps": 128,
+            "preserves_source": true
+          }
+        ]
+      }
+    },
+    {
+      "name": "hdr10_exact_direct",
+      "category": "hdr_dv_matrix",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "file_id": 42,
+        "profile_id": "profile-1",
+        "playback_attempt_id": "attempt-hdr10-direct",
+        "quality_preference": "original",
+        "subtitle_fidelity_preference": "compatible",
+        "start_position": 12.5,
+        "audio_track_id": "file:42:audio:0",
+        "audio_track_index": 0,
+        "metered": false,
+        "client_capabilities": {
+          "video_evidence": "exact",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "hevc"
+          ],
+          "codecs_video_hardware": [
+            "hevc"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mkv"
+          ],
+          "max_resolution": "2160p",
+          "hdr": true,
+          "hdr_details": {
+            "hdr10": true,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision_profiles": []
+          },
+          "video_decode": [
+            {
+              "codec": "hevc",
+              "profiles": [
+                "main 10"
+              ],
+              "levels": [
+                153
+              ],
+              "bit_depths": [
+                10
+              ],
+              "max_width": 3840,
+              "max_height": 2160,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 80000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "fixture"
+          },
+          "output": {
+            "hdr_details": {
+              "hdr10": true,
+              "hdr10_plus": false,
+              "hlg": false,
+              "dolby_vision_profiles": []
+            },
+            "output_context_id": "output-a"
+          },
+          "deliveries": {
+            "hls": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "hls"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mkv",
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "progressive": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "source": {
+        "media_file_id": 42,
+        "duration_seconds": 7200,
+        "container": "mkv",
+        "video_codec": "hevc",
+        "video_profile": "main 10",
+        "video_level": 153,
+        "bit_depth": 10,
+        "color_range": "tv",
+        "width": 3840,
+        "height": 2160,
+        "frame_rate": 23.976023976023978,
+        "bitrate_kbps": 60000,
+        "dynamic_range": "hdr10",
+        "hdr10_plus": false,
+        "dv_enhancement_layer": "none",
+        "audio_codec": "aac",
+        "audio_channels": 2,
+        "audio_layout": "stereo"
+      },
+      "expected": {
+        "outcome": "playable",
+        "delivery": "original_http",
+        "decision_reason": "validated_original_playback",
+        "plan_id": "plan:cb1eb35f5bf87af3b5f07bd08aad0c5b",
+        "plan_attempt_key": "v3:dfd23f2418e283b5",
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:0",
+            "index": 0
+          }
+        },
+        "subtitle": {
+          "mode": "off",
+          "inventory": []
+        },
+        "claims": {
+          "video": {
+            "hdr10": true,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision": false
+          },
+          "audio": {
+            "codec": "aac",
+            "passthrough": false,
+            "atmos_preserved": false,
+            "reason": "client_decode_supported"
+          },
+          "subtitles": {
+            "ass_styling_preserved": false,
+            "bitmap_overlay": false,
+            "bitmap_sidecar": false
+          }
+        },
+        "available_qualities": [
+          {
+            "label": "original",
+            "height": 2160,
+            "bitrate_kbps": 60000,
+            "preserves_source": true
+          }
+        ]
+      }
+    },
+    {
+      "name": "dolby_vision_8_exact_direct",
+      "category": "hdr_dv_matrix",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "file_id": 42,
+        "profile_id": "profile-1",
+        "playback_attempt_id": "attempt-dv8-direct",
+        "quality_preference": "original",
+        "subtitle_fidelity_preference": "compatible",
+        "start_position": 12.5,
+        "audio_track_id": "file:42:audio:0",
+        "audio_track_index": 0,
+        "metered": false,
+        "client_capabilities": {
+          "video_evidence": "exact",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "hevc"
+          ],
+          "codecs_video_hardware": [
+            "hevc"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mkv"
+          ],
+          "max_resolution": "2160p",
+          "hdr": true,
+          "hdr_details": {
+            "hdr10": true,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision_profiles": [
+              8
+            ]
+          },
+          "video_decode": [
+            {
+              "codec": "hevc",
+              "profiles": [
+                "main 10"
+              ],
+              "levels": [
+                153
+              ],
+              "bit_depths": [
+                10
+              ],
+              "max_width": 3840,
+              "max_height": 2160,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 80000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "fixture"
+          },
+          "output": {
+            "hdr_details": {
+              "hdr10": true,
+              "hdr10_plus": false,
+              "hlg": false,
+              "dolby_vision_profiles": [
+                8
+              ]
+            },
+            "output_context_id": "output-a"
+          },
+          "deliveries": {
+            "hls": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "hls"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mkv",
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "progressive": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "source": {
+        "media_file_id": 42,
+        "duration_seconds": 7200,
+        "container": "mkv",
+        "video_codec": "hevc",
+        "video_profile": "main 10",
+        "video_level": 153,
+        "bit_depth": 10,
+        "color_range": "tv",
+        "width": 3840,
+        "height": 2160,
+        "frame_rate": 23.976023976023978,
+        "bitrate_kbps": 60000,
+        "dynamic_range": "dolby_vision",
+        "hdr10_plus": false,
+        "dolby_vision_profile": 8,
+        "dv_bl_compat_id": 1,
+        "dv_enhancement_layer": "none",
+        "audio_codec": "aac",
+        "audio_channels": 2,
+        "audio_layout": "stereo"
+      },
+      "expected": {
+        "outcome": "playable",
+        "delivery": "original_http",
+        "decision_reason": "validated_original_playback",
+        "plan_id": "plan:dc16d317492afc93b5e082f54c3b5c34",
+        "plan_attempt_key": "v3:3ce8b4a367030abc",
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:0",
+            "index": 0
+          }
+        },
+        "subtitle": {
+          "mode": "off",
+          "inventory": []
+        },
+        "claims": {
+          "video": {
+            "hdr10": false,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision": true,
+            "dolby_vision_reason": "native_profile_supported"
+          },
+          "audio": {
+            "codec": "aac",
+            "passthrough": false,
+            "atmos_preserved": false,
+            "reason": "client_decode_supported"
+          },
+          "subtitles": {
+            "ass_styling_preserved": false,
+            "bitmap_overlay": false,
+            "bitmap_sidecar": false
+          }
+        },
+        "available_qualities": [
+          {
+            "label": "original",
+            "height": 2160,
+            "bitrate_kbps": 60000,
+            "preserves_source": true
+          }
+        ]
+      }
+    },
+    {
+      "name": "dolby_vision_7_hdr10_fallback",
+      "category": "hdr_dv_matrix",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "file_id": 42,
+        "profile_id": "profile-1",
+        "playback_attempt_id": "attempt-dv7-hdr10",
+        "quality_preference": "original",
+        "subtitle_fidelity_preference": "compatible",
+        "start_position": 12.5,
+        "audio_track_id": "file:42:audio:0",
+        "audio_track_index": 0,
+        "metered": false,
+        "client_capabilities": {
+          "video_evidence": "exact",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "hevc"
+          ],
+          "codecs_video_hardware": [
+            "hevc"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mkv"
+          ],
+          "max_resolution": "2160p",
+          "hdr": true,
+          "hdr_details": {
+            "hdr10": true,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision_profiles": []
+          },
+          "video_decode": [
+            {
+              "codec": "hevc",
+              "profiles": [
+                "main 10"
+              ],
+              "levels": [
+                153
+              ],
+              "bit_depths": [
+                10
+              ],
+              "max_width": 3840,
+              "max_height": 2160,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 80000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "fixture"
+          },
+          "output": {
+            "hdr_details": {
+              "hdr10": true,
+              "hdr10_plus": false,
+              "hlg": false,
+              "dolby_vision_profiles": []
+            },
+            "output_context_id": "output-a"
+          },
+          "deliveries": {
+            "hls": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "hls"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mkv",
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "progressive": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "source": {
+        "media_file_id": 42,
+        "duration_seconds": 7200,
+        "container": "mkv",
+        "video_codec": "hevc",
+        "video_profile": "main 10",
+        "video_level": 153,
+        "bit_depth": 10,
+        "color_range": "tv",
+        "width": 3840,
+        "height": 2160,
+        "frame_rate": 23.976023976023978,
+        "bitrate_kbps": 60000,
+        "dynamic_range": "dolby_vision",
+        "hdr10_plus": false,
+        "dolby_vision_profile": 7,
+        "dv_bl_compat_id": 6,
+        "dv_enhancement_layer": "unknown",
+        "audio_codec": "aac",
+        "audio_channels": 2,
+        "audio_layout": "stereo"
+      },
+      "expected": {
+        "outcome": "playable",
+        "delivery": "server_remux_progressive",
+        "decision_reason": "container_normalization",
+        "plan_id": "plan:e88fbdcf1a40478d50f19e6a1c9d2e41",
+        "plan_attempt_key": "v3:e3784d73c47008f0",
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:0",
+            "index": 0
+          }
+        },
+        "subtitle": {
+          "mode": "off",
+          "inventory": []
+        },
+        "claims": {
+          "video": {
+            "hdr10": true,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision": false
+          },
+          "audio": {
+            "codec": "aac",
+            "passthrough": false,
+            "atmos_preserved": false,
+            "reason": "client_decode_supported"
+          },
+          "subtitles": {
+            "ass_styling_preserved": false,
+            "bitmap_overlay": false,
+            "bitmap_sidecar": false
+          }
+        },
+        "transformations": [
+          {
+            "name": "server_dv7_to_hdr10",
+            "executor": "server",
+            "recipe_version": "1",
+            "validated_claims": [
+              "dolby_vision_metadata_removed",
+              "hdr10_base_layer_preserved",
+              "enhancement_layer_discarded"
+            ]
+          }
+        ],
+        "available_qualities": [
+          {
+            "label": "original",
+            "height": 2160,
+            "bitrate_kbps": 60000,
+            "preserves_source": true
+          }
+        ]
+      }
+    },
+    {
+      "name": "truehd_audio_conversion",
+      "category": "audio_matrix",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "file_id": 42,
+        "profile_id": "profile-1",
+        "playback_attempt_id": "attempt-truehd-aac",
+        "quality_preference": "original",
+        "subtitle_fidelity_preference": "compatible",
+        "start_position": 12.5,
+        "audio_track_id": "file:42:audio:0",
+        "audio_track_index": 0,
+        "metered": false,
+        "client_capabilities": {
+          "video_evidence": "exact",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "hevc"
+          ],
+          "codecs_video_hardware": [
+            "hevc"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mkv"
+          ],
+          "max_resolution": "2160p",
+          "hdr": true,
+          "hdr_details": {
+            "hdr10": true,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision_profiles": []
+          },
+          "video_decode": [
+            {
+              "codec": "hevc",
+              "profiles": [
+                "main 10"
+              ],
+              "levels": [
+                153
+              ],
+              "bit_depths": [
+                10
+              ],
+              "max_width": 3840,
+              "max_height": 2160,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 80000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "fixture"
+          },
+          "output": {
+            "hdr_details": {
+              "hdr10": true,
+              "hdr10_plus": false,
+              "hlg": false,
+              "dolby_vision_profiles": []
+            },
+            "output_context_id": "output-a"
+          },
+          "deliveries": {
+            "hls": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "hls"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mkv",
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "progressive": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "source": {
+        "media_file_id": 42,
+        "duration_seconds": 7200,
+        "container": "mkv",
+        "video_codec": "hevc",
+        "video_profile": "main 10",
+        "video_level": 153,
+        "bit_depth": 10,
+        "color_range": "tv",
+        "width": 3840,
+        "height": 2160,
+        "frame_rate": 23.976023976023978,
+        "bitrate_kbps": 60000,
+        "dynamic_range": "hdr10",
+        "hdr10_plus": false,
+        "dv_enhancement_layer": "none",
+        "audio_codec": "truehd",
+        "audio_channels": 8,
+        "audio_layout": "7.1"
+      },
+      "expected": {
+        "outcome": "playable",
+        "delivery": "server_remux_progressive",
+        "decision_reason": "audio_adaptation",
+        "plan_id": "plan:cccf704a0487d09d54a95b51d095c474",
+        "plan_attempt_key": "v3:8a79df3157b88939",
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:0",
+            "index": 0
+          }
+        },
+        "subtitle": {
+          "mode": "off",
+          "inventory": []
+        },
+        "claims": {
+          "video": {
+            "hdr10": true,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision": false
+          },
+          "audio": {
+            "codec": "aac",
+            "passthrough": false,
+            "atmos_preserved": false,
+            "reason": "server_audio_adaptation"
+          },
+          "subtitles": {
+            "ass_styling_preserved": false,
+            "bitmap_overlay": false,
+            "bitmap_sidecar": false
+          }
+        },
+        "transformations": [
+          {
+            "name": "audio_to_aac",
+            "executor": "server",
+            "recipe_version": "1",
+            "validated_claims": [
+              "audio_decode"
+            ]
+          }
+        ],
+        "available_qualities": [
+          {
+            "label": "original",
+            "height": 2160,
+            "bitrate_kbps": 60000,
+            "preserves_source": true
+          }
+        ]
+      }
+    },
+    {
+      "name": "truehd_exact_layout_passthrough",
+      "category": "audio_matrix",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3",
+          "layout_aware_passthrough"
+        ],
+        "file_id": 42,
+        "profile_id": "profile-1",
+        "playback_attempt_id": "attempt-truehd-passthrough",
+        "quality_preference": "original",
+        "subtitle_fidelity_preference": "compatible",
+        "start_position": 12.5,
+        "audio_track_id": "file:42:audio:0",
+        "audio_track_index": 0,
+        "metered": false,
+        "client_capabilities": {
+          "video_evidence": "exact",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "hevc"
+          ],
+          "codecs_video_hardware": [
+            "hevc"
+          ],
+          "codecs_audio": [
+            "truehd"
+          ],
+          "containers": [
+            "mkv"
+          ],
+          "max_resolution": "2160p",
+          "hdr": true,
+          "hdr_details": {
+            "hdr10": true,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision_profiles": []
+          },
+          "audio_passthrough": {
+            "passthrough_codecs": [
+              "truehd"
+            ],
+            "spatializer_enabled": false,
+            "max_channels": 8,
+            "entries": [
+              {
+                "codec": "truehd",
+                "channel_counts": [
+                  8
+                ],
+                "layouts": [
+                  "7.1"
+                ]
+              }
+            ]
+          },
+          "video_decode": [
+            {
+              "codec": "hevc",
+              "profiles": [
+                "main 10"
+              ],
+              "levels": [
+                153
+              ],
+              "bit_depths": [
+                10
+              ],
+              "max_width": 3840,
+              "max_height": 2160,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 80000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "fixture"
+          },
+          "output": {
+            "hdr_details": {
+              "hdr10": true,
+              "hdr10_plus": false,
+              "hlg": false,
+              "dolby_vision_profiles": []
+            },
+            "output_context_id": "output-a"
+          },
+          "deliveries": {
+            "hls": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "hls"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mkv",
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "progressive": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "source": {
+        "media_file_id": 42,
+        "duration_seconds": 7200,
+        "container": "mkv",
+        "video_codec": "hevc",
+        "video_profile": "main 10",
+        "video_level": 153,
+        "bit_depth": 10,
+        "color_range": "tv",
+        "width": 3840,
+        "height": 2160,
+        "frame_rate": 23.976023976023978,
+        "bitrate_kbps": 60000,
+        "dynamic_range": "hdr10",
+        "hdr10_plus": false,
+        "dv_enhancement_layer": "none",
+        "audio_codec": "truehd",
+        "audio_channels": 8,
+        "audio_layout": "7.1"
+      },
+      "expected": {
+        "outcome": "playable",
+        "delivery": "original_http",
+        "decision_reason": "validated_original_playback",
+        "plan_id": "plan:eb0f4227bac497cc2f43f2a7b3a90318",
+        "plan_attempt_key": "v3:8630acbb4ae17a89",
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:0",
+            "index": 0
+          }
+        },
+        "subtitle": {
+          "mode": "off",
+          "inventory": []
+        },
+        "claims": {
+          "video": {
+            "hdr10": true,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision": false
+          },
+          "audio": {
+            "codec": "truehd",
+            "passthrough": true,
+            "atmos_preserved": false,
+            "reason": "sink_passthrough_validated"
+          },
+          "subtitles": {
+            "ass_styling_preserved": false,
+            "bitmap_overlay": false,
+            "bitmap_sidecar": false
+          }
+        },
+        "available_qualities": [
+          {
+            "label": "original",
+            "height": 2160,
+            "bitrate_kbps": 60000,
+            "preserves_source": true
+          }
+        ]
+      }
+    },
+    {
+      "name": "embedded_pgs_sidecar",
+      "category": "subtitle_matrix",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "file_id": 42,
+        "profile_id": "profile-1",
+        "playback_attempt_id": "attempt-pgs-sidecar",
+        "quality_preference": "original",
+        "subtitle_fidelity_preference": "compatible",
+        "start_position": 12.5,
+        "audio_track_id": "file:42:audio:0",
+        "audio_track_index": 0,
+        "subtitle_track_id": "file:42:subtitle:0",
+        "subtitle_track_index": 0,
+        "metered": false,
+        "client_capabilities": {
+          "video_evidence": "exact",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "hevc"
+          ],
+          "codecs_video_hardware": [
+            "hevc"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mkv"
+          ],
+          "max_resolution": "2160p",
+          "hdr": true,
+          "hdr_details": {
+            "hdr10": true,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision_profiles": []
+          },
+          "video_decode": [
+            {
+              "codec": "hevc",
+              "profiles": [
+                "main 10"
+              ],
+              "levels": [
+                153
+              ],
+              "bit_depths": [
+                10
+              ],
+              "max_width": 3840,
+              "max_height": 2160,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 80000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "fixture"
+          },
+          "output": {
+            "hdr_details": {
+              "hdr10": true,
+              "hdr10_plus": false,
+              "hlg": false,
+              "dolby_vision_profiles": []
+            },
+            "output_context_id": "output-a"
+          },
+          "deliveries": {
+            "hls": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "hls"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": true,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mkv",
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": true,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "progressive": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": true,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "source": {
+        "media_file_id": 42,
+        "duration_seconds": 7200,
+        "container": "mkv",
+        "video_codec": "hevc",
+        "video_profile": "main 10",
+        "video_level": 153,
+        "bit_depth": 10,
+        "color_range": "tv",
+        "width": 3840,
+        "height": 2160,
+        "frame_rate": 23.976023976023978,
+        "bitrate_kbps": 60000,
+        "dynamic_range": "hdr10",
+        "hdr10_plus": false,
+        "dv_enhancement_layer": "none",
+        "audio_codec": "aac",
+        "audio_channels": 2,
+        "audio_layout": "stereo"
+      },
+      "expected": {
+        "outcome": "playable",
+        "delivery": "original_http",
+        "decision_reason": "validated_original_playback",
+        "plan_id": "plan:797ce06d50c911460783eff5e16e678c",
+        "plan_attempt_key": "v3:b424954be87ffe90",
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:0",
+            "index": 0
+          },
+          "subtitle": {
+            "id": "file:42:subtitle:0",
+            "index": 0
+          }
+        },
+        "subtitle": {
+          "mode": "render",
+          "track_id": "file:42:subtitle:0",
+          "inventory": [
+            {
+              "track_id": "file:42:subtitle:0",
+              "combined_index": 0,
+              "source": "embedded",
+              "codec": "hdmv_pgs_subtitle",
+              "language": "jpn",
+              "label": "Japanese",
+              "forced": false,
+              "default": false,
+              "hearing_impaired": false,
+              "delivery": "sidecar"
+            }
+          ]
+        },
+        "claims": {
+          "video": {
+            "hdr10": true,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision": false
+          },
+          "audio": {
+            "codec": "aac",
+            "passthrough": false,
+            "atmos_preserved": false,
+            "reason": "client_decode_supported"
+          },
+          "subtitles": {
+            "ass_styling_preserved": false,
+            "bitmap_overlay": false,
+            "bitmap_sidecar": true,
+            "reason": "client_bitmap_render_supported"
+          }
+        },
+        "available_qualities": [
+          {
+            "label": "original",
+            "height": 2160,
+            "bitrate_kbps": 60000,
+            "preserves_source": true
+          }
+        ]
+      }
+    },
+    {
+      "name": "embedded_ass_authored_render",
+      "category": "subtitle_matrix",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "file_id": 42,
+        "profile_id": "profile-1",
+        "playback_attempt_id": "attempt-ass-authored",
+        "quality_preference": "original",
+        "subtitle_fidelity_preference": "preserve",
+        "start_position": 12.5,
+        "audio_track_id": "file:42:audio:0",
+        "audio_track_index": 0,
+        "subtitle_track_id": "file:42:subtitle:0",
+        "subtitle_track_index": 0,
+        "metered": false,
+        "client_capabilities": {
+          "video_evidence": "exact",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "hevc"
+          ],
+          "codecs_video_hardware": [
+            "hevc"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mkv"
+          ],
+          "max_resolution": "2160p",
+          "hdr": true,
+          "hdr_details": {
+            "hdr10": true,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision_profiles": []
+          },
+          "video_decode": [
+            {
+              "codec": "hevc",
+              "profiles": [
+                "main 10"
+              ],
+              "levels": [
+                153
+              ],
+              "bit_depths": [
+                10
+              ],
+              "max_width": 3840,
+              "max_height": 2160,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 80000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "fixture"
+          },
+          "output": {
+            "hdr_details": {
+              "hdr10": true,
+              "hdr10_plus": false,
+              "hlg": false,
+              "dolby_vision_profiles": []
+            },
+            "output_context_id": "output-a"
+          },
+          "deliveries": {
+            "hls": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "hls"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": true,
+                "sidecar_text": false,
+                "ass_styling": true,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": true
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mkv",
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": true,
+                "sidecar_text": false,
+                "ass_styling": true,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": true
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "progressive": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": true,
+                "sidecar_text": false,
+                "ass_styling": true,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": true
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "source": {
+        "media_file_id": 42,
+        "duration_seconds": 7200,
+        "container": "mkv",
+        "video_codec": "hevc",
+        "video_profile": "main 10",
+        "video_level": 153,
+        "bit_depth": 10,
+        "color_range": "tv",
+        "width": 3840,
+        "height": 2160,
+        "frame_rate": 23.976023976023978,
+        "bitrate_kbps": 60000,
+        "dynamic_range": "hdr10",
+        "hdr10_plus": false,
+        "dv_enhancement_layer": "none",
+        "audio_codec": "aac",
+        "audio_channels": 2,
+        "audio_layout": "stereo"
+      },
+      "expected": {
+        "outcome": "playable",
+        "delivery": "original_http",
+        "decision_reason": "validated_original_playback",
+        "plan_id": "plan:fb18d142b453e46d895b516db09f7c8a",
+        "plan_attempt_key": "v3:f50777d24ac9fe32",
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:0",
+            "index": 0
+          },
+          "subtitle": {
+            "id": "file:42:subtitle:0",
+            "index": 0
+          }
+        },
+        "subtitle": {
+          "mode": "render",
+          "track_id": "file:42:subtitle:0",
+          "inventory": [
+            {
+              "track_id": "file:42:subtitle:0",
+              "combined_index": 0,
+              "source": "embedded",
+              "codec": "ass",
+              "language": "eng",
+              "label": "English Signs",
+              "forced": false,
+              "default": false,
+              "hearing_impaired": false,
+              "delivery": "sidecar"
+            }
+          ]
+        },
+        "claims": {
+          "video": {
+            "hdr10": true,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision": false
+          },
+          "audio": {
+            "codec": "aac",
+            "passthrough": false,
+            "atmos_preserved": false,
+            "reason": "client_decode_supported"
+          },
+          "subtitles": {
+            "ass_styling_preserved": true,
+            "bitmap_overlay": false,
+            "bitmap_sidecar": false,
+            "reason": "client_render_supported"
+          }
+        },
+        "available_qualities": [
+          {
+            "label": "original",
+            "height": 2160,
+            "bitrate_kbps": 60000,
+            "preserves_source": true
+          }
+        ]
+      }
+    },
+    {
+      "name": "embedded_dvd_burn_in",
+      "category": "subtitle_matrix",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "file_id": 42,
+        "profile_id": "profile-1",
+        "playback_attempt_id": "attempt-dvd-burn-in",
+        "quality_preference": "original",
+        "subtitle_fidelity_preference": "compatible",
+        "start_position": 12.5,
+        "audio_track_id": "file:42:audio:0",
+        "audio_track_index": 0,
+        "subtitle_track_id": "file:42:subtitle:0",
+        "subtitle_track_index": 0,
+        "metered": false,
+        "client_capabilities": {
+          "video_evidence": "exact",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "hevc"
+          ],
+          "codecs_video_hardware": [
+            "hevc"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mkv"
+          ],
+          "max_resolution": "1080p",
+          "hdr": false,
+          "video_decode": [
+            {
+              "codec": "hevc",
+              "profiles": [
+                "main 10"
+              ],
+              "levels": [
+                41
+              ],
+              "bit_depths": [
+                8
+              ],
+              "max_width": 1920,
+              "max_height": 1080,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 20000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "fixture"
+          },
+          "output": {
+            "output_context_id": "output-a"
+          },
+          "deliveries": {
+            "hls": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "hls"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mkv",
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "progressive": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "source": {
+        "media_file_id": 42,
+        "duration_seconds": 7200,
+        "container": "mkv",
+        "video_codec": "hevc",
+        "video_profile": "main",
+        "video_level": 41,
+        "bit_depth": 8,
+        "width": 1920,
+        "height": 1080,
+        "frame_rate": 23.976023976023978,
+        "bitrate_kbps": 8000,
+        "dynamic_range": "sdr",
+        "hdr10_plus": false,
+        "dv_enhancement_layer": "none",
+        "audio_codec": "aac",
+        "audio_channels": 2,
+        "audio_layout": "stereo"
+      },
+      "expected": {
+        "outcome": "playable",
+        "delivery": "server_transcode_hls",
+        "decision_reason": "subtitle_burn_in_required",
+        "plan_id": "plan:d7b6522ee3cef9299cdb650f339848c6",
+        "plan_attempt_key": "v3:624c543b8e5e7f44",
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:0",
+            "index": 0
+          },
+          "subtitle": {
+            "id": "file:42:subtitle:0",
+            "index": 0
+          }
+        },
+        "subtitle": {
+          "mode": "burn_in",
+          "track_id": "file:42:subtitle:0",
+          "inventory": [
+            {
+              "track_id": "file:42:subtitle:0",
+              "combined_index": 0,
+              "source": "embedded",
+              "codec": "dvd_subtitle",
+              "language": "eng",
+              "label": "English",
+              "forced": false,
+              "default": false,
+              "hearing_impaired": false,
+              "delivery": "burn_in_only"
+            }
+          ]
+        },
+        "claims": {
+          "video": {
+            "hdr10": false,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision": false
+          },
+          "audio": {
+            "codec": "aac",
+            "passthrough": false,
+            "atmos_preserved": false,
+            "reason": "server_audio_adaptation"
+          },
+          "subtitles": {
+            "ass_styling_preserved": false,
+            "bitmap_overlay": true,
+            "bitmap_sidecar": false,
+            "reason": "server_burn_in_required"
+          }
+        },
+        "transformations": [
+          {
+            "name": "video_to_h264",
+            "executor": "server",
+            "recipe_version": "1",
+            "validated_claims": [
+              "h264_decode"
+            ]
+          },
+          {
+            "name": "audio_to_aac",
+            "executor": "server",
+            "recipe_version": "1",
+            "validated_claims": [
+              "audio_decode"
+            ]
+          }
+        ],
+        "available_qualities": [
+          {
+            "label": "original",
+            "height": 1080,
+            "bitrate_kbps": 8000,
+            "preserves_source": true
+          },
+          {
+            "label": "720p",
+            "height": 720,
+            "bitrate_kbps": 2000,
+            "preserves_source": false
+          },
+          {
+            "label": "480p",
+            "height": 480,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "available_qualities",
+      "category": "available_qualities",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "file_id": 42,
+        "profile_id": "profile-1",
+        "playback_attempt_id": "attempt-available-qualities",
+        "quality_preference": "original",
+        "subtitle_fidelity_preference": "compatible",
+        "start_position": 12.5,
+        "audio_track_id": "file:42:audio:0",
+        "audio_track_index": 0,
+        "metered": false,
+        "client_capabilities": {
+          "video_evidence": "declared",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "h264"
+          ],
+          "codecs_video_hardware": [
+            "h264"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mp4"
+          ],
+          "max_resolution": "1080p",
+          "hdr": false
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "fixture"
+          },
+          "output": {
+            "output_context_id": "output-a"
+          },
+          "deliveries": {
+            "hls": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "hls"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mkv",
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "progressive": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "source": {
+        "media_file_id": 42,
+        "duration_seconds": 7200,
+        "container": "mp4",
+        "video_codec": "h264",
+        "video_profile": "high",
+        "video_level": 41,
+        "bit_depth": 8,
+        "width": 1920,
+        "height": 1080,
+        "frame_rate": 23.976023976023978,
+        "bitrate_kbps": 8000,
+        "dynamic_range": "sdr",
+        "hdr10_plus": false,
+        "dv_enhancement_layer": "none",
+        "audio_codec": "aac",
+        "audio_channels": 2,
+        "audio_layout": "stereo"
+      },
+      "expected": {
+        "outcome": "playable",
+        "delivery": "original_http",
+        "decision_reason": "validated_original_playback",
+        "plan_id": "plan:4da88570903f3211bf0b1cfd5c4b534b",
+        "plan_attempt_key": "v3:b469cbb1ebe407fa",
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:0",
+            "index": 0
+          }
+        },
+        "subtitle": {
+          "mode": "off",
+          "inventory": []
+        },
+        "claims": {
+          "video": {
+            "hdr10": false,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision": false
+          },
+          "audio": {
+            "codec": "aac",
+            "passthrough": false,
+            "atmos_preserved": false,
+            "reason": "client_decode_supported"
+          },
+          "subtitles": {
+            "ass_styling_preserved": false,
+            "bitmap_overlay": false,
+            "bitmap_sidecar": false
+          }
+        },
+        "available_qualities": [
+          {
+            "label": "original",
+            "height": 1080,
+            "bitrate_kbps": 8000,
+            "preserves_source": true
+          },
+          {
+            "label": "720p",
+            "height": 720,
+            "bitrate_kbps": 2000,
+            "preserves_source": false
+          },
+          {
+            "label": "480p",
+            "height": 480,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          }
+        ]
+      }
+    }
+  ],
+  "replan_scenarios": [
+    {
+      "name": "track_change",
+      "category": "track_change_replan",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "operation": "track_change",
+        "playback_attempt_id": "attempt-golden-0001",
+        "replan_request_id": "replan-track-change-0001",
+        "failed_plan_id": "plan:478677870860e5e5108c18bff749b34b",
+        "plan_attempt_id": "plan-attempt-golden-0001",
+        "plan_attempt_key": "v3:f0144c47fa349e3e",
+        "attempted_plan_keys": [
+          "v3:f0144c47fa349e3e"
+        ],
+        "attempt_count": 1,
+        "quality_preference": "auto",
+        "position_seconds": 321.25,
+        "metered": true,
+        "bandwidth_estimate_kbps": 3500,
+        "bandwidth_cap_kbps": 4000,
+        "selected_tracks": {
+          "audio": {
+            "id": "",
+            "index": 1
+          }
+        },
+        "client_capabilities": {
+          "video_evidence": "exact",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "h264"
+          ],
+          "codecs_video_hardware": [
+            "h264"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mp4"
+          ],
+          "max_resolution": "1080p",
+          "hdr": false,
+          "video_decode": [
+            {
+              "codec": "h264",
+              "profiles": [
+                "high"
+              ],
+              "levels": [
+                41
+              ],
+              "bit_depths": [
+                8
+              ],
+              "max_width": 1920,
+              "max_height": 1080,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 20000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "android",
+            "os_version": "15",
+            "manufacturer": "NVIDIA",
+            "model": "SHIELD Android TV",
+            "platform_details": {
+              "abis": "arm64-v8a",
+              "sdk_int": "35"
+            }
+          },
+          "output": {
+            "output_context_id": "7"
+          },
+          "deliveries": {
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": true,
+                "sidecar_text": true,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": true,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "expected": {
+        "http_status": 200,
+        "preserve_unmodified_tracks": true
+      }
+    },
+    {
+      "name": "quality_change",
+      "category": "quality_change_replan",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "operation": "quality_change",
+        "playback_attempt_id": "attempt-golden-0001",
+        "replan_request_id": "replan-quality-change-0001",
+        "failed_plan_id": "plan:478677870860e5e5108c18bff749b34b",
+        "plan_attempt_id": "plan-attempt-golden-0001",
+        "plan_attempt_key": "v3:f0144c47fa349e3e",
+        "attempted_plan_keys": [
+          "v3:f0144c47fa349e3e"
+        ],
+        "attempt_count": 1,
+        "quality_preference": "720p",
+        "position_seconds": 321.25,
+        "metered": true,
+        "bandwidth_estimate_kbps": 3500,
+        "bandwidth_cap_kbps": 4000,
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:0",
+            "index": 0
+          }
+        },
+        "client_capabilities": {
+          "video_evidence": "exact",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "h264"
+          ],
+          "codecs_video_hardware": [
+            "h264"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mp4"
+          ],
+          "max_resolution": "1080p",
+          "hdr": false,
+          "video_decode": [
+            {
+              "codec": "h264",
+              "profiles": [
+                "high"
+              ],
+              "levels": [
+                41
+              ],
+              "bit_depths": [
+                8
+              ],
+              "max_width": 1920,
+              "max_height": 1080,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 20000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "android",
+            "os_version": "15",
+            "manufacturer": "NVIDIA",
+            "model": "SHIELD Android TV",
+            "platform_details": {
+              "abis": "arm64-v8a",
+              "sdk_int": "35"
+            }
+          },
+          "output": {
+            "output_context_id": "7"
+          },
+          "deliveries": {
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": true,
+                "sidecar_text": true,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": true,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "expected": {
+        "http_status": 200,
+        "selected_quality": "720p"
+      }
+    },
+    {
+      "name": "track_change_idempotent_duplicate",
+      "category": "idempotent_replan",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "operation": "track_change",
+        "playback_attempt_id": "attempt-golden-0001",
+        "replan_request_id": "replan-track-duplicate-0001",
+        "failed_plan_id": "plan:478677870860e5e5108c18bff749b34b",
+        "plan_attempt_id": "plan-attempt-golden-0001",
+        "plan_attempt_key": "v3:f0144c47fa349e3e",
+        "attempted_plan_keys": [
+          "v3:f0144c47fa349e3e"
+        ],
+        "attempt_count": 1,
+        "quality_preference": "auto",
+        "position_seconds": 321.25,
+        "metered": true,
+        "bandwidth_estimate_kbps": 3500,
+        "bandwidth_cap_kbps": 4000,
+        "selected_tracks": {
+          "audio": {
+            "id": "",
+            "index": 1
+          }
+        },
+        "client_capabilities": {
+          "video_evidence": "exact",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "h264"
+          ],
+          "codecs_video_hardware": [
+            "h264"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mp4"
+          ],
+          "max_resolution": "1080p",
+          "hdr": false,
+          "video_decode": [
+            {
+              "codec": "h264",
+              "profiles": [
+                "high"
+              ],
+              "levels": [
+                41
+              ],
+              "bit_depths": [
+                8
+              ],
+              "max_width": 1920,
+              "max_height": 1080,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 20000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "android",
+            "os_version": "15",
+            "manufacturer": "NVIDIA",
+            "model": "SHIELD Android TV",
+            "platform_details": {
+              "abis": "arm64-v8a",
+              "sdk_int": "35"
+            }
+          },
+          "output": {
+            "output_context_id": "7"
+          },
+          "deliveries": {
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": true,
+                "sidecar_text": true,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": true,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "expected": {
+        "same_request_and_body_status": 200,
+        "response_replayed_verbatim": true,
+        "changed_body_status": 409,
+        "changed_body_error": "idempotency_key_reused"
+      }
+    },
+    {
+      "name": "quality_change_idempotent_duplicate",
+      "category": "idempotent_replan",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "operation": "quality_change",
+        "playback_attempt_id": "attempt-golden-0001",
+        "replan_request_id": "replan-quality-duplicate-0001",
+        "failed_plan_id": "plan:478677870860e5e5108c18bff749b34b",
+        "plan_attempt_id": "plan-attempt-golden-0001",
+        "plan_attempt_key": "v3:f0144c47fa349e3e",
+        "attempted_plan_keys": [
+          "v3:f0144c47fa349e3e"
+        ],
+        "attempt_count": 1,
+        "quality_preference": "720p",
+        "position_seconds": 321.25,
+        "metered": true,
+        "bandwidth_estimate_kbps": 3500,
+        "bandwidth_cap_kbps": 4000,
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:0",
+            "index": 0
+          }
+        },
+        "client_capabilities": {
+          "video_evidence": "exact",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "h264"
+          ],
+          "codecs_video_hardware": [
+            "h264"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mp4"
+          ],
+          "max_resolution": "1080p",
+          "hdr": false,
+          "video_decode": [
+            {
+              "codec": "h264",
+              "profiles": [
+                "high"
+              ],
+              "levels": [
+                41
+              ],
+              "bit_depths": [
+                8
+              ],
+              "max_width": 1920,
+              "max_height": 1080,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 20000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "android",
+            "os_version": "15",
+            "manufacturer": "NVIDIA",
+            "model": "SHIELD Android TV",
+            "platform_details": {
+              "abis": "arm64-v8a",
+              "sdk_int": "35"
+            }
+          },
+          "output": {
+            "output_context_id": "7"
+          },
+          "deliveries": {
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": true,
+                "sidecar_text": true,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": true,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "expected": {
+        "same_request_and_body_status": 200,
+        "response_replayed_verbatim": true,
+        "changed_body_status": 409,
+        "changed_body_error": "idempotency_key_reused"
+      }
+    },
+    {
+      "name": "track_change_concurrent_duplicate",
+      "category": "concurrent_replan",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "operation": "track_change",
+        "playback_attempt_id": "attempt-golden-0001",
+        "replan_request_id": "replan-track-concurrent-0001",
+        "failed_plan_id": "plan:478677870860e5e5108c18bff749b34b",
+        "plan_attempt_id": "plan-attempt-golden-0001",
+        "plan_attempt_key": "v3:f0144c47fa349e3e",
+        "attempted_plan_keys": [
+          "v3:f0144c47fa349e3e"
+        ],
+        "attempt_count": 1,
+        "quality_preference": "auto",
+        "position_seconds": 321.25,
+        "metered": true,
+        "bandwidth_estimate_kbps": 3500,
+        "bandwidth_cap_kbps": 4000,
+        "selected_tracks": {
+          "audio": {
+            "id": "",
+            "index": 1
+          }
+        },
+        "client_capabilities": {
+          "video_evidence": "exact",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "h264"
+          ],
+          "codecs_video_hardware": [
+            "h264"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mp4"
+          ],
+          "max_resolution": "1080p",
+          "hdr": false,
+          "video_decode": [
+            {
+              "codec": "h264",
+              "profiles": [
+                "high"
+              ],
+              "levels": [
+                41
+              ],
+              "bit_depths": [
+                8
+              ],
+              "max_width": 1920,
+              "max_height": 1080,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 20000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "android",
+            "os_version": "15",
+            "manufacturer": "NVIDIA",
+            "model": "SHIELD Android TV",
+            "platform_details": {
+              "abis": "arm64-v8a",
+              "sdk_int": "35"
+            }
+          },
+          "output": {
+            "output_context_id": "7"
+          },
+          "deliveries": {
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": true,
+                "sidecar_text": true,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": true,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "expected": {
+        "response_replayed_verbatim": true,
+        "while_first_lease_active_status": 409,
+        "concurrent_error": "replan_in_progress",
+        "after_completion_status": 200
+      }
+    },
+    {
+      "name": "quality_change_concurrent_duplicate",
+      "category": "concurrent_replan",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "operation": "quality_change",
+        "playback_attempt_id": "attempt-golden-0001",
+        "replan_request_id": "replan-quality-concurrent-0001",
+        "failed_plan_id": "plan:478677870860e5e5108c18bff749b34b",
+        "plan_attempt_id": "plan-attempt-golden-0001",
+        "plan_attempt_key": "v3:f0144c47fa349e3e",
+        "attempted_plan_keys": [
+          "v3:f0144c47fa349e3e"
+        ],
+        "attempt_count": 1,
+        "quality_preference": "720p",
+        "position_seconds": 321.25,
+        "metered": true,
+        "bandwidth_estimate_kbps": 3500,
+        "bandwidth_cap_kbps": 4000,
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:0",
+            "index": 0
+          }
+        },
+        "client_capabilities": {
+          "video_evidence": "exact",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "h264"
+          ],
+          "codecs_video_hardware": [
+            "h264"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mp4"
+          ],
+          "max_resolution": "1080p",
+          "hdr": false,
+          "video_decode": [
+            {
+              "codec": "h264",
+              "profiles": [
+                "high"
+              ],
+              "levels": [
+                41
+              ],
+              "bit_depths": [
+                8
+              ],
+              "max_width": 1920,
+              "max_height": 1080,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 20000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "android",
+            "os_version": "15",
+            "manufacturer": "NVIDIA",
+            "model": "SHIELD Android TV",
+            "platform_details": {
+              "abis": "arm64-v8a",
+              "sdk_int": "35"
+            }
+          },
+          "output": {
+            "output_context_id": "7"
+          },
+          "deliveries": {
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": true,
+                "sidecar_text": true,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": true,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "expected": {
+        "response_replayed_verbatim": true,
+        "while_first_lease_active_status": 409,
+        "concurrent_error": "replan_in_progress",
+        "after_completion_status": 200
+      }
+    },
+    {
+      "name": "track_change_mid_seek",
+      "category": "mid_seek_replan",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "operation": "track_change",
+        "playback_attempt_id": "attempt-golden-0001",
+        "replan_request_id": "replan-track-mid-seek-0001",
+        "failed_plan_id": "plan:478677870860e5e5108c18bff749b34b",
+        "plan_attempt_id": "plan-attempt-golden-0001",
+        "plan_attempt_key": "v3:f0144c47fa349e3e",
+        "attempted_plan_keys": [
+          "v3:f0144c47fa349e3e"
+        ],
+        "attempt_count": 1,
+        "quality_preference": "auto",
+        "position_seconds": 321.25,
+        "metered": true,
+        "bandwidth_estimate_kbps": 3500,
+        "bandwidth_cap_kbps": 4000,
+        "selected_tracks": {
+          "audio": {
+            "id": "",
+            "index": 1
+          }
+        },
+        "client_capabilities": {
+          "video_evidence": "exact",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "h264"
+          ],
+          "codecs_video_hardware": [
+            "h264"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mp4"
+          ],
+          "max_resolution": "1080p",
+          "hdr": false,
+          "video_decode": [
+            {
+              "codec": "h264",
+              "profiles": [
+                "high"
+              ],
+              "levels": [
+                41
+              ],
+              "bit_depths": [
+                8
+              ],
+              "max_width": 1920,
+              "max_height": 1080,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 20000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "android",
+            "os_version": "15",
+            "manufacturer": "NVIDIA",
+            "model": "SHIELD Android TV",
+            "platform_details": {
+              "abis": "arm64-v8a",
+              "sdk_int": "35"
+            }
+          },
+          "output": {
+            "output_context_id": "7"
+          },
+          "deliveries": {
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": true,
+                "sidecar_text": true,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": true,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "expected": {
+        "http_status": 200,
+        "position_seconds": 321.25,
+        "position_preserved": true
+      }
+    },
+    {
+      "name": "quality_change_mid_seek",
+      "category": "mid_seek_replan",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "operation": "quality_change",
+        "playback_attempt_id": "attempt-golden-0001",
+        "replan_request_id": "replan-quality-mid-seek-0001",
+        "failed_plan_id": "plan:478677870860e5e5108c18bff749b34b",
+        "plan_attempt_id": "plan-attempt-golden-0001",
+        "plan_attempt_key": "v3:f0144c47fa349e3e",
+        "attempted_plan_keys": [
+          "v3:f0144c47fa349e3e"
+        ],
+        "attempt_count": 1,
+        "quality_preference": "720p",
+        "position_seconds": 321.25,
+        "metered": true,
+        "bandwidth_estimate_kbps": 3500,
+        "bandwidth_cap_kbps": 4000,
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:0",
+            "index": 0
+          }
+        },
+        "client_capabilities": {
+          "video_evidence": "exact",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "h264"
+          ],
+          "codecs_video_hardware": [
+            "h264"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mp4"
+          ],
+          "max_resolution": "1080p",
+          "hdr": false,
+          "video_decode": [
+            {
+              "codec": "h264",
+              "profiles": [
+                "high"
+              ],
+              "levels": [
+                41
+              ],
+              "bit_depths": [
+                8
+              ],
+              "max_width": 1920,
+              "max_height": 1080,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 20000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "android",
+            "os_version": "15",
+            "manufacturer": "NVIDIA",
+            "model": "SHIELD Android TV",
+            "platform_details": {
+              "abis": "arm64-v8a",
+              "sdk_int": "35"
+            }
+          },
+          "output": {
+            "output_context_id": "7"
+          },
+          "deliveries": {
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": true,
+                "sidecar_text": true,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": true,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "expected": {
+        "http_status": 200,
+        "position_seconds": 321.25,
+        "position_preserved": true
+      }
+    },
+    {
+      "name": "mid_seek_reanchor",
+      "category": "mid_seek_replan",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "operation": "seek_reanchor",
+        "playback_attempt_id": "attempt-golden-0001",
+        "replan_request_id": "replan-seek-reanchor-0001",
+        "failed_plan_id": "plan:478677870860e5e5108c18bff749b34b",
+        "plan_attempt_id": "plan-attempt-golden-0001",
+        "plan_attempt_key": "v3:f0144c47fa349e3e",
+        "attempted_plan_keys": [
+          "v3:f0144c47fa349e3e"
+        ],
+        "attempt_count": 1,
+        "quality_preference": "auto",
+        "position_seconds": 321.25,
+        "metered": true,
+        "bandwidth_estimate_kbps": 3500,
+        "bandwidth_cap_kbps": 4000,
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:0",
+            "index": 0
+          }
+        },
+        "client_capabilities": {
+          "video_evidence": "exact",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "h264"
+          ],
+          "codecs_video_hardware": [
+            "h264"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mp4"
+          ],
+          "max_resolution": "1080p",
+          "hdr": false,
+          "video_decode": [
+            {
+              "codec": "h264",
+              "profiles": [
+                "high"
+              ],
+              "levels": [
+                41
+              ],
+              "bit_depths": [
+                8
+              ],
+              "max_width": 1920,
+              "max_height": 1080,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 20000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "android",
+            "os_version": "15",
+            "manufacturer": "NVIDIA",
+            "model": "SHIELD Android TV",
+            "platform_details": {
+              "abis": "arm64-v8a",
+              "sdk_int": "35"
+            }
+          },
+          "output": {
+            "output_context_id": "7"
+          },
+          "deliveries": {
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": true,
+                "sidecar_text": true,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": true,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "expected": {
+        "http_status": 200,
+        "position_seconds": 321.25,
+        "position_preserved": true
+      }
+    }
+  ],
+  "protocol_scenarios": [
+    {
+      "name": "legacy_start_requires_upgrade",
+      "category": "legacy_426",
+      "input": {
+        "body": {
+          "file_id": 42
+        }
+      },
+      "expected": {
+        "http_status": 426,
+        "error": "client_upgrade_required"
+      }
+    },
+    {
+      "name": "output_context_change_invalidates_attempt",
+      "category": "output_context_invalidation",
+      "input": {
+        "plan_id": "plan:478677870860e5e5108c18bff749b34b",
+        "first_output_context_id": "output-a",
+        "second_output_context_id": "output-b",
+        "first_plan_attempt_key": "v3:28cb8a408ea7f446",
+        "second_plan_attempt_key": "v3:28c88c408ea5c1d5"
+      },
+      "expected": {
+        "plan_id_unchanged": true,
+        "plan_attempt_key_changed": true
+      }
+    },
+    {
+      "name": "opaque_attempt_key_loop",
+      "category": "attempt_key_echo_and_loop",
+      "input": {
+        "server_plan_attempt_key": "v3:f0144c47fa349e3e",
+        "replan_echo": "v3:f0144c47fa349e3e",
+        "attempted_plan_keys": [
+          "v3:f0144c47fa349e3e"
+        ]
+      },
+      "expected": {
+        "action": "reject_already_attempted_plan"
+      }
+    },
+    {
+      "name": "failure_recovery_preserves_intent",
+      "category": "recovery_matrix",
+      "input": {
+        "replan_request": {
+          "protocol_version": 3,
+          "client_features": [
+            "playback_plan_v3"
+          ],
+          "operation": "failure_recovery",
+          "playback_attempt_id": "attempt-golden-0001",
+          "replan_request_id": "replan-failure-matrix-0001",
+          "failed_plan_id": "plan:478677870860e5e5108c18bff749b34b",
+          "plan_attempt_id": "plan-attempt-golden-0001",
+          "plan_attempt_key": "v3:f0144c47fa349e3e",
+          "attempted_plan_keys": [
+            "v3:f0144c47fa349e3e"
+          ],
+          "attempt_count": 1,
+          "quality_preference": "auto",
+          "position_seconds": 321.25,
+          "metered": true,
+          "bandwidth_estimate_kbps": 3500,
+          "bandwidth_cap_kbps": 4000,
+          "selected_tracks": {
+            "audio": {
+              "id": "file:42:audio:0",
+              "index": 0
+            },
+            "subtitle": {
+              "id": "file:42:subtitle:2",
+              "index": 2
+            }
+          },
+          "failure": {
+            "classification": "network_degraded"
+          },
+          "client_capabilities": {
+            "video_evidence": "exact",
+            "audio_evidence": "exact",
+            "codecs_video": [
+              "h264"
+            ],
+            "codecs_video_hardware": [
+              "h264"
+            ],
+            "codecs_audio": [
+              "aac"
+            ],
+            "containers": [
+              "mp4"
+            ],
+            "max_resolution": "1080p",
+            "hdr": false,
+            "video_decode": [
+              {
+                "codec": "h264",
+                "profiles": [
+                  "high"
+                ],
+                "levels": [
+                  41
+                ],
+                "bit_depths": [
+                  8
+                ],
+                "max_width": 1920,
+                "max_height": 1080,
+                "max_frame_rate": 60,
+                "max_bitrate_kbps": 20000,
+                "hardware": true
+              }
+            ]
+          },
+          "client_playback_context": {
+            "protocol_version": 3,
+            "form_factor": "tv",
+            "app_version": "3.0-test",
+            "device": {
+              "platform": "android",
+              "os_version": "15",
+              "manufacturer": "NVIDIA",
+              "model": "SHIELD Android TV",
+              "platform_details": {
+                "abis": "arm64-v8a",
+                "sdk_int": "35"
+              }
+            },
+            "output": {
+              "output_context_id": "7"
+            },
+            "deliveries": {
+              "original_http": {
+                "enabled": true,
+                "supported_on_device": true,
+                "containers": [
+                  "mp4"
+                ],
+                "video_codecs": [
+                  "h264"
+                ],
+                "audio_decode_codecs": [
+                  "aac"
+                ],
+                "audio_passthrough_codecs": [],
+                "subtitles": {
+                  "embedded_text": true,
+                  "sidecar_text": true,
+                  "ass_styling": false,
+                  "embedded_bitmap": false,
+                  "sidecar_bitmap": false,
+                  "font_attachments": false
+                },
+                "features": [],
+                "auth_header_refresh": true,
+                "validated_claims": [],
+                "transformations": []
+              }
+            }
+          }
+        }
+      },
+      "expected": {
+        "http_status": 200,
+        "selection_preserved": true,
+        "position_preserved": true,
+        "action": "preserve_selected_tracks_and_position"
+      }
+    },
+    {
+      "name": "restart_replays_terminal_attempt",
+      "category": "restart_matrix",
+      "input": {
+        "start_request": {
+          "protocol_version": 3,
+          "client_features": [
+            "playback_plan_v3"
+          ],
+          "file_id": 42,
+          "profile_id": "profile-1",
+          "playback_attempt_id": "attempt-restart-terminal",
+          "quality_preference": "original",
+          "subtitle_fidelity_preference": "compatible",
+          "start_position": 12.5,
+          "audio_track_id": "file:42:audio:0",
+          "audio_track_index": 0,
+          "metered": false,
+          "client_capabilities": {
+            "video_evidence": "exact",
+            "audio_evidence": "exact",
+            "codecs_video": [
+              "h264"
+            ],
+            "codecs_video_hardware": [
+              "h264"
+            ],
+            "codecs_audio": [
+              "aac"
+            ],
+            "containers": [
+              "mp4"
+            ],
+            "max_resolution": "1080p",
+            "hdr": false,
+            "video_decode": [
+              {
+                "codec": "h264",
+                "profiles": [
+                  "high"
+                ],
+                "levels": [
+                  41
+                ],
+                "bit_depths": [
+                  8
+                ],
+                "max_width": 1920,
+                "max_height": 1080,
+                "max_frame_rate": 60,
+                "max_bitrate_kbps": 20000,
+                "hardware": true
+              }
+            ]
+          },
+          "client_playback_context": {
+            "protocol_version": 3,
+            "form_factor": "tv",
+            "app_version": "3.0-test",
+            "device": {
+              "platform": "android",
+              "os_version": "15",
+              "manufacturer": "NVIDIA",
+              "model": "SHIELD Android TV",
+              "platform_details": {
+                "abis": "arm64-v8a",
+                "sdk_int": "35"
+              }
+            },
+            "output": {
+              "output_context_id": "7"
+            },
+            "deliveries": {
+              "original_http": {
+                "enabled": true,
+                "supported_on_device": true,
+                "containers": [
+                  "mp4"
+                ],
+                "video_codecs": [
+                  "h264"
+                ],
+                "audio_decode_codecs": [
+                  "aac"
+                ],
+                "audio_passthrough_codecs": [],
+                "subtitles": {
+                  "embedded_text": true,
+                  "sidecar_text": true,
+                  "ass_styling": false,
+                  "embedded_bitmap": false,
+                  "sidecar_bitmap": false,
+                  "font_attachments": false
+                },
+                "features": [],
+                "auth_header_refresh": true,
+                "validated_claims": [],
+                "transformations": []
+              }
+            }
+          }
+        },
+        "persisted_decision": {
+          "protocol_version": 3,
+          "server_features": [
+            "playback_plan_v3",
+            "layout_aware_passthrough",
+            "playback_route_diagnostics",
+            "device_quirks_v1",
+            "seek_reanchor_v1",
+            "direct_stream_resume_v1",
+            "plan_source_duration_v1"
+          ],
+          "outcome": "adaptation_unavailable",
+          "terminal": {
+            "reason": "transcode_start_failed",
+            "message": "The playback transport did not become ready in time.",
+            "retryable": true
+          }
+        },
+        "restarted": true
+      },
+      "expected": {
+        "http_status": 201,
+        "outcome": "adaptation_unavailable",
+        "terminal_reason": "transcode_start_failed",
+        "response_replayed_verbatim": true,
+        "capacity_delta": 0
+      }
+    },
+    {
+      "name": "capacity_unavailable_cleans_up",
+      "category": "capacity_matrix",
+      "input": {
+        "start_request": {
+          "protocol_version": 3,
+          "client_features": [
+            "playback_plan_v3"
+          ],
+          "file_id": 42,
+          "profile_id": "profile-1",
+          "playback_attempt_id": "attempt-capacity-unavailable",
+          "quality_preference": "original",
+          "subtitle_fidelity_preference": "compatible",
+          "start_position": 12.5,
+          "audio_track_id": "file:42:audio:0",
+          "audio_track_index": 0,
+          "metered": false,
+          "client_capabilities": {
+            "video_evidence": "exact",
+            "audio_evidence": "exact",
+            "codecs_video": [
+              "h264"
+            ],
+            "codecs_video_hardware": [
+              "h264"
+            ],
+            "codecs_audio": [
+              "aac"
+            ],
+            "containers": [
+              "mp4"
+            ],
+            "max_resolution": "1080p",
+            "hdr": false,
+            "video_decode": [
+              {
+                "codec": "h264",
+                "profiles": [
+                  "high"
+                ],
+                "levels": [
+                  41
+                ],
+                "bit_depths": [
+                  8
+                ],
+                "max_width": 1920,
+                "max_height": 1080,
+                "max_frame_rate": 60,
+                "max_bitrate_kbps": 20000,
+                "hardware": true
+              }
+            ]
+          },
+          "client_playback_context": {
+            "protocol_version": 3,
+            "form_factor": "tv",
+            "app_version": "3.0-test",
+            "device": {
+              "platform": "android",
+              "os_version": "15",
+              "manufacturer": "NVIDIA",
+              "model": "SHIELD Android TV",
+              "platform_details": {
+                "abis": "arm64-v8a",
+                "sdk_int": "35"
+              }
+            },
+            "output": {
+              "output_context_id": "7"
+            },
+            "deliveries": {
+              "original_http": {
+                "enabled": true,
+                "supported_on_device": true,
+                "containers": [
+                  "mp4"
+                ],
+                "video_codecs": [
+                  "h264"
+                ],
+                "audio_decode_codecs": [
+                  "aac"
+                ],
+                "audio_passthrough_codecs": [],
+                "subtitles": {
+                  "embedded_text": true,
+                  "sidecar_text": true,
+                  "ass_styling": false,
+                  "embedded_bitmap": false,
+                  "sidecar_bitmap": false,
+                  "font_attachments": false
+                },
+                "features": [],
+                "auth_header_refresh": true,
+                "validated_claims": [],
+                "transformations": []
+              }
+            }
+          }
+        },
+        "capacity_available": false
+      },
+      "expected": {
+        "http_status": 201,
+        "outcome": "adaptation_unavailable",
+        "terminal_reason": "capacity_unavailable",
+        "capacity_delta": 0,
+        "cleanup_complete": true
+      }
+    },
+    {
+      "name": "route_event_diagnostic_limit",
+      "category": "route_event_limits",
+      "input": {
+        "route_event": {
+          "protocol_version": 3,
+          "playback_attempt_id": "attempt-route-limit",
+          "session_id": "11111111-1111-4111-8111-111111111111",
+          "plan_id": "plan:478677870860e5e5108c18bff749b34b",
+          "plan_attempt_id": "plan-attempt-golden-0001",
+          "plan_attempt_key": "v3:f0144c47fa349e3e",
+          "event": "first_frame",
+          "output_context_id": "7",
+          "diagnostics": {
+            "diagnostic_00": "value",
+            "diagnostic_01": "value",
+            "diagnostic_02": "value",
+            "diagnostic_03": "value",
+            "diagnostic_04": "value",
+            "diagnostic_05": "value",
+            "diagnostic_06": "value",
+            "diagnostic_07": "value",
+            "diagnostic_08": "value",
+            "diagnostic_09": "value",
+            "diagnostic_10": "value",
+            "diagnostic_11": "value",
+            "diagnostic_12": "value",
+            "diagnostic_13": "value",
+            "diagnostic_14": "value",
+            "diagnostic_15": "value",
+            "diagnostic_16": "value",
+            "diagnostic_17": "value",
+            "diagnostic_18": "value",
+            "diagnostic_19": "value",
+            "diagnostic_20": "value",
+            "diagnostic_21": "value",
+            "diagnostic_22": "value",
+            "diagnostic_23": "value",
+            "diagnostic_24": "value",
+            "diagnostic_25": "value",
+            "diagnostic_26": "value",
+            "diagnostic_27": "value",
+            "diagnostic_28": "value",
+            "diagnostic_29": "value",
+            "diagnostic_30": "value",
+            "diagnostic_31": "value",
+            "diagnostic_32": "value"
+          }
+        }
+      },
+      "expected": {
+        "http_status": 400,
+        "error": "bad_request",
+        "action": "reject_without_persisting"
+      }
+    }
+  ]
+}

--- a/iosApp/Tests/Fixtures/PlaybackV3/decision_response.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/decision_response.json
@@ -2,6 +2,7 @@
   "protocol_version": 3,
   "server_features": [
     "playback_plan_v3",
+    "neutral_playback_v3_contract_v1",
     "layout_aware_passthrough",
     "playback_route_diagnostics",
     "device_quirks_v1",

--- a/iosApp/Tests/Fixtures/PlaybackV3/decision_response.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/decision_response.json
@@ -46,7 +46,7 @@
       "audio_codec": "aac",
       "width": 1920,
       "height": 1080,
-      "frame_rate": 23.976,
+      "frame_rate": 23.976023976023978,
       "bitrate_kbps": 8000,
       "dynamic_range": "sdr",
       "audio_channels": 2,
@@ -150,18 +150,6 @@
         "height": 1080,
         "bitrate_kbps": 8000,
         "preserves_source": true
-      },
-      {
-        "label": "720p",
-        "height": 720,
-        "bitrate_kbps": 2000,
-        "preserves_source": false
-      },
-      {
-        "label": "480p",
-        "height": 480,
-        "bitrate_kbps": 1500,
-        "preserves_source": false
       }
     ],
     "degradation_warnings": [],
@@ -170,7 +158,7 @@
     "effective_media_file_id": 42,
     "source": {
       "media_file_id": 42,
-      "duration_seconds": 7265.5,
+      "duration_seconds": 7200,
       "container": "mp4",
       "video_codec": "h264",
       "video_profile": "high",
@@ -178,7 +166,7 @@
       "bit_depth": 8,
       "width": 1920,
       "height": 1080,
-      "frame_rate": 23.976,
+      "frame_rate": 23.976023976023978,
       "bitrate_kbps": 8000,
       "dynamic_range": "sdr",
       "hdr10_plus": false,

--- a/iosApp/Tests/Fixtures/PlaybackV3/decision_response.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/decision_response.json
@@ -1,0 +1,191 @@
+{
+  "protocol_version": 3,
+  "server_features": [
+    "playback_plan_v3",
+    "layout_aware_passthrough",
+    "playback_route_diagnostics",
+    "device_quirks_v1",
+    "seek_reanchor_v1",
+    "direct_stream_resume_v1",
+    "plan_source_duration_v1"
+  ],
+  "outcome": "playable",
+  "session_id": "11111111-1111-4111-8111-111111111111",
+  "playback_plan": {
+    "protocol_version": 3,
+    "plan_id": "plan:478677870860e5e5108c18bff749b34b",
+    "plan_attempt_key": "v3:f0144c47fa349e3e",
+    "session_id": "11111111-1111-4111-8111-111111111111",
+    "expires_at": "2030-01-01T00:00:00Z",
+    "delivery": "original_http",
+    "stream": {
+      "url": "/stream/11111111-1111-4111-8111-111111111111",
+      "protocol": "http_progressive",
+      "container": "mp4",
+      "mime_type": "video/mp4",
+      "headers": {},
+      "header_refresh": "session"
+    },
+    "timeline": {
+      "source_start_seconds": 12.5,
+      "stream_origin_seconds": 0,
+      "player_start_seconds": 12.5,
+      "timeline_offset_seconds": 0,
+      "can_seek_anywhere": true,
+      "seek_restoration": "player_position"
+    },
+    "selected_tracks": {
+      "audio": {
+        "id": "file:42:audio:0",
+        "index": 0
+      }
+    },
+    "effective_recipe": {
+      "video_codec": "h264",
+      "audio_codec": "aac",
+      "width": 1920,
+      "height": 1080,
+      "frame_rate": 23.976,
+      "bitrate_kbps": 8000,
+      "dynamic_range": "sdr",
+      "audio_channels": 2,
+      "audio_layout": "stereo"
+    },
+    "claims": {
+      "video": {
+        "hdr10": false,
+        "hdr10_plus": false,
+        "hlg": false,
+        "dolby_vision": false
+      },
+      "audio": {
+        "codec": "aac",
+        "passthrough": false,
+        "atmos_preserved": false,
+        "reason": "client_decode_supported"
+      },
+      "subtitles": {
+        "ass_styling_preserved": false,
+        "bitmap_overlay": false,
+        "bitmap_sidecar": false
+      }
+    },
+    "subtitle": {
+      "mode": "off",
+      "inventory": [
+        {
+          "track_id": "file:42:subtitle:0",
+          "combined_index": 0,
+          "source": "external",
+          "codec": "srt",
+          "language": "eng",
+          "label": "English",
+          "forced": false,
+          "default": false,
+          "hearing_impaired": false,
+          "delivery": "sidecar",
+          "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/0.vtt?file_id=42"
+        },
+        {
+          "track_id": "file:42:subtitle:1",
+          "combined_index": 1,
+          "source": "embedded",
+          "codec": "ass",
+          "language": "eng",
+          "label": "English (Signs)",
+          "forced": true,
+          "default": false,
+          "hearing_impaired": false,
+          "delivery": "sidecar",
+          "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/1.ass?file_id=42",
+          "font_bundle_url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/1/fonts?file_id=42"
+        },
+        {
+          "track_id": "file:42:subtitle:2",
+          "combined_index": 2,
+          "source": "embedded",
+          "codec": "pgs",
+          "language": "jpn",
+          "label": "Japanese",
+          "forced": false,
+          "default": false,
+          "hearing_impaired": false,
+          "delivery": "sidecar",
+          "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/2.sup?file_id=42"
+        },
+        {
+          "track_id": "file:42:subtitle:3",
+          "combined_index": 3,
+          "source": "embedded",
+          "codec": "dvd_subtitle",
+          "language": "fre",
+          "label": "French",
+          "forced": false,
+          "default": false,
+          "hearing_impaired": false,
+          "delivery": "burn_in_only"
+        },
+        {
+          "track_id": "file:42:subtitle:4",
+          "combined_index": 4,
+          "source": "downloaded",
+          "codec": "srt",
+          "language": "spa",
+          "label": "Spanish (downloaded)",
+          "forced": false,
+          "default": false,
+          "hearing_impaired": false,
+          "delivery": "sidecar",
+          "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/4.vtt?file_id=42"
+        }
+      ]
+    },
+    "transformations": [],
+    "applied_quirks": [],
+    "runtime_corrections": [],
+    "available_qualities": [
+      {
+        "label": "original",
+        "height": 1080,
+        "bitrate_kbps": 8000,
+        "preserves_source": true
+      },
+      {
+        "label": "720p",
+        "height": 720,
+        "bitrate_kbps": 2000,
+        "preserves_source": false
+      },
+      {
+        "label": "480p",
+        "height": 480,
+        "bitrate_kbps": 1500,
+        "preserves_source": false
+      }
+    ],
+    "degradation_warnings": [],
+    "decision_reason": "validated_original_playback",
+    "requested_media_file_id": 42,
+    "effective_media_file_id": 42,
+    "source": {
+      "media_file_id": 42,
+      "duration_seconds": 7265.5,
+      "container": "mp4",
+      "video_codec": "h264",
+      "video_profile": "high",
+      "video_level": 41,
+      "bit_depth": 8,
+      "width": 1920,
+      "height": 1080,
+      "frame_rate": 23.976,
+      "bitrate_kbps": 8000,
+      "dynamic_range": "sdr",
+      "hdr10_plus": false,
+      "dv_enhancement_layer": "none",
+      "audio_codec": "aac",
+      "audio_channels": 2,
+      "audio_layout": "stereo"
+    },
+    "subtitle_fidelity_policy": "allow_simplified_rendering"
+  }
+}

--- a/iosApp/Tests/Fixtures/PlaybackV3/error_response.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/error_response.json
@@ -1,0 +1,4 @@
+{
+  "error": "client_upgrade_required",
+  "message": "This server requires playback protocol v3. Update the app to continue."
+}

--- a/iosApp/Tests/Fixtures/PlaybackV3/replan_request.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/replan_request.json
@@ -6,11 +6,11 @@
   "operation": "failure_recovery",
   "playback_attempt_id": "attempt-golden-0001",
   "replan_request_id": "replan-golden-0001",
-  "failed_plan_id": "plan:golden-0001",
+  "failed_plan_id": "plan:478677870860e5e5108c18bff749b34b",
   "plan_attempt_id": "plan-attempt-golden-0001",
-  "plan_attempt_key": "v3:0000000000000001",
+  "plan_attempt_key": "v3:f0144c47fa349e3e",
   "attempted_plan_keys": [
-    "v3:0000000000000001"
+    "v3:f0144c47fa349e3e"
   ],
   "attempt_count": 1,
   "quality_preference": "auto",

--- a/iosApp/Tests/Fixtures/PlaybackV3/replan_request.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/replan_request.json
@@ -1,0 +1,113 @@
+{
+  "protocol_version": 3,
+  "client_features": [
+    "playback_plan_v3"
+  ],
+  "operation": "failure_recovery",
+  "playback_attempt_id": "attempt-golden-0001",
+  "replan_request_id": "replan-golden-0001",
+  "failed_plan_id": "plan:golden-0001",
+  "plan_attempt_id": "plan-attempt-golden-0001",
+  "plan_attempt_key": "v3:0000000000000001",
+  "attempted_plan_keys": [
+    "v3:0000000000000001"
+  ],
+  "attempt_count": 1,
+  "quality_preference": "auto",
+  "position_seconds": 42.5,
+  "metered": true,
+  "bandwidth_estimate_kbps": 3500,
+  "bandwidth_cap_kbps": 4000,
+  "selected_tracks": {
+    "audio": {
+      "id": "file:42:audio:0",
+      "index": 0
+    }
+  },
+  "failure": {
+    "classification": "network_degraded"
+  },
+  "client_capabilities": {
+    "video_evidence": "exact",
+    "audio_evidence": "exact",
+    "codecs_video": [
+      "h264"
+    ],
+    "codecs_video_hardware": [
+      "h264"
+    ],
+    "codecs_audio": [
+      "aac"
+    ],
+    "containers": [
+      "mp4"
+    ],
+    "max_resolution": "1080p",
+    "hdr": false,
+    "video_decode": [
+      {
+        "codec": "h264",
+        "profiles": [
+          "high"
+        ],
+        "levels": [
+          41
+        ],
+        "bit_depths": [
+          8
+        ],
+        "max_width": 1920,
+        "max_height": 1080,
+        "max_frame_rate": 60,
+        "max_bitrate_kbps": 20000,
+        "hardware": true
+      }
+    ]
+  },
+  "client_playback_context": {
+    "protocol_version": 3,
+    "form_factor": "tv",
+    "app_version": "3.0-test",
+    "device": {
+      "platform": "android",
+      "os_version": "15",
+      "manufacturer": "NVIDIA",
+      "model": "SHIELD Android TV",
+      "platform_details": {
+        "abis": "arm64-v8a",
+        "sdk_int": "35"
+      }
+    },
+    "output": {
+      "output_context_id": "7"
+    },
+    "deliveries": {
+      "original_http": {
+        "enabled": true,
+        "supported_on_device": true,
+        "containers": [
+          "mp4"
+        ],
+        "video_codecs": [
+          "h264"
+        ],
+        "audio_decode_codecs": [
+          "aac"
+        ],
+        "audio_passthrough_codecs": [],
+        "subtitles": {
+          "embedded_text": true,
+          "sidecar_text": true,
+          "ass_styling": false,
+          "embedded_bitmap": false,
+          "sidecar_bitmap": false,
+          "font_attachments": false
+        },
+        "features": [],
+        "auth_header_refresh": true,
+        "validated_claims": [],
+        "transformations": []
+      }
+    }
+  }
+}

--- a/iosApp/Tests/Fixtures/PlaybackV3/route_event.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/route_event.json
@@ -2,9 +2,9 @@
   "protocol_version": 3,
   "playback_attempt_id": "attempt-golden-0001",
   "session_id": "11111111-1111-4111-8111-111111111111",
-  "plan_id": "plan:golden-0001",
+  "plan_id": "plan:478677870860e5e5108c18bff749b34b",
   "plan_attempt_id": "plan-attempt-golden-0001",
-  "plan_attempt_key": "v3:0000000000000001",
+  "plan_attempt_key": "v3:f0144c47fa349e3e",
   "event": "first_frame",
   "output_context_id": "7",
   "diagnostics": {

--- a/iosApp/Tests/Fixtures/PlaybackV3/route_event.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/route_event.json
@@ -1,0 +1,15 @@
+{
+  "protocol_version": 3,
+  "playback_attempt_id": "attempt-golden-0001",
+  "session_id": "11111111-1111-4111-8111-111111111111",
+  "plan_id": "plan:golden-0001",
+  "plan_attempt_id": "plan-attempt-golden-0001",
+  "plan_attempt_key": "v3:0000000000000001",
+  "event": "first_frame",
+  "output_context_id": "7",
+  "diagnostics": {
+    "decoder_name": "c2.android.avc.decoder",
+    "first_frame_ms": "412",
+    "video_mime": "video/avc"
+  }
+}

--- a/iosApp/Tests/Fixtures/PlaybackV3/start_request.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/start_request.json
@@ -9,6 +9,7 @@
   "quality_preference": "original",
   "subtitle_fidelity_preference": "compatible",
   "start_position": 12.5,
+  "progress_persistence": "client",
   "audio_track_id": "file:42:audio:0",
   "audio_track_index": 0,
   "metered": false,

--- a/iosApp/Tests/Fixtures/PlaybackV3/start_request.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/start_request.json
@@ -1,0 +1,98 @@
+{
+  "protocol_version": 3,
+  "client_features": [
+    "playback_plan_v3"
+  ],
+  "file_id": 42,
+  "profile_id": "profile-1",
+  "playback_attempt_id": "attempt-golden-0001",
+  "quality_preference": "original",
+  "subtitle_fidelity_preference": "compatible",
+  "start_position": 12.5,
+  "audio_track_id": "file:42:audio:0",
+  "audio_track_index": 0,
+  "metered": false,
+  "client_capabilities": {
+    "video_evidence": "exact",
+    "audio_evidence": "exact",
+    "codecs_video": [
+      "h264"
+    ],
+    "codecs_video_hardware": [
+      "h264"
+    ],
+    "codecs_audio": [
+      "aac"
+    ],
+    "containers": [
+      "mp4"
+    ],
+    "max_resolution": "1080p",
+    "hdr": false,
+    "video_decode": [
+      {
+        "codec": "h264",
+        "profiles": [
+          "high"
+        ],
+        "levels": [
+          41
+        ],
+        "bit_depths": [
+          8
+        ],
+        "max_width": 1920,
+        "max_height": 1080,
+        "max_frame_rate": 60,
+        "max_bitrate_kbps": 20000,
+        "hardware": true
+      }
+    ]
+  },
+  "client_playback_context": {
+    "protocol_version": 3,
+    "form_factor": "tv",
+    "app_version": "3.0-test",
+    "device": {
+      "platform": "android",
+      "os_version": "15",
+      "manufacturer": "NVIDIA",
+      "model": "SHIELD Android TV",
+      "platform_details": {
+        "abis": "arm64-v8a",
+        "sdk_int": "35"
+      }
+    },
+    "output": {
+      "output_context_id": "7"
+    },
+    "deliveries": {
+      "original_http": {
+        "enabled": true,
+        "supported_on_device": true,
+        "containers": [
+          "mp4"
+        ],
+        "video_codecs": [
+          "h264"
+        ],
+        "audio_decode_codecs": [
+          "aac"
+        ],
+        "audio_passthrough_codecs": [],
+        "subtitles": {
+          "embedded_text": true,
+          "sidecar_text": true,
+          "ass_styling": false,
+          "embedded_bitmap": false,
+          "sidecar_bitmap": false,
+          "font_attachments": false
+        },
+        "features": [],
+        "auth_header_refresh": true,
+        "validated_claims": [],
+        "transformations": []
+      }
+    }
+  }
+}

--- a/iosApp/Tests/Fixtures/PlaybackV3/subtitle_inventory.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/subtitle_inventory.json
@@ -1,0 +1,128 @@
+{
+  "description": "Combined subtitle ordinals are dense and gap-free across externals, embedded tracks, then downloaded tracks. A track with no sidecar representation keeps its ordinal and is published as burn_in_only without a URL rather than omitted.",
+  "session_id": "11111111-1111-4111-8111-111111111111",
+  "media_file_id": 42,
+  "source": {
+    "external_subtitles": [
+      {
+        "path": "/library/movie.en.srt",
+        "language": "eng",
+        "format": "srt",
+        "title": "English",
+        "forced": false,
+        "default": false,
+        "hearing_impaired": false
+      }
+    ],
+    "subtitle_tracks": [
+      {
+        "index": 0,
+        "language": "eng",
+        "codec": "ass",
+        "title": "English (Signs)",
+        "forced": true,
+        "default": false,
+        "hearing_impaired": false,
+        "external": false
+      },
+      {
+        "index": 1,
+        "language": "jpn",
+        "codec": "pgs",
+        "title": "Japanese",
+        "forced": false,
+        "default": false,
+        "hearing_impaired": false,
+        "external": false
+      },
+      {
+        "index": 2,
+        "language": "fre",
+        "codec": "dvd_subtitle",
+        "title": "French",
+        "forced": false,
+        "default": false,
+        "hearing_impaired": false,
+        "external": false
+      }
+    ],
+    "downloaded": [
+      {
+        "CombinedIndex": 0,
+        "Codec": "srt",
+        "Source": "downloaded",
+        "Language": "spa",
+        "Label": "Spanish (downloaded)",
+        "Forced": false,
+        "HearingImpaired": false
+      }
+    ]
+  },
+  "inventory": [
+    {
+      "track_id": "file:42:subtitle:0",
+      "combined_index": 0,
+      "source": "external",
+      "codec": "srt",
+      "language": "eng",
+      "label": "English",
+      "forced": false,
+      "default": false,
+      "hearing_impaired": false,
+      "delivery": "sidecar",
+      "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/0.vtt?file_id=42"
+    },
+    {
+      "track_id": "file:42:subtitle:1",
+      "combined_index": 1,
+      "source": "embedded",
+      "codec": "ass",
+      "language": "eng",
+      "label": "English (Signs)",
+      "forced": true,
+      "default": false,
+      "hearing_impaired": false,
+      "delivery": "sidecar",
+      "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/1.ass?file_id=42",
+      "font_bundle_url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/1/fonts?file_id=42"
+    },
+    {
+      "track_id": "file:42:subtitle:2",
+      "combined_index": 2,
+      "source": "embedded",
+      "codec": "pgs",
+      "language": "jpn",
+      "label": "Japanese",
+      "forced": false,
+      "default": false,
+      "hearing_impaired": false,
+      "delivery": "sidecar",
+      "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/2.sup?file_id=42"
+    },
+    {
+      "track_id": "file:42:subtitle:3",
+      "combined_index": 3,
+      "source": "embedded",
+      "codec": "dvd_subtitle",
+      "language": "fre",
+      "label": "French",
+      "forced": false,
+      "default": false,
+      "hearing_impaired": false,
+      "delivery": "burn_in_only"
+    },
+    {
+      "track_id": "file:42:subtitle:4",
+      "combined_index": 4,
+      "source": "downloaded",
+      "codec": "srt",
+      "language": "spa",
+      "label": "Spanish (downloaded)",
+      "forced": false,
+      "default": false,
+      "hearing_impaired": false,
+      "delivery": "sidecar",
+      "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/4.vtt?file_id=42"
+    }
+  ]
+}

--- a/iosApp/Tests/PlaybackMediaFixtureTests.swift
+++ b/iosApp/Tests/PlaybackMediaFixtureTests.swift
@@ -236,7 +236,7 @@ final class PlaybackMediaFixtureTests: XCTestCase {
         XCTAssertEqual(plan.loopbackSession?.videoMode, .passthroughProfile5)
         XCTAssertEqual(
             plan.loopbackSession?.selectedAudio,
-            LoopbackSessionSpec.SelectedAudio.none
+            LoopbackSessionSpec.SelectedAudio.absent
         )
         XCTAssertEqual(plan.normalizationSummary.audioMode, "none")
     }

--- a/iosApp/Tests/PlaybackMediaFixtureTests.swift
+++ b/iosApp/Tests/PlaybackMediaFixtureTests.swift
@@ -172,6 +172,75 @@ final class PlaybackMediaFixtureTests: XCTestCase {
         }
     }
 
+    func testAppleLoopbackRouteSupportsVideoOnlyDolbyVision() throws {
+        let streamURL = try XCTUnwrap(URL(string: "https://example.invalid/video-only-dv.mp4"))
+        let session = PlaybackSessionResponse(
+            sessionId: "video-only-dv-session",
+            userId: nil,
+            profileId: nil,
+            mediaFileId: 43,
+            playMethod: "direct",
+            position: 0,
+            isPaused: false,
+            streamUrl: streamURL.absoluteString,
+            audioTrackIndex: nil,
+            durationSeconds: 30,
+            subtitleUrls: nil,
+            playbackInfo: nil
+        )
+        let version = FileVersion(
+            fileId: 43,
+            fileName: "video-only-dv.mp4",
+            resolution: "2160p",
+            codecVideo: "hevc",
+            codecAudio: nil,
+            hdr: true,
+            container: "mp4",
+            fileSize: 100_000,
+            duration: 30,
+            bitrate: 40_000,
+            videoTracks: [
+                VideoTrack(
+                    index: 0, codec: "hevc", width: 3840, height: 2160,
+                    frameRate: "60.000", bitrate: 40_000, profile: "Main 10",
+                    level: 153, bitDepth: 10, colorRange: "pc", colorSpace: nil,
+                    colorPrimaries: nil, colorTransfer: nil,
+                    videoRange: "DolbyVision", dolbyVision: "Profile 5",
+                    title: nil, language: nil
+                )
+            ],
+            audioTracks: [],
+            subtitleTracks: [],
+            chapters: nil
+        )
+        let stream = StreamRequest(url: streamURL, headers: [:], serverUrl: "")
+
+        let plan = ApplePlaybackRoutePlanner().makeExecutionPlan(
+            input: ApplePlaybackPlannerInput(
+                session: session,
+                selectedVersion: version,
+                streamRequest: stream,
+                routeRequirements: .baseline,
+                selectedAudioTrackId: nil,
+                pendingAudioFfIndex: nil,
+                preferredAudioTrackIndex: nil,
+                selectedPrimarySubtitleTrackId: nil,
+                selectedSecondarySubtitleTrackId: nil,
+                hlsRouteFeatureEnabled: true,
+                siloPlayerPrimaryEnabled: true,
+                dolbyVisionPolicy: .default
+            )
+        )
+
+        XCTAssertEqual(plan.engine, .siloPlayerLoopback)
+        XCTAssertEqual(plan.loopbackSession?.videoMode, .passthroughProfile5)
+        XCTAssertEqual(
+            plan.loopbackSession?.selectedAudio,
+            LoopbackSessionSpec.SelectedAudio.none
+        )
+        XCTAssertEqual(plan.normalizationSummary.audioMode, "none")
+    }
+
     private func fixtureURL(_ fixture: Fixture) throws -> URL {
         try XCTUnwrap(
             Bundle(for: Self.self).url(forResource: fixture.resource, withExtension: fixture.ext),

--- a/iosApp/Tests/PlaybackProtocolV3ConformanceFixtureTests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3ConformanceFixtureTests.swift
@@ -15,7 +15,7 @@ final class PlaybackProtocolV3ConformanceFixtureTests: XCTestCase {
         XCTAssertEqual(matrix.schemaVersion, 1)
         XCTAssertEqual(matrix.plannerScenarios.count, 17)
         XCTAssertEqual(matrix.replanScenarios.count, 9)
-        XCTAssertEqual(matrix.protocolScenarios.count, 7)
+        XCTAssertEqual(matrix.protocolScenarios.count, 8)
 
         let categories = Set(
             matrix.plannerScenarios.map(\.category)
@@ -37,6 +37,7 @@ final class PlaybackProtocolV3ConformanceFixtureTests: XCTestCase {
                 "concurrent_replan",
                 "mid_seek_replan",
                 "legacy_426",
+                "draft_v3_426",
                 "output_context_invalidation",
                 "attempt_key_echo_and_loop",
                 "recovery_matrix",
@@ -132,6 +133,21 @@ final class PlaybackProtocolV3ConformanceFixtureTests: XCTestCase {
         XCTAssertEqual(opaque.input.replanEcho, serverKey)
         XCTAssertEqual(opaque.input.attemptedPlanKeys, [serverKey])
         XCTAssertEqual(opaque.expected.action, "reject_already_attempted_plan")
+
+        let draft = try protocolScenario(named: "draft_v3_start_requires_upgrade", in: matrix)
+        XCTAssertEqual(draft.input.body?.protocolVersion, 3)
+        XCTAssertEqual(draft.input.body?.fileId, 42)
+        XCTAssertEqual(draft.expected.httpStatus, 426)
+        XCTAssertEqual(draft.expected.error, "client_upgrade_required")
+
+        let restartRequest = try XCTUnwrap(restart.input.startRequest)
+        XCTAssertEqual(restartRequest.progressPersistence, "client")
+        XCTAssertNotNil(restartRequest.startPosition)
+        XCTAssertTrue(
+            restart.input.persistedDecision?.serverFeatures.contains(
+                PlaybackProtocolV3.neutralContractFeature
+            ) == true
+        )
     }
 
     private var decoder: JSONDecoder {
@@ -191,6 +207,8 @@ private struct PlaybackV3ConformanceStartRequest: Decodable {
     let protocolVersion: Int
     let playbackAttemptId: String
     let qualityPreference: String
+    let progressPersistence: String?
+    let startPosition: Double?
     let subtitleTrackId: String?
     let subtitleTrackIndex: Int?
     let clientCapabilities: PlaybackV3ConformanceCapabilities
@@ -279,7 +297,7 @@ private struct PlaybackV3ConformanceProtocolScenario: Decodable {
 }
 
 private struct PlaybackV3ConformanceProtocolInput: Decodable {
-    let body: [String: Int]?
+    let body: PlaybackV3ConformanceDraftBody?
     let planId: String?
     let firstOutputContextId: String?
     let secondOutputContextId: String?
@@ -294,6 +312,11 @@ private struct PlaybackV3ConformanceProtocolInput: Decodable {
     let restarted: Bool?
     let capacityAvailable: Bool?
     let routeEvent: PlaybackV3ConformanceRouteEvent?
+}
+
+private struct PlaybackV3ConformanceDraftBody: Decodable {
+    let protocolVersion: Int?
+    let fileId: Int
 }
 
 private struct PlaybackV3ConformanceRouteEvent: Decodable {

--- a/iosApp/Tests/PlaybackProtocolV3ConformanceFixtureTests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3ConformanceFixtureTests.swift
@@ -232,14 +232,9 @@ private struct PlaybackV3ConformancePlannerExpectation: Decodable {
     let subtitle: PlaybackV3SubtitleDecision?
     let claims: PlaybackV3ValidationClaims?
     let transformations: [PlaybackV3Transformation]?
-    let availableQualities: [PlaybackV3ConformanceAvailableQuality]?
-}
-
-private struct PlaybackV3ConformanceAvailableQuality: Decodable {
-    let label: String
-    let height: Int?
-    let bitrateKbps: Int
-    let preservesSource: Bool
+    // Decode through the production model so audio-only rungs without a
+    // video height exercise the same contract used by the app.
+    let availableQualities: [PlaybackV3AvailableQuality]?
 }
 
 private struct PlaybackV3ConformanceReplanScenario: Decodable {

--- a/iosApp/Tests/PlaybackProtocolV3ConformanceFixtureTests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3ConformanceFixtureTests.swift
@@ -4,14 +4,22 @@ import XCTest
 
 final class PlaybackProtocolV3ConformanceFixtureTests: XCTestCase {
     func testServerErrorEnvelopeDecodes() throws {
-        let fixture = try decodeFixture(PlaybackV3ErrorFixture.self, named: "error_response")
+        let fixture = try PlaybackV3FixtureTestSupport.decode(
+            PlaybackV3ErrorFixture.self,
+            named: "error_response",
+            bundleClass: Self.self
+        )
 
         XCTAssertEqual(fixture.error, "client_upgrade_required")
         XCTAssertFalse(fixture.message.isEmpty)
     }
 
     func testMatrixCoversEveryNeutralContractCategory() throws {
-        let matrix = try decodeFixture(PlaybackV3ConformanceMatrix.self, named: "conformance_matrix")
+        let matrix = try PlaybackV3FixtureTestSupport.decode(
+            PlaybackV3ConformanceMatrix.self,
+            named: "conformance_matrix",
+            bundleClass: Self.self
+        )
         XCTAssertEqual(matrix.schemaVersion, 1)
         XCTAssertEqual(matrix.plannerScenarios.count, 17)
         XCTAssertEqual(matrix.replanScenarios.count, 9)
@@ -54,7 +62,11 @@ final class PlaybackProtocolV3ConformanceFixtureTests: XCTestCase {
     }
 
     func testMatrixDecodesHDRDVAudioAndSubtitleExpectations() throws {
-        let matrix = try decodeFixture(PlaybackV3ConformanceMatrix.self, named: "conformance_matrix")
+        let matrix = try PlaybackV3FixtureTestSupport.decode(
+            PlaybackV3ConformanceMatrix.self,
+            named: "conformance_matrix",
+            bundleClass: Self.self
+        )
 
         let hdr10 = try plannerScenario(named: "hdr10_exact_direct", in: matrix)
         XCTAssertEqual(hdr10.source.dynamicRange, "hdr10")
@@ -96,7 +108,11 @@ final class PlaybackProtocolV3ConformanceFixtureTests: XCTestCase {
     }
 
     func testMatrixPreservesOpaqueAttemptIdentityAndClientIntent() throws {
-        let matrix = try decodeFixture(PlaybackV3ConformanceMatrix.self, named: "conformance_matrix")
+        let matrix = try PlaybackV3FixtureTestSupport.decode(
+            PlaybackV3ConformanceMatrix.self,
+            named: "conformance_matrix",
+            bundleClass: Self.self
+        )
 
         XCTAssertTrue(
             matrix.replanScenarios.allSatisfy { $0.request.failure == nil },
@@ -148,23 +164,6 @@ final class PlaybackProtocolV3ConformanceFixtureTests: XCTestCase {
                 PlaybackProtocolV3.neutralContractFeature
             ) == true
         )
-    }
-
-    private var decoder: JSONDecoder {
-        let decoder = JSONDecoder()
-        decoder.keyDecodingStrategy = .convertFromSnakeCase
-        return decoder
-    }
-
-    private func fixtureURL(named name: String) throws -> URL {
-        try XCTUnwrap(
-            Bundle(for: Self.self).url(forResource: name, withExtension: "json"),
-            "Missing vendored Playback V3 fixture \(name).json"
-        )
-    }
-
-    private func decodeFixture<T: Decodable>(_ type: T.Type, named name: String) throws -> T {
-        try decoder.decode(type, from: Data(contentsOf: fixtureURL(named: name)))
     }
 
     private func plannerScenario(

--- a/iosApp/Tests/PlaybackProtocolV3ConformanceFixtureTests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3ConformanceFixtureTests.swift
@@ -1,0 +1,329 @@
+import Foundation
+import XCTest
+@testable import Silo
+
+final class PlaybackProtocolV3ConformanceFixtureTests: XCTestCase {
+    func testServerErrorEnvelopeDecodes() throws {
+        let fixture = try decodeFixture(PlaybackV3ErrorFixture.self, named: "error_response")
+
+        XCTAssertEqual(fixture.error, "client_upgrade_required")
+        XCTAssertFalse(fixture.message.isEmpty)
+    }
+
+    func testMatrixCoversEveryNeutralContractCategory() throws {
+        let matrix = try decodeFixture(PlaybackV3ConformanceMatrix.self, named: "conformance_matrix")
+        XCTAssertEqual(matrix.schemaVersion, 1)
+        XCTAssertEqual(matrix.plannerScenarios.count, 17)
+        XCTAssertEqual(matrix.replanScenarios.count, 9)
+        XCTAssertEqual(matrix.protocolScenarios.count, 7)
+
+        let categories = Set(
+            matrix.plannerScenarios.map(\.category)
+                + matrix.replanScenarios.map(\.category)
+                + matrix.protocolScenarios.map(\.category)
+        )
+        XCTAssertTrue(
+            Set([
+                "evidence_tier_gating",
+                "deliveries_negotiation",
+                "audio_only_planning",
+                "hdr_dv_matrix",
+                "audio_matrix",
+                "subtitle_matrix",
+                "available_qualities",
+                "track_change_replan",
+                "quality_change_replan",
+                "idempotent_replan",
+                "concurrent_replan",
+                "mid_seek_replan",
+                "legacy_426",
+                "output_context_invalidation",
+                "attempt_key_echo_and_loop",
+                "recovery_matrix",
+                "restart_matrix",
+                "capacity_matrix",
+                "route_event_limits"
+            ]).isSubset(of: categories)
+        )
+
+        let names = matrix.plannerScenarios.map(\.name)
+            + matrix.replanScenarios.map(\.name)
+            + matrix.protocolScenarios.map(\.name)
+        XCTAssertEqual(Set(names).count, names.count, "conformance scenario names must be unique")
+    }
+
+    func testMatrixDecodesHDRDVAudioAndSubtitleExpectations() throws {
+        let matrix = try decodeFixture(PlaybackV3ConformanceMatrix.self, named: "conformance_matrix")
+
+        let hdr10 = try plannerScenario(named: "hdr10_exact_direct", in: matrix)
+        XCTAssertEqual(hdr10.source.dynamicRange, "hdr10")
+        XCTAssertEqual(hdr10.expected.delivery, "original_http")
+        XCTAssertEqual(hdr10.expected.claims?.video.hdr10, true)
+
+        let dolbyVision = try plannerScenario(named: "dolby_vision_8_exact_direct", in: matrix)
+        XCTAssertEqual(dolbyVision.source.dolbyVisionProfile, 8)
+        XCTAssertEqual(dolbyVision.expected.delivery, "original_http")
+        XCTAssertEqual(dolbyVision.expected.claims?.video.dolbyVision, true)
+
+        let fallback = try plannerScenario(named: "dolby_vision_7_hdr10_fallback", in: matrix)
+        XCTAssertEqual(fallback.source.dolbyVisionProfile, 7)
+        XCTAssertEqual(fallback.expected.delivery, "server_remux_progressive")
+        XCTAssertEqual(fallback.expected.transformations?.map(\.executor), ["server"])
+
+        let audioConversion = try plannerScenario(named: "truehd_audio_conversion", in: matrix)
+        XCTAssertEqual(audioConversion.source.audioCodec, "truehd")
+        XCTAssertEqual(audioConversion.expected.claims?.audio.codec, "aac")
+        XCTAssertEqual(audioConversion.expected.claims?.audio.passthrough, false)
+
+        let passthrough = try plannerScenario(named: "truehd_exact_layout_passthrough", in: matrix)
+        XCTAssertEqual(passthrough.expected.claims?.audio.codec, "truehd")
+        XCTAssertEqual(passthrough.expected.claims?.audio.passthrough, true)
+
+        let pgs = try plannerScenario(named: "embedded_pgs_sidecar", in: matrix)
+        XCTAssertEqual(pgs.request.subtitleTrackIndex, 0)
+        XCTAssertEqual(pgs.expected.subtitle?.mode, "render")
+        XCTAssertEqual(pgs.expected.subtitle?.inventory.first?.codec, "hdmv_pgs_subtitle")
+        XCTAssertEqual(pgs.expected.subtitle?.inventory.first?.delivery, "sidecar")
+
+        let ass = try plannerScenario(named: "embedded_ass_authored_render", in: matrix)
+        XCTAssertEqual(ass.expected.subtitle?.mode, "render")
+        XCTAssertEqual(ass.expected.subtitle?.inventory.first?.codec, "ass")
+
+        let dvd = try plannerScenario(named: "embedded_dvd_burn_in", in: matrix)
+        XCTAssertEqual(dvd.expected.subtitle?.mode, "burn_in")
+        XCTAssertEqual(dvd.expected.delivery, "server_transcode_hls")
+    }
+
+    func testMatrixPreservesOpaqueAttemptIdentityAndClientIntent() throws {
+        let matrix = try decodeFixture(PlaybackV3ConformanceMatrix.self, named: "conformance_matrix")
+
+        XCTAssertTrue(
+            matrix.replanScenarios.allSatisfy { $0.request.failure == nil },
+            "track, quality, and seek-reanchor intent vectors must omit failure"
+        )
+
+        let recovery = try protocolScenario(named: "failure_recovery_preserves_intent", in: matrix)
+        let recoveryRequest = try XCTUnwrap(recovery.input.replanRequest)
+        XCTAssertEqual(recoveryRequest.operation, PlaybackProtocolV3.ReplanOperation.failureRecovery)
+        XCTAssertEqual(recoveryRequest.failure?.classification, "network_degraded")
+        XCTAssertEqual(recoveryRequest.attemptedPlanKeys, [recoveryRequest.planAttemptKey])
+        XCTAssertEqual(recoveryRequest.selectedTracks.subtitle?.index, 2)
+        XCTAssertEqual(recovery.expected.selectionPreserved, true)
+        XCTAssertEqual(recovery.expected.positionPreserved, true)
+
+        let restart = try protocolScenario(named: "restart_replays_terminal_attempt", in: matrix)
+        XCTAssertEqual(restart.input.restarted, true)
+        XCTAssertEqual(restart.input.persistedDecision?.terminal?.reason, "transcode_start_failed")
+        XCTAssertEqual(restart.expected.responseReplayedVerbatim, true)
+        XCTAssertEqual(restart.expected.capacityDelta, 0)
+
+        let capacity = try protocolScenario(named: "capacity_unavailable_cleans_up", in: matrix)
+        XCTAssertEqual(capacity.input.capacityAvailable, false)
+        XCTAssertEqual(capacity.expected.terminalReason, "capacity_unavailable")
+        XCTAssertEqual(capacity.expected.cleanupComplete, true)
+
+        let routeLimit = try protocolScenario(named: "route_event_diagnostic_limit", in: matrix)
+        XCTAssertEqual(routeLimit.input.routeEvent?.diagnostics.count, 33)
+        XCTAssertEqual(routeLimit.expected.httpStatus, 400)
+        XCTAssertEqual(routeLimit.expected.action, "reject_without_persisting")
+
+        let opaque = try protocolScenario(named: "opaque_attempt_key_loop", in: matrix)
+        let serverKey = try XCTUnwrap(opaque.input.serverPlanAttemptKey)
+        XCTAssertEqual(opaque.input.replanEcho, serverKey)
+        XCTAssertEqual(opaque.input.attemptedPlanKeys, [serverKey])
+        XCTAssertEqual(opaque.expected.action, "reject_already_attempted_plan")
+    }
+
+    private var decoder: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return decoder
+    }
+
+    private func fixtureURL(named name: String) throws -> URL {
+        try XCTUnwrap(
+            Bundle(for: Self.self).url(forResource: name, withExtension: "json"),
+            "Missing vendored Playback V3 fixture \(name).json"
+        )
+    }
+
+    private func decodeFixture<T: Decodable>(_ type: T.Type, named name: String) throws -> T {
+        try decoder.decode(type, from: Data(contentsOf: fixtureURL(named: name)))
+    }
+
+    private func plannerScenario(
+        named name: String,
+        in matrix: PlaybackV3ConformanceMatrix
+    ) throws -> PlaybackV3ConformancePlannerScenario {
+        try XCTUnwrap(matrix.plannerScenarios.first { $0.name == name })
+    }
+
+    private func protocolScenario(
+        named name: String,
+        in matrix: PlaybackV3ConformanceMatrix
+    ) throws -> PlaybackV3ConformanceProtocolScenario {
+        try XCTUnwrap(matrix.protocolScenarios.first { $0.name == name })
+    }
+}
+
+private struct PlaybackV3ErrorFixture: Decodable {
+    let error: String
+    let message: String
+}
+
+private struct PlaybackV3ConformanceMatrix: Decodable {
+    let schemaVersion: Int
+    let plannerScenarios: [PlaybackV3ConformancePlannerScenario]
+    let replanScenarios: [PlaybackV3ConformanceReplanScenario]
+    let protocolScenarios: [PlaybackV3ConformanceProtocolScenario]
+}
+
+private struct PlaybackV3ConformancePlannerScenario: Decodable {
+    let name: String
+    let category: String
+    let request: PlaybackV3ConformanceStartRequest
+    let source: PlaybackV3SourceDescriptor
+    let attemptedPlanKeys: [String]?
+    let expected: PlaybackV3ConformancePlannerExpectation
+}
+
+private struct PlaybackV3ConformanceStartRequest: Decodable {
+    let protocolVersion: Int
+    let playbackAttemptId: String
+    let qualityPreference: String
+    let subtitleTrackId: String?
+    let subtitleTrackIndex: Int?
+    let clientCapabilities: PlaybackV3ConformanceCapabilities
+    let clientPlaybackContext: PlaybackV3ConformanceClientContext
+}
+
+private struct PlaybackV3ConformanceCapabilities: Decodable {
+    let videoEvidence: String
+    let audioEvidence: String
+    let hdr: Bool
+    let hdrDetails: PlaybackV3HDRCapabilities?
+    let audioPassthrough: PlaybackV3AudioPassthrough?
+}
+
+private struct PlaybackV3ConformanceClientContext: Decodable {
+    let protocolVersion: Int
+    let device: PlaybackV3ConformanceDevice
+    let output: PlaybackV3OutputContext
+    let deliveries: [String: PlaybackV3ConformanceDelivery]
+}
+
+private struct PlaybackV3ConformanceDevice: Decodable {
+    let platform: String
+}
+
+private struct PlaybackV3ConformanceDelivery: Decodable {
+    let enabled: Bool
+    let supportedOnDevice: Bool
+    let transformations: [PlaybackV3Transformation]?
+}
+
+private struct PlaybackV3ConformancePlannerExpectation: Decodable {
+    let outcome: String
+    let delivery: String?
+    let decisionReason: String?
+    let planId: String?
+    let planAttemptKey: String?
+    let selectedTracks: PlaybackV3SelectedTracks?
+    let subtitle: PlaybackV3SubtitleDecision?
+    let claims: PlaybackV3ValidationClaims?
+    let transformations: [PlaybackV3Transformation]?
+    let availableQualities: [PlaybackV3ConformanceAvailableQuality]?
+}
+
+private struct PlaybackV3ConformanceAvailableQuality: Decodable {
+    let label: String
+    let height: Int?
+    let bitrateKbps: Int
+    let preservesSource: Bool
+}
+
+private struct PlaybackV3ConformanceReplanScenario: Decodable {
+    let name: String
+    let category: String
+    let request: PlaybackV3ConformanceReplanRequest
+    let expected: PlaybackV3ConformanceReplanExpectation
+}
+
+private struct PlaybackV3ConformanceReplanRequest: Decodable {
+    let operation: String
+    let playbackAttemptId: String
+    let replanRequestId: String
+    let failedPlanId: String
+    let planAttemptKey: String
+    let attemptedPlanKeys: [String]
+    let positionSeconds: Double
+    let selectedTracks: PlaybackV3SelectedTracks
+    let failure: PlaybackV3Failure?
+}
+
+private struct PlaybackV3ConformanceReplanExpectation: Decodable {
+    let httpStatus: Int?
+    let preserveUnmodifiedTracks: Bool?
+    let selectedQuality: String?
+    let positionPreserved: Bool?
+    let positionSeconds: Double?
+    let responseReplayedVerbatim: Bool?
+    let sameRequestAndBodyStatus: Int?
+    let changedBodyStatus: Int?
+    let changedBodyError: String?
+    let whileFirstLeaseActiveStatus: Int?
+    let concurrentError: String?
+    let afterCompletionStatus: Int?
+}
+
+private struct PlaybackV3ConformanceProtocolScenario: Decodable {
+    let name: String
+    let category: String
+    let input: PlaybackV3ConformanceProtocolInput
+    let expected: PlaybackV3ConformanceProtocolExpectation
+}
+
+private struct PlaybackV3ConformanceProtocolInput: Decodable {
+    let body: [String: Int]?
+    let planId: String?
+    let firstOutputContextId: String?
+    let secondOutputContextId: String?
+    let firstPlanAttemptKey: String?
+    let secondPlanAttemptKey: String?
+    let serverPlanAttemptKey: String?
+    let replanEcho: String?
+    let attemptedPlanKeys: [String]?
+    let replanRequest: PlaybackV3ConformanceReplanRequest?
+    let startRequest: PlaybackV3ConformanceStartRequest?
+    let persistedDecision: PlaybackV3DecisionResponse?
+    let restarted: Bool?
+    let capacityAvailable: Bool?
+    let routeEvent: PlaybackV3ConformanceRouteEvent?
+}
+
+private struct PlaybackV3ConformanceRouteEvent: Decodable {
+    let protocolVersion: Int
+    let playbackAttemptId: String
+    let sessionId: String?
+    let planId: String?
+    let planAttemptId: String?
+    let planAttemptKey: String?
+    let event: String
+    let outputContextId: String?
+    let diagnostics: [String: String]
+}
+
+private struct PlaybackV3ConformanceProtocolExpectation: Decodable {
+    let httpStatus: Int?
+    let error: String?
+    let outcome: String?
+    let terminalReason: String?
+    let planIdUnchanged: Bool?
+    let planAttemptKeyChanged: Bool?
+    let selectionPreserved: Bool?
+    let positionPreserved: Bool?
+    let responseReplayedVerbatim: Bool?
+    let capacityDelta: Int?
+    let cleanupComplete: Bool?
+    let action: String?
+}

--- a/iosApp/Tests/PlaybackProtocolV3Tests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3Tests.swift
@@ -3,160 +3,191 @@ import XCTest
 @testable import Silo
 
 final class PlaybackProtocolV3Tests: XCTestCase {
-    func testDecisionValidationAndSessionTimeline() throws {
-        let plan = makePlan(playerStart: 12.5, timelineOffset: 7.25)
-        let response = PlaybackV3DecisionResponse(
-            protocolVersion: 3,
-            serverFeatures: ["playback_plan_v3", "seek_reanchor_v1"],
-            outcome: "playable",
-            sessionId: "session-v3",
-            playbackPlan: plan,
-            terminal: nil
+    func testServerGoldenDecisionDecodesAndPublishesCompleteSubtitleInventory() throws {
+        let response = try decodeFixture(
+            PlaybackV3DecisionResponse.self,
+            named: "decision_response"
         )
 
-        guard case .playable(let validated, let sessionId) = response.validatedForApple() else {
-            return XCTFail("Expected a playable V3 response")
+        guard case .playable(let plan, let sessionId) = response.validatedForApple() else {
+            return XCTFail("Expected the recovered server fixture to be playable")
         }
-        XCTAssertEqual(sessionId, "session-v3")
-        XCTAssertEqual(validated.planId, "plan:fixture")
+        XCTAssertEqual(sessionId, "11111111-1111-4111-8111-111111111111")
+        XCTAssertEqual(plan.planAttemptKey, "v3:f0144c47fa349e3e")
+        XCTAssertEqual(plan.source.durationSeconds, 7_265.5)
+        XCTAssertEqual(plan.availableQualities.map(\.label), ["original", "720p", "480p"])
+        XCTAssertEqual(plan.subtitle.inventory.map(\.combinedIndex), [0, 1, 2, 3, 4])
+        XCTAssertEqual(plan.subtitle.inventory[3].delivery, "burn_in_only")
+        XCTAssertNil(plan.subtitle.inventory[3].url)
+        let qualityOptions = ApplePlaybackQuality.playbackOptions(
+            serverQualities: plan.availableQualities,
+            fallbackVersion: nil
+        )
+        XCTAssertEqual(qualityOptions.map(\.id), ["auto", "original", "720p", "480p"])
+        XCTAssertEqual(qualityOptions.map(\.bitrateKbps), [0, 8_000, 2_000, 1_500])
 
         let session = ApplePlaybackV3PlanAdapter.playbackSession(
-            plan: validated,
+            plan: plan,
             sessionId: sessionId,
-            selectedVersion: makeVersion(container: "mp4", videoCodec: "h264", audioCodec: "aac")
+            selectedVersion: makeVersion(
+                container: "mp4",
+                videoCodec: "h264",
+                audioCodec: "aac"
+            )
         )
         XCTAssertEqual(session.position, 12.5)
-        XCTAssertEqual(session.timelineOffsetSeconds, 7.25)
-        XCTAssertEqual(session.playMethod, "direct")
+        XCTAssertEqual(session.durationSeconds, 7_265.5)
+        // Starting with subtitles off must not hide selectable sidecars.
+        XCTAssertEqual(session.subtitleUrls?.count, 4)
     }
 
-    // The plan describes the effective file the server actually chose, which
-    // need not be the version the client picked, so its runtime wins over the
-    // catalog's.
-    func testPlanRuntimeOverridesTheCatalogVersionDuration() {
-        let session = ApplePlaybackV3PlanAdapter.playbackSession(
-            plan: makePlan(sourceDurationSeconds: 5_400),
-            sessionId: "session-v3",
-            selectedVersion: makeVersion(container: "mp4", videoCodec: "h264", audioCodec: "aac")
+    func testRecoveredServerRequestAndCapabilityFixturesDecode() throws {
+        let capability = try decodeFixture(
+            PlaybackV3CapabilityResponse.self,
+            named: "capability_response"
         )
-
-        XCTAssertEqual(session.durationSeconds, 5_400)
-    }
-
-    // Servers predating source.duration_seconds omit it; the catalog value is
-    // the only remaining source and must still be used.
-    func testMissingPlanRuntimeFallsBackToTheCatalogVersionDuration() {
-        let session = ApplePlaybackV3PlanAdapter.playbackSession(
-            plan: makePlan(sourceDurationSeconds: nil),
-            sessionId: "session-v3",
-            selectedVersion: makeVersion(container: "mp4", videoCodec: "h264", audioCodec: "aac")
-        )
-
-        XCTAssertEqual(session.durationSeconds, 120)
-    }
-
-    // A plan without the field at all must decode: every non-Optional property
-    // on the descriptor is a required key, so a non-Optional duration would
-    // fail the whole plan against an older server.
-    func testPlanDecodesWhenTheSourceRuntimeIsAbsent() throws {
-        let json = """
-        {
-          "media_file_id": 42,
-          "container": "mp4",
-          "hdr10_plus": false,
-          "dv_enhancement_layer": "none"
-        }
-        """
-        let decoder = JSONDecoder()
-        decoder.keyDecodingStrategy = .convertFromSnakeCase
-        let source = try decoder.decode(PlaybackV3SourceDescriptor.self, from: Data(json.utf8))
-
-        XCTAssertNil(source.durationSeconds)
-        XCTAssertEqual(source.mediaFileId, 42)
-    }
-
-    func testCanonicalAttemptKeyMatchesGoAndAndroidFixtures() {
-        let hls = makePlan(
-            planId: "plan:fixture",
-            delivery: "server_remux_hls",
-            engine: "media3_hls",
-            streamProtocol: "hls",
-            container: "hls",
-            videoCodec: "hevc",
-            audioCodec: "aac",
-            width: 3_840,
-            height: 2_160,
-            bitrateKbps: 20_000,
-            dynamicRange: "hdr10",
-            subtitleMode: "burn_in",
-            transformations: [
-                .init(name: "hdr_to_sdr_tonemap", executor: "server", recipeVersion: "1", validatedClaims: []),
-                .init(name: "audio_to_aac", executor: "server", recipeVersion: "1", validatedClaims: [])
+        XCTAssertEqual(capability.protocolVersions, [3])
+        XCTAssertEqual(
+            Set(capability.deliveries),
+            [
+                "original_http",
+                "server_remux_progressive",
+                "server_remux_hls",
+                "server_transcode_hls"
             ]
+        )
+
+        let start = try decodeFixture(PlaybackV3StartRequest.self, named: "start_request")
+        XCTAssertEqual(start.clientCapabilities.videoEvidence, PlaybackProtocolV3.Evidence.exact)
+        XCTAssertEqual(start.clientPlaybackContext.device.platform, "android")
+        XCTAssertEqual(start.clientPlaybackContext.output.outputContextId, "7")
+        XCTAssertEqual(Set(start.clientPlaybackContext.deliveries.keys), ["original_http"])
+
+        let replan = try fixtureObject(named: "replan_request")
+        XCTAssertEqual(replan["plan_attempt_key"] as? String, "v3:0000000000000001")
+        XCTAssertNil(replan["engine"])
+        XCTAssertNil(replan["output_route_generation"])
+
+        let routeEvent = try fixtureObject(named: "route_event")
+        XCTAssertEqual(routeEvent["output_context_id"] as? String, "7")
+        XCTAssertEqual(routeEvent["plan_attempt_key"] as? String, "v3:0000000000000001")
+
+        let subtitleFixture = try fixtureObject(named: "subtitle_inventory")
+        let inventory = try XCTUnwrap(subtitleFixture["inventory"] as? [[String: Any]])
+        XCTAssertEqual(inventory.compactMap { $0["combined_index"] as? Int }, [0, 1, 2, 3, 4])
+
+        let attemptKeys = try fixtureArray(named: "attempt_keys")
+        XCTAssertFalse(attemptKeys.isEmpty)
+    }
+
+    func testPlanAttemptKeyIsOpaqueAndEchoedVerbatim() throws {
+        let serverKey = "v3:server-owned-token"
+        let plan = makePlan(planAttemptKey: serverKey)
+        let prepared = PreparedPlaybackV3(
+            playbackAttemptId: "apple:attempt",
+            planAttemptId: "apple-plan:attempt",
+            planAttemptKey: plan.planAttemptKey,
+            outputContextId: "apple:output",
+            serverFeatures: [PlaybackProtocolV3.planFeature],
+            plan: plan
+        )
+        XCTAssertEqual(prepared.planAttemptKey, serverKey)
+
+        let request = makeReplanRequest(
+            planAttemptKey: prepared.planAttemptKey,
+            operation: PlaybackProtocolV3.ReplanOperation.failureRecovery,
+            failure: PlaybackV3Failure(
+                classification: "decoder_failed",
+                message: "fixture",
+                decoderName: nil
+            )
+        )
+        let object = try encodedObject(request)
+        XCTAssertEqual(object["plan_attempt_key"] as? String, serverKey)
+        XCTAssertNil(object["engine"])
+        XCTAssertNil(object["output_route_generation"])
+    }
+
+    func testSilentRenewalAcceptsOnlyTheSameEffectiveDirectRoute() {
+        let current = makePlan(
+            planAttemptKey: "v3:first",
+            playerStart: 10
+        )
+        let renewed = makePlan(
+            planId: "plan:renewed",
+            planAttemptKey: "v3:second",
+            playerStart: 42
+        )
+        XCTAssertTrue(
+            PlaybackSessionBridge.canRetargetDirectSession(from: current, to: renewed),
+            "fresh plan and attempt identities plus a later player start are safe behind the proxy"
+        )
+        XCTAssertFalse(
+            PlaybackSessionBridge.canRetargetDirectSession(
+                from: current,
+                to: makePlan(
+                    planAttemptKey: "v3:changed-recipe",
+                    audioCodec: "eac3",
+                    playerStart: 42
+                )
+            )
+        )
+        XCTAssertFalse(
+            PlaybackSessionBridge.canRetargetDirectSession(
+                from: current,
+                to: makePlan(
+                    planAttemptKey: "v3:changed-delivery",
+                    delivery: "server_remux_hls",
+                    streamProtocol: "hls",
+                    container: "hls",
+                    playerStart: 42
+                )
+            )
+        )
+    }
+
+    func testIntentReplansCarryNoFailureAndUseNeutralOperations() throws {
+        XCTAssertEqual(
+            PlaybackSessionBridge.replanOperation(forClassification: "audio_track_changed"),
+            PlaybackProtocolV3.ReplanOperation.trackChange
         )
         XCTAssertEqual(
-            hls.attemptKey(
-                outputRouteGeneration: 7,
-                localMutations: ["transport_reopen", "pcm:truehd:8"]
-            ),
-            "v3:6d4724f01b6ff692"
+            PlaybackSessionBridge.replanOperation(forClassification: "subtitle_track_changed"),
+            PlaybackProtocolV3.ReplanOperation.trackChange
+        )
+        XCTAssertEqual(
+            PlaybackSessionBridge.replanOperation(forClassification: "quality_changed"),
+            PlaybackProtocolV3.ReplanOperation.qualityChange
+        )
+        XCTAssertEqual(
+            PlaybackSessionBridge.replanOperation(forClassification: "decoder_failed"),
+            PlaybackProtocolV3.ReplanOperation.failureRecovery
         )
 
-        let dv81 = makePlan(
-            planId: "plan:dv81-fixture",
-            container: "mkv",
-            videoCodec: "hevc",
-            audioCodec: "truehd",
-            width: 3_840,
-            height: 2_160,
-            bitrateKbps: 65_000,
-            dynamicRange: "dolby_vision",
-            transformations: [
-                .init(name: "client_dv7_to_dv81", executor: "client", recipeVersion: "1", validatedClaims: [])
-            ]
+        let request = makeReplanRequest(
+            planAttemptKey: "v3:intent",
+            operation: PlaybackProtocolV3.ReplanOperation.qualityChange,
+            failure: nil
         )
-        XCTAssertEqual(dv81.attemptKey(outputRouteGeneration: 9), "v3:2a88b5e686373440")
-
-        let quirk = makePlan(
-            planId: "plan:quirk",
-            container: "mkv",
-            videoCodec: "hevc",
-            audioCodec: "eac3",
-            width: 3_840,
-            height: 2_160,
-            bitrateKbps: 60_000,
-            dynamicRange: "dolby_vision",
-            appliedQuirks: [
-                .init(
-                    id: "android.fire_tv.dv8_hdr10plus_sei_v1",
-                    registryRevision: "2026-07-13.1",
-                    action: "client_runtime_correction",
-                    reason: nil
-                )
-            ],
-            runtimeCorrections: ["client_dv8_hdr10plus_sanitizer_v1"]
-        )
-        XCTAssertEqual(quirk.attemptKey(outputRouteGeneration: 9), "v3:8d843bfffeb3adc3")
+        let object = try encodedObject(request)
+        XCTAssertEqual(object["operation"] as? String, "quality_change")
+        XCTAssertNil(object["failure"])
+        XCTAssertEqual(object["attempted_plan_keys"] as? [String], [])
     }
 
-    func testDeliveryMatrixMapsToAppleEngines() throws {
-        let streamRequest = StreamRequest(
-            url: URL(string: "https://example.test/video")!,
-            headers: ["Authorization": "Bearer test"],
-            serverUrl: "https://example.test"
-        )
+    func testDeliveryClassesMapToAppleExecutorsWithoutEngineAliases() throws {
+        let streamRequest = makeStreamRequest()
         let base = makeBaseExecutionPlan(streamRequest: streamRequest)
-        let cases: [(String, String, String, PlaybackEngineKind, PlaybackDeliveryStrategy)] = [
-            ("original_http", "media3_direct", "http_progressive", .playerCoreDirect, .direct),
-            ("server_remux_progressive", "media3_progressive_remux", "http_progressive", .avPlayerNativeDirect, .remux),
-            ("server_remux_hls", "media3_hls", "hls", .avPlayerHLS, .remux),
-            ("server_transcode_hls", "media3_hls", "hls", .avPlayerHLS, .transcode)
+        let cases: [(String, String, PlaybackEngineKind, PlaybackDeliveryStrategy)] = [
+            ("original_http", "http_progressive", .playerCoreDirect, .direct),
+            ("server_remux_progressive", "http_progressive", .avPlayerNativeDirect, .remux),
+            ("server_remux_hls", "hls", .avPlayerHLS, .remux),
+            ("server_transcode_hls", "hls", .avPlayerHLS, .transcode)
         ]
 
-        for (delivery, engine, streamProtocol, expectedEngine, expectedDelivery) in cases {
+        for (delivery, streamProtocol, expectedEngine, expectedDelivery) in cases {
             let plan = makePlan(
                 delivery: delivery,
-                engine: engine,
                 streamProtocol: streamProtocol,
                 container: streamProtocol == "hls" ? "hls" : "mp4"
             )
@@ -164,12 +195,12 @@ final class PlaybackProtocolV3Tests: XCTestCase {
                 v3: PreparedPlaybackV3(
                     playbackAttemptId: "apple:attempt",
                     planAttemptId: "apple-plan:attempt",
-                    planAttemptKey: plan.attemptKey(outputRouteGeneration: 1),
-                    outputRouteGeneration: 1,
+                    planAttemptKey: plan.planAttemptKey,
+                    outputContextId: "apple:output",
                     serverFeatures: [
-                        "playback_plan_v3",
-                        "seek_reanchor_v1",
-                        "direct_stream_resume_v1"
+                        PlaybackProtocolV3.planFeature,
+                        PlaybackProtocolV3.seekReanchorFeature,
+                        PlaybackProtocolV3.directStreamResumeFeature
                     ],
                     plan: plan
                 ),
@@ -180,42 +211,22 @@ final class PlaybackProtocolV3Tests: XCTestCase {
             XCTAssertEqual(adapted.engine, expectedEngine, delivery)
             XCTAssertEqual(adapted.delivery.name, expectedDelivery.name, delivery)
             XCTAssertEqual(adapted.wireDelivery, delivery)
-            XCTAssertTrue(
-                adapted.serverFeatures.contains(PlaybackProtocolV3.directStreamResumeFeature)
-            )
-            XCTAssertEqual(
-                adapted.supportsDirectStreamResume,
-                delivery == "original_http",
-                delivery
-            )
-            XCTAssertEqual(adapted.startMode.seconds, 4.5, delivery)
+            XCTAssertEqual(adapted.supportsDirectStreamResume, delivery == "original_http")
+            XCTAssertEqual(adapted.startMode.seconds, 4.5)
+            XCTAssertEqual(adapted.sourceMetadata.colorRange, "tv")
         }
-        XCTAssertTrue(
-            ApplePlaybackV3Capabilities.features.contains(
-                PlaybackProtocolV3.directStreamResumeFeature
-            )
-        )
     }
 
-    func testDirectStreamResumeRequiresResponseFeature() throws {
-        let streamRequest = StreamRequest(
-            url: URL(string: "https://example.test/video")!,
-            headers: ["Authorization": "Bearer test"],
-            serverUrl: "https://example.test"
-        )
-        let plan = makePlan(
-            delivery: "original_http",
-            engine: "media3_direct",
-            streamProtocol: "http_progressive",
-            container: "mp4"
-        )
+    func testDirectStreamResumeRequiresNegotiatedResponseFeature() throws {
+        let streamRequest = makeStreamRequest()
+        let plan = makePlan()
         let adapted = try ApplePlaybackV3PlanAdapter.makeExecutionPlan(
             v3: PreparedPlaybackV3(
                 playbackAttemptId: "apple:attempt",
                 planAttemptId: "apple-plan:attempt",
-                planAttemptKey: plan.attemptKey(outputRouteGeneration: 1),
-                outputRouteGeneration: 1,
-                serverFeatures: ["playback_plan_v3"],
+                planAttemptKey: plan.planAttemptKey,
+                outputContextId: "apple:output",
+                serverFeatures: [PlaybackProtocolV3.planFeature],
                 plan: plan
             ),
             basePlan: makeBaseExecutionPlan(streamRequest: streamRequest),
@@ -226,9 +237,14 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         XCTAssertFalse(adapted.supportsDirectStreamResume)
     }
 
-    func testUnsupportedClientRequirementsAreRejected() {
+    func testUnsupportedPlanRequirementsAreRejected() {
         let unknownTransform = makePlan(transformations: [
-            .init(name: "client_unknown_transform", executor: "client", recipeVersion: "1", validatedClaims: [])
+            .init(
+                name: "client_unknown_transform",
+                executor: "client",
+                recipeVersion: "1",
+                validatedClaims: []
+            )
         ])
         XCTAssertThrowsError(try ApplePlaybackV3PlanAdapter.validate(unknownTransform)) { error in
             XCTAssertEqual(
@@ -237,33 +253,45 @@ final class PlaybackProtocolV3Tests: XCTestCase {
             )
         }
 
-        let unknownCorrection = makePlan(runtimeCorrections: ["client_unknown_correction"])
-        XCTAssertThrowsError(try ApplePlaybackV3PlanAdapter.validate(unknownCorrection))
-
-        let mismatchedEngine = makePlan(engine: "media3_hls")
-        XCTAssertThrowsError(try ApplePlaybackV3PlanAdapter.validate(mismatchedEngine))
-
-        let conflicting = makePlan(transformations: [
-            .init(name: "client_dv7_to_dv81", executor: "client", recipeVersion: "1", validatedClaims: []),
-            .init(name: "client_dv7_to_hdr10", executor: "client", recipeVersion: "1", validatedClaims: [])
-        ])
-        XCTAssertThrowsError(try ApplePlaybackV3PlanAdapter.validate(conflicting))
+        XCTAssertThrowsError(
+            try ApplePlaybackV3PlanAdapter.validate(
+                makePlan(runtimeCorrections: ["client_unknown_correction"])
+            )
+        )
+        XCTAssertThrowsError(
+            try ApplePlaybackV3PlanAdapter.validate(
+                makePlan(streamProtocol: "dash")
+            )
+        )
+        XCTAssertThrowsError(
+            try ApplePlaybackV3PlanAdapter.validate(
+                makePlan(transformations: [
+                    .init(
+                        name: "client_dv7_to_dv81",
+                        executor: "client",
+                        recipeVersion: "1",
+                        validatedClaims: []
+                    ),
+                    .init(
+                        name: "client_dv7_to_hdr10",
+                        executor: "client",
+                        recipeVersion: "1",
+                        validatedClaims: []
+                    )
+                ])
+            )
+        )
     }
 
     func testClientDolbyVisionTransformExecutesExactServerSelection() throws {
-        let streamRequest = StreamRequest(
-            url: URL(string: "https://example.test/dv7.mkv")!,
-            headers: ["Authorization": "Bearer test"],
-            serverUrl: "https://example.test"
-        )
-        let baseLoopback = makeLoopbackSession(
-            streamRequest: streamRequest,
-            videoMode: .passthroughHEVC
-        )
+        let streamRequest = makeStreamRequest(path: "dv7.mkv")
         let base = makeBaseExecutionPlan(
             streamRequest: streamRequest,
             engine: .siloPlayerLoopback,
-            loopbackSession: baseLoopback
+            loopbackSession: makeLoopbackSession(
+                streamRequest: streamRequest,
+                videoMode: .passthroughHEVC
+            )
         )
 
         let dv81 = try adaptedPlan(
@@ -312,7 +340,7 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         XCTAssertEqual(hdr10.loopbackSession?.manifestMetadata.videoRange, "PQ")
     }
 
-    func testSubtitleIdentityTranslatesAppleStreamIndexToServerCombinedOrdinal() {
+    func testSubtitleIdentityUsesDenseServerCombinedOrdinals() {
         let version = makeVersion(
             container: "mkv",
             videoCodec: "h264",
@@ -338,81 +366,235 @@ final class PlaybackProtocolV3Tests: XCTestCase {
             ),
             2
         )
-
-        let externalPlayerTrack = makePlayerSubtitle(
-            trackId: SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: 0),
-            isExternal: true,
-            ffIndex: nil,
-            srcId: 0
-        )
         XCTAssertEqual(
             ApplePlaybackV3PlanAdapter.serverCombinedSubtitleIndex(
-                for: externalPlayerTrack,
+                for: makePlayerSubtitle(
+                    trackId: SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: 0),
+                    isExternal: true,
+                    ffIndex: nil,
+                    srcId: 0
+                ),
                 in: version
             ),
             0
         )
-
-        let embeddedPlayerTrack = makePlayerSubtitle(
-            trackId: 12,
-            isExternal: false,
-            ffIndex: 5,
-            srcId: 1
-        )
         XCTAssertEqual(
             ApplePlaybackV3PlanAdapter.serverCombinedSubtitleIndex(
-                for: embeddedPlayerTrack,
+                for: makePlayerSubtitle(
+                    trackId: 12,
+                    isExternal: false,
+                    ffIndex: 5,
+                    srcId: 1
+                ),
                 in: version
             ),
             2
         )
+        XCTAssertEqual(
+            ApplePlaybackV3PlanAdapter.ffmpegSubtitleStreamIndex(
+                serverCombinedIndex: 2,
+                in: version
+            ),
+            5
+        )
+        XCTAssertNil(
+            ApplePlaybackV3PlanAdapter.ffmpegSubtitleStreamIndex(
+                serverCombinedIndex: 0,
+                in: version
+            ),
+            "an external combined ordinal has no embedded FFmpeg stream index"
+        )
     }
 
-    func testSimulatorCapabilitySnapshotIsConservativeAndComplete() throws {
+    func testAdoptedPlanBecomesDurableRenewalIntent() {
+        let version = makeVersion(
+            container: "mkv",
+            videoCodec: "h264",
+            audioCodec: "aac",
+            subtitleTracks: [
+                makeSubtitle(index: 2, codec: "ass", external: false, path: nil),
+                makeSubtitle(index: 5, codec: "pgs", external: false, path: nil),
+                makeSubtitle(index: nil, codec: "srt", external: true, path: "movie.en.srt")
+            ]
+        )
+        let selectedSubtitle = PlaybackV3SubtitleInventoryItem(
+            trackId: "file:42:subtitle:2",
+            combinedIndex: 2,
+            source: "embedded",
+            codec: "pgs",
+            language: "en",
+            label: "English PGS",
+            forced: false,
+            default: false,
+            hearingImpaired: false,
+            delivery: "sidecar",
+            url: "/api/v1/playback/session-v3/subtitles/2.sup",
+            fontBundleUrl: nil
+        )
+        let original = PlayerViewModel.LoadRequest(
+            contentId: "movie-1",
+            preferredFileId: 7,
+            preferredAudioTrackIndex: 0,
+            preferredSubtitleTrackIndex: nil,
+            preferredSidecarSubtitleTrackId: nil,
+            startFromBeginning: true
+        )
+        let plan = makePlan(
+            selectedAudioIndex: 3,
+            selectedSubtitleIndex: 2,
+            subtitleMode: "render",
+            subtitleInventory: [selectedSubtitle]
+        )
+
+        let renewal = original.adoptingProtocolV3Intent(
+            plan: plan,
+            selectedVersion: version,
+            activeQualityId: "720p"
+        )
+
+        XCTAssertEqual(renewal.preferredFileId, 42)
+        XCTAssertEqual(renewal.preferredAudioTrackIndex, 3)
+        XCTAssertEqual(renewal.preferredSubtitleTrackIndex, 5)
+        XCTAssertEqual(renewal.preferredProtocolV3SubtitleIndex, 2)
+        XCTAssertEqual(
+            renewal.preferredSidecarSubtitleTrackId,
+            SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: 2)
+        )
+        XCTAssertEqual(renewal.preferredQualityOverride, "720p")
+        XCTAssertFalse(renewal.startFromBeginning)
+    }
+
+    func testAdoptedSubtitleOffPlanClearsDurableSubtitleIntent() {
+        let version = makeVersion(
+            container: "mkv",
+            videoCodec: "h264",
+            audioCodec: "aac",
+            subtitleTracks: [
+                makeSubtitle(index: 5, codec: "pgs", external: false, path: nil)
+            ]
+        )
+        let original = PlayerViewModel.LoadRequest(
+            contentId: "movie-1",
+            preferredFileId: 7,
+            preferredAudioTrackIndex: 0,
+            preferredSubtitleTrackIndex: 5,
+            preferredSidecarSubtitleTrackId: SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: 2),
+            startFromBeginning: true,
+            preferredProtocolV3SubtitleIndex: 2
+        )
+
+        let renewal = original.adoptingProtocolV3Intent(
+            plan: makePlan(selectedAudioIndex: 3),
+            selectedVersion: version,
+            activeQualityId: "original"
+        )
+
+        XCTAssertEqual(renewal.preferredFileId, 42)
+        XCTAssertEqual(renewal.preferredAudioTrackIndex, 3)
+        XCTAssertNil(renewal.preferredSubtitleTrackIndex)
+        XCTAssertNil(renewal.preferredProtocolV3SubtitleIndex)
+        XCTAssertNil(renewal.preferredSidecarSubtitleTrackId)
+        XCTAssertEqual(renewal.preferredQualityOverride, "original")
+        XCTAssertFalse(renewal.startFromBeginning)
+    }
+
+    func testInitialAutoSubtitleIntentIsFrozenIntoProtocolV3Plan() {
+        let version = makeVersion(
+            container: "mkv",
+            videoCodec: "h264",
+            audioCodec: "aac",
+            subtitleTracks: [
+                makeSubtitle(index: nil, codec: "srt", external: true, path: "movie.en.srt"),
+                makeSubtitle(index: 2, codec: "subrip", external: false, path: nil),
+                makeSubtitle(
+                    index: 4,
+                    codec: "hdmv_pgs_subtitle",
+                    external: false,
+                    path: nil,
+                    forced: true,
+                    isDefault: true
+                )
+            ]
+        )
+
+        XCTAssertEqual(
+            PlaybackSessionBridge.initialProtocolV3SubtitleIntent(
+                version: version,
+                explicitFFmpegIndex: nil,
+                explicitCombinedIndex: nil,
+                preferredLanguage: nil,
+                mode: nil,
+                showForced: false,
+                trackSignature: nil,
+                currentAudioLanguage: nil
+            ),
+            PlaybackSessionBridge.InitialProtocolV3SubtitleIntent(
+                ffmpegStreamIndex: 4,
+                combinedIndex: 2
+            )
+        )
+        XCTAssertEqual(
+            PlaybackSessionBridge.initialProtocolV3SubtitleIntent(
+                version: version,
+                explicitFFmpegIndex: -1,
+                explicitCombinedIndex: nil,
+                preferredLanguage: nil,
+                mode: nil,
+                showForced: false,
+                trackSignature: nil,
+                currentAudioLanguage: nil
+            ),
+            PlaybackSessionBridge.InitialProtocolV3SubtitleIntent(
+                ffmpegStreamIndex: nil,
+                combinedIndex: nil
+            )
+        )
+    }
+
+    func testSimulatorCapabilitiesAreNeutralAttestedAndOutputScoped() throws {
         let snapshot = ApplePlaybackV3Capabilities.snapshot()
         XCTAssertEqual(snapshot.context.protocolVersion, 3)
-        XCTAssertEqual(snapshot.context.platform, "ios")
-        XCTAssertTrue(snapshot.context.features.contains("playback_plan_v3"))
-        XCTAssertEqual(Set(snapshot.context.engines.keys), [
-            "media3_direct", "media3_progressive_remux", "media3_hls"
-        ])
+        XCTAssertEqual(snapshot.context.device.platform, "ios")
+        XCTAssertEqual(
+            Set(snapshot.context.deliveries.keys),
+            [
+                PlaybackProtocolV3.DeliveryClass.originalHTTP,
+                PlaybackProtocolV3.DeliveryClass.progressive,
+                PlaybackProtocolV3.DeliveryClass.hls
+            ]
+        )
+        XCTAssertEqual(
+            snapshot.capabilities.videoEvidence,
+            PlaybackProtocolV3.Evidence.platformAttested
+        )
+        XCTAssertEqual(
+            snapshot.capabilities.audioEvidence,
+            PlaybackProtocolV3.Evidence.platformAttested
+        )
         XCTAssertEqual(snapshot.capabilities.codecsVideo, ["h264"])
+        XCTAssertEqual(snapshot.capabilities.codecsVideoHardware, ["h264"])
+        XCTAssertEqual(snapshot.capabilities.videoDecode.first?.profiles, [])
+        XCTAssertEqual(snapshot.capabilities.videoDecode.first?.levels, [])
+        XCTAssertNil(snapshot.capabilities.audioPassthrough)
+        XCTAssertNil(snapshot.context.output.audioPassthrough)
+        XCTAssertTrue(snapshot.outputContextId?.hasPrefix("apple:") == true)
         XCTAssertFalse(snapshot.capabilities.hdr)
-        XCTAssertGreaterThanOrEqual(snapshot.outputRouteGeneration, 0)
 
-        // The per-format detail has to agree with the coarse flag, or the
-        // server plans an HDR delivery this client just said it cannot render.
         let hdrDetails = try XCTUnwrap(snapshot.capabilities.hdrDetails)
-        XCTAssertFalse(hdrDetails.hdr10)
-        XCTAssertFalse(hdrDetails.hdr10Plus)
-        XCTAssertFalse(hdrDetails.hlg)
-        XCTAssertEqual(hdrDetails.dolbyVisionProfiles, [])
-        XCTAssertEqual(snapshot.capabilities.hdr, hdrDetails.claimsAnyHDR)
-        for (name, engine) in snapshot.context.engines {
-            XCTAssertEqual(engine.hdrDetails, hdrDetails, "engine \(name) disagrees on HDR")
+        XCTAssertFalse(hdrDetails.claimsAnyHDR)
+        for (name, delivery) in snapshot.context.deliveries {
+            XCTAssertEqual(delivery.hdrDetails, hdrDetails, "delivery \(name) disagrees on HDR")
+            XCTAssertEqual(delivery.audioPassthroughCodecs, [])
         }
+        let original = try XCTUnwrap(
+            snapshot.context.deliveries[PlaybackProtocolV3.DeliveryClass.originalHTTP]
+        )
+        XCTAssertTrue(original.subtitles.embeddedBitmap)
+        XCTAssertFalse(original.subtitles.sidecarBitmap)
+        XCTAssertTrue(original.subtitles.fontAttachments)
     }
 
-    func testHDRCapabilityFlagIsDerivedFromPerFormatDetail() {
-        XCTAssertFalse(
-            PlaybackV3HDRCapabilities(
-                hdr10: false, hdr10Plus: false, hlg: false, dolbyVisionProfiles: []
-            ).claimsAnyHDR
-        )
-        XCTAssertTrue(
-            PlaybackV3HDRCapabilities(
-                hdr10: false, hdr10Plus: false, hlg: true, dolbyVisionProfiles: []
-            ).claimsAnyHDR
-        )
-        // Dolby-Vision-only is still an HDR claim.
-        XCTAssertTrue(
-            PlaybackV3HDRCapabilities(
-                hdr10: false, hdr10Plus: false, hlg: false, dolbyVisionProfiles: [8]
-            ).claimsAnyHDR
-        )
-    }
-
-    func testStartRequestUsesSnakeCaseContract() throws {
+    func testStartRequestUsesOnlyNeutralSnakeCaseContract() throws {
         let snapshot = ApplePlaybackV3Capabilities.snapshot()
         let request = PlaybackV3StartRequest(
             protocolVersion: 3,
@@ -427,28 +609,140 @@ final class PlaybackProtocolV3Tests: XCTestCase {
             audioTrackIndex: 0,
             subtitleTrackId: nil,
             subtitleTrackIndex: nil,
-            outputRouteGeneration: snapshot.outputRouteGeneration,
             metered: false,
             bandwidthEstimateKbps: nil,
             bandwidthCapKbps: nil,
             clientCapabilities: snapshot.capabilities,
             clientPlaybackContext: snapshot.context
         )
-        let encoder = JSONEncoder()
-        encoder.keyEncodingStrategy = .convertToSnakeCase
-        let object = try XCTUnwrap(
-            JSONSerialization.jsonObject(with: encoder.encode(request)) as? [String: Any]
-        )
+        let object = try encodedObject(request)
         XCTAssertEqual(object["protocol_version"] as? Int, 3)
         XCTAssertEqual(object["playback_attempt_id"] as? String, "apple:12345678")
         XCTAssertNotNil(object["client_capabilities"])
-        XCTAssertNotNil(object["client_playback_context"])
+        let context = try XCTUnwrap(object["client_playback_context"] as? [String: Any])
+        XCTAssertNotNil(context["deliveries"])
+        XCTAssertNil(context["engines"])
+        XCTAssertNil(context["platform"])
+        XCTAssertNil(object["engine"])
+        XCTAssertNil(object["output_route_generation"])
+        let output = try XCTUnwrap(context["output"] as? [String: Any])
+        XCTAssertEqual(output["output_context_id"] as? String, snapshot.outputContextId)
+    }
+
+    func testPlanRuntimeFallbackIsUsedOnlyWhenSourceRuntimeIsAbsent() throws {
+        let catalog = makeVersion(container: "mp4", videoCodec: "h264", audioCodec: "aac")
+        let authoritative = ApplePlaybackV3PlanAdapter.playbackSession(
+            plan: makePlan(sourceDurationSeconds: 5_400),
+            sessionId: "session-v3",
+            selectedVersion: catalog
+        )
+        XCTAssertEqual(authoritative.durationSeconds, 5_400)
+
+        let fallback = ApplePlaybackV3PlanAdapter.playbackSession(
+            plan: makePlan(sourceDurationSeconds: nil),
+            sessionId: "session-v3",
+            selectedVersion: catalog
+        )
+        XCTAssertEqual(fallback.durationSeconds, 120)
+
+        let json = """
+        {
+          "media_file_id": 42,
+          "container": "mp4",
+          "hdr10_plus": false,
+          "dv_enhancement_layer": "none"
+        }
+        """
+        let source = try decoder.decode(
+            PlaybackV3SourceDescriptor.self,
+            from: Data(json.utf8)
+        )
+        XCTAssertNil(source.durationSeconds)
+    }
+
+    private var decoder: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return decoder
+    }
+
+    private var encoder: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }
+
+    private func fixtureURL(named name: String) throws -> URL {
+        try XCTUnwrap(
+            Bundle(for: Self.self).url(forResource: name, withExtension: "json"),
+            "Missing vendored Playback V3 fixture \(name).json"
+        )
+    }
+
+    private func decodeFixture<T: Decodable>(_ type: T.Type, named name: String) throws -> T {
+        try decoder.decode(type, from: Data(contentsOf: fixtureURL(named: name)))
+    }
+
+    private func fixtureObject(named name: String) throws -> [String: Any] {
+        try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: fixtureURL(named: name)))
+                as? [String: Any]
+        )
+    }
+
+    private func fixtureArray(named name: String) throws -> [[String: Any]] {
+        try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: fixtureURL(named: name)))
+                as? [[String: Any]]
+        )
+    }
+
+    private func encodedObject<T: Encodable>(_ value: T) throws -> [String: Any] {
+        try XCTUnwrap(
+            JSONSerialization.jsonObject(with: encoder.encode(value)) as? [String: Any]
+        )
+    }
+
+    private func makeReplanRequest(
+        planAttemptKey: String,
+        operation: String,
+        failure: PlaybackV3Failure?
+    ) -> PlaybackV3ReplanRequest {
+        let snapshot = ApplePlaybackV3Capabilities.snapshot()
+        return PlaybackV3ReplanRequest(
+            protocolVersion: 3,
+            clientFeatures: ApplePlaybackV3Capabilities.features,
+            operation: operation,
+            playbackAttemptId: "apple:attempt",
+            replanRequestId: "apple-replan:request",
+            failedPlanId: "plan:fixture",
+            planAttemptId: "apple-plan:attempt",
+            planAttemptKey: planAttemptKey,
+            attemptedPlanKeys: operation == PlaybackProtocolV3.ReplanOperation.failureRecovery
+                ? [planAttemptKey]
+                : [],
+            attemptCount: 1,
+            qualityPreference: "auto",
+            positionSeconds: 42.5,
+            metered: false,
+            bandwidthEstimateKbps: nil,
+            bandwidthCapKbps: nil,
+            selectedTracks: PlaybackV3SelectedTracks(
+                audio: PlaybackV3TrackIdentity(id: "file:42:audio:0", index: 0),
+                subtitle: nil
+            ),
+            failure: failure,
+            localMutations: [],
+            clientCapabilities: snapshot.capabilities,
+            clientPlaybackContext: snapshot.context
+        )
     }
 
     private func makePlan(
         planId: String = "plan:fixture",
+        planAttemptKey: String = "v3:opaque-fixture",
         delivery: String = "original_http",
-        engine: String = "media3_direct",
         streamProtocol: String = "http_progressive",
         container: String = "mp4",
         videoCodec: String = "h264",
@@ -457,7 +751,10 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         height: Int = 1_080,
         bitrateKbps: Int = 8_000,
         dynamicRange: String = "sdr",
+        selectedAudioIndex: Int = 0,
+        selectedSubtitleIndex: Int? = nil,
         subtitleMode: String = "off",
+        subtitleInventory: [PlaybackV3SubtitleInventoryItem] = [],
         transformations: [PlaybackV3Transformation] = [],
         appliedQuirks: [PlaybackV3AppliedQuirk] = [],
         runtimeCorrections: [String] = [],
@@ -471,12 +768,14 @@ final class PlaybackProtocolV3Tests: XCTestCase {
             sessionId: "session-v3",
             expiresAt: "2030-01-01T00:00:00Z",
             delivery: delivery,
-            engine: engine,
+            planAttemptKey: planAttemptKey,
             stream: PlaybackV3Stream(
                 url: "/stream/session-v3",
                 protocol: streamProtocol,
                 container: container,
-                mimeType: streamProtocol == "hls" ? "application/vnd.apple.mpegurl" : "video/mp4",
+                mimeType: streamProtocol == "hls"
+                    ? "application/vnd.apple.mpegurl"
+                    : "video/mp4",
                 headers: [:],
                 headerRefresh: "session",
                 headerRefreshUrl: nil
@@ -492,8 +791,13 @@ final class PlaybackProtocolV3Tests: XCTestCase {
                 seekRestoration: "player_position"
             ),
             selectedTracks: PlaybackV3SelectedTracks(
-                audio: PlaybackV3TrackIdentity(id: "file:42:audio:0", index: 0),
-                subtitle: nil
+                audio: PlaybackV3TrackIdentity(
+                    id: "file:42:audio:\(selectedAudioIndex)",
+                    index: selectedAudioIndex
+                ),
+                subtitle: selectedSubtitleIndex.map {
+                    PlaybackV3TrackIdentity(id: "file:42:subtitle:\($0)", index: $0)
+                }
             ),
             effectiveRecipe: PlaybackV3EffectiveRecipe(
                 videoCodec: videoCodec,
@@ -528,7 +832,12 @@ final class PlaybackProtocolV3Tests: XCTestCase {
                     reason: nil
                 )
             ),
-            subtitle: PlaybackV3SubtitleDecision(mode: subtitleMode, trackId: nil, artifact: nil),
+            subtitle: PlaybackV3SubtitleDecision(
+                mode: subtitleMode,
+                trackId: selectedSubtitleIndex.map { "file:42:subtitle:\($0)" },
+                artifact: nil,
+                inventory: subtitleInventory
+            ),
             transformations: transformations,
             appliedQuirks: appliedQuirks,
             runtimeCorrections: runtimeCorrections,
@@ -544,6 +853,7 @@ final class PlaybackProtocolV3Tests: XCTestCase {
                 videoProfile: "high",
                 videoLevel: 41,
                 bitDepth: dynamicRange == "sdr" ? 8 : 10,
+                colorRange: "tv",
                 width: width,
                 height: height,
                 frameRate: 23.976,
@@ -555,9 +865,18 @@ final class PlaybackProtocolV3Tests: XCTestCase {
                 dvEnhancementLayer: "none",
                 audioCodec: audioCodec,
                 audioChannels: 2,
-                audioLayout: "stereo"
+                audioLayout: "stereo",
+                videoCopyUnsafe: false
             ),
-            subtitleFidelityPolicy: "allow_simplified_rendering"
+            subtitleFidelityPolicy: "allow_simplified_rendering",
+            availableQualities: [
+                PlaybackV3AvailableQuality(
+                    label: "original",
+                    height: height,
+                    bitrateKbps: bitrateKbps,
+                    preservesSource: true
+                )
+            ]
         )
     }
 
@@ -570,14 +889,25 @@ final class PlaybackProtocolV3Tests: XCTestCase {
             v3: PreparedPlaybackV3(
                 playbackAttemptId: "apple:attempt",
                 planAttemptId: "apple-plan:attempt",
-                planAttemptKey: plan.attemptKey(outputRouteGeneration: 1),
-                outputRouteGeneration: 1,
-                serverFeatures: ["playback_plan_v3", "seek_reanchor_v1"],
+                planAttemptKey: plan.planAttemptKey,
+                outputContextId: "apple:output",
+                serverFeatures: [
+                    PlaybackProtocolV3.planFeature,
+                    PlaybackProtocolV3.seekReanchorFeature
+                ],
                 plan: plan
             ),
             basePlan: base,
             streamRequest: streamRequest,
             routeRequirements: .baseline
+        )
+    }
+
+    private func makeStreamRequest(path: String = "video") -> StreamRequest {
+        StreamRequest(
+            url: URL(string: "https://example.test/\(path)")!,
+            headers: ["Authorization": "Bearer test"],
+            serverUrl: "https://example.test"
         )
     }
 
@@ -662,7 +992,9 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         index: Int?,
         codec: String,
         external: Bool,
-        path: String?
+        path: String?,
+        forced: Bool = false,
+        isDefault: Bool = false
     ) -> SubtitleTrack {
         SubtitleTrack(
             index: index,
@@ -670,9 +1002,9 @@ final class PlaybackProtocolV3Tests: XCTestCase {
             language: "en",
             title: codec.uppercased(),
             embeddedTitle: nil,
-            forced: false,
+            forced: forced,
             hearingImpaired: false,
-            isDefault: false,
+            isDefault: isDefault,
             external: external,
             externalPath: path
         )

--- a/iosApp/Tests/PlaybackProtocolV3Tests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3Tests.swift
@@ -47,6 +47,7 @@ final class PlaybackProtocolV3Tests: XCTestCase {
             named: "capability_response"
         )
         XCTAssertEqual(capability.protocolVersions, [3])
+        XCTAssertTrue(capability.features.contains(PlaybackProtocolV3.neutralContractFeature))
         XCTAssertEqual(
             Set(capability.deliveries),
             [
@@ -58,6 +59,8 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         )
 
         let start = try decodeFixture(PlaybackV3StartRequest.self, named: "start_request")
+        XCTAssertEqual(start.progressPersistence, "client")
+        XCTAssertEqual(start.startPosition, 12.5)
         XCTAssertEqual(start.clientCapabilities.videoEvidence, PlaybackProtocolV3.Evidence.exact)
         XCTAssertEqual(start.clientPlaybackContext.device.platform, "android")
         XCTAssertEqual(start.clientPlaybackContext.output.outputContextId, "7")
@@ -69,6 +72,7 @@ final class PlaybackProtocolV3Tests: XCTestCase {
             named: "decision_response"
         )
         let plan = try XCTUnwrap(decision.playbackPlan)
+        XCTAssertTrue(decision.serverFeatures.contains(PlaybackProtocolV3.neutralContractFeature))
         XCTAssertEqual(replan["failed_plan_id"] as? String, plan.planId)
         XCTAssertEqual(replan["plan_attempt_key"] as? String, plan.planAttemptKey)
         XCTAssertEqual(replan["attempted_plan_keys"] as? [String], [plan.planAttemptKey])

--- a/iosApp/Tests/PlaybackProtocolV3Tests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3Tests.swift
@@ -180,6 +180,21 @@ final class PlaybackProtocolV3Tests: XCTestCase {
             PlaybackSessionBridge.replanOperation(forClassification: "decoder_failed"),
             PlaybackProtocolV3.ReplanOperation.failureRecovery
         )
+        XCTAssertNil(
+            PlaybackSessionBridge.replanFailure(
+                operation: PlaybackProtocolV3.ReplanOperation.seekReanchor,
+                classification: "seek_reanchor",
+                message: "intent"
+            )
+        )
+        XCTAssertEqual(
+            PlaybackSessionBridge.replanFailure(
+                operation: PlaybackProtocolV3.ReplanOperation.failureRecovery,
+                classification: "decoder_failed",
+                message: "broken"
+            )?.classification,
+            "decoder_failed"
+        )
 
         let request = makeReplanRequest(
             planAttemptKey: "v3:intent",
@@ -471,7 +486,7 @@ final class PlaybackProtocolV3Tests: XCTestCase {
 
         XCTAssertEqual(renewal.preferredFileId, 42)
         XCTAssertEqual(renewal.preferredAudioTrackIndex, 3)
-        XCTAssertEqual(renewal.preferredSubtitleTrackIndex, 5)
+        XCTAssertNil(renewal.preferredSubtitleTrackIndex)
         XCTAssertEqual(renewal.preferredProtocolV3SubtitleIndex, 2)
         XCTAssertEqual(
             renewal.preferredSidecarSubtitleTrackId,
@@ -550,6 +565,40 @@ final class PlaybackProtocolV3Tests: XCTestCase {
                 combinedIndex: 2
             )
         )
+
+        let accessibilityVersion = makeVersion(
+            container: "mkv",
+            videoCodec: "h264",
+            audioCodec: "aac",
+            subtitleTracks: [
+                makeSubtitle(index: 2, codec: "subrip", external: false, path: nil),
+                makeSubtitle(
+                    index: 4,
+                    codec: "subrip",
+                    external: false,
+                    path: nil,
+                    hearingImpaired: true
+                )
+            ]
+        )
+        XCTAssertEqual(
+            PlaybackSessionBridge.initialProtocolV3SubtitleIntent(
+                version: accessibilityVersion,
+                explicitFFmpegIndex: nil,
+                explicitCombinedIndex: nil,
+                preferredLanguage: "en",
+                mode: .always,
+                showForced: false,
+                preferAccessibilityTracks: true,
+                disableWhenNoLanguageMatch: true,
+                trackSignature: nil,
+                currentAudioLanguage: "ja"
+            ),
+            PlaybackSessionBridge.InitialProtocolV3SubtitleIntent(
+                ffmpegStreamIndex: 4,
+                combinedIndex: 1
+            )
+        )
         XCTAssertEqual(
             PlaybackSessionBridge.initialProtocolV3SubtitleIntent(
                 version: version,
@@ -621,6 +670,7 @@ final class PlaybackProtocolV3Tests: XCTestCase {
             playbackAttemptId: "apple:12345678",
             qualityPreference: "auto",
             subtitleFidelityPreference: "preserve",
+            progressPersistence: nil,
             startPosition: 12.5,
             audioTrackId: "file:42:audio:0",
             audioTrackIndex: 0,
@@ -642,8 +692,103 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         XCTAssertNil(context["platform"])
         XCTAssertNil(object["engine"])
         XCTAssertNil(object["output_route_generation"])
+        XCTAssertNil(object["progress_persistence"])
         let output = try XCTUnwrap(context["output"] as? [String: Any])
         XCTAssertEqual(output["output_context_id"] as? String, snapshot.outputContextId)
+    }
+
+    func testAudioStartUsesClientOwnedProgressWithExplicitZeroPosition() throws {
+        let snapshot = ApplePlaybackV3Capabilities.snapshot()
+        let request = PlaybackV3StartRequest(
+            protocolVersion: 3,
+            clientFeatures: ApplePlaybackV3Capabilities.features,
+            fileId: 42,
+            profileId: "profile-1",
+            playbackAttemptId: "apple-audio:12345678",
+            qualityPreference: "auto",
+            subtitleFidelityPreference: "preserve",
+            progressPersistence: "client",
+            startPosition: 0,
+            audioTrackId: nil,
+            audioTrackIndex: nil,
+            subtitleTrackId: nil,
+            subtitleTrackIndex: nil,
+            metered: false,
+            bandwidthEstimateKbps: nil,
+            bandwidthCapKbps: nil,
+            clientCapabilities: snapshot.capabilities,
+            clientPlaybackContext: snapshot.context
+        )
+        let object = try encodedObject(request)
+        XCTAssertEqual(object["progress_persistence"] as? String, "client")
+        XCTAssertEqual(object["start_position"] as? Double, 0)
+    }
+
+    func testNeutralCapabilityGateAndLegacyEndpointUpgradeMapping() {
+        let capability = PlaybackV3CapabilityResponse(
+            enabled: true,
+            protocolVersions: [3],
+            features: [
+                PlaybackProtocolV3.planFeature,
+                PlaybackProtocolV3.neutralContractFeature
+            ],
+            deliveries: ["original_http"],
+            transformations: [],
+            reason: nil
+        )
+        XCTAssertTrue(PlaybackSessionBridge.supportsNeutralProtocolV3(capability))
+        XCTAssertFalse(PlaybackSessionBridge.supportsNeutralProtocolV3(
+            PlaybackV3CapabilityResponse(
+                enabled: true,
+                protocolVersions: [3],
+                features: [PlaybackProtocolV3.planFeature],
+                deliveries: ["original_http"],
+                transformations: [],
+                reason: nil
+            )
+        ))
+        XCTAssertTrue(PlaybackSessionBridge.isMissingProtocolV3Capability(
+            HTTPError.http(statusCode: 404, body: nil)
+        ))
+        XCTAssertTrue(PlaybackSessionBridge.isMissingProtocolV3Capability(
+            HTTPError.http(statusCode: 405, body: nil)
+        ))
+        XCTAssertFalse(PlaybackSessionBridge.isMissingProtocolV3Capability(
+            HTTPError.http(statusCode: 500, body: nil)
+        ))
+    }
+
+    func testHDRAttestationDoesNotInventHDR10PlusOrMacDolbyVision() {
+        let details = ApplePlaybackV3Capabilities.hdrDetails(
+            hdr10: true,
+            hlg: true,
+            dolbyVision: false
+        )
+        XCTAssertTrue(details.hdr10)
+        XCTAssertTrue(details.hlg)
+        XCTAssertFalse(details.hdr10Plus)
+        XCTAssertEqual(details.dolbyVisionProfiles, [])
+    }
+
+    func testEmptySubtitleInventoryStartsDownloadedIdentityAtZero() {
+        XCTAssertEqual(PlayerViewModel.protocolV3DownloadedSubtitleBaseTrackCount([]), 0)
+    }
+
+    func testAudioOnlyAndUnknownServerQualityRungsRemainUsable() {
+        let options = ApplePlaybackQuality.playbackOptions(
+            serverQualities: [
+                PlaybackV3AvailableQuality(
+                    label: "audio_high",
+                    height: nil,
+                    bitrateKbps: 320,
+                    preservesSource: false
+                )
+            ],
+            fallbackVersion: nil
+        )
+        XCTAssertEqual(options.map(\.id), ["auto", "audio_high"])
+        XCTAssertEqual(options.last?.resolution, "")
+        XCTAssertEqual(options.last?.bitrateKbps, 320)
     }
 
     func testPlanRuntimeFallbackIsUsedOnlyWhenSourceRuntimeIsAbsent() throws {
@@ -1011,7 +1156,8 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         external: Bool,
         path: String?,
         forced: Bool = false,
-        isDefault: Bool = false
+        isDefault: Bool = false,
+        hearingImpaired: Bool = false
     ) -> SubtitleTrack {
         SubtitleTrack(
             index: index,
@@ -1020,7 +1166,7 @@ final class PlaybackProtocolV3Tests: XCTestCase {
             title: codec.uppercased(),
             embeddedTitle: nil,
             forced: forced,
-            hearingImpaired: false,
+            hearingImpaired: hearingImpaired,
             isDefault: isDefault,
             external: external,
             externalPath: path

--- a/iosApp/Tests/PlaybackProtocolV3Tests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3Tests.swift
@@ -762,6 +762,27 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         ))
     }
 
+    func testMissingPlaybackSessionDetectionRequiresTheSpecific404() {
+        XCTAssertTrue(PlaybackSessionBridge.isPlaybackSessionMissing(
+            HTTPError.http(
+                statusCode: 404,
+                body: #"{"error":"playback_session_not_found","message":"Playback session not found"}"#
+            )
+        ))
+        XCTAssertTrue(PlaybackSessionBridge.isPlaybackSessionMissing(
+            HTTPError.http(statusCode: 404, body: "Playback session not found")
+        ))
+        XCTAssertFalse(PlaybackSessionBridge.isPlaybackSessionMissing(
+            HTTPError.http(statusCode: 404, body: "Not found")
+        ))
+        XCTAssertFalse(PlaybackSessionBridge.isPlaybackSessionMissing(
+            HTTPError.http(
+                statusCode: 500,
+                body: #"{"error":"playback_session_not_found"}"#
+            )
+        ))
+    }
+
     func testHDRAttestationDoesNotInventHDR10PlusOrMacDolbyVision() {
         let details = ApplePlaybackV3Capabilities.hdrDetails(
             hdr10: true,

--- a/iosApp/Tests/PlaybackProtocolV3Tests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3Tests.swift
@@ -4,9 +4,10 @@ import XCTest
 
 final class PlaybackProtocolV3Tests: XCTestCase {
     func testServerGoldenDecisionDecodesAndPublishesCompleteSubtitleInventory() throws {
-        let response = try decodeFixture(
+        let response = try PlaybackV3FixtureTestSupport.decode(
             PlaybackV3DecisionResponse.self,
-            named: "decision_response"
+            named: "decision_response",
+            bundleClass: Self.self
         )
 
         guard case .playable(let plan, let sessionId) = response.validatedForApple() else {
@@ -14,8 +15,8 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         }
         XCTAssertEqual(sessionId, "11111111-1111-4111-8111-111111111111")
         XCTAssertFalse(plan.planAttemptKey.isEmpty)
-        XCTAssertEqual(plan.source.durationSeconds, 7_265.5)
-        XCTAssertEqual(plan.availableQualities.map(\.label), ["original", "720p", "480p"])
+        XCTAssertEqual(plan.source.durationSeconds, 7_200)
+        XCTAssertEqual(plan.availableQualities.map(\.label), ["original"])
         XCTAssertEqual(plan.subtitle.inventory.map(\.combinedIndex), [0, 1, 2, 3, 4])
         XCTAssertEqual(plan.subtitle.inventory[3].delivery, "burn_in_only")
         XCTAssertNil(plan.subtitle.inventory[3].url)
@@ -23,8 +24,8 @@ final class PlaybackProtocolV3Tests: XCTestCase {
             serverQualities: plan.availableQualities,
             fallbackVersion: nil
         )
-        XCTAssertEqual(qualityOptions.map(\.id), ["auto", "original", "720p", "480p"])
-        XCTAssertEqual(qualityOptions.map(\.bitrateKbps), [0, 8_000, 2_000, 1_500])
+        XCTAssertEqual(qualityOptions.map(\.id), ["auto", "original"])
+        XCTAssertEqual(qualityOptions.map(\.bitrateKbps), [0, 8_000])
 
         let session = ApplePlaybackV3PlanAdapter.playbackSession(
             plan: plan,
@@ -33,10 +34,11 @@ final class PlaybackProtocolV3Tests: XCTestCase {
                 container: "mp4",
                 videoCodec: "h264",
                 audioCodec: "aac"
-            )
+            ),
+            serverFeatures: response.serverFeatures
         )
         XCTAssertEqual(session.position, 12.5)
-        XCTAssertEqual(session.durationSeconds, 7_265.5)
+        XCTAssertEqual(session.durationSeconds, 7_200)
         // Starting with subtitles off must not hide selectable sidecars.
         XCTAssertEqual(session.subtitleUrls?.count, 4)
         let authoredASS = try XCTUnwrap(session.subtitleUrls?.first(where: { $0.index == 1 }))
@@ -49,9 +51,10 @@ final class PlaybackProtocolV3Tests: XCTestCase {
     }
 
     func testRecoveredServerRequestAndCapabilityFixturesDecode() throws {
-        let capability = try decodeFixture(
+        let capability = try PlaybackV3FixtureTestSupport.decode(
             PlaybackV3CapabilityResponse.self,
-            named: "capability_response"
+            named: "capability_response",
+            bundleClass: Self.self
         )
         XCTAssertEqual(capability.protocolVersions, [3])
         XCTAssertTrue(capability.features.contains(PlaybackProtocolV3.neutralContractFeature))
@@ -65,7 +68,11 @@ final class PlaybackProtocolV3Tests: XCTestCase {
             ]
         )
 
-        let start = try decodeFixture(PlaybackV3StartRequest.self, named: "start_request")
+        let start = try PlaybackV3FixtureTestSupport.decode(
+            PlaybackV3StartRequest.self,
+            named: "start_request",
+            bundleClass: Self.self
+        )
         XCTAssertEqual(start.progressPersistence, "client")
         XCTAssertEqual(start.startPosition, 12.5)
         XCTAssertEqual(start.clientCapabilities.videoEvidence, PlaybackProtocolV3.Evidence.exact)
@@ -74,9 +81,10 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         XCTAssertEqual(Set(start.clientPlaybackContext.deliveries.keys), ["original_http"])
 
         let replan = try fixtureObject(named: "replan_request")
-        let decision = try decodeFixture(
+        let decision = try PlaybackV3FixtureTestSupport.decode(
             PlaybackV3DecisionResponse.self,
-            named: "decision_response"
+            named: "decision_response",
+            bundleClass: Self.self
         )
         let plan = try XCTUnwrap(decision.playbackPlan)
         XCTAssertTrue(decision.serverFeatures.contains(PlaybackProtocolV3.neutralContractFeature))
@@ -712,6 +720,10 @@ final class PlaybackProtocolV3Tests: XCTestCase {
     }
 
     func testSimulatorCapabilitiesAreNeutralAttestedAndOutputScoped() throws {
+        try XCTSkipUnless(
+            AppleDecodeCapabilities.isSimulator,
+            "Attested codec and HDR values are device-specific; this vector pins the simulator profile."
+        )
         let snapshot = ApplePlaybackV3Capabilities.snapshot()
         XCTAssertEqual(snapshot.context.protocolVersion, 3)
         XCTAssertEqual(snapshot.context.device.platform, "ios")
@@ -756,6 +768,18 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         XCTAssertTrue(original.subtitles.embeddedBitmap)
         XCTAssertFalse(original.subtitles.sidecarBitmap)
         XCTAssertTrue(original.subtitles.fontAttachments)
+    }
+
+    func testAVPlayerDeliveriesExcludeSoftwareOnlyVideoCodecs() throws {
+        let snapshot = ApplePlaybackV3Capabilities.snapshot()
+        for deliveryClass in [
+            PlaybackProtocolV3.DeliveryClass.progressive,
+            PlaybackProtocolV3.DeliveryClass.hls
+        ] {
+            let delivery = try XCTUnwrap(snapshot.context.deliveries[deliveryClass])
+            XCTAssertEqual(delivery.videoCodecs, AppleDecodeCapabilities.videoCodecs)
+            XCTAssertFalse(delivery.videoCodecs.contains(AppleDecodeCapabilities.mpeg2VideoCodec))
+        }
     }
 
     func testStartRequestUsesOnlyNeutralSnakeCaseContract() throws {
@@ -856,6 +880,31 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         ))
     }
 
+    func testTerminalStartRouteEventIsSessionlessAndAttemptScoped() {
+        let snapshot = ApplePlaybackV3Capabilities.audiobookSnapshot()
+        let event = PlaybackSessionBridge.terminalStartRouteEvent(
+            playbackAttemptId: "apple:attempt-terminal",
+            snapshot: snapshot,
+            terminal: PlaybackV3Terminal(
+                reason: "adaptation_unavailable",
+                message: "No executable route is available.",
+                retryable: false
+            )
+        )
+
+        XCTAssertEqual(event.protocolVersion, 3)
+        XCTAssertEqual(event.playbackAttemptId, "apple:attempt-terminal")
+        XCTAssertEqual(event.event, "terminal")
+        XCTAssertEqual(event.fallbackReason, "adaptation_unavailable")
+        XCTAssertEqual(event.outputContextId, snapshot.outputContextId)
+        XCTAssertNil(event.sessionId)
+        XCTAssertNil(event.planId)
+        XCTAssertNil(event.planAttemptId)
+        XCTAssertNil(event.planAttemptKey)
+        XCTAssertEqual(event.appliedQuirkIds, [])
+        XCTAssertEqual(event.diagnostics["error_cause"], "No executable route is available.")
+    }
+
     func testMissingPlaybackSessionDetectionRequiresTheSpecific404() {
         XCTAssertTrue(PlaybackSessionBridge.isPlaybackSessionMissing(
             HTTPError.http(
@@ -893,20 +942,6 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         XCTAssertEqual(PlayerViewModel.protocolV3DownloadedSubtitleBaseTrackCount([]), 0)
     }
 
-    func testNonRenderPlanDoesNotRestoreSidecarSnapshot() {
-        let sidecarId = SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: 3)
-        XCTAssertEqual(
-            PlayerViewModel.protocolV3RestoredSidecarTrackId(sidecarId, subtitleMode: "render"),
-            sidecarId
-        )
-        XCTAssertNil(
-            PlayerViewModel.protocolV3RestoredSidecarTrackId(sidecarId, subtitleMode: "burn_in")
-        )
-        XCTAssertNil(
-            PlayerViewModel.protocolV3RestoredSidecarTrackId(sidecarId, subtitleMode: "off")
-        )
-    }
-
     func testV3ReplanRestoresServerRenderedSubtitleAsDisplayOnlySelection() {
         let sidecarId = SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: 3)
 
@@ -935,6 +970,11 @@ final class PlaybackProtocolV3Tests: XCTestCase {
             snapshot: sidecarId,
             selectedSubtitleIndex: 4,
             subtitleMode: "burn_in"
+        ))
+        XCTAssertNil(PlayerViewModel.protocolV3SidecarRestoreIntent(
+            snapshot: sidecarId,
+            selectedSubtitleIndex: 4,
+            subtitleMode: "render"
         ))
     }
 
@@ -1102,6 +1142,34 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         )
     }
 
+    func testAudiobookSnapshotOnlyAdvertisesAVPlayerExecutableRoutes() throws {
+        let snapshot = ApplePlaybackV3Capabilities.audiobookSnapshot()
+        XCTAssertEqual(snapshot.capabilities.codecsVideo, [])
+        XCTAssertEqual(snapshot.capabilities.codecsVideoHardware, [])
+        XCTAssertEqual(snapshot.capabilities.videoDecode, [])
+        XCTAssertFalse(snapshot.capabilities.codecsAudio.contains("dts"))
+        XCTAssertFalse(snapshot.capabilities.codecsAudio.contains("truehd"))
+        XCTAssertFalse(snapshot.capabilities.codecsAudio.contains("vorbis"))
+        XCTAssertFalse(snapshot.capabilities.containers.contains("mkv"))
+        XCTAssertFalse(snapshot.capabilities.containers.contains("matroska"))
+        XCTAssertTrue(snapshot.capabilities.containers.contains("mp4"))
+        XCTAssertTrue(snapshot.capabilities.containers.contains("m4b"))
+        XCTAssertTrue(snapshot.capabilities.containers.contains("flac"))
+
+        for delivery in snapshot.context.deliveries.values {
+            XCTAssertEqual(delivery.videoCodecs, [])
+            XCTAssertEqual(delivery.audioPassthroughCodecs, [])
+            XCTAssertEqual(delivery.transformations, [])
+        }
+        let original = try XCTUnwrap(
+            snapshot.context.deliveries[PlaybackProtocolV3.DeliveryClass.originalHTTP]
+        )
+        XCTAssertEqual(original.features, ["apple_native_direct"])
+        XCTAssertFalse(original.audioDecodeCodecs.contains("dts"))
+        XCTAssertFalse(original.audioDecodeCodecs.contains("truehd"))
+        XCTAssertFalse(original.audioDecodeCodecs.contains("vorbis"))
+    }
+
     func testAudioOnlyAndUnknownServerQualityRungsRemainUsable() {
         let options = ApplePlaybackQuality.playbackOptions(
             serverQualities: [
@@ -1162,19 +1230,29 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         )
     }
 
-    func testPlanRuntimeFallbackIsUsedOnlyWhenSourceRuntimeIsAbsent() throws {
+    func testPlanRuntimeDistinguishesUnknownFromFeatureAbsence() throws {
         let catalog = makeVersion(container: "mp4", videoCodec: "h264", audioCodec: "aac")
         let authoritative = ApplePlaybackV3PlanAdapter.playbackSession(
             plan: makePlan(sourceDurationSeconds: 5_400),
             sessionId: "session-v3",
-            selectedVersion: catalog
+            selectedVersion: catalog,
+            serverFeatures: [PlaybackProtocolV3.planSourceDurationFeature]
         )
         XCTAssertEqual(authoritative.durationSeconds, 5_400)
+
+        let explicitlyUnknown = ApplePlaybackV3PlanAdapter.playbackSession(
+            plan: makePlan(sourceDurationSeconds: nil),
+            sessionId: "session-v3",
+            selectedVersion: catalog,
+            serverFeatures: [PlaybackProtocolV3.planSourceDurationFeature]
+        )
+        XCTAssertNil(explicitlyUnknown.durationSeconds)
 
         let fallback = ApplePlaybackV3PlanAdapter.playbackSession(
             plan: makePlan(sourceDurationSeconds: nil),
             sessionId: "session-v3",
-            selectedVersion: catalog
+            selectedVersion: catalog,
+            serverFeatures: []
         )
         XCTAssertEqual(fallback.durationSeconds, 120)
 
@@ -1186,17 +1264,11 @@ final class PlaybackProtocolV3Tests: XCTestCase {
           "dv_enhancement_layer": "none"
         }
         """
-        let source = try decoder.decode(
+        let source = try PlaybackV3FixtureTestSupport.decoder.decode(
             PlaybackV3SourceDescriptor.self,
             from: Data(json.utf8)
         )
         XCTAssertNil(source.durationSeconds)
-    }
-
-    private var decoder: JSONDecoder {
-        let decoder = JSONDecoder()
-        decoder.keyDecodingStrategy = .convertFromSnakeCase
-        return decoder
     }
 
     private var encoder: JSONEncoder {
@@ -1206,27 +1278,22 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         return encoder
     }
 
-    private func fixtureURL(named name: String) throws -> URL {
-        try XCTUnwrap(
-            Bundle(for: Self.self).url(forResource: name, withExtension: "json"),
-            "Missing vendored Playback V3 fixture \(name).json"
-        )
-    }
-
-    private func decodeFixture<T: Decodable>(_ type: T.Type, named name: String) throws -> T {
-        try decoder.decode(type, from: Data(contentsOf: fixtureURL(named: name)))
-    }
-
     private func fixtureObject(named name: String) throws -> [String: Any] {
         try XCTUnwrap(
-            JSONSerialization.jsonObject(with: Data(contentsOf: fixtureURL(named: name)))
+            JSONSerialization.jsonObject(with: Data(contentsOf: PlaybackV3FixtureTestSupport.fixtureURL(
+                named: name,
+                bundleClass: Self.self
+            )))
                 as? [String: Any]
         )
     }
 
     private func fixtureArray(named name: String) throws -> [[String: Any]] {
         try XCTUnwrap(
-            JSONSerialization.jsonObject(with: Data(contentsOf: fixtureURL(named: name)))
+            JSONSerialization.jsonObject(with: Data(contentsOf: PlaybackV3FixtureTestSupport.fixtureURL(
+                named: name,
+                bundleClass: Self.self
+            )))
                 as? [[String: Any]]
         )
     }

--- a/iosApp/Tests/PlaybackProtocolV3Tests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3Tests.swift
@@ -218,6 +218,89 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         XCTAssertEqual(object["attempted_plan_keys"] as? [String], [])
     }
 
+    func testOutputRouteReplanRequiresChangedOutputContextIdentity() {
+        XCTAssertFalse(
+            PlaybackSessionBridge.isMaterialOutputRouteChange(
+                activeOutputContextId: "apple:bedroom",
+                observedOutputContextId: "apple:bedroom"
+            ),
+            "player-owned AVAudioSession configuration notifications must not invalidate the plan"
+        )
+        XCTAssertTrue(
+            PlaybackSessionBridge.isMaterialOutputRouteChange(
+                activeOutputContextId: "apple:bedroom",
+                observedOutputContextId: "apple:airplay"
+            ),
+            "a genuinely different output identity must request a new plan"
+        )
+        XCTAssertFalse(
+            PlaybackSessionBridge.isMaterialOutputRouteChange(
+                activeOutputContextId: nil,
+                observedOutputContextId: nil
+            )
+        )
+        XCTAssertTrue(
+            PlaybackSessionBridge.isMaterialOutputRouteChange(
+                activeOutputContextId: nil,
+                observedOutputContextId: "apple:bedroom"
+            )
+        )
+    }
+
+    func testPlaybackCoordinatorReusesEngineForSameImplementationRoute() {
+        var avPlayerBackendCreations = 0
+        let coordinator = PlaybackCoordinator(
+            makeCore: {
+                XCTFail("The AVFoundation route must not construct PlayerCore")
+                return PlayerCore()
+            },
+            makeAVPlayer: { _ in
+                avPlayerBackendCreations += 1
+                return AVPlayerBackend()
+            }
+        )
+        defer { coordinator.dispose() }
+
+        let initial = coordinator.prepareEngine(for: .siloPlayerLoopback)
+        let replacement = coordinator.prepareEngine(for: .siloPlayerLoopback)
+
+        XCTAssertTrue(initial === replacement)
+        XCTAssertEqual(avPlayerBackendCreations, 1)
+    }
+
+    func testLoopbackSessionPublishesTheAudioTrackSelectedForMuxing() {
+        let tracks = [
+            makePlayerAudioTrack(trackId: 10_000, sourceIndex: 0, ffIndex: 1, isSelected: true),
+            makePlayerAudioTrack(trackId: 10_001, sourceIndex: 1, ffIndex: 2, isSelected: false),
+        ]
+
+        let session = LoopbackSessionSpec(
+            sourceURL: URL(string: "https://example.test/video")!,
+            headers: [:],
+            videoMode: .passthroughH264,
+            sourceVideoFrameRate: 24,
+            selectedAudio: LoopbackSessionSpec.SelectedAudio(
+                trackIndex: 1,
+                ffIndex: 2,
+                sourceCodec: "eac3",
+                sourceChannelCount: 6,
+                sourceChannelLayout: "5.1(side)",
+                outputMode: .copy,
+                preservesAtmos: false
+            ),
+            availableAudioTracks: tracks,
+            manifestMetadata: LoopbackSessionSpec.ManifestMetadata(
+                advertisedDolbyVisionProfile: nil,
+                compatibilityBrand: nil,
+                videoRange: "SDR",
+                mayClaimAtmos: false
+            )
+        )
+
+        XCTAssertEqual(session.availableAudioTracks.map(\.isSelected), [false, true])
+        XCTAssertEqual(session.availableAudioTracks.first(where: \.isSelected)?.srcId, 1)
+    }
+
     func testDeliveryClassesMapToAppleExecutorsWithoutEngineAliases() throws {
         let streamRequest = makeStreamRequest()
         let base = makeBaseExecutionPlan(streamRequest: streamRequest)
@@ -1358,6 +1441,32 @@ final class PlaybackProtocolV3Tests: XCTestCase {
             url: URL(string: "https://example.test/\(path)")!,
             headers: ["Authorization": "Bearer test"],
             serverUrl: "https://example.test"
+        )
+    }
+
+    private func makePlayerAudioTrack(
+        trackId: Int64,
+        sourceIndex: Int,
+        ffIndex: Int,
+        isSelected: Bool
+    ) -> PlayerTrack {
+        PlayerTrack(
+            trackId: trackId,
+            kind: .audio,
+            title: nil,
+            lang: nil,
+            codec: "eac3",
+            audioChannelsLayout: "5.1(side)",
+            audioChannelCount: 6,
+            bitrate: nil,
+            isDefault: sourceIndex == 0,
+            isForced: false,
+            isHearingImpaired: false,
+            isVisualImpaired: false,
+            isExternal: false,
+            isSelected: isSelected,
+            ffIndex: ffIndex,
+            srcId: sourceIndex
         )
     }
 

--- a/iosApp/Tests/PlaybackProtocolV3Tests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3Tests.swift
@@ -39,6 +39,13 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         XCTAssertEqual(session.durationSeconds, 7_265.5)
         // Starting with subtitles off must not hide selectable sidecars.
         XCTAssertEqual(session.subtitleUrls?.count, 4)
+        let authoredASS = try XCTUnwrap(session.subtitleUrls?.first(where: { $0.index == 1 }))
+        XCTAssertEqual(authoredASS.default, false)
+        XCTAssertEqual(authoredASS.hearingImpaired, false)
+        XCTAssertEqual(
+            authoredASS.fontBundleUrl,
+            "/stream/11111111-1111-4111-8111-111111111111/subtitles/1/fonts?file_id=42"
+        )
     }
 
     func testRecoveredServerRequestAndCapabilityFixturesDecode() throws {
@@ -645,6 +652,10 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         XCTAssertEqual(snapshot.capabilities.codecsVideoHardware, ["h264"])
         XCTAssertEqual(snapshot.capabilities.videoDecode.first?.profiles, [])
         XCTAssertEqual(snapshot.capabilities.videoDecode.first?.levels, [])
+        XCTAssertEqual(
+            snapshot.context.deliveries[PlaybackProtocolV3.DeliveryClass.progressive]?.videoCodecs,
+            AppleDecodeCapabilities.videoCodecs
+        )
         XCTAssertNil(snapshot.capabilities.audioPassthrough)
         XCTAssertNil(snapshot.context.output.audioPassthrough)
         XCTAssertTrue(snapshot.outputContextId?.hasPrefix("apple:") == true)
@@ -799,6 +810,215 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         XCTAssertEqual(PlayerViewModel.protocolV3DownloadedSubtitleBaseTrackCount([]), 0)
     }
 
+    func testNonRenderPlanDoesNotRestoreSidecarSnapshot() {
+        let sidecarId = SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: 3)
+        XCTAssertEqual(
+            PlayerViewModel.protocolV3RestoredSidecarTrackId(sidecarId, subtitleMode: "render"),
+            sidecarId
+        )
+        XCTAssertNil(
+            PlayerViewModel.protocolV3RestoredSidecarTrackId(sidecarId, subtitleMode: "burn_in")
+        )
+        XCTAssertNil(
+            PlayerViewModel.protocolV3RestoredSidecarTrackId(sidecarId, subtitleMode: "off")
+        )
+    }
+
+    func testV3ReplanRestoresServerRenderedSubtitleAsDisplayOnlySelection() {
+        let sidecarId = SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: 3)
+
+        XCTAssertEqual(
+            PlayerViewModel.protocolV3SidecarRestoreIntent(
+                snapshot: sidecarId,
+                selectedSubtitleIndex: 3,
+                subtitleMode: "render"
+            ),
+            .renderLocally(sidecarId)
+        )
+        XCTAssertEqual(
+            PlayerViewModel.protocolV3SidecarRestoreIntent(
+                snapshot: sidecarId,
+                selectedSubtitleIndex: 3,
+                subtitleMode: "burn_in"
+            ),
+            .serverRendered(sidecarId)
+        )
+        XCTAssertNil(PlayerViewModel.protocolV3SidecarRestoreIntent(
+            snapshot: sidecarId,
+            selectedSubtitleIndex: 3,
+            subtitleMode: "off"
+        ))
+        XCTAssertNil(PlayerViewModel.protocolV3SidecarRestoreIntent(
+            snapshot: sidecarId,
+            selectedSubtitleIndex: 4,
+            subtitleMode: "burn_in"
+        ))
+    }
+
+    func testV3AudioIntentOverridesBackendDefaultAfterReplan() {
+        let version = makeVersion(
+            container: "mkv",
+            videoCodec: "h264",
+            audioCodec: "truehd",
+            audioTracks: [
+                makeAudio(index: 0, codec: "truehd", isDefault: true),
+                makeAudio(index: 1, codec: "ac3", isDefault: false)
+            ]
+        )
+        let original = PlayerViewModel.LoadRequest(
+            contentId: "movie-1",
+            preferredFileId: 42,
+            preferredAudioTrackIndex: 0,
+            preferredSubtitleTrackIndex: -1,
+            preferredSidecarSubtitleTrackId: nil,
+            startFromBeginning: false
+        )
+        let adopted = original.adoptingProtocolV3Intent(
+            plan: makePlan(selectedAudioIndex: 1),
+            selectedVersion: version,
+            activeQualityId: "original"
+        )
+
+        let intent = PlayerViewModel.protocolV3PendingTrackIntent(
+            plan: makePlan(selectedAudioIndex: 1),
+            request: adopted
+        )
+
+        XCTAssertEqual(adopted.preferredAudioTrackIndex, 1)
+        XCTAssertEqual(intent.audioIndex, 1)
+        XCTAssertEqual(intent.embeddedSubtitleIndex, -1)
+        XCTAssertNil(intent.sidecarSubtitleTrackId)
+    }
+
+    func testStaleStreamGenerationCannotConsumePendingTrackIntent() {
+        XCTAssertTrue(
+            PlayerViewModel.isCurrentStreamCallback(7, currentGeneration: 7)
+        )
+        XCTAssertFalse(
+            PlayerViewModel.isCurrentStreamCallback(6, currentGeneration: 7)
+        )
+    }
+
+    func testReplacementLoaderCannotMovePlaybackBackwardsWithoutASeek() {
+        XCTAssertTrue(
+            PlayerViewModel.isUnexpectedBackwardPlaybackTime(
+                32.1,
+                currentTime: 35,
+                explicitSeekInFlight: false
+            )
+        )
+        XCTAssertFalse(
+            PlayerViewModel.isUnexpectedBackwardPlaybackTime(
+                32.1,
+                currentTime: 35,
+                explicitSeekInFlight: true
+            )
+        )
+        XCTAssertFalse(
+            PlayerViewModel.isUnexpectedBackwardPlaybackTime(
+                34.5,
+                currentTime: 35,
+                explicitSeekInFlight: false
+            )
+        )
+    }
+
+    func testLoopbackVODReplanKeepsStablePlaylistTimeline() {
+        XCTAssertEqual(
+            PlayerViewModel.initialLoopbackTimelineOffset(
+                servingMode: .vodPlan,
+                startTime: 21.5
+            ),
+            0
+        )
+        XCTAssertEqual(
+            PlayerViewModel.initialLoopbackTimelineOffset(
+                servingMode: .event,
+                startTime: 21.5
+            ),
+            21.5
+        )
+    }
+
+    func testGrowingTranscodePlaylistCannotReplaceKnownVODDuration() {
+        XCTAssertFalse(
+            PlayerViewModel.shouldAdoptBackendDuration(
+                73,
+                currentDuration: 57,
+                delivery: .transcode
+            )
+        )
+        XCTAssertTrue(
+            PlayerViewModel.shouldAdoptBackendDuration(
+                73,
+                currentDuration: 0,
+                delivery: .transcode
+            )
+        )
+        XCTAssertTrue(
+            PlayerViewModel.shouldAdoptBackendDuration(
+                73,
+                currentDuration: 57,
+                delivery: .direct
+            )
+        )
+        XCTAssertFalse(
+            PlayerViewModel.shouldAdoptBackendDuration(
+                50,
+                currentDuration: 57,
+                delivery: .direct
+            )
+        )
+    }
+
+    func testV3RouteSubtitleFilteringRetainsOnlySelectedEmbeddedSidecar() {
+        let external = makeSubtitleUrl(index: 3, source: "external")
+        let selectedEmbedded = makeSubtitleUrl(index: 9, source: "embedded")
+        let redundantEmbedded = makeSubtitleUrl(index: 10, source: "EmBeDdEd")
+        let urls = [external, selectedEmbedded, redundantEmbedded]
+
+        XCTAssertEqual(
+            PlayerViewModel.protocolV3SubtitleUrlsForCurrentRoute(
+                urls,
+                routeUsesEmbeddedExtraction: true,
+                selectedSubtitleIndex: 9,
+                subtitleMode: "render"
+            ).map(\.index),
+            [3, 9]
+        )
+        XCTAssertEqual(
+            PlayerViewModel.protocolV3SubtitleUrlsForCurrentRoute(
+                urls,
+                routeUsesEmbeddedExtraction: true,
+                selectedSubtitleIndex: 9,
+                subtitleMode: "burn_in"
+            ).map(\.index),
+            [3]
+        )
+        XCTAssertEqual(
+            PlayerViewModel.protocolV3SubtitleUrlsForCurrentRoute(
+                urls,
+                routeUsesEmbeddedExtraction: false,
+                selectedSubtitleIndex: 9,
+                subtitleMode: "render"
+            ),
+            urls
+        )
+    }
+
+    func testAudiobookFeaturesDoNotClaimSeekReanchor() {
+        XCTAssertFalse(
+            ApplePlaybackV3Capabilities.audiobookFeatures.contains(
+                PlaybackProtocolV3.seekReanchorFeature
+            )
+        )
+        XCTAssertTrue(
+            ApplePlaybackV3Capabilities.audiobookFeatures.contains(
+                PlaybackProtocolV3.planFeature
+            )
+        )
+    }
+
     func testAudioOnlyAndUnknownServerQualityRungsRemainUsable() {
         let options = ApplePlaybackQuality.playbackOptions(
             serverQualities: [
@@ -814,6 +1034,49 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         XCTAssertEqual(options.map(\.id), ["auto", "audio_high"])
         XCTAssertEqual(options.last?.resolution, "")
         XCTAssertEqual(options.last?.bitrateKbps, 320)
+    }
+
+    func testEmptyServerQualityCatalogOnlyOffersAuto() {
+        let options = ApplePlaybackQuality.playbackOptions(
+            serverQualities: [],
+            fallbackVersion: makeVersion(
+                container: "mp4",
+                videoCodec: "h264",
+                audioCodec: "aac"
+            )
+        )
+        XCTAssertEqual(options.map(\.id), [ApplePlaybackQuality.autoId])
+    }
+
+    func testCompoundAndUnknownV3QualityIdsSurvivePlanMatching() {
+        let qualities = [
+            PlaybackV3AvailableQuality(
+                label: "1080p",
+                height: 1_080,
+                bitrateKbps: 8_000,
+                preservesSource: false
+            ),
+            PlaybackV3AvailableQuality(
+                label: "audio_high",
+                height: nil,
+                bitrateKbps: 320,
+                preservesSource: false
+            )
+        ]
+        XCTAssertEqual(
+            ApplePlaybackQuality.activeProtocolV3QualityId(
+                requestedQualityId: "1080p-8",
+                availableQualities: qualities
+            ),
+            "1080p-8"
+        )
+        XCTAssertEqual(
+            ApplePlaybackQuality.activeProtocolV3QualityId(
+                requestedQualityId: "audio_high",
+                availableQualities: qualities
+            ),
+            "audio_high"
+        )
     }
 
     func testPlanRuntimeFallbackIsUsedOnlyWhenSourceRuntimeIsAbsent() throws {
@@ -1155,6 +1418,7 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         container: String,
         videoCodec: String,
         audioCodec: String,
+        audioTracks: [AudioTrack]? = nil,
         subtitleTracks: [SubtitleTrack]? = nil
     ) -> FileVersion {
         FileVersion(
@@ -1169,9 +1433,40 @@ final class PlaybackProtocolV3Tests: XCTestCase {
             duration: 120,
             bitrate: 8_000_000,
             videoTracks: nil,
-            audioTracks: nil,
+            audioTracks: audioTracks,
             subtitleTracks: subtitleTracks,
             chapters: nil
+        )
+    }
+
+    private func makeAudio(
+        index: Int,
+        codec: String,
+        isDefault: Bool
+    ) -> AudioTrack {
+        AudioTrack(
+            index: index,
+            codec: codec,
+            channels: 6,
+            channelLayout: "5.1",
+            bitrate: 640_000,
+            sampleRate: 48_000,
+            language: "en",
+            title: codec.uppercased(),
+            embeddedTitle: nil,
+            isDefault: isDefault
+        )
+    }
+
+    private func makeSubtitleUrl(index: Int, source: String) -> SubtitleUrl {
+        SubtitleUrl(
+            index: index,
+            language: "en",
+            codec: "srt",
+            label: "English",
+            source: source,
+            forced: false,
+            url: "/stream/subtitles/\(index)"
         )
     }
 

--- a/iosApp/Tests/PlaybackProtocolV3Tests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3Tests.swift
@@ -13,7 +13,7 @@ final class PlaybackProtocolV3Tests: XCTestCase {
             return XCTFail("Expected the recovered server fixture to be playable")
         }
         XCTAssertEqual(sessionId, "11111111-1111-4111-8111-111111111111")
-        XCTAssertEqual(plan.planAttemptKey, "v3:f0144c47fa349e3e")
+        XCTAssertFalse(plan.planAttemptKey.isEmpty)
         XCTAssertEqual(plan.source.durationSeconds, 7_265.5)
         XCTAssertEqual(plan.availableQualities.map(\.label), ["original", "720p", "480p"])
         XCTAssertEqual(plan.subtitle.inventory.map(\.combinedIndex), [0, 1, 2, 3, 4])
@@ -64,13 +64,21 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         XCTAssertEqual(Set(start.clientPlaybackContext.deliveries.keys), ["original_http"])
 
         let replan = try fixtureObject(named: "replan_request")
-        XCTAssertEqual(replan["plan_attempt_key"] as? String, "v3:0000000000000001")
+        let decision = try decodeFixture(
+            PlaybackV3DecisionResponse.self,
+            named: "decision_response"
+        )
+        let plan = try XCTUnwrap(decision.playbackPlan)
+        XCTAssertEqual(replan["failed_plan_id"] as? String, plan.planId)
+        XCTAssertEqual(replan["plan_attempt_key"] as? String, plan.planAttemptKey)
+        XCTAssertEqual(replan["attempted_plan_keys"] as? [String], [plan.planAttemptKey])
         XCTAssertNil(replan["engine"])
         XCTAssertNil(replan["output_route_generation"])
 
         let routeEvent = try fixtureObject(named: "route_event")
         XCTAssertEqual(routeEvent["output_context_id"] as? String, "7")
-        XCTAssertEqual(routeEvent["plan_attempt_key"] as? String, "v3:0000000000000001")
+        XCTAssertEqual(routeEvent["plan_id"] as? String, plan.planId)
+        XCTAssertEqual(routeEvent["plan_attempt_key"] as? String, plan.planAttemptKey)
 
         let subtitleFixture = try fixtureObject(named: "subtitle_inventory")
         let inventory = try XCTUnwrap(subtitleFixture["inventory"] as? [[String: Any]])
@@ -78,6 +86,15 @@ final class PlaybackProtocolV3Tests: XCTestCase {
 
         let attemptKeys = try fixtureArray(named: "attempt_keys")
         XCTAssertFalse(attemptKeys.isEmpty)
+        for vector in attemptKeys {
+            let serverKey = try XCTUnwrap(vector["server_plan_attempt_key"] as? String)
+            XCTAssertEqual(vector["replan_echo"] as? String, serverKey)
+            XCTAssertEqual(vector["attempted_plan_keys"] as? [String], [serverKey])
+            XCTAssertEqual(
+                vector["expected_server_action"] as? String,
+                "reject_already_attempted_plan"
+            )
+        }
     }
 
     func testPlanAttemptKeyIsOpaqueAndEchoedVerbatim() throws {

--- a/iosApp/Tests/PlaybackV3FixtureTestSupport.swift
+++ b/iosApp/Tests/PlaybackV3FixtureTestSupport.swift
@@ -1,0 +1,28 @@
+import Foundation
+import XCTest
+
+enum PlaybackV3FixtureTestSupport {
+    static var decoder: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return decoder
+    }
+
+    static func fixtureURL(named name: String, bundleClass: AnyClass) throws -> URL {
+        try XCTUnwrap(
+            Bundle(for: bundleClass).url(forResource: name, withExtension: "json"),
+            "Missing vendored Playback V3 fixture \(name).json"
+        )
+    }
+
+    static func decode<T: Decodable>(
+        _ type: T.Type,
+        named name: String,
+        bundleClass: AnyClass
+    ) throws -> T {
+        try decoder.decode(
+            type,
+            from: Data(contentsOf: fixtureURL(named: name, bundleClass: bundleClass))
+        )
+    }
+}

--- a/iosApp/Tests/SidecarSubtitleFetcherTests.swift
+++ b/iosApp/Tests/SidecarSubtitleFetcherTests.swift
@@ -85,17 +85,22 @@ final class SidecarSubtitleFetcherTests: XCTestCase {
         let fetcher = SidecarSubtitleFetcher(
             session: makeSession(),
             fontBundleResponseByteLimit: 1_024,
-            fontBundleCacheByteLimit: 2
+            fontBundleCacheByteLimit: 4
         )
         let first = try XCTUnwrap(URL(string: "https://example.invalid/first"))
         let second = try XCTUnwrap(URL(string: "https://example.invalid/second"))
+        let third = try XCTUnwrap(URL(string: "https://example.invalid/third"))
 
         _ = try await fetcher.fetchFontBundle(url: first)
         _ = try await fetcher.fetchFontBundle(url: second)
         _ = try await fetcher.fetchFontBundle(url: first)
+        _ = try await fetcher.fetchFontBundle(url: third)
+        _ = try await fetcher.fetchFontBundle(url: first)
+        _ = try await fetcher.fetchFontBundle(url: second)
 
-        XCTAssertEqual(FontBundleURLProtocol.requestCount(for: first), 2)
-        XCTAssertEqual(FontBundleURLProtocol.requestCount(for: second), 1)
+        XCTAssertEqual(FontBundleURLProtocol.requestCount(for: first), 1)
+        XCTAssertEqual(FontBundleURLProtocol.requestCount(for: second), 2)
+        XCTAssertEqual(FontBundleURLProtocol.requestCount(for: third), 1)
     }
 
     private func makeSession() -> URLSession {

--- a/iosApp/Tests/SidecarSubtitleFetcherTests.swift
+++ b/iosApp/Tests/SidecarSubtitleFetcherTests.swift
@@ -1,0 +1,168 @@
+import Foundation
+import XCTest
+@testable import Silo
+
+final class SidecarSubtitleFetcherTests: XCTestCase {
+    override func tearDown() {
+        FontBundleURLProtocol.reset()
+        super.tearDown()
+    }
+
+    func testFontBundleRejectsOversizedDeclaredResponse() async throws {
+        FontBundleURLProtocol.configure { request in
+            let data = Data("[]".utf8)
+            let response = try XCTUnwrap(HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: [
+                    "Content-Type": "application/json",
+                    "Content-Length": "11"
+                ]
+            ))
+            return (response, data)
+        }
+        let fetcher = SidecarSubtitleFetcher(
+            session: makeSession(),
+            fontBundleResponseByteLimit: 10,
+            fontBundleCacheByteLimit: 10
+        )
+
+        do {
+            _ = try await fetcher.fetchFontBundle(url: try XCTUnwrap(URL(string: "https://example.invalid/large")))
+            XCTFail("Expected an oversized font bundle to be rejected")
+        } catch let error as SidecarSubtitleFetchError {
+            guard case .responseTooLarge(let maxBytes) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(maxBytes, 10)
+        }
+    }
+
+    func testFontBundleStopsStreamingAtResponseLimitWithoutContentLength() async throws {
+        FontBundleURLProtocol.configure { request in
+            let data = Data("12345678901".utf8)
+            let response = try XCTUnwrap(HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            ))
+            return (response, data)
+        }
+        let fetcher = SidecarSubtitleFetcher(
+            session: makeSession(),
+            fontBundleResponseByteLimit: 10,
+            fontBundleCacheByteLimit: 10
+        )
+
+        do {
+            _ = try await fetcher.fetchFontBundle(url: try XCTUnwrap(URL(string: "https://example.invalid/streamed")))
+            XCTFail("Expected streaming to stop at the font-bundle limit")
+        } catch let error as SidecarSubtitleFetchError {
+            guard case .responseTooLarge(let maxBytes) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(maxBytes, 10)
+        }
+    }
+
+    func testFontBundleCacheEvictsLeastRecentlyUsedEntryByDecodedBytes() async throws {
+        FontBundleURLProtocol.configure { request in
+            let payload = #"[{"name":"font.ttf","data":"YWE="}]"#
+            let data = Data(payload.utf8)
+            let response = try XCTUnwrap(HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: [
+                    "Content-Type": "application/json",
+                    "Content-Length": String(data.count)
+                ]
+            ))
+            return (response, data)
+        }
+        let fetcher = SidecarSubtitleFetcher(
+            session: makeSession(),
+            fontBundleResponseByteLimit: 1_024,
+            fontBundleCacheByteLimit: 2
+        )
+        let first = try XCTUnwrap(URL(string: "https://example.invalid/first"))
+        let second = try XCTUnwrap(URL(string: "https://example.invalid/second"))
+
+        _ = try await fetcher.fetchFontBundle(url: first)
+        _ = try await fetcher.fetchFontBundle(url: second)
+        _ = try await fetcher.fetchFontBundle(url: first)
+
+        XCTAssertEqual(FontBundleURLProtocol.requestCount(for: first), 2)
+        XCTAssertEqual(FontBundleURLProtocol.requestCount(for: second), 1)
+    }
+
+    private func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [FontBundleURLProtocol.self]
+        configuration.urlCache = nil
+        return URLSession(configuration: configuration)
+    }
+}
+
+private final class FontBundleURLProtocol: URLProtocol {
+    typealias Handler = @Sendable (URLRequest) throws -> (HTTPURLResponse, Data)
+
+    private final class State: @unchecked Sendable {
+        let lock = NSLock()
+        var handler: Handler?
+        var requestCounts: [URL: Int] = [:]
+    }
+
+    private static let state = State()
+
+    static func configure(_ handler: @escaping Handler) {
+        state.lock.lock()
+        state.handler = handler
+        state.requestCounts = [:]
+        state.lock.unlock()
+    }
+
+    static func reset() {
+        state.lock.lock()
+        state.handler = nil
+        state.requestCounts = [:]
+        state.lock.unlock()
+    }
+
+    static func requestCount(for url: URL) -> Int {
+        state.lock.lock()
+        defer { state.lock.unlock() }
+        return state.requestCounts[url, default: 0]
+    }
+
+    override class func canInit(with _: URLRequest) -> Bool { true }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let handler: Handler?
+        Self.state.lock.lock()
+        if let url = request.url {
+            Self.state.requestCounts[url, default: 0] += 1
+        }
+        handler = Self.state.handler
+        Self.state.lock.unlock()
+
+        guard let handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/iosApp/iosApp/Networking/Models.swift
+++ b/iosApp/iosApp/Networking/Models.swift
@@ -1122,8 +1122,35 @@ struct SubtitleUrl: Codable, Identifiable, Hashable {
     let label: String?
     let source: String?
     let forced: Bool?
+    let `default`: Bool?
+    let hearingImpaired: Bool?
+    let fontBundleUrl: String?
     let url: String
     var id: Int { index }
+
+    init(
+        index: Int,
+        language: String?,
+        codec: String?,
+        label: String?,
+        source: String?,
+        forced: Bool?,
+        `default`: Bool? = nil,
+        hearingImpaired: Bool? = nil,
+        fontBundleUrl: String? = nil,
+        url: String
+    ) {
+        self.index = index
+        self.language = language
+        self.codec = codec
+        self.label = label
+        self.source = source
+        self.forced = forced
+        self.default = `default`
+        self.hearingImpaired = hearingImpaired
+        self.fontBundleUrl = fontBundleUrl
+        self.url = url
+    }
 }
 
 // MARK: - Transcode Start Response

--- a/iosApp/iosApp/Screens/Audio/AudioPlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Audio/AudioPlayerViewModel.swift
@@ -19,8 +19,6 @@ final class AudioPlayerViewModel {
     /// engine. Audiobooks get one session per file; crossing a part
     /// boundary retires this session and starts a fresh one.
     private var activeSession: PlaybackSessionResponse?
-    private var protocolV3Available: Bool?
-    private var protocolV3AvailabilityServerId: String?
     /// Converts engine-local time back to the effective file's source time.
     private var activeTimelineOffsetSeconds: Double = 0
     /// Invalidates an in-flight track load when the user seeks again or
@@ -262,30 +260,7 @@ final class AudioPlayerViewModel {
         for track: AudioPlaybackTrack,
         localTime: Double
     ) async throws -> StartedAudioSession {
-        let activeServerId = await TokenStore.shared.getActiveServerId()
-        if protocolV3AvailabilityServerId != activeServerId {
-            protocolV3AvailabilityServerId = activeServerId
-            protocolV3Available = nil
-        }
-        if protocolV3Available == nil {
-            do {
-                let capability = try await ContinuumAPI.shared.playbackV3Capability()
-                protocolV3Available = PlaybackSessionBridge.supportsNeutralProtocolV3(capability)
-            } catch {
-                if PlaybackSessionBridge.isMissingProtocolV3Capability(error) {
-                    protocolV3Available = false
-                } else {
-                    throw error
-                }
-            }
-        }
-        guard protocolV3Available == true else {
-            throw PlaybackV3TerminalFailure(
-                reason: "server_upgrade_required",
-                message: "This server does not support the playback protocol this app requires. Update the server to continue.",
-                retryable: false
-            )
-        }
+        try await PlaybackV3CapabilityGate.shared.requireNeutralProtocolV3()
         guard let profileId = await TokenStore.shared.getProfileId(),
               !profileId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw PlaybackV3TerminalFailure(
@@ -295,7 +270,7 @@ final class AudioPlayerViewModel {
             )
         }
 
-        let snapshot = ApplePlaybackV3Capabilities.snapshot()
+        let snapshot = ApplePlaybackV3Capabilities.audiobookSnapshot()
         let playbackAttemptId = "apple-audio:\(UUID().uuidString.lowercased())"
         // Audiobook resume is a whole-item timeline stitched across files.
         // The server keeps session-local progress for liveness, while the
@@ -332,6 +307,13 @@ final class AudioPlayerViewModel {
 
         switch response.validatedForApple() {
         case .terminal(let terminal):
+            Task {
+                await PlaybackSessionBridge.reportTerminalStart(
+                    playbackAttemptId: playbackAttemptId,
+                    snapshot: snapshot,
+                    terminal: terminal
+                )
+            }
             throw PlaybackV3TerminalFailure(
                 reason: terminal.reason,
                 message: terminal.message,
@@ -347,7 +329,12 @@ final class AudioPlayerViewModel {
                 retryable: false
             )
         case .playable(let plan, let sessionId):
-            try ApplePlaybackV3PlanAdapter.validate(plan)
+            do {
+                try ApplePlaybackV3PlanAdapter.validate(plan)
+            } catch {
+                try? await ContinuumAPI.shared.stopPlayback(sessionId: sessionId)
+                throw error
+            }
             guard let effectiveTrack = context?.tracks.first(where: {
                 $0.fileId == plan.effectiveMediaFileId
             }) else {
@@ -361,7 +348,8 @@ final class AudioPlayerViewModel {
             let session = ApplePlaybackV3PlanAdapter.playbackSession(
                 plan: plan,
                 sessionId: sessionId,
-                selectedVersion: effectiveTrack.version
+                selectedVersion: effectiveTrack.version,
+                serverFeatures: response.serverFeatures
             )
             return StartedAudioSession(
                 session: session,

--- a/iosApp/iosApp/Screens/Audio/AudioPlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Audio/AudioPlayerViewModel.swift
@@ -5,6 +5,12 @@ import OSLog
 @Observable
 @MainActor
 final class AudioPlayerViewModel {
+    private struct StartedAudioSession {
+        let session: PlaybackSessionResponse
+        let track: AudioPlaybackTrack
+        let streamHeaders: [String: String]
+    }
+
     private let engine = AudioPlayerEngine()
     private let nowPlaying = NowPlayingController()
     private var syncTask: Task<Void, Never>?
@@ -14,6 +20,9 @@ final class AudioPlayerViewModel {
     /// boundary retires this session and starts a fresh one.
     private var activeSession: PlaybackSessionResponse?
     private var protocolV3Available: Bool?
+    private var protocolV3AvailabilityServerId: String?
+    /// Converts engine-local time back to the effective file's source time.
+    private var activeTimelineOffsetSeconds: Double = 0
     /// Invalidates an in-flight track load when the user seeks again or
     /// closes the player while `/playback/start` is still on the wire.
     private var loadGeneration = 0
@@ -184,6 +193,7 @@ final class AudioPlayerViewModel {
         context = nil
         activeSession = nil
         activeTrackIndex = nil
+        activeTimelineOffsetSeconds = 0
         currentTime = 0
         duration = 0
         palette = .fallback
@@ -208,28 +218,39 @@ final class AudioPlayerViewModel {
             throw APIError.unsupportedMedia("No playable audio track is available.")
         }
         let localTime = AudioPlaybackTimeline.localTime(for: globalTime, in: track)
+        var resolvedGlobalTime = globalTime
         if activeTrackIndex == index, activeSession != nil {
-            engine.seek(to: localTime)
+            engine.seek(to: max(0, localTime - activeTimelineOffsetSeconds))
         } else {
             loadGeneration += 1
             let generation = loadGeneration
             retireActiveSession()
-            let session = try await startSession(for: track, localTime: localTime)
+            let started = try await startSession(for: track, localTime: localTime)
             guard generation == loadGeneration, self.context != nil else {
                 // Superseded by a newer seek or a close while the request
                 // was in flight — release the session we no longer need.
-                Task { try? await ContinuumAPI.shared.stopPlayback(sessionId: session.sessionId) }
+                Task { try? await ContinuumAPI.shared.stopPlayback(sessionId: started.session.sessionId) }
                 return
             }
-            guard let url = await resolvedStreamURL(session.streamUrl) else {
-                Task { try? await ContinuumAPI.shared.stopPlayback(sessionId: session.sessionId) }
+            guard let url = await resolvedStreamURL(started.session.streamUrl) else {
+                Task { try? await ContinuumAPI.shared.stopPlayback(sessionId: started.session.sessionId) }
                 throw APIError.unsupportedMedia("No playable audio track is available.")
             }
-            activeSession = session
-            activeTrackIndex = index
-            engine.load(url: url, headers: await authHeaders(), startSeconds: localTime)
+            activeSession = started.session
+            activeTrackIndex = started.track.index
+            activeTimelineOffsetSeconds = max(0, started.session.timelineOffsetSeconds)
+            let headers = started.streamHeaders.merging(await authHeaders()) { _, auth in auth }
+            engine.load(
+                url: url,
+                headers: headers,
+                startSeconds: max(0, started.session.position)
+            )
+            resolvedGlobalTime =
+                started.track.startOffsetSeconds
+                    + max(0, started.session.position)
+                    + activeTimelineOffsetSeconds
         }
-        currentTime = clampGlobal(globalTime)
+        currentTime = clampGlobal(resolvedGlobalTime)
         if autoplay {
             isPlaying = true
             engine.setRate(playbackRate, shouldResume: true)
@@ -240,7 +261,12 @@ final class AudioPlayerViewModel {
     private func startSession(
         for track: AudioPlaybackTrack,
         localTime: Double
-    ) async throws -> PlaybackSessionResponse {
+    ) async throws -> StartedAudioSession {
+        let activeServerId = await TokenStore.shared.getActiveServerId()
+        if protocolV3AvailabilityServerId != activeServerId {
+            protocolV3AvailabilityServerId = activeServerId
+            protocolV3Available = nil
+        }
         if protocolV3Available == nil {
             do {
                 let capability = try await ContinuumAPI.shared.playbackV3Capability()
@@ -276,7 +302,7 @@ final class AudioPlayerViewModel {
         // client owns durable resume/history through /sync/progress.
         let request = PlaybackV3StartRequest(
             protocolVersion: PlaybackProtocolV3.version,
-            clientFeatures: ApplePlaybackV3Capabilities.features,
+            clientFeatures: ApplePlaybackV3Capabilities.audiobookFeatures,
             fileId: track.fileId,
             profileId: profileId,
             playbackAttemptId: playbackAttemptId,
@@ -322,9 +348,9 @@ final class AudioPlayerViewModel {
             )
         case .playable(let plan, let sessionId):
             try ApplePlaybackV3PlanAdapter.validate(plan)
-            guard let selectedVersion = context?.tracks.first(where: {
+            guard let effectiveTrack = context?.tracks.first(where: {
                 $0.fileId == plan.effectiveMediaFileId
-            })?.version else {
+            }) else {
                 try? await ContinuumAPI.shared.stopPlayback(sessionId: sessionId)
                 throw PlaybackV3TerminalFailure(
                     reason: "effective_file_unavailable",
@@ -332,10 +358,15 @@ final class AudioPlayerViewModel {
                     retryable: false
                 )
             }
-            return ApplePlaybackV3PlanAdapter.playbackSession(
+            let session = ApplePlaybackV3PlanAdapter.playbackSession(
                 plan: plan,
                 sessionId: sessionId,
-                selectedVersion: selectedVersion
+                selectedVersion: effectiveTrack.version
+            )
+            return StartedAudioSession(
+                session: session,
+                track: effectiveTrack,
+                streamHeaders: plan.stream.headers
             )
         }
     }
@@ -353,6 +384,7 @@ final class AudioPlayerViewModel {
         guard let session = activeSession else { return }
         activeSession = nil
         activeTrackIndex = nil
+        activeTimelineOffsetSeconds = 0
         Task { try? await ContinuumAPI.shared.stopPlayback(sessionId: session.sessionId) }
     }
 
@@ -360,7 +392,12 @@ final class AudioPlayerViewModel {
         guard let context,
               let activeTrackIndex,
               let track = context.tracks.first(where: { $0.index == activeTrackIndex }) else { return }
-        currentTime = clampGlobal(AudioPlaybackTimeline.globalTime(for: localTime, in: track))
+        currentTime = clampGlobal(
+            AudioPlaybackTimeline.globalTime(
+                for: localTime + activeTimelineOffsetSeconds,
+                in: track
+            )
+        )
         pushNowPlaying()
     }
 

--- a/iosApp/iosApp/Screens/Audio/AudioPlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Audio/AudioPlayerViewModel.swift
@@ -13,6 +13,7 @@ final class AudioPlayerViewModel {
     /// engine. Audiobooks get one session per file; crossing a part
     /// boundary retires this session and starts a fresh one.
     private var activeSession: PlaybackSessionResponse?
+    private var protocolV3Available: Bool?
     /// Invalidates an in-flight track load when the user seeks again or
     /// closes the player while `/playback/start` is still on the wire.
     private var loadGeneration = 0
@@ -240,21 +241,103 @@ final class AudioPlayerViewModel {
         for track: AudioPlaybackTrack,
         localTime: Double
     ) async throws -> PlaybackSessionResponse {
-        let profileId = await TokenStore.shared.getProfileId()
-        return try await ContinuumAPI.shared.startPlayback(request: StartPlaybackRequest(
+        if protocolV3Available == nil {
+            do {
+                let capability = try await ContinuumAPI.shared.playbackV3Capability()
+                protocolV3Available = PlaybackSessionBridge.supportsNeutralProtocolV3(capability)
+            } catch {
+                if PlaybackSessionBridge.isMissingProtocolV3Capability(error) {
+                    protocolV3Available = false
+                } else {
+                    throw error
+                }
+            }
+        }
+        guard protocolV3Available == true else {
+            throw PlaybackV3TerminalFailure(
+                reason: "server_upgrade_required",
+                message: "This server does not support the playback protocol this app requires. Update the server to continue.",
+                retryable: false
+            )
+        }
+        guard let profileId = await TokenStore.shared.getProfileId(),
+              !profileId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw PlaybackV3TerminalFailure(
+                reason: "profile_required",
+                message: "Select a profile before starting playback.",
+                retryable: false
+            )
+        }
+
+        let snapshot = ApplePlaybackV3Capabilities.snapshot()
+        let playbackAttemptId = "apple-audio:\(UUID().uuidString.lowercased())"
+        // Audiobook resume is a whole-item timeline stitched across files.
+        // The server keeps session-local progress for liveness, while the
+        // client owns durable resume/history through /sync/progress.
+        let request = PlaybackV3StartRequest(
+            protocolVersion: PlaybackProtocolV3.version,
+            clientFeatures: ApplePlaybackV3Capabilities.features,
             fileId: track.fileId,
             profileId: profileId,
-            playMethod: "direct",
-            startPosition: localTime,
+            playbackAttemptId: playbackAttemptId,
+            qualityPreference: ApplePlaybackQuality.autoId,
+            subtitleFidelityPreference: "preserve",
+            progressPersistence: "client",
+            startPosition: localTime.isFinite ? max(0, localTime) : 0,
+            audioTrackId: nil,
             audioTrackIndex: nil,
-            preserveDirectAudioSelection: false,
-            codecsVideo: [],
-            codecsAudio: [],
-            containers: [],
-            maxResolution: nil,
-            hdr: false,
-            disableProgressPersistence: true
-        ))
+            subtitleTrackId: nil,
+            subtitleTrackIndex: nil,
+            metered: false,
+            bandwidthEstimateKbps: nil,
+            bandwidthCapKbps: nil,
+            clientCapabilities: snapshot.capabilities,
+            clientPlaybackContext: snapshot.context
+        )
+        let response: PlaybackV3DecisionResponse
+        do {
+            response = try await ContinuumAPI.shared.startPlaybackV3(request: request)
+        } catch let error as HTTPError {
+            guard case .network = error else { throw error }
+            // Preserve the logical attempt identity across an ambiguous
+            // transport retry so the server replays instead of double-starting.
+            response = try await ContinuumAPI.shared.startPlaybackV3(request: request)
+        }
+
+        switch response.validatedForApple() {
+        case .terminal(let terminal):
+            throw PlaybackV3TerminalFailure(
+                reason: terminal.reason,
+                message: terminal.message,
+                retryable: terminal.retryable
+            )
+        case .incompatible(let allocatedSessionId):
+            if let allocatedSessionId {
+                try? await ContinuumAPI.shared.stopPlayback(sessionId: allocatedSessionId)
+            }
+            throw PlaybackV3TerminalFailure(
+                reason: "invalid_playback_plan",
+                message: "The server returned an incompatible protocol V3 playback plan.",
+                retryable: false
+            )
+        case .playable(let plan, let sessionId):
+            try ApplePlaybackV3PlanAdapter.validate(plan)
+            guard let selectedVersion = context?.tracks.first(where: {
+                $0.fileId == plan.effectiveMediaFileId
+            })?.version else {
+                try? await ContinuumAPI.shared.stopPlayback(sessionId: sessionId)
+                throw PlaybackV3TerminalFailure(
+                    reason: "effective_file_unavailable",
+                    message: "The server selected an unavailable audiobook part.",
+                    retryable: false
+                )
+            }
+            return ApplePlaybackV3PlanAdapter.playbackSession(
+                plan: plan,
+                sessionId: sessionId,
+                selectedVersion: selectedVersion
+            )
+        }
     }
 
     private func loadPalette(posterUrl: String?) {

--- a/iosApp/iosApp/Screens/Audio/AudiobookPlaybackContext.swift
+++ b/iosApp/iosApp/Screens/Audio/AudiobookPlaybackContext.swift
@@ -7,6 +7,7 @@ struct AudioPlaybackTrack: Identifiable, Hashable {
     let index: Int
     let fileId: Int
     let fileName: String?
+    let version: FileVersion
     let durationSeconds: Double
     let startOffsetSeconds: Double
     var id: Int { index }
@@ -49,6 +50,7 @@ struct AudiobookPlaybackContext {
                 index: index,
                 fileId: part.fileId,
                 fileName: part.fileName,
+                version: part,
                 durationSeconds: duration,
                 startOffsetSeconds: offset
             ))

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
@@ -1433,7 +1433,8 @@ final class AVPlayerBackend {
                     compatibilityBrand: spec.manifestMetadata.compatibilityBrand,
                     videoRange: spec.manifestMetadata.videoRange,
                     mayClaimAtmos: Self.loopbackPreservesAtmos(for: selectedTrack)
-                )
+                ),
+                servingMode: spec.servingMode
             )
             Self.logger.info(
                 "[CMP-AVP] rebuilding loopback for audio trackId=\(trackId, privacy: .public) trackIndex=\(selectedTrackIndex, privacy: .public) ffIndex=\(selectedTrack.ffIndex ?? -1, privacy: .public)"
@@ -2141,6 +2142,12 @@ final class AVPlayerBackend {
                 guard let self, !self.isDisposed else { return }
                 guard self.activeLoopbackSessionID == sessionID else { return }
                 guard case .siloLoopback = self.currentSourceStrategy else { return }
+                // EVENT fragments are normalized to a fresh zero-based
+                // timeline and need their observed source anchor. Static VOD
+                // fragments stay on the segment plan's stable playlist axis;
+                // replacing that plan anchor with a mid-title packet timestamp
+                // briefly doubles the playhead and can trigger a false replan.
+                guard sessionSpec.servingMode != .vodPlan else { return }
                 self.setMediaTimelineOffset(sourceStartSeconds)
             }
         }
@@ -2717,7 +2724,8 @@ final class AVPlayerBackend {
 
     @MainActor
     private func audioStats(for item: AVPlayerItem) async -> PlaybackStats.MediaStream {
-        if case .siloLoopback(let spec) = currentSourceStrategy {
+        if case .siloLoopback(let spec) = currentSourceStrategy,
+           spec.selectedAudio.isPresent {
             let outputMode = Self.audioOutputModeLabel(spec.selectedAudio.outputMode)
             let liveStream = await AVFoundationPlaybackIntrospection.audioStream(for: item)
             return PlaybackStats.MediaStream(

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
@@ -1387,6 +1387,12 @@ final class AVPlayerBackend {
                   let selectedTrackIndex = selectedTrack.srcId else {
                 return
             }
+            guard selectedTrackIndex != spec.selectedAudio.trackIndex else {
+                Self.logger.debug(
+                    "[CMP-AVP] ignoring unchanged loopback audio trackId=\(trackId, privacy: .public) trackIndex=\(selectedTrackIndex, privacy: .public)"
+                )
+                return
+            }
             let playerSeconds = currentTime()
             let startTime = playerSeconds.isFinite
                 ? mediaTime(for: max(0, playerSeconds))
@@ -1686,7 +1692,10 @@ final class AVPlayerBackend {
             from: currentSourceStrategy,
             to: strategy
         )
-        teardownMediaPipeline(clearDisplayCriteria: !preserveDisplayCriteria)
+        teardownMediaPipeline(
+            clearDisplayCriteria: !preserveDisplayCriteria,
+            deactivateAudioSession: false
+        )
         isPreservingTVDisplayCriteriaForReload = preserveDisplayCriteria
         currentSourceStrategy = strategy
         applyExternalPlaybackPolicy(for: strategy)
@@ -4345,7 +4354,10 @@ final class AVPlayerBackend {
         )
     }
 
-    private func teardownMediaPipeline(clearDisplayCriteria: Bool = true) {
+    private func teardownMediaPipeline(
+        clearDisplayCriteria: Bool = true,
+        deactivateAudioSession: Bool = true
+    ) {
         cancelSeekDeadline()
         loopbackItemDeathRecoveryState.reset()
         loopbackItemDeathConfirmationState.reset()
@@ -4396,7 +4408,9 @@ final class AVPlayerBackend {
             didTemporarilyMuteForInitialVideoDisplay = false
         }
         avPlayer.replaceCurrentItem(with: nil)
-        deactivateAudioSession()
+        if deactivateAudioSession {
+            self.deactivateAudioSession()
+        }
         currentItem = nil
         subtitleSession?.teardown()
         lastBitmapCueRenderKey = nil
@@ -4520,8 +4534,9 @@ final class AVPlayerBackend {
                 // A reload that preserved criteria left the panel in the
                 // right mode already; only a fresh apply can start an HDMI
                 // negotiation the item creation must not race. The settle
-                // helper early-outs in one poll when the panel is already
-                // hosting HDR, so an in-mode start pays no real latency.
+                // helper watches the bounded switch-start window even when
+                // EDR is already elevated because HDR10 and Dolby Vision are
+                // indistinguishable from headroom alone.
                 return !preservedForReload
             case .formatUnavailable:
                 break

--- a/iosApp/iosApp/Screens/Player/ApplePlaybackQuality.swift
+++ b/iosApp/iosApp/Screens/Player/ApplePlaybackQuality.swift
@@ -115,6 +115,47 @@ enum ApplePlaybackQuality {
         settingsOptions
     }
 
+    /// Build the in-player menu from the server's V3 plan. The server owns
+    /// which rungs are executable for this source; showing the wider Settings
+    /// catalog here would let the user request qualities the active plan never
+    /// offered.
+    static func playbackOptions(
+        serverQualities: [PlaybackV3AvailableQuality],
+        fallbackVersion: FileVersion?
+    ) -> [ApplePlaybackQualityOption] {
+        guard !serverQualities.isEmpty else {
+            return playbackOptions(for: fallbackVersion)
+        }
+        var seen = Set<String>()
+        let planned = serverQualities.compactMap { quality -> ApplePlaybackQualityOption? in
+            let id = normalizeStoredId(quality.label)
+            guard id != autoId, seen.insert(id).inserted else { return nil }
+            let isOriginal = quality.preservesSource || id == originalId
+            return ApplePlaybackQualityOption(
+                id: id,
+                label: playbackLabel(id: id, height: quality.height, isOriginal: isOriginal),
+                resolution: isOriginal || quality.height <= 0 ? "" : "\(quality.height)p",
+                bitrateKbps: max(0, quality.bitrateKbps),
+                isOriginal: isOriginal,
+                isAuto: false
+            )
+        }
+        return [auto] + planned
+    }
+
+    private static func playbackLabel(id: String, height: Int, isOriginal: Bool) -> String {
+        if isOriginal { return "Original" }
+        switch height {
+        case 2_160: return "Up to 4K"
+        case 1_080: return "Up to 1080p HD"
+        case 720: return "Up to 720p HD"
+        case 480: return "Up to 480p"
+        default:
+            return settingsOptions.first(where: { $0.id == id })?.label
+                ?? (height > 0 ? "Up to \(height)p" : id)
+        }
+    }
+
     static func resolvedRequestOption(
         preferredQualityId: String?,
         selectedVersion: FileVersion,

--- a/iosApp/iosApp/Screens/Player/ApplePlaybackQuality.swift
+++ b/iosApp/iosApp/Screens/Player/ApplePlaybackQuality.swift
@@ -124,7 +124,7 @@ enum ApplePlaybackQuality {
         fallbackVersion: FileVersion?
     ) -> [ApplePlaybackQualityOption] {
         guard !serverQualities.isEmpty else {
-            return playbackOptions(for: fallbackVersion)
+            return [auto]
         }
         var seen = Set<String>()
         let planned = serverQualities.compactMap { quality -> ApplePlaybackQualityOption? in
@@ -212,8 +212,15 @@ enum ApplePlaybackQuality {
     ) -> String {
         let requested = protocolV3QualityId(requestedQualityId)
         guard requested != autoId else { return autoId }
-        return availableQualities.contains(where: {
-            protocolV3QualityId($0.label) == requested
+        let requestedResolution = settingsOptions.contains(where: { $0.id == requested })
+            ? AppleQualityAxes.split(requested).resolution
+            : nil
+        return availableQualities.contains(where: { quality in
+            let offered = protocolV3QualityId(quality.label)
+            return offered == requested
+                || requestedResolution.map {
+                    AppleQualityAxes.split(offered).resolution == $0
+                } == true
         }) ? requested : autoId
     }
 

--- a/iosApp/iosApp/Screens/Player/ApplePlaybackQuality.swift
+++ b/iosApp/iosApp/Screens/Player/ApplePlaybackQuality.swift
@@ -128,19 +128,38 @@ enum ApplePlaybackQuality {
         }
         var seen = Set<String>()
         let planned = serverQualities.compactMap { quality -> ApplePlaybackQualityOption? in
-            let id = normalizeStoredId(quality.label)
+            let id = protocolV3QualityId(quality.label)
             guard id != autoId, seen.insert(id).inserted else { return nil }
             let isOriginal = quality.preservesSource || id == originalId
+            let height = quality.height ?? 0
             return ApplePlaybackQualityOption(
                 id: id,
-                label: playbackLabel(id: id, height: quality.height, isOriginal: isOriginal),
-                resolution: isOriginal || quality.height <= 0 ? "" : "\(quality.height)p",
+                label: playbackLabel(id: id, height: height, isOriginal: isOriginal),
+                resolution: isOriginal || height <= 0 ? "" : "\(height)p",
                 bitrateKbps: max(0, quality.bitrateKbps),
                 isOriginal: isOriginal,
                 isAuto: false
             )
         }
         return [auto] + planned
+    }
+
+    /// Quality labels in an active V3 plan are server-owned identifiers. Keep
+    /// unknown additive rungs instead of coercing them to Auto; only Settings
+    /// persistence uses the closed local catalog in `normalizeStoredId`.
+    static func protocolV3QualityId(_ raw: String?) -> String {
+        let value = raw?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased() ?? ""
+        guard !value.isEmpty else { return autoId }
+        switch value {
+        case "4k", "uhd":
+            return ultraHDId
+        case "420p":
+            return "328p"
+        default:
+            return value
+        }
     }
 
     private static func playbackLabel(id: String, height: Int, isOriginal: Bool) -> String {
@@ -185,6 +204,17 @@ enum ApplePlaybackQuality {
             return id
         }
         return autoId
+    }
+
+    static func activeProtocolV3QualityId(
+        requestedQualityId: String?,
+        availableQualities: [PlaybackV3AvailableQuality]
+    ) -> String {
+        let requested = protocolV3QualityId(requestedQualityId)
+        guard requested != autoId else { return autoId }
+        return availableQualities.contains(where: {
+            protocolV3QualityId($0.label) == requested
+        }) ? requested : autoId
     }
 
     /// Whether changing quality must re-run source-version selection instead

--- a/iosApp/iosApp/Screens/Player/ApplePlaybackRoutePlanner.swift
+++ b/iosApp/iosApp/Screens/Player/ApplePlaybackRoutePlanner.swift
@@ -398,13 +398,26 @@ struct ApplePlaybackRoutePlanner {
                 pendingAudioFfIndex: pendingAudioFfIndex,
                 preferredAudioTrackIndex: preferredAudioTrackIndex
             )
-        guard let selectedTrack,
-              let selectedTrackIndex = selectedTrack.srcId ?? selectedAudioTrackIndex else {
-            return nil
+        let selectedAudio: LoopbackSessionSpec.SelectedAudio
+        if tracks.isEmpty {
+            selectedAudio = .none
+        } else {
+            guard let selectedTrack,
+                  let selectedTrackIndex = selectedTrack.srcId ?? selectedAudioTrackIndex else {
+                return nil
+            }
+            let outputMode = loopbackAudioOutputMode(for: selectedTrack)
+            let preservesAtmos = outputMode == .copy && loopbackAudioPreservesAtmos(for: selectedTrack)
+            selectedAudio = LoopbackSessionSpec.SelectedAudio(
+                trackIndex: selectedTrackIndex,
+                ffIndex: selectedTrack.ffIndex,
+                sourceCodec: selectedTrack.codec,
+                sourceChannelCount: selectedTrack.audioChannelCount,
+                sourceChannelLayout: selectedTrack.audioChannelsLayout,
+                outputMode: outputMode,
+                preservesAtmos: preservesAtmos
+            )
         }
-
-        let outputMode = loopbackAudioOutputMode(for: selectedTrack)
-        let preservesAtmos = outputMode == .copy && loopbackAudioPreservesAtmos(for: selectedTrack)
         let advertisedProfile: Int? = switch videoMode {
         case .passthroughProfile5:
             5
@@ -439,21 +452,13 @@ struct ApplePlaybackRoutePlanner {
             sourceBitrateBps: version.bitrate.map { Double($0) * 1_000 },
             videoMode: videoMode,
             sourceVideoFrameRate: loopbackSourceFrameRate(for: version),
-            selectedAudio: LoopbackSessionSpec.SelectedAudio(
-                trackIndex: selectedTrackIndex,
-                ffIndex: selectedTrack.ffIndex,
-                sourceCodec: selectedTrack.codec,
-                sourceChannelCount: selectedTrack.audioChannelCount,
-                sourceChannelLayout: selectedTrack.audioChannelsLayout,
-                outputMode: outputMode,
-                preservesAtmos: preservesAtmos
-            ),
+            selectedAudio: selectedAudio,
             availableAudioTracks: tracks,
             manifestMetadata: LoopbackSessionSpec.ManifestMetadata(
                 advertisedDolbyVisionProfile: advertisedProfile,
                 compatibilityBrand: compatibilityBrand,
                 videoRange: videoRange,
-                mayClaimAtmos: preservesAtmos
+                mayClaimAtmos: selectedAudio.preservesAtmos
             ),
             servingMode: servingMode
         )
@@ -768,7 +773,11 @@ private extension ApplePlaybackRoutePlanner {
             return PlaybackNormalizationSummary(
                 containerMode: "local_fmp4_hls",
                 videoMode: loopbackSession?.videoMode.logToken ?? "loopback_unresolved",
-                audioMode: loopbackSession?.selectedAudio.outputMode.logToken ?? "loopback_unresolved",
+                audioMode: loopbackSession.map {
+                    $0.selectedAudio.isPresent
+                        ? $0.selectedAudio.outputMode.logToken
+                        : "none"
+                } ?? "loopback_unresolved",
                 subtitleMode: sourceMetadata.subtitleCodecs.isEmpty ? "none" : "extract_or_sidecar"
             )
         case .avPlayerNativeDirect:

--- a/iosApp/iosApp/Screens/Player/ApplePlaybackRoutePlanner.swift
+++ b/iosApp/iosApp/Screens/Player/ApplePlaybackRoutePlanner.swift
@@ -400,7 +400,7 @@ struct ApplePlaybackRoutePlanner {
             )
         let selectedAudio: LoopbackSessionSpec.SelectedAudio
         if tracks.isEmpty {
-            selectedAudio = .none
+            selectedAudio = .absent
         } else {
             guard let selectedTrack,
                   let selectedTrackIndex = selectedTrack.srcId ?? selectedAudioTrackIndex else {

--- a/iosApp/iosApp/Screens/Player/CoreMedia/TVDisplayCriteria.swift
+++ b/iosApp/iosApp/Screens/Player/CoreMedia/TVDisplayCriteria.swift
@@ -147,8 +147,9 @@ enum TVDisplayCriteria {
     /// property assignment; the renegotiation it requests only surfaces on
     /// `isDisplayModeSwitchInProgress` after a short delay, so a lone
     /// immediate check would race it. Phase one polls until the manager
-    /// reports a switch underway, bailing out early when the panel's EDR
-    /// headroom already clears the HDR floor (nothing left to negotiate).
+    /// reports a switch underway. Existing EDR headroom must not end this
+    /// phase: it cannot distinguish HDR10 from Dolby Vision and says nothing
+    /// about a pending refresh-rate switch.
     /// Phase two polls until the manager reports the switch finished. A
     /// switch that never surfaces within budget means the criteria were
     /// unsatisfiable or a no-op — playback proceeds and AVPlayer tonemaps.
@@ -171,14 +172,9 @@ enum TVDisplayCriteria {
                 negotiationBegan = true
                 break
             }
-            if screen.currentEDRHeadroom > HDRDisplayCriteriaPolicy.hdrHeadroomFloor {
-                logger.info("settle: panel already HDR")
-                print(String(format: "[CMP] displayModeSettle already-hdr headroom=%.3f", screen.currentEDRHeadroom))
-                return true
-            }
             startBudget -= 1
             try? await Task.sleep(
-                nanoseconds: UInt64(HDRDisplayCriteriaPolicy.switchStartPollIntervalMs) * 1_000_000
+                for: .milliseconds(HDRDisplayCriteriaPolicy.switchStartPollIntervalMs)
             )
         }
         if Task.isCancelled { return panelIsHostingHDR() }
@@ -192,7 +188,7 @@ enum TVDisplayCriteria {
         var settledAfterMs = 0
         while settleBudget > 0, !Task.isCancelled {
             try? await Task.sleep(
-                nanoseconds: UInt64(HDRDisplayCriteriaPolicy.switchSettlePollIntervalMs) * 1_000_000
+                for: .milliseconds(HDRDisplayCriteriaPolicy.switchSettlePollIntervalMs)
             )
             settleBudget -= 1
             settledAfterMs += HDRDisplayCriteriaPolicy.switchSettlePollIntervalMs

--- a/iosApp/iosApp/Screens/Player/PlaybackCoordinator.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackCoordinator.swift
@@ -67,13 +67,7 @@ final class PlaybackCoordinator {
     }
 
     func load(plan: PlaybackExecutionPlan) throws {
-        let engine: PlaybackEngine
-        if let activeEngine, activeEngine.kind == plan.engine {
-            engine = activeEngine
-        } else {
-            engine = installEngine(for: plan.engine)
-        }
-        try engine.load(plan: plan)
+        try prepareEngine(for: plan.engine).load(plan: plan)
     }
 
     func play() { activeEngine?.play() }

--- a/iosApp/iosApp/Screens/Player/PlaybackCoordinator.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackCoordinator.swift
@@ -50,10 +50,26 @@ final class PlaybackCoordinator {
         return engine
     }
 
+    /// Keeps an already-installed engine when the implementation route did
+    /// not change. In-place replans (notably an audio-track change on the
+    /// SiloPlayer loopback route) need the backend to survive so it can keep
+    /// the active audio session and identical tvOS display criteria instead
+    /// of renegotiating HDMI around the replacement item.
+    @discardableResult
+    func prepareEngine(for kind: PlaybackEngineKind) -> PlaybackEngine {
+        if let activeEngine, activeEngine.kind == kind {
+            Self.logger.info(
+                "[CMP-ENGINE] reusing kind=\(kind.label, privacy: .public) family=\(kind.routeFamily.diagnosticsLabel, privacy: .public)"
+            )
+            return activeEngine
+        }
+        return installEngine(for: kind)
+    }
+
     func load(plan: PlaybackExecutionPlan) throws {
         let engine: PlaybackEngine
-        if let current = activeEngine, current.kind == plan.engine {
-            engine = current
+        if let activeEngine, activeEngine.kind == plan.engine {
+            engine = activeEngine
         } else {
             engine = installEngine(for: plan.engine)
         }

--- a/iosApp/iosApp/Screens/Player/PlaybackExecutionPlan.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackExecutionPlan.swift
@@ -114,7 +114,7 @@ struct LoopbackSessionSpec {
         let outputMode: AudioOutputMode
         let preservesAtmos: Bool
 
-        static let none = SelectedAudio(
+        static let absent = SelectedAudio(
             trackIndex: -1,
             ffIndex: nil,
             sourceCodec: nil,

--- a/iosApp/iosApp/Screens/Player/PlaybackExecutionPlan.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackExecutionPlan.swift
@@ -171,9 +171,52 @@ struct LoopbackSessionSpec {
         self.videoMode = videoMode
         self.sourceVideoFrameRate = sourceVideoFrameRate
         self.selectedAudio = selectedAudio
-        self.availableAudioTracks = availableAudioTracks
+        self.availableAudioTracks = Self.markSelectedAudioTrack(
+            in: availableAudioTracks,
+            selectedAudio: selectedAudio
+        )
         self.manifestMetadata = manifestMetadata
         self.servingMode = servingMode
+    }
+
+    /// The selected mux input is authoritative. The planner can resolve it
+    /// from a server-provided audio ordinal after the inventory was initially
+    /// marked from local preferences; publishing those stale flags makes the
+    /// view model "correct" an already-correct selection and rebuild the
+    /// loopback item immediately after its first frame.
+    private static func markSelectedAudioTrack(
+        in tracks: [PlayerTrack],
+        selectedAudio: SelectedAudio
+    ) -> [PlayerTrack] {
+        guard selectedAudio.isPresent else { return tracks }
+        let selectedTrack = tracks.first(where: { $0.srcId == selectedAudio.trackIndex })
+            ?? selectedAudio.ffIndex.flatMap { ffIndex in
+                tracks.first(where: { $0.ffIndex == ffIndex })
+            }
+        guard let selectedTrack else { return tracks }
+
+        return tracks.map { track in
+            let isSelected = track.trackId == selectedTrack.trackId
+            guard track.isSelected != isSelected else { return track }
+            return PlayerTrack(
+                trackId: track.trackId,
+                kind: track.kind,
+                title: track.title,
+                lang: track.lang,
+                codec: track.codec,
+                audioChannelsLayout: track.audioChannelsLayout,
+                audioChannelCount: track.audioChannelCount,
+                bitrate: track.bitrate,
+                isDefault: track.isDefault,
+                isForced: track.isForced,
+                isHearingImpaired: track.isHearingImpaired,
+                isVisualImpaired: track.isVisualImpaired,
+                isExternal: track.isExternal,
+                isSelected: isSelected,
+                ffIndex: track.ffIndex,
+                srcId: track.srcId
+            )
+        }
     }
 
     func reanchored(at mediaSeconds: Double) -> LoopbackSessionSpec {

--- a/iosApp/iosApp/Screens/Player/PlaybackExecutionPlan.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackExecutionPlan.swift
@@ -113,6 +113,23 @@ struct LoopbackSessionSpec {
         let sourceChannelLayout: String?
         let outputMode: AudioOutputMode
         let preservesAtmos: Bool
+
+        static let none = SelectedAudio(
+            trackIndex: -1,
+            ffIndex: nil,
+            sourceCodec: nil,
+            sourceChannelCount: nil,
+            sourceChannelLayout: nil,
+            outputMode: .copy,
+            preservesAtmos: false
+        )
+
+        var isPresent: Bool {
+            if let ffIndex {
+                return ffIndex >= 0
+            }
+            return trackIndex >= 0
+        }
     }
 
     struct ManifestMetadata: Equatable {
@@ -595,8 +612,11 @@ struct PlaybackExecutionPlan {
         PlaybackNormalizationSummary(
             containerMode: "local_fmp4_hls",
             videoMode: loopbackSession?.videoMode.logToken ?? "loopback_unresolved",
-            audioMode: loopbackSession.map { audioModeLogToken($0.selectedAudio.outputMode) }
-                ?? "loopback_unresolved",
+            audioMode: loopbackSession.map {
+                $0.selectedAudio.isPresent
+                    ? audioModeLogToken($0.selectedAudio.outputMode)
+                    : "none"
+            } ?? "loopback_unresolved",
             subtitleMode: sourceMetadata.subtitleCodecs.isEmpty ? "none" : "extract_or_sidecar"
         )
     }

--- a/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
@@ -174,6 +174,58 @@ enum PlaybackDeliveryStrategy {
     }
 }
 
+/// One capability probe per active server, shared by video and audiobook
+/// playback. Keeping the in-flight task in the cache prevents two player
+/// models starting together from issuing duplicate probes.
+actor PlaybackV3CapabilityGate {
+    static let shared = PlaybackV3CapabilityGate()
+
+    private var availabilityByServerId: [String: Bool] = [:]
+    private var probeByServerId: [String: Task<Bool, Error>] = [:]
+
+    func requireNeutralProtocolV3() async throws {
+        let serverId = await TokenStore.shared.getActiveServerId()
+        let available: Bool
+        if let cached = availabilityByServerId[serverId] {
+            available = cached
+        } else {
+            let probe: Task<Bool, Error>
+            if let pending = probeByServerId[serverId] {
+                probe = pending
+            } else {
+                probe = Task {
+                    do {
+                        let capability = try await ContinuumAPI.shared.playbackV3Capability()
+                        return PlaybackSessionBridge.supportsNeutralProtocolV3(capability)
+                    } catch {
+                        if PlaybackSessionBridge.isMissingProtocolV3Capability(error) {
+                            return false
+                        }
+                        throw error
+                    }
+                }
+                probeByServerId[serverId] = probe
+            }
+            do {
+                available = try await probe.value
+                availabilityByServerId[serverId] = available
+                probeByServerId[serverId] = nil
+            } catch {
+                probeByServerId[serverId] = nil
+                throw error
+            }
+        }
+
+        guard available else {
+            throw PlaybackV3TerminalFailure(
+                reason: "server_upgrade_required",
+                message: "This server does not support the playback protocol this app requires. Update the server to continue.",
+                retryable: false
+            )
+        }
+    }
+}
+
 /// Manages the lifecycle of a playback session with the Continuum API.
 /// Handles session creation, periodic progress reporting, and cleanup.
 ///
@@ -191,7 +243,6 @@ actor PlaybackSessionBridge {
 
     private var sessionId: String?
     private var currentSession: PlaybackSessionResponse?
-    private var protocolV3Available: Bool?
 
     private struct ActiveProtocolV3 {
         let playbackAttemptId: String
@@ -614,27 +665,7 @@ actor PlaybackSessionBridge {
         audioTrackIndex: Int?,
         subtitleCombinedIndex: Int?
     ) async throws -> StagedProtocolV3Start {
-        if protocolV3Available == nil {
-            do {
-                let capability = try await ContinuumAPI.shared.playbackV3Capability()
-                protocolV3Available = Self.supportsNeutralProtocolV3(capability)
-            } catch {
-                if Self.isMissingProtocolV3Capability(error) {
-                    protocolV3Available = false
-                } else {
-                    throw error
-                }
-            }
-        }
-        // A server that cannot speak v3 cannot serve this client at all; there
-        // is no downgrade path left to take.
-        guard protocolV3Available == true else {
-            throw PlaybackV3TerminalFailure(
-                reason: "server_upgrade_required",
-                message: "This server does not support the playback protocol this app requires. Update the server to continue.",
-                retryable: false
-            )
-        }
+        try await PlaybackV3CapabilityGate.shared.requireNeutralProtocolV3()
 
         let snapshot = ApplePlaybackV3Capabilities.snapshot()
         let playbackAttemptId = "apple:\(UUID().uuidString.lowercased())"
@@ -678,6 +709,13 @@ actor PlaybackSessionBridge {
 
         switch response.validatedForApple() {
         case .terminal(let terminal):
+            Task {
+                await Self.reportTerminalStart(
+                    playbackAttemptId: playbackAttemptId,
+                    snapshot: snapshot,
+                    terminal: terminal
+                )
+            }
             throw PlaybackV3TerminalFailure(
                 reason: terminal.reason,
                 message: terminal.message,
@@ -693,7 +731,12 @@ actor PlaybackSessionBridge {
                 retryable: false
             )
         case .playable(let plan, let resolvedSessionId):
-            try ApplePlaybackV3PlanAdapter.validate(plan)
+            do {
+                try ApplePlaybackV3PlanAdapter.validate(plan)
+            } catch {
+                try? await ContinuumAPI.shared.stopPlayback(sessionId: resolvedSessionId)
+                throw error
+            }
             guard let effectiveVersion = watchDetail.versions.first(where: {
                 $0.fileId == plan.effectiveMediaFileId
             }) else {
@@ -707,7 +750,8 @@ actor PlaybackSessionBridge {
             let session = ApplePlaybackV3PlanAdapter.playbackSession(
                 plan: plan,
                 sessionId: resolvedSessionId,
-                selectedVersion: effectiveVersion
+                selectedVersion: effectiveVersion,
+                serverFeatures: response.serverFeatures
             )
             return StagedProtocolV3Start(
                 playbackAttemptId: playbackAttemptId,
@@ -888,6 +932,50 @@ actor PlaybackSessionBridge {
             return false
         }
         return statusCode == 404 || statusCode == 405
+    }
+
+    static func terminalStartRouteEvent(
+        playbackAttemptId: String,
+        snapshot: ApplePlaybackV3CapabilitySnapshot,
+        terminal: PlaybackV3Terminal
+    ) -> PlaybackV3RouteEvent {
+        PlaybackV3RouteEvent(
+            protocolVersion: PlaybackProtocolV3.version,
+            playbackAttemptId: playbackAttemptId,
+            sessionId: nil,
+            planId: nil,
+            planAttemptId: nil,
+            planAttemptKey: nil,
+            event: "terminal",
+            failureClassification: nil,
+            fallbackReason: terminal.reason,
+            appliedQuirkIds: [],
+            quirkRegistryRevision: nil,
+            outputContextId: snapshot.outputContextId,
+            diagnostics: ["error_cause": String(terminal.message.prefix(256))]
+        )
+    }
+
+    static func reportTerminalStart(
+        playbackAttemptId: String,
+        snapshot: ApplePlaybackV3CapabilitySnapshot,
+        terminal: PlaybackV3Terminal
+    ) async {
+        let event = terminalStartRouteEvent(
+            playbackAttemptId: playbackAttemptId,
+            snapshot: snapshot,
+            terminal: terminal
+        )
+        do {
+            try await ContinuumAPI.shared.reportPlaybackRouteEventV3(event)
+        } catch {
+            Logger(
+                subsystem: Bundle.main.bundleIdentifier ?? "com.continuum.app",
+                category: "Playback"
+            ).warning(
+                "Protocol V3 terminal-start route event failed: \(String(describing: error), privacy: .public)"
+            )
+        }
     }
 
     static func replanFailure(
@@ -1126,7 +1214,8 @@ actor PlaybackSessionBridge {
             let nextSession = ApplePlaybackV3PlanAdapter.playbackSession(
                 plan: nextPlan,
                 sessionId: nextSessionId,
-                selectedVersion: selectedVersion
+                selectedVersion: selectedVersion,
+                serverFeatures: response.serverFeatures
             )
             if isSeekReanchor {
                 guard nextSessionId == currentSessionId,

--- a/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
@@ -220,15 +220,29 @@ actor PlaybackSessionBridge {
         }
     }
 
-    private struct ActiveQualityIntent {
-        var clientQualityId: String
-        var bandwidthCapKbps: Int?
+    enum DirectSessionRenewalError: Error {
+        case noActiveDirectSession
+        case replacementPlanChanged
+    }
+
+    private struct StagedProtocolV3Start {
+        let playbackAttemptId: String
+        let clientQualityId: String
+        let bandwidthCapKbps: Int?
+        let snapshot: ApplePlaybackV3CapabilitySnapshot
+        let serverFeatures: [String]
+        let plan: PlaybackV3Plan
+        let sessionId: String
+        let selectedVersion: FileVersion
+        let session: PlaybackSessionResponse
+    }
+
+    struct InitialProtocolV3SubtitleIntent: Equatable {
+        let ffmpegStreamIndex: Int?
+        let combinedIndex: Int?
     }
 
     private var activeProtocolV3: ActiveProtocolV3?
-    /// Exact session-level quality intent. The cap cannot be reconstructed from
-    /// `clientQualityId`: a foreign 1080p/6 Mbps pair maps to Apple's 8 Mbps rung.
-    private var activeQualityIntent: ActiveQualityIntent?
     private var protocolV3FirstFramePlanIds: Set<String> = []
 
     private func isCurrentProtocolV3Attempt(
@@ -303,6 +317,7 @@ actor PlaybackSessionBridge {
         preferredFileId: Int? = nil,
         preferredAudioTrackIndex: Int? = nil,
         preferredSubtitleTrackIndex: Int? = nil,
+        preferredProtocolV3SubtitleIndex: Int? = nil,
         startFromBeginning: Bool,
         resumePosition: Double? = nil,
         allowNearEndResume: Bool = false,
@@ -364,6 +379,21 @@ actor PlaybackSessionBridge {
             )
         }
         let selectedVersion = initiallySelectedVersion
+        let resolvedAudioTrackIndex = preferredAudioTrackIndex
+            ?? selectedVersion.effectiveAudioTrackIndex
+        let selectedAudioLanguage = selectedVersion.audioTracks?.first(where: {
+            $0.index == resolvedAudioTrackIndex
+        })?.language
+        let subtitleIntent = Self.initialProtocolV3SubtitleIntent(
+            version: selectedVersion,
+            explicitFFmpegIndex: preferredSubtitleTrackIndex,
+            explicitCombinedIndex: preferredProtocolV3SubtitleIndex,
+            preferredLanguage: watchDetail.effectiveSubtitleLanguage,
+            mode: SubtitleMode(rawValue: watchDetail.effectiveSubtitleMode ?? ""),
+            showForced: watchDetail.effectiveShowForcedSubtitles ?? false,
+            trackSignature: watchDetail.effectiveSubtitleTrackSignature,
+            currentAudioLanguage: selectedAudioLanguage
+        )
         let effectiveStartPosition = resolvedStartPosition(
             startFromBeginning: startFromBeginning,
             explicitResumePosition: normalizedResumePosition,
@@ -376,13 +406,9 @@ actor PlaybackSessionBridge {
             "Selected version fileId=\(selectedVersion.fileId, privacy: .public) resolution=\(selectedVersion.resolution ?? "unknown", privacy: .public) codec=\(selectedVersion.codecVideo ?? "unknown", privacy: .public) bitrate=\(selectedVersion.bitrate ?? 0)"
         )
 
-        // Quality preference is still used downstream to pick the transcode
-        // target if the server decides remux/transcode is needed. The server
-        // itself infers delivery strategy from the codec/container caps
-        // below and does not read a `quality_preference` field.
-        // An explicit override is the user's in-player choice — honor it
-        // directly instead of re-deriving from the manually selected version
-        // (which would report the version's native tier as the active quality).
+        // Quality preference is a server-owned planning input. An explicit
+        // override is the user's in-player choice, so preserve it verbatim
+        // instead of deriving a different rung from the selected file.
         let resolvedQualityPreference = preferredQualityOverride != nil
             ? preferredQuality
             : requestedQualityPreference(
@@ -411,8 +437,108 @@ actor PlaybackSessionBridge {
             startPosition: effectiveStartPosition,
             // Without an explicit pick, send the server's own detail-resolved
             // effective audio index so a movie's remembered track survives.
-            audioTrackIndex: preferredAudioTrackIndex ?? selectedVersion.effectiveAudioTrackIndex,
-            subtitleTrackIndex: preferredSubtitleTrackIndex
+            audioTrackIndex: resolvedAudioTrackIndex,
+            subtitleTrackIndex: subtitleIntent.ffmpegStreamIndex,
+            subtitleCombinedIndex: subtitleIntent.combinedIndex
+        )
+    }
+
+    /// Resolves "Auto" before the first V3 request. The player otherwise
+    /// applies the same preference resolver only after opening the file,
+    /// which can make it render a container-default/forced track while the
+    /// server still believes the authoritative plan has subtitles off.
+    static func initialProtocolV3SubtitleIntent(
+        version: FileVersion,
+        explicitFFmpegIndex: Int?,
+        explicitCombinedIndex: Int?,
+        preferredLanguage: String?,
+        mode: SubtitleMode?,
+        showForced: Bool,
+        trackSignature: SubtitleTrackSignature?,
+        currentAudioLanguage: String?
+    ) -> InitialProtocolV3SubtitleIntent {
+        if let explicitCombinedIndex {
+            return InitialProtocolV3SubtitleIntent(
+                ffmpegStreamIndex: explicitFFmpegIndex.flatMap { $0 >= 0 ? $0 : nil },
+                combinedIndex: explicitCombinedIndex >= 0 ? explicitCombinedIndex : nil
+            )
+        }
+        if let explicitFFmpegIndex {
+            guard explicitFFmpegIndex >= 0 else {
+                return InitialProtocolV3SubtitleIntent(ffmpegStreamIndex: nil, combinedIndex: nil)
+            }
+            return InitialProtocolV3SubtitleIntent(
+                ffmpegStreamIndex: explicitFFmpegIndex,
+                combinedIndex: ApplePlaybackV3PlanAdapter.serverCombinedSubtitleIndex(
+                    ffmpegStreamIndex: explicitFFmpegIndex,
+                    in: version
+                )
+            )
+        }
+
+        var externalOrdinal = 0
+        let candidates = (version.subtitleTracks ?? []).compactMap { track -> PlayerTrack? in
+            let isExternal = track.external == true
+            let trackId: Int64
+            let sourceIndex: Int?
+            if isExternal {
+                sourceIndex = externalOrdinal
+                trackId = SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: externalOrdinal)
+                externalOrdinal += 1
+            } else {
+                guard let index = track.index else { return nil }
+                sourceIndex = nil
+                trackId = Int64(index)
+            }
+            return PlayerTrack(
+                trackId: trackId,
+                kind: .sub,
+                title: track.title ?? track.embeddedTitle,
+                lang: track.language,
+                codec: track.codec,
+                audioChannelsLayout: nil,
+                audioChannelCount: nil,
+                bitrate: nil,
+                isDefault: track.isDefault ?? false,
+                isForced: track.forced ?? false,
+                isHearingImpaired: track.hearingImpaired ?? false,
+                isVisualImpaired: false,
+                isExternal: isExternal,
+                isSelected: false,
+                ffIndex: isExternal ? nil : track.index,
+                srcId: sourceIndex
+            )
+        }
+        let resolution = SubtitleAutoResolver.resolve(.init(
+            preferredLanguage: preferredLanguage,
+            mode: mode,
+            showForced: showForced,
+            trackSignature: trackSignature,
+            availableSubtitles: candidates,
+            currentAudioLanguage: currentAudioLanguage
+        ))
+        let selected: PlayerTrack?
+        switch resolution {
+        case .select(let track):
+            selected = track
+        case .disable:
+            selected = nil
+        case .noChange:
+            // "Leave the player alone" means its demuxer keeps the media's
+            // default track; the sidecar route also promotes a forced track.
+            // Freeze that deterministic choice into the plan up front.
+            selected = candidates.first(where: { $0.isDefault })
+                ?? candidates.first(where: { $0.isForced })
+        }
+        guard let selected else {
+            return InitialProtocolV3SubtitleIntent(ffmpegStreamIndex: nil, combinedIndex: nil)
+        }
+        return InitialProtocolV3SubtitleIntent(
+            ffmpegStreamIndex: selected.ffIndex,
+            combinedIndex: ApplePlaybackV3PlanAdapter.serverCombinedSubtitleIndex(
+                for: selected,
+                in: version
+            )
         )
     }
 
@@ -424,8 +550,38 @@ actor PlaybackSessionBridge {
         bandwidthCapKbps: Int?,
         startPosition: Double?,
         audioTrackIndex: Int?,
-        subtitleTrackIndex: Int?
+        subtitleTrackIndex: Int?,
+        subtitleCombinedIndex: Int? = nil
     ) async throws -> PreparedPlayback {
+        let resolvedSubtitleCombinedIndex = subtitleCombinedIndex ?? subtitleTrackIndex.flatMap {
+            ApplePlaybackV3PlanAdapter.serverCombinedSubtitleIndex(
+                ffmpegStreamIndex: $0,
+                in: selectedVersion
+            )
+        }
+        let staged = try await stageProtocolV3Start(
+            watchDetail: watchDetail,
+            selectedVersion: selectedVersion,
+            profileId: profileId,
+            qualityPreference: qualityPreference,
+            bandwidthCapKbps: bandwidthCapKbps,
+            startPosition: startPosition,
+            audioTrackIndex: audioTrackIndex,
+            subtitleCombinedIndex: resolvedSubtitleCombinedIndex
+        )
+        return adoptProtocolV3Start(staged, watchDetail: watchDetail)
+    }
+
+    private func stageProtocolV3Start(
+        watchDetail: WatchDetail,
+        selectedVersion: FileVersion,
+        profileId: String,
+        qualityPreference: String?,
+        bandwidthCapKbps: Int?,
+        startPosition: Double?,
+        audioTrackIndex: Int?,
+        subtitleCombinedIndex: Int?
+    ) async throws -> StagedProtocolV3Start {
         if protocolV3Available == nil {
             let capability = try await ContinuumAPI.shared.playbackV3Capability()
             protocolV3Available = capability.enabled
@@ -444,12 +600,6 @@ actor PlaybackSessionBridge {
 
         let snapshot = ApplePlaybackV3Capabilities.snapshot()
         let playbackAttemptId = "apple:\(UUID().uuidString.lowercased())"
-        let protocolV3SubtitleTrackIndex = subtitleTrackIndex.flatMap {
-            ApplePlaybackV3PlanAdapter.serverCombinedSubtitleIndex(
-                ffmpegStreamIndex: $0,
-                in: selectedVersion
-            )
-        }
         let request = PlaybackV3StartRequest(
             protocolVersion: PlaybackProtocolV3.version,
             clientFeatures: ApplePlaybackV3Capabilities.features,
@@ -463,10 +613,10 @@ actor PlaybackSessionBridge {
                 $0 >= 0 ? protocolV3TrackId(fileId: selectedVersion.fileId, kind: "audio", index: $0) : nil
             },
             audioTrackIndex: audioTrackIndex.flatMap { $0 >= 0 ? $0 : nil },
-            subtitleTrackId: protocolV3SubtitleTrackIndex.flatMap {
+            subtitleTrackId: subtitleCombinedIndex.flatMap {
                 $0 >= 0 ? protocolV3TrackId(fileId: selectedVersion.fileId, kind: "subtitle", index: $0) : nil
             },
-            subtitleTrackIndex: protocolV3SubtitleTrackIndex,
+            subtitleTrackIndex: subtitleCombinedIndex,
             metered: false,
             bandwidthEstimateKbps: nil,
             bandwidthCapKbps: bandwidthCapKbps,
@@ -520,52 +670,146 @@ actor PlaybackSessionBridge {
                 sessionId: resolvedSessionId,
                 selectedVersion: effectiveVersion
             )
-            let planAttemptId = "apple-plan:\(UUID().uuidString.lowercased())"
-            // Attempt keys are server-owned; the client only ever echoes them.
-            let planAttemptKey = plan.planAttemptKey
-            let serverFeatures = response.serverFeatures
-            activeProtocolV3 = ActiveProtocolV3(
+            return StagedProtocolV3Start(
                 playbackAttemptId: playbackAttemptId,
-                planAttemptId: planAttemptId,
-                planAttemptKey: planAttemptKey,
-                attemptedPlanKeys: [planAttemptKey],
-                attemptCount: 1,
                 clientQualityId: ApplePlaybackQuality.normalizeStoredId(qualityPreference),
                 bandwidthCapKbps: bandwidthCapKbps,
                 snapshot: snapshot,
-                serverFeatures: serverFeatures,
-                plan: plan
-            )
-            activeQualityIntent = ActiveQualityIntent(
-                clientQualityId: ApplePlaybackQuality.normalizeStoredId(qualityPreference),
-                bandwidthCapKbps: bandwidthCapKbps
-            )
-            protocolV3FirstFramePlanIds.removeAll()
-            sessionId = resolvedSessionId
-            currentSession = session
-            let preparedV3 = PreparedPlaybackV3(
-                playbackAttemptId: playbackAttemptId,
-                planAttemptId: planAttemptId,
-                planAttemptKey: planAttemptKey,
-                outputContextId: snapshot.outputContextId,
-                serverFeatures: serverFeatures,
-                plan: plan
-            )
-            logger.info(
-                "Protocol V3 plan selected id=\(plan.planId, privacy: .public) delivery=\(plan.delivery, privacy: .public)"
-            )
-            return PreparedPlayback(
-                watchDetail: watchDetail,
+                serverFeatures: response.serverFeatures,
+                plan: plan,
+                sessionId: resolvedSessionId,
                 selectedVersion: effectiveVersion,
-                session: session,
-                activeQualityId: ApplePlaybackQuality.activeQualityId(
-                    requestedQualityId: qualityPreference,
-                    selectedVersion: effectiveVersion,
-                    delivery: PlaybackDeliveryStrategy(playMethod: session.playMethod)
-                ),
-                protocolV3: preparedV3
+                session: session
             )
         }
+    }
+
+    private func adoptProtocolV3Start(
+        _ staged: StagedProtocolV3Start,
+        watchDetail: WatchDetail
+    ) -> PreparedPlayback {
+        let planAttemptId = "apple-plan:\(UUID().uuidString.lowercased())"
+        // Attempt keys are server-owned; the client only ever echoes them.
+        let planAttemptKey = staged.plan.planAttemptKey
+        activeProtocolV3 = ActiveProtocolV3(
+            playbackAttemptId: staged.playbackAttemptId,
+            planAttemptId: planAttemptId,
+            planAttemptKey: planAttemptKey,
+            attemptedPlanKeys: [planAttemptKey],
+            attemptCount: 1,
+            clientQualityId: staged.clientQualityId,
+            bandwidthCapKbps: staged.bandwidthCapKbps,
+            snapshot: staged.snapshot,
+            serverFeatures: staged.serverFeatures,
+            plan: staged.plan
+        )
+        protocolV3FirstFramePlanIds.removeAll()
+        sessionId = staged.sessionId
+        currentSession = staged.session
+        let preparedV3 = PreparedPlaybackV3(
+            playbackAttemptId: staged.playbackAttemptId,
+            planAttemptId: planAttemptId,
+            planAttemptKey: planAttemptKey,
+            outputContextId: staged.snapshot.outputContextId,
+            serverFeatures: staged.serverFeatures,
+            plan: staged.plan
+        )
+        logger.info(
+            "Protocol V3 plan selected id=\(staged.plan.planId, privacy: .public) delivery=\(staged.plan.delivery, privacy: .public)"
+        )
+        return PreparedPlayback(
+            watchDetail: watchDetail,
+            selectedVersion: staged.selectedVersion,
+            session: staged.session,
+            activeQualityId: ApplePlaybackQuality.activeQualityId(
+                requestedQualityId: protocolV3QualityPreference(staged.clientQualityId),
+                selectedVersion: staged.selectedVersion,
+                delivery: PlaybackDeliveryStrategy(playMethod: staged.session.playMethod)
+            ),
+            protocolV3: preparedV3
+        )
+    }
+
+    /// Creates a fresh V3 session for an expired direct stream, but publishes
+    /// it only when the transport can be swapped underneath the existing
+    /// source proxy without changing what the player is rendering.
+    func renewDirectSession(
+        watchDetail: WatchDetail,
+        position: Double,
+        audioTrackIndex: Int?,
+        subtitleTrackIndex: Int?
+    ) async throws -> PreparedPlayback {
+        guard let active = activeProtocolV3,
+              let oldSessionId = sessionId,
+              active.plan.delivery == "original_http",
+              currentSession?.playMethod.lowercased() == "direct" else {
+            throw DirectSessionRenewalError.noActiveDirectSession
+        }
+        let expectedAttempt = ProtocolV3AttemptIdentity(active)
+        guard let requestedVersion = watchDetail.versions.first(where: {
+            $0.fileId == active.plan.requestedMediaFileId
+        }), let profileId = await TokenStore.shared.getProfileId(),
+              !profileId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw DirectSessionRenewalError.noActiveDirectSession
+        }
+
+        let selectedAudioIndex = audioTrackIndex ?? active.plan.selectedTracks.audio?.index
+        let selectedSubtitleIndex = subtitleTrackIndex ?? active.plan.selectedTracks.subtitle?.index
+        let staged = try await stageProtocolV3Start(
+            watchDetail: watchDetail,
+            selectedVersion: requestedVersion,
+            profileId: profileId,
+            qualityPreference: active.clientQualityId,
+            bandwidthCapKbps: active.bandwidthCapKbps,
+            startPosition: position.isFinite ? max(0, position) : 0,
+            audioTrackIndex: selectedAudioIndex,
+            subtitleCombinedIndex: selectedSubtitleIndex
+        )
+        guard isCurrentProtocolV3Attempt(expectedAttempt, sessionId: oldSessionId) else {
+            stopStaleSession(staged.sessionId)
+            throw CancellationError()
+        }
+        guard Self.canRetargetDirectSession(from: active.plan, to: staged.plan) else {
+            stopStaleSession(staged.sessionId)
+            throw DirectSessionRenewalError.replacementPlanChanged
+        }
+
+        let prepared = adoptProtocolV3Start(staged, watchDetail: watchDetail)
+        if staged.sessionId != oldSessionId {
+            stopStaleSession(oldSessionId)
+        }
+        return prepared
+    }
+
+    static func canRetargetDirectSession(
+        from current: PlaybackV3Plan,
+        to replacement: PlaybackV3Plan
+    ) -> Bool {
+        current.delivery == "original_http"
+            && replacement.delivery == current.delivery
+            && replacement.requestedMediaFileId == current.requestedMediaFileId
+            && replacement.effectiveMediaFileId == current.effectiveMediaFileId
+            && replacement.stream.protocol == current.stream.protocol
+            && replacement.stream.container == current.stream.container
+            && replacement.stream.mimeType == current.stream.mimeType
+            && replacement.stream.headerRefresh == current.stream.headerRefresh
+            && replacement.timeline.streamOriginSeconds == current.timeline.streamOriginSeconds
+            && replacement.timeline.timelineOffsetSeconds == current.timeline.timelineOffsetSeconds
+            && replacement.timeline.canSeekAnywhere == current.timeline.canSeekAnywhere
+            && replacement.timeline.seekRestoration == current.timeline.seekRestoration
+            && replacement.selectedTracks == current.selectedTracks
+            && replacement.effectiveRecipe == current.effectiveRecipe
+            && replacement.claims == current.claims
+            && replacement.subtitle.mode == current.subtitle.mode
+            && replacement.subtitle.trackId == current.subtitle.trackId
+            && replacement.subtitle.artifact?.mimeType == current.subtitle.artifact?.mimeType
+            && replacement.subtitle.artifact?.format == current.subtitle.artifact?.format
+            && replacement.subtitle.artifact?.timingOriginSeconds == current.subtitle.artifact?.timingOriginSeconds
+            && replacement.transformations == current.transformations
+            && replacement.appliedQuirks == current.appliedQuirks
+            && replacement.runtimeCorrections == current.runtimeCorrections
+            && replacement.source == current.source
+            && replacement.subtitleFidelityPolicy == current.subtitleFidelityPolicy
     }
 
     /// Maps a local failure/intent classification onto the protocol's replan
@@ -669,7 +913,7 @@ actor PlaybackSessionBridge {
             event: eventName,
             classification: classification,
             fallbackReason: nil,
-            diagnostics: ["message": String(message.prefix(512))]
+            diagnostics: ["error_cause": String(message.prefix(512))]
         )
         guard isCurrentProtocolV3Attempt(expectedAttempt, sessionId: currentSessionId) else {
             throw CancellationError()
@@ -829,10 +1073,6 @@ actor PlaybackSessionBridge {
             active.clientQualityId = requestedClientQualityId
             active.bandwidthCapKbps = requestedBandwidthCapKbps
             activeProtocolV3 = active
-            activeQualityIntent = ActiveQualityIntent(
-                clientQualityId: requestedClientQualityId,
-                bandwidthCapKbps: requestedBandwidthCapKbps
-            )
             sessionId = nextSessionId
             self.currentSession = nextSession
             if isSeekReanchor {
@@ -858,7 +1098,7 @@ actor PlaybackSessionBridge {
                 selectedVersion: selectedVersion,
                 session: nextSession,
                 activeQualityId: ApplePlaybackQuality.activeQualityId(
-                    requestedQualityId: requestedClientQualityId,
+                    requestedQualityId: protocolV3QualityPreference(requestedClientQualityId),
                     selectedVersion: selectedVersion,
                     delivery: PlaybackDeliveryStrategy(playMethod: nextSession.playMethod)
                 ),
@@ -948,7 +1188,7 @@ actor PlaybackSessionBridge {
             event: "terminal",
             classification: nil,
             fallbackReason: reason,
-            diagnostics: ["message": String(message.prefix(512))]
+            diagnostics: ["error_cause": String(message.prefix(512))]
         )
     }
 
@@ -1129,7 +1369,6 @@ actor PlaybackSessionBridge {
         sessionId = nil
         currentSession = nil
         activeProtocolV3 = nil
-        activeQualityIntent = nil
         protocolV3FirstFramePlanIds.removeAll()
         consecutiveProgressFailures = 0
         emittedOrphanedSessionWarning = false

--- a/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
@@ -1455,7 +1455,7 @@ actor PlaybackSessionBridge {
 
     // MARK: - Helpers
 
-    private static func isPlaybackSessionMissing(_ error: Error) -> Bool {
+    static func isPlaybackSessionMissing(_ error: Error) -> Bool {
         guard case let HTTPError.http(statusCode, body) = error,
               statusCode == 404 else {
             return false

--- a/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
@@ -349,9 +349,9 @@ actor PlaybackSessionBridge {
         // A mid-stream quality-change replan passes an explicit override
         // (e.g. back to Auto) that must win over the persisted setting.
         let playerSettings = PlayerSettings.shared
-        let preferredQuality = normalizedQualityPreference(
-            preferredQualityOverride ?? playerSettings.preferredQuality
-        )
+        let preferredQuality = preferredQualityOverride.map {
+            ApplePlaybackQuality.protocolV3QualityId($0)
+        } ?? normalizedQualityPreference(playerSettings.preferredQuality)
         let bandwidthCapKbps = AppleQualityAxes.resolvedBitrateCap(
             qualityOverride: preferredQualityOverride,
             fallbackBitrateKbps: playerSettings.maxBitrateKbps

--- a/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
@@ -191,10 +191,6 @@ actor PlaybackSessionBridge {
 
     private var sessionId: String?
     private var currentSession: PlaybackSessionResponse?
-    /// The exact request that started the current session, kept as the
-    /// template for a silent same-plan renewal after the server loses the
-    /// session (restart, idle reap, expired reconstruct token).
-    private var lastStartRequest: StartPlaybackRequest?
     private var protocolV3Available: Bool?
 
     private struct ActiveProtocolV3 {
@@ -300,19 +296,6 @@ actor PlaybackSessionBridge {
         #endif
     }
 
-    private struct ClientPlaybackPlan {
-        let selectedVersion: FileVersion
-        let playMethod: String?
-        let prefersSDRTranscode: Bool
-        let capabilities: (
-            codecsVideo: [String],
-            codecsAudio: [String],
-            containers: [String],
-            maxResolution: String?,
-            hdr: Bool
-        )
-    }
-
     // MARK: - Start Session
 
     func startSession(
@@ -380,13 +363,7 @@ actor PlaybackSessionBridge {
                 preferredQuality: preferredQuality
             )
         }
-        let playbackPlan = planClientPlayback(
-            watchDetail: watchDetail,
-            initiallySelectedVersion: initiallySelectedVersion,
-            preferredQuality: preferredQuality,
-            bandwidthCapKbps: bandwidthCapKbps
-        )
-        let selectedVersion = playbackPlan.selectedVersion
+        let selectedVersion = initiallySelectedVersion
         let effectiveStartPosition = resolvedStartPosition(
             startFromBeginning: startFromBeginning,
             explicitResumePosition: normalizedResumePosition,
@@ -414,87 +391,32 @@ actor PlaybackSessionBridge {
                 hasManualSelection: preferredFileId != nil
             )
         let profileId = await TokenStore.shared.getProfileId()
-        if let profileId,
-           !profileId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-           let prepared = try await startProtocolV3IfAvailable(
-               watchDetail: watchDetail,
-               selectedVersion: selectedVersion,
-               profileId: profileId,
-               qualityPreference: resolvedQualityPreference,
-               bandwidthCapKbps: bandwidthCapKbps,
-               startPosition: effectiveStartPosition,
-               audioTrackIndex: preferredAudioTrackIndex ?? selectedVersion.effectiveAudioTrackIndex,
-               subtitleTrackIndex: preferredSubtitleTrackIndex
-           ) {
-            return prepared
-        }
-        // Without an explicit pick, send the server's own detail-resolved
-        // effective audio index. /playback/start only consults saved audio
-        // prefs for episodes (its series-id lookup is empty for movies), so
-        // a movie's remembered track would otherwise be dropped here even
-        // though the watch detail above already resolved it.
-        let request = StartPlaybackRequest(
-            fileId: selectedVersion.fileId,
-            profileId: profileId,
-            playMethod: playbackPlan.playMethod,
-            startPosition: effectiveStartPosition,
-            audioTrackIndex: preferredAudioTrackIndex ?? selectedVersion.effectiveAudioTrackIndex,
-            preserveDirectAudioSelection: playbackPlan.playMethod == PlaybackDeliveryStrategy.direct.name,
-            codecsVideo: playbackPlan.capabilities.codecsVideo,
-            codecsAudio: playbackPlan.capabilities.codecsAudio,
-            containers: playbackPlan.capabilities.containers,
-            maxResolution: playbackPlan.capabilities.maxResolution,
-            hdr: playbackPlan.capabilities.hdr
-        )
-
-        logger.info("Starting session for fileId=\(selectedVersion.fileId, privacy: .public)")
-        let initialSession: PlaybackSessionResponse = try await ContinuumAPI.shared.post(
-            "/api/v1/playback/start",
-            body: request
-        )
-        lastStartRequest = request
-        logger.info(
-            "Session started: method=\(initialSession.playMethod, privacy: .public)"
-        )
-
-        var session = try await preparePlaybackSessionIfNeeded(
-            initialSession,
-            watchDetail: watchDetail,
-            selectedVersion: selectedVersion,
-            preferredQuality: resolvedQualityPreference,
-            bandwidthCapKbps: bandwidthCapKbps,
-            effectiveStartPosition: effectiveStartPosition,
-            prefersSDRTranscode: playbackPlan.prefersSDRTranscode
-        )
-        // Older direct-play servers that ignore `startPosition` may still echo
-        // the stored resume point; force the caller's chosen start position
-        // locally so the player doesn't snap elsewhere after bootstrap. Do not
-        // do this for HLS: remux manifests are player-local timelines and carry
-        // the movie-time mapping in `timelineOffsetSeconds`.
-        if let effectiveStartPosition,
-           PlaybackDeliveryStrategy(playMethod: session.playMethod) == .direct {
-            session.position = effectiveStartPosition
-        }
-
-        activeProtocolV3 = nil
-        adoptSession(session)
-        activeQualityIntent = ActiveQualityIntent(
-            clientQualityId: ApplePlaybackQuality.normalizeStoredId(resolvedQualityPreference),
-            bandwidthCapKbps: bandwidthCapKbps
-        )
-        return PreparedPlayback(
-            watchDetail: watchDetail,
-            selectedVersion: selectedVersion,
-            session: session,
-            activeQualityId: ApplePlaybackQuality.activeQualityId(
-                requestedQualityId: resolvedQualityPreference,
-                selectedVersion: selectedVersion,
-                delivery: PlaybackDeliveryStrategy(playMethod: session.playMethod)
+        guard let profileId,
+              !profileId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw PlaybackV3TerminalFailure(
+                reason: "profile_required",
+                message: "Select a profile before starting playback.",
+                retryable: false
             )
+        }
+        // Protocol v3 is the only playback contract. There is no legacy start
+        // path to fall back to — `/api/v1/playback/start` rejects any body
+        // whose `protocol_version` is not 3.
+        return try await startProtocolV3(
+            watchDetail: watchDetail,
+            selectedVersion: selectedVersion,
+            profileId: profileId,
+            qualityPreference: resolvedQualityPreference,
+            bandwidthCapKbps: bandwidthCapKbps,
+            startPosition: effectiveStartPosition,
+            // Without an explicit pick, send the server's own detail-resolved
+            // effective audio index so a movie's remembered track survives.
+            audioTrackIndex: preferredAudioTrackIndex ?? selectedVersion.effectiveAudioTrackIndex,
+            subtitleTrackIndex: preferredSubtitleTrackIndex
         )
     }
 
-    private func startProtocolV3IfAvailable(
+    private func startProtocolV3(
         watchDetail: WatchDetail,
         selectedVersion: FileVersion,
         profileId: String,
@@ -503,18 +425,22 @@ actor PlaybackSessionBridge {
         startPosition: Double?,
         audioTrackIndex: Int?,
         subtitleTrackIndex: Int?
-    ) async throws -> PreparedPlayback? {
+    ) async throws -> PreparedPlayback {
         if protocolV3Available == nil {
-            do {
-                let capability = try await ContinuumAPI.shared.playbackV3Capability()
-                protocolV3Available = capability.enabled
-                    && capability.protocolVersions.contains(PlaybackProtocolV3.version)
-                    && capability.features.contains(PlaybackProtocolV3.planFeature)
-            } catch let error as HTTPError where error.statusCode == 404 || error.statusCode == 405 {
-                protocolV3Available = false
-            }
+            let capability = try await ContinuumAPI.shared.playbackV3Capability()
+            protocolV3Available = capability.enabled
+                && capability.protocolVersions.contains(PlaybackProtocolV3.version)
+                && capability.features.contains(PlaybackProtocolV3.planFeature)
         }
-        guard protocolV3Available == true else { return nil }
+        // A server that cannot speak v3 cannot serve this client at all; there
+        // is no downgrade path left to take.
+        guard protocolV3Available == true else {
+            throw PlaybackV3TerminalFailure(
+                reason: "server_upgrade_required",
+                message: "This server does not support the playback protocol this app requires. Update the server to continue.",
+                retryable: false
+            )
+        }
 
         let snapshot = ApplePlaybackV3Capabilities.snapshot()
         let playbackAttemptId = "apple:\(UUID().uuidString.lowercased())"
@@ -541,7 +467,6 @@ actor PlaybackSessionBridge {
                 $0 >= 0 ? protocolV3TrackId(fileId: selectedVersion.fileId, kind: "subtitle", index: $0) : nil
             },
             subtitleTrackIndex: protocolV3SubtitleTrackIndex,
-            outputRouteGeneration: snapshot.outputRouteGeneration,
             metered: false,
             bandwidthEstimateKbps: nil,
             bandwidthCapKbps: bandwidthCapKbps,
@@ -596,7 +521,8 @@ actor PlaybackSessionBridge {
                 selectedVersion: effectiveVersion
             )
             let planAttemptId = "apple-plan:\(UUID().uuidString.lowercased())"
-            let planAttemptKey = plan.attemptKey(outputRouteGeneration: snapshot.outputRouteGeneration)
+            // Attempt keys are server-owned; the client only ever echoes them.
+            let planAttemptKey = plan.planAttemptKey
             let serverFeatures = response.serverFeatures
             activeProtocolV3 = ActiveProtocolV3(
                 playbackAttemptId: playbackAttemptId,
@@ -617,12 +543,11 @@ actor PlaybackSessionBridge {
             protocolV3FirstFramePlanIds.removeAll()
             sessionId = resolvedSessionId
             currentSession = session
-            lastStartRequest = nil
             let preparedV3 = PreparedPlaybackV3(
                 playbackAttemptId: playbackAttemptId,
                 planAttemptId: planAttemptId,
                 planAttemptKey: planAttemptKey,
-                outputRouteGeneration: snapshot.outputRouteGeneration,
+                outputContextId: snapshot.outputContextId,
                 serverFeatures: serverFeatures,
                 plan: plan
             )
@@ -643,16 +568,32 @@ actor PlaybackSessionBridge {
         }
     }
 
+    /// Maps a local failure/intent classification onto the protocol's replan
+    /// operation. A user-initiated track or quality change is an intent, not a
+    /// failure, and carries no `failure` block. An output-route change stays
+    /// failure recovery: the route the plan was chosen for no longer exists.
+    static func replanOperation(forClassification classification: String) -> String {
+        switch classification {
+        case "audio_track_changed", "subtitle_track_changed":
+            return PlaybackProtocolV3.ReplanOperation.trackChange
+        case "quality_changed":
+            return PlaybackProtocolV3.ReplanOperation.qualityChange
+        default:
+            return PlaybackProtocolV3.ReplanOperation.failureRecovery
+        }
+    }
+
     func replanProtocolV3(
         watchDetail: WatchDetail,
         position: Double,
         classification: String,
         message: String,
-        operation: String = "failure_recovery",
+        operation: String? = nil,
         qualityPreference: String? = nil,
         audioTrackIndex: Int? = nil,
         subtitleTrackIndex: Int? = nil
     ) async throws -> PreparedPlayback? {
+        let operation = operation ?? Self.replanOperation(forClassification: classification)
         guard var active = activeProtocolV3,
               let currentSessionId = sessionId else {
             return nil
@@ -676,10 +617,10 @@ actor PlaybackSessionBridge {
             active.snapshot = ApplePlaybackV3Capabilities.snapshot()
         }
 
-        let invalidatesIntent = [
-            "audio_track_changed", "subtitle_track_changed", "quality_changed", "output_route_changed"
-        ].contains(classification)
-        let isSeekReanchor = operation == "seek_reanchor"
+        let isIntent = operation == PlaybackProtocolV3.ReplanOperation.trackChange
+            || operation == PlaybackProtocolV3.ReplanOperation.qualityChange
+        let invalidatesIntent = isIntent || classification == "output_route_changed"
+        let isSeekReanchor = operation == PlaybackProtocolV3.ReplanOperation.seekReanchor
         if isSeekReanchor,
            !active.serverFeatures.contains(PlaybackProtocolV3.seekReanchorFeature) {
             return nil
@@ -736,6 +677,7 @@ actor PlaybackSessionBridge {
 
         let request = PlaybackV3ReplanRequest(
             protocolVersion: PlaybackProtocolV3.version,
+            clientFeatures: ApplePlaybackV3Capabilities.features,
             operation: operation,
             playbackAttemptId: active.playbackAttemptId,
             replanRequestId: "apple-replan:\(UUID().uuidString.lowercased())",
@@ -746,16 +688,19 @@ actor PlaybackSessionBridge {
             attemptCount: invalidatesIntent ? 1 : active.attemptCount,
             qualityPreference: protocolV3QualityPreference(requestedClientQualityId),
             positionSeconds: normalizedPosition,
-            outputRouteGeneration: active.snapshot.outputRouteGeneration,
             metered: false,
             bandwidthEstimateKbps: nil,
             bandwidthCapKbps: requestedBandwidthCapKbps,
             selectedTracks: selectedTracks,
-            failure: PlaybackV3Failure(
+            // A user intent carries no failure. Only recovery does.
+            failure: isIntent ? nil : PlaybackV3Failure(
                 classification: classification,
                 message: String(message.prefix(512)),
                 decoderName: nil
             ),
+            // Apple never mutates a server plan locally, so it never has a
+            // mutation to fold into the server's next attempt key.
+            localMutations: [],
             clientCapabilities: active.snapshot.capabilities,
             clientPlaybackContext: active.snapshot.context
         )
@@ -811,9 +756,7 @@ actor PlaybackSessionBridge {
                 )
                 throw error
             }
-            let nextKey = nextPlan.attemptKey(
-                outputRouteGeneration: active.snapshot.outputRouteGeneration
-            )
+            let nextKey = nextPlan.planAttemptKey
             guard isSeekReanchor || !attemptedKeys.contains(nextKey) else {
                 if nextSessionId != currentSessionId {
                     try? await ContinuumAPI.shared.stopPlayback(sessionId: nextSessionId)
@@ -858,7 +801,6 @@ actor PlaybackSessionBridge {
                       response.serverFeatures.contains(PlaybackProtocolV3.seekReanchorFeature),
                       nextKey == active.planAttemptKey,
                       nextPlan.delivery == active.plan.delivery,
-                      nextPlan.engine == active.plan.engine,
                       nextPlan.effectiveRecipe == active.plan.effectiveRecipe,
                       nextPlan.selectedTracks == active.plan.selectedTracks,
                       nextPlan.transformations == active.plan.transformations,
@@ -907,7 +849,7 @@ actor PlaybackSessionBridge {
                 playbackAttemptId: active.playbackAttemptId,
                 planAttemptId: active.planAttemptId,
                 planAttemptKey: active.planAttemptKey,
-                outputRouteGeneration: active.snapshot.outputRouteGeneration,
+                outputContextId: active.snapshot.outputContextId,
                 serverFeatures: active.serverFeatures,
                 plan: nextPlan
             )
@@ -984,7 +926,7 @@ actor PlaybackSessionBridge {
             fallbackReason: fallbackReason,
             appliedQuirkIds: active.plan.appliedQuirks.map(\.id),
             quirkRegistryRevision: active.plan.appliedQuirks.first?.registryRevision,
-            outputRouteGeneration: active.snapshot.outputRouteGeneration,
+            outputContextId: active.snapshot.outputContextId,
             diagnostics: diagnostics
         )
         do {
@@ -1008,180 +950,6 @@ actor PlaybackSessionBridge {
             fallbackReason: reason,
             diagnostics: ["message": String(message.prefix(512))]
         )
-    }
-
-    enum DirectSessionRenewalError: Error {
-        /// No live direct-play session (or no captured start request) to
-        /// renew — the caller must run a full visible renewal instead.
-        case noRenewableSession
-        /// The server re-planned playback (different delivery or file); the
-        /// renewed session cannot be adopted in place.
-        case planChanged(playMethod: String, mediaFileId: Int?)
-    }
-
-    /// Renews a lost direct-play session in place: re-POSTs the captured
-    /// start request (same file, same capability set) at the given position
-    /// and adopts the new session id/stream URL without touching playback.
-    /// The bytes of a direct-play stream are the file itself, so a renewed
-    /// session serves the identical content and the source proxy can simply
-    /// retarget. Throws `planChanged` — after best-effort stopping the
-    /// unwanted new session so it doesn't hold a concurrency-cap slot —
-    /// when the server answers with anything but direct play of the same
-    /// file.
-    func renewDirectSession(
-        position: Double,
-        audioTrackIndex: Int?
-    ) async throws -> PlaybackSessionResponse {
-        guard let template = lastStartRequest,
-              let current = currentSession,
-              PlaybackDeliveryStrategy(playMethod: current.playMethod) == .direct else {
-            throw DirectSessionRenewalError.noRenewableSession
-        }
-        let normalizedPosition = position.isFinite ? max(0, position) : 0
-        let request = StartPlaybackRequest(
-            fileId: template.fileId,
-            profileId: template.profileId,
-            playMethod: template.playMethod,
-            startPosition: normalizedPosition,
-            audioTrackIndex: audioTrackIndex ?? template.audioTrackIndex,
-            preserveDirectAudioSelection: template.preserveDirectAudioSelection,
-            codecsVideo: template.codecsVideo,
-            codecsAudio: template.codecsAudio,
-            containers: template.containers,
-            maxResolution: template.maxResolution,
-            hdr: template.hdr,
-            disableProgressPersistence: template.disableProgressPersistence
-        )
-        logger.info(
-            "Renewing direct session fileId=\(template.fileId, privacy: .public) position=\(normalizedPosition, privacy: .public)"
-        )
-        var renewed: PlaybackSessionResponse = try await ContinuumAPI.shared.post(
-            "/api/v1/playback/start",
-            body: request
-        )
-        guard PlaybackDeliveryStrategy(playMethod: renewed.playMethod) == .direct,
-              renewed.mediaFileId == current.mediaFileId else {
-            try? await ContinuumAPI.shared.delete("/api/v1/playback/\(renewed.sessionId)")
-            throw DirectSessionRenewalError.planChanged(
-                playMethod: renewed.playMethod,
-                mediaFileId: renewed.mediaFileId
-            )
-        }
-        // Same rule as startSession's direct path: pin the caller's position
-        // locally so a server echoing the stored resume point can't snap the
-        // timeline elsewhere.
-        renewed.position = normalizedPosition
-        lastStartRequest = request
-        adoptSession(renewed)
-        consecutiveProgressFailures = 0
-        emittedOrphanedSessionWarning = false
-        logger.info("Direct session renewed: \(renewed.sessionId, privacy: .public)")
-        return renewed
-    }
-
-    func restartCurrentTranscode(
-        selectedVersion: FileVersion,
-        seekSeconds: Double,
-        qualityOverride: String? = nil
-    ) async throws -> PlaybackSessionResponse {
-        guard let currentSession else {
-            throw APIError.unsupportedMedia("No active playback session")
-        }
-        let expectedSessionId = currentSession.sessionId
-        let expectedProtocolV3Attempt = activeProtocolV3.map(ProtocolV3AttemptIdentity.init)
-
-        let playerSettings = PlayerSettings.shared
-        let preferredQuality = qualityOverride.map {
-            ApplePlaybackQuality.normalizeStoredId($0)
-        } ?? activeQualityIntent?.clientQualityId ?? requestedQualityPreference(
-            preferredQuality: normalizedQualityPreference(playerSettings.preferredQuality),
-            selectedVersion: selectedVersion,
-            hasManualSelection: true
-        )
-        let qualityOption = ApplePlaybackQuality.resolvedRequestOption(
-            preferredQualityId: preferredQuality,
-            selectedVersion: selectedVersion,
-            delivery: PlaybackDeliveryStrategy(playMethod: currentSession.playMethod)
-        )
-        let currentDelivery = PlaybackDeliveryStrategy(playMethod: currentSession.playMethod)
-        let fallbackCapKbps: Int?
-        if let activeQualityIntent {
-            fallbackCapKbps = activeQualityIntent.bandwidthCapKbps
-        } else {
-            fallbackCapKbps = playerSettings.maxBitrateKbps
-        }
-        let capKbps = AppleQualityAxes.resolvedBitrateCap(
-            qualityOverride: qualityOverride,
-            fallbackBitrateKbps: fallbackCapKbps
-        )
-        let forcedByQuality = ApplePlaybackQuality.shouldForceTranscode(
-            preferredQualityId: preferredQuality,
-            selectedVersion: selectedVersion,
-            capKbps: capKbps
-        )
-        let useCopyVideo = ApplePlaybackQuality.shouldUseLegacyCopyVideo(
-            delivery: currentDelivery,
-            option: qualityOption,
-            forcedByQuality: forcedByQuality
-        )
-        let transcodeRequest = TranscodeStartRequest(
-            sessionId: currentSession.sessionId,
-            seekSeconds: seekSeconds,
-            targetResolution: useCopyVideo ? "" : ApplePlaybackQuality.targetResolution(
-                for: qualityOption,
-                selectedVersion: selectedVersion
-            ),
-            targetCodecVideo: useCopyVideo ? "copy" : "h264",
-            targetCodecAudio: "aac",
-            targetBitrateKbps: useCopyVideo ? 0 : ApplePlaybackQuality.targetBitrateKbps(
-                for: qualityOption,
-                selectedVersion: selectedVersion,
-                capKbps: capKbps
-            ),
-            segmentDuration: 2,
-            subtitleTrackIndex: -1,
-            subtitleBurnIn: false
-        )
-
-        logger.info(
-            "Restarting current transcode session=\(currentSession.sessionId, privacy: .public) seek=\(seekSeconds, privacy: .public)"
-        )
-        let transcodeResponse = try await ContinuumAPI.shared.startTranscode(
-            request: transcodeRequest
-        )
-        let currentProtocolV3Attempt = activeProtocolV3.map(ProtocolV3AttemptIdentity.init)
-        guard !Task.isCancelled,
-              sessionId == expectedSessionId,
-              self.currentSession?.sessionId == expectedSessionId,
-              currentProtocolV3Attempt == expectedProtocolV3Attempt else {
-            if transcodeResponse.sessionId != sessionId {
-                stopStaleSession(transcodeResponse.sessionId)
-            }
-            throw CancellationError()
-        }
-        let restartedSession = PlaybackSessionResponse(
-            sessionId: transcodeResponse.sessionId,
-            userId: currentSession.userId,
-            profileId: currentSession.profileId,
-            mediaFileId: currentSession.mediaFileId,
-            playMethod: transcodeResponse.canSeekAnywhere
-                ? PlaybackDeliveryStrategy.transcode.name
-                : PlaybackDeliveryStrategy.remux.name,
-            position: transcodeResponse.playerStartSeconds,
-            isPaused: false,
-            streamUrl: transcodeResponse.manifestUrl,
-            audioTrackIndex: currentSession.audioTrackIndex,
-            durationSeconds: transcodeResponse.durationSeconds ?? currentSession.durationSeconds,
-            timelineOffsetSeconds: transcodeResponse.timelineOffsetSeconds,
-            subtitleUrls: currentSession.subtitleUrls,
-            playbackInfo: currentSession.playbackInfo
-        )
-        adoptSession(restartedSession)
-        activeQualityIntent = ActiveQualityIntent(
-            clientQualityId: ApplePlaybackQuality.normalizeStoredId(preferredQuality),
-            bandwidthCapKbps: capKbps
-        )
-        return restartedSession
     }
 
     private func resolvedStartPosition(
@@ -1363,7 +1131,6 @@ actor PlaybackSessionBridge {
         activeProtocolV3 = nil
         activeQualityIntent = nil
         protocolV3FirstFramePlanIds.removeAll()
-        lastStartRequest = nil
         consecutiveProgressFailures = 0
         emittedOrphanedSessionWarning = false
 
@@ -1387,258 +1154,6 @@ actor PlaybackSessionBridge {
         return (body ?? "").contains("Playback session not found")
     }
 
-    private func preparePlaybackSessionIfNeeded(
-        _ session: PlaybackSessionResponse,
-        watchDetail: WatchDetail,
-        selectedVersion: FileVersion,
-        preferredQuality: String?,
-        bandwidthCapKbps: Int?,
-        effectiveStartPosition: Double?,
-        prefersSDRTranscode: Bool
-    ) async throws -> PlaybackSessionResponse {
-        // Trust the server's selected delivery strategy: remux/transcode
-        // responses still need the HLS pipeline kicked off via
-        // /playback/transcode/start.
-        let strategy = PlaybackDeliveryStrategy(playMethod: session.playMethod)
-
-        guard strategy != .direct else {
-            return session
-        }
-        logger.info("Requesting HLS delivery: \(strategy.name, privacy: .public)")
-
-        // Resume point for the HLS manifest. "Start over" forces 0 so the
-        // server generates a fresh segment window from the top of the file
-        // — the stored `userData.positionSeconds` would otherwise win here.
-        let resumeSeconds = effectiveStartPosition ?? watchDetail.userData?.positionSeconds ?? session.position
-
-        // Remux = codec copy in HLS container (original video quality, AAC audio).
-        // Transcode = server re-encodes video at the requested target.
-        let qualityOption = ApplePlaybackQuality.resolvedRequestOption(
-            preferredQualityId: preferredQuality,
-            selectedVersion: selectedVersion,
-            delivery: strategy
-        )
-        let forcedByQuality = ApplePlaybackQuality.shouldForceTranscode(
-            preferredQualityId: preferredQuality,
-            selectedVersion: selectedVersion,
-            capKbps: bandwidthCapKbps
-        )
-        let useCopyVideo = ApplePlaybackQuality.shouldUseLegacyCopyVideo(
-            delivery: strategy,
-            option: qualityOption,
-            forcedByQuality: forcedByQuality
-        )
-        let transcodeRequest = TranscodeStartRequest(
-            sessionId: session.sessionId,
-            seekSeconds: resumeSeconds,
-            targetResolution: useCopyVideo ? "" : ApplePlaybackQuality.targetResolution(
-                for: qualityOption,
-                selectedVersion: selectedVersion
-            ),
-            targetCodecVideo: useCopyVideo ? "copy" : "h264",
-            targetCodecAudio: "aac",
-            targetBitrateKbps: useCopyVideo ? 0 : ApplePlaybackQuality.targetBitrateKbps(
-                for: qualityOption,
-                selectedVersion: selectedVersion,
-                capKbps: bandwidthCapKbps
-            ),
-            segmentDuration: 2,
-            subtitleTrackIndex: -1,
-            subtitleBurnIn: false
-        )
-
-        let transcodeResponse: TranscodeStartResponse
-        do {
-            transcodeResponse = try await ContinuumAPI.shared.post(
-                "/api/v1/playback/transcode/start",
-                body: transcodeRequest
-            )
-        } catch {
-            // Two distinct 422 cases the server emits:
-            //   1. Copy-mode request against an older server without the
-            //      codec-copy bypass — fall back to 1080p h264 transcode.
-            //   2. Non-copy transcode request against a 4K source without
-            //      `allow_4k_transcode=true` and no lower-res alternate
-            //      (the "no_alternate_version" guard). Only way past that
-            //      guard is to ask for copy mode, which skips the check.
-            //      Common on simulator where caps only advertise h264.
-            // CDNs often replace 4xx JSON with HTML, so the `no_alternate`
-            // substring check is best-effort; trust the 422 code.
-            let isRecoverable: Bool = {
-                if case let HTTPError.http(statusCode, body) = error {
-                    return statusCode == 422 || (body ?? "").contains("no_alternate")
-                }
-                return false
-            }()
-            guard isRecoverable else { throw error }
-
-            if useCopyVideo {
-                guard ApplePlaybackQuality.allowsLegacyCopyFallbackToTranscode(
-                    preferredQualityId: preferredQuality
-                ) else {
-                    throw error
-                }
-                logger.warning("Video copy rejected, falling back to 1080p transcode")
-                let fallback = TranscodeStartRequest(
-                    sessionId: session.sessionId,
-                    seekSeconds: resumeSeconds,
-                    targetResolution: "1080p",
-                    targetCodecVideo: "h264",
-                    targetCodecAudio: "aac",
-                    targetBitrateKbps: ApplePlaybackQuality.legacyCopyFallbackBitrateKbps(
-                        capKbps: bandwidthCapKbps
-                    ),
-                    segmentDuration: 2,
-                    subtitleTrackIndex: -1,
-                    subtitleBurnIn: false
-                )
-                transcodeResponse = try await ContinuumAPI.shared.post(
-                    "/api/v1/playback/transcode/start",
-                    body: fallback
-                )
-            } else {
-                if prefersSDRTranscode {
-                    throw APIError.unsupportedMedia(
-                        "This iPhone build cannot direct-play this HDR source yet. "
-                        + "Add a 1080p/SDR version for this item or enable 4K transcoding "
-                        + "on the Silo server."
-                    )
-                }
-                #if targetEnvironment(simulator)
-                // Simulator's software HEVC decoder can't keep up with 4K in
-                // real time. Surface a readable error instead of asking the
-                // server for codec-copy — that would succeed server-side but
-                // stall the display pipeline as every decoded frame arrives
-                // too late to show, leaving a black screen.
-                throw APIError.unsupportedMedia(
-                    "This 4K content cannot be played on the iOS simulator. "
-                    + "Test on a real Apple TV or iPhone, enable 4K transcoding "
-                    + "on the Silo server, or add a lower-resolution version."
-                )
-                #else
-                logger.warning("Transcode rejected and no lower server fallback is available")
-                throw APIError.unsupportedMedia(
-                    "4K Transcoding has been disabled by the server Admin. Adjust your settings or choose a lower quality version."
-                )
-                #endif
-            }
-        }
-
-        if let switchedFileId = transcodeResponse.switchedFileId {
-            logger.info("Server switched playback to fileId=\(switchedFileId, privacy: .public)")
-        }
-
-        let effectiveStrategy: PlaybackDeliveryStrategy = transcodeResponse.canSeekAnywhere
-            ? .transcode
-            : .remux
-        if effectiveStrategy != strategy {
-            logger.info(
-                "HLS delivery mode changed during bootstrap requested=\(strategy.name, privacy: .public) effective=\(effectiveStrategy.name, privacy: .public)"
-            )
-        }
-
-        return PlaybackSessionResponse(
-            sessionId: transcodeResponse.sessionId,
-            userId: session.userId,
-            profileId: session.profileId,
-            mediaFileId: session.mediaFileId,
-            // Use the effective post-bootstrap HLS mode, not just the
-            // originally requested strategy. The server can promote seeked
-            // copy-mode requests into real transcodes so resumed playback lands
-            // on independently decodable segments.
-            playMethod: effectiveStrategy.name,
-            position: transcodeResponse.playerStartSeconds,
-            isPaused: false,
-            streamUrl: transcodeResponse.manifestUrl,
-            audioTrackIndex: session.audioTrackIndex,
-            durationSeconds: transcodeResponse.durationSeconds ?? session.durationSeconds,
-            timelineOffsetSeconds: transcodeResponse.timelineOffsetSeconds,
-            subtitleUrls: session.subtitleUrls,
-            playbackInfo: session.playbackInfo
-        )
-    }
-
-    /// Codec/container capabilities reported to the server. Returned as a
-    /// simple tuple since the wire body is flat — there's no transport
-    /// struct to reify on iOS.
-    ///
-    /// The previous Apple bootstrap still claimed broader direct-play
-    /// coverage (`av1`, `vp9`, `mpeg2video`, etc.), but the live PlayerCore path only direct
-    /// decodes H.264/HEVC. Keep this list truthful so the server does not
-    /// select versions the Apple stack cannot actually open.
-    ///
-    /// These caps describe what the direct startup path can request from the
-    /// server. iPhone HDR files may still switch off PlayerCore later if VT
-    /// rejects the stream, but that backend handoff needs the original direct
-    /// source URL first, so we keep capability reporting truthful here.
-    ///
-    /// The lists themselves come from `AppleDecodeCapabilities` — the same
-    /// ones the V3 snapshot and download creation report, so the server sees
-    /// one client whichever door a request arrives through.
-    private func makeClientCaps(includingMPEG2: Bool = false) -> (
-        codecsVideo: [String],
-        codecsAudio: [String],
-        containers: [String],
-        maxResolution: String?,
-        hdr: Bool
-    ) {
-        (
-            codecsVideo: AppleDecodeCapabilities.videoCodecs(includingMPEG2: includingMPEG2),
-            codecsAudio: AppleDecodeCapabilities.audioCodecs,
-            containers: AppleDecodeCapabilities.containers,
-            maxResolution: AppleDecodeCapabilities.maxResolution,
-            hdr: !AppleDecodeCapabilities.isSimulator
-        )
-    }
-
-    private func planClientPlayback(
-        watchDetail: WatchDetail,
-        initiallySelectedVersion: FileVersion,
-        preferredQuality: String?,
-        bandwidthCapKbps: Int?
-    ) -> ClientPlaybackPlan {
-        let requestedTranscode = ApplePlaybackQuality.shouldForceTranscode(
-            preferredQualityId: preferredQuality,
-            selectedVersion: initiallySelectedVersion,
-            capKbps: bandwidthCapKbps
-        )
-        return ClientPlaybackPlan(
-            selectedVersion: initiallySelectedVersion,
-            playMethod: requestedTranscode
-                ? PlaybackDeliveryStrategy.transcode.name
-                : PlaybackDeliveryStrategy.direct.name,
-            prefersSDRTranscode: false,
-            capabilities: makeClientCaps(
-                includingMPEG2: isMPEG2Video(initiallySelectedVersion)
-            )
-        )
-    }
-
-    private func isMPEG2Video(_ version: FileVersion) -> Bool {
-        normalizedVideoCodec(version.codecVideo) == "mpeg2video"
-    }
-
-    private func normalizedVideoCodec(_ raw: String?) -> String? {
-        switch normalizedToken(raw) {
-        case "h264", "h.264", "avc", "avc1":
-            return "h264"
-        case "hevc", "h265", "h.265", "hvc1", "hev1":
-            return "hevc"
-        case "mpeg2", "mpeg-2", "mpeg2video", "mpeg-2 video", "mp2v":
-            return "mpeg2video"
-        default:
-            return normalizedToken(raw)
-        }
-    }
-
-    private func normalizedToken(_ raw: String?) -> String? {
-        guard let raw else { return nil }
-        let token = raw
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased()
-        return token.isEmpty ? nil : token
-    }
-
     private func normalizedQualityPreference(_ quality: String?) -> String? {
         let normalized = ApplePlaybackQuality.normalizeStoredId(quality)
         return normalized == ApplePlaybackQuality.autoId ? nil : normalized
@@ -1654,10 +1169,10 @@ actor PlaybackSessionBridge {
         "file:\(fileId):\(kind):\(index)"
     }
 
-    /// Pick the best version for the user's preferred quality. Compatibility
-    /// filtering happens separately in `planClientPlayback`; this ranking step
-    /// only decides the user's preferred source before device-specific fallbacks
-    /// are applied.
+    /// Pick the best version for the user's preferred quality. The server does
+    /// the compatibility filtering from the reported capability snapshot and
+    /// may answer with a different `effective_media_file_id`; this ranking step
+    /// only decides which version the request asks for.
     static func selectVersion(
         from versions: [FileVersion],
         lastFileId: Int?,

--- a/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
@@ -242,6 +242,17 @@ actor PlaybackSessionBridge {
         let combinedIndex: Int?
     }
 
+    struct InitialProtocolV3SubtitlePreferences: Equatable {
+        let preferredLanguage: String?
+        let additionalPreferredLanguages: [String]
+        let mode: SubtitleMode?
+        let showForced: Bool
+        let forcedOnly: Bool
+        let preferAccessibilityTracks: Bool
+        let disableWhenNoLanguageMatch: Bool
+        let trackSignature: SubtitleTrackSignature?
+    }
+
     private var activeProtocolV3: ActiveProtocolV3?
     private var protocolV3FirstFramePlanIds: Set<String> = []
 
@@ -287,6 +298,7 @@ actor PlaybackSessionBridge {
     private func adoptSession(_ session: PlaybackSessionResponse) {
         sessionId = session.sessionId
         currentSession = session
+        consecutiveProgressFailures = 0
         #if os(iOS) || os(tvOS)
         // Only record the session id for later diagnostics bundling when
         // diagnostics is actually collecting for the active binding. Recording
@@ -318,6 +330,7 @@ actor PlaybackSessionBridge {
         preferredAudioTrackIndex: Int? = nil,
         preferredSubtitleTrackIndex: Int? = nil,
         preferredProtocolV3SubtitleIndex: Int? = nil,
+        initialSubtitlePreferences: InitialProtocolV3SubtitlePreferences? = nil,
         startFromBeginning: Bool,
         resumePosition: Double? = nil,
         allowNearEndResume: Bool = false,
@@ -388,10 +401,21 @@ actor PlaybackSessionBridge {
             version: selectedVersion,
             explicitFFmpegIndex: preferredSubtitleTrackIndex,
             explicitCombinedIndex: preferredProtocolV3SubtitleIndex,
-            preferredLanguage: watchDetail.effectiveSubtitleLanguage,
-            mode: SubtitleMode(rawValue: watchDetail.effectiveSubtitleMode ?? ""),
-            showForced: watchDetail.effectiveShowForcedSubtitles ?? false,
-            trackSignature: watchDetail.effectiveSubtitleTrackSignature,
+            preferredLanguage: initialSubtitlePreferences == nil
+                ? watchDetail.effectiveSubtitleLanguage
+                : initialSubtitlePreferences?.preferredLanguage,
+            additionalPreferredLanguages: initialSubtitlePreferences?.additionalPreferredLanguages ?? [],
+            mode: initialSubtitlePreferences == nil
+                ? SubtitleMode(rawValue: watchDetail.effectiveSubtitleMode ?? "")
+                : initialSubtitlePreferences?.mode,
+            showForced: initialSubtitlePreferences?.showForced
+                ?? (watchDetail.effectiveShowForcedSubtitles ?? false),
+            forcedOnly: initialSubtitlePreferences?.forcedOnly ?? false,
+            preferAccessibilityTracks: initialSubtitlePreferences?.preferAccessibilityTracks ?? false,
+            disableWhenNoLanguageMatch: initialSubtitlePreferences?.disableWhenNoLanguageMatch ?? false,
+            trackSignature: initialSubtitlePreferences == nil
+                ? watchDetail.effectiveSubtitleTrackSignature
+                : initialSubtitlePreferences?.trackSignature,
             currentAudioLanguage: selectedAudioLanguage
         )
         let effectiveStartPosition = resolvedStartPosition(
@@ -452,8 +476,12 @@ actor PlaybackSessionBridge {
         explicitFFmpegIndex: Int?,
         explicitCombinedIndex: Int?,
         preferredLanguage: String?,
+        additionalPreferredLanguages: [String] = [],
         mode: SubtitleMode?,
         showForced: Bool,
+        forcedOnly: Bool = false,
+        preferAccessibilityTracks: Bool = false,
+        disableWhenNoLanguageMatch: Bool = false,
         trackSignature: SubtitleTrackSignature?,
         currentAudioLanguage: String?
     ) -> InitialProtocolV3SubtitleIntent {
@@ -511,8 +539,12 @@ actor PlaybackSessionBridge {
         }
         let resolution = SubtitleAutoResolver.resolve(.init(
             preferredLanguage: preferredLanguage,
+            additionalPreferredLanguages: additionalPreferredLanguages,
             mode: mode,
             showForced: showForced,
+            forcedOnly: forcedOnly,
+            preferAccessibilityTracks: preferAccessibilityTracks,
+            disableWhenNoLanguageMatch: disableWhenNoLanguageMatch,
             trackSignature: trackSignature,
             availableSubtitles: candidates,
             currentAudioLanguage: currentAudioLanguage
@@ -583,10 +615,16 @@ actor PlaybackSessionBridge {
         subtitleCombinedIndex: Int?
     ) async throws -> StagedProtocolV3Start {
         if protocolV3Available == nil {
-            let capability = try await ContinuumAPI.shared.playbackV3Capability()
-            protocolV3Available = capability.enabled
-                && capability.protocolVersions.contains(PlaybackProtocolV3.version)
-                && capability.features.contains(PlaybackProtocolV3.planFeature)
+            do {
+                let capability = try await ContinuumAPI.shared.playbackV3Capability()
+                protocolV3Available = Self.supportsNeutralProtocolV3(capability)
+            } catch {
+                if Self.isMissingProtocolV3Capability(error) {
+                    protocolV3Available = false
+                } else {
+                    throw error
+                }
+            }
         }
         // A server that cannot speak v3 cannot serve this client at all; there
         // is no downgrade path left to take.
@@ -608,6 +646,7 @@ actor PlaybackSessionBridge {
             playbackAttemptId: playbackAttemptId,
             qualityPreference: protocolV3QualityPreference(qualityPreference),
             subtitleFidelityPreference: "preserve",
+            progressPersistence: nil,
             startPosition: startPosition,
             audioTrackId: audioTrackIndex.flatMap {
                 $0 >= 0 ? protocolV3TrackId(fileId: selectedVersion.fileId, kind: "audio", index: $0) : nil
@@ -672,7 +711,7 @@ actor PlaybackSessionBridge {
             )
             return StagedProtocolV3Start(
                 playbackAttemptId: playbackAttemptId,
-                clientQualityId: ApplePlaybackQuality.normalizeStoredId(qualityPreference),
+                clientQualityId: ApplePlaybackQuality.protocolV3QualityId(qualityPreference),
                 bandwidthCapKbps: bandwidthCapKbps,
                 snapshot: snapshot,
                 serverFeatures: response.serverFeatures,
@@ -704,8 +743,7 @@ actor PlaybackSessionBridge {
             plan: staged.plan
         )
         protocolV3FirstFramePlanIds.removeAll()
-        sessionId = staged.sessionId
-        currentSession = staged.session
+        adoptSession(staged.session)
         let preparedV3 = PreparedPlaybackV3(
             playbackAttemptId: staged.playbackAttemptId,
             planAttemptId: planAttemptId,
@@ -721,10 +759,9 @@ actor PlaybackSessionBridge {
             watchDetail: watchDetail,
             selectedVersion: staged.selectedVersion,
             session: staged.session,
-            activeQualityId: ApplePlaybackQuality.activeQualityId(
-                requestedQualityId: protocolV3QualityPreference(staged.clientQualityId),
-                selectedVersion: staged.selectedVersion,
-                delivery: PlaybackDeliveryStrategy(playMethod: staged.session.playMethod)
+            activeQualityId: ApplePlaybackQuality.activeProtocolV3QualityId(
+                requestedQualityId: staged.clientQualityId,
+                availableQualities: staged.plan.availableQualities
             ),
             protocolV3: preparedV3
         )
@@ -827,6 +864,40 @@ actor PlaybackSessionBridge {
         }
     }
 
+    static func supportsNeutralProtocolV3(_ capability: PlaybackV3CapabilityResponse) -> Bool {
+        capability.enabled
+            && capability.protocolVersions.contains(PlaybackProtocolV3.version)
+            && capability.features.contains(PlaybackProtocolV3.planFeature)
+            && capability.features.contains(PlaybackProtocolV3.neutralContractFeature)
+    }
+
+    static func isMissingProtocolV3Capability(_ error: Error) -> Bool {
+        guard let httpError = error as? HTTPError,
+              case .http(let statusCode, _) = httpError else {
+            return false
+        }
+        return statusCode == 404 || statusCode == 405
+    }
+
+    static func replanFailure(
+        operation: String,
+        classification: String,
+        message: String
+    ) -> PlaybackV3Failure? {
+        switch operation {
+        case PlaybackProtocolV3.ReplanOperation.trackChange,
+             PlaybackProtocolV3.ReplanOperation.qualityChange,
+             PlaybackProtocolV3.ReplanOperation.seekReanchor:
+            return nil
+        default:
+            return PlaybackV3Failure(
+                classification: classification,
+                message: String(message.prefix(512)),
+                decoderName: nil
+            )
+        }
+    }
+
     func replanProtocolV3(
         watchDetail: WatchDetail,
         position: Double,
@@ -898,7 +969,7 @@ actor PlaybackSessionBridge {
         let selectedTracks = PlaybackV3SelectedTracks(audio: selectedAudio, subtitle: selectedSubtitle)
         let normalizedPosition = position.isFinite ? max(0, position) : 0
         let requestedClientQualityId = qualityPreference.map {
-            ApplePlaybackQuality.normalizeStoredId($0)
+            ApplePlaybackQuality.protocolV3QualityId($0)
         } ?? active.clientQualityId
         let requestedBandwidthCapKbps = AppleQualityAxes.resolvedBitrateCap(
             qualityOverride: qualityPreference,
@@ -907,14 +978,20 @@ actor PlaybackSessionBridge {
         let eventName = isSeekReanchor
             ? "seek_reanchor_requested"
             : (invalidatesIntent ? "plan_invalidated" : "plan_failed")
-        await emitProtocolV3Event(
-            active: active,
-            sessionId: currentSessionId,
-            event: eventName,
-            classification: classification,
-            fallbackReason: nil,
-            diagnostics: ["error_cause": String(message.prefix(512))]
-        )
+        // Telemetry is best-effort and must not hold the route transition on
+        // a separate HTTP round-trip. The immutable prior-attempt identity is
+        // captured here so a later replan cannot change what the event names.
+        let eventActive = active
+        Task {
+            await emitProtocolV3Event(
+                active: eventActive,
+                sessionId: currentSessionId,
+                event: eventName,
+                classification: classification,
+                fallbackReason: nil,
+                diagnostics: ["error_cause": String(message.prefix(512))]
+            )
+        }
         guard isCurrentProtocolV3Attempt(expectedAttempt, sessionId: currentSessionId) else {
             throw CancellationError()
         }
@@ -936,11 +1013,10 @@ actor PlaybackSessionBridge {
             bandwidthEstimateKbps: nil,
             bandwidthCapKbps: requestedBandwidthCapKbps,
             selectedTracks: selectedTracks,
-            // A user intent carries no failure. Only recovery does.
-            failure: isIntent ? nil : PlaybackV3Failure(
+            failure: Self.replanFailure(
+                operation: operation,
                 classification: classification,
-                message: String(message.prefix(512)),
-                decoderName: nil
+                message: message
             ),
             // Apple never mutates a server plan locally, so it never has a
             // mutation to fold into the server's next attempt key.
@@ -1073,8 +1149,7 @@ actor PlaybackSessionBridge {
             active.clientQualityId = requestedClientQualityId
             active.bandwidthCapKbps = requestedBandwidthCapKbps
             activeProtocolV3 = active
-            sessionId = nextSessionId
-            self.currentSession = nextSession
+            adoptSession(nextSession)
             if isSeekReanchor {
                 await emitProtocolV3Event(
                     active: active,
@@ -1097,10 +1172,9 @@ actor PlaybackSessionBridge {
                 watchDetail: watchDetail,
                 selectedVersion: selectedVersion,
                 session: nextSession,
-                activeQualityId: ApplePlaybackQuality.activeQualityId(
-                    requestedQualityId: protocolV3QualityPreference(requestedClientQualityId),
-                    selectedVersion: selectedVersion,
-                    delivery: PlaybackDeliveryStrategy(playMethod: nextSession.playMethod)
+                activeQualityId: ApplePlaybackQuality.activeProtocolV3QualityId(
+                    requestedQualityId: requestedClientQualityId,
+                    availableQualities: nextPlan.availableQualities
                 ),
                 protocolV3: preparedV3
             )
@@ -1399,9 +1473,11 @@ actor PlaybackSessionBridge {
     }
 
     private func protocolV3QualityPreference(_ quality: String?) -> String {
-        AppleQualityAxes.split(
-            ApplePlaybackQuality.normalizeStoredId(quality)
-        ).resolution
+        let serverId = ApplePlaybackQuality.protocolV3QualityId(quality)
+        if ApplePlaybackQuality.settingsOptions.contains(where: { $0.id == serverId }) {
+            return AppleQualityAxes.split(serverId).resolution
+        }
+        return serverId
     }
 
     private func protocolV3TrackId(fileId: Int, kind: String, index: Int) -> String {

--- a/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
@@ -864,6 +864,17 @@ actor PlaybackSessionBridge {
         }
     }
 
+    /// AVAudioSession emits route-change notifications for configuration
+    /// updates performed by the player itself (for example, selecting a new
+    /// preferred multichannel layout). A V3 route replan is only warranted
+    /// when the opaque output identity used to select the active plan changed.
+    static func isMaterialOutputRouteChange(
+        activeOutputContextId: String?,
+        observedOutputContextId: String?
+    ) -> Bool {
+        activeOutputContextId != observedOutputContextId
+    }
+
     static func supportsNeutralProtocolV3(_ capability: PlaybackV3CapabilityResponse) -> Bool {
         capability.enabled
             && capability.protocolVersions.contains(PlaybackProtocolV3.version)
@@ -906,7 +917,8 @@ actor PlaybackSessionBridge {
         operation: String? = nil,
         qualityPreference: String? = nil,
         audioTrackIndex: Int? = nil,
-        subtitleTrackIndex: Int? = nil
+        subtitleTrackIndex: Int? = nil,
+        outputRouteSnapshot: ApplePlaybackV3CapabilitySnapshot? = nil
     ) async throws -> PreparedPlayback? {
         let operation = operation ?? Self.replanOperation(forClassification: classification)
         guard var active = activeProtocolV3,
@@ -929,7 +941,7 @@ actor PlaybackSessionBridge {
         }
 
         if classification == "output_route_changed" {
-            active.snapshot = ApplePlaybackV3Capabilities.snapshot()
+            active.snapshot = outputRouteSnapshot ?? ApplePlaybackV3Capabilities.snapshot()
         }
 
         let isIntent = operation == PlaybackProtocolV3.ReplanOperation.trackChange

--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -297,11 +297,19 @@ struct PlayerView: View {
             dismissPlayer()
         }
         .onAppear {
+            let activeViewModel: PlayerViewModel
+            if viewModel.needsReplacementForPresentation {
+                let replacement = PlayerViewModel()
+                viewModel = replacement
+                activeViewModel = replacement
+            } else {
+                activeViewModel = viewModel
+            }
             #if os(iOS)
             orientationCoordinator.activatePlayer()
             #endif
-            viewModel.applyArtworkURLHints(posterURL: posterURLHint, backdropURL: backdropURLHint)
-            viewModel.loadAndPlay(
+            activeViewModel.applyArtworkURLHints(posterURL: posterURLHint, backdropURL: backdropURLHint)
+            activeViewModel.loadAndPlay(
                 contentId: contentId,
                 preferredFileId: preferredFileId,
                 preferredAudioTrackIndex: preferredAudioTrackIndex,
@@ -311,7 +319,7 @@ struct PlayerView: View {
                 offlineDownloadId: offlineDownloadId
             )
             #if os(tvOS)
-            TVControlReceiver.shared.registerPlayer(viewModel, contentId: contentId)
+            TVControlReceiver.shared.registerPlayer(activeViewModel, contentId: contentId)
             withAnimation(.easeInOut(duration: 0.2)) {
                 remoteIdentityNotice = RemotePlaybackIdentityManager.shared.activeIdentity
             }

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -5349,12 +5349,21 @@ class PlayerViewModel {
                 // restored as sidecar and not as embedded): its cues can't
                 // be replayed, so live re-selection is M4's responsibility
                 // via the live coordinator.
-                if let restoredSidecarTrackId = Self.protocolV3RestoredSidecarTrackId(
-                    selectedSubtitleSnapshot,
+                switch Self.protocolV3SidecarRestoreIntent(
+                    snapshot: selectedSubtitleSnapshot,
+                    selectedSubtitleIndex: prepared.protocolV3?.plan.selectedTracks.subtitle?.index,
                     subtitleMode: prepared.protocolV3?.plan.subtitle.mode
-                ),
-                   SubtitleTrackIdSpace.isSidecar(restoredSidecarTrackId) {
-                    self.pendingSidecarSubtitleTrackId = restoredSidecarTrackId
+                ) {
+                case .renderLocally(let trackId):
+                    self.pendingSidecarSubtitleTrackId = trackId
+                    self.pendingServerRenderedSubtitleTrackId = nil
+                case .serverRendered(let trackId):
+                    self.pendingSidecarSubtitleTrackId = nil
+                    self.pendingServerRenderedSubtitleTrackId = trackId
+                case nil:
+                    // `armAdoptedProtocolV3TrackIntent` already carries the
+                    // replacement plan's authoritative local selection.
+                    self.pendingServerRenderedSubtitleTrackId = nil
                 }
                 self.pendingRecoveredSubtitleSelection = embeddedSubtitleSelectionSnapshot
                 self.hasExplicitSubtitleChoice = explicitSubtitleChoiceSnapshot
@@ -5955,13 +5964,6 @@ class PlayerViewModel {
         inventory.filter {
             $0.source.caseInsensitiveCompare("downloaded") != .orderedSame
         }.count
-    }
-
-    static func protocolV3RestoredSidecarTrackId(
-        _ snapshot: Int64?,
-        subtitleMode: String?
-    ) -> Int64? {
-        subtitleMode == "render" ? snapshot : nil
     }
 
     enum ProtocolV3SidecarRestoreIntent: Equatable {
@@ -7238,7 +7240,7 @@ class PlayerViewModel {
             ?? resolveLoopbackSelectedAudioTrack(from: tracks)
         let selectedAudio: LoopbackSessionSpec.SelectedAudio
         if tracks.isEmpty {
-            selectedAudio = .none
+            selectedAudio = .absent
         } else {
             guard let selectedTrack,
                   let selectedTrackIndex = selectedTrack.srcId ?? selectedAudioTrackIndex else {

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -982,6 +982,10 @@ class PlayerViewModel {
         let preferredSubtitleTrackIndex: Int?
         let preferredSidecarSubtitleTrackId: Int64?
         let startFromBeginning: Bool
+        /// Authoritative protocol-v3 combined ordinal. Unlike
+        /// `preferredSubtitleTrackIndex`, this also represents external,
+        /// downloaded, and server-extracted subtitle rows.
+        var preferredProtocolV3SubtitleIndex: Int? = nil
         /// Set for local playback of a completed download. Routes the
         /// prepare through `OfflinePlaybackBuilder` instead of a server
         /// session, so retry after an error stays on the offline path.
@@ -1000,7 +1004,7 @@ class PlayerViewModel {
             preferredSidecarSubtitleTrackId: Int64?,
             offlineDownloadId: String?
         ) -> LoadRequest {
-            LoadRequest(
+            var request = LoadRequest(
                 contentId: contentId,
                 preferredFileId: preferredFileId,
                 preferredAudioTrackIndex: preferredAudioTrackIndex,
@@ -1010,6 +1014,43 @@ class PlayerViewModel {
                 offlineDownloadId: offlineDownloadId,
                 preferredQualityOverride: preferredQualityOverride
             )
+            request.preferredProtocolV3SubtitleIndex = preferredProtocolV3SubtitleIndex
+            return request
+        }
+
+        /// Refresh the inputs used by session renewal from an adopted V3 plan.
+        /// Player track lists are transient and may already be empty when a
+        /// failed transport reports that its server session disappeared.
+        func adoptingProtocolV3Intent(
+            plan: PlaybackV3Plan,
+            selectedVersion: FileVersion,
+            activeQualityId: String
+        ) -> LoadRequest {
+            let selectedSubtitleIndex = plan.selectedTracks.subtitle?.index
+            let selectedSubtitle = selectedSubtitleIndex.flatMap { selectedIndex in
+                plan.subtitle.inventory.first(where: { $0.combinedIndex == selectedIndex })
+            }
+            let embeddedFFmpegIndex: Int? = selectedSubtitle.flatMap { item in
+                guard item.source == "embedded" else { return nil }
+                return ApplePlaybackV3PlanAdapter.ffmpegSubtitleStreamIndex(
+                    serverCombinedIndex: item.combinedIndex,
+                    in: selectedVersion
+                )
+            }
+            let sidecarTrackId: Int64? = selectedSubtitle.flatMap { item in
+                guard item.delivery == "sidecar" else { return nil }
+                return SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: item.combinedIndex)
+            }
+            var request = copyForRecovery(
+                preferredFileId: plan.effectiveMediaFileId,
+                preferredAudioTrackIndex: plan.selectedTracks.audio?.index,
+                preferredSubtitleTrackIndex: embeddedFFmpegIndex,
+                preferredSidecarSubtitleTrackId: sidecarTrackId,
+                offlineDownloadId: offlineDownloadId
+            )
+            request.preferredProtocolV3SubtitleIndex = selectedSubtitleIndex
+            request.preferredQualityOverride = activeQualityId
+            return request
         }
     }
 
@@ -1609,11 +1650,16 @@ class PlayerViewModel {
                 self.currentWatchDetail = prepared.watchDetail
                 self.currentSelectedVersion = prepared.selectedVersion
                 self.activePreparedProtocolV3 = prepared.protocolV3
+                self.adoptProtocolV3RenewalIntent(from: prepared)
                 self.pendingExternalSubtitles = prepared.session.subtitleUrls ?? []
                 self.knownExternalSubtitles = self.pendingExternalSubtitles
                 self.duration = prepared.session.durationSeconds ?? prepared.selectedVersion.duration ?? self.duration
                 self.currentTime = self.movieTime(for: prepared.session)
                 self.activeQualityId = prepared.activeQualityId
+                self.qualityOptions = ApplePlaybackQuality.playbackOptions(
+                    serverQualities: prepared.protocolV3?.plan.availableQualities ?? [],
+                    fallbackVersion: prepared.selectedVersion
+                )
 
                 if previousSessionId != prepared.session.sessionId {
                     await self.realtimeClient.unbind()
@@ -3248,6 +3294,35 @@ class PlayerViewModel {
         return lastLoadRequest?.preferredSidecarSubtitleTrackId
     }
 
+    private func adoptProtocolV3RenewalIntent(from prepared: PreparedPlayback) {
+        guard let protocolV3 = prepared.protocolV3,
+              let lastLoadRequest,
+              lastLoadRequest.offlineDownloadId == nil else {
+            return
+        }
+        let adopted = lastLoadRequest.adoptingProtocolV3Intent(
+            plan: protocolV3.plan,
+            selectedVersion: prepared.selectedVersion,
+            activeQualityId: prepared.activeQualityId
+        )
+        self.lastLoadRequest = adopted
+
+        // The V3 plan is authoritative for the tracks actually rendered.
+        // Apply it before the new source publishes a track list so container
+        // defaults and the post-open Auto resolver cannot drift away from the
+        // selection the server will preserve through replans and renewals.
+        let rendersSubtitleLocally = protocolV3.plan.subtitle.mode == "render"
+        pendingSubtitleFfIndex = rendersSubtitleLocally
+            ? adopted.preferredSubtitleTrackIndex
+            : -1
+        pendingSidecarSubtitleTrackId = rendersSubtitleLocally
+            ? adopted.preferredSidecarSubtitleTrackId
+            : nil
+        hasExplicitSubtitleChoice = true
+        prefsForCurrentItem = nil
+        prefsResolvedForCurrentItem = true
+    }
+
     private func makeSuspendedPlaybackContext() -> SuspendedPlaybackContext? {
         guard let lastLoadRequest else { return nil }
         let request = lastLoadRequest.copyForRecovery(
@@ -3424,6 +3499,7 @@ class PlayerViewModel {
                 self.currentWatchDetail = prepared.watchDetail
                 self.currentSelectedVersion = prepared.selectedVersion
                 self.activePreparedProtocolV3 = prepared.protocolV3
+                self.adoptProtocolV3RenewalIntent(from: prepared)
                 // Artwork and Next Up are catalog fetches; the offline path
                 // already published its cached poster above and has no
                 // server to resolve a next episode against.
@@ -3432,7 +3508,10 @@ class PlayerViewModel {
                     self.loadNextUpCandidate(for: prepared.watchDetail)
                     self.loadNextUpOnDeckItems(for: prepared.watchDetail)
                 }
-                self.qualityOptions = ApplePlaybackQuality.playbackOptions(for: prepared.selectedVersion)
+                self.qualityOptions = ApplePlaybackQuality.playbackOptions(
+                    serverQualities: prepared.protocolV3?.plan.availableQualities ?? [],
+                    fallbackVersion: prepared.selectedVersion
+                )
                 self.activeQualityId = prepared.activeQualityId
                 self.isQualitySwitching = false
                 self.qualitySwitchError = nil
@@ -3529,6 +3608,7 @@ class PlayerViewModel {
                     preferredFileId: request.preferredFileId,
                     preferredAudioTrackIndex: request.preferredAudioTrackIndex,
                     preferredSubtitleTrackIndex: request.preferredSubtitleTrackIndex,
+                    preferredProtocolV3SubtitleIndex: request.preferredProtocolV3SubtitleIndex,
                     startFromBeginning: request.startFromBeginning,
                     resumePosition: resumePosition,
                     allowNearEndResume: allowNearEndResume,
@@ -3555,6 +3635,7 @@ class PlayerViewModel {
                 preferredFileId: request.preferredFileId,
                 preferredAudioTrackIndex: request.preferredAudioTrackIndex,
                 preferredSubtitleTrackIndex: request.preferredSubtitleTrackIndex,
+                preferredProtocolV3SubtitleIndex: request.preferredProtocolV3SubtitleIndex,
                 startFromBeginning: request.startFromBeginning,
                 resumePosition: resumePosition,
                 allowNearEndResume: allowNearEndResume,
@@ -3684,6 +3765,13 @@ class PlayerViewModel {
     }
 
     private func finalizeTerminalPlaybackError(_ message: String) {
+        progressTask?.cancel()
+        progressTask = nil
+        staleSessionRecoveryTask?.cancel()
+        staleSessionRecoveryTask = nil
+        backgroundRenewalTask?.cancel()
+        backgroundRenewalTask = nil
+        backgroundRenewalSessionId = nil
         clearForegroundInterruptionState()
         clearSuspendedPlaybackState()
         clearServerOutageRecoveryState()
@@ -3692,15 +3780,17 @@ class PlayerViewModel {
         sourceProxy?.stop()
         sourceProxy = nil
         activePlaybackSessionId = nil
+        activePreparedProtocolV3 = nil
+        activeExecutionPlan = nil
         error = message
         isLoading = false
         isPlaying = false
     }
 
-    /// Silently renews a lost server session in place: the bridge re-POSTs
-    /// the captured start request (same file, same plan), the source proxy
-    /// is retargeted at the renewed stream URL, and the player, remuxer, and
-    /// cache are never touched — zero user-visible effect. Returns false
+    /// Silently renews a lost server session in place: the bridge stages a
+    /// fresh V3 start and accepts it only when the effective direct route is
+    /// unchanged. The source proxy is then retargeted at the renewed stream
+    /// URL while the player, remuxer, and cache remain untouched. Returns false
     /// when this playback cannot be renewed in place (offline, non-direct
     /// delivery, no proxy); the caller falls back to the visible renewal.
     /// A renewal that fails with a re-plan escalates to the visible renewal
@@ -3711,6 +3801,7 @@ class PlayerViewModel {
         guard !isDisposed,
               offlinePlaybackContext == nil,
               currentDeliveryStrategy == .direct,
+              let currentWatchDetail,
               sourceProxy != nil else {
             return false
         }
@@ -3732,8 +3823,13 @@ class PlayerViewModel {
             guard let self, !self.isDisposed else { return }
             do {
                 let renewed = try await self.sessionBridge.renewDirectSession(
+                    watchDetail: currentWatchDetail,
                     position: resumePosition,
-                    audioTrackIndex: self.resolvedAudioTrackIndexForResume()
+                    // The bridge owns the adopted V3 plan. Passing no
+                    // overrides makes renewal repeat that exact tuple instead
+                    // of consulting player tracks that may already be empty.
+                    audioTrackIndex: nil,
+                    subtitleTrackIndex: nil
                 )
                 guard !Task.isCancelled, !self.isDisposed else { return }
                 // A fresh load may have replaced this playback while the
@@ -3746,7 +3842,10 @@ class PlayerViewModel {
                     )
                     return
                 }
-                guard let streamRequest = await self.makeStreamRequest(session: renewed) else {
+                guard let streamRequest = await self.makeStreamRequest(
+                    session: renewed.session,
+                    additionalHeaders: renewed.protocolV3?.plan.stream.headers ?? [:]
+                ) else {
                     self.failBackgroundRenewal(
                         reason: reason,
                         observedPosition: resumePosition,
@@ -3755,15 +3854,27 @@ class PlayerViewModel {
                     return
                 }
                 proxy.retargetOrigin(url: streamRequest.url, headers: streamRequest.headers)
-                self.activePlaybackSessionId = renewed.sessionId
+                self.activePlaybackSessionId = renewed.session.sessionId
+                self.currentWatchDetail = renewed.watchDetail
+                self.currentSelectedVersion = renewed.selectedVersion
+                self.activePreparedProtocolV3 = renewed.protocolV3
+                self.adoptProtocolV3RenewalIntent(from: renewed)
+                self.pendingExternalSubtitles = renewed.session.subtitleUrls ?? self.pendingExternalSubtitles
+                self.knownExternalSubtitles = self.pendingExternalSubtitles
+                self.duration = renewed.session.durationSeconds ?? renewed.selectedVersion.duration ?? self.duration
+                self.activeQualityId = renewed.activeQualityId
+                self.qualityOptions = ApplePlaybackQuality.playbackOptions(
+                    serverQualities: renewed.protocolV3?.plan.availableQualities ?? [],
+                    fallbackVersion: renewed.selectedVersion
+                )
                 self.staleSessionRecoverySessionId = nil
                 self.backgroundRenewalSessionId = nil
                 self.backgroundRenewalTransientFailures = 0
                 await self.realtimeClient.unbind()
                 guard !Task.isCancelled, !self.isDisposed else { return }
-                await self.realtimeClient.bind(sessionId: renewed.sessionId)
+                await self.realtimeClient.bind(sessionId: renewed.session.sessionId)
                 Self.logger.info(
-                    "[CMP-RECOVERY] background session renewal succeeded old=\(staleSessionId, privacy: .public) new=\(renewed.sessionId, privacy: .public) reason=\(reason, privacy: .public)"
+                    "[CMP-RECOVERY] background session renewal succeeded old=\(staleSessionId, privacy: .public) new=\(renewed.session.sessionId, privacy: .public) reason=\(reason, privacy: .public)"
                 )
             } catch let error as PlaybackSessionBridge.DirectSessionRenewalError {
                 guard !Task.isCancelled, !self.isDisposed else { return }
@@ -4851,13 +4962,18 @@ class PlayerViewModel {
         qualityId: String,
         source: String
     ) -> Bool {
-        guard let currentWatchDetail,
-              let selectedVersion = currentSelectedVersion else {
-            Self.logger.warning("[CMP-SEEK] in-place transcode restart skipped: missing current item snapshot")
+        guard let protocolV3 = activePreparedProtocolV3,
+              let currentWatchDetail,
+              currentSelectedVersion != nil else {
+            Self.logger.warning("[CMP-SEEK] V3 stream replan skipped: missing active protocol or item snapshot")
             if source == "quality" {
                 isQualitySwitching = false
                 qualitySwitchError = "Quality unavailable for this item."
             }
+            return false
+        }
+        if source == "seek",
+           !protocolV3.serverFeatures.contains(PlaybackProtocolV3.seekReanchorFeature) {
             return false
         }
 
@@ -4904,16 +5020,36 @@ class PlayerViewModel {
             }
 
             do {
-                let session = try await self.sessionBridge.restartCurrentTranscode(
-                    selectedVersion: selectedVersion,
-                    seekSeconds: target,
-                    qualityOverride: source == "quality" ? qualityId : nil
-                )
+                guard let prepared = try await self.sessionBridge.replanProtocolV3(
+                    watchDetail: currentWatchDetail,
+                    position: target,
+                    classification: source == "quality" ? "quality_changed" : "seek_reanchor",
+                    message: source == "quality"
+                        ? "User selected playback quality \(qualityId)."
+                        : "Reanchor the active stream at the requested source position.",
+                    operation: source == "quality"
+                        ? PlaybackProtocolV3.ReplanOperation.qualityChange
+                        : PlaybackProtocolV3.ReplanOperation.seekReanchor,
+                    qualityPreference: source == "quality" ? qualityId : nil,
+                    audioTrackIndex: self.resolvedAudioTrackIndexForResume(),
+                    subtitleTrackIndex: self.resolvedProtocolV3SubtitleIndexForResume()
+                ) else {
+                    throw PlaybackV3TerminalFailure(
+                        reason: "replan_unavailable",
+                        message: "The active V3 playback plan cannot be replaced in place.",
+                        retryable: false
+                    )
+                }
                 guard !Task.isCancelled, !self.isDisposed else { return }
                 if source == "quality" {
                     self.lastLoadRequest?.preferredQualityOverride = qualityId
                 }
+                let session = prepared.session
                 self.activePlaybackSessionId = session.sessionId
+                self.currentWatchDetail = prepared.watchDetail
+                self.currentSelectedVersion = prepared.selectedVersion
+                self.activePreparedProtocolV3 = prepared.protocolV3
+                self.adoptProtocolV3RenewalIntent(from: prepared)
                 self.autoSkippedIntroKey = nil
                 self.autoSkippedCreditsKey = nil
                 self.autoSkipIntroCancelledKey = nil
@@ -4926,16 +5062,6 @@ class PlayerViewModel {
                     self.activePlayer.dispose()
                 }
 
-                let prepared = PreparedPlayback(
-                    watchDetail: currentWatchDetail,
-                    selectedVersion: selectedVersion,
-                    session: session,
-                    activeQualityId: ApplePlaybackQuality.activeQualityId(
-                        requestedQualityId: qualityId,
-                        selectedVersion: selectedVersion,
-                        delivery: PlaybackDeliveryStrategy(playMethod: session.playMethod)
-                    )
-                )
                 self.pendingExternalSubtitles = session.subtitleUrls ?? externalSubtitleSnapshot
                 self.knownExternalSubtitles = self.pendingExternalSubtitles
                 // Re-establish the subtitle selection across the backend
@@ -4955,13 +5081,19 @@ class PlayerViewModel {
                 self.pendingRecoveredSubtitleSelection = embeddedSubtitleSelectionSnapshot
                 self.hasExplicitSubtitleChoice = explicitSubtitleChoiceSnapshot
                 self.pendingRecoveredSecondarySubtitleId = selectedSecondarySubtitleSnapshot
-                self.duration = session.durationSeconds ?? selectedVersion.duration ?? self.duration
+                self.duration = session.durationSeconds ?? prepared.selectedVersion.duration ?? self.duration
                 self.currentTime = self.movieTime(for: session)
-                self.qualityOptions = ApplePlaybackQuality.playbackOptions(for: selectedVersion)
+                self.qualityOptions = ApplePlaybackQuality.playbackOptions(
+                    serverQualities: prepared.protocolV3?.plan.availableQualities ?? [],
+                    fallbackVersion: prepared.selectedVersion
+                )
                 self.activeQualityId = prepared.activeQualityId
                 self.qualitySwitchError = nil
 
-                guard let streamRequest = await self.makeStreamRequest(session: session) else {
+                guard let streamRequest = await self.makeStreamRequest(
+                    session: session,
+                    additionalHeaders: prepared.protocolV3?.plan.stream.headers ?? [:]
+                ) else {
                     self.finalizeTerminalPlaybackError("Invalid stream URL")
                     return
                 }
@@ -7275,12 +7407,14 @@ class PlayerViewModel {
             }
         }
 
-        // If a forced sidecar is present, auto-select it. Forced tracks
-        // (for non-native dialogue or song lyrics in anime) are meant
-        // to display regardless of the Silo subtitle preference. Device
-        // settings mode instead routes every sidecar through Apple's ordered
-        // language policy, including Forced Only.
+        // If a forced sidecar is present, auto-select it when the protocol plan
+        // has not already made an explicit choice. Forced tracks (for
+        // non-native dialogue or song lyrics in anime) otherwise display
+        // regardless of the Silo subtitle preference. Device settings mode
+        // routes every sidecar through Apple's ordered language policy,
+        // including Forced Only.
         if !settings.subtitleMatchesSystemAppearance,
+           !hasExplicitSubtitleChoice,
            selectedSubtitleId == nil,
            let forced = descriptors.first(where: { $0.forced == true }) {
             let trackId = SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: forced.index)

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -1687,6 +1687,13 @@ class PlayerViewModel {
             } catch {
                 guard !Task.isCancelled, !self.isDisposed else { return }
                 Self.logger.error("Protocol V3 replan failed: \(String(describing: error), privacy: .public)")
+                if PlaybackSessionBridge.isPlaybackSessionMissing(error),
+                   self.attemptStaleSessionRenewal(
+                       reason: "protocol_v3_replan_missing_session",
+                       observedPosition: position
+                   ) {
+                    return
+                }
                 self.finalizeTerminalPlaybackError(error.localizedDescription)
             }
         }

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -645,6 +645,7 @@ class PlayerViewModel {
     /// on this so a late-landing handoff signal can't spin up a fresh
     /// pipeline on a view that's already gone.
     private var isDisposed = false
+    var needsReplacementForPresentation: Bool { isDisposed }
     #if os(iOS)
     /// Mirrors the last `ScenePhase` handed to `handleScenePhase`. Lets the
     /// AirPlay route observer tell "receiver disconnected while we're in the
@@ -930,6 +931,11 @@ class PlayerViewModel {
     /// reload/resume has to remember the synthesised sidecar `trackId`
     /// and re-apply it once `subtitle_urls` have been registered again.
     private var pendingSidecarSubtitleTrackId: Int64?
+    /// A protocol-v3 subtitle can remain represented by a sidecar picker row
+    /// even when the replacement plan renders it on the server (for example,
+    /// bitmap PGS subtitles burned into HLS). Preserve that picker selection
+    /// across the backend rebuild without also opening the sidecar locally.
+    private var pendingServerRenderedSubtitleTrackId: Int64?
     /// M5 seamless live→persisted swap: the synthetic AI-live track id whose
     /// row + libass track must be closed AFTER the handed-off persisted track is
     /// selected. Set by `armDeferredLiveSubtitleClose` when a live job completes;
@@ -1250,6 +1256,7 @@ class PlayerViewModel {
     }
 
     private func configurePrimaryCore(_ core: PlayerCore) {
+        let callbackGeneration = streamLoadGeneration
         let callbacks = makeCallbacks()
         applyCallbacks(callbacks, to: core)
         wireSubtitleCallbacks(to: core)
@@ -1257,7 +1264,13 @@ class PlayerViewModel {
         // a typed fallback plan by the view model rather than by the decode
         // core.
         core.onUnsupportedStream = { [weak self] reason, url, headers, startTime in
-            self?.handleUnsupportedStream(reason: reason, url: url, headers: headers, startTime: startTime)
+            guard let self,
+                  !self.isDisposed,
+                  Self.isCurrentStreamCallback(
+                      callbackGeneration,
+                      currentGeneration: self.streamLoadGeneration
+                  ) else { return }
+            self.handleUnsupportedStream(reason: reason, url: url, headers: headers, startTime: startTime)
         }
 
         // HDR preference is persistent; push it in at construction so the
@@ -1307,23 +1320,45 @@ class PlayerViewModel {
 
     /// Subtitle-specific callbacks for PlayerCore's shared subtitle session.
     private func wireSubtitleCallbacks(to core: PlayerCore) {
+        let callbackGeneration = streamLoadGeneration
         core.onSidecarTracksRegistered = { [weak self] descriptors in
-            guard let self, !self.isDisposed else { return }
+            guard let self,
+                  !self.isDisposed,
+                  Self.isCurrentStreamCallback(
+                      callbackGeneration,
+                      currentGeneration: self.streamLoadGeneration
+                  ) else { return }
             self.appendSidecarTracks(descriptors)
         }
         core.onSubtitleLoadStatusChange = { [weak self] slot, status in
-            guard let self, !self.isDisposed else { return }
+            guard let self,
+                  !self.isDisposed,
+                  Self.isCurrentStreamCallback(
+                      callbackGeneration,
+                      currentGeneration: self.streamLoadGeneration
+                  ) else { return }
             self.subtitleLoadStatus[slot] = status
         }
     }
 
     private func wireSubtitleCallbacks(to backend: AVPlayerBackend) {
+        let callbackGeneration = streamLoadGeneration
         backend.onSidecarTracksRegistered = { [weak self] descriptors in
-            guard let self, !self.isDisposed else { return }
+            guard let self,
+                  !self.isDisposed,
+                  Self.isCurrentStreamCallback(
+                      callbackGeneration,
+                      currentGeneration: self.streamLoadGeneration
+                  ) else { return }
             self.appendSidecarTracks(descriptors)
         }
         backend.onSubtitleLoadStatusChange = { [weak self] slot, status in
-            guard let self, !self.isDisposed else { return }
+            guard let self,
+                  !self.isDisposed,
+                  Self.isCurrentStreamCallback(
+                      callbackGeneration,
+                      currentGeneration: self.streamLoadGeneration
+                  ) else { return }
             self.subtitleLoadStatus[slot] = status
         }
     }
@@ -1333,11 +1368,30 @@ class PlayerViewModel {
     /// owning them may outlive the VM in teardown races, so the
     /// `guard let self` is structural protection rather than cosmetic.
     private func makeCallbacks() -> PlayerCallbacks {
+        let callbackGeneration = streamLoadGeneration
         var cb = PlayerCallbacks()
         cb.onTimeChange = { [weak self] seconds in
-            guard let self, !self.isDisposed, seconds.isFinite else { return }
+            guard let self,
+                  !self.isDisposed,
+                  seconds.isFinite,
+                  Self.isCurrentStreamCallback(
+                      callbackGeneration,
+                      currentGeneration: self.streamLoadGeneration
+                  ) else { return }
             guard !self.hasReachedEndOfFile else { return }
             let movieTime = seconds + self.playbackTimelineOffset
+            // A replacement loopback item can briefly publish its anchor
+            // segment before its resume pre-seek lands. Outside an explicit
+            // seek, playback time is monotonic; do not let that loader frame
+            // move the UI or progress reporter backwards.
+            if Self.isUnexpectedBackwardPlaybackTime(
+                movieTime,
+                currentTime: self.currentTime,
+                explicitSeekInFlight: self.seekTargetTime != nil
+            ) {
+                self.pushNowPlayingIfDue()
+                return
+            }
             if let origin = self.seekOriginTime, let target = self.seekTargetTime {
                 // A seek is in flight. Reports closer to the pre-seek
                 // position than to the target are stale drainage frames
@@ -1368,15 +1422,27 @@ class PlayerViewModel {
             self.pushNowPlayingIfDue()
         }
         cb.onDurationChange = { [weak self] seconds in
-            guard let self, !self.isDisposed, seconds.isFinite, seconds > 0 else { return }
-            if self.duration > 0, seconds < self.duration {
-                return
-            }
+            guard let self,
+                  !self.isDisposed,
+                  Self.isCurrentStreamCallback(
+                      callbackGeneration,
+                      currentGeneration: self.streamLoadGeneration
+                  ),
+                  Self.shouldAdoptBackendDuration(
+                      seconds,
+                      currentDuration: self.duration,
+                      delivery: self.currentDeliveryStrategy
+                  ) else { return }
             self.duration = seconds
             self.updateNextUpPresentation(for: self.currentTime)
         }
         cb.onPauseChange = { [weak self] paused in
-            guard let self, !self.isDisposed else { return }
+            guard let self,
+                  !self.isDisposed,
+                  Self.isCurrentStreamCallback(
+                      callbackGeneration,
+                      currentGeneration: self.streamLoadGeneration
+                  ) else { return }
             let wasPlaying = self.isPlaying
             self.isPlaying = !paused
             // A pause from any source (remote button, transport button,
@@ -1398,27 +1464,57 @@ class PlayerViewModel {
             )
         }
         cb.onFileLoaded = { [weak self] in
-            guard let self, !self.isDisposed else { return }
+            guard let self,
+                  !self.isDisposed,
+                  Self.isCurrentStreamCallback(
+                      callbackGeneration,
+                      currentGeneration: self.streamLoadGeneration
+                  ) else { return }
             self.handleFileLoaded()
         }
         cb.onFirstFrame = { [weak self] milliseconds in
-            guard let self, !self.isDisposed else { return }
+            guard let self,
+                  !self.isDisposed,
+                  Self.isCurrentStreamCallback(
+                      callbackGeneration,
+                      currentGeneration: self.streamLoadGeneration
+                  ) else { return }
             Task { await self.sessionBridge.reportProtocolV3FirstFrame(milliseconds: milliseconds) }
         }
         cb.onError = { [weak self] message in
-            guard let self, !self.isDisposed else { return }
+            guard let self,
+                  !self.isDisposed,
+                  Self.isCurrentStreamCallback(
+                      callbackGeneration,
+                      currentGeneration: self.streamLoadGeneration
+                  ) else { return }
             self.handlePlaybackError(message)
         }
         cb.onTracksChange = { [weak self] tracks in
-            guard let self, !self.isDisposed else { return }
+            guard let self,
+                  !self.isDisposed,
+                  Self.isCurrentStreamCallback(
+                      callbackGeneration,
+                      currentGeneration: self.streamLoadGeneration
+                  ) else { return }
             self.applyTrackList(tracks)
         }
         cb.onChaptersChange = { [weak self] chapters in
-            guard let self, !self.isDisposed else { return }
+            guard let self,
+                  !self.isDisposed,
+                  Self.isCurrentStreamCallback(
+                      callbackGeneration,
+                      currentGeneration: self.streamLoadGeneration
+                  ) else { return }
             self.chapters = chapters
         }
         cb.onBufferingChange = { [weak self] buffering in
-            guard let self, !self.isDisposed else { return }
+            guard let self,
+                  !self.isDisposed,
+                  Self.isCurrentStreamCallback(
+                      callbackGeneration,
+                      currentGeneration: self.streamLoadGeneration
+                  ) else { return }
             self.isBuffering = buffering
             if buffering {
                 Task { @MainActor [weak self] in
@@ -1430,15 +1526,32 @@ class PlayerViewModel {
             }
         }
         cb.onBufferingProgress = { [weak self] progress in
-            guard let self, !self.isDisposed, progress.isFinite else { return }
+            guard let self,
+                  !self.isDisposed,
+                  progress.isFinite,
+                  Self.isCurrentStreamCallback(
+                      callbackGeneration,
+                      currentGeneration: self.streamLoadGeneration
+                  ) else { return }
             self.bufferingProgress = min(100, max(0, progress))
         }
         cb.onBufferedAheadChange = { [weak self] seconds in
-            guard let self, !self.isDisposed, seconds.isFinite else { return }
+            guard let self,
+                  !self.isDisposed,
+                  seconds.isFinite,
+                  Self.isCurrentStreamCallback(
+                      callbackGeneration,
+                      currentGeneration: self.streamLoadGeneration
+                  ) else { return }
             self.bufferedAheadSeconds = max(0, seconds)
         }
         cb.onPlaybackStatsChange = { [weak self] stats in
-            guard let self, !self.isDisposed else { return }
+            guard let self,
+                  !self.isDisposed,
+                  Self.isCurrentStreamCallback(
+                      callbackGeneration,
+                      currentGeneration: self.streamLoadGeneration
+                  ) else { return }
             var enrichedStats = stats
             self.applySourceCacheStats(&enrichedStats)
             self.applyFileBitrateStats(&enrichedStats)
@@ -1447,7 +1560,12 @@ class PlayerViewModel {
             self.playbackStats = enrichedStats
         }
         cb.onEndOfFile = { [weak self] in
-            guard let self, !self.isDisposed else { return }
+            guard let self,
+                  !self.isDisposed,
+                  Self.isCurrentStreamCallback(
+                      callbackGeneration,
+                      currentGeneration: self.streamLoadGeneration
+                  ) else { return }
             self.handleEndOfFile()
         }
         return cb
@@ -1469,6 +1587,7 @@ class PlayerViewModel {
     }
 
     private func applyCallbacks(_ cb: PlayerCallbacks, to backend: AVPlayerBackend) {
+        let callbackGeneration = streamLoadGeneration
         backend.onTimeChange          = cb.onTimeChange
         backend.onDurationChange      = cb.onDurationChange
         backend.onPauseChange         = cb.onPauseChange
@@ -1482,7 +1601,13 @@ class PlayerViewModel {
         backend.onPlaybackStatsChange = cb.onPlaybackStatsChange
         backend.onEndOfFile           = cb.onEndOfFile
         backend.onTimelineOffsetChange = { [weak self] offset in
-            guard let self, !self.isDisposed, offset.isFinite else { return }
+            guard let self,
+                  !self.isDisposed,
+                  offset.isFinite,
+                  Self.isCurrentStreamCallback(
+                      callbackGeneration,
+                      currentGeneration: self.streamLoadGeneration
+                  ) else { return }
             self.playbackTimelineOffset = max(0, offset)
         }
         #if os(iOS)
@@ -1490,18 +1615,33 @@ class PlayerViewModel {
             PictureInPictureCoordinator.shared.isActive
         }
         backend.onExternalPlaybackActiveChange = { [weak self] active in
-            guard let self, !self.isDisposed else { return }
+            guard let self,
+                  !self.isDisposed,
+                  Self.isCurrentStreamCallback(
+                      callbackGeneration,
+                      currentGeneration: self.streamLoadGeneration
+                  ) else { return }
             self.handleExternalPlaybackActiveChange(active)
         }
         backend.onExternalPlaybackAllowedChange = { [weak self] allowed in
-            guard let self, !self.isDisposed else { return }
+            guard let self,
+                  !self.isDisposed,
+                  Self.isCurrentStreamCallback(
+                      callbackGeneration,
+                      currentGeneration: self.streamLoadGeneration
+                  ) else { return }
             self.supportsExternalPlayback = allowed
         }
         backend.onExternalPlaybackUnavailable = { [weak self] in
             // `showNotice` is `@MainActor`; this callback may not be, so
             // dispatch onto the main actor explicitly.
             Task { @MainActor [weak self] in
-                guard let self, !self.isDisposed else { return }
+                guard let self,
+                      !self.isDisposed,
+                      Self.isCurrentStreamCallback(
+                          callbackGeneration,
+                          currentGeneration: self.streamLoadGeneration
+                      ) else { return }
                 self.showNotice(
                     title: "AirPlay Unavailable",
                     message: "This device has no Wi-Fi address the receiver can reach. Playback stayed on this device.",
@@ -1619,6 +1759,7 @@ class PlayerViewModel {
             if completesQualitySwitch { isQualitySwitching = false }
             return
         }
+        let selectedSubtitleSnapshot = selectedSubtitleId
         progressTask?.cancel()
         isLoading = true
         isBuffering = false
@@ -1654,6 +1795,20 @@ class PlayerViewModel {
                 self.currentSelectedVersion = prepared.selectedVersion
                 self.activePreparedProtocolV3 = prepared.protocolV3
                 self.adoptProtocolV3RenewalIntent(from: prepared)
+                switch Self.protocolV3SidecarRestoreIntent(
+                    snapshot: selectedSubtitleSnapshot,
+                    selectedSubtitleIndex: prepared.protocolV3?.plan.selectedTracks.subtitle?.index,
+                    subtitleMode: prepared.protocolV3?.plan.subtitle.mode
+                ) {
+                case .renderLocally(let trackId):
+                    self.pendingSidecarSubtitleTrackId = trackId
+                    self.pendingServerRenderedSubtitleTrackId = nil
+                case .serverRendered(let trackId):
+                    self.pendingSidecarSubtitleTrackId = nil
+                    self.pendingServerRenderedSubtitleTrackId = trackId
+                case nil:
+                    self.pendingServerRenderedSubtitleTrackId = nil
+                }
                 self.pendingExternalSubtitles = prepared.session.subtitleUrls ?? []
                 self.knownExternalSubtitles = self.pendingExternalSubtitles
                 self.duration = prepared.session.durationSeconds ?? prepared.selectedVersion.duration ?? self.duration
@@ -2410,6 +2565,11 @@ class PlayerViewModel {
         let loadGeneration = streamLoadGeneration
         activePlayer.dispose()
         activePlayer = .none
+        // Re-arm the authoritative V3 intent after disposing the old player.
+        // A final track callback from that player may have consumed the first
+        // copy between replan adoption and this teardown; generation-gated
+        // callbacks cannot consume this post-teardown copy.
+        rearmAdoptedProtocolV3TrackIntent()
         stashSourceCacheHandoff()
         sourceProxy?.stop()
         sourceProxy = nil
@@ -2731,8 +2891,10 @@ class PlayerViewModel {
         requestedStart: Double?
     ) -> Double {
         if plan.engine == .siloPlayerLoopback {
-            let start = plan.startMode.seconds
-            return start.isFinite ? max(0, start) : 0
+            return Self.initialLoopbackTimelineOffset(
+                servingMode: plan.loopbackSession?.servingMode,
+                startTime: plan.startMode.seconds
+            )
         }
         guard plan.delivery == .remux,
               plan.engine == .avPlayerHLS,
@@ -2754,12 +2916,49 @@ class PlayerViewModel {
     ) -> Double {
         switch plan.engine {
         case .siloPlayerLoopback:
-            return startTime.isFinite ? max(0, startTime) : 0
+            return Self.initialLoopbackTimelineOffset(
+                servingMode: plan.loopbackSession?.servingMode,
+                startTime: startTime
+            )
         case .avPlayerHLS:
             return playbackTimelineOffset
         case .avPlayerNativeDirect, .playerCoreDirect:
             return 0
         }
+    }
+
+    /// The growing EVENT playlist is reanchored at each requested start, so
+    /// its AVPlayer clock is relative to that start. A static VOD playlist is
+    /// different: the requested start is an in-item seek on the plan's stable
+    /// playlist axis. Treating it as the playlist origin doubles the reported
+    /// position after a mid-playback replan. Start VOD at zero and let the
+    /// backend publish the resolved segment-plan anchor before item creation.
+    static func initialLoopbackTimelineOffset(
+        servingMode: LoopbackServingMode?,
+        startTime: Double
+    ) -> Double {
+        if servingMode == .vodPlan {
+            return 0
+        }
+        return startTime.isFinite ? max(0, startTime) : 0
+    }
+
+    /// A server transcode is exposed as a growing HLS playlist while FFmpeg is
+    /// producing it. AVPlayer reports the currently published playlist length
+    /// as the item duration, but that is not the VOD duration and can grow past
+    /// the probed media length. Keep a known server duration authoritative;
+    /// backend duration remains the fallback when the server has no value.
+    static func shouldAdoptBackendDuration(
+        _ reportedDuration: Double,
+        currentDuration: Double,
+        delivery: PlaybackDeliveryStrategy
+    ) -> Bool {
+        guard reportedDuration.isFinite, reportedDuration > 0 else { return false }
+        guard currentDuration.isFinite, currentDuration > 0 else { return true }
+        if case .transcode = delivery {
+            return false
+        }
+        return reportedDuration >= currentDuration
     }
 
     private func movieTime(for session: PlaybackSessionResponse) -> Double {
@@ -3247,6 +3446,7 @@ class PlayerViewModel {
         pendingRecoveredAudioSelection = nil
         pendingRecoveredSubtitleSelection = nil
         pendingRecoveredSecondarySubtitleId = nil
+        pendingServerRenderedSubtitleTrackId = nil
         // Subtitle `-1` is the explicit "Off" sentinel; `applyTrackList`
         // disables subs when it sees a negative value.
         pendingAudioFfIndex = preferredAudioTrackIndex
@@ -3320,17 +3520,11 @@ class PlayerViewModel {
         )
         self.lastLoadRequest = adopted
 
-        // The V3 plan is authoritative for the tracks actually rendered.
-        // Apply it before the new source publishes a track list so container
-        // defaults and the post-open Auto resolver cannot drift away from the
-        // selection the server will preserve through replans and renewals.
-        let rendersSubtitleLocally = protocolV3.plan.subtitle.mode == "render"
-        pendingSubtitleFfIndex = rendersSubtitleLocally
-            ? adopted.preferredSubtitleTrackIndex
-            : -1
-        pendingSidecarSubtitleTrackId = rendersSubtitleLocally
-            ? adopted.preferredSidecarSubtitleTrackId
-            : nil
+        armAdoptedProtocolV3TrackIntent(
+            plan: protocolV3.plan,
+            request: adopted
+        )
+
         // Adopting an authoritative server plan does not convert an automatic
         // system/server policy into a user choice. Manual choices stay latched;
         // automatic choices remain eligible for later policy changes.
@@ -3338,6 +3532,26 @@ class PlayerViewModel {
             prefsForCurrentItem = nil
             prefsResolvedForCurrentItem = true
         }
+    }
+
+    private func rearmAdoptedProtocolV3TrackIntent() {
+        guard let plan = activePreparedProtocolV3?.plan,
+              let request = lastLoadRequest else { return }
+        armAdoptedProtocolV3TrackIntent(plan: plan, request: request)
+    }
+
+    private func armAdoptedProtocolV3TrackIntent(
+        plan: PlaybackV3Plan,
+        request: LoadRequest
+    ) {
+        // The V3 plan is authoritative for the tracks actually rendered.
+        // Apply it before the new source publishes a track list so container
+        // defaults and the post-open Auto resolver cannot drift away from the
+        // selection the server will preserve through replans and renewals.
+        let intent = Self.protocolV3PendingTrackIntent(plan: plan, request: request)
+        pendingAudioFfIndex = intent.audioIndex
+        pendingSubtitleFfIndex = intent.embeddedSubtitleIndex
+        pendingSidecarSubtitleTrackId = intent.sidecarSubtitleTrackId
     }
 
     private func makeSuspendedPlaybackContext() -> SuspendedPlaybackContext? {
@@ -3897,6 +4111,7 @@ class PlayerViewModel {
                 self.adoptProtocolV3RenewalIntent(from: renewed)
                 self.pendingExternalSubtitles = renewed.session.subtitleUrls ?? self.pendingExternalSubtitles
                 self.knownExternalSubtitles = self.pendingExternalSubtitles
+                self.loadPendingExternalSubtitles()
                 self.duration = renewed.session.durationSeconds ?? renewed.selectedVersion.duration ?? self.duration
                 self.activeQualityId = renewed.activeQualityId
                 self.qualityOptions = ApplePlaybackQuality.playbackOptions(
@@ -5098,9 +5313,12 @@ class PlayerViewModel {
                 // restored as sidecar and not as embedded): its cues can't
                 // be replayed, so live re-selection is M4's responsibility
                 // via the live coordinator.
-                if let selectedSubtitleSnapshot,
-                   SubtitleTrackIdSpace.isSidecar(selectedSubtitleSnapshot) {
-                    self.pendingSidecarSubtitleTrackId = selectedSubtitleSnapshot
+                if let restoredSidecarTrackId = Self.protocolV3RestoredSidecarTrackId(
+                    selectedSubtitleSnapshot,
+                    subtitleMode: prepared.protocolV3?.plan.subtitle.mode
+                ),
+                   SubtitleTrackIdSpace.isSidecar(restoredSidecarTrackId) {
+                    self.pendingSidecarSubtitleTrackId = restoredSidecarTrackId
                 }
                 self.pendingRecoveredSubtitleSelection = embeddedSubtitleSelectionSnapshot
                 self.hasExplicitSubtitleChoice = explicitSubtitleChoiceSnapshot
@@ -5703,6 +5921,96 @@ class PlayerViewModel {
         }.count
     }
 
+    static func protocolV3RestoredSidecarTrackId(
+        _ snapshot: Int64?,
+        subtitleMode: String?
+    ) -> Int64? {
+        subtitleMode == "render" ? snapshot : nil
+    }
+
+    enum ProtocolV3SidecarRestoreIntent: Equatable {
+        case renderLocally(Int64)
+        case serverRendered(Int64)
+    }
+
+    static func protocolV3SidecarRestoreIntent(
+        snapshot: Int64?,
+        selectedSubtitleIndex: Int?,
+        subtitleMode: String?
+    ) -> ProtocolV3SidecarRestoreIntent? {
+        guard let snapshot,
+              SubtitleTrackIdSpace.isSidecar(snapshot),
+              SubtitleTrackIdSpace.sidecarIndex(from: snapshot) == selectedSubtitleIndex else {
+            return nil
+        }
+        switch subtitleMode {
+        case "render":
+            return .renderLocally(snapshot)
+        case "burn_in":
+            return .serverRendered(snapshot)
+        default:
+            return nil
+        }
+    }
+
+    static func isCurrentStreamCallback(
+        _ callbackGeneration: UInt64,
+        currentGeneration: UInt64
+    ) -> Bool {
+        callbackGeneration == currentGeneration
+    }
+
+    static func isUnexpectedBackwardPlaybackTime(
+        _ candidate: Double,
+        currentTime: Double,
+        explicitSeekInFlight: Bool
+    ) -> Bool {
+        guard !explicitSeekInFlight,
+              candidate.isFinite,
+              currentTime.isFinite else {
+            return false
+        }
+        return candidate + 0.75 < currentTime
+    }
+
+    struct ProtocolV3PendingTrackIntent: Equatable {
+        let audioIndex: Int?
+        let embeddedSubtitleIndex: Int?
+        let sidecarSubtitleTrackId: Int64?
+    }
+
+    static func protocolV3PendingTrackIntent(
+        plan: PlaybackV3Plan,
+        request: LoadRequest
+    ) -> ProtocolV3PendingTrackIntent {
+        let rendersSubtitleLocally = plan.subtitle.mode == "render"
+        return ProtocolV3PendingTrackIntent(
+            audioIndex: request.preferredAudioTrackIndex,
+            embeddedSubtitleIndex: rendersSubtitleLocally
+                ? request.preferredSubtitleTrackIndex
+                : -1,
+            sidecarSubtitleTrackId: rendersSubtitleLocally
+                ? request.preferredSidecarSubtitleTrackId
+                : nil
+        )
+    }
+
+    static func protocolV3SubtitleUrlsForCurrentRoute(
+        _ urls: [SubtitleUrl],
+        routeUsesEmbeddedExtraction: Bool,
+        selectedSubtitleIndex: Int?,
+        subtitleMode: String?
+    ) -> [SubtitleUrl] {
+        guard routeUsesEmbeddedExtraction else { return urls }
+        let selectedRenderedSidecarIndex = subtitleMode == "render"
+            ? selectedSubtitleIndex
+            : nil
+        return urls.filter { subtitle in
+            subtitle.source?.localizedCaseInsensitiveCompare("embedded") != .orderedSame
+                || subtitle.index == selectedRenderedSidecarIndex
+        }
+    }
+
     /// Completion handoff for a finished AI subtitle job: register the
     /// controller-synthesized descriptor through the **same** sidecar path the
     /// playback session uses, then auto-select it.
@@ -6104,6 +6412,7 @@ class PlayerViewModel {
         pendingRecoveredAudioSelection = nil
         pendingRecoveredSubtitleSelection = nil
         pendingRecoveredSecondarySubtitleId = nil
+        pendingServerRenderedSubtitleTrackId = nil
         noticeDismissTask?.cancel()
         noticeDismissTask = nil
         remoteDismissTask?.cancel()
@@ -6891,16 +7200,29 @@ class PlayerViewModel {
         let tracks = normalizedLoopbackAudioTracks(for: version)
         let selectedTrack = tracks.first(where: { $0.srcId == selectedAudioTrackIndex })
             ?? resolveLoopbackSelectedAudioTrack(from: tracks)
-        guard let selectedTrack,
-              let selectedTrackIndex = selectedTrack.srcId ?? selectedAudioTrackIndex else {
-            Self.logger.error(
-                "[CMP-ROUTE] loopback session missing resolved audio track videoMode=\(videoMode.logToken, privacy: .public)"
+        let selectedAudio: LoopbackSessionSpec.SelectedAudio
+        if tracks.isEmpty {
+            selectedAudio = .none
+        } else {
+            guard let selectedTrack,
+                  let selectedTrackIndex = selectedTrack.srcId ?? selectedAudioTrackIndex else {
+                Self.logger.error(
+                    "[CMP-ROUTE] loopback session missing resolved audio track videoMode=\(videoMode.logToken, privacy: .public)"
+                )
+                return nil
+            }
+            let outputMode = loopbackAudioOutputMode(for: selectedTrack)
+            let preservesAtmos = outputMode == .copy && loopbackAudioPreservesAtmos(for: selectedTrack)
+            selectedAudio = LoopbackSessionSpec.SelectedAudio(
+                trackIndex: selectedTrackIndex,
+                ffIndex: selectedTrack.ffIndex,
+                sourceCodec: selectedTrack.codec,
+                sourceChannelCount: selectedTrack.audioChannelCount,
+                sourceChannelLayout: selectedTrack.audioChannelsLayout,
+                outputMode: outputMode,
+                preservesAtmos: preservesAtmos
             )
-            return nil
         }
-
-        let outputMode = loopbackAudioOutputMode(for: selectedTrack)
-        let preservesAtmos = outputMode == .copy && loopbackAudioPreservesAtmos(for: selectedTrack)
         let advertisedProfile: Int? = switch videoMode {
         case .passthroughProfile5:
             5
@@ -6935,21 +7257,13 @@ class PlayerViewModel {
             sourceBitrateBps: version.bitrate.map { Double($0) * 1_000 },
             videoMode: videoMode,
             sourceVideoFrameRate: loopbackSourceFrameRate(for: version),
-            selectedAudio: LoopbackSessionSpec.SelectedAudio(
-                trackIndex: selectedTrackIndex,
-                ffIndex: selectedTrack.ffIndex,
-                sourceCodec: selectedTrack.codec,
-                sourceChannelCount: selectedTrack.audioChannelCount,
-                sourceChannelLayout: selectedTrack.audioChannelsLayout,
-                outputMode: outputMode,
-                preservesAtmos: preservesAtmos
-            ),
+            selectedAudio: selectedAudio,
             availableAudioTracks: tracks,
             manifestMetadata: LoopbackSessionSpec.ManifestMetadata(
                 advertisedDolbyVisionProfile: advertisedProfile,
                 compatibilityBrand: compatibilityBrand,
                 videoRange: videoRange,
-                mayClaimAtmos: preservesAtmos
+                mayClaimAtmos: selectedAudio.preservesAtmos
             ),
             servingMode: .gated
         )
@@ -7094,11 +7408,10 @@ class PlayerViewModel {
             : pendingExternalSubtitles
         let pending = subtitleUrlsForCurrentRoute(allPending)
         pendingExternalSubtitles = []
-        guard !pending.isEmpty else {
+        if pending.isEmpty {
             Self.logger.info(
                 "[CMP-SUB] no external subtitles to register route=\(self.activeRouteKind.label, privacy: .public) currentTracks=\(self.subtitleTracks.count, privacy: .public)"
             )
-            return
         }
 
         Self.logger.info(
@@ -7119,12 +7432,16 @@ class PlayerViewModel {
                 label: sub.label,
                 source: sub.source,
                 forced: sub.forced,
+                isDefault: sub.default,
+                isHearingImpaired: sub.hearingImpaired,
+                fontBundleUrl: sub.fontBundleUrl.flatMap {
+                    resolveServerUrl($0, serverUrl: resolvedServerUrl)
+                },
                 url: url
             ))
         }
-        guard !descriptors.isEmpty else {
+        if !pending.isEmpty, descriptors.isEmpty {
             Self.logger.warning("[CMP-SUB] no external subtitle descriptors survived URL resolution")
-            return
         }
         if backendCapabilities.supportsExternalPrimarySubtitles {
             Self.logger.info(
@@ -7146,10 +7463,12 @@ class PlayerViewModel {
     }
 
     private func subtitleUrlsForCurrentRoute(_ urls: [SubtitleUrl]) -> [SubtitleUrl] {
-        guard activeRouteUsesEmbeddedAVPlayerSubtitleExtraction else { return urls }
-        let filtered = urls.filter { subtitle in
-            subtitle.source?.localizedCaseInsensitiveCompare("embedded") != .orderedSame
-        }
+        let filtered = Self.protocolV3SubtitleUrlsForCurrentRoute(
+            urls,
+            routeUsesEmbeddedExtraction: activeRouteUsesEmbeddedAVPlayerSubtitleExtraction,
+            selectedSubtitleIndex: activePreparedProtocolV3?.plan.selectedTracks.subtitle?.index,
+            subtitleMode: activePreparedProtocolV3?.plan.subtitle.mode
+        )
         if filtered.count != urls.count {
             Self.logger.info(
                 "[CMP-SUB] skipped embedded sidecar subtitle urls count=\(urls.count - filtered.count, privacy: .public) route=\(self.activeRouteKind.label, privacy: .public)"
@@ -7361,6 +7680,20 @@ class PlayerViewModel {
         var existingEmbedded = subtitleTracks.filter { track in
             !SubtitleTrackIdSpace.isSidecar(track.trackId)
         }
+        if let version = currentSelectedVersion {
+            let shadowedEmbeddedFFmpegIndices: Set<Int> = Set(descriptors.compactMap { descriptor in
+                guard descriptor.source?.caseInsensitiveCompare("embedded") == .orderedSame else {
+                    return nil
+                }
+                return ApplePlaybackV3PlanAdapter.ffmpegSubtitleStreamIndex(
+                    serverCombinedIndex: descriptor.index,
+                    in: version
+                )
+            })
+            existingEmbedded.removeAll { track in
+                track.ffIndex.map { shadowedEmbeddedFFmpegIndices.contains($0) } == true
+            }
+        }
         for d in descriptors {
             let trackId = SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: d.index)
             existingEmbedded.append(PlayerTrack(
@@ -7372,9 +7705,9 @@ class PlayerViewModel {
                 audioChannelsLayout: nil,
                 audioChannelCount: nil,
                 bitrate: nil,
-                isDefault: false,
+                isDefault: d.isDefault ?? false,
                 isForced: d.forced ?? false,
-                isHearingImpaired: false,
+                isHearingImpaired: d.isHearingImpaired ?? false,
                 isVisualImpaired: false,
                 isExternal: true,
                 isSelected: false,
@@ -7400,6 +7733,13 @@ class PlayerViewModel {
                 // safe to drop the synthetic live row + libass track with no
                 // no-subtitle flicker. (No-op unless a deferred close is armed.)
                 performDeferredLiveSubtitleCloseIfNeeded()
+            }
+        }
+        if let pendingTrackId = pendingServerRenderedSubtitleTrackId {
+            pendingServerRenderedSubtitleTrackId = nil
+            if subtitleTracks.contains(where: { $0.trackId == pendingTrackId }) {
+                restoredPrimarySidecar = true
+                selectedSubtitleId = pendingTrackId
             }
         }
 
@@ -7468,12 +7808,13 @@ class PlayerViewModel {
         audioTracks = tracks.filter { $0.kind == .audio }
         let shadowedEmbeddedFFmpegIndices: Set<Int> = {
             guard let version = currentSelectedVersion else { return [] }
-            return Set(knownExternalSubtitles.compactMap { subtitle in
-                guard subtitle.source?.caseInsensitiveCompare("embedded") == .orderedSame else {
+            return Set(subtitleTracks.compactMap { track in
+                guard SubtitleTrackIdSpace.isSidecar(track.trackId),
+                      let combinedIndex = track.srcId else {
                     return nil
                 }
                 return ApplePlaybackV3PlanAdapter.ffmpegSubtitleStreamIndex(
-                    serverCombinedIndex: subtitle.index,
+                    serverCombinedIndex: combinedIndex,
                     in: version
                 )
             })
@@ -7706,7 +8047,9 @@ class PlayerViewModel {
     /// would make selected_tracks and later recovery disagree with the UI.
     private func replanAutomaticProtocolV3SubtitleSelection(_ track: PlayerTrack?) -> Bool {
         guard let activePreparedProtocolV3,
-              let version = currentSelectedVersion else {
+              let version = currentSelectedVersion,
+              protocolV3ReplanTask == nil,
+              currentWatchDetail != nil else {
             return false
         }
         let combinedIndex = track.flatMap {

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -1240,13 +1240,24 @@ class PlayerViewModel {
             queue: .main
         ) { [weak self] _ in
             guard let self,
-                  self.activePreparedProtocolV3 != nil,
+                  let activeProtocolV3 = self.activePreparedProtocolV3,
                   !self.isDisposed,
                   !self.isLoading else { return }
+            let observedSnapshot = ApplePlaybackV3Capabilities.snapshot()
+            guard PlaybackSessionBridge.isMaterialOutputRouteChange(
+                activeOutputContextId: activeProtocolV3.outputContextId,
+                observedOutputContextId: observedSnapshot.outputContextId
+            ) else {
+                Self.logger.debug(
+                    "Ignoring AVAudioSession route notification with unchanged Playback V3 output context"
+                )
+                return
+            }
             self.attemptProtocolV3Replan(
                 position: self.currentTime,
                 classification: "output_route_changed",
-                message: "The Apple audio output route changed."
+                message: "The Apple audio output route changed.",
+                outputRouteSnapshot: observedSnapshot
             )
         }
         #endif
@@ -1752,7 +1763,8 @@ class PlayerViewModel {
         message: String,
         operation: String? = nil,
         qualityPreference: String? = nil,
-        completesQualitySwitch: Bool = false
+        completesQualitySwitch: Bool = false,
+        outputRouteSnapshot: ApplePlaybackV3CapabilitySnapshot? = nil
     ) {
         guard protocolV3ReplanTask == nil,
               let watchDetail = currentWatchDetail else {
@@ -1779,7 +1791,8 @@ class PlayerViewModel {
                     operation: operation,
                     qualityPreference: qualityPreference,
                     audioTrackIndex: self.resolvedAudioTrackIndexForResume(),
-                    subtitleTrackIndex: self.resolvedProtocolV3SubtitleIndexForResume()
+                    subtitleTrackIndex: self.resolvedProtocolV3SubtitleIndexForResume(),
+                    outputRouteSnapshot: outputRouteSnapshot
                 ) else {
                     self.finalizeTerminalPlaybackError(message)
                     return
@@ -1836,7 +1849,7 @@ class PlayerViewModel {
                 self.playbackTimelineOffset = prepared.session.timelineOffsetSeconds
                 self.logExecutionPlan(plan)
                 await self.sessionBridge.reportProtocolV3PlanExecutionStarted()
-                await self.loadStream(plan: plan)
+                await self.loadStream(plan: plan, reusingActiveEngine: true)
             } catch is CancellationError {
                 return
             } catch {
@@ -2560,15 +2573,22 @@ class PlayerViewModel {
         cmpLog(message)
     }
 
-    private func loadStream(plan: PlaybackExecutionPlan) async {
+    private func loadStream(
+        plan: PlaybackExecutionPlan,
+        reusingActiveEngine: Bool = false
+    ) async {
         streamLoadGeneration &+= 1
         let loadGeneration = streamLoadGeneration
-        activePlayer.dispose()
-        activePlayer = .none
-        // Re-arm the authoritative V3 intent after disposing the old player.
-        // A final track callback from that player may have consumed the first
-        // copy between replan adoption and this teardown; generation-gated
-        // callbacks cannot consume this post-teardown copy.
+        // Stop presentation while the replacement proxy is prepared, but
+        // retain the engine. If the implementation route is unchanged,
+        // PlaybackCoordinator will reload that backend in place so tvOS can
+        // preserve identical display criteria and the active audio session.
+        // The loading indicator remains over the outgoing surface meanwhile.
+        activePlayer.pause()
+        // Re-arm the authoritative V3 intent after invalidating the old
+        // callback generation. A final track callback from that player may
+        // have consumed the first copy between replan adoption and this
+        // point; generation-gated callbacks cannot consume this copy.
         rearmAdoptedProtocolV3TrackIntent()
         stashSourceCacheHandoff()
         sourceProxy?.stop()
@@ -2597,7 +2617,23 @@ class PlayerViewModel {
         sourceProxyFileId = prepared.proxy != nil ? currentSelectedVersion?.fileId : nil
         let loadPlan = prepared.plan
         activeExecutionPlan = loadPlan
-        installPlayer(for: loadPlan.engine)
+        // Only a live protocol replan has a known-good outgoing engine to
+        // preserve. Fresh loads and recovery paths may have disposed their
+        // ActivePlayer while the coordinator still owns the wrapper, so they
+        // must install a new implementation even when the route kind matches.
+        let installed = reusingActiveEngine && !activePlayer.isNone
+            ? playbackCoordinator.prepareEngine(for: loadPlan.engine)
+            : playbackCoordinator.installEngine(for: loadPlan.engine)
+        activePlayer = ActivePlayer(renderTarget: installed.renderTarget)
+        activeRouteKind = loadPlan.engine
+        if let core = activePlayer.core {
+            configurePrimaryCore(core)
+        }
+        if let backend = activePlayer.avBackend {
+            applyCallbacks(makeCallbacks(), to: backend)
+            wireSubtitleCallbacks(to: backend)
+            backend.setServerChapters(serverProvidedChapters)
+        }
         let startTime = loadPlan.startMode.seconds
         let backendTimelineOffset = avPlayerTimelineOffset(for: loadPlan, startTime: startTime)
         if loadPlan.engine == .siloPlayerLoopback {

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -5506,11 +5506,14 @@ class PlayerViewModel {
     /// the controller treats `nil` as a soft failure so the user isn't left on
     /// a dismissed menu with no track.
     ///
-    /// `baseTrackCount` mirrors Android's `SubtitleTrackMerge` `baseIndex`:
-    /// `(max combined index over the session's non-downloaded subtitle_urls) + 1`
-    /// — computed `+1` over the max, not the count, so server-side burn-in
-    /// skipping (which can leave index gaps) is honored and the synthesized
-    /// stream URL still resolves on the combined-index stream mount.
+    /// `baseTrackCount` is the combined ordinal the **first** downloaded track
+    /// occupies. The V3 plan's subtitle inventory is the authoritative track
+    /// list — it publishes every track, including burn-in-only bitmap streams
+    /// that carry no fetchable URL, over one dense ordinal space ordered
+    /// externals → embedded → downloaded. So the first downloaded ordinal is
+    /// exactly the number of non-downloaded inventory entries. Never derive
+    /// this by counting or max-ing the delivered sidecar URLs: those omit
+    /// burn-in-only tracks and would address the wrong track.
     @MainActor
     private func makeSubtitleHandoffContext() -> SubtitleAIController.HandoffContext? {
         guard backendCapabilities.supportsExternalPrimarySubtitles else {
@@ -5524,26 +5527,13 @@ class PlayerViewModel {
             return nil
         }
         let serverUrl = resolvedServerUrl
-        // KNOWN LIMITATION (intentionally inherited from Android's
-        // `SubtitleTrackMerge`; do NOT "fix" Apple-side — no purely-client fix is
-        // correct). The server's `buildSubtitleURLs` (`playback.go:1503`) OMITS
-        // non-PGS burn-in subtitle tracks from `subtitle_urls`, yet still counts
-        // them in the downloaded combined-index offset (`downloadedOffset` at
-        // `playback.go:1520`, served by the combined-index stream mount in
-        // `stream.go:244`). So `max(visible index) + 1` here UNDERCOUNTS whenever
-        // the LAST embedded track is a non-PGS bitmap sub: the synthesized stream
-        // URL then targets the wrong combined index and the live→persisted handoff
-        // SOFT-FAILS. This is graceful — the job already completed server-side, and
-        // a fresh playback session re-indexes the persisted track correctly. The
-        // robust fix is cross-repo: have the server carry the combined index (or a
-        // ready-to-use stream URL) in `subtitle_translation_completed` /
-        // `subtitle_ready` so the client never has to reconstruct it.
-        let baseTrackCount = (
-            knownExternalSubtitles
-                .filter { ($0.source ?? "").caseInsensitiveCompare("downloaded") != .orderedSame }
-                .map(\.index)
-                .max() ?? -1
-        ) + 1
+        guard let inventory = activePreparedProtocolV3?.plan.subtitle.inventory, !inventory.isEmpty else {
+            Self.logger.warning("[AI-SUB] no V3 subtitle inventory for subtitle handoff")
+            return nil
+        }
+        let baseTrackCount = inventory
+            .filter { $0.source.caseInsensitiveCompare("downloaded") != .orderedSame }
+            .count
         return SubtitleAIController.HandoffContext(
             sessionId: sessionId,
             baseTrackCount: baseTrackCount,

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -1031,7 +1031,10 @@ class PlayerViewModel {
                 plan.subtitle.inventory.first(where: { $0.combinedIndex == selectedIndex })
             }
             let embeddedFFmpegIndex: Int? = selectedSubtitle.flatMap { item in
-                guard item.source == "embedded" else { return nil }
+                // A sidecar is the server-selected artifact even when it was
+                // extracted from an embedded stream. Arming both identities
+                // would publish and select the same subtitle twice.
+                guard item.source == "embedded", item.delivery != "sidecar" else { return nil }
                 return ApplePlaybackV3PlanAdapter.ffmpegSubtitleStreamIndex(
                     serverCombinedIndex: item.combinedIndex,
                     in: selectedVersion
@@ -1607,7 +1610,7 @@ class PlayerViewModel {
         position: Double,
         classification: String,
         message: String,
-        operation: String = "failure_recovery",
+        operation: String? = nil,
         qualityPreference: String? = nil,
         completesQualitySwitch: Bool = false
     ) {
@@ -3169,6 +3172,7 @@ class PlayerViewModel {
         preferredAudioTrackIndex: Int?,
         preferredSubtitleTrackIndex: Int?,
         preferredSidecarSubtitleTrackId: Int64?,
+        preferredProtocolV3SubtitleIndex: Int? = nil,
         resetRouteRecoveryFlags: Bool = true
     ) {
         isLoading = true
@@ -3242,7 +3246,9 @@ class PlayerViewModel {
         pendingSubtitleFfIndex = preferredSubtitleTrackIndex
         pendingSidecarSubtitleTrackId = preferredSidecarSubtitleTrackId
         hasExplicitSubtitleChoice =
-            preferredSubtitleTrackIndex != nil || preferredSidecarSubtitleTrackId != nil
+            preferredSubtitleTrackIndex != nil
+            || preferredSidecarSubtitleTrackId != nil
+            || preferredProtocolV3SubtitleIndex != nil
         prefsForCurrentItem = nil
         prefsResolvedForCurrentItem = false
     }
@@ -3318,9 +3324,13 @@ class PlayerViewModel {
         pendingSidecarSubtitleTrackId = rendersSubtitleLocally
             ? adopted.preferredSidecarSubtitleTrackId
             : nil
-        hasExplicitSubtitleChoice = true
-        prefsForCurrentItem = nil
-        prefsResolvedForCurrentItem = true
+        // Adopting an authoritative server plan does not convert an automatic
+        // system/server policy into a user choice. Manual choices stay latched;
+        // automatic choices remain eligible for later policy changes.
+        if hasExplicitSubtitleChoice {
+            prefsForCurrentItem = nil
+            prefsResolvedForCurrentItem = true
+        }
     }
 
     private func makeSuspendedPlaybackContext() -> SuspendedPlaybackContext? {
@@ -3378,7 +3388,8 @@ class PlayerViewModel {
         resetPublishedLoadState(
             preferredAudioTrackIndex: request.preferredAudioTrackIndex,
             preferredSubtitleTrackIndex: request.preferredSubtitleTrackIndex,
-            preferredSidecarSubtitleTrackId: request.preferredSidecarSubtitleTrackId
+            preferredSidecarSubtitleTrackId: request.preferredSidecarSubtitleTrackId,
+            preferredProtocolV3SubtitleIndex: request.preferredProtocolV3SubtitleIndex
         )
 
         freshLoadTask?.cancel()
@@ -3601,6 +3612,22 @@ class PlayerViewModel {
         allowNearEndResume: Bool,
         timeout: TimeInterval?
     ) async throws -> PreparedPlayback {
+        let initialSubtitlePreferences: PlaybackSessionBridge.InitialProtocolV3SubtitlePreferences? = {
+            guard settings.subtitleMatchesSystemAppearance, !hasExplicitSubtitleChoice else {
+                return nil
+            }
+            let preferences = systemCaptionPrefsSnapshot()
+            return PlaybackSessionBridge.InitialProtocolV3SubtitlePreferences(
+                preferredLanguage: preferences.preferredLanguage,
+                additionalPreferredLanguages: preferences.additionalPreferredLanguages,
+                mode: preferences.mode,
+                showForced: preferences.showForced,
+                forcedOnly: preferences.forcedOnly,
+                preferAccessibilityTracks: preferences.preferAccessibilityTracks,
+                disableWhenNoLanguageMatch: preferences.disableWhenNoLanguageMatch,
+                trackSignature: preferences.trackSignature
+            )
+        }()
         if let timeout {
             let startTask = Task<PreparedPlayback, Error> { [sessionBridge] in
                 try await sessionBridge.startSession(
@@ -3609,6 +3636,7 @@ class PlayerViewModel {
                     preferredAudioTrackIndex: request.preferredAudioTrackIndex,
                     preferredSubtitleTrackIndex: request.preferredSubtitleTrackIndex,
                     preferredProtocolV3SubtitleIndex: request.preferredProtocolV3SubtitleIndex,
+                    initialSubtitlePreferences: initialSubtitlePreferences,
                     startFromBeginning: request.startFromBeginning,
                     resumePosition: resumePosition,
                     allowNearEndResume: allowNearEndResume,
@@ -3636,6 +3664,7 @@ class PlayerViewModel {
                 preferredAudioTrackIndex: request.preferredAudioTrackIndex,
                 preferredSubtitleTrackIndex: request.preferredSubtitleTrackIndex,
                 preferredProtocolV3SubtitleIndex: request.preferredProtocolV3SubtitleIndex,
+                initialSubtitlePreferences: initialSubtitlePreferences,
                 startFromBeginning: request.startFromBeginning,
                 resumePosition: resumePosition,
                 allowNearEndResume: allowNearEndResume,
@@ -4341,7 +4370,9 @@ class PlayerViewModel {
     func switchQuality(_ qualityId: String) {
         guard !isBackgroundSuspended else { return }
         guard let plan = activeExecutionPlan else { return }
-        let normalized = ApplePlaybackQuality.normalizeStoredId(qualityId)
+        let normalized = activePreparedProtocolV3 == nil
+            ? ApplePlaybackQuality.normalizeStoredId(qualityId)
+            : ApplePlaybackQuality.protocolV3QualityId(qualityId)
         let resolvedQualityId = normalized
 
         guard resolvedQualityId != activeQualityId || qualitySwitchError != nil else { return }
@@ -4866,11 +4897,6 @@ class PlayerViewModel {
             "[CMP-SEEK] server-backed HLS reload seek delivery=\(plan.delivery.name, privacy: .public) target=\(clampedTarget, privacy: .public) origin=\(origin, privacy: .public) offset=\(self.playbackTimelineOffset, privacy: .public)"
         )
 
-        if plan.delivery == .transcode,
-           restartCurrentTranscodeHLSForSeek(to: clampedTarget, origin: origin) {
-            return true
-        }
-
         let seekRequest = lastLoadRequest.copyForRecovery(
             preferredFileId: lastLoadRequest.preferredFileId,
             preferredAudioTrackIndex: lastLoadRequest.preferredAudioTrackIndex,
@@ -4945,15 +4971,6 @@ class PlayerViewModel {
             await self?.loadStream(plan: updatedPlan)
         }
         return true
-    }
-
-    private func restartCurrentTranscodeHLSForSeek(to target: Double, origin: Double) -> Bool {
-        return restartCurrentTranscodeHLS(
-            to: target,
-            origin: origin,
-            qualityId: activeQualityId,
-            source: "seek"
-        )
     }
 
     private func restartCurrentTranscodeHLS(
@@ -5659,18 +5676,24 @@ class PlayerViewModel {
             return nil
         }
         let serverUrl = resolvedServerUrl
-        guard let inventory = activePreparedProtocolV3?.plan.subtitle.inventory, !inventory.isEmpty else {
+        guard let inventory = activePreparedProtocolV3?.plan.subtitle.inventory else {
             Self.logger.warning("[AI-SUB] no V3 subtitle inventory for subtitle handoff")
             return nil
         }
-        let baseTrackCount = inventory
-            .filter { $0.source.caseInsensitiveCompare("downloaded") != .orderedSame }
-            .count
+        let baseTrackCount = Self.protocolV3DownloadedSubtitleBaseTrackCount(inventory)
         return SubtitleAIController.HandoffContext(
             sessionId: sessionId,
             baseTrackCount: baseTrackCount,
             resolveURL: { [weak self] path in self?.resolveServerUrl(path, serverUrl: serverUrl) }
         )
+    }
+
+    static func protocolV3DownloadedSubtitleBaseTrackCount(
+        _ inventory: [PlaybackV3SubtitleInventoryItem]
+    ) -> Int {
+        inventory.filter {
+            $0.source.caseInsensitiveCompare("downloaded") != .orderedSame
+        }.count
     }
 
     /// Completion handoff for a finished AI subtitle job: register the
@@ -7436,7 +7459,23 @@ class PlayerViewModel {
     /// `onSidecarTracksRegistered` are layered in separately.
     private func applyTrackList(_ tracks: [PlayerTrack]) {
         audioTracks = tracks.filter { $0.kind == .audio }
-        let embeddedSubs = tracks.filter { $0.kind == .sub }
+        let shadowedEmbeddedFFmpegIndices: Set<Int> = {
+            guard let version = currentSelectedVersion else { return [] }
+            return Set(knownExternalSubtitles.compactMap { subtitle in
+                guard subtitle.source?.caseInsensitiveCompare("embedded") == .orderedSame else {
+                    return nil
+                }
+                return ApplePlaybackV3PlanAdapter.ffmpegSubtitleStreamIndex(
+                    serverCombinedIndex: subtitle.index,
+                    in: version
+                )
+            })
+        }()
+        let embeddedSubs = tracks.filter { track in
+            guard track.kind == .sub else { return false }
+            guard let ffIndex = track.ffIndex else { return true }
+            return !shadowedEmbeddedFFmpegIndices.contains(ffIndex)
+        }
         // Preserve separately-layered subtitle rows that `onTracksChange`
         // does not enumerate: server sidecars (from
         // `onSidecarTracksRegistered`) and synthetic live AI tracks (from
@@ -7543,6 +7582,10 @@ class PlayerViewModel {
         }
 
         let allSubs = subtitleTracks
+        guard !allSubs.isEmpty else {
+            prefsResolvedForCurrentItem = false
+            return
+        }
 
         let audioLang = audioTracks
             .first(where: { $0.trackId == selectedAudioId })?
@@ -7637,16 +7680,43 @@ class PlayerViewModel {
         case .noChange:
             return
         case .disable:
+            if replanAutomaticProtocolV3SubtitleSelection(nil) { return }
             if selectedSubtitleId != nil {
                 selectedSubtitleId = nil
                 applySubtitleTrackSelection(nil)
             }
         case .select(let track):
+            if replanAutomaticProtocolV3SubtitleSelection(track) { return }
             if selectedSubtitleId != track.trackId {
                 selectedSubtitleId = track.trackId
                 applySubtitleTrackSelection(track.trackId)
             }
         }
+    }
+
+    /// System/server caption policy changes are protocol intent on V3. The
+    /// server must mint the replacement plan; mutating only the local player
+    /// would make selected_tracks and later recovery disagree with the UI.
+    private func replanAutomaticProtocolV3SubtitleSelection(_ track: PlayerTrack?) -> Bool {
+        guard let activePreparedProtocolV3,
+              let version = currentSelectedVersion else {
+            return false
+        }
+        let combinedIndex = track.flatMap {
+            ApplePlaybackV3PlanAdapter.serverCombinedSubtitleIndex(for: $0, in: version)
+        }
+        guard combinedIndex != activePreparedProtocolV3.plan.selectedTracks.subtitle?.index else {
+            return false
+        }
+
+        selectedSubtitleId = track?.trackId
+        lastLoadRequest?.preferredProtocolV3SubtitleIndex = combinedIndex
+        attemptProtocolV3Replan(
+            position: currentTime,
+            classification: "subtitle_track_changed",
+            message: "Automatic caption policy selected a different subtitle track."
+        )
+        return true
     }
 
     private func startProgressReporting() {

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3Capabilities.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3Capabilities.swift
@@ -98,7 +98,10 @@ enum ApplePlaybackV3Capabilities {
             sidecarText: true,
             assStyling: true,
             embeddedBitmap: true,
-            sidecarBitmap: true,
+            // SidecarSubtitleFetcher intentionally accepts text payloads only;
+            // bitmap subtitles are supported when embedded in the original
+            // source and decoded by the loopback extractor, not as sidecars.
+            sidecarBitmap: false,
             fontAttachments: true
         )
         let avPlayerSubtitles = PlaybackV3DeliverySubtitleCapabilities(
@@ -276,7 +279,7 @@ enum ApplePlaybackV3Capabilities {
         sinkType = outputs.map { $0.portType.rawValue }.sorted().joined(separator: ",")
         #endif
         let hdrIdentity = hdrDetails.map {
-            "\($0.hdr10)|\($0.hdr10Plus)|\($0.hlg)|\($0.dolbyVisionProfiles.map(String.init).joined(separator: ","))"
+            "\($0.hdr10)|\($0.hdr10Plus)|\($0.hlg)|\($0.dolbyVisionProfiles.map { String($0) }.joined(separator: ","))"
         } ?? "unknown"
         let identity = [platformName, formFactor, sink, sinkType, hdrIdentity].joined(separator: "|")
         return PlaybackV3OutputContext(

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3Capabilities.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3Capabilities.swift
@@ -1,4 +1,6 @@
 import AVFoundation
+import CoreMedia
+import CryptoKit
 import Foundation
 import VideoToolbox
 
@@ -6,13 +8,18 @@ struct ApplePlaybackV3CapabilitySnapshot: Equatable {
     let capabilities: PlaybackV3CodecCapabilities
     let context: PlaybackV3ClientContext
 
-    var outputRouteGeneration: Int64 { context.output.outputRouteGeneration }
+    var outputContextId: String? { context.output.outputContextId }
 }
 
 enum ApplePlaybackV3Capabilities {
+    /// Features this client understands, advertised on every request.
+    ///
+    /// `layout_aware_passthrough` is deliberately absent: the server grants a
+    /// validated passthrough claim only to a client that enumerates real sink
+    /// channel layouts at `exact` audio evidence, and Apple attests neither.
+    /// Advertising it would be a claim we cannot back.
     static let features = [
         PlaybackProtocolV3.planFeature,
-        PlaybackProtocolV3.detailedDecodeFeature,
         PlaybackProtocolV3.clientTransformFeature,
         PlaybackProtocolV3.routeDiagnosticsFeature,
         PlaybackProtocolV3.deviceQuirksFeature,
@@ -20,49 +27,48 @@ enum ApplePlaybackV3Capabilities {
         PlaybackProtocolV3.directStreamResumeFeature
     ]
 
+    /// Video codecs the Apple playback stack decodes on a direct route. This
+    /// mirrors `ApplePlaybackRoutePlanner`'s native-direct and loopback
+    /// allowlists rather than the wider set FFmpeg can demux: a codec claimed
+    /// here is one the server may hand us untranscoded.
+    private static let directVideoCodecs = ["h264", "hevc"]
+
     static func snapshot() -> ApplePlaybackV3CapabilitySnapshot {
         let output = outputSnapshot()
         let isSimulator = AppleDecodeCapabilities.isSimulator
+        let videoDecode = videoDecodeAttestation()
+        let videoCodecs = videoDecode.map(\.codec)
+        let hardwareVideoCodecs = videoDecode.filter(\.hardware).map(\.codec)
 
-        // This snapshot describes every route the plan can land on, including
-        // the software decoder, so it claims MPEG-2.
-        let videoCodecs = AppleDecodeCapabilities.videoCodecs(includingMPEG2: true)
-        let hardwareVideoCodecs = AppleDecodeCapabilities.hardwareVideoCodecs
+        // Audio is decoded by the bundled FFmpeg demuxer on the loopback route,
+        // so the flat list is wider than what AVPlayer alone accepts. The
+        // narrower per-delivery lists below carry that distinction.
         let audioCodecs = AppleDecodeCapabilities.audioCodecs
         let containers = AppleDecodeCapabilities.containers
-        let maxWidth = AppleDecodeCapabilities.maxDecodeWidth
-        let maxHeight = AppleDecodeCapabilities.maxDecodeHeight
+        let hdr = output.hdrDetails.map { $0.hdr10 || $0.hlg || !$0.dolbyVisionProfiles.isEmpty } ?? false
 
         let capabilities = PlaybackV3CodecCapabilities(
+            // VideoToolbox attests that a codec family is hardware-decodable;
+            // it cannot enumerate the profiles and levels a decoder accepts.
+            // The server skips profile/level matching at this tier and still
+            // applies every bound we do supply.
+            videoEvidence: PlaybackProtocolV3.Evidence.platformAttested,
+            audioEvidence: PlaybackProtocolV3.Evidence.platformAttested,
             codecsVideo: videoCodecs,
             codecsVideoHardware: hardwareVideoCodecs,
             codecsAudio: audioCodecs,
             containers: containers,
             maxResolution: AppleDecodeCapabilities.maxResolutionToken,
-            hdr: output.hdrDetails?.claimsAnyHDR ?? false,
+            hdr: hdr,
             hdrDetails: output.hdrDetails,
+            // No passthrough entries: Apple routes audio through the system
+            // mixer and cannot enumerate a receiver's per-codec channel
+            // layouts, so there is nothing here the server could validate.
             audioPassthrough: output.audioPassthrough,
-            videoDecode: videoCodecs.map { codec in
-                let hardware = hardwareVideoCodecs.contains(codec)
-                return PlaybackV3VideoDecodeCapability(
-                    codec: codec,
-                    // MPEG-2 is the one claimed codec PlayerCore routes to the
-                    // FFmpeg decoder (`videoDecodeMode = .software`); naming
-                    // VideoToolbox for it would contradict `hardware: false`.
-                    decoderName: hardware ? "VideoToolbox" : "FFmpeg",
-                    profiles: [],
-                    levels: [],
-                    bitDepths: codec == "hevc" ? [8, 10] : [8],
-                    maxWidth: maxWidth,
-                    maxHeight: maxHeight,
-                    maxFrameRate: 60,
-                    maxBitrateKbps: isSimulator ? 25_000 : 120_000,
-                    hardware: hardware
-                )
-            }
+            videoDecode: videoDecode
         )
 
-        let directTransformations: [PlaybackV3Transformation] = isSimulator ? [] : [
+        let clientTransformations: [PlaybackV3Transformation] = isSimulator ? [] : [
             PlaybackV3Transformation(
                 name: "client_dv7_to_dv81",
                 executor: "client",
@@ -85,7 +91,9 @@ enum ApplePlaybackV3Capabilities {
             )
         ]
 
-        let directSubtitles = PlaybackV3EngineSubtitleCapabilities(
+        // The loopback executor demuxes and renders subtitles itself; AVPlayer
+        // only carries what the stream already presents as a media selection.
+        let loopbackSubtitles = PlaybackV3DeliverySubtitleCapabilities(
             embeddedText: true,
             sidecarText: true,
             assStyling: true,
@@ -93,7 +101,7 @@ enum ApplePlaybackV3Capabilities {
             sidecarBitmap: true,
             fontAttachments: true
         )
-        let avPlayerSubtitles = PlaybackV3EngineSubtitleCapabilities(
+        let avPlayerSubtitles = PlaybackV3DeliverySubtitleCapabilities(
             embeddedText: true,
             sidecarText: true,
             assStyling: false,
@@ -103,11 +111,8 @@ enum ApplePlaybackV3Capabilities {
         )
         let commonClaims = ["apple_execution_plan_v1", "authenticated_stream_headers"]
 
-        // The protocol currently uses Media3 engine identifiers as wire-level
-        // route slots. They are compatibility aliases here: each is translated
-        // into a typed Apple PlaybackExecutionPlan before any player is loaded.
-        let engines = [
-            "media3_direct": PlaybackV3EngineCapability(
+        let deliveries = [
+            PlaybackProtocolV3.DeliveryClass.originalHTTP: PlaybackV3DeliveryCapability(
                 enabled: true,
                 supportedOnDevice: true,
                 failureReason: nil,
@@ -117,18 +122,18 @@ enum ApplePlaybackV3Capabilities {
                 audioPassthroughCodecs: [],
                 maxChannels: 8,
                 hdrDetails: output.hdrDetails,
-                subtitles: directSubtitles,
+                subtitles: loopbackSubtitles,
                 features: ["apple_native_direct", "apple_local_loopback", "apple_playercore"],
                 authHeaderRefresh: true,
                 validatedClaims: commonClaims + ["client_subtitle_overlay"],
-                transformations: directTransformations
+                transformations: clientTransformations
             ),
-            "media3_progressive_remux": PlaybackV3EngineCapability(
+            PlaybackProtocolV3.DeliveryClass.progressive: PlaybackV3DeliveryCapability(
                 enabled: true,
                 supportedOnDevice: true,
                 failureReason: nil,
                 containers: ["mp4", "mov", "m4v"],
-                videoCodecs: ["h264", "hevc"],
+                videoCodecs: videoCodecs,
                 audioDecodeCodecs: ["aac", "ac3", "eac3", "alac", "mp3"],
                 audioPassthroughCodecs: [],
                 maxChannels: 8,
@@ -139,12 +144,12 @@ enum ApplePlaybackV3Capabilities {
                 validatedClaims: commonClaims,
                 transformations: []
             ),
-            "media3_hls": PlaybackV3EngineCapability(
+            PlaybackProtocolV3.DeliveryClass.hls: PlaybackV3DeliveryCapability(
                 enabled: true,
                 supportedOnDevice: true,
                 failureReason: nil,
                 containers: ["hls", "mpegts", "fmp4", "mp4"],
-                videoCodecs: ["h264", "hevc"],
+                videoCodecs: videoCodecs,
                 audioDecodeCodecs: ["aac", "ac3", "eac3"],
                 audioPassthroughCodecs: [],
                 maxChannels: 8,
@@ -159,35 +164,80 @@ enum ApplePlaybackV3Capabilities {
 
         let context = PlaybackV3ClientContext(
             protocolVersion: PlaybackProtocolV3.version,
-            features: features,
-            platform: platformName,
             formFactor: formFactor,
             appVersion: appVersion,
             device: deviceContext,
             output: output,
-            engines: engines
+            deliveries: deliveries
         )
         return ApplePlaybackV3CapabilitySnapshot(capabilities: capabilities, context: context)
     }
 
+    /// What VideoToolbox will actually say about this device's decoders.
+    ///
+    /// Profiles and levels stay empty because there is no API that enumerates
+    /// them — under `platform_attested` the server skips both rather than
+    /// treating the gap as a refusal, so fabricating plausible tuples would add
+    /// risk and buy nothing. Every other bound here is a real platform fact.
+    private static func videoDecodeAttestation() -> [PlaybackV3VideoDecodeCapability] {
+        let codecTypes: [(String, CMVideoCodecType)] = [
+            ("h264", kCMVideoCodecType_H264),
+            ("hevc", kCMVideoCodecType_HEVC)
+        ]
+        return codecTypes.compactMap { codec, codecType in
+            guard directVideoCodecs.contains(codec), hardwareDecodeSupported(codecType) else {
+                return nil
+            }
+            return PlaybackV3VideoDecodeCapability(
+                codec: codec,
+                decoderName: "VideoToolbox",
+                profiles: [],
+                levels: [],
+                // Apple hardware decodes HEVC Main and Main10; H.264 High 10
+                // has no hardware path on any supported device.
+                bitDepths: codec == "hevc" ? [8, 10] : [8],
+                maxWidth: maxDecodeHeight >= 2_160 ? 3_840 : 1_920,
+                maxHeight: maxDecodeHeight,
+                // Every device that reaches the minimum OS decodes 4K60. Higher
+                // frame rates are only guaranteed below 4K, and the contract has
+                // no way to express a rate that depends on resolution, so the
+                // lower of the two is the bound we can stand behind.
+                maxFrameRate: 60,
+                maxBitrateKbps: maxDecodeHeight >= 2_160 ? 120_000 : 25_000,
+                hardware: true
+            )
+        }
+    }
+
+    /// Whether the platform routes this codec to an accelerated decoder.
+    private static func hardwareDecodeSupported(_ codecType: CMVideoCodecType) -> Bool {
+        #if targetEnvironment(simulator)
+        // The simulator services VideoToolbox through the host Mac, so
+        // `VTIsHardwareDecodeSupported` answers for the host GPU rather than
+        // for any device we could ship to. H.264 is accelerated on every host
+        // that can run the simulator; nothing else is worth attesting.
+        return codecType == kCMVideoCodecType_H264
+        #else
+        return VTIsHardwareDecodeSupported(codecType)
+        #endif
+    }
+
+    /// The tallest frame this build's decoders are guaranteed to accept.
+    private static var maxDecodeHeight: Int {
+        #if targetEnvironment(simulator)
+        1_080
+        #else
+        2_160
+        #endif
+    }
+
     private static func outputSnapshot() -> PlaybackV3OutputContext {
-        // Per format: can this client be handed such a source and render it
-        // correctly? That is what the server plans against, and it does not
-        // depend on the display — PQ, HLG and the HDR10 base of HDR10+ all tone
-        // map on the display layer, and Dolby Vision is resolved during decode.
-        //
-        // Dolby Vision is per-platform because Profile 5 carries IPT-PQ-c2
-        // pixels with no HDR10-compatible base layer: rendering it correctly
-        // needs a display in Dolby Vision mode. tvOS negotiates that mode over
-        // HDMI and refuses playback when the panel declines
-        // (`PlayerCore.applyDvGatedDisplayCriteria`); iOS drives its own
-        // Dolby-Vision-capable panel. macOS has neither — an arbitrary
-        // attached display is never negotiated — so it claims only the
-        // base-layer-compatible Profile 8.
+        // This describes the active output, not just formats the decoder can
+        // open. The server gives output HDR evidence precedence over device
+        // decoder evidence, so a hardcoded device-wide claim could select an
+        // HDR route for an SDR display chain.
         let hdrDetails: PlaybackV3HDRCapabilities? = {
             #if targetEnvironment(simulator)
-            // The simulator decodes H.264 only, matching the rest of this
-            // snapshot and `PlaybackSessionBridge.makeClientCaps()`.
             return PlaybackV3HDRCapabilities(
                 hdr10: false,
                 hdr10Plus: false,
@@ -195,18 +245,22 @@ enum ApplePlaybackV3Capabilities {
                 dolbyVisionProfiles: []
             )
             #elseif os(macOS)
+            // macOS does not expose AVPlayer.availableHDRModes. Avoid
+            // advertising display-specific HDR facts that cannot be attested.
             return PlaybackV3HDRCapabilities(
-                hdr10: true,
-                hdr10Plus: true,
-                hlg: true,
-                dolbyVisionProfiles: [8]
+                hdr10: false,
+                hdr10Plus: false,
+                hlg: false,
+                dolbyVisionProfiles: []
             )
             #else
+            let modes = AVPlayer.availableHDRModes
             return PlaybackV3HDRCapabilities(
-                hdr10: true,
-                hdr10Plus: true,
-                hlg: true,
-                dolbyVisionProfiles: [5, 8]
+                hdr10: modes.contains(.hdr10),
+                // Apple has no separate HDR10+ output-mode attestation.
+                hdr10Plus: false,
+                hlg: modes.contains(.hlg),
+                dolbyVisionProfiles: modes.contains(.dolbyVision) ? [5, 8] : []
             )
             #endif
         }()
@@ -221,28 +275,37 @@ enum ApplePlaybackV3Capabilities {
         sink = outputs.map { $0.uid }.sorted().joined(separator: ",")
         sinkType = outputs.map { $0.portType.rawValue }.sorted().joined(separator: ",")
         #endif
-        let identity = [platformName, formFactor, sink, sinkType, String(describing: hdrDetails)].joined(separator: "|")
+        let hdrIdentity = hdrDetails.map {
+            "\($0.hdr10)|\($0.hdr10Plus)|\($0.hlg)|\($0.dolbyVisionProfiles.map(String.init).joined(separator: ","))"
+        } ?? "unknown"
+        let identity = [platformName, formFactor, sink, sinkType, hdrIdentity].joined(separator: "|")
         return PlaybackV3OutputContext(
             hdrDetails: hdrDetails,
-            audioPassthrough: PlaybackV3AudioPassthrough(
-                passthroughCodecs: [],
-                spatializerEnabled: false,
-                maxChannels: 8,
-                entries: []
-            ),
-            currentSink: sink.isEmpty ? nil : sink,
-            sinkType: sinkType.isEmpty ? nil : sinkType,
-            outputRouteGeneration: stableGeneration(identity)
+            // Apple cannot enumerate receiver codec/layout passthrough facts,
+            // and platform-attested audio evidence never earns passthrough.
+            audioPassthrough: nil,
+            currentSink: boundedField(sink),
+            sinkType: boundedField(sinkType),
+            outputContextId: outputContextId(identity)
         )
     }
 
-    private static func stableGeneration(_ identity: String) -> Int64 {
-        var hash: UInt64 = 0xcbf29ce484222325
-        for byte in identity.utf8 {
-            hash ^= UInt64(byte)
-            hash &*= 0x100000001b3
-        }
-        return Int64(hash & UInt64(Int64.max))
+    /// A stable, opaque token for the current output route.
+    ///
+    /// The server only ever compares this for equality — in attempt keys and
+    /// plan invalidation — so a digest of the route identity is exactly as
+    /// useful as the identity itself, and stays inside the contract's 128-byte
+    /// field bound however many sinks are attached.
+    private static func outputContextId(_ identity: String) -> String {
+        let digest = SHA256.hash(data: Data(identity.utf8))
+        return "apple:" + digest.map { String(format: "%02x", $0) }.joined().prefix(16)
+    }
+
+    /// Truncate to the contract's 128-character limit for free-form context
+    /// strings; an over-long value is rejected outright by the server.
+    private static func boundedField(_ value: String) -> String? {
+        guard !value.isEmpty else { return nil }
+        return String(value.prefix(128))
     }
 
     private static var platformName: String {
@@ -273,23 +336,24 @@ enum ApplePlaybackV3Capabilities {
         var systemInfo = utsname()
         uname(&systemInfo)
         let mirror = Mirror(reflecting: systemInfo.machine)
-        let model = mirror.children.reduce(into: "") { result, element in
+        let machine = mirror.children.reduce(into: "") { result, element in
             guard let value = element.value as? Int8, value != 0 else { return }
             result.append(Character(UnicodeScalar(UInt8(value))))
         }
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        var details = ["os_name": platformName]
+        if !machine.isEmpty {
+            details["machine"] = machine
+        }
+        #if targetEnvironment(simulator)
+        details["simulator"] = "true"
+        #endif
         return PlaybackV3DeviceContext(
+            platform: platformName,
+            osVersion: "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)",
             manufacturer: "Apple",
-            model: model.isEmpty ? nil : model,
-            brand: "Apple",
-            device: model.isEmpty ? nil : model,
-            product: formFactor,
-            socManufacturer: "Apple",
-            socModel: nil,
-            buildId: nil,
-            buildDisplay: ProcessInfo.processInfo.operatingSystemVersionString,
-            securityPatch: nil,
-            sdkInt: nil,
-            abis: ["arm64"]
+            model: boundedField(machine),
+            platformDetails: details
         )
     }
 }

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3Capabilities.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3Capabilities.swift
@@ -31,7 +31,7 @@ enum ApplePlaybackV3Capabilities {
     /// mirrors `ApplePlaybackRoutePlanner`'s native-direct and loopback
     /// allowlists rather than the wider set FFmpeg can demux: a codec claimed
     /// here is one the server may hand us untranscoded.
-    private static let directVideoCodecs = ["h264", "hevc"]
+    private static let directVideoCodecs = ["h264", "hevc", AppleDecodeCapabilities.mpeg2VideoCodec]
 
     static func snapshot() -> ApplePlaybackV3CapabilitySnapshot {
         let output = outputSnapshot()
@@ -187,7 +187,7 @@ enum ApplePlaybackV3Capabilities {
             ("h264", kCMVideoCodecType_H264),
             ("hevc", kCMVideoCodecType_HEVC)
         ]
-        return codecTypes.compactMap { codec, codecType in
+        var capabilities: [PlaybackV3VideoDecodeCapability] = codecTypes.compactMap { codec, codecType in
             guard directVideoCodecs.contains(codec), hardwareDecodeSupported(codecType) else {
                 return nil
             }
@@ -210,6 +210,24 @@ enum ApplePlaybackV3Capabilities {
                 hardware: true
             )
         }
+        #if !targetEnvironment(simulator)
+        // PlayerCore carries a bounded FFmpeg software path for MPEG-2. Keep
+        // it out of the hardware list while still advertising the route the
+        // production executor can actually decode.
+        capabilities.append(PlaybackV3VideoDecodeCapability(
+            codec: AppleDecodeCapabilities.mpeg2VideoCodec,
+            decoderName: "FFmpeg",
+            profiles: [],
+            levels: [],
+            bitDepths: [8],
+            maxWidth: 1_920,
+            maxHeight: 1_080,
+            maxFrameRate: 60,
+            maxBitrateKbps: 50_000,
+            hardware: false
+        ))
+        #endif
+        return capabilities
     }
 
     /// Whether the platform routes this codec to an accelerated decoder.
@@ -239,7 +257,7 @@ enum ApplePlaybackV3Capabilities {
         // open. The server gives output HDR evidence precedence over device
         // decoder evidence, so a hardcoded device-wide claim could select an
         // HDR route for an SDR display chain.
-        let hdrDetails: PlaybackV3HDRCapabilities? = {
+        let hdrCapabilities: PlaybackV3HDRCapabilities? = {
             #if targetEnvironment(simulator)
             return PlaybackV3HDRCapabilities(
                 hdr10: false,
@@ -248,22 +266,20 @@ enum ApplePlaybackV3Capabilities {
                 dolbyVisionProfiles: []
             )
             #elseif os(macOS)
-            // macOS does not expose AVPlayer.availableHDRModes. Avoid
-            // advertising display-specific HDR facts that cannot be attested.
-            return PlaybackV3HDRCapabilities(
-                hdr10: false,
-                hdr10Plus: false,
-                hlg: false,
-                dolbyVisionProfiles: []
+            // macOS exposes a live output-chain eligibility signal instead of
+            // AVPlayer.availableHDRModes. It attests HDR presentation, but not
+            // Dolby Vision format support, so keep DV profiles empty.
+            return hdrDetails(
+                hdr10: AVPlayer.eligibleForHDRPlayback,
+                hlg: AVPlayer.eligibleForHDRPlayback,
+                dolbyVision: false
             )
             #else
             let modes = AVPlayer.availableHDRModes
-            return PlaybackV3HDRCapabilities(
+            return hdrDetails(
                 hdr10: modes.contains(.hdr10),
-                // Apple has no separate HDR10+ output-mode attestation.
-                hdr10Plus: false,
                 hlg: modes.contains(.hlg),
-                dolbyVisionProfiles: modes.contains(.dolbyVision) ? [5, 8] : []
+                dolbyVision: modes.contains(.dolbyVision)
             )
             #endif
         }()
@@ -278,18 +294,32 @@ enum ApplePlaybackV3Capabilities {
         sink = outputs.map { $0.uid }.sorted().joined(separator: ",")
         sinkType = outputs.map { $0.portType.rawValue }.sorted().joined(separator: ",")
         #endif
-        let hdrIdentity = hdrDetails.map {
+        let hdrIdentity = hdrCapabilities.map {
             "\($0.hdr10)|\($0.hdr10Plus)|\($0.hlg)|\($0.dolbyVisionProfiles.map { String($0) }.joined(separator: ","))"
         } ?? "unknown"
         let identity = [platformName, formFactor, sink, sinkType, hdrIdentity].joined(separator: "|")
         return PlaybackV3OutputContext(
-            hdrDetails: hdrDetails,
+            hdrDetails: hdrCapabilities,
             // Apple cannot enumerate receiver codec/layout passthrough facts,
             // and platform-attested audio evidence never earns passthrough.
             audioPassthrough: nil,
             currentSink: boundedField(sink),
             sinkType: boundedField(sinkType),
             outputContextId: outputContextId(identity)
+        )
+    }
+
+    static func hdrDetails(
+        hdr10: Bool,
+        hlg: Bool,
+        dolbyVision: Bool
+    ) -> PlaybackV3HDRCapabilities {
+        PlaybackV3HDRCapabilities(
+            hdr10: hdr10,
+            // Apple exposes no independent HDR10+ output attestation.
+            hdr10Plus: false,
+            hlg: hlg,
+            dolbyVisionProfiles: dolbyVision ? [5, 8] : []
         )
     }
 

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3Capabilities.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3Capabilities.swift
@@ -167,8 +167,9 @@ enum ApplePlaybackV3Capabilities {
                 supportedOnDevice: true,
                 failureReason: nil,
                 containers: ["hls", "mpegts", "fmp4", "mp4"],
-                // HLS always executes through AVPlayer. The wider flat list
-                // also contains the PlayerCore-only MPEG-2 software decoder.
+                // HLS always executes through AVPlayer. The locally attested
+                // `videoCodecs` list also contains PlayerCore-only MPEG-2;
+                // the shared AVPlayer list deliberately does not.
                 videoCodecs: AppleDecodeCapabilities.videoCodecs,
                 audioDecodeCodecs: ["aac", "ac3", "eac3"],
                 audioPassthroughCodecs: [],

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3Capabilities.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3Capabilities.swift
@@ -27,6 +27,12 @@ enum ApplePlaybackV3Capabilities {
         PlaybackProtocolV3.directStreamResumeFeature
     ]
 
+    /// Audiobooks currently restart sessions at part boundaries and do not
+    /// retain enough plan identity to request seek re-anchors in place.
+    static let audiobookFeatures = features.filter {
+        $0 != PlaybackProtocolV3.seekReanchorFeature
+    }
+
     /// Video codecs the Apple playback stack decodes on a direct route. This
     /// mirrors `ApplePlaybackRoutePlanner`'s native-direct and loopback
     /// allowlists rather than the wider set FFmpeg can demux: a codec claimed
@@ -136,7 +142,7 @@ enum ApplePlaybackV3Capabilities {
                 supportedOnDevice: true,
                 failureReason: nil,
                 containers: ["mp4", "mov", "m4v"],
-                videoCodecs: videoCodecs,
+                videoCodecs: AppleDecodeCapabilities.videoCodecs,
                 audioDecodeCodecs: ["aac", "ac3", "eac3", "alac", "mp3"],
                 audioPassthroughCodecs: [],
                 maxChannels: 8,

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3Capabilities.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3Capabilities.swift
@@ -33,6 +33,17 @@ enum ApplePlaybackV3Capabilities {
         $0 != PlaybackProtocolV3.seekReanchorFeature
     }
 
+    /// The AVPlayer-backed audiobook engine does not execute PlayerCore or
+    /// local-loopback plans. Keep its flat codec/container cross-product to
+    /// combinations AVPlayer opens directly rather than inheriting the video
+    /// player's FFmpeg-only DTS, TrueHD, Vorbis, and Matroska claims.
+    private static let audiobookAudioCodecs = [
+        "aac", "ac3", "eac3", "alac", "mp3", "flac",
+        "pcm", "pcm_s16le", "pcm_s24le"
+    ]
+    private static let audiobookOriginalContainers = ["mp4"] + AppleDecodeCapabilities.audioContainers
+    private static let commonClaims = ["apple_execution_plan_v1", "authenticated_stream_headers"]
+
     /// Video codecs the Apple playback stack decodes on a direct route. This
     /// mirrors `ApplePlaybackRoutePlanner`'s native-direct and loopback
     /// allowlists rather than the wider set FFmpeg can demux: a codec claimed
@@ -118,8 +129,6 @@ enum ApplePlaybackV3Capabilities {
             sidecarBitmap: false,
             fontAttachments: false
         )
-        let commonClaims = ["apple_execution_plan_v1", "authenticated_stream_headers"]
-
         let deliveries = [
             PlaybackProtocolV3.DeliveryClass.originalHTTP: PlaybackV3DeliveryCapability(
                 enabled: true,
@@ -158,7 +167,9 @@ enum ApplePlaybackV3Capabilities {
                 supportedOnDevice: true,
                 failureReason: nil,
                 containers: ["hls", "mpegts", "fmp4", "mp4"],
-                videoCodecs: videoCodecs,
+                // HLS always executes through AVPlayer. The wider flat list
+                // also contains the PlayerCore-only MPEG-2 software decoder.
+                videoCodecs: AppleDecodeCapabilities.videoCodecs,
                 audioDecodeCodecs: ["aac", "ac3", "eac3"],
                 audioPassthroughCodecs: [],
                 maxChannels: 8,
@@ -176,6 +187,100 @@ enum ApplePlaybackV3Capabilities {
             formFactor: formFactor,
             appVersion: appVersion,
             device: deviceContext,
+            output: output,
+            deliveries: deliveries
+        )
+        return ApplePlaybackV3CapabilitySnapshot(capabilities: capabilities, context: context)
+    }
+
+    /// Capability evidence for the standalone audiobook engine. The engine
+    /// is AVPlayer-only, so every advertised delivery must remain executable
+    /// without the video player's PlayerCore or local-loopback adapters.
+    static func audiobookSnapshot() -> ApplePlaybackV3CapabilitySnapshot {
+        let base = snapshot()
+        let noSubtitles = PlaybackV3DeliverySubtitleCapabilities(
+            embeddedText: false,
+            sidecarText: false,
+            assStyling: false,
+            embeddedBitmap: false,
+            sidecarBitmap: false,
+            fontAttachments: false
+        )
+        let deliveries = [
+            PlaybackProtocolV3.DeliveryClass.originalHTTP: PlaybackV3DeliveryCapability(
+                enabled: true,
+                supportedOnDevice: true,
+                failureReason: nil,
+                containers: audiobookOriginalContainers,
+                videoCodecs: [],
+                audioDecodeCodecs: audiobookAudioCodecs,
+                audioPassthroughCodecs: [],
+                maxChannels: 8,
+                hdrDetails: nil,
+                subtitles: noSubtitles,
+                features: ["apple_native_direct"],
+                authHeaderRefresh: true,
+                validatedClaims: commonClaims,
+                transformations: []
+            ),
+            PlaybackProtocolV3.DeliveryClass.progressive: PlaybackV3DeliveryCapability(
+                enabled: true,
+                supportedOnDevice: true,
+                failureReason: nil,
+                containers: ["mp4", "mov", "m4v"],
+                videoCodecs: [],
+                audioDecodeCodecs: ["aac", "ac3", "eac3", "alac", "mp3"],
+                audioPassthroughCodecs: [],
+                maxChannels: 8,
+                hdrDetails: nil,
+                subtitles: noSubtitles,
+                features: ["apple_avplayer_progressive"],
+                authHeaderRefresh: true,
+                validatedClaims: commonClaims,
+                transformations: []
+            ),
+            PlaybackProtocolV3.DeliveryClass.hls: PlaybackV3DeliveryCapability(
+                enabled: true,
+                supportedOnDevice: true,
+                failureReason: nil,
+                containers: ["hls", "mpegts", "fmp4", "mp4"],
+                videoCodecs: [],
+                audioDecodeCodecs: ["aac", "ac3", "eac3"],
+                audioPassthroughCodecs: [],
+                maxChannels: 8,
+                hdrDetails: nil,
+                subtitles: noSubtitles,
+                features: ["apple_avplayer_hls"],
+                authHeaderRefresh: true,
+                validatedClaims: commonClaims,
+                transformations: []
+            )
+        ]
+        let capabilities = PlaybackV3CodecCapabilities(
+            videoEvidence: base.capabilities.videoEvidence,
+            audioEvidence: base.capabilities.audioEvidence,
+            codecsVideo: [],
+            codecsVideoHardware: [],
+            codecsAudio: audiobookAudioCodecs,
+            containers: audiobookOriginalContainers,
+            maxResolution: nil,
+            hdr: false,
+            hdrDetails: nil,
+            audioPassthrough: nil,
+            videoDecode: []
+        )
+        let output = PlaybackV3OutputContext(
+            hdrDetails: nil,
+            audioPassthrough: nil,
+            currentSink: base.context.output.currentSink,
+            sinkType: base.context.output.sinkType,
+            outputContextId: base.context.output.outputContextId
+        )
+        let context = PlaybackV3ClientContext(
+            protocolVersion: base.context.protocolVersion,
+            formFactor: base.context.formFactor,
+            appVersion: base.context.appVersion,
+            device: base.context.device,
             output: output,
             deliveries: deliveries
         )

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3PlanAdapter.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3PlanAdapter.swift
@@ -91,19 +91,41 @@ enum ApplePlaybackV3PlanAdapter {
         sessionId: String,
         selectedVersion: FileVersion
     ) -> PlaybackSessionResponse {
-        let subtitleUrls: [SubtitleUrl]? = plan.subtitle.artifact.map { artifact in
+        var subtitleUrls = plan.subtitle.inventory.compactMap { item -> SubtitleUrl? in
+            guard item.delivery == "sidecar",
+                  let url = item.url?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !url.isEmpty else {
+                return nil
+            }
+            return SubtitleUrl(
+                index: item.combinedIndex,
+                language: item.language,
+                codec: item.codec,
+                label: item.label,
+                source: item.source,
+                forced: item.forced,
+                url: url
+            )
+        }
+        // Inventory is authoritative in the neutral contract. Keep a narrow
+        // fallback for a selected sidecar artifact so an otherwise executable
+        // plan does not lose its active subtitle if a transitional server
+        // omitted that one inventory URL.
+        if let artifact = plan.subtitle.artifact,
+           let selectedIndex = plan.selectedTracks.subtitle?.index,
+           !subtitleUrls.contains(where: { $0.index == selectedIndex }) {
             let selected = plan.selectedTracks.subtitle?.index.flatMap {
                 subtitleTrack(atServerCombinedIndex: $0, in: selectedVersion)
             }
-            return [SubtitleUrl(
-                index: plan.selectedTracks.subtitle?.index ?? 0,
+            subtitleUrls.append(SubtitleUrl(
+                index: selectedIndex,
                 language: selected?.language,
                 codec: artifact.format,
                 label: selected?.title,
                 source: selected.map { $0.external == true ? "external" : "embedded" } ?? "protocol_v3",
                 forced: selected?.forced,
                 url: artifact.url
-            )]
+            ))
         }
         return PlaybackSessionResponse(
             sessionId: sessionId,
@@ -121,7 +143,7 @@ enum ApplePlaybackV3PlanAdapter {
             // the server reports an unknown runtime would reintroduce a guess.
             durationSeconds: plan.source.durationSeconds ?? selectedVersion.duration,
             timelineOffsetSeconds: max(0, plan.timeline.timelineOffsetSeconds),
-            subtitleUrls: subtitleUrls,
+            subtitleUrls: subtitleUrls.isEmpty ? nil : subtitleUrls,
             playbackInfo: PlaybackInfo(
                 streamType: plan.stream.protocol,
                 transcodeAudio: plan.transformations.contains { $0.name == "audio_to_aac" },
@@ -163,6 +185,19 @@ enum ApplePlaybackV3PlanAdapter {
             ffmpegStreamIndex: ffmpegStreamIndex,
             in: version
         )
+    }
+
+    static func ffmpegSubtitleStreamIndex(
+        serverCombinedIndex: Int,
+        in version: FileVersion
+    ) -> Int? {
+        guard serverCombinedIndex >= 0 else { return nil }
+        let tracks = version.subtitleTracks ?? []
+        let externalCount = tracks.filter { $0.external == true }.count
+        let embedded = tracks.filter { $0.external != true }
+        let embeddedOrdinal = serverCombinedIndex - externalCount
+        guard embedded.indices.contains(embeddedOrdinal) else { return nil }
+        return embedded[embeddedOrdinal].index
     }
 
     static func makeExecutionPlan(
@@ -212,7 +247,9 @@ enum ApplePlaybackV3PlanAdapter {
             audioCodec: plan.source.audioCodec,
             subtitleCodecs: basePlan.sourceMetadata.subtitleCodecs,
             dolbyVisionProfile: plan.source.dolbyVisionProfile,
-            colorRange: basePlan.sourceMetadata.colorRange
+            // Prefer the server's probed source fact. Catalog metadata remains
+            // the compatibility fallback for plans that omit color_range.
+            colorRange: plan.source.colorRange ?? basePlan.sourceMetadata.colorRange
         )
         let transformationTokens = plan.transformations.map {
             "v3_transform_\($0.executor)_\($0.name)_\($0.recipeVersion)"

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3PlanAdapter.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3PlanAdapter.swift
@@ -4,14 +4,13 @@ struct PreparedPlaybackV3: Equatable {
     let playbackAttemptId: String
     let planAttemptId: String
     let planAttemptKey: String
-    let outputRouteGeneration: Int64
+    let outputContextId: String?
     let serverFeatures: [String]
     let plan: PlaybackV3Plan
 }
 
 enum ApplePlaybackV3PlanError: LocalizedError, Equatable {
     case unsupportedDelivery(String)
-    case unsupportedEngine(String)
     case invalidTransport(String)
     case unsupportedClientTransformation(String)
     case invalidClientTransformation(String)
@@ -21,8 +20,6 @@ enum ApplePlaybackV3PlanError: LocalizedError, Equatable {
         switch self {
         case .unsupportedDelivery(let value):
             return "The server selected an unsupported V3 delivery: \(value)."
-        case .unsupportedEngine(let value):
-            return "The server selected an unsupported V3 execution engine: \(value)."
         case .invalidTransport(let value):
             return "The V3 playback transport is invalid: \(value)."
         case .unsupportedClientTransformation(let value):
@@ -48,19 +45,6 @@ enum ApplePlaybackV3PlanAdapter {
             "original_http", "server_remux_hls", "server_remux_progressive", "server_transcode_hls"
         ].contains(plan.delivery) else {
             throw ApplePlaybackV3PlanError.unsupportedDelivery(plan.delivery)
-        }
-        guard ["media3_direct", "media3_progressive_remux", "media3_hls"].contains(plan.engine) else {
-            throw ApplePlaybackV3PlanError.unsupportedEngine(plan.engine)
-        }
-        let expectedEngine: String = switch plan.delivery {
-        case "original_http": "media3_direct"
-        case "server_remux_progressive": "media3_progressive_remux"
-        default: "media3_hls"
-        }
-        guard plan.engine == expectedEngine else {
-            throw ApplePlaybackV3PlanError.invalidTransport(
-                "delivery \(plan.delivery) requires engine \(expectedEngine)"
-            )
         }
         guard !plan.stream.url.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw ApplePlaybackV3PlanError.invalidTransport("empty stream URL")
@@ -92,10 +76,9 @@ enum ApplePlaybackV3PlanAdapter {
                 "multiple mutually exclusive client transformations"
             )
         }
-        if !selectedClientTransformations.isEmpty
-            && (plan.delivery != "original_http" || plan.engine != "media3_direct") {
+        if !selectedClientTransformations.isEmpty && plan.delivery != "original_http" {
             throw ApplePlaybackV3PlanError.invalidClientTransformation(
-                "client transformations require original_http/media3_direct"
+                "client transformations require the original_http delivery"
             )
         }
         if let unsupported = plan.runtimeCorrections.first(where: { !runtimeCorrections.contains($0) }) {
@@ -257,7 +240,7 @@ enum ApplePlaybackV3PlanAdapter {
             featureFlagEnabled: true,
             parityBlockers: routeCapabilities.blockingReasons(for: routeRequirements),
             decisionTrace: basePlan.decisionTrace + [
-                "protocol_v3", "v3_plan_\(plan.planId)", "v3_engine_\(plan.engine)", "v3_delivery_\(plan.delivery)"
+                "protocol_v3", "v3_plan_\(plan.planId)", "v3_delivery_\(plan.delivery)"
             ] + transformationTokens + quirkTokens + correctionTokens,
             degradationWarnings: warnings + routeCapabilities.degradationNotes(for: routeRequirements),
             reason: "v3_\(plan.decisionReason)",

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3PlanAdapter.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3PlanAdapter.swift
@@ -102,6 +102,9 @@ enum ApplePlaybackV3PlanAdapter {
                 label: item.label,
                 source: item.source,
                 forced: item.forced,
+                default: item.default,
+                hearingImpaired: item.hearingImpaired,
+                fontBundleUrl: item.fontBundleUrl,
                 url: url
             )
         }
@@ -122,6 +125,9 @@ enum ApplePlaybackV3PlanAdapter {
                 label: selected?.title,
                 source: selected.map { $0.external == true ? "external" : "embedded" } ?? "protocol_v3",
                 forced: selected?.forced,
+                default: selected?.isDefault,
+                hearingImpaired: selected?.hearingImpaired,
+                fontBundleUrl: nil,
                 url: artifact.url
             ))
         }
@@ -141,7 +147,7 @@ enum ApplePlaybackV3PlanAdapter {
             // the server reports an unknown runtime would reintroduce a guess.
             durationSeconds: plan.source.durationSeconds ?? selectedVersion.duration,
             timelineOffsetSeconds: max(0, plan.timeline.timelineOffsetSeconds),
-            subtitleUrls: subtitleUrls.isEmpty ? nil : subtitleUrls,
+            subtitleUrls: subtitleUrls,
             playbackInfo: PlaybackInfo(
                 streamType: plan.stream.protocol,
                 transcodeAudio: plan.transformations.contains { $0.name == "audio_to_aac" },
@@ -258,7 +264,8 @@ enum ApplePlaybackV3PlanAdapter {
         let normalization = PlaybackNormalizationSummary(
             containerMode: plan.delivery == "original_http" ? basePlan.normalizationSummary.containerMode : plan.delivery,
             videoMode: plan.effectiveRecipe.videoCodec ?? "copy",
-            audioMode: plan.effectiveRecipe.audioCodec ?? "copy",
+            audioMode: plan.effectiveRecipe.audioCodec
+                ?? (plan.source.audioCodec == nil ? "none" : "copy"),
             subtitleMode: plan.subtitle.mode
         )
 

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3PlanAdapter.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3PlanAdapter.swift
@@ -87,7 +87,8 @@ enum ApplePlaybackV3PlanAdapter {
     static func playbackSession(
         plan: PlaybackV3Plan,
         sessionId: String,
-        selectedVersion: FileVersion
+        selectedVersion: FileVersion,
+        serverFeatures: [String]
     ) -> PlaybackSessionResponse {
         var subtitleUrls = plan.subtitle.inventory.compactMap { item -> SubtitleUrl? in
             guard item.delivery == "sidecar",
@@ -131,6 +132,16 @@ enum ApplePlaybackV3PlanAdapter {
                 url: artifact.url
             ))
         }
+        let durationSeconds: Double?
+        if serverFeatures.contains(PlaybackProtocolV3.planSourceDurationFeature) {
+            // Presence of the feature makes nil authoritative: the server
+            // knows the field but could not determine this source's runtime.
+            durationSeconds = plan.source.durationSeconds
+        } else {
+            // Transitional servers predate the field, so the catalog value is
+            // still the only duration evidence available.
+            durationSeconds = plan.source.durationSeconds ?? selectedVersion.duration
+        }
         return PlaybackSessionResponse(
             sessionId: sessionId,
             userId: nil,
@@ -141,11 +152,7 @@ enum ApplePlaybackV3PlanAdapter {
             isPaused: false,
             streamUrl: plan.stream.url,
             audioTrackIndex: plan.selectedTracks.audio?.index,
-            // The plan's runtime is authoritative and describes the effective
-            // file the server actually chose. Fall back to the catalog version
-            // only for servers that predate the field; substituting it when
-            // the server reports an unknown runtime would reintroduce a guess.
-            durationSeconds: plan.source.durationSeconds ?? selectedVersion.duration,
+            durationSeconds: durationSeconds,
             timelineOffsetSeconds: max(0, plan.timeline.timelineOffsetSeconds),
             subtitleUrls: subtitleUrls,
             playbackInfo: PlaybackInfo(

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3PlanAdapter.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3PlanAdapter.swift
@@ -41,9 +41,7 @@ enum ApplePlaybackV3PlanAdapter {
     ]
 
     static func validate(_ plan: PlaybackV3Plan) throws {
-        guard [
-            "original_http", "server_remux_hls", "server_remux_progressive", "server_transcode_hls"
-        ].contains(plan.delivery) else {
+        guard PlaybackProtocolV3.PlanDelivery.supported.contains(plan.delivery) else {
             throw ApplePlaybackV3PlanError.unsupportedDelivery(plan.delivery)
         }
         guard !plan.stream.url.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/PlaybackProtocolV3Models.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/PlaybackProtocolV3Models.swift
@@ -3,13 +3,45 @@ import Foundation
 enum PlaybackProtocolV3 {
     static let version = 3
     static let planFeature = "playback_plan_v3"
-    static let detailedDecodeFeature = "detailed_decode_capabilities"
     static let layoutPassthroughFeature = "layout_aware_passthrough"
     static let clientTransformFeature = "client_video_transformations_v1"
     static let routeDiagnosticsFeature = "playback_route_diagnostics"
     static let deviceQuirksFeature = "device_quirks_v1"
     static let seekReanchorFeature = "seek_reanchor_v1"
     static let directStreamResumeFeature = "direct_stream_resume_v1"
+    static let planSourceDurationFeature = "plan_source_duration_v1"
+
+    /// Delivery classes are the unit a client negotiates in
+    /// `client_playback_context.deliveries`. They are deliberately coarser than
+    /// the four plan-level `delivery` outcomes the server reports back: the
+    /// server folds `server_remux_hls` and `server_transcode_hls` onto `hls`,
+    /// and `server_remux_progressive` onto `progressive`.
+    enum DeliveryClass {
+        static let originalHTTP = "original_http"
+        static let progressive = "progressive"
+        static let hls = "hls"
+    }
+
+    /// How much the client actually knows about its own decoders. The server
+    /// gates direct/copy routes on this: `exact` and `platformAttested` are
+    /// matched against `video_decode` entries, `declared` only against the flat
+    /// codec list.
+    enum Evidence {
+        static let exact = "exact"
+        static let platformAttested = "platform_attested"
+        static let declared = "declared"
+    }
+
+    /// Why the client is asking for a new plan. `failureRecovery` is the
+    /// server's default when the field is absent; the two intent operations
+    /// carry no `failure`.
+    enum ReplanOperation {
+        static let failureRecovery = "failure_recovery"
+        static let seekReanchor = "seek_reanchor"
+        static let seekFailureRecovery = "seek_failure_recovery"
+        static let trackChange = "track_change"
+        static let qualityChange = "quality_change"
+    }
 }
 
 struct PlaybackV3HDRCapabilities: Codable, Equatable {
@@ -52,6 +84,12 @@ struct PlaybackV3VideoDecodeCapability: Codable, Equatable {
 }
 
 struct PlaybackV3CodecCapabilities: Codable, Equatable {
+    /// How this client knows what it can decode. Apple attests through
+    /// VideoToolbox rather than enumerating a decoder registry, so it claims
+    /// `platform_attested`: codec, bit depth and dimension bounds are real,
+    /// profile/level are not enumerable and the server skips matching them.
+    let videoEvidence: String
+    let audioEvidence: String
     let codecsVideo: [String]
     let codecsVideoHardware: [String]
     let codecsAudio: [String]
@@ -64,18 +102,13 @@ struct PlaybackV3CodecCapabilities: Codable, Equatable {
 }
 
 struct PlaybackV3DeviceContext: Codable, Equatable {
+    let platform: String
+    let osVersion: String?
     let manufacturer: String?
     let model: String?
-    let brand: String?
-    let device: String?
-    let product: String?
-    let socManufacturer: String?
-    let socModel: String?
-    let buildId: String?
-    let buildDisplay: String?
-    let securityPatch: String?
-    let sdkInt: Int?
-    let abis: [String]
+    /// Free-form platform-specific detail. Bounded by the server at 16 entries
+    /// with keys and values of at most 128 characters each.
+    let platformDetails: [String: String]
 }
 
 struct PlaybackV3OutputContext: Codable, Equatable {
@@ -83,10 +116,12 @@ struct PlaybackV3OutputContext: Codable, Equatable {
     let audioPassthrough: PlaybackV3AudioPassthrough?
     let currentSink: String?
     let sinkType: String?
-    let outputRouteGeneration: Int64
+    /// Opaque token identifying the current output route. The server only ever
+    /// compares it for equality, so any stable platform-native identity works.
+    let outputContextId: String?
 }
 
-struct PlaybackV3EngineSubtitleCapabilities: Codable, Equatable {
+struct PlaybackV3DeliverySubtitleCapabilities: Codable, Equatable {
     let embeddedText: Bool
     let sidecarText: Bool
     let assStyling: Bool
@@ -102,7 +137,7 @@ struct PlaybackV3Transformation: Codable, Equatable {
     let validatedClaims: [String]
 }
 
-struct PlaybackV3EngineCapability: Codable, Equatable {
+struct PlaybackV3DeliveryCapability: Codable, Equatable {
     let enabled: Bool
     let supportedOnDevice: Bool
     let failureReason: String?
@@ -112,7 +147,7 @@ struct PlaybackV3EngineCapability: Codable, Equatable {
     let audioPassthroughCodecs: [String]
     let maxChannels: Int?
     let hdrDetails: PlaybackV3HDRCapabilities?
-    let subtitles: PlaybackV3EngineSubtitleCapabilities
+    let subtitles: PlaybackV3DeliverySubtitleCapabilities
     let features: [String]
     let authHeaderRefresh: Bool
     let validatedClaims: [String]
@@ -121,13 +156,12 @@ struct PlaybackV3EngineCapability: Codable, Equatable {
 
 struct PlaybackV3ClientContext: Codable, Equatable {
     let protocolVersion: Int
-    let features: [String]
-    let platform: String
     let formFactor: String
     let appVersion: String
     let device: PlaybackV3DeviceContext
     let output: PlaybackV3OutputContext
-    let engines: [String: PlaybackV3EngineCapability]
+    /// Keyed by delivery class, never by an engine name.
+    let deliveries: [String: PlaybackV3DeliveryCapability]
 }
 
 struct PlaybackV3StartRequest: Codable, Equatable {
@@ -143,7 +177,6 @@ struct PlaybackV3StartRequest: Codable, Equatable {
     let audioTrackIndex: Int?
     let subtitleTrackId: String?
     let subtitleTrackIndex: Int?
-    let outputRouteGeneration: Int64
     let metered: Bool
     let bandwidthEstimateKbps: Int?
     let bandwidthCapKbps: Int?
@@ -169,22 +202,29 @@ struct PlaybackV3Failure: Codable, Equatable {
 
 struct PlaybackV3ReplanRequest: Codable, Equatable {
     let protocolVersion: Int
+    let clientFeatures: [String]
     let operation: String
     let playbackAttemptId: String
     let replanRequestId: String
     let failedPlanId: String
     let planAttemptId: String
+    /// The key the server minted for the plan being replaced, echoed verbatim.
+    /// Clients never compute one.
     let planAttemptKey: String
     let attemptedPlanKeys: [String]
     let attemptCount: Int
     let qualityPreference: String
     let positionSeconds: Double
-    let outputRouteGeneration: Int64
     let metered: Bool
     let bandwidthEstimateKbps: Int?
     let bandwidthCapKbps: Int?
     let selectedTracks: PlaybackV3SelectedTracks
-    let failure: PlaybackV3Failure
+    /// Absent for the intent operations (`track_change`, `quality_change`),
+    /// which replan because the user asked, not because playback broke.
+    let failure: PlaybackV3Failure?
+    /// Client-side state the server should fold into the next attempt key, so
+    /// a locally-mutated route does not collide with the plan it replaced.
+    let localMutations: [String]
     let clientCapabilities: PlaybackV3CodecCapabilities
     let clientPlaybackContext: PlaybackV3ClientContext
 }
@@ -201,7 +241,7 @@ struct PlaybackV3RouteEvent: Codable, Equatable {
     let fallbackReason: String?
     let appliedQuirkIds: [String]
     let quirkRegistryRevision: String?
-    let outputRouteGeneration: Int64
+    let outputContextId: String?
     let diagnostics: [String: String]
 }
 
@@ -306,10 +346,34 @@ struct PlaybackV3SubtitleArtifact: Codable, Equatable {
     let timingOriginSeconds: Double
 }
 
+/// One selectable subtitle track, as the server sees it.
+///
+/// `combinedIndex` is a dense server-assigned ordinal over embedded, external
+/// and downloaded tracks together. It is not an index into any client-side
+/// array.
+struct PlaybackV3SubtitleInventoryItem: Codable, Equatable {
+    let trackId: String
+    let combinedIndex: Int
+    let source: String
+    let codec: String?
+    let language: String?
+    let label: String?
+    let forced: Bool
+    let `default`: Bool
+    let hearingImpaired: Bool
+    let delivery: String
+    let url: String?
+    let fontBundleUrl: String?
+}
+
 struct PlaybackV3SubtitleDecision: Codable, Equatable {
     let mode: String
     let trackId: String?
     let artifact: PlaybackV3SubtitleArtifact?
+    /// Authoritative list of every subtitle track for this plan. Select a track
+    /// by echoing an entry's `trackId` or `combinedIndex` — never by counting
+    /// tracks, summing arrays, or taking max(index) + 1.
+    let inventory: [PlaybackV3SubtitleInventoryItem]
 }
 
 struct PlaybackV3AppliedQuirk: Codable, Equatable {
@@ -324,13 +388,22 @@ struct PlaybackV3DegradationWarning: Codable, Equatable {
     let message: String
 }
 
+struct PlaybackV3AvailableQuality: Codable, Equatable {
+    let label: String
+    let height: Int
+    let bitrateKbps: Int
+    let preservesSource: Bool
+}
+
 struct PlaybackV3Plan: Codable, Equatable {
     let protocolVersion: Int
     let planId: String
     let sessionId: String?
     let expiresAt: String?
     let delivery: String
-    let engine: String
+    /// Server-minted identity for this attempt. Echo it on replan and route
+    /// events; the client never computes one.
+    let planAttemptKey: String
     let stream: PlaybackV3Stream
     let timeline: PlaybackV3Timeline
     let selectedTracks: PlaybackV3SelectedTracks
@@ -346,39 +419,8 @@ struct PlaybackV3Plan: Codable, Equatable {
     let effectiveMediaFileId: Int
     let source: PlaybackV3SourceDescriptor
     let subtitleFidelityPolicy: String
-
-    func attemptKey(outputRouteGeneration: Int64, localMutations: [String] = []) -> String {
-        let transformations = transformations
-            .map { "\($0.executor.lowercased()):\($0.name):\($0.recipeVersion)" }
-            .sorted()
-            .joined(separator: ",")
-        var parts = [
-            planId,
-            delivery.uppercased(),
-            stream.protocol.uppercased(),
-            (stream.container ?? "").lowercased(),
-            (effectiveRecipe.videoCodec ?? "").lowercased(),
-            (effectiveRecipe.audioCodec ?? "").lowercased(),
-            "\(effectiveRecipe.width ?? 0)x\(effectiveRecipe.height ?? 0)",
-            "\(effectiveRecipe.bitrateKbps ?? 0)",
-            (effectiveRecipe.dynamicRange ?? "").lowercased(),
-            subtitle.mode.uppercased(),
-            transformations
-        ]
-        if !appliedQuirks.isEmpty || !runtimeCorrections.isEmpty {
-            parts.append(appliedQuirks.map { "\($0.registryRevision):\($0.id)" }.sorted().joined(separator: ","))
-            parts.append(runtimeCorrections.sorted().joined(separator: ","))
-        }
-        parts.append(String(outputRouteGeneration))
-        parts.append(localMutations.sorted().joined(separator: ","))
-
-        var hash: UInt64 = 0xcbf29ce484222325
-        for byte in parts.joined(separator: "|").utf8 {
-            hash ^= UInt64(byte)
-            hash &*= 0x100000001b3
-        }
-        return String(format: "v3:%016llx", hash)
-    }
+    /// Quality rungs the server will honour for a `quality_change` replan.
+    let availableQualities: [PlaybackV3AvailableQuality]
 }
 
 struct PlaybackV3Terminal: Codable, Equatable {
@@ -437,8 +479,7 @@ extension PlaybackV3DecisionResponse {
         let supportedDelivery = [
             "original_http", "server_remux_hls", "server_remux_progressive", "server_transcode_hls"
         ].contains(plan.delivery)
-        let supportedEngine = ["media3_direct", "media3_progressive_remux", "media3_hls"].contains(plan.engine)
-        guard supportedDelivery, supportedEngine else {
+        guard supportedDelivery else {
             return .incompatible(allocatedSessionId: sessionId)
         }
         return .playable(plan: plan, sessionId: sessionId)

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/PlaybackProtocolV3Models.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/PlaybackProtocolV3Models.swift
@@ -3,6 +3,10 @@ import Foundation
 enum PlaybackProtocolV3 {
     static let version = 3
     static let planFeature = "playback_plan_v3"
+    /// Server-only compatibility marker for the neutral V3 contract. Unlike
+    /// `playback_plan_v3`, this guarantees opaque server-minted attempt keys
+    /// and distinct intent replan operations.
+    static let neutralContractFeature = "neutral_playback_v3_contract_v1"
     static let layoutPassthroughFeature = "layout_aware_passthrough"
     static let clientTransformFeature = "client_video_transformations_v1"
     static let routeDiagnosticsFeature = "playback_route_diagnostics"
@@ -20,6 +24,17 @@ enum PlaybackProtocolV3 {
         static let originalHTTP = "original_http"
         static let progressive = "progressive"
         static let hls = "hls"
+    }
+
+    enum PlanDelivery {
+        static let originalHTTP = "original_http"
+        static let remuxProgressive = "server_remux_progressive"
+        static let remuxHLS = "server_remux_hls"
+        static let transcodeHLS = "server_transcode_hls"
+
+        static let supported: Set<String> = [
+            originalHTTP, remuxProgressive, remuxHLS, transcodeHLS
+        ]
     }
 
     /// How much the client actually knows about its own decoders. The server
@@ -172,6 +187,10 @@ struct PlaybackV3StartRequest: Codable, Equatable {
     let playbackAttemptId: String
     let qualityPreference: String
     let subtitleFidelityPreference: String
+    /// `client` keeps session-local progress reporting active while leaving
+    /// durable resume/history ownership to the client (audiobook timeline).
+    /// Omission is the normal server-owned policy.
+    let progressPersistence: String?
     let startPosition: Double?
     let audioTrackId: String?
     let audioTrackIndex: Int?
@@ -219,8 +238,8 @@ struct PlaybackV3ReplanRequest: Codable, Equatable {
     let bandwidthEstimateKbps: Int?
     let bandwidthCapKbps: Int?
     let selectedTracks: PlaybackV3SelectedTracks
-    /// Absent for the intent operations (`track_change`, `quality_change`),
-    /// which replan because the user asked, not because playback broke.
+    /// Absent for intent operations (`track_change`, `quality_change`) and
+    /// `seek_reanchor`, which describe desired state rather than a failure.
     let failure: PlaybackV3Failure?
     /// Client-side state the server should fold into the next attempt key, so
     /// a locally-mutated route does not collide with the plan it replaced.
@@ -392,7 +411,8 @@ struct PlaybackV3DegradationWarning: Codable, Equatable {
 
 struct PlaybackV3AvailableQuality: Codable, Equatable {
     let label: String
-    let height: Int
+    /// Audio-only quality rungs have no meaningful video height.
+    let height: Int?
     let bitrateKbps: Int
     let preservesSource: Bool
 }
@@ -478,10 +498,7 @@ extension PlaybackV3DecisionResponse {
               ["none", "session"].contains(plan.stream.headerRefresh) else {
             return .incompatible(allocatedSessionId: sessionId)
         }
-        let supportedDelivery = [
-            "original_http", "server_remux_hls", "server_remux_progressive", "server_transcode_hls"
-        ].contains(plan.delivery)
-        guard supportedDelivery else {
+        guard PlaybackProtocolV3.PlanDelivery.supported.contains(plan.delivery) else {
             return .incompatible(allocatedSessionId: sessionId)
         }
         return .playable(plan: plan, sessionId: sessionId)

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/PlaybackProtocolV3Models.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/PlaybackProtocolV3Models.swift
@@ -296,6 +296,7 @@ struct PlaybackV3SourceDescriptor: Codable, Equatable {
     let videoProfile: String?
     let videoLevel: Int?
     let bitDepth: Int?
+    let colorRange: String?
     let width: Int?
     let height: Int?
     let frameRate: Double?
@@ -308,6 +309,7 @@ struct PlaybackV3SourceDescriptor: Codable, Equatable {
     let audioCodec: String?
     let audioChannels: Int?
     let audioLayout: String?
+    let videoCopyUnsafe: Bool?
 }
 
 struct PlaybackV3VideoClaims: Codable, Equatable {

--- a/iosApp/iosApp/Screens/Player/Subtitles/SidecarSubtitleFetcher.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SidecarSubtitleFetcher.swift
@@ -17,6 +17,7 @@ enum SidecarSubtitleFetchError: Error {
     case statusCode(Int)
     case transport(underlying: Error)
     case emptyBody
+    case responseTooLarge(maxBytes: Int)
 }
 
 struct SubtitleFontAttachment: Sendable, Equatable {
@@ -31,16 +32,33 @@ actor SidecarSubtitleFetcher {
         let data: String
     }
 
+    private struct CachedFontBundle {
+        let attachments: [SubtitleFontAttachment]
+        let decodedBytes: Int
+    }
+
+    static let maxFontBundleResponseBytes = 32 * 1_024 * 1_024
+    static let maxFontBundleCacheBytes = 64 * 1_024 * 1_024
+    private static let maxFontBundleCacheEntries = 8
+
     private let session: URLSession
     private let tokenStore: TokenStore
-    private var fontBundleCache: [URL: [SubtitleFontAttachment]] = [:]
+    private let fontBundleResponseByteLimit: Int
+    private let fontBundleCacheByteLimit: Int
+    private var fontBundleCache: [URL: CachedFontBundle] = [:]
+    private var fontBundleCacheOrder: [URL] = []
+    private var fontBundleCacheBytes = 0
 
     init(
         session: URLSession? = nil,
-        tokenStore: TokenStore = .shared
+        tokenStore: TokenStore = .shared,
+        fontBundleResponseByteLimit: Int = SidecarSubtitleFetcher.maxFontBundleResponseBytes,
+        fontBundleCacheByteLimit: Int = SidecarSubtitleFetcher.maxFontBundleCacheBytes
     ) {
         self.session = session ?? Self.makeSession()
         self.tokenStore = tokenStore
+        self.fontBundleResponseByteLimit = max(0, fontBundleResponseByteLimit)
+        self.fontBundleCacheByteLimit = max(0, fontBundleCacheByteLimit)
     }
 
     /// Auth-gated sidecar fetches must not share `URLSession.shared`'s cache:
@@ -108,14 +126,18 @@ actor SidecarSubtitleFetcher {
 
     /// Fetch the server's JSON/base64 font bundle for an authored ASS track.
     func fetchFontBundle(url: URL) async throws -> [SubtitleFontAttachment] {
-        if let cached = fontBundleCache[url] { return cached }
+        if let cached = fontBundleCache[url] {
+            markFontBundleRecentlyUsed(url)
+            return cached.attachments
+        }
 
         var request = await buildRequest(url: url)
         request.setValue("application/json", forHTTPHeaderField: "Accept")
 
-        let (data, response): (Data, URLResponse)
+        let bytes: URLSession.AsyncBytes
+        let response: URLResponse
         do {
-            (data, response) = try await session.data(for: request)
+            (bytes, response) = try await session.bytes(for: request)
         } catch {
             throw SidecarSubtitleFetchError.transport(underlying: error)
         }
@@ -124,6 +146,34 @@ actor SidecarSubtitleFetcher {
         }
         guard (200..<300).contains(http.statusCode) else {
             throw SidecarSubtitleFetchError.statusCode(http.statusCode)
+        }
+        let declaredLength = max(
+            http.expectedContentLength,
+            http.value(forHTTPHeaderField: "Content-Length").flatMap(Int64.init) ?? -1
+        )
+        guard declaredLength <= Int64(fontBundleResponseByteLimit) else {
+            throw SidecarSubtitleFetchError.responseTooLarge(
+                maxBytes: fontBundleResponseByteLimit
+            )
+        }
+
+        var data = Data()
+        if declaredLength > 0 {
+            data.reserveCapacity(Int(declaredLength))
+        }
+        do {
+            for try await byte in bytes {
+                guard data.count < fontBundleResponseByteLimit else {
+                    throw SidecarSubtitleFetchError.responseTooLarge(
+                        maxBytes: fontBundleResponseByteLimit
+                    )
+                }
+                data.append(byte)
+            }
+        } catch let error as SidecarSubtitleFetchError {
+            throw error
+        } catch {
+            throw SidecarSubtitleFetchError.transport(underlying: error)
         }
 
         let items: [FontBundleItem]
@@ -138,8 +188,44 @@ actor SidecarSubtitleFetcher {
             }
             return SubtitleFontAttachment(name: item.name, data: decoded)
         }
-        fontBundleCache[url] = attachments
+        cacheFontBundle(attachments, for: url)
         return attachments
+    }
+
+    private func markFontBundleRecentlyUsed(_ url: URL) {
+        fontBundleCacheOrder.removeAll { $0 == url }
+        fontBundleCacheOrder.append(url)
+    }
+
+    private func cacheFontBundle(
+        _ attachments: [SubtitleFontAttachment],
+        for url: URL
+    ) {
+        let decodedBytes = attachments.reduce(0) { $0 + $1.data.count }
+        guard decodedBytes <= fontBundleCacheByteLimit,
+              fontBundleCacheByteLimit > 0 else {
+            return
+        }
+
+        if let replaced = fontBundleCache.removeValue(forKey: url) {
+            fontBundleCacheBytes -= replaced.decodedBytes
+            fontBundleCacheOrder.removeAll { $0 == url }
+        }
+        while (fontBundleCacheBytes + decodedBytes > fontBundleCacheByteLimit
+                || fontBundleCache.count >= Self.maxFontBundleCacheEntries),
+              let leastRecentlyUsed = fontBundleCacheOrder.first {
+            fontBundleCacheOrder.removeFirst()
+            if let evicted = fontBundleCache.removeValue(forKey: leastRecentlyUsed) {
+                fontBundleCacheBytes -= evicted.decodedBytes
+            }
+        }
+
+        fontBundleCache[url] = CachedFontBundle(
+            attachments: attachments,
+            decodedBytes: decodedBytes
+        )
+        fontBundleCacheBytes += decodedBytes
+        fontBundleCacheOrder.append(url)
     }
 
     // MARK: - Local (offline) sidecars

--- a/iosApp/iosApp/Screens/Player/Subtitles/SidecarSubtitleFetcher.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SidecarSubtitleFetcher.swift
@@ -19,10 +19,21 @@ enum SidecarSubtitleFetchError: Error {
     case emptyBody
 }
 
+struct SubtitleFontAttachment: Sendable, Equatable {
+    let name: String
+    let data: Data
+}
+
 actor SidecarSubtitleFetcher {
+
+    private struct FontBundleItem: Decodable {
+        let name: String
+        let data: String
+    }
 
     private let session: URLSession
     private let tokenStore: TokenStore
+    private var fontBundleCache: [URL: [SubtitleFontAttachment]] = [:]
 
     init(
         session: URLSession? = nil,
@@ -93,6 +104,42 @@ actor SidecarSubtitleFetcher {
             body: content
         )
         return (content, format)
+    }
+
+    /// Fetch the server's JSON/base64 font bundle for an authored ASS track.
+    func fetchFontBundle(url: URL) async throws -> [SubtitleFontAttachment] {
+        if let cached = fontBundleCache[url] { return cached }
+
+        var request = await buildRequest(url: url)
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw SidecarSubtitleFetchError.transport(underlying: error)
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw SidecarSubtitleFetchError.invalidResponse
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw SidecarSubtitleFetchError.statusCode(http.statusCode)
+        }
+
+        let items: [FontBundleItem]
+        do {
+            items = try JSONDecoder().decode([FontBundleItem].self, from: data)
+        } catch {
+            throw SidecarSubtitleFetchError.transport(underlying: error)
+        }
+        let attachments = try items.map { item in
+            guard let decoded = Data(base64Encoded: item.data) else {
+                throw SidecarSubtitleFetchError.invalidResponse
+            }
+            return SubtitleFontAttachment(name: item.name, data: decoded)
+        }
+        fontBundleCache[url] = attachments
+        return attachments
     }
 
     // MARK: - Local (offline) sidecars

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleAIController.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleAIController.swift
@@ -146,10 +146,11 @@ final class SubtitleAIController {
     /// current track list. Nil when no session is active (then the handoff is
     /// reported as a soft failure rather than silently dropped).
     ///
-    /// Mirrors Android's `SubtitleTrackMerge`: `sessionId` scopes the stream
-    /// mount, `baseTrackCount` is `(max(existing non-downloaded index) + 1)`,
-    /// and `resolveURL` turns the synthesized API-relative path into an
-    /// absolute URL against the active server base.
+    /// `sessionId` scopes the stream mount, `baseTrackCount` is the combined
+    /// ordinal the first downloaded track occupies (the count of non-downloaded
+    /// entries in the plan's authoritative subtitle inventory), and
+    /// `resolveURL` turns the synthesized API-relative path into an absolute
+    /// URL against the active server base.
     struct HandoffContext {
         let sessionId: String
         let baseTrackCount: Int

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleSession.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleSession.swift
@@ -25,9 +25,36 @@ struct SidecarSubtitleDescriptor: Hashable {
     let label: String?
     let source: String?
     let forced: Bool?
+    let isDefault: Bool?
+    let isHearingImpaired: Bool?
+    let fontBundleUrl: URL?
     /// Absolute URL (server URL already resolved against the relative
     /// path that came back from `/playback/start`).
     let url: URL
+
+    init(
+        index: Int,
+        language: String?,
+        codec: String?,
+        label: String?,
+        source: String?,
+        forced: Bool?,
+        isDefault: Bool? = nil,
+        isHearingImpaired: Bool? = nil,
+        fontBundleUrl: URL? = nil,
+        url: URL
+    ) {
+        self.index = index
+        self.language = language
+        self.codec = codec
+        self.label = label
+        self.source = source
+        self.forced = forced
+        self.isDefault = isDefault
+        self.isHearingImpaired = isHearingImpaired
+        self.fontBundleUrl = fontBundleUrl
+        self.url = url
+    }
 }
 
 final class SubtitleSession {
@@ -246,26 +273,30 @@ final class SubtitleSession {
         descriptor: SidecarSubtitleDescriptor,
         slot: SubtitleSlot
     ) {
-        // Fast path: cached.
-        if let cached = withLock({ sidecarCache[urlIndex] }) {
-            installSidecarContent(
-                content: cached,
-                codecHint: descriptor.codec,
-                url: descriptor.url,
-                slot: slot
-            )
-            return
-        }
-
+        let cached = withLock { sidecarCache[urlIndex] }
         let localFetcher = fetcher
         let task = Task { [weak self] in
             do {
-                let result = try await localFetcher.fetch(
-                    url: descriptor.url,
-                    preferredFormatHint: Self.codecToFormat(descriptor.codec)
+                async let fontAttachments = Self.fetchFontAttachments(
+                    for: descriptor,
+                    with: localFetcher
                 )
+                let result: (content: String, format: SubtitleFormat?)
+                if let cached {
+                    result = (cached, nil)
+                } else {
+                    let fetched = try await localFetcher.fetch(
+                        url: descriptor.url,
+                        preferredFormatHint: Self.codecToFormat(descriptor.codec)
+                    )
+                    result = (fetched.content, fetched.format)
+                }
                 guard let self else { return }
                 if Task.isCancelled { return }
+
+                for attachment in await fontAttachments {
+                    self.registerEmbeddedFont(name: attachment.name, data: attachment.data)
+                }
 
                 Self.logger.info(
                     "[CMP-SUB] fetched sidecar index=\(urlIndex, privacy: .public) slot=\(slot.rawValue, privacy: .public) format=\(String(describing: result.format), privacy: .public) chars=\(result.content.count, privacy: .public)"
@@ -284,6 +315,21 @@ final class SubtitleSession {
             }
         }
         withLock { fetchTasks[slot] = task }
+    }
+
+    private static func fetchFontAttachments(
+        for descriptor: SidecarSubtitleDescriptor,
+        with fetcher: SidecarSubtitleFetcher
+    ) async -> [SubtitleFontAttachment] {
+        guard let url = descriptor.fontBundleUrl else { return [] }
+        do {
+            return try await fetcher.fetchFontBundle(url: url)
+        } catch {
+            logger.warning(
+                "sidecar font bundle fetch failed: \(String(describing: error), privacy: .public)"
+            )
+            return []
+        }
     }
 
     /// Close the given slot. Drops the libass track and cancels any

--- a/iosApp/iosApp/Shared/AppleDecodeCapabilities.swift
+++ b/iosApp/iosApp/Shared/AppleDecodeCapabilities.swift
@@ -45,12 +45,27 @@ enum AppleDecodeCapabilities {
             "opus", "vorbis", "pcm", "pcm_s16le", "pcm_s24le"
         ]
 
-    /// Containers the client demuxes. Both spellings of the two aliased ones
-    /// (`mkv`/`matroska`, `ts`/`mpegts`) are listed: the server sends whichever
-    /// its scanner recorded, and a claim it cannot match reads as "unsupported".
-    static let containers: [String] = isSimulator
+    /// Video containers the client demuxes. Both spellings of the two aliased
+    /// ones (`mkv`/`matroska`, `ts`/`mpegts`) are listed: the server sends
+    /// whichever its scanner recorded, and a claim it cannot match reads as
+    /// "unsupported".
+    static let videoContainers: [String] = isSimulator
         ? ["mp4", "mov", "m4v", "mkv", "matroska", "ts", "m2ts", "mpegts"]
         : ["mp4", "mov", "m4v", "mkv", "matroska", "webm", "avi", "ts", "m2ts", "mpegts"]
+
+    /// Bare audio containers AVPlayer opens directly on every supported Apple
+    /// platform. The scanner currently normalizes M4A/M4B to `mp4`, but the
+    /// aliases remain honest for legacy metadata and future scanner changes.
+    ///
+    /// Ogg is deliberately absent. AVPlayer opens Ogg/Opus on current OSes but
+    /// rejects Ogg/Vorbis, while V3 advertises codecs and containers as
+    /// independent flat lists. Claiming `ogg` alongside the valid `vorbis`
+    /// codec claim would therefore authorize an unplayable original route.
+    static let audioContainers = ["mp3", "m4a", "m4b", "aac", "flac", "wav"]
+
+    /// The full direct-play container vocabulary used by flat capability
+    /// surfaces and by the `original_http` V3 delivery.
+    static let containers = videoContainers + audioContainers
 
     /// The resolution ceiling to claim, or nil for "no client-imposed cap".
     /// The simulator renders at 1080p; on device the ceiling is the display

--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -286,6 +286,8 @@ targets:
           # the directory itself, and everything under it.
           - "Fixtures/SettingsContract"
           - "Fixtures/SettingsContract/**"
+          - "Fixtures/PlaybackV3"
+          - "Fixtures/PlaybackV3/**"
       # The vendored settings contract. SettingsConformanceTests reads both
       # files out of the test bundle at runtime and fails hard when either is
       # missing, so the build phase is stated rather than left to XcodeGen's
@@ -299,6 +301,29 @@ targets:
       # from, and how to re-vendor. In the project so it is discoverable next
       # to them, out of the bundle because nothing reads it at runtime.
       - path: Tests/Fixtures/SettingsContract/SOURCE
+        buildPhase: none
+      # Playback V3's server-generated contract corpus. List every executable
+      # fixture explicitly so an XcodeGen inference change cannot silently
+      # remove this cross-repository gate from the test bundle.
+      - path: Tests/Fixtures/PlaybackV3/attempt_keys.json
+        buildPhase: resources
+      - path: Tests/Fixtures/PlaybackV3/capability_response.json
+        buildPhase: resources
+      - path: Tests/Fixtures/PlaybackV3/conformance_matrix.json
+        buildPhase: resources
+      - path: Tests/Fixtures/PlaybackV3/decision_response.json
+        buildPhase: resources
+      - path: Tests/Fixtures/PlaybackV3/error_response.json
+        buildPhase: resources
+      - path: Tests/Fixtures/PlaybackV3/replan_request.json
+        buildPhase: resources
+      - path: Tests/Fixtures/PlaybackV3/route_event.json
+        buildPhase: resources
+      - path: Tests/Fixtures/PlaybackV3/start_request.json
+        buildPhase: resources
+      - path: Tests/Fixtures/PlaybackV3/subtitle_inventory.json
+        buildPhase: resources
+      - path: Tests/Fixtures/PlaybackV3/SOURCE
         buildPhase: none
     dependencies:
       - target: Silo


### PR DESCRIPTION
## Problem

Part of Silo-Server/silo-server#135

The Apple player still implemented the platform-shaped playback-v3 draft and hard-coded old attempt tokens in contract tests. That left iOS, tvOS, and macOS without an exact executable binding to the server-owned neutral contract used by the web and Android clients.

## Approach

- Adopt neutral v3 capability evidence, server delivery plans, opaque attempt-key echoing, output context, route events, terminal decisions, and intent/seek/failure replans.
- Update the playback bridge, plan adapter, player model, quality selection, and subtitle AI handoff to preserve server-selected tracks and lifecycle ownership.
- Remove the old client plan-attempt hash shim and cross-check decision/replan/route identities rather than hard-coding a token implementation.
- Vendor all nine canonical fixtures from [server PR #567](https://github.com/Silo-Server/silo-server/pull/567), pin the exact server SHA, and exercise the typed planner/replan/protocol matrix including HDR/DV, TrueHD, ASS/PGS/DVD, restart, recovery, capacity, and route-limit cases.
- Assert that intent and seek-reanchor requests omit `failure`, while real recovery requests carry a classification.

Coordinated release train:

- Server: [Silo-Server/silo-server#567](https://github.com/Silo-Server/silo-server/pull/567)
- Android: [Silo-Server/silo-android#200](https://github.com/Silo-Server/silo-android/pull/200)

## Risks and follow-up

- Requires the coordinated server contract; there is intentionally no compatibility window for the removed draft-v3 fields.
- The server is the one-way authority for attempt identities and golden wire vectors.
- No physical-device or signed-in runtime playback was exercised in this closeout; coverage is simulator tests plus platform build/compile checks.

## Testing

- Focused Playback V3, conformance, media-fixture, font-fetch, and decode-capability suite: 59/59 passed on an iPhone 17 Pro simulator.
- Post-review focused rerun covering font-cache LRU recency plus the AVPlayer codec invariant: 4/4 passed.
- tvOS simulator build/compile: passed.
- macOS arm64 compile: passed.
- All nine vendored JSON fixtures are byte-identical to server PR #567 at `ce2f3e6df084f52c62595db8e3011f55c3a925ef`.
- `git diff --check`: passed.

## Review closeout (`a1eb44b`)

- Answered and resolved all 18 review threads that were open before the closeout push.
- Refuted and resolved the post-push MPEG-2 thread with source/test evidence, and strengthened the top-level LRU recency test in the follow-up commit.
- Restricted HLS and audiobook capability evidence to routes their actual AVPlayer executors can run.
- Preserved authoritative V3 sidecar selection across HLS replans and stopped rejected allocated sessions.
- Added supported sessionless terminal-start telemetry, feature-aware source-duration fallback, a shared server-scoped capability gate, and bounded font-bundle streaming/LRU caching.
- Synced the vendored corpus to the current server PR head and addressed the top-level sentinel-name and duration reviews.

### AI Disclosure
- Tool(s): OpenAI Codex; Claude Code
- Model(s): gpt-5; gpt-5.6-sol; claude-fable-5 (server-side xhigh review attempt produced no result)
- Involvement: AI-assisted
- Adversarial review: Independent Standards and Spec passes plus a fresh thread audit found stale fixtures, executor-inaccurate claims, subtitle restoration drift, session cleanup gaps, unbounded font bundles, and unknown-duration fallback. The actionable contract/runtime findings were fixed and revalidated at the pushed head.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Playback now uses the latest protocol for improved session setup, recovery, device capabilities, and stream selection.
  * Added server-provided quality options with resolution and bitrate details.
  * Subtitle preferences persist across playback actions, including seeking and recovery.
  * Added support for embedded, external, downloaded, and font-enhanced subtitles.

* **Bug Fixes**
  * Improved playback recovery and session renewal during network changes.
  * Enhanced HDR, Dolby Vision, audio, and video capability handling.
  * Improved subtitle indexing, timeline handling, and video-only playback support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Issue #134 remediation

- Advertise the bare audio containers Apple can safely direct-play (mp3, m4a, m4b, aac, flac, wav) in both the flat V3 snapshot and original_http delivery.
- Preserve the scanner's canonical M4A/M4B match through the existing mp4 claim.
- Renew a missing playback session during V3 seek/replan instead of tearing playback down.
- Keep Ogg off the flat claim because current Apple runtimes accept Ogg/Opus but reject Ogg/Vorbis, and V3 cannot yet express that codec/container pairing safely.

Fixes #134