### PR TITLE
fix(ipad): improve sidebar behavior and pinned library navigation

### DIFF
--- a/iosApp/Tests/UICustomizationPreferencesTests.swift
+++ b/iosApp/Tests/UICustomizationPreferencesTests.swift
@@ -840,6 +840,34 @@ final class UICustomizationPreferencesTests: XCTestCase {
             second.id,
             "changing a reused fixed-root scope must immediately select the new exact library"
         )
+
+        let sibling = Library(
+            id: 9, name: "Sibling", type: "series", sortOrder: 2, posterUrl: nil
+        )
+        XCTAssertEqual(
+            resolvedLibraryIdForRoot(
+                [first, second, sibling],
+                category: nil,
+                fixedLibraryId: second.id,
+                showAudiobooks: true,
+                storedLibraryId: 0,
+                currentSelectionId: sibling.id
+            ),
+            sibling.id,
+            "an in-session switch to a same-type sibling must survive re-resolution"
+        )
+        XCTAssertEqual(
+            resolvedLibraryIdForRoot(
+                [first, second, sibling],
+                category: nil,
+                fixedLibraryId: second.id,
+                showAudiobooks: true,
+                storedLibraryId: 0,
+                currentSelectionId: first.id
+            ),
+            second.id,
+            "a selection outside the root scope must fall back to the pinned library"
+        )
     }
 
     func testLibrarySelectionPersistenceIsScopedByAuthorityAndRoot() throws {

--- a/iosApp/Tests/UICustomizationPreferencesTests.swift
+++ b/iosApp/Tests/UICustomizationPreferencesTests.swift
@@ -250,7 +250,13 @@ final class UICustomizationPreferencesTests: XCTestCase {
     }
 
     func testMainTabProjectionKeepsLibraryIdentityAndHidesUnsupportedShortcuts() {
-        let movie = Library(id: 7, name: "Movies", type: "movies", sortOrder: 0, posterUrl: nil)
+        let movie = Library(
+            id: 7,
+            name: "Renamed Movies",
+            type: "movies",
+            sortOrder: 0,
+            posterUrl: nil
+        )
         let series = Library(id: 8, name: "Series", type: "series", sortOrder: 1, posterUrl: nil)
         let audiobook = Library(
             id: 9,
@@ -288,7 +294,11 @@ final class UICustomizationPreferencesTests: XCTestCase {
                 .app(.calendar),
             ]
         )
-        XCTAssertEqual(destinations[4].title, "Movies")
+        XCTAssertEqual(
+            destinations[4].title,
+            "Renamed Movies",
+            "pinned destinations should use current library metadata instead of their stored label"
+        )
         XCTAssertFalse(
             destinations.contains { $0.id == .app(.libraries) },
             "authored categories and unsupported shortcut IDs must not collapse into an aggregate tab"

--- a/iosApp/Tests/UICustomizationPreferencesTests.swift
+++ b/iosApp/Tests/UICustomizationPreferencesTests.swift
@@ -503,7 +503,7 @@ final class UICustomizationPreferencesTests: XCTestCase {
             availablePrimaryMenuShortcuts(
                 candidates: [.builtin(.home), .builtin(.forYou)],
                 libraries: [availableLibrary, visibleLibrary],
-                visibleIds: [.builtin(.home).id, visibleItem.id]
+                visibleIds: [PrimaryMenuItem.builtin(.home).id, visibleItem.id]
             ),
             [
                 .builtin(.forYou),
@@ -785,8 +785,12 @@ final class UICustomizationPreferencesTests: XCTestCase {
             "an inaccessible pinned ID must not fall through to another library"
         )
         XCTAssertFalse(
+            libraryRootCanSwitch(fixedLibraryId: second.id, visibleLibraryCount: 1),
+            "a direct root with no same-type siblings disables the library picker"
+        )
+        XCTAssertTrue(
             libraryRootCanSwitch(fixedLibraryId: second.id, visibleLibraryCount: 2),
-            "a direct root keeps top-bar utilities but disables the library picker"
+            "a direct root with same-type siblings allows switching via the top selector"
         )
         XCTAssertTrue(libraryRootCanSwitch(fixedLibraryId: nil, visibleLibraryCount: 2))
 

--- a/iosApp/Tests/UICustomizationPreferencesTests.swift
+++ b/iosApp/Tests/UICustomizationPreferencesTests.swift
@@ -662,6 +662,31 @@ final class UICustomizationPreferencesTests: XCTestCase {
         XCTAssertEqual(mixed.selectedNavigationIcon, "square.stack.3d.up.fill")
     }
 
+    func testPinnedMixedLibraryOnlySwitchesAmongMixedLibraries() {
+        let mixed = Library(
+            id: 1, name: "Mixed A", type: "mixed", sortOrder: 0, posterUrl: nil
+        )
+        let otherMixed = Library(
+            id: 2, name: "Mixed B", type: "mixed", sortOrder: 1, posterUrl: nil
+        )
+        let movies = Library(
+            id: 3, name: "Movies", type: "movies", sortOrder: 2, posterUrl: nil
+        )
+        let series = Library(
+            id: 4, name: "Series", type: "series", sortOrder: 3, posterUrl: nil
+        )
+
+        XCTAssertEqual(
+            visibleLibrariesForRoot(
+                [mixed, otherMixed, movies, series],
+                category: nil,
+                fixedLibraryId: mixed.id,
+                showAudiobooks: true
+            ).map(\.id),
+            [mixed.id, otherMixed.id]
+        )
+    }
+
     func testPrimaryMenuEditorOnlyOffsetsLibrariesWithinTheirMediaType() {
         let rows = [
             PrimaryMenuEditorRow(item: .builtin(.movies), parentMediaType: nil),

--- a/iosApp/Tests/UICustomizationPreferencesTests.swift
+++ b/iosApp/Tests/UICustomizationPreferencesTests.swift
@@ -313,7 +313,10 @@ final class UICustomizationPreferencesTests: XCTestCase {
         ])
 
         let unavailable = projectedMainTabDestinations(primaryMenu: menu)
-        XCTAssertEqual(unavailable.map(\.id), [.app(.home)])
+        XCTAssertEqual(
+            unavailable.map(\.id),
+            [.app(.home), .app(.recommendations), .app(.calendar)]
+        )
 
         let known = projectedMainTabDestinations(
             primaryMenu: menu,
@@ -332,7 +335,32 @@ final class UICustomizationPreferencesTests: XCTestCase {
         )
 
         let knownEmpty = projectedMainTabDestinations(primaryMenu: menu, availableLibraries: [])
-        XCTAssertEqual(knownEmpty.map(\.id), [.app(.home)])
+        XCTAssertEqual(
+            knownEmpty.map(\.id),
+            [.app(.home), .app(.recommendations), .app(.calendar)]
+        )
+    }
+
+    func testHomeOnlyMainTabProjectionRestoresAppleDefaults() {
+        let menu = PrimaryMenuPreference(items: [.builtin(.home)])
+        let destinations = projectedMainTabDestinations(
+            primaryMenu: menu,
+            availableLibraries: [
+                Library(id: 1, name: "Movies", type: "movies", sortOrder: 0, posterUrl: nil),
+                Library(id: 2, name: "Series", type: "series", sortOrder: 1, posterUrl: nil),
+            ]
+        )
+
+        XCTAssertEqual(
+            destinations.map(\.id),
+            [
+                .app(.home),
+                .libraryCategory(.movies),
+                .libraryCategory(.series),
+                .app(.recommendations),
+                .app(.calendar),
+            ]
+        )
     }
 
     func testLibraryTabRequestUsesFirstAuthoredLibraryRoot() {

--- a/iosApp/Tests/UICustomizationPreferencesTests.swift
+++ b/iosApp/Tests/UICustomizationPreferencesTests.swift
@@ -482,23 +482,260 @@ final class UICustomizationPreferencesTests: XCTestCase {
         )
     }
 
-    func testAvailableLibraryShortcutsExcludeInaccessibleAndVisibleItems() {
-        let removed = PrimaryMenuItem.library(libraryId: 7, label: "Removed")
-        let available = PrimaryMenuItem.library(libraryId: 8, label: "Available")
-        let alreadyVisible = PrimaryMenuItem.library(libraryId: 9, label: "Visible")
-        let section = PrimaryMenuItem.section(
-            libraryId: 8,
-            sectionId: "recent",
-            label: "Recent"
+    func testAvailableShortcutsExcludeItemsAlreadyInPrimaryMenu() {
+        let availableLibrary = Library(
+            id: 8,
+            name: "Available",
+            type: "movies",
+            sortOrder: 0,
+            posterUrl: nil
+        )
+        let visibleLibrary = Library(
+            id: 9,
+            name: "Visible",
+            type: "series",
+            sortOrder: 1,
+            posterUrl: nil
+        )
+        let visibleItem = PrimaryMenuItem.library(libraryId: 9, label: "Old Name")
+
+        XCTAssertEqual(
+            availablePrimaryMenuShortcuts(
+                candidates: [.builtin(.home), .builtin(.forYou)],
+                libraries: [availableLibrary, visibleLibrary],
+                visibleIds: [.builtin(.home).id, visibleItem.id]
+            ),
+            [
+                .builtin(.forYou),
+                .library(libraryId: 8, label: "Available"),
+            ]
+        )
+    }
+
+    func testShortcutTypeTitlesUseCustomizationCategories() {
+        XCTAssertEqual(primaryMenuShortcutTypeTitle(.builtin(.movies)), "Media Type")
+        XCTAssertEqual(
+            primaryMenuShortcutTypeTitle(.library(libraryId: 1, label: "Movies")),
+            "Library"
+        )
+        XCTAssertEqual(primaryMenuShortcutTypeTitle(.builtin(.forYou)), "Discover")
+        XCTAssertEqual(primaryMenuShortcutTypeTitle(.builtin(.home)), "Your Stuff")
+
+        let mixed = Library(
+            id: 2,
+            name: "Mixed",
+            type: "mixed",
+            sortOrder: 0,
+            posterUrl: nil
+        )
+        XCTAssertEqual(
+            primaryMenuShortcutTypeTitle(
+                .library(libraryId: 2, label: "Mixed"),
+                libraries: [mixed]
+            ),
+            "Mixed Library"
+        )
+
+        let movies = Library(
+            id: 3,
+            name: "Movies",
+            type: "movies",
+            sortOrder: 1,
+            posterUrl: nil
+        )
+        let series = Library(
+            id: 4,
+            name: "Series",
+            type: "series",
+            sortOrder: 2,
+            posterUrl: nil
+        )
+        XCTAssertEqual(
+            primaryMenuShortcutTypeTitle(
+                .library(libraryId: 3, label: "Movies"),
+                libraries: [movies, series]
+            ),
+            "Movies Library"
+        )
+        XCTAssertEqual(
+            primaryMenuShortcutTypeTitle(
+                .library(libraryId: 4, label: "Series"),
+                libraries: [movies, series]
+            ),
+            "Series Library"
+        )
+        XCTAssertEqual(
+            primaryMenuShortcutTypeTitle(
+                .library(libraryId: 3, label: "Movies"),
+                libraries: [movies, series],
+                isNestedLibrary: true
+            ),
+            "Library"
+        )
+    }
+
+    func testPrimaryMenuItemsUseMainMenuNavigationIcons() {
+        XCTAssertEqual(PrimaryMenuItem.builtin(.home).navigationIcon, AppTab.home.icon)
+        XCTAssertEqual(PrimaryMenuItem.builtin(.movies).navigationIcon, "film.stack")
+        XCTAssertEqual(PrimaryMenuItem.builtin(.series).navigationIcon, "tv")
+        XCTAssertEqual(PrimaryMenuItem.builtin(.music).navigationIcon, "rectangle.stack")
+        XCTAssertEqual(PrimaryMenuItem.builtin(.audiobooks).navigationIcon, "book.closed")
+        XCTAssertEqual(
+            PrimaryMenuItem.builtin(.forYou).navigationIcon,
+            AppTab.recommendations.icon
+        )
+        XCTAssertEqual(PrimaryMenuItem.builtin(.calendar).navigationIcon, AppTab.calendar.icon)
+        XCTAssertEqual(
+            PrimaryMenuItem.library(libraryId: 1, label: "Movies").navigationIcon,
+            "rectangle.stack"
+        )
+    }
+
+    func testPrimaryMenuEditorGroupsLibrariesUnderTheirVisibleMediaType() {
+        let movies = Library(
+            id: 1,
+            name: "Movies A",
+            type: "movies",
+            sortOrder: 0,
+            posterUrl: nil
+        )
+        let series = Library(
+            id: 2,
+            name: "Series A",
+            type: "series",
+            sortOrder: 1,
+            posterUrl: nil
+        )
+        let mixed = Library(
+            id: 3,
+            name: "Mixed",
+            type: "mixed",
+            sortOrder: 2,
+            posterUrl: nil
+        )
+        let items: [PrimaryMenuItem] = [
+            .builtin(.home),
+            .library(libraryId: 2, label: "Series A"),
+            .builtin(.movies),
+            .builtin(.series),
+            .library(libraryId: 1, label: "Movies A"),
+            .library(libraryId: 3, label: "Mixed"),
+            .builtin(.forYou),
+        ]
+
+        let rows = groupedPrimaryMenuEditorRows(
+            items,
+            libraries: [movies, series, mixed]
         )
 
         XCTAssertEqual(
-            availablePrimaryMenuLibraryShortcuts(
-                [removed, available, alreadyVisible, section],
-                visibleIds: [alreadyVisible.id],
-                availableLibraryIds: [8, 9]
+            rows.map(\.item),
+            [
+                .builtin(.home),
+                .builtin(.movies),
+                .library(libraryId: 1, label: "Movies A"),
+                .builtin(.series),
+                .library(libraryId: 2, label: "Series A"),
+                .library(libraryId: 3, label: "Mixed"),
+                .builtin(.forYou),
+            ]
+        )
+        XCTAssertEqual(
+            rows.map(\.parentMediaType),
+            [nil, nil, .movies, nil, .series, nil, nil]
+        )
+    }
+
+    func testMixedLibraryStaysOutsidePrimaryMenuMediaTypes() {
+        let mixed = Library(
+            id: 3,
+            name: "Mixed",
+            type: "mixed",
+            sortOrder: 0,
+            posterUrl: nil
+        )
+
+        XCTAssertNil(
+            primaryMenuParentCategory(for: mixed, among: [.movies, .series])
+        )
+        XCTAssertEqual(mixed.navigationIcon, "square.stack.3d.up")
+        XCTAssertEqual(mixed.selectedNavigationIcon, "square.stack.3d.up.fill")
+    }
+
+    func testPrimaryMenuEditorOnlyOffsetsLibrariesWithinTheirMediaType() {
+        let rows = [
+            PrimaryMenuEditorRow(item: .builtin(.movies), parentMediaType: nil),
+            PrimaryMenuEditorRow(
+                item: .library(libraryId: 1, label: "Movies A"),
+                parentMediaType: .movies
             ),
-            [available]
+            PrimaryMenuEditorRow(
+                item: .library(libraryId: 2, label: "Movies B"),
+                parentMediaType: .movies
+            ),
+            PrimaryMenuEditorRow(item: .builtin(.series), parentMediaType: nil),
+            PrimaryMenuEditorRow(
+                item: .library(libraryId: 3, label: "Series A"),
+                parentMediaType: .series
+            ),
+        ]
+
+        XCTAssertNil(
+            offsetPrimaryMenuEditorItem(
+                rows,
+                itemId: "library:1",
+                by: 2
+            )
+        )
+        XCTAssertEqual(
+            offsetPrimaryMenuEditorItem(
+                rows,
+                itemId: "library:1",
+                by: 1
+            ),
+            [
+                .builtin(.movies),
+                .library(libraryId: 2, label: "Movies B"),
+                .library(libraryId: 1, label: "Movies A"),
+                .builtin(.series),
+                .library(libraryId: 3, label: "Series A"),
+            ]
+        )
+    }
+
+    func testPrimaryMenuEditorMovesMediaTypeWithAssociatedLibraries() {
+        let rows = [
+            PrimaryMenuEditorRow(item: .builtin(.home), parentMediaType: nil),
+            PrimaryMenuEditorRow(item: .builtin(.movies), parentMediaType: nil),
+            PrimaryMenuEditorRow(
+                item: .library(libraryId: 1, label: "Movies A"),
+                parentMediaType: .movies
+            ),
+            PrimaryMenuEditorRow(
+                item: .library(libraryId: 2, label: "Movies B"),
+                parentMediaType: .movies
+            ),
+            PrimaryMenuEditorRow(item: .builtin(.series), parentMediaType: nil),
+            PrimaryMenuEditorRow(
+                item: .library(libraryId: 3, label: "Series A"),
+                parentMediaType: .series
+            ),
+        ]
+
+        XCTAssertEqual(
+            offsetPrimaryMenuEditorItem(
+                rows,
+                itemId: "builtin:series",
+                by: -1
+            ),
+            [
+                .builtin(.home),
+                .builtin(.series),
+                .library(libraryId: 3, label: "Series A"),
+                .builtin(.movies),
+                .library(libraryId: 1, label: "Movies A"),
+                .library(libraryId: 2, label: "Movies B"),
+            ]
         )
     }
 

--- a/iosApp/iosApp/Assets.xcassets/SiloWordmark.imageset/Contents.json
+++ b/iosApp/iosApp/Assets.xcassets/SiloWordmark.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "filename": "Content.png",
-      "idiom": "universal",
-      "scale": "1x"
+      "filename" : "Content.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "author": "xcode",
-    "version": 1
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/iosApp/iosApp/Components/SidebarToggleButton.swift
+++ b/iosApp/iosApp/Components/SidebarToggleButton.swift
@@ -17,14 +17,28 @@ extension EnvironmentValues {
     }
 }
 
+struct ReservesSidebarToggleSpaceEnvironmentKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
+extension EnvironmentValues {
+    var reservesSidebarToggleSpace: Bool {
+        get { self[ReservesSidebarToggleSpaceEnvironmentKey.self] }
+        set { self[ReservesSidebarToggleSpaceEnvironmentKey.self] = newValue }
+    }
+}
+
 /// Leading sidebar button that opens the iPad overlay.
 ///
-/// Renders nothing unless a toggle action is present in the environment —
-/// i.e. only on iPad in the sidebar layout. Styled to match the circular
-/// icon buttons used by `TabTopBarActions`.
+/// Renders the button only while the iPad sidebar is closed. While the overlay
+/// is open, the sidebar layout can reserve the same footprint so neighboring
+/// header content does not shift. Styled to match the circular icon buttons
+/// used by `TabTopBarActions`.
 struct SidebarToggleButton: View {
     @Environment(\.sidebarToggle) private var toggle
+    @Environment(\.reservesSidebarToggleSpace) private var reservesSpace
 
+    @ViewBuilder
     var body: some View {
         if let toggle {
             Button(action: toggle) {
@@ -36,6 +50,13 @@ struct SidebarToggleButton: View {
             }
             .buttonStyle(.plain)
             .accessibilityLabel("Open sidebar")
+        } else if reservesSpace {
+            Color.clear
+                .frame(
+                    width: ContinuumTheme.topBarIconHitSize,
+                    height: ContinuumTheme.topBarIconHitSize
+                )
+                .accessibilityHidden(true)
         }
     }
 }

--- a/iosApp/iosApp/Components/SidebarToggleButton.swift
+++ b/iosApp/iosApp/Components/SidebarToggleButton.swift
@@ -17,7 +17,7 @@ extension EnvironmentValues {
     }
 }
 
-/// Leading hamburger-style button that toggles the iPad sidebar.
+/// Leading sidebar button that opens the iPad overlay.
 ///
 /// Renders nothing unless a toggle action is present in the environment —
 /// i.e. only on iPad in the sidebar layout. Styled to match the circular
@@ -35,6 +35,7 @@ struct SidebarToggleButton: View {
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("Open sidebar")
         }
     }
 }

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -1245,8 +1245,11 @@ func projectedMainTabDestinations(
         return AppTab.visibleCases.map(MainTabDestination.app)
     }
 
+    let menuItems = primaryMenu.items.count == 1 && primaryMenu.items[0].isHome
+        ? appleDefaultPrimaryMenuItems()
+        : primaryMenu.items
     var destinations: [MainTabDestination] = []
-    for item in primaryMenu.items {
+    for item in menuItems {
         guard mainTabSupportsDestination(item, availableLibraries: availableLibraries) else {
             continue
         }
@@ -1277,6 +1280,24 @@ func projectedMainTabDestinations(
     }
     if !destinations.contains(where: { $0.id == .app(.home) }) {
         destinations.insert(.app(.home), at: 0)
+    }
+    if destinations.count == 1, destinations[0].id == .app(.home) {
+        var defaults: [MainTabDestination] = [.app(.home)]
+        if availableLibraries.contains(where: {
+            libraryMatchesPrimaryMenuCategory($0, category: .movies)
+        }) {
+            defaults.append(.libraryCategory(.movies))
+        }
+        if availableLibraries.contains(where: {
+            libraryMatchesPrimaryMenuCategory($0, category: .series)
+        }) {
+            defaults.append(.libraryCategory(.series))
+        }
+        defaults.append(contentsOf: [
+            .app(.recommendations),
+            .app(.calendar),
+        ])
+        return defaults
     }
     return destinations
 }

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -738,6 +738,7 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
         var onSwipeLeft: () -> Void
         private var dragStartOffset: CGFloat = 0
         private weak var managedSplitViewController: UISplitViewController?
+        private weak var dragPresentationView: UIView?
         private weak var swipeHostView: UIView?
         private lazy var swipeLeftRecognizer: UIPanGestureRecognizer = {
             let recognizer = UIPanGestureRecognizer(
@@ -812,11 +813,19 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
         }
 
         @objc private func handleSwipeLeft(_ gestureRecognizer: UIPanGestureRecognizer) {
-            guard let splitViewController = splitViewControllerAncestor,
-                  let presentationView = splitViewController
-                    .viewController(for: .primary)?
-                    .view
-            else { return }
+            guard let splitViewController = splitViewControllerAncestor else { return }
+
+            let presentationView: UIView
+            if gestureRecognizer.state == .began {
+                guard let resolvedView = sidebarPresentationView(in: splitViewController) else {
+                    return
+                }
+                presentationView = resolvedView
+                dragPresentationView = resolvedView
+            } else {
+                guard let activeView = dragPresentationView else { return }
+                presentationView = activeView
+            }
 
             switch gestureRecognizer.state {
             case .began:
@@ -867,6 +876,7 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
                             self.onSwipeLeft()
                             presentationView.transform = .identity
                             splitViewController.view.layoutIfNeeded()
+                            self.dragPresentationView = nil
                         }
                     }
                 } else {
@@ -891,7 +901,32 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
                 options: [.beginFromCurrentState, .allowUserInteraction]
             ) {
                 presentationView.transform = .identity
+            } completion: { finished in
+                if finished {
+                    self.dragPresentationView = nil
+                }
             }
+        }
+
+        private func sidebarPresentationView(
+            in splitViewController: UISplitViewController
+        ) -> UIView? {
+            guard let primaryView = splitViewController
+                .viewController(for: .primary)?
+                .view
+            else { return nil }
+
+            // On iPadOS the navigation controller is wrapped by a clipping
+            // view and then by the adaptive column surface that owns the
+            // sidebar's glass background and shadow. Move that complete
+            // fixed-width surface when it matches the primary geometry;
+            // otherwise fall back to the public primary view.
+            guard let columnView = primaryView.superview?.superview,
+                  columnView !== splitViewController.view,
+                  abs(columnView.bounds.width - width) <= 1,
+                  abs(columnView.bounds.height - primaryView.bounds.height) <= 1
+            else { return primaryView }
+            return columnView
         }
 
         private func installSwipeRecognizer(in splitViewController: UISplitViewController) {
@@ -907,6 +942,9 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
         }
 
         func tearDown() {
+            dragPresentationView?.layer.removeAllAnimations()
+            dragPresentationView?.transform = .identity
+            dragPresentationView = nil
             swipeHostView?.layer.removeAllAnimations()
             swipeHostView?.transform = .identity
             swipeHostView?.removeGestureRecognizer(swipeLeftRecognizer)

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -964,6 +964,7 @@ struct MainTabView: View {
     /// its cache invalidation and network refresh finish.
     @State private var librarySnapshot = MainTabLibrarySnapshot.cachedForCurrentAuthority()
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
+    @State private var iPadColumnVisibility: NavigationSplitViewVisibility = .detailOnly
     /// Shared namespace for the poster → detail zoom transition. Injected into
     /// the environment (`\.zoomNamespace`) so both the cards and the central
     /// detail destination resolve the same identity.
@@ -1173,55 +1174,112 @@ struct MainTabView: View {
         .environment(\.zoomNamespace, zoomNamespace)
     }
 
-    /// iPad regular width: sidebar list + detail pane.
-    /// Selection drives both the highlighted row and the detail content.
+    /// iPad regular width: the native sidebar overlays the detail pane without
+    /// changing its original system material or row-selection appearance.
+    /// macOS keeps the standard side-by-side split-view layout.
     ///
     /// Home / Libraries / Recommendations hide the nav bar (so SwiftUI's
     /// default sidebar toggle isn't visible on those screens). We inject a
     /// toggle closure through `\.sidebarToggle` instead — each custom header
-    /// renders a `SidebarToggleButton` on its leading edge, which collapses
-    /// and re-expands the sidebar. Video playback doesn't overlap the sidebar
-    /// because the player is presented via `fullScreenCover` on
-    /// `router.presentedPlayer` rather than pushed into the detail pane.
+    /// renders a `SidebarToggleButton` on its leading edge while the overlay is
+    /// closed. Video playback doesn't overlap the sidebar because the player is
+    /// presented via `fullScreenCover` on `router.presentedPlayer` rather than
+    /// pushed into the detail pane.
     private var sidebarLayout: some View {
-        NavigationSplitView(columnVisibility: $columnVisibility) {
-            List(selection: Binding<MainTabDestinationID?>(
-                get: { selectedDestinationID },
-                set: { if let value = $0 { selectSidebarDestination(value) } }
-            )) {
-                ForEach(visibleDestinations) { destination in
-                    Label(
-                        destination.title,
-                        systemImage: selectedDestinationID == destination.id
-                            ? destination.selectedIcon
-                            : destination.icon
-                    )
-                    .tag(destination.id)
-                }
-            }
-            .navigationTitle("Silo")
-            .navigationSplitViewColumnWidth(min: 240, ideal: 260, max: 280)
-        } detail: {
-            NavigationStack(path: $router.path) {
-                destinationContent(for: selectedDestination)
-                    .id(selectedDestination.id)
-                    .navigationDestination(for: Route.self) { route in
-                        routeContent(for: route)
-                    }
-            }
+        Group {
+            #if os(iOS)
+            iPadSidebarLayout
+                .environment(
+                    \.sidebarToggle,
+                    iPadColumnVisibility == .detailOnly ? toggleSidebar : nil
+                )
+            #else
+            macSidebarLayout
+                .environment(\.sidebarToggle, toggleSidebar)
+            #endif
         }
-        .environment(\.sidebarToggle, toggleSidebar)
         .environment(\.zoomNamespace, zoomNamespace)
         .safeAreaInset(edge: .bottom, spacing: 0) {
             NowPlayingShelf(style: .card)
         }
     }
 
-    /// Collapses or re-expands the sidebar. Animated so the detail pane
-    /// slides into place rather than snapping.
+    #if os(iOS)
+    private let iPadSidebarWidth: CGFloat = 320
+
+    private var iPadSidebarLayout: some View {
+        NavigationSplitView(columnVisibility: $iPadColumnVisibility) {
+            sidebarList(dismissAfterSelection: true)
+                .navigationTitle("Silo")
+                .navigationSplitViewColumnWidth(iPadSidebarWidth)
+                .toolbar(removing: .sidebarToggle)
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button(action: dismissSidebar) {
+                            Image(systemName: "arrow.left")
+                        }
+                        .accessibilityLabel("Close sidebar")
+                    }
+                }
+        } detail: {
+            sidebarDetailContent
+                .toolbar(removing: .sidebarToggle)
+        }
+        .navigationSplitViewStyle(.prominentDetail)
+    }
+
+    #else
+    private var macSidebarLayout: some View {
+        NavigationSplitView(columnVisibility: $columnVisibility) {
+            sidebarList(dismissAfterSelection: false)
+                .navigationTitle("Silo")
+        } detail: {
+            sidebarDetailContent
+        }
+    }
+    #endif
+
+    private var sidebarDetailContent: some View {
+        NavigationStack(path: $router.path) {
+            destinationContent(for: selectedDestination)
+                .id(selectedDestination.id)
+                .navigationDestination(for: Route.self) { route in
+                    routeContent(for: route)
+                }
+        }
+    }
+
+    private func sidebarList(dismissAfterSelection: Bool) -> some View {
+        List(selection: Binding<MainTabDestinationID?>(
+            get: { selectedDestinationID },
+            set: { value in
+                guard let value else { return }
+                selectSidebarDestination(value)
+                if dismissAfterSelection {
+                    dismissSidebar()
+                }
+            }
+        )) {
+            ForEach(visibleDestinations) { destination in
+                Label(
+                    destination.title,
+                    systemImage: selectedDestinationID == destination.id
+                        ? destination.selectedIcon
+                        : destination.icon
+                )
+                .tag(destination.id)
+            }
+        }
+    }
+
+    /// Collapses or re-expands the sidebar without moving the detail content.
     private func toggleSidebar() {
         withAnimation(.easeInOut(duration: 0.25)) {
+            #if os(iOS)
+            iPadColumnVisibility = iPadColumnVisibility == .detailOnly ? .all : .detailOnly
+            #else
             columnVisibility = columnVisibility == .detailOnly ? .all : .detailOnly
+            #endif
         }
     }
 
@@ -1231,6 +1289,15 @@ struct MainTabView: View {
     private func selectSidebarDestination(_ destinationID: MainTabDestinationID) {
         router.popToRoot()
         selectedDestinationID = destinationID
+    }
+
+    private func dismissSidebar() {
+        #if os(iOS)
+        guard iPadColumnVisibility != .detailOnly else { return }
+        withAnimation(.easeInOut(duration: 0.25)) {
+            iPadColumnVisibility = .detailOnly
+        }
+        #endif
     }
 
     @ViewBuilder

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -745,6 +745,8 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
         private var isDismissAnimationRunning = false
         private weak var managedSplitViewController: UISplitViewController?
         private weak var dragPresentationView: UIView?
+        private weak var dragDimmingView: UIView?
+        private var dimmingBaseAlpha: CGFloat = 1
         private weak var swipeHostView: UIView?
         private lazy var swipeLeftRecognizer: UIPanGestureRecognizer = {
             let recognizer = UIPanGestureRecognizer(
@@ -798,6 +800,7 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
             else { return }
             strandedView.transform = .identity
             dragPresentationView = nil
+            releaseDimmingView(restoring: true)
         }
 
         func applyWidthLock() {
@@ -862,6 +865,10 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
                     presentationView.transform = visibleTransform
                 }
                 dragStartOffset = visibleTransform.tx
+                resolveDimmingView(
+                    in: splitViewController,
+                    excluding: presentationView
+                )
 
             case .changed:
                 let translation = gestureRecognizer.translation(in: splitViewController.view)
@@ -873,6 +880,7 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
                     translationX: horizontalOffset,
                     y: 0
                 )
+                updateDimming(forSidebarOffset: horizontalOffset)
 
             case .ended:
                 let translation = gestureRecognizer.translation(in: splitViewController.view)
@@ -895,6 +903,7 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
                             translationX: -self.width,
                             y: 0
                         )
+                        self.dragDimmingView?.alpha = 0
                     } completion: { finished in
                         self.isDismissAnimationRunning = false
                         // A new drag re-owns the view mid-animation; leave its
@@ -907,6 +916,7 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
                             splitViewController.hide(.primary)
                             self.onSwipeLeft()
                             presentationView.transform = .identity
+                            self.releaseDimmingView()
                             splitViewController.view.layoutIfNeeded()
                             self.dragPresentationView = nil
                         }
@@ -922,6 +932,93 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
             default:
                 break
             }
+        }
+
+        /// UIKit's overlay presentation dims the detail pane behind the
+        /// sidebar but knows nothing about our interactive drag, so the dim
+        /// would stay opaque until dismissal completes and then pop off. Track
+        /// the dimming view (identified structurally: a full-size, non-opaque
+        /// scrim under the sidebar surface) and fade it with the drag. If the
+        /// hierarchy doesn't match, everything degrades to the old pop.
+        private func resolveDimmingView(
+            in splitViewController: UISplitViewController,
+            excluding presentationView: UIView
+        ) {
+            guard dragDimmingView == nil else { return }
+            guard let dimmingView = findDimmingView(
+                from: splitViewController.view,
+                excluding: presentationView,
+                depth: 0
+            ) else {
+                #if DEBUG
+                logSidebarHierarchy(splitViewController.view, presentationView: presentationView)
+                #endif
+                return
+            }
+            dragDimmingView = dimmingView
+            dimmingBaseAlpha = dimmingView.alpha
+        }
+
+        #if DEBUG
+        /// One-shot dump of the split view's subtree when no scrim was found,
+        /// so a mismatched iPadOS hierarchy is diagnosable from device logs.
+        private static var didLogSidebarHierarchy = false
+        private func logSidebarHierarchy(_ root: UIView, presentationView: UIView) {
+            guard !Self.didLogSidebarHierarchy else { return }
+            Self.didLogSidebarHierarchy = true
+            func describe(_ view: UIView, indent: String) -> String {
+                let marker = view === presentationView ? " <sidebar-surface>" : ""
+                let color = view.backgroundColor.map { " bg=\($0)" } ?? ""
+                var lines = "\(indent)\(type(of: view)) frame=\(view.frame) alpha=\(view.alpha)\(color)\(marker)\n"
+                guard indent.count < 12 else { return lines }
+                for subview in view.subviews {
+                    lines += describe(subview, indent: indent + "  ")
+                }
+                return lines
+            }
+            print("[SidebarDrag] no dimming view found; hierarchy:\n\(describe(root, indent: ""))")
+        }
+        #endif
+
+        /// The scrim is identified by class name ("Dimming"), the same way
+        /// UIKit names it across releases (`UIDimmingView`, knockout backdrop
+        /// variants). The sidebar surface's own subtree is excluded so we
+        /// never fade something that slides with the drag.
+        private func findDimmingView(
+            from root: UIView,
+            excluding presentationView: UIView,
+            depth: Int
+        ) -> UIView? {
+            guard depth <= 6 else { return nil }
+            for candidate in root.subviews {
+                guard candidate !== presentationView else { continue }
+                if !candidate.isHidden,
+                   String(describing: type(of: candidate))
+                       .localizedCaseInsensitiveContains("dimming") {
+                    return candidate
+                }
+                if let nested = findDimmingView(
+                    from: candidate,
+                    excluding: presentationView,
+                    depth: depth + 1
+                ) {
+                    return nested
+                }
+            }
+            return nil
+        }
+
+        private func updateDimming(forSidebarOffset horizontalOffset: CGFloat) {
+            guard let dimmingView = dragDimmingView, width > 0 else { return }
+            let visibleFraction = max(0, min(1, 1 + horizontalOffset / width))
+            dimmingView.alpha = dimmingBaseAlpha * visibleFraction
+        }
+
+        private func releaseDimmingView(restoring: Bool = false) {
+            if restoring {
+                dragDimmingView?.alpha = dimmingBaseAlpha
+            }
+            dragDimmingView = nil
         }
 
         /// Whether a pan is actively re-owning the sidebar mid-animation.
@@ -941,9 +1038,11 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
                 options: [.beginFromCurrentState, .allowUserInteraction]
             ) {
                 presentationView.transform = .identity
+                self.dragDimmingView?.alpha = self.dimmingBaseAlpha
             } completion: { finished in
                 if finished {
                     self.dragPresentationView = nil
+                    self.releaseDimmingView(restoring: true)
                 }
             }
         }
@@ -985,6 +1084,7 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
             dragPresentationView?.layer.removeAllAnimations()
             dragPresentationView?.transform = .identity
             dragPresentationView = nil
+            releaseDimmingView(restoring: true)
             swipeHostView?.layer.removeAllAnimations()
             swipeHostView?.transform = .identity
             swipeHostView?.removeGestureRecognizer(swipeLeftRecognizer)
@@ -1638,6 +1738,9 @@ struct MainTabView: View {
                 .tag(destination.id)
             }
         }
+        // The sidebar's few rows rarely overflow; without this the list
+        // still rubber-bands on drag, visually dragging the whole bar.
+        .scrollBounceBehavior(.basedOnSize)
     }
 
     private func sidebarDestinations(

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -992,7 +992,11 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
                 }
                 return lines
             }
-            print("[SidebarDrag] no dimming view found; hierarchy:\n\(describe(root, indent: ""))")
+            DiagLog.d(
+                .other,
+                "SidebarDrag",
+                "No dimming view found; hierarchy:\n\(describe(root, indent: ""))"
+            )
         }
         #endif
 
@@ -1676,18 +1680,30 @@ struct MainTabView: View {
     /// Custom sidebar header replacing the navigation bar so the server name
     /// and close button can sit lower than the system bar allows.
     private var iPadSidebarHeader: some View {
-        HStack {
+        HStack(spacing: 0) {
+            Color.clear
+                .frame(
+                    width: ContinuumTheme.topBarIconHitSize,
+                    height: ContinuumTheme.topBarIconHitSize
+                )
+                .accessibilityHidden(true)
+
             Text(sidebarTitle)
                 .font(.headline)
                 .lineLimit(1)
                 .frame(maxWidth: .infinity, alignment: .center)
-                .overlay(alignment: .trailing) {
-                    Button(action: dismissSidebar) {
-                        Image(systemName: "arrow.left")
-                            .font(.body.weight(.semibold))
-                    }
-                    .accessibilityLabel("Close sidebar")
-                }
+
+            Button(action: dismissSidebar) {
+                Image(systemName: "arrow.left")
+                    .font(.body.weight(.semibold))
+                    .frame(
+                        width: ContinuumTheme.topBarIconHitSize,
+                        height: ContinuumTheme.topBarIconHitSize
+                    )
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Close sidebar")
         }
         .padding(.horizontal, 20)
         .padding(.top, 24)

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -1540,26 +1540,42 @@ struct MainTabView: View {
                     )
                         .frame(width: 0, height: 0)
                 }
-                .navigationTitle(sidebarTitle)
                 .navigationSplitViewColumnWidth(
                     min: iPadSidebarWidth,
                     ideal: iPadSidebarWidth,
                     max: iPadSidebarWidth
                 )
                 .toolbar(removing: .sidebarToggle)
-                .toolbar {
-                    ToolbarItem(placement: .topBarTrailing) {
-                        Button(action: dismissSidebar) {
-                            Image(systemName: "arrow.left")
-                        }
-                        .accessibilityLabel("Close sidebar")
-                    }
+                .toolbar(.hidden, for: .navigationBar)
+                .safeAreaInset(edge: .top, spacing: 0) {
+                    iPadSidebarHeader
                 }
         } detail: {
             sidebarDetailContent
                 .toolbar(removing: .sidebarToggle)
         }
         .navigationSplitViewStyle(.prominentDetail)
+    }
+
+    /// Custom sidebar header replacing the navigation bar so the server name
+    /// and close button can sit lower than the system bar allows.
+    private var iPadSidebarHeader: some View {
+        HStack {
+            Text(sidebarTitle)
+                .font(.headline)
+                .lineLimit(1)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .overlay(alignment: .trailing) {
+                    Button(action: dismissSidebar) {
+                        Image(systemName: "arrow.left")
+                            .font(.body.weight(.semibold))
+                    }
+                    .accessibilityLabel("Close sidebar")
+                }
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 24)
+        .padding(.bottom, 12)
     }
 
     #else

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -1064,7 +1064,8 @@ func projectedMainTabDestinations(
         case .builtin(.forYou): destination = .app(.recommendations)
         case .builtin(.calendar): destination = .app(.calendar)
         case .library(let libraryId, let label):
-            destination = .library(id: libraryId, label: label)
+            let currentLabel = availableLibraries.first(where: { $0.id == libraryId })?.name
+            destination = .library(id: libraryId, label: currentLabel ?? label)
         case .section, .collection:
             destination = nil
         }
@@ -1268,6 +1269,13 @@ struct MainTabView: View {
                 selectedDestinationID,
                 visibleDestinations: visibleDestinations
             )
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .userLibrariesDidRefresh)) {
+            notification in
+            guard let authority = currentLibraryAuthority,
+                  let response = notification.object as? LibrariesResponse
+            else { return }
+            librarySnapshot = .init(authority: authority, libraries: response.libraries)
         }
         #if !os(macOS)
         .fullScreenCover(isPresented: Binding(

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -1193,6 +1193,7 @@ struct MainTabView: View {
                     \.sidebarToggle,
                     iPadColumnVisibility == .detailOnly ? toggleSidebar : nil
                 )
+                .environment(\.reservesSidebarToggleSpace, true)
             #else
             macSidebarLayout
                 .environment(\.sidebarToggle, toggleSidebar)

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -1,5 +1,5 @@
 import SwiftUI
-#if os(tvOS)
+#if os(iOS) || os(tvOS)
 import UIKit
 #endif
 
@@ -711,6 +711,77 @@ struct ContentView: View {
     }
 }
 
+#if os(iOS)
+/// SwiftUI treats `navigationSplitViewColumnWidth` as a preference on iPad.
+/// Pin the backing UIKit split controller to the same width so its divider
+/// cannot resize the overlay while retaining the system sidebar presentation.
+private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
+    let width: CGFloat
+
+    func makeUIViewController(context: Context) -> Controller {
+        Controller(width: width)
+    }
+
+    func updateUIViewController(_ controller: Controller, context: Context) {
+        controller.width = width
+        controller.applyWidthLock()
+    }
+
+    final class Controller: UIViewController {
+        var width: CGFloat
+
+        init(width: CGFloat) {
+            self.width = width
+            super.init(nibName: nil, bundle: nil)
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        override func didMove(toParent parent: UIViewController?) {
+            super.didMove(toParent: parent)
+            applyWidthLock()
+        }
+
+        override func viewDidAppear(_ animated: Bool) {
+            super.viewDidAppear(animated)
+            applyWidthLock()
+        }
+
+        override func viewDidLayoutSubviews() {
+            super.viewDidLayoutSubviews()
+            applyWidthLock()
+        }
+
+        func applyWidthLock() {
+            guard let splitViewController = splitViewControllerAncestor else { return }
+            if splitViewController.preferredPrimaryColumnWidth != width {
+                splitViewController.preferredPrimaryColumnWidth = width
+            }
+            if splitViewController.minimumPrimaryColumnWidth != width {
+                splitViewController.minimumPrimaryColumnWidth = width
+            }
+            if splitViewController.maximumPrimaryColumnWidth != width {
+                splitViewController.maximumPrimaryColumnWidth = width
+            }
+        }
+
+        private var splitViewControllerAncestor: UISplitViewController? {
+            var ancestor = parent
+            while let controller = ancestor {
+                if let splitViewController = controller as? UISplitViewController {
+                    return splitViewController
+                }
+                ancestor = controller.parent
+            }
+            return nil
+        }
+    }
+}
+#endif
+
 private struct DebugPlayerPresentationModifier: ViewModifier {
     let contentId: String?
     @Binding var isPresented: Bool
@@ -1211,8 +1282,16 @@ struct MainTabView: View {
     private var iPadSidebarLayout: some View {
         NavigationSplitView(columnVisibility: $iPadColumnVisibility) {
             sidebarList(dismissAfterSelection: true)
+                .background {
+                    FixedPrimarySplitViewWidth(width: iPadSidebarWidth)
+                        .frame(width: 0, height: 0)
+                }
                 .navigationTitle("Silo")
-                .navigationSplitViewColumnWidth(iPadSidebarWidth)
+                .navigationSplitViewColumnWidth(
+                    min: iPadSidebarWidth,
+                    ideal: iPadSidebarWidth,
+                    max: iPadSidebarWidth
+                )
                 .toolbar(removing: .sidebarToggle)
                 .toolbar {
                     ToolbarItem(placement: .topBarTrailing) {

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -717,21 +717,37 @@ struct ContentView: View {
 /// cannot resize the overlay while retaining the system sidebar presentation.
 private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
     let width: CGFloat
+    let onSwipeLeft: () -> Void
 
     func makeUIViewController(context: Context) -> Controller {
-        Controller(width: width)
+        Controller(width: width, onSwipeLeft: onSwipeLeft)
     }
 
     func updateUIViewController(_ controller: Controller, context: Context) {
         controller.width = width
+        controller.onSwipeLeft = onSwipeLeft
         controller.applyWidthLock()
     }
 
-    final class Controller: UIViewController {
+    final class Controller: UIViewController, UIGestureRecognizerDelegate {
         var width: CGFloat
+        var onSwipeLeft: () -> Void
+        private weak var swipeHostView: UIView?
+        private lazy var swipeLeftRecognizer: UIPanGestureRecognizer = {
+            let recognizer = UIPanGestureRecognizer(
+                target: self,
+                action: #selector(handleSwipeLeft(_:))
+            )
+            recognizer.maximumNumberOfTouches = 1
+            recognizer.allowedTouchTypes = [NSNumber(value: UITouch.TouchType.direct.rawValue)]
+            recognizer.cancelsTouchesInView = false
+            recognizer.delegate = self
+            return recognizer
+        }()
 
-        init(width: CGFloat) {
+        init(width: CGFloat, onSwipeLeft: @escaping () -> Void) {
             self.width = width
+            self.onSwipeLeft = onSwipeLeft
             super.init(nibName: nil, bundle: nil)
         }
 
@@ -757,6 +773,7 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
 
         func applyWidthLock() {
             guard let splitViewController = splitViewControllerAncestor else { return }
+            splitViewController.presentsWithGesture = true
             if splitViewController.preferredPrimaryColumnWidth != width {
                 splitViewController.preferredPrimaryColumnWidth = width
             }
@@ -766,6 +783,118 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
             if splitViewController.maximumPrimaryColumnWidth != width {
                 splitViewController.maximumPrimaryColumnWidth = width
             }
+            installSwipeRecognizer(in: splitViewController)
+        }
+
+        func gestureRecognizer(
+            _ gestureRecognizer: UIGestureRecognizer,
+            shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+        ) -> Bool {
+            true
+        }
+
+        func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+            guard let panGesture = gestureRecognizer as? UIPanGestureRecognizer else {
+                return true
+            }
+            let velocity = panGesture.velocity(in: swipeHostView)
+            return velocity.x < 0 && abs(velocity.x) > abs(velocity.y) * 1.1
+        }
+
+        @objc private func handleSwipeLeft(_ gestureRecognizer: UIPanGestureRecognizer) {
+            guard let splitViewController = splitViewControllerAncestor,
+                  let presentationView = sidebarPresentationView(in: splitViewController)
+            else { return }
+
+            switch gestureRecognizer.state {
+            case .began:
+                presentationView.layer.removeAllAnimations()
+
+            case .changed:
+                let translation = gestureRecognizer.translation(in: splitViewController.view)
+                let horizontalOffset = max(-width, min(0, translation.x))
+                presentationView.transform = CGAffineTransform(
+                    translationX: horizontalOffset,
+                    y: 0
+                )
+
+            case .ended:
+                let translation = gestureRecognizer.translation(in: splitViewController.view)
+                let velocity = gestureRecognizer.velocity(in: splitViewController.view)
+                let shouldDismiss = translation.x <= -(width * 0.25) || velocity.x <= -700
+
+                if shouldDismiss {
+                    UIView.animate(
+                        withDuration: 0.18,
+                        delay: 0,
+                        options: [.curveEaseOut, .beginFromCurrentState]
+                    ) {
+                        presentationView.transform = CGAffineTransform(
+                            translationX: -self.width,
+                            y: 0
+                        )
+                    } completion: { _ in
+                        UIView.performWithoutAnimation {
+                            splitViewController.hide(.primary)
+                            self.onSwipeLeft()
+                            presentationView.transform = .identity
+                            splitViewController.view.layoutIfNeeded()
+                        }
+                    }
+                } else {
+                    restoreSidebarPosition(presentationView)
+                }
+
+            case .cancelled, .failed:
+                restoreSidebarPosition(presentationView)
+
+            default:
+                break
+            }
+        }
+
+        private func restoreSidebarPosition(_ presentationView: UIView) {
+            UIView.animate(
+                withDuration: 0.25,
+                delay: 0,
+                usingSpringWithDamping: 0.9,
+                initialSpringVelocity: 0,
+                options: [.beginFromCurrentState, .allowUserInteraction]
+            ) {
+                presentationView.transform = .identity
+            }
+        }
+
+        private func installSwipeRecognizer(in splitViewController: UISplitViewController) {
+            guard let primaryView = splitViewController
+                .viewController(for: .primary)?
+                .view,
+                  swipeHostView !== primaryView
+            else { return }
+
+            swipeHostView?.removeGestureRecognizer(swipeLeftRecognizer)
+            primaryView.addGestureRecognizer(swipeLeftRecognizer)
+            swipeHostView = primaryView
+        }
+
+        private func sidebarPresentationView(
+            in splitViewController: UISplitViewController
+        ) -> UIView? {
+            guard let primaryView = splitViewController
+                .viewController(for: .primary)?
+                .view
+            else { return nil }
+
+            var presentationView = primaryView
+            var ancestor = primaryView.superview
+            while let candidate = ancestor,
+                  candidate !== splitViewController.view,
+                  candidate.bounds.width > 0,
+                  candidate.bounds.width <= width + 64 {
+                presentationView = candidate
+                ancestor = candidate.superview
+            }
+            return presentationView
         }
 
         private var splitViewControllerAncestor: UISplitViewController? {
@@ -1208,6 +1337,10 @@ struct MainTabView: View {
             ?? .app(.home)
     }
 
+    private var sidebarTitle: String {
+        serverRegistry.activeServer?.displayName ?? "Silo"
+    }
+
     /// iPhone + iPad compact width: bottom tab bar, single navigation stack.
     private var tabLayout: some View {
         NavigationStack(path: $router.path) {
@@ -1283,10 +1416,13 @@ struct MainTabView: View {
         NavigationSplitView(columnVisibility: $iPadColumnVisibility) {
             sidebarList(dismissAfterSelection: true)
                 .background {
-                    FixedPrimarySplitViewWidth(width: iPadSidebarWidth)
+                    FixedPrimarySplitViewWidth(
+                        width: iPadSidebarWidth,
+                        onSwipeLeft: finishInteractiveSidebarDismissal
+                    )
                         .frame(width: 0, height: 0)
                 }
-                .navigationTitle("Silo")
+                .navigationTitle(sidebarTitle)
                 .navigationSplitViewColumnWidth(
                     min: iPadSidebarWidth,
                     ideal: iPadSidebarWidth,
@@ -1301,7 +1437,6 @@ struct MainTabView: View {
                         .accessibilityLabel("Close sidebar")
                     }
                 }
-                .simultaneousGesture(iPadSidebarDismissGesture)
         } detail: {
             sidebarDetailContent
                 .toolbar(removing: .sidebarToggle)
@@ -1313,7 +1448,7 @@ struct MainTabView: View {
     private var macSidebarLayout: some View {
         NavigationSplitView(columnVisibility: $columnVisibility) {
             sidebarList(dismissAfterSelection: false)
-                .navigationTitle("Silo")
+                .navigationTitle(sidebarTitle)
         } detail: {
             sidebarDetailContent
         }
@@ -1382,24 +1517,12 @@ struct MainTabView: View {
     }
 
     #if os(iOS)
-    private var iPadSidebarDismissGesture: some Gesture {
-        DragGesture(minimumDistance: 16)
-            .onEnded { value in
-                let leftwardDistance = max(
-                    -value.translation.width,
-                    -value.predictedEndTranslation.width
-                )
-                let verticalDistance = max(
-                    abs(value.translation.height),
-                    abs(value.predictedEndTranslation.height)
-                )
-
-                guard leftwardDistance >= 72,
-                      leftwardDistance > verticalDistance * 1.25
-                else { return }
-
-                dismissSidebar()
-            }
+    private func finishInteractiveSidebarDismissal() {
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            iPadColumnVisibility = .detailOnly
+        }
     }
     #endif
 

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -1301,6 +1301,7 @@ struct MainTabView: View {
                         .accessibilityLabel("Close sidebar")
                     }
                 }
+                .simultaneousGesture(iPadSidebarDismissGesture)
         } detail: {
             sidebarDetailContent
                 .toolbar(removing: .sidebarToggle)
@@ -1379,6 +1380,28 @@ struct MainTabView: View {
         }
         #endif
     }
+
+    #if os(iOS)
+    private var iPadSidebarDismissGesture: some Gesture {
+        DragGesture(minimumDistance: 16)
+            .onEnded { value in
+                let leftwardDistance = max(
+                    -value.translation.width,
+                    -value.predictedEndTranslation.width
+                )
+                let verticalDistance = max(
+                    abs(value.translation.height),
+                    abs(value.predictedEndTranslation.height)
+                )
+
+                guard leftwardDistance >= 72,
+                      leftwardDistance > verticalDistance * 1.25
+                else { return }
+
+                dismissSidebar()
+            }
+    }
+    #endif
 
     @ViewBuilder
     private func destinationContent(for destination: MainTabDestination) -> some View {

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -1030,6 +1030,13 @@ struct MainTabDestination: Identifiable, Equatable {
     }
 }
 
+private struct MainTabSidebarDestination: Identifiable {
+    let destination: MainTabDestination
+    let isNestedLibrary: Bool
+
+    var id: MainTabDestinationID { destination.id }
+}
+
 /// Projects the cross-client menu into roots this Apple shell can navigate
 /// without discarding destination identity. Sections and collections remain
 /// stored in the synced document, but stay hidden until this shell has a
@@ -1432,7 +1439,10 @@ struct MainTabView: View {
 
     private var iPadSidebarLayout: some View {
         NavigationSplitView(columnVisibility: $iPadColumnVisibility) {
-            sidebarList(dismissAfterSelection: true)
+            sidebarList(
+                dismissAfterSelection: true,
+                nestsPinnedLibraries: true
+            )
                 .background {
                     FixedPrimarySplitViewWidth(
                         width: iPadSidebarWidth,
@@ -1465,7 +1475,10 @@ struct MainTabView: View {
     #else
     private var macSidebarLayout: some View {
         NavigationSplitView(columnVisibility: $columnVisibility) {
-            sidebarList(dismissAfterSelection: false)
+            sidebarList(
+                dismissAfterSelection: false,
+                nestsPinnedLibraries: false
+            )
                 .navigationTitle(sidebarTitle)
                 .navigationSplitViewColumnWidth(min: 240, ideal: 260, max: 280)
         } detail: {
@@ -1493,7 +1506,10 @@ struct MainTabView: View {
         }
     }
 
-    private func sidebarList(dismissAfterSelection: Bool) -> some View {
+    private func sidebarList(
+        dismissAfterSelection: Bool,
+        nestsPinnedLibraries: Bool
+    ) -> some View {
         List(selection: Binding<MainTabDestinationID?>(
             get: { selectedDestinationID },
             set: { value in
@@ -1504,16 +1520,78 @@ struct MainTabView: View {
                 }
             }
         )) {
-            ForEach(visibleDestinations) { destination in
+            ForEach(sidebarDestinations(nestingPinnedLibraries: nestsPinnedLibraries)) { item in
+                let destination = item.destination
                 Label(
                     destination.title,
                     systemImage: selectedDestinationID == destination.id
                         ? destination.selectedIcon
                         : destination.icon
                 )
+                .padding(.leading, item.isNestedLibrary ? 24 : 0)
                 .tag(destination.id)
             }
         }
+    }
+
+    private func sidebarDestinations(
+        nestingPinnedLibraries: Bool
+    ) -> [MainTabSidebarDestination] {
+        guard nestingPinnedLibraries else {
+            return visibleDestinations.map {
+                MainTabSidebarDestination(destination: $0, isNestedLibrary: false)
+            }
+        }
+
+        let availableLibraries = librarySnapshot.availableLibraries(
+            for: currentLibraryAuthority
+        )
+        let librariesByID = Dictionary(
+            uniqueKeysWithValues: availableLibraries.map { ($0.id, $0) }
+        )
+        let visibleCategories = visibleDestinations.compactMap { destination -> PrimaryMenuBuiltin? in
+            guard case .libraryCategory(let category) = destination.id else { return nil }
+            return category
+        }
+        var parentCategoryByLibraryID: [Int: PrimaryMenuBuiltin] = [:]
+        for destination in visibleDestinations {
+            guard case .library(let libraryID) = destination.id,
+                  let library = librariesByID[libraryID],
+                  let category = visibleCategories.first(where: {
+                      libraryMatchesPrimaryMenuCategory(library, category: $0)
+                  })
+            else { continue }
+            parentCategoryByLibraryID[libraryID] = category
+        }
+
+        var items: [MainTabSidebarDestination] = []
+
+        for destination in visibleDestinations {
+            guard case .library(let libraryID) = destination.id else {
+                items.append(.init(destination: destination, isNestedLibrary: false))
+
+                guard case .libraryCategory(let category) = destination.id else {
+                    continue
+                }
+                for pinnedDestination in visibleDestinations {
+                    guard case .library(let libraryID) = pinnedDestination.id,
+                          parentCategoryByLibraryID[libraryID] == category
+                    else { continue }
+
+                    items.append(.init(
+                        destination: pinnedDestination,
+                        isNestedLibrary: true
+                    ))
+                }
+                continue
+            }
+
+            if parentCategoryByLibraryID[libraryID] == nil {
+                items.append(.init(destination: destination, isNestedLibrary: false))
+            }
+        }
+
+        return items
     }
 
     /// Collapses or re-expands the sidebar without moving the detail content.

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -865,6 +865,18 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
                     presentationView.transform = visibleTransform
                 }
                 dragStartOffset = visibleTransform.tx
+                // The dismiss/restore animations also own the scrim's alpha.
+                // Strip that animation alongside the transform one, or the
+                // shared animation transaction outlives the re-grab and its
+                // delayed completion can hide the column mid-drag.
+                if let dimmingView = dragDimmingView {
+                    let visibleAlpha = dimmingView.layer.presentation()?.opacity
+                        ?? Float(dimmingView.alpha)
+                    dimmingView.layer.removeAllAnimations()
+                    UIView.performWithoutAnimation {
+                        dimmingView.alpha = CGFloat(visibleAlpha)
+                    }
+                }
                 resolveDimmingView(
                     in: splitViewController,
                     excluding: presentationView
@@ -916,7 +928,11 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
                             splitViewController.hide(.primary)
                             self.onSwipeLeft()
                             presentationView.transform = .identity
-                            self.releaseDimmingView()
+                            // The hide dismantles the overlay presentation,
+                            // but UIKit may reuse the scrim next time the
+                            // sidebar opens — leave it at its resting alpha,
+                            // not the zero we faded it to.
+                            self.releaseDimmingView(restoring: true)
                             splitViewController.view.layoutIfNeeded()
                             self.dragPresentationView = nil
                         }

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -729,9 +729,15 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
         controller.applyWidthLock()
     }
 
+    static func dismantleUIViewController(_ controller: Controller, coordinator: Void) {
+        controller.tearDown()
+    }
+
     final class Controller: UIViewController, UIGestureRecognizerDelegate {
         var width: CGFloat
         var onSwipeLeft: () -> Void
+        private var dragStartOffset: CGFloat = 0
+        private weak var managedSplitViewController: UISplitViewController?
         private weak var swipeHostView: UIView?
         private lazy var swipeLeftRecognizer: UIPanGestureRecognizer = {
             let recognizer = UIPanGestureRecognizer(
@@ -773,7 +779,11 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
 
         func applyWidthLock() {
             guard let splitViewController = splitViewControllerAncestor else { return }
-            splitViewController.presentsWithGesture = true
+            managedSplitViewController = splitViewController
+            // The direct-touch pan below is the sole interactive transition
+            // owner. Keeping UIKit's built-in pan enabled would let both
+            // recognizers move the same primary column simultaneously.
+            splitViewController.presentsWithGesture = false
             if splitViewController.preferredPrimaryColumnWidth != width {
                 splitViewController.preferredPrimaryColumnWidth = width
             }
@@ -803,16 +813,28 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
 
         @objc private func handleSwipeLeft(_ gestureRecognizer: UIPanGestureRecognizer) {
             guard let splitViewController = splitViewControllerAncestor,
-                  let presentationView = sidebarPresentationView(in: splitViewController)
+                  let presentationView = splitViewController
+                    .viewController(for: .primary)?
+                    .view
             else { return }
 
             switch gestureRecognizer.state {
             case .began:
+                let visibleTransform = presentationView.layer
+                    .presentation()?
+                    .affineTransform() ?? presentationView.transform
                 presentationView.layer.removeAllAnimations()
+                UIView.performWithoutAnimation {
+                    presentationView.transform = visibleTransform
+                }
+                dragStartOffset = visibleTransform.tx
 
             case .changed:
                 let translation = gestureRecognizer.translation(in: splitViewController.view)
-                let horizontalOffset = max(-width, min(0, translation.x))
+                let horizontalOffset = max(
+                    -width,
+                    min(0, dragStartOffset + translation.x)
+                )
                 presentationView.transform = CGAffineTransform(
                     translationX: horizontalOffset,
                     y: 0
@@ -821,7 +843,12 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
             case .ended:
                 let translation = gestureRecognizer.translation(in: splitViewController.view)
                 let velocity = gestureRecognizer.velocity(in: splitViewController.view)
-                let shouldDismiss = translation.x <= -(width * 0.25) || velocity.x <= -700
+                let horizontalOffset = max(
+                    -width,
+                    min(0, dragStartOffset + translation.x)
+                )
+                let shouldDismiss = horizontalOffset <= -(width * 0.25) || velocity.x <= -700
+                dragStartOffset = 0
 
                 if shouldDismiss {
                     UIView.animate(
@@ -833,7 +860,8 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
                             translationX: -self.width,
                             y: 0
                         )
-                    } completion: { _ in
+                    } completion: { finished in
+                        guard finished else { return }
                         UIView.performWithoutAnimation {
                             splitViewController.hide(.primary)
                             self.onSwipeLeft()
@@ -846,6 +874,7 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
                 }
 
             case .cancelled, .failed:
+                dragStartOffset = 0
                 restoreSidebarPosition(presentationView)
 
             default:
@@ -877,24 +906,13 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
             swipeHostView = primaryView
         }
 
-        private func sidebarPresentationView(
-            in splitViewController: UISplitViewController
-        ) -> UIView? {
-            guard let primaryView = splitViewController
-                .viewController(for: .primary)?
-                .view
-            else { return nil }
-
-            var presentationView = primaryView
-            var ancestor = primaryView.superview
-            while let candidate = ancestor,
-                  candidate !== splitViewController.view,
-                  candidate.bounds.width > 0,
-                  candidate.bounds.width <= width + 64 {
-                presentationView = candidate
-                ancestor = candidate.superview
-            }
-            return presentationView
+        func tearDown() {
+            swipeHostView?.layer.removeAllAnimations()
+            swipeHostView?.transform = .identity
+            swipeHostView?.removeGestureRecognizer(swipeLeftRecognizer)
+            swipeHostView = nil
+            managedSplitViewController?.presentsWithGesture = true
+            managedSplitViewController = nil
         }
 
         private var splitViewControllerAncestor: UISplitViewController? {
@@ -1449,6 +1467,7 @@ struct MainTabView: View {
         NavigationSplitView(columnVisibility: $columnVisibility) {
             sidebarList(dismissAfterSelection: false)
                 .navigationTitle(sidebarTitle)
+                .navigationSplitViewColumnWidth(min: 240, ideal: 260, max: 280)
         } detail: {
             sidebarDetailContent
         }
@@ -1461,6 +1480,15 @@ struct MainTabView: View {
                 .id(selectedDestination.id)
                 .navigationDestination(for: Route.self) { route in
                     routeContent(for: route)
+                        #if os(iOS)
+                        .toolbar {
+                            if routeNeedsSidebarToggle(route) {
+                                ToolbarItem(placement: .topBarLeading) {
+                                    SidebarToggleButton()
+                                }
+                            }
+                        }
+                        #endif
                 }
         }
     }
@@ -1716,6 +1744,17 @@ struct MainTabView: View {
                 .continuumBackground()
         }
     }
+
+    #if os(iOS)
+    private func routeNeedsSidebarToggle(_ route: Route) -> Bool {
+        switch route {
+        case .downloads, .recommendations:
+            false
+        default:
+            true
+        }
+    }
+    #endif
 
     private var settingsPlaceholder: some View {
         List {

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -1042,28 +1042,26 @@ struct MainTabDestination: Identifiable, Equatable {
         .init(id: .app(tab), title: tab.rawValue, icon: tab.icon, selectedIcon: tab.selectedIcon)
     }
 
-    static func library(id: Int, label: String) -> MainTabDestination {
+    static func library(
+        id: Int,
+        label: String,
+        icon: String = "rectangle.stack",
+        selectedIcon: String = "rectangle.stack.fill"
+    ) -> MainTabDestination {
         .init(
             id: .library(id),
             title: label,
-            icon: "rectangle.stack",
-            selectedIcon: "rectangle.stack.fill"
+            icon: icon,
+            selectedIcon: selectedIcon
         )
     }
 
     static func libraryCategory(_ category: PrimaryMenuBuiltin) -> MainTabDestination {
-        let icon: String
-        switch category {
-        case .movies: icon = "film.stack"
-        case .series: icon = "tv"
-        case .audiobooks: icon = "book.closed"
-        default: icon = "rectangle.stack"
-        }
         return .init(
             id: .libraryCategory(category),
             title: category.title,
-            icon: icon,
-            selectedIcon: icon
+            icon: category.navigationIcon,
+            selectedIcon: category.navigationIcon
         )
     }
 }
@@ -1102,8 +1100,13 @@ func projectedMainTabDestinations(
         case .builtin(.forYou): destination = .app(.recommendations)
         case .builtin(.calendar): destination = .app(.calendar)
         case .library(let libraryId, let label):
-            let currentLabel = availableLibraries.first(where: { $0.id == libraryId })?.name
-            destination = .library(id: libraryId, label: currentLabel ?? label)
+            let library = availableLibraries.first(where: { $0.id == libraryId })
+            destination = .library(
+                id: libraryId,
+                label: library?.name ?? label,
+                icon: library?.navigationIcon ?? "rectangle.stack",
+                selectedIcon: library?.selectedNavigationIcon ?? "rectangle.stack.fill"
+            )
         case .section, .collection:
             destination = nil
         }
@@ -1603,9 +1606,10 @@ struct MainTabView: View {
         for destination in visibleDestinations {
             guard case .library(let libraryID) = destination.id,
                   let library = librariesByID[libraryID],
-                  let category = visibleCategories.first(where: {
-                      libraryMatchesPrimaryMenuCategory(library, category: $0)
-                  })
+                  let category = primaryMenuParentCategory(
+                      for: library,
+                      among: visibleCategories
+                  )
             else { continue }
             parentCategoryByLibraryID[libraryID] = category
         }

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -717,14 +717,18 @@ struct ContentView: View {
 /// cannot resize the overlay while retaining the system sidebar presentation.
 private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
     let width: CGFloat
+    let sidebarIsHidden: Bool
     let onSwipeLeft: () -> Void
 
     func makeUIViewController(context: Context) -> Controller {
-        Controller(width: width, onSwipeLeft: onSwipeLeft)
+        let controller = Controller(width: width, onSwipeLeft: onSwipeLeft)
+        controller.sidebarIsHidden = sidebarIsHidden
+        return controller
     }
 
     func updateUIViewController(_ controller: Controller, context: Context) {
         controller.width = width
+        controller.sidebarIsHidden = sidebarIsHidden
         controller.onSwipeLeft = onSwipeLeft
         controller.applyWidthLock()
     }
@@ -735,8 +739,10 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
 
     final class Controller: UIViewController, UIGestureRecognizerDelegate {
         var width: CGFloat
+        var sidebarIsHidden = false
         var onSwipeLeft: () -> Void
         private var dragStartOffset: CGFloat = 0
+        private var isDismissAnimationRunning = false
         private weak var managedSplitViewController: UISplitViewController?
         private weak var dragPresentationView: UIView?
         private weak var swipeHostView: UIView?
@@ -776,15 +782,34 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
         override func viewDidLayoutSubviews() {
             super.viewDidLayoutSubviews()
             applyWidthLock()
+            resetStrandedSidebarTransformIfNeeded()
+        }
+
+        /// `sidebarPresentationView` walks one level of private hierarchy; if
+        /// an iPadOS release reshuffles it, or an interrupted animation leaks
+        /// a translation, a stale transform would leave the sidebar visually
+        /// offset with no gesture in flight. Layout passes are the safety net:
+        /// when nothing owns the view, force it back to identity.
+        private func resetStrandedSidebarTransformIfNeeded() {
+            guard !isDragActive, !isDismissAnimationRunning,
+                  let strandedView = dragPresentationView,
+                  strandedView.transform != .identity,
+                  strandedView.layer.animationKeys()?.isEmpty != false
+            else { return }
+            strandedView.transform = .identity
+            dragPresentationView = nil
         }
 
         func applyWidthLock() {
             guard let splitViewController = splitViewControllerAncestor else { return }
             managedSplitViewController = splitViewController
-            // The direct-touch pan below is the sole interactive transition
-            // owner. Keeping UIKit's built-in pan enabled would let both
-            // recognizers move the same primary column simultaneously.
-            splitViewController.presentsWithGesture = false
+            // While the sidebar is visible the direct-touch pan below is the
+            // sole interactive transition owner: keeping UIKit's built-in pan
+            // enabled would let both recognizers move the same primary column
+            // simultaneously. While the sidebar is hidden our recognizer only
+            // accepts leftward swipes, so the system edge swipe stays enabled
+            // to reveal the sidebar.
+            splitViewController.presentsWithGesture = sidebarIsHidden
             if splitViewController.preferredPrimaryColumnWidth != width {
                 splitViewController.preferredPrimaryColumnWidth = width
             }
@@ -860,6 +885,7 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
                 dragStartOffset = 0
 
                 if shouldDismiss {
+                    isDismissAnimationRunning = true
                     UIView.animate(
                         withDuration: 0.18,
                         delay: 0,
@@ -870,7 +896,13 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
                             y: 0
                         )
                     } completion: { finished in
-                        guard finished else { return }
+                        self.isDismissAnimationRunning = false
+                        // A new drag re-owns the view mid-animation; leave its
+                        // state alone. Any other interruption (rotation, split
+                        // relayout) must still complete the hide, or the
+                        // sidebar stays "visible" while translated off-screen
+                        // with no toggle button rendered to recover it.
+                        guard finished || !self.isDragActive else { return }
                         UIView.performWithoutAnimation {
                             splitViewController.hide(.primary)
                             self.onSwipeLeft()
@@ -889,6 +921,14 @@ private struct FixedPrimarySplitViewWidth: UIViewControllerRepresentable {
 
             default:
                 break
+            }
+        }
+
+        /// Whether a pan is actively re-owning the sidebar mid-animation.
+        private var isDragActive: Bool {
+            switch swipeLeftRecognizer.state {
+            case .began, .changed: return true
+            default: return false
             }
         }
 
@@ -1495,6 +1535,7 @@ struct MainTabView: View {
                 .background {
                     FixedPrimarySplitViewWidth(
                         width: iPadSidebarWidth,
+                        sidebarIsHidden: iPadColumnVisibility == .detailOnly,
                         onSwipeLeft: finishInteractiveSidebarDismissal
                     )
                         .frame(width: 0, height: 0)
@@ -1595,53 +1636,25 @@ struct MainTabView: View {
         let availableLibraries = librarySnapshot.availableLibraries(
             for: currentLibraryAuthority
         )
-        let librariesByID = Dictionary(
-            uniqueKeysWithValues: availableLibraries.map { ($0.id, $0) }
-        )
-        let visibleCategories = visibleDestinations.compactMap { destination -> PrimaryMenuBuiltin? in
-            guard case .libraryCategory(let category) = destination.id else { return nil }
-            return category
-        }
-        var parentCategoryByLibraryID: [Int: PrimaryMenuBuiltin] = [:]
-        for destination in visibleDestinations {
-            guard case .library(let libraryID) = destination.id,
-                  let library = librariesByID[libraryID],
-                  let category = primaryMenuParentCategory(
-                      for: library,
-                      among: visibleCategories
-                  )
-            else { continue }
-            parentCategoryByLibraryID[libraryID] = category
-        }
-
-        var items: [MainTabSidebarDestination] = []
-
-        for destination in visibleDestinations {
-            guard case .library(let libraryID) = destination.id else {
-                items.append(.init(destination: destination, isNestedLibrary: false))
-
+        return groupPinnedLibrariesUnderMediaTypes(
+            visibleDestinations,
+            libraries: availableLibraries,
+            libraryID: { destination in
+                guard case .library(let libraryID) = destination.id else { return nil }
+                return libraryID
+            },
+            mediaTypeCategory: { destination in
                 guard case .libraryCategory(let category) = destination.id else {
-                    continue
+                    return nil
                 }
-                for pinnedDestination in visibleDestinations {
-                    guard case .library(let libraryID) = pinnedDestination.id,
-                          parentCategoryByLibraryID[libraryID] == category
-                    else { continue }
-
-                    items.append(.init(
-                        destination: pinnedDestination,
-                        isNestedLibrary: true
-                    ))
-                }
-                continue
+                return category
             }
-
-            if parentCategoryByLibraryID[libraryID] == nil {
-                items.append(.init(destination: destination, isNestedLibrary: false))
-            }
+        ).map {
+            MainTabSidebarDestination(
+                destination: $0.element,
+                isNestedLibrary: $0.isNestedLibrary
+            )
         }
-
-        return items
     }
 
     /// Collapses or re-expands the sidebar without moving the detail content.

--- a/iosApp/iosApp/Downloads/DownloadsView.swift
+++ b/iosApp/iosApp/Downloads/DownloadsView.swift
@@ -289,6 +289,12 @@ struct DownloadsView: View {
 
     @ToolbarContentBuilder
     private var toolbarContent: some ToolbarContent {
+        #if os(iOS)
+        ToolbarItem(placement: .topBarLeading) {
+            SidebarToggleButton()
+        }
+        #endif
+
         if isSelecting {
             ToolbarItem(placement: .navigation) {
                 Button(allSelected ? "Clear" : "Select All") { toggleSelectAll() }

--- a/iosApp/iosApp/Navigation/UICustomizationPreferences.swift
+++ b/iosApp/iosApp/Navigation/UICustomizationPreferences.swift
@@ -124,6 +124,18 @@ enum PrimaryMenuBuiltin: String, Codable, CaseIterable, Identifiable, Sendable {
         case .calendar: return "Calendar"
         }
     }
+
+    var navigationIcon: String {
+        switch self {
+        case .home: return AppTab.home.icon
+        case .movies: return "film.stack"
+        case .series: return "tv"
+        case .music: return "rectangle.stack"
+        case .audiobooks: return "book.closed"
+        case .forYou: return AppTab.recommendations.icon
+        case .calendar: return AppTab.calendar.icon
+        }
+    }
 }
 
 /// One item in `nav.primary_menu` or `nav.shortcuts`.
@@ -174,6 +186,13 @@ enum PrimaryMenuItem: Hashable, Identifiable, Sendable {
     }
 
     var isHome: Bool { self == .builtin(.home) }
+
+    var navigationIcon: String {
+        switch self {
+        case .builtin(let destination): return destination.navigationIcon
+        case .library, .section, .collection: return "rectangle.stack"
+        }
+    }
 
     var isContractValid: Bool {
         switch self {

--- a/iosApp/iosApp/Navigation/UICustomizationPreferences.swift
+++ b/iosApp/iosApp/Navigation/UICustomizationPreferences.swift
@@ -138,6 +138,16 @@ enum PrimaryMenuBuiltin: String, Codable, CaseIterable, Identifiable, Sendable {
     }
 }
 
+func appleDefaultPrimaryMenuItems() -> [PrimaryMenuItem] {
+    [
+        .builtin(.home),
+        .builtin(.movies),
+        .builtin(.series),
+        .builtin(.forYou),
+        .builtin(.calendar),
+    ]
+}
+
 /// One item in `nav.primary_menu` or `nav.shortcuts`.
 ///
 /// The associated-value representation keeps impossible combinations out of

--- a/iosApp/iosApp/Networking/Models.swift
+++ b/iosApp/iosApp/Networking/Models.swift
@@ -1251,6 +1251,14 @@ struct Library: Codable, Identifiable, Hashable {
     var isSeriesLibrary: Bool { SiloMediaType.isSeries(type) }
     var isMixedLibrary: Bool { SiloMediaType.isMixedLibrary(type) }
     var isSupportedLibrary: Bool { SiloMediaType.isSupportedLibrary(type) }
+
+    var navigationIcon: String {
+        isMixedLibrary ? "square.stack.3d.up" : "rectangle.stack"
+    }
+
+    var selectedNavigationIcon: String {
+        isMixedLibrary ? "square.stack.3d.up.fill" : "rectangle.stack.fill"
+    }
 }
 
 struct LibrariesResponse: Codable {

--- a/iosApp/iosApp/Screens/Browse/LibrariesTabView.swift
+++ b/iosApp/iosApp/Screens/Browse/LibrariesTabView.swift
@@ -26,6 +26,69 @@ func primaryMenuParentCategory(
     }
 }
 
+struct PinnedLibraryGroupedElement<Element> {
+    let element: Element
+    let parentCategory: PrimaryMenuBuiltin?
+
+    var isNestedLibrary: Bool { parentCategory != nil }
+}
+
+/// Orders navigation elements so pinned libraries sit directly beneath the
+/// media-type category that contains them, while libraries without a visible
+/// parent (mixed libraries, or categories the user hid) stay at root level.
+/// Shared by the iPad sidebar and the interface-customization editor so the
+/// two surfaces cannot drift apart.
+func groupPinnedLibrariesUnderMediaTypes<Element>(
+    _ elements: [Element],
+    libraries: [Library],
+    libraryID: (Element) -> Int?,
+    mediaTypeCategory: (Element) -> PrimaryMenuBuiltin?
+) -> [PinnedLibraryGroupedElement<Element>] {
+    let librariesByID = Dictionary(
+        uniqueKeysWithValues: libraries.map { ($0.id, $0) }
+    )
+    let visibleCategories = elements.compactMap(mediaTypeCategory)
+    var parentByLibraryID: [Int: PrimaryMenuBuiltin] = [:]
+    for element in elements {
+        guard let libraryID = libraryID(element),
+              let library = librariesByID[libraryID],
+              let parent = primaryMenuParentCategory(
+                  for: library,
+                  among: visibleCategories
+              )
+        else { continue }
+        parentByLibraryID[libraryID] = parent
+    }
+
+    var grouped: [PinnedLibraryGroupedElement<Element>] = []
+    for element in elements {
+        if let libraryID = libraryID(element) {
+            if parentByLibraryID[libraryID] == nil {
+                grouped.append(.init(element: element, parentCategory: nil))
+            }
+            continue
+        }
+
+        grouped.append(.init(element: element, parentCategory: nil))
+        guard let category = mediaTypeCategory(element) else { continue }
+        for child in elements {
+            guard let childLibraryID = libraryID(child),
+                  parentByLibraryID[childLibraryID] == category
+            else { continue }
+            grouped.append(.init(element: child, parentCategory: category))
+        }
+    }
+    return grouped
+}
+
+private func sharesPrimaryMenuCategory(_ lhs: Library, _ rhs: Library) -> Bool {
+    let categories: [PrimaryMenuBuiltin] = [.movies, .series, .audiobooks]
+    return categories.contains {
+        libraryMatchesPrimaryMenuCategory(lhs, category: $0)
+            && libraryMatchesPrimaryMenuCategory(rhs, category: $0)
+    }
+}
+
 func visibleLibrariesForRoot(
     _ libraries: [Library],
     category: PrimaryMenuBuiltin?,
@@ -33,7 +96,15 @@ func visibleLibrariesForRoot(
     showAudiobooks: Bool
 ) -> [Library] {
     if let fixedLibraryId {
-        return libraries.filter { $0.id == fixedLibraryId }
+        // A direct library root still requires the exact library to be
+        // accessible, but exposes sibling libraries of the same media type
+        // so the top selector can switch between them like media-type roots.
+        guard let fixed = libraries.first(where: { $0.id == fixedLibraryId }) else {
+            return []
+        }
+        return libraries.filter {
+            $0.id == fixed.id || sharesPrimaryMenuCategory(fixed, $0)
+        }
     }
     guard let category else {
         return libraries.filter { showAudiobooks || !$0.isAudiobookLibrary }
@@ -42,7 +113,7 @@ func visibleLibrariesForRoot(
 }
 
 func libraryRootCanSwitch(fixedLibraryId: Int?, visibleLibraryCount: Int) -> Bool {
-    fixedLibraryId == nil && visibleLibraryCount > 1
+    visibleLibraryCount > 1
 }
 
 func resolvedLibraryIdForRoot(
@@ -50,7 +121,8 @@ func resolvedLibraryIdForRoot(
     category: PrimaryMenuBuiltin?,
     fixedLibraryId: Int?,
     showAudiobooks: Bool,
-    storedLibraryId: Int
+    storedLibraryId: Int,
+    currentSelectionId: Int? = nil
 ) -> Int? {
     let visible = visibleLibrariesForRoot(
         libraries,
@@ -58,8 +130,14 @@ func resolvedLibraryIdForRoot(
         fixedLibraryId: fixedLibraryId,
         showAudiobooks: showAudiobooks
     )
-    if fixedLibraryId != nil {
-        return visible.first?.id
+    if let fixedLibraryId {
+        // Keep an in-session switch to a sibling library, but always land on
+        // the exact pinned library when entering the root fresh.
+        if let current = currentSelectionId,
+           visible.contains(where: { $0.id == current }) {
+            return current
+        }
+        return visible.first(where: { $0.id == fixedLibraryId })?.id
     }
     if storedLibraryId != 0,
        let restored = visible.first(where: { $0.id == storedLibraryId }) {
@@ -139,6 +217,11 @@ struct LibrariesTabView: View {
     /// have no persistence key because their destination already fixes the ID.
     private let selectionStorageKey: String?
     @State private var storedLibraryId: Int
+    /// Scope the current `selectedLibraryId` belongs to. A direct-library
+    /// root allows switching to sibling libraries in-session, but a fresh
+    /// visit (or a reused view whose destination changed) must land on the
+    /// exact pinned library again.
+    @State private var appliedScopeID: String?
 
     @Environment(AppRouter.self) private var router
 
@@ -249,9 +332,7 @@ struct LibrariesTabView: View {
                     visibleLibraryCount: visibleLibraries.count
                 ),
                 profile: currentProfile,
-                onLibraryTap: {
-                    if fixedLibraryId == nil { showPicker = true }
-                },
+                onLibraryTap: { showPicker = true },
                 onSearch: { router.navigate(to: .search) },
                 onOpenSettings: { router.navigate(to: .settings) },
                 onOpenRequests: { router.navigate(to: .requestsHub) },
@@ -317,21 +398,49 @@ struct LibrariesTabView: View {
     /// Preserve the stored selection if it still exists; otherwise fall
     /// back to the first available library.
     private func applyLibrarySelection() {
+        let scopeID = libraryRootScopeID(
+            category: category,
+            fixedLibraryId: fixedLibraryId,
+            authority: libraryAuthority
+        )
         let resolved = resolvedLibraryIdForRoot(
             libraries,
             category: category,
             fixedLibraryId: fixedLibraryId,
             showAudiobooks: navPrefs.showAudiobooks,
-            storedLibraryId: storedLibraryId
+            storedLibraryId: storedLibraryId,
+            currentSelectionId: appliedScopeID == scopeID ? selectedLibraryId : nil
         )
+        appliedScopeID = scopeID
         selectedLibraryId = resolved
         if let resolved { persistLibrarySelection(resolved) }
     }
 
     private func persistLibrarySelection(_ libraryId: Int) {
-        guard let selectionStorageKey else { return }
-        storedLibraryId = libraryId
-        UserDefaults.standard.set(libraryId, forKey: selectionStorageKey)
+        if let selectionStorageKey {
+            storedLibraryId = libraryId
+            UserDefaults.standard.set(libraryId, forKey: selectionStorageKey)
+        }
+        mirrorSelectionToMediaTypeRoots(libraryId)
+    }
+
+    /// Landing on (or switching within) a direct-library root also records
+    /// the selection for the matching media-type roots, so tapping "Movies"
+    /// after visiting "4K Movies" lands on 4K Movies.
+    private func mirrorSelectionToMediaTypeRoots(_ libraryId: Int) {
+        guard fixedLibraryId != nil,
+              libraryAuthority != nil,
+              let library = libraries.first(where: { $0.id == libraryId })
+        else { return }
+        for mediaType in [PrimaryMenuBuiltin.movies, .series, .audiobooks]
+        where libraryMatchesPrimaryMenuCategory(library, category: mediaType) {
+            guard let key = librarySelectionStorageKey(
+                category: mediaType,
+                fixedLibraryId: nil,
+                authority: libraryAuthority
+            ) else { continue }
+            UserDefaults.standard.set(libraryId, forKey: key)
+        }
     }
 
     /// Load the currently-selected profile so we can render its avatar in

--- a/iosApp/iosApp/Screens/Browse/LibrariesTabView.swift
+++ b/iosApp/iosApp/Screens/Browse/LibrariesTabView.swift
@@ -16,6 +16,16 @@ func libraryMatchesPrimaryMenuCategory(
     }
 }
 
+func primaryMenuParentCategory(
+    for library: Library,
+    among categories: [PrimaryMenuBuiltin]
+) -> PrimaryMenuBuiltin? {
+    guard !library.isMixedLibrary else { return nil }
+    return categories.first {
+        libraryMatchesPrimaryMenuCategory(library, category: $0)
+    }
+}
+
 func visibleLibrariesForRoot(
     _ libraries: [Library],
     category: PrimaryMenuBuiltin?,

--- a/iosApp/iosApp/Screens/Browse/LibrariesTabView.swift
+++ b/iosApp/iosApp/Screens/Browse/LibrariesTabView.swift
@@ -358,11 +358,14 @@ struct LibrariesTabView: View {
     }
 
     /// The media-type scope the picker opened under, if any. A direct-library
-    /// root inherits the pinned library's type since its siblings share it.
+    /// root inherits the pinned library's type since its siblings share it —
+    /// unless the pinned library is mixed, whose sibling list spans both
+    /// movie and series libraries and so has no single scope.
     private var pickerScopeCategory: PrimaryMenuBuiltin? {
         if let category { return category }
         guard let fixedLibraryId,
-              let fixed = libraries.first(where: { $0.id == fixedLibraryId })
+              let fixed = libraries.first(where: { $0.id == fixedLibraryId }),
+              !fixed.isMixedLibrary
         else { return nil }
         return [PrimaryMenuBuiltin.movies, .series, .audiobooks].first {
             libraryMatchesPrimaryMenuCategory(fixed, category: $0)

--- a/iosApp/iosApp/Screens/Browse/LibrariesTabView.swift
+++ b/iosApp/iosApp/Screens/Browse/LibrariesTabView.swift
@@ -289,6 +289,11 @@ struct LibrariesTabView: View {
         .onChange(of: navPrefs.showAudiobooks) {
             applyLibrarySelection()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .userLibrariesDidRefresh)) {
+            notification in
+            guard let response = notification.object as? LibrariesResponse else { return }
+            acceptRefreshedLibraries(response)
+        }
         .sheet(isPresented: $showPicker) {
             LibraryPickerSheet(
                 libraries: visibleLibraries,
@@ -404,18 +409,27 @@ struct LibrariesTabView: View {
         do {
             let response = try await StartupContentPrefetcher.fetchUserLibraries()
             guard !Task.isCancelled else { return }
-            libraries = response.libraries
-            applyLibrarySelection()
-            onLibrariesLoaded?(libraryAuthority, response.libraries)
-            if let selectedLibraryId {
-                StartupContentPrefetcher.prefetchLibraryLanding(libraryId: selectedLibraryId)
-            }
+            acceptRefreshedLibraries(response)
         } catch {
             if libraries.isEmpty {
                 self.error = ErrorState(error)
             }
         }
         isLoading = false
+    }
+
+    /// Apply library metadata refreshed elsewhere (for example Home pull to
+    /// refresh) so retained tab instances cannot keep renamed or revoked
+    /// libraries in their local state.
+    private func acceptRefreshedLibraries(_ response: LibrariesResponse) {
+        libraries = response.libraries
+        error = nil
+        isLoading = false
+        applyLibrarySelection()
+        onLibrariesLoaded?(libraryAuthority, response.libraries)
+        if let selectedLibraryId {
+            StartupContentPrefetcher.prefetchLibraryLanding(libraryId: selectedLibraryId)
+        }
     }
 
     /// Preserve the stored selection if it still exists; otherwise fall

--- a/iosApp/iosApp/Screens/Browse/LibrariesTabView.swift
+++ b/iosApp/iosApp/Screens/Browse/LibrariesTabView.swift
@@ -82,6 +82,13 @@ func groupPinnedLibrariesUnderMediaTypes<Element>(
 }
 
 private func sharesPrimaryMenuCategory(_ lhs: Library, _ rhs: Library) -> Bool {
+    // Mixed libraries participate in both authored Movies and Series roots,
+    // but a pinned mixed-library root is its own scope. Treating its two
+    // category memberships as sibling relationships would expose every movie
+    // and series library from that direct root.
+    if lhs.isMixedLibrary {
+        return rhs.isMixedLibrary
+    }
     let categories: [PrimaryMenuBuiltin] = [.movies, .series, .audiobooks]
     return categories.contains {
         libraryMatchesPrimaryMenuCategory(lhs, category: $0)
@@ -358,9 +365,9 @@ struct LibrariesTabView: View {
     }
 
     /// The media-type scope the picker opened under, if any. A direct-library
-    /// root inherits the pinned library's type since its siblings share it —
-    /// unless the pinned library is mixed, whose sibling list spans both
-    /// movie and series libraries and so has no single scope.
+    /// root inherits the pinned library's type since its siblings share it.
+    /// Mixed-library roots have their own scope rather than inheriting either
+    /// Movies or Series.
     private var pickerScopeCategory: PrimaryMenuBuiltin? {
         if let category { return category }
         guard let fixedLibraryId,

--- a/iosApp/iosApp/Screens/Browse/LibrariesTabView.swift
+++ b/iosApp/iosApp/Screens/Browse/LibrariesTabView.swift
@@ -285,6 +285,7 @@ struct LibrariesTabView: View {
         .sheet(isPresented: $showPicker) {
             LibraryPickerSheet(
                 libraries: visibleLibraries,
+                scopedCategory: pickerScopeCategory,
                 selectedLibraryId: selectedLibraryId,
                 onSelect: { id in
                     selectedLibraryId = id
@@ -354,6 +355,18 @@ struct LibrariesTabView: View {
 
     private var activeLibrary: Library? {
         visibleLibraries.first(where: { $0.id == selectedLibraryId })
+    }
+
+    /// The media-type scope the picker opened under, if any. A direct-library
+    /// root inherits the pinned library's type since its siblings share it.
+    private var pickerScopeCategory: PrimaryMenuBuiltin? {
+        if let category { return category }
+        guard let fixedLibraryId,
+              let fixed = libraries.first(where: { $0.id == fixedLibraryId })
+        else { return nil }
+        return [PrimaryMenuBuiltin.movies, .series, .audiobooks].first {
+            libraryMatchesPrimaryMenuCategory(fixed, category: $0)
+        }
     }
 
     private var visibleLibraries: [Library] {
@@ -544,6 +557,7 @@ private struct LibrarySelectorButton: View {
 /// switching the active library from the Libraries tab.
 private struct LibraryPickerSheet: View {
     let libraries: [Library]
+    let scopedCategory: PrimaryMenuBuiltin?
     let selectedLibraryId: Int?
     let onSelect: (Int) -> Void
 
@@ -582,6 +596,7 @@ private struct LibraryPickerSheet: View {
                 ForEach(libraries) { library in
                     LibraryPickerRow(
                         library: library,
+                        scopedCategory: scopedCategory,
                         isSelected: library.id == selectedLibraryId,
                         onTap: { onSelect(library.id) }
                     )
@@ -597,6 +612,7 @@ private struct LibraryPickerSheet: View {
 
 private struct LibraryPickerRow: View {
     let library: Library
+    let scopedCategory: PrimaryMenuBuiltin?
     let isSelected: Bool
     let onTap: () -> Void
 
@@ -616,9 +632,11 @@ private struct LibraryPickerRow: View {
                     Text(library.name)
                         .font(.continuumHeadline)
                         .foregroundColor(.continuumOnSurface)
-                    Text(typeLabel)
-                        .font(.continuumCaption)
-                        .foregroundColor(.continuumSecondaryText)
+                    if let typeLabel {
+                        Text(typeLabel)
+                            .font(.continuumCaption)
+                            .foregroundColor(.continuumSecondaryText)
+                    }
                 }
 
                 Spacer()
@@ -652,7 +670,11 @@ private struct LibraryPickerRow: View {
         return "square.stack.3d.up.fill"
     }
 
-    private var typeLabel: String {
+    /// Nil when the caption would just repeat the media-type scope the picker
+    /// opened under — every non-mixed library there shares that type. Mixed
+    /// libraries keep their caption since they stand out from the scope.
+    private var typeLabel: String? {
+        if scopedCategory != nil && !library.isMixedLibrary { return nil }
         if library.isAudiobookLibrary { return "Audiobooks library" }
         if library.isMixedLibrary { return "Movies & Series library" }
         if library.isSeriesLibrary { return "TV library" }

--- a/iosApp/iosApp/Screens/Home/HomeView.swift
+++ b/iosApp/iosApp/Screens/Home/HomeView.swift
@@ -268,7 +268,10 @@ struct HomeView: View {
             showRefreshStatus()
         }
 
-        await viewModel.loadSections()
+        async let homeRefresh: Void = viewModel.loadSections()
+        async let libraryRefresh: LibrariesResponse? = try? await StartupContentPrefetcher
+            .fetchUserLibraries()
+        _ = await (homeRefresh, libraryRefresh)
 
         await MainActor.run {
             scheduleRefreshStatusHide()

--- a/iosApp/iosApp/Screens/Settings/InterfaceCustomizationView.swift
+++ b/iosApp/iosApp/Screens/Settings/InterfaceCustomizationView.swift
@@ -39,48 +39,29 @@ func groupedPrimaryMenuEditorRows(
     _ items: [PrimaryMenuItem],
     libraries: [Library]
 ) -> [PrimaryMenuEditorRow] {
-    let librariesById = Dictionary(uniqueKeysWithValues: libraries.map { ($0.id, $0) })
-    let mediaTypes = items.compactMap { item -> PrimaryMenuBuiltin? in
-        guard case .builtin(let builtin) = item,
-              builtin == .movies
-                || builtin == .series
-                || builtin == .music
-                || builtin == .audiobooks
-        else { return nil }
-        return builtin
-    }
-    var parentByLibraryId: [Int: PrimaryMenuBuiltin] = [:]
-    for item in items {
-        guard case .library(let libraryId, _) = item,
-              let library = librariesById[libraryId],
-              let parent = primaryMenuParentCategory(for: library, among: mediaTypes)
-        else { continue }
-        parentByLibraryId[libraryId] = parent
-    }
-
-    var rows: [PrimaryMenuEditorRow] = []
-    for item in items {
-        if case .library(let libraryId, _) = item,
-           parentByLibraryId[libraryId] != nil {
-            continue
+    groupPinnedLibrariesUnderMediaTypes(
+        items,
+        libraries: libraries,
+        libraryID: { item in
+            guard case .library(let libraryId, _) = item else { return nil }
+            return libraryId
+        },
+        mediaTypeCategory: { item in
+            guard case .builtin(let builtin) = item,
+                  builtin == .movies
+                    || builtin == .series
+                    || builtin == .music
+                    || builtin == .audiobooks
+            else { return nil }
+            return builtin
         }
-
-        rows.append(.init(item: item, parentMediaType: nil))
-        guard case .builtin(let builtin) = item else { continue }
-        for child in items {
-            guard case .library(let libraryId, _) = child,
-                  parentByLibraryId[libraryId] == builtin
-            else { continue }
-            rows.append(.init(item: child, parentMediaType: builtin))
-        }
-    }
-    return rows
+    ).map { .init(item: $0.element, parentMediaType: $0.parentCategory) }
 }
 
 func availablePrimaryMenuShortcuts(
     candidates: [PrimaryMenuItem],
     libraries: [Library],
-    visibleIds: Set<String>,
+    visibleIds: Set<String>
 ) -> [PrimaryMenuItem] {
     let libraryItems = libraries.map {
         PrimaryMenuItem.library(libraryId: $0.id, label: $0.name)
@@ -411,7 +392,7 @@ struct InterfaceCustomizationView: View {
         return availablePrimaryMenuShortcuts(
             candidates: candidates,
             libraries: libraries.sorted(by: librarySort),
-            visibleIds: visible,
+            visibleIds: visible
         )
     }
 

--- a/iosApp/iosApp/Screens/Settings/InterfaceCustomizationView.swift
+++ b/iosApp/iosApp/Screens/Settings/InterfaceCustomizationView.swift
@@ -291,6 +291,23 @@ struct InterfaceCustomizationView: View {
                 }
             }
 
+            if !pinnedLibraries.isEmpty {
+                Section {
+                    ForEach(pinnedLibraries) { library in
+                        Button(role: .destructive) {
+                            preferences.setLibraryPinned(library, isPinned: false)
+                        } label: {
+                            Label("Unpin \(library.name)", systemImage: "pin.slash.fill")
+                        }
+                    }
+                } header: {
+                    Text("Pinned Libraries")
+                } footer: {
+                    Text("Unpinning removes the library shortcut from your profile and from this menu.")
+                }
+                .disabled(!preferences.allowsEditing)
+            }
+
             if let message = preferences.syncErrorMessage,
                message != preferences.capabilityMessage {
                 Section {
@@ -399,6 +416,12 @@ struct InterfaceCustomizationView: View {
             libraries: libraries.sorted(by: librarySort),
             visibleIds: visible
         )
+    }
+
+    private var pinnedLibraries: [Library] {
+        libraries
+            .filter { preferences.isLibraryPinned($0.id) }
+            .sorted(by: librarySort)
     }
 
     private func displayTitle(for item: PrimaryMenuItem) -> String {

--- a/iosApp/iosApp/Screens/Settings/InterfaceCustomizationView.swift
+++ b/iosApp/iosApp/Screens/Settings/InterfaceCustomizationView.swift
@@ -243,7 +243,7 @@ struct InterfaceCustomizationView: View {
                                 .accessibilityLabel("Move \(displayTitle(for: item)) down")
 
                                 Button {
-                                    hide(item)
+                                    remove(item)
                                 } label: {
                                     Image(systemName: "minus.circle.fill")
                                         .foregroundStyle(.red)
@@ -251,7 +251,9 @@ struct InterfaceCustomizationView: View {
                                         .contentShape(Rectangle())
                                 }
                                 .buttonStyle(.plain)
-                                .accessibilityLabel("Hide \(displayTitle(for: item))")
+                                .accessibilityLabel(
+                                    "\(removalVerb(for: item)) \(displayTitle(for: item))"
+                                )
                             }
                             // The controls never compress; the flexible title
                             // column absorbs narrow widths by truncating.
@@ -262,7 +264,7 @@ struct InterfaceCustomizationView: View {
             } header: {
                 Text("Primary Menu")
             } footer: {
-                Text("Home is required. Use the arrows to reorder items. Libraries stay grouped under their media type and can only move within that group. Downloads (when available), Search, and Profile stay automatic.")
+                Text("Home is required. Use the arrows to reorder items. Libraries stay grouped under their media type and can only move within that group. Removing a library unpins it from your profile. Downloads (when available), Search, and Profile stay automatic.")
             }
             .disabled(
                 !preferences.allowsEditing
@@ -459,11 +461,19 @@ struct InterfaceCustomizationView: View {
         ) != nil
     }
 
-    private func hide(_ item: PrimaryMenuItem) {
+    private func remove(_ item: PrimaryMenuItem) {
         guard !item.isHome else { return }
-        // This control edits the current family menu. A library shortcut is
-        // profile-wide, so hiding its placement must not unpin it elsewhere.
+        if case .library(let libraryId, _) = item,
+           let library = libraries.first(where: { $0.id == libraryId }) {
+            preferences.setLibraryPinned(library, isPinned: false)
+            return
+        }
         persistVisibleDestinations(visibleDestinations.filter { $0.id != item.id })
+    }
+
+    private func removalVerb(for item: PrimaryMenuItem) -> String {
+        if case .library = item { return "Unpin" }
+        return "Hide"
     }
 
     private func addAvailableShortcut(_ item: PrimaryMenuItem) {

--- a/iosApp/iosApp/Screens/Settings/InterfaceCustomizationView.swift
+++ b/iosApp/iosApp/Screens/Settings/InterfaceCustomizationView.swift
@@ -297,7 +297,11 @@ struct InterfaceCustomizationView: View {
     }
 
     private func displayTitle(for item: PrimaryMenuItem) -> String {
-        item.title
+        if case .library(let libraryId, _) = item,
+           let currentName = libraries.first(where: { $0.id == libraryId })?.name {
+            return currentName
+        }
+        return item.title
     }
 
     private func move(from source: IndexSet, to destination: Int) {

--- a/iosApp/iosApp/Screens/Settings/InterfaceCustomizationView.swift
+++ b/iosApp/iosApp/Screens/Settings/InterfaceCustomizationView.swift
@@ -461,11 +461,8 @@ struct InterfaceCustomizationView: View {
 
     private func hide(_ item: PrimaryMenuItem) {
         guard !item.isHome else { return }
-        if case .library(let libraryId, _) = item,
-           let library = libraries.first(where: { $0.id == libraryId }) {
-            preferences.setLibraryPinned(library, isPinned: false)
-            return
-        }
+        // This control edits the current family menu. A library shortcut is
+        // profile-wide, so hiding its placement must not unpin it elsewhere.
         persistVisibleDestinations(visibleDestinations.filter { $0.id != item.id })
     }
 
@@ -482,9 +479,8 @@ struct InterfaceCustomizationView: View {
         persistVisibleDestinations(visibleDestinations + [item])
     }
 
-    private func canEditAvailableShortcut(_ item: PrimaryMenuItem) -> Bool {
+    private func canEditAvailableShortcut(_: PrimaryMenuItem) -> Bool {
         guard preferences.allowsEditing else { return false }
-        if case .library = item { return true }
         return !preferences.primaryMenuUsesDeviceOverride
     }
 

--- a/iosApp/iosApp/Screens/Settings/InterfaceCustomizationView.swift
+++ b/iosApp/iosApp/Screens/Settings/InterfaceCustomizationView.swift
@@ -264,7 +264,11 @@ struct InterfaceCustomizationView: View {
             } header: {
                 Text("Primary Menu")
             } footer: {
-                Text("Home is required. Use the arrows to reorder items. Libraries stay grouped under their media type and can only move within that group. Removing a library unpins it from your profile. Downloads (when available), Search, and Profile stay automatic.")
+                if isDefaultMenuApplied {
+                    Text("Default menu applied. Add shortcuts to customize.")
+                } else {
+                    Text("Home is required. Use the arrows to reorder items. Libraries stay grouped under their media type and can only move within that group. Removing a library unpins it from your profile. Downloads (when available), Search, and Profile stay automatic.")
+                }
             }
             .disabled(
                 !preferences.allowsEditing
@@ -289,23 +293,6 @@ struct InterfaceCustomizationView: View {
                         .disabled(!canEditAvailableShortcut(item))
                     }
                 }
-            }
-
-            if !pinnedLibraries.isEmpty {
-                Section {
-                    ForEach(pinnedLibraries) { library in
-                        Button(role: .destructive) {
-                            preferences.setLibraryPinned(library, isPinned: false)
-                        } label: {
-                            Label("Unpin \(library.name)", systemImage: "pin.slash.fill")
-                        }
-                    }
-                } header: {
-                    Text("Pinned Libraries")
-                } footer: {
-                    Text("Unpinning removes the library shortcut from your profile and from this menu.")
-                }
-                .disabled(!preferences.allowsEditing)
             }
 
             if let message = preferences.syncErrorMessage,
@@ -406,6 +393,10 @@ struct InterfaceCustomizationView: View {
         groupedPrimaryMenuEditorRows(visibleDestinations, libraries: libraries)
     }
 
+    private var isDefaultMenuApplied: Bool {
+        visibleDestinations.count == 1 && visibleDestinations[0].isHome
+    }
+
     private var availableShortcuts: [PrimaryMenuItem] {
         let visible = Set(visibleDestinations.map(\.id))
         let candidates = Self.candidates.filter {
@@ -416,12 +407,6 @@ struct InterfaceCustomizationView: View {
             libraries: libraries.sorted(by: librarySort),
             visibleIds: visible
         )
-    }
-
-    private var pinnedLibraries: [Library] {
-        libraries
-            .filter { preferences.isLibraryPinned($0.id) }
-            .sorted(by: librarySort)
     }
 
     private func displayTitle(for item: PrimaryMenuItem) -> String {
@@ -488,7 +473,17 @@ struct InterfaceCustomizationView: View {
         guard !item.isHome else { return }
         if case .library(let libraryId, _) = item,
            let library = libraries.first(where: { $0.id == libraryId }) {
-            preferences.setLibraryPinned(library, isPinned: false)
+            if preferences.isLibraryPinned(libraryId) {
+                preferences.setLibraryPinned(library, isPinned: false)
+            } else {
+                // Older or independently-authored menus can contain a library
+                // placement without a matching profile shortcut. There is
+                // nothing to unpin in that case, so remove the placement
+                // directly instead of letting setLibraryPinned no-op.
+                persistVisibleDestinations(
+                    visibleDestinations.filter { $0.id != item.id }
+                )
+            }
             return
         }
         persistVisibleDestinations(visibleDestinations.filter { $0.id != item.id })

--- a/iosApp/iosApp/Screens/Settings/InterfaceCustomizationView.swift
+++ b/iosApp/iosApp/Screens/Settings/InterfaceCustomizationView.swift
@@ -215,15 +215,15 @@ struct InterfaceCustomizationView: View {
                         } else {
                             shortcutLabel(for: item)
                         }
-                        Spacer()
+                        Spacer(minLength: 8)
                         if !item.isHome {
-                            HStack(spacing: 12) {
+                            HStack(spacing: 4) {
                                 Button {
                                     move(item, by: -1)
                                 } label: {
                                     Image(systemName: "arrow.up")
                                         .font(.title3.weight(.semibold))
-                                        .frame(width: 52, height: 48)
+                                        .frame(width: 44, height: 44)
                                         .contentShape(Rectangle())
                                 }
                                 .buttonStyle(.plain)
@@ -235,24 +235,27 @@ struct InterfaceCustomizationView: View {
                                 } label: {
                                     Image(systemName: "arrow.down")
                                         .font(.title3.weight(.semibold))
-                                        .frame(width: 52, height: 48)
+                                        .frame(width: 44, height: 44)
                                         .contentShape(Rectangle())
                                 }
                                 .buttonStyle(.plain)
                                 .disabled(!canMove(item, by: 1))
                                 .accessibilityLabel("Move \(displayTitle(for: item)) down")
-                            }
 
-                            Button {
-                                hide(item)
-                            } label: {
-                                Image(systemName: "minus.circle.fill")
-                                    .foregroundStyle(.red)
-                                    .frame(width: 44, height: 44)
-                                    .contentShape(Rectangle())
+                                Button {
+                                    hide(item)
+                                } label: {
+                                    Image(systemName: "minus.circle.fill")
+                                        .foregroundStyle(.red)
+                                        .frame(width: 44, height: 44)
+                                        .contentShape(Rectangle())
+                                }
+                                .buttonStyle(.plain)
+                                .accessibilityLabel("Hide \(displayTitle(for: item))")
                             }
-                            .buttonStyle(.plain)
-                            .accessibilityLabel("Hide \(displayTitle(for: item))")
+                            // The controls never compress; the flexible title
+                            // column absorbs narrow widths by truncating.
+                            .fixedSize()
                         }
                     }
                 }
@@ -411,8 +414,12 @@ struct InterfaceCustomizationView: View {
         HStack(spacing: 10) {
             Image(systemName: navigationIcon(for: item))
                 .frame(width: 22)
-            HStack(spacing: 10) {
+            // The type caption sits under the title rather than beside it so
+            // narrow screens never squeeze either into per-character wraps;
+            // the title truncates instead of wrapping.
+            VStack(alignment: .leading, spacing: 2) {
                 Text(displayTitle(for: item))
+                    .lineLimit(1)
                 Text(
                     primaryMenuShortcutTypeTitle(
                         item,
@@ -422,6 +429,7 @@ struct InterfaceCustomizationView: View {
                 )
                     .font(.caption.weight(.medium))
                     .foregroundStyle(Color.continuumSecondaryText.opacity(0.75))
+                    .lineLimit(1)
             }
         }
     }

--- a/iosApp/iosApp/Screens/Settings/InterfaceCustomizationView.swift
+++ b/iosApp/iosApp/Screens/Settings/InterfaceCustomizationView.swift
@@ -1,15 +1,150 @@
 #if !os(tvOS)
 import SwiftUI
 
-func availablePrimaryMenuLibraryShortcuts(
-    _ shortcuts: [PrimaryMenuItem],
-    visibleIds: Set<String>,
-    availableLibraryIds: Set<Int>
-) -> [PrimaryMenuItem] {
-    shortcuts.filter { item in
-        guard case .library(let libraryId, _) = item else { return false }
-        return availableLibraryIds.contains(libraryId) && !visibleIds.contains(item.id)
+struct PrimaryMenuEditorRow: Identifiable, Equatable {
+    let item: PrimaryMenuItem
+    let parentMediaType: PrimaryMenuBuiltin?
+
+    var id: String { item.id }
+    var isNestedLibrary: Bool { parentMediaType != nil }
+}
+
+func primaryMenuShortcutTypeTitle(
+    _ item: PrimaryMenuItem,
+    libraries: [Library] = [],
+    isNestedLibrary: Bool = false
+) -> String {
+    switch item {
+    case .builtin(.movies), .builtin(.series), .builtin(.music), .builtin(.audiobooks):
+        return "Media Type"
+    case .library(let libraryId, _):
+        guard !isNestedLibrary,
+              let library = libraries.first(where: { $0.id == libraryId })
+        else { return "Library" }
+        if library.isMixedLibrary { return "Mixed Library" }
+        if library.isMovieLibrary { return "Movies Library" }
+        if library.isSeriesLibrary { return "Series Library" }
+        if library.isAudiobookLibrary { return "Audiobooks Library" }
+        return "Library"
+    case .section, .collection:
+        return "Library"
+    case .builtin(.forYou), .builtin(.calendar):
+        return "Discover"
+    case .builtin(.home):
+        return "Your Stuff"
     }
+}
+
+func groupedPrimaryMenuEditorRows(
+    _ items: [PrimaryMenuItem],
+    libraries: [Library]
+) -> [PrimaryMenuEditorRow] {
+    let librariesById = Dictionary(uniqueKeysWithValues: libraries.map { ($0.id, $0) })
+    let mediaTypes = items.compactMap { item -> PrimaryMenuBuiltin? in
+        guard case .builtin(let builtin) = item,
+              builtin == .movies
+                || builtin == .series
+                || builtin == .music
+                || builtin == .audiobooks
+        else { return nil }
+        return builtin
+    }
+    var parentByLibraryId: [Int: PrimaryMenuBuiltin] = [:]
+    for item in items {
+        guard case .library(let libraryId, _) = item,
+              let library = librariesById[libraryId],
+              let parent = primaryMenuParentCategory(for: library, among: mediaTypes)
+        else { continue }
+        parentByLibraryId[libraryId] = parent
+    }
+
+    var rows: [PrimaryMenuEditorRow] = []
+    for item in items {
+        if case .library(let libraryId, _) = item,
+           parentByLibraryId[libraryId] != nil {
+            continue
+        }
+
+        rows.append(.init(item: item, parentMediaType: nil))
+        guard case .builtin(let builtin) = item else { continue }
+        for child in items {
+            guard case .library(let libraryId, _) = child,
+                  parentByLibraryId[libraryId] == builtin
+            else { continue }
+            rows.append(.init(item: child, parentMediaType: builtin))
+        }
+    }
+    return rows
+}
+
+func availablePrimaryMenuShortcuts(
+    candidates: [PrimaryMenuItem],
+    libraries: [Library],
+    visibleIds: Set<String>,
+) -> [PrimaryMenuItem] {
+    let libraryItems = libraries.map {
+        PrimaryMenuItem.library(libraryId: $0.id, label: $0.name)
+    }
+    return (candidates + libraryItems).filter { !visibleIds.contains($0.id) }
+}
+
+func offsetPrimaryMenuEditorItem(
+    _ rows: [PrimaryMenuEditorRow],
+    itemId: String,
+    by offset: Int
+) -> [PrimaryMenuItem]? {
+    guard offset != 0,
+          let sourceIndex = rows.firstIndex(where: { $0.id == itemId })
+    else { return nil }
+    let sourceRow = rows[sourceIndex]
+    guard !sourceRow.item.isHome else { return nil }
+
+    if let parent = sourceRow.parentMediaType {
+        let siblingIndices = rows.indices.filter {
+            rows[$0].parentMediaType == parent
+        }
+        guard let siblingSourceIndex = siblingIndices.firstIndex(of: sourceIndex) else {
+            return nil
+        }
+        let siblingTargetIndex = siblingSourceIndex + offset
+        guard siblingIndices.indices.contains(siblingTargetIndex) else { return nil }
+
+        var reorderedRows = rows
+        reorderedRows.swapAt(
+            siblingIndices[siblingSourceIndex],
+            siblingIndices[siblingTargetIndex]
+        )
+        return reorderedRows.map(\.item)
+    }
+
+    let movableRoots = rows.filter {
+        $0.parentMediaType == nil && !$0.item.isHome
+    }
+    guard let rootSourceIndex = movableRoots.firstIndex(where: { $0.id == itemId }) else {
+        return nil
+    }
+    let rootTargetIndex = rootSourceIndex + offset
+    guard movableRoots.indices.contains(rootTargetIndex) else { return nil }
+
+    var rootIds = rows.compactMap { row in
+        row.parentMediaType == nil ? row.id : nil
+    }
+    guard let sourceRootIndex = rootIds.firstIndex(of: itemId),
+          let targetRootIndex = rootIds.firstIndex(of: movableRoots[rootTargetIndex].id)
+    else { return nil }
+    rootIds.swapAt(sourceRootIndex, targetRootIndex)
+
+    var blockByRootId: [String: [PrimaryMenuItem]] = [:]
+    var currentRootId: String?
+    for row in rows {
+        if row.parentMediaType == nil {
+            currentRootId = row.id
+            blockByRootId[row.id] = [row.item]
+        } else if let currentRootId {
+            blockByRootId[currentRootId, default: []].append(row.item)
+        }
+    }
+    return rootIds.flatMap { blockByRootId[$0] ?? [] }
 }
 
 /// Family-synced navigation and card presets for iPhone, iPad, and Mac.
@@ -84,33 +219,49 @@ struct InterfaceCustomizationView: View {
             )
 
             Section {
-                ForEach(visibleDestinations) { item in
+                ForEach(visibleRows) { row in
+                    let item = row.item
                     HStack(spacing: 12) {
-                        Image(systemName: item.isHome ? "lock.fill" : "line.3.horizontal")
-                            .foregroundStyle(Color.continuumSecondaryText)
-                            .frame(width: 22)
-                        Text(displayTitle(for: item))
+                        if row.isNestedLibrary {
+                            HStack(spacing: 8) {
+                                Image(systemName: "arrow.turn.down.right")
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundStyle(Color.continuumSecondaryText)
+                                    .frame(width: 18)
+                                shortcutLabel(for: item, isNestedLibrary: true)
+                            }
+                            .padding(.leading, 20)
+                        } else {
+                            shortcutLabel(for: item)
+                        }
                         Spacer()
-#if os(macOS)
-                        Button {
-                            move(item, by: -1)
-                        } label: {
-                            Image(systemName: "arrow.up")
-                        }
-                        .buttonStyle(.plain)
-                        .disabled(visibleDestinations.first?.id == item.id)
-                        .accessibilityLabel("Move \(displayTitle(for: item)) up")
-
-                        Button {
-                            move(item, by: 1)
-                        } label: {
-                            Image(systemName: "arrow.down")
-                        }
-                        .buttonStyle(.plain)
-                        .disabled(visibleDestinations.last?.id == item.id)
-                        .accessibilityLabel("Move \(displayTitle(for: item)) down")
-#endif
                         if !item.isHome {
+                            HStack(spacing: 12) {
+                                Button {
+                                    move(item, by: -1)
+                                } label: {
+                                    Image(systemName: "arrow.up")
+                                        .font(.title3.weight(.semibold))
+                                        .frame(width: 52, height: 48)
+                                        .contentShape(Rectangle())
+                                }
+                                .buttonStyle(.plain)
+                                .disabled(!canMove(item, by: -1))
+                                .accessibilityLabel("Move \(displayTitle(for: item)) up")
+
+                                Button {
+                                    move(item, by: 1)
+                                } label: {
+                                    Image(systemName: "arrow.down")
+                                        .font(.title3.weight(.semibold))
+                                        .frame(width: 52, height: 48)
+                                        .contentShape(Rectangle())
+                                }
+                                .buttonStyle(.plain)
+                                .disabled(!canMove(item, by: 1))
+                                .accessibilityLabel("Move \(displayTitle(for: item)) down")
+                            }
+
                             Button {
                                 hide(item)
                             } label: {
@@ -124,62 +275,34 @@ struct InterfaceCustomizationView: View {
                         }
                     }
                 }
-                .onMove(perform: move)
             } header: {
                 Text("Primary Menu")
             } footer: {
-                Text("Home is required. Downloads (when available), Search, and Profile stay automatic. Media categories share Libraries; pinned libraries open directly. Unsupported section and collection rows stay synced for clients that can show them.")
+                Text("Home is required. Use the arrows to reorder items. Libraries stay grouped under their media type and can only move within that group. Downloads (when available), Search, and Profile stay automatic.")
             }
             .disabled(
                 !preferences.allowsEditing
                     || preferences.primaryMenuUsesDeviceOverride
             )
 
-            if !hiddenDestinations.isEmpty {
-                Section("Hidden") {
-                    ForEach(hiddenDestinations) { item in
-                        Button {
-                            show(item)
-                        } label: {
-                            Label("Show \(displayTitle(for: item))", systemImage: "plus.circle.fill")
-                        }
-                    }
-                }
-                .disabled(
-                    !preferences.allowsEditing
-                        || preferences.primaryMenuUsesDeviceOverride
-                )
-            }
-
             if !availableShortcuts.isEmpty {
                 Section("Available Shortcuts") {
                     ForEach(availableShortcuts) { item in
                         Button {
-                            show(item)
+                            addAvailableShortcut(item)
                         } label: {
-                            Label("Show \(item.title)", systemImage: "pin.circle.fill")
+                            HStack(spacing: 10) {
+                                Image(systemName: "plus.circle.fill")
+                                shortcutLabel(for: item)
+                            }
                         }
-                    }
-                }
-                .disabled(
-                    !preferences.allowsEditing
-                        || preferences.primaryMenuUsesDeviceOverride
-                )
-            }
-
-            if !libraries.isEmpty {
-                Section("Pinned Libraries") {
-                    ForEach(libraries.sorted(by: librarySort)) { library in
-                        Toggle(
-                            library.name,
-                            isOn: Binding(
-                                get: { preferences.isLibraryPinned(library.id) },
-                                set: { preferences.setLibraryPinned(library, isPinned: $0) }
-                            )
+                        .accessibilityLabel(
+                            "Pin \(displayTitle(for: item)), "
+                                + primaryMenuShortcutTypeTitle(item, libraries: libraries)
                         )
+                        .disabled(!canEditAvailableShortcut(item))
                     }
                 }
-                .disabled(!preferences.allowsEditing)
             }
 
             if let message = preferences.syncErrorMessage,
@@ -193,9 +316,6 @@ struct InterfaceCustomizationView: View {
         }
         .continuumGroupedListStyle()
         .navigationTitle("Interface")
-#if os(iOS)
-        .toolbar { EditButton() }
-#endif
         .task {
             await preferences.refresh()
         }
@@ -279,20 +399,19 @@ struct InterfaceCustomizationView: View {
         }
     }
 
-    private var hiddenDestinations: [PrimaryMenuItem] {
-        let visible = Set(visibleDestinations.map(\.id))
-        return Self.candidates.filter {
-            mainTabSupportsDestination($0, availableLibraries: libraries)
-                && !visible.contains($0.id)
-        }
+    private var visibleRows: [PrimaryMenuEditorRow] {
+        groupedPrimaryMenuEditorRows(visibleDestinations, libraries: libraries)
     }
 
     private var availableShortcuts: [PrimaryMenuItem] {
         let visible = Set(visibleDestinations.map(\.id))
-        return availablePrimaryMenuLibraryShortcuts(
-            preferences.shortcuts.items,
+        let candidates = Self.candidates.filter {
+            mainTabSupportsDestination($0, availableLibraries: libraries)
+        }
+        return availablePrimaryMenuShortcuts(
+            candidates: candidates,
+            libraries: libraries.sorted(by: librarySort),
             visibleIds: visible,
-            availableLibraryIds: Set(libraries.map(\.id))
         )
     }
 
@@ -304,28 +423,80 @@ struct InterfaceCustomizationView: View {
         return item.title
     }
 
-    private func move(from source: IndexSet, to destination: Int) {
-        var items = visibleDestinations
-        items.move(fromOffsets: source, toOffset: destination)
-        persistVisibleDestinations(items)
+    private func shortcutLabel(
+        for item: PrimaryMenuItem,
+        isNestedLibrary: Bool = false
+    ) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: navigationIcon(for: item))
+                .frame(width: 22)
+            HStack(spacing: 10) {
+                Text(displayTitle(for: item))
+                Text(
+                    primaryMenuShortcutTypeTitle(
+                        item,
+                        libraries: libraries,
+                        isNestedLibrary: isNestedLibrary
+                    ).uppercased()
+                )
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(Color.continuumSecondaryText.opacity(0.75))
+            }
+        }
+    }
+
+    private func navigationIcon(for item: PrimaryMenuItem) -> String {
+        guard case .library(let libraryId, _) = item else {
+            return item.navigationIcon
+        }
+        return libraries.first(where: { $0.id == libraryId })?.navigationIcon
+            ?? item.navigationIcon
     }
 
     private func move(_ item: PrimaryMenuItem, by offset: Int) {
-        var items = visibleDestinations
-        guard let source = items.firstIndex(where: { $0.id == item.id }) else { return }
-        let destination = source + offset
-        guard items.indices.contains(destination) else { return }
-        items.swapAt(source, destination)
+        guard let items = offsetPrimaryMenuEditorItem(
+            visibleRows,
+            itemId: item.id,
+            by: offset
+        ) else { return }
         persistVisibleDestinations(items)
+    }
+
+    private func canMove(_ item: PrimaryMenuItem, by offset: Int) -> Bool {
+        offsetPrimaryMenuEditorItem(
+            visibleRows,
+            itemId: item.id,
+            by: offset
+        ) != nil
     }
 
     private func hide(_ item: PrimaryMenuItem) {
         guard !item.isHome else { return }
+        if case .library(let libraryId, _) = item,
+           let library = libraries.first(where: { $0.id == libraryId }) {
+            preferences.setLibraryPinned(library, isPinned: false)
+            return
+        }
         persistVisibleDestinations(visibleDestinations.filter { $0.id != item.id })
     }
 
-    private func show(_ item: PrimaryMenuItem) {
+    private func addAvailableShortcut(_ item: PrimaryMenuItem) {
+        if case .library(let libraryId, _) = item,
+           let library = libraries.first(where: { $0.id == libraryId }) {
+            if preferences.isLibraryPinned(libraryId) {
+                persistVisibleDestinations(visibleDestinations + [item])
+            } else {
+                preferences.setLibraryPinned(library, isPinned: true)
+            }
+            return
+        }
         persistVisibleDestinations(visibleDestinations + [item])
+    }
+
+    private func canEditAvailableShortcut(_ item: PrimaryMenuItem) -> Bool {
+        guard preferences.allowsEditing else { return false }
+        if case .library = item { return true }
+        return !preferences.primaryMenuUsesDeviceOverride
     }
 
     private func persistVisibleDestinations(_ destinations: [PrimaryMenuItem]) {

--- a/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
+++ b/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+extension Notification.Name {
+    static let userLibrariesDidRefresh = Notification.Name("userLibrariesDidRefresh")
+}
+
 @MainActor
 enum StartupContentPrefetcher {
     // tvOS paints a full-width first row plus the focus marquee's logo and
@@ -197,6 +201,10 @@ enum StartupContentPrefetcher {
                 userLibrariesTask = nil
             }
             ResponseCache.shared.set(response, for: CacheKey.userLibraries)
+            NotificationCenter.default.post(
+                name: .userLibrariesDidRefresh,
+                object: response
+            )
             return response
         } catch {
             if profileScopedGeneration == generation {


### PR DESCRIPTION
## Problem

On regular-width iPad layouts, the primary navigation behaved like a resizable split column. Opening it could shift the detail view, its width could drift, and custom-header or pushed screens did not always provide a reliable way back to the sidebar.

Pinned libraries also appeared as unrelated root rows, could display stale names, and direct-library destinations could not switch cleanly among compatible libraries. Menu-only library entries could become impossible to remove, and removing every customization could leave the rendered sidebar with Home as its only destination.

## Approach

- Present the iPad sidebar as a fixed-width overlay that starts closed and leaves the detail layout in place.
- Add finger-following swipe dismissal, coordinated dimming, a dedicated close control, and stable header spacing for long server names.
- Preserve sidebar access from custom headers, Downloads, and pushed detail routes while retaining the standard macOS split layout.
- Group pinned libraries under visible media types, refresh their names and icons from current library metadata, and keep mixed libraries in their own direct-library scope.
- Preserve in-session switching between compatible libraries and mirror direct selections back to their media-type roots.
- Make the Primary Menu removal control unpin profile shortcuts when present and directly remove legacy/menu-only library placements otherwise.
- Treat a rendered Home-only menu as the default state: Home, Movies, Series, For You, and Calendar. Settings communicates that defaults are active and invites the user to add shortcuts to customize.
- Propagate Home-triggered library refreshes into retained library tabs so renamed or revoked libraries cannot remain in local tab state.
- Expand focused coverage for grouping, ordering, selection scope, mixed-library behavior, and default-menu projection.

## Validation

- `xcodegen generate`
- iOS simulator build succeeded for `Silo` on iOS 26.5
- `git diff --check`
- Original CodeRabbit actionable threads addressed and resolved
- Latest Codex retained-library refresh finding addressed in `00a3721`

The focused test target is currently blocked by unrelated existing `LoopbackSegmentStoreVODRetentionTests` references to a missing `spillDirectoryForTesting` hook.

## Risk

Medium. The sidebar drag implementation coordinates with UIKit's split-view presentation hierarchy, so physical iPad validation is still recommended for touch dismissal, interrupted gestures, rotation, and pointer scrolling. macOS retains its existing side-by-side layout.