### PR TITLE
fix(ios): polish detail chrome and player launch

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -1552,6 +1552,19 @@ struct MainTabView: View {
         )) {
             AudioFullPlayerView()
         }
+        // Fade the presenting content to black as soon as the player cover
+        // starts sliding up. The detail hero extends bright artwork under the
+        // status bar, and the cover spring's slow ease-out tail leaves that
+        // band as the last uncovered thing on screen — reading as a stutter
+        // at the top of the wipe. Black under black makes the tail (and the
+        // status-bar/rotation changes at completion) invisible.
+        .overlay {
+            if router.presentedPlayer != nil {
+                Color.black.ignoresSafeArea()
+                    .transition(.opacity)
+            }
+        }
+        .animation(.easeOut(duration: 0.15), value: router.presentedPlayer == nil)
         .fullScreenCover(item: $router.presentedPlayer) { payload in
             PlayerView(
                 contentId: payload.contentId,

--- a/iosApp/iosApp/Screens/Detail/ItemDetailView.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailView.swift
@@ -79,6 +79,11 @@ private struct ItemDetailPhoneContent: View {
     #if os(iOS)
     @Environment(SiloControlClient.self) private var siloControl
     @State private var controlRequestBox: ControlRequestBox?
+    /// Top overscroll of the detail scroll view (pt). The interactive zoom
+    /// pull-down always begins as top overscroll, so this drives the
+    /// in-place fade of the custom top chrome; if the pull is cancelled the
+    /// bounce-back restores it to zero and the chrome fades back in.
+    @State private var chromeOverscroll: CGFloat = 0
     #endif
     @Environment(AppRouter.self) private var router
 
@@ -194,20 +199,18 @@ private struct ItemDetailPhoneContent: View {
                 : "You're offline. Connect to a network to stream, or play a downloaded title.")
         }
         #if os(iOS)
-        .toolbar {
-            if let detail = viewModel.detail, isDirectlyPlayable(detail) {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button {
-                        playOnTV(currentControlRequest(for: detail))
-                    } label: {
-                        Image(systemName: siloControl.hasActiveSession
-                            ? "appletvremote.gen4.fill"
-                            : "appletvremote.gen4")
-                    }
-                    .tint(.continuumOnSurface)
-                    .accessibilityLabel("Remote Control")
-                }
-            }
+        // The system bar owns its items' animation during the interactive
+        // zoom dismiss and slides them horizontally, which reads as broken
+        // chrome. Hide the bar and draw the same buttons as an overlay so
+        // they can fade in place the instant the pull-down starts.
+        .toolbar(.hidden, for: .navigationBar)
+        .overlay(alignment: .top) {
+            detailChrome
+        }
+        .onScrollGeometryChange(for: CGFloat.self) { geometry in
+            geometry.contentOffset.y + geometry.contentInsets.top
+        } action: { _, offset in
+            chromeOverscroll = max(0, -offset)
         }
         .sheet(item: $controlRequestBox) { box in
             SiloControlTargetPickerView(request: box.request, controller: siloControl)
@@ -216,11 +219,92 @@ private struct ItemDetailPhoneContent: View {
     }
 
     #if os(iOS)
+    /// Custom top chrome standing in for the hidden navigation bar: back,
+    /// sidebar toggle (iPad), and the remote-control action. Fades out in
+    /// place over the first points of the zoom pull-down instead of
+    /// inheriting the system bar's sideways slide.
+    private var detailChrome: some View {
+        HStack(spacing: 8) {
+            Button {
+                router.goBack()
+            } label: {
+                Image(systemName: "chevron.left")
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(Color.continuumOnSurface)
+                    .frame(
+                        width: ContinuumTheme.topBarIconHitSize,
+                        height: ContinuumTheme.topBarIconHitSize
+                    )
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .siloGlass(in: Circle(), interactive: true)
+            .accessibilityLabel("Back")
+
+            SidebarToggleButton()
+
+            Spacer()
+
+            if let detail = viewModel.detail, let request = chromeControlRequest(for: detail) {
+                Button {
+                    playOnTV(request)
+                } label: {
+                    Image(systemName: siloControl.hasActiveSession
+                        ? "appletvremote.gen4.fill"
+                        : "appletvremote.gen4")
+                        .foregroundStyle(Color.continuumOnSurface)
+                        .frame(
+                            width: ContinuumTheme.topBarIconHitSize,
+                            height: ContinuumTheme.topBarIconHitSize
+                        )
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .siloGlass(in: Circle(), interactive: true)
+                .accessibilityLabel("Remote Control")
+            }
+        }
+        .padding(.horizontal, 12)
+        .opacity(chromeOpacity)
+        .allowsHitTesting(chromeOpacity > 0.5)
+    }
+
+    /// Fully opaque at rest, gone within the first ~30 pt of pull so the
+    /// chrome reads as fading in place rather than travelling with the card.
+    /// The 6 pt dead zone keeps casual scroll bounce from flickering it.
+    private var chromeOpacity: CGFloat {
+        guard chromeOverscroll > 6 else { return 1 }
+        return max(0, 1 - (chromeOverscroll - 6) / 24)
+    }
+
     /// True when the loaded detail routes to `MovieDetailContent` — the only
     /// branch whose primary item maps to a single playback request. Series,
     /// season, and audiobook containers have no single "this item" to cast.
     private func isDirectlyPlayable(_ detail: ItemDetail) -> Bool {
         !detail.isAudiobook && detail.type != "season" && detail.type != "series"
+    }
+
+    /// The cast request behind the chrome's remote button, or nil to hide it.
+    /// Movies/episodes cast themselves; series/season pages cast the same
+    /// next-up episode their Play button targets. Audiobooks have no cast
+    /// support, and the container button waits for the episode list so the
+    /// remote can't race ahead of the page's own Play action.
+    private func chromeControlRequest(for detail: ItemDetail) -> SiloControlPlaybackRequest? {
+        if isDirectlyPlayable(detail) {
+            return currentControlRequest(for: detail)
+        }
+        guard let nextUp = nextUpEpisode(for: detail) else { return nil }
+        return currentControlRequest(
+            contentId: nextUp.contentId,
+            fileId: nextUpPlaybackFileId(resolvedFileId: preferredNextUpFileId),
+            audioTrackIndex: preferredNextUpAudioTrackIndex,
+            subtitleTrackIndex: preferredNextUpSubtitleTrackIndex,
+            startFromBeginning: false,
+            resumePosition: playableResumePosition(
+                position: nextUp.userData?.positionSeconds,
+                duration: nextUp.userData?.durationSeconds
+            )
+        )
     }
 
     /// Builds the cast request for the visible movie/episode using the

--- a/iosApp/iosApp/Screens/Detail/MovieDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/MovieDetailContent.swift
@@ -100,7 +100,6 @@ struct MovieDetailContent<BelowOverview: View>: View {
             ratingChip: PhoneHeroMetadata.contentRatingChip(from: detail),
             overview: detail.overview,
             factsLine: PhoneHeroMetadata.movieFactsLine(from: detail, version: effectiveVersion),
-            overlayData: OverlayData.from(detail),
             actions: { actionStack },
             belowOverview: belowOverview
         )

--- a/iosApp/iosApp/Screens/Detail/MovieDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/MovieDetailContent.swift
@@ -78,7 +78,9 @@ struct MovieDetailContent<BelowOverview: View>: View {
     }
 
     private var heroToContentSpacing: CGFloat {
-        horizontalSizeClass == .regular ? 16 : 32
+        MobileDetailLayout.supportsExpandedPresentation && horizontalSizeClass == .regular
+            ? 16
+            : 32
     }
 
     // MARK: - Hero

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneDetailHero.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneDetailHero.swift
@@ -39,9 +39,6 @@ struct PhoneDetailHero<Actions: View, BelowOverview: View>: View {
     let ratingChip: String?
     let overview: String?
     let factsLine: [PhoneHeroFactToken]
-    /// Overlay data for the backdrop. `nil` skips overlay rendering
-    /// (e.g. when the detail payload didn't carry an OverlaySummary).
-    var overlayData: OverlayData? = nil
     @ViewBuilder let actions: () -> Actions
     /// Affordance rendered directly under the overview (e.g. the on-view
     /// description-translation control). Pass `{ EmptyView() }` when there's
@@ -51,7 +48,6 @@ struct PhoneDetailHero<Actions: View, BelowOverview: View>: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var availableWidth: CGFloat = 0
     @State private var showFullOverview = false
-    @EnvironmentObject private var overlayStore: OverlayPrefsStore
 
     private let expandedLayoutBreakpoint: CGFloat = 640
 
@@ -183,14 +179,6 @@ struct PhoneDetailHero<Actions: View, BelowOverview: View>: View {
                 endPoint: .bottom
             )
 
-            if let overlayData, overlayStore.enabled {
-                CardOverlays(
-                    data: overlayData,
-                    prefs: overlayStore.prefs,
-                    variant: .hero
-                )
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-            }
         }
         .backgroundExtensionEffect()
         .allowsHitTesting(false)
@@ -217,15 +205,6 @@ struct PhoneDetailHero<Actions: View, BelowOverview: View>: View {
     private var backdropBlock: some View {
         ZStack(alignment: .bottom) {
             backdrop
-            if let overlayData, overlayStore.enabled {
-                CardOverlays(
-                    data: overlayData,
-                    prefs: overlayStore.prefs,
-                    variant: .hero
-                )
-                .frame(height: backdropHeight)
-                .frame(maxWidth: .infinity)
-            }
             bottomFade
         }
         .frame(height: backdropHeight)

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneDetailHero.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneDetailHero.swift
@@ -1,6 +1,24 @@
 #if !os(tvOS)
 import SwiftUI
 
+#if os(iOS)
+import UIKit
+#endif
+
+/// Device gate for detail-page presentations that are designed specifically
+/// for iPad. A landscape iPhone can have a regular size class and a container
+/// wider than the iPad breakpoint, so neither signal identifies an iPad by
+/// itself.
+enum MobileDetailLayout {
+    static var supportsExpandedPresentation: Bool {
+        #if os(iOS)
+        UIDevice.current.userInterfaceIdiom == .pad
+        #else
+        true
+        #endif
+    }
+}
+
 /// Adaptive iOS detail hero. Compact containers retain the phone's
 /// backdrop-first, centered editorial composition. At regular iPad detail
 /// widths, poster art and a left-aligned editorial column share a single
@@ -38,7 +56,9 @@ struct PhoneDetailHero<Actions: View, BelowOverview: View>: View {
     private let expandedLayoutBreakpoint: CGFloat = 640
 
     private var backdropHeight: CGFloat {
-        horizontalSizeClass == .regular ? 420 : 360
+        MobileDetailLayout.supportsExpandedPresentation && horizontalSizeClass == .regular
+            ? 420
+            : 360
     }
 
     var body: some View {
@@ -58,6 +78,7 @@ struct PhoneDetailHero<Actions: View, BelowOverview: View>: View {
     }
 
     private var usesExpandedLayout: Bool {
+        guard MobileDetailLayout.supportsExpandedPresentation else { return false }
         if availableWidth > 0 {
             return availableWidth >= expandedLayoutBreakpoint
         }
@@ -306,7 +327,9 @@ struct PhoneDetailHero<Actions: View, BelowOverview: View>: View {
     /// and pushed Play toward the fold. This keeps the logo dominant without
     /// crowding out the actions it exists to introduce.
     private var compactLogoHeight: CGFloat {
-        horizontalSizeClass == .regular ? 168 : 132
+        MobileDetailLayout.supportsExpandedPresentation && horizontalSizeClass == .regular
+            ? 168
+            : 132
     }
 
     @ViewBuilder

--- a/iosApp/iosApp/Screens/Detail/Phone/PhonePlaybackSelectorRow.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhonePlaybackSelectorRow.swift
@@ -86,7 +86,7 @@ struct PhonePlaybackSelectorRow: View {
 
     private var usesPopoverLayout: Bool {
         #if os(iOS)
-        horizontalSizeClass == .regular
+        MobileDetailLayout.supportsExpandedPresentation && horizontalSizeClass == .regular
         #else
         false
         #endif

--- a/iosApp/iosApp/Screens/Detail/SeasonDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/SeasonDetailContent.swift
@@ -63,7 +63,9 @@ struct SeasonDetailContent<BelowOverview: View>: View {
     }
 
     private var heroToContentSpacing: CGFloat {
-        horizontalSizeClass == .regular ? 16 : 32
+        MobileDetailLayout.supportsExpandedPresentation && horizontalSizeClass == .regular
+            ? 16
+            : 32
     }
 
     // MARK: - Hero

--- a/iosApp/iosApp/Screens/Detail/SeasonDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/SeasonDetailContent.swift
@@ -87,7 +87,6 @@ struct SeasonDetailContent<BelowOverview: View>: View {
             ratingChip: nil,
             overview: detail.overview,
             factsLine: [],
-            overlayData: OverlayData.from(detail),
             actions: { actionStack },
             belowOverview: belowOverview
         )

--- a/iosApp/iosApp/Screens/Detail/SeriesDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/SeriesDetailContent.swift
@@ -75,7 +75,9 @@ struct SeriesDetailContent<BelowOverview: View>: View {
     }
 
     private var heroToContentSpacing: CGFloat {
-        horizontalSizeClass == .regular ? 16 : 32
+        MobileDetailLayout.supportsExpandedPresentation && horizontalSizeClass == .regular
+            ? 16
+            : 32
     }
 
     // MARK: - Hero

--- a/iosApp/iosApp/Screens/Detail/SeriesDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/SeriesDetailContent.swift
@@ -96,7 +96,6 @@ struct SeriesDetailContent<BelowOverview: View>: View {
             ratingChip: PhoneHeroMetadata.contentRatingChip(from: detail),
             overview: detail.overview,
             factsLine: PhoneHeroMetadata.seriesFactsLine(from: detail),
-            overlayData: OverlayData.from(detail),
             actions: { actionStack },
             belowOverview: belowOverview
         )

--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -32,6 +32,18 @@ struct PlayerView: View {
     @Environment(\.scenePhase) private var scenePhase
     #if os(iOS)
     @State private var orientationCoordinator = PlayerOrientationCoordinator.shared
+    /// The player's container size, tracked so the HUD can wait out the
+    /// portrait→landscape rotation that `activatePlayer()` starts after the
+    /// full-screen cover presents. Mounting the HUD during that re-layout
+    /// walks the close button across the screen; instead it stays unmounted
+    /// (only black video surface shows) until geometry settles, then fades
+    /// in at its final position.
+    @State private var playerContainerSize: CGSize = .zero
+    /// Deferred `.statusBarHidden()` flag. Hiding the bar while the cover is
+    /// still sliding up animates the top safe area mid-transition, which
+    /// reads as a stutter at the top of the wipe; flip it only after the
+    /// presentation has settled (the bar is invisible over black anyway).
+    @State private var hidesStatusBar = false
     #endif
     #if os(tvOS)
     @State private var remoteIdentityNotice: RemotePlaybackIdentityManager.ActiveIdentity?
@@ -201,7 +213,7 @@ struct PlayerView: View {
                     // force-quitting the app. tvOS gets this via Menu in
                     // `onExitCommand`; macOS keeps its controls (and Escape)
                     // during loading.
-                    if viewModel.isLoading {
+                    if viewModel.isLoading, hudGeometryReady {
                         loadingCloseButton
                     }
 
@@ -213,11 +225,13 @@ struct PlayerView: View {
                             viewModel: viewModel,
                             onDismiss: { dismissPlayer() }
                         )
-                        MobilePlayerControls(
-                            viewModel: viewModel,
-                            orientationCoordinator: orientationCoordinator,
-                            onDismiss: { dismissPlayer() }
-                        )
+                        if hudGeometryReady {
+                            MobilePlayerControls(
+                                viewModel: viewModel,
+                                orientationCoordinator: orientationCoordinator,
+                                onDismiss: { dismissPlayer() }
+                            )
+                        }
                     }
                     #endif
 
@@ -236,6 +250,14 @@ struct PlayerView: View {
                 }
             }
         }
+        #if os(iOS)
+        .onGeometryChange(for: CGSize.self) { proxy in
+            proxy.size
+        } action: { size in
+            playerContainerSize = size
+        }
+        .animation(.easeOut(duration: 0.18), value: hudGeometryReady)
+        #endif
         #if os(tvOS)
         // Physical Play/Pause on the Siri remote always toggles playback
         // and brings the transport bar back.
@@ -307,6 +329,9 @@ struct PlayerView: View {
             }
             #if os(iOS)
             orientationCoordinator.activatePlayer()
+            orientationCoordinator.afterActivePresentationTransition {
+                hidesStatusBar = true
+            }
             #endif
             activeViewModel.applyArtworkURLHints(posterURL: posterURLHint, backdropURL: backdropURLHint)
             activeViewModel.loadAndPlay(
@@ -362,7 +387,13 @@ struct PlayerView: View {
             }
             #endif
         }
+        #if os(iOS)
+        // Deferred (see `hidesStatusBar`) rather than the unconditional
+        // `continuumStatusBarHidden()` the other full-screen surfaces use.
+        .statusBarHidden(hidesStatusBar)
+        #else
         .continuumStatusBarHidden()
+        #endif
         #if !os(tvOS)
         .navigationBarHidden(true)
         #endif
@@ -477,6 +508,20 @@ struct PlayerView: View {
     }
 
     #if !os(tvOS)
+    /// True once the player frame has the orientation the HUD will live in,
+    /// so controls mount directly at their final positions. Only landscape-
+    /// locked iPhone playback ever has to wait (for the post-present
+    /// rotation); every other configuration is ready immediately.
+    private var hudGeometryReady: Bool {
+        #if os(iOS)
+        guard orientationCoordinator.isLandscapeLocked,
+              UIDevice.current.userInterfaceIdiom == .phone else { return true }
+        return playerContainerSize.width > playerContainerSize.height
+        #else
+        return true
+        #endif
+    }
+
     /// Close control shown while the player is still loading/buffering, in
     /// the same spot (and glass style) as the close button in
     /// `MobilePlayerControls`' top strip so the two read as one control.

--- a/iosApp/iosApp/Screens/Player/iOS/MobilePlayerControls.swift
+++ b/iosApp/iosApp/Screens/Player/iOS/MobilePlayerControls.swift
@@ -147,50 +147,74 @@ struct MobilePlayerControls: View {
 
             Spacer(minLength: 12)
 
-            if viewModel.avPlayerBackend != nil {
-                if pictureInPicture.isSupported {
-                    controlButton(
-                        systemName: pictureInPicture.isActive ? "pip.exit" : "pip.enter"
-                    ) {
-                        pictureInPicture.toggle()
-                    }
-                    .disabled(!pictureInPicture.isPossible)
-                    .accessibilityLabel(
-                        pictureInPicture.isActive
-                            ? "Stop Picture in Picture"
-                            : "Start Picture in Picture"
-                    )
-                }
+            // Both trailing slots are reserved from the first frame. The
+            // backend (and its external-playback verdict) resolves a beat
+            // after the player appears; conditional buttons here would pop
+            // in right-aligned and shove their neighbors sideways. A slot
+            // that ends up unused (CoreMedia route, AirPlay disallowed)
+            // just stays empty trailing space.
+            pipSlot
+            airPlaySlot
+        }
+    }
 
-                // Only shown where the receiver could actually fetch the
-                // media. On routes whose URL is authenticated by a request
-                // header, AirPlay video would leave the TV on a 401.
-                if viewModel.supportsExternalPlayback {
-                    AirPlayRoutePicker { isPresentingRoutes in
-                        // The route sheet is a UIKit presentation the auto-hide
-                        // timer knows nothing about; pin the controls so it can't
-                        // dismantle the picker mid-selection.
-                        if isPresentingRoutes {
-                            viewModel.pinControlsVisible()
-                        } else {
-                            viewModel.resumeAutoHide()
-                        }
-                    }
-                    .frame(width: 44, height: 44)
+    @ViewBuilder
+    private var pipSlot: some View {
+        if viewModel.avPlayerBackend != nil, pictureInPicture.isSupported {
+            controlButton(
+                systemName: pictureInPicture.isActive ? "pip.exit" : "pip.enter"
+            ) {
+                pictureInPicture.toggle()
+            }
+            .disabled(!pictureInPicture.isPossible)
+            .accessibilityLabel(
+                pictureInPicture.isActive
+                    ? "Stop Picture in Picture"
+                    : "Start Picture in Picture"
+            )
+        } else {
+            Color.clear
+                .frame(width: 40, height: 40)
+                .accessibilityHidden(true)
+        }
+    }
+
+    /// Only interactive where the receiver could actually fetch the media.
+    /// On routes whose URL is authenticated by a request header, AirPlay
+    /// video would leave the TV on a 401.
+    @ViewBuilder
+    private var airPlaySlot: some View {
+        if viewModel.avPlayerBackend != nil, viewModel.supportsExternalPlayback {
+            AirPlayRoutePicker { isPresentingRoutes in
+                // The route sheet is a UIKit presentation the auto-hide
+                // timer knows nothing about; pin the controls so it can't
+                // dismantle the picker mid-selection.
+                if isPresentingRoutes {
+                    viewModel.pinControlsVisible()
+                } else {
+                    viewModel.resumeAutoHide()
                 }
             }
+            .frame(width: 44, height: 44)
+        } else {
+            Color.clear
+                .frame(width: 44, height: 44)
+                .accessibilityHidden(true)
         }
     }
 
     private var titleBlock: some View {
         VStack(alignment: .leading, spacing: 1) {
-            if let eyebrow = titleEyebrow {
-                Text(eyebrow)
-                    .font(.system(size: 10, weight: .semibold))
-                    .tracking(0.8)
-                    .foregroundStyle(.white.opacity(0.65))
-                    .lineLimit(1)
-            }
+            // The eyebrow's line is reserved even before metadata resolves
+            // (a beat after launch) so the title doesn't jump down when the
+            // context line fills in.
+            Text(titleEyebrow ?? " ")
+                .font(.system(size: 10, weight: .semibold))
+                .tracking(0.8)
+                .foregroundStyle(.white.opacity(0.65))
+                .lineLimit(1)
+                .opacity(titleEyebrow == nil ? 0 : 1)
+                .accessibilityHidden(titleEyebrow == nil)
             Text(heroTitle)
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundStyle(.white)
@@ -521,10 +545,13 @@ struct MobilePlayerControls: View {
                 .opacity(noTracks ? 0.4 : 1)
                 .accessibilityLabel("Audio & Subtitles")
 
-            if !viewModel.chapters.isEmpty {
-                chaptersMenu(style: style)
-                    .accessibilityLabel("Chapters")
-            }
+            // Always present so the row doesn't re-layout when chapters
+            // resolve (they arrive after FFmpeg opens the stream); same
+            // disabled treatment as the track menu when there are none.
+            chaptersMenu(style: style)
+                .disabled(viewModel.chapters.isEmpty)
+                .opacity(viewModel.chapters.isEmpty ? 0.4 : 1)
+                .accessibilityLabel("Chapters")
 
             lockControl(compact: style != .full)
 

--- a/iosApp/iosApp/Screens/Player/iOS/PlayerOrientationCoordinator.swift
+++ b/iosApp/iosApp/Screens/Player/iOS/PlayerOrientationCoordinator.swift
@@ -84,6 +84,22 @@ final class PlayerOrientationCoordinator {
         rotateIntoLandscape: Bool,
         attemptDeviceRotation: Bool
     ) {
+        // If a presentation (the player's full-screen cover) is mid-flight,
+        // rotating now makes the scene re-layout fight the cover animation —
+        // the slide-up visibly stutters near the end. Wait for the
+        // transition to finish, then rotate behind the settled black cover.
+        if rotateIntoLandscape,
+           let coordinator = topmostPresentationTransitionCoordinator(),
+           coordinator.isAnimated {
+            coordinator.animate(alongsideTransition: nil) { [weak self] _ in
+                self?.updateOrientationPolicy(
+                    rotateIntoLandscape: rotateIntoLandscape,
+                    attemptDeviceRotation: attemptDeviceRotation
+                )
+            }
+            return
+        }
+
         let scenes = activeWindowScenes()
         for scene in scenes {
             for window in scene.windows {
@@ -123,6 +139,36 @@ final class PlayerOrientationCoordinator {
         for child in viewController.children {
             notifyOrientationChange(for: child)
         }
+    }
+
+    /// Runs `block` after the in-flight presentation transition (the player
+    /// cover sliding up) completes — immediately if nothing is animating.
+    /// Lets late-stage chrome changes (status bar hide, rotation) stay out
+    /// of the cover animation's final frames, where they read as a stutter.
+    func afterActivePresentationTransition(_ block: @escaping () -> Void) {
+        if let coordinator = topmostPresentationTransitionCoordinator(),
+           coordinator.isAnimated {
+            coordinator.animate(alongsideTransition: nil) { _ in block() }
+        } else {
+            block()
+        }
+    }
+
+    /// Transition coordinator of the deepest presented view controller, if
+    /// one is currently animating (i.e. the player cover is sliding up).
+    private func topmostPresentationTransitionCoordinator() -> UIViewControllerTransitionCoordinator? {
+        for scene in activeWindowScenes() {
+            for window in scene.windows {
+                var viewController = window.rootViewController
+                while let presented = viewController?.presentedViewController {
+                    viewController = presented
+                }
+                if let coordinator = viewController?.transitionCoordinator {
+                    return coordinator
+                }
+            }
+        }
+        return nil
     }
 
     private func activeWindowScenes() -> [UIWindowScene] {


### PR DESCRIPTION
## Summary

- Fade the detail page's top chrome in place during the zoom pull-down dismiss instead of the system bar's sideways slide
- Show the remote button on series/season pages, targeting the same next-up episode as the Play button
- Stop rendering card overlay badges (resolution, HDR, ratings) on the detail hero
- Stabilize the iOS player HUD through launch: no more close-button walk, control reflows, or presentation stutter

## Details

**Detail chrome (`ItemDetailView`)**
- The nav-bar buttons slid horizontally during the interactive zoom dismiss (system toolbar animation, not overridable). The bar is now hidden and back/sidebar/remote render as a custom overlay whose opacity tracks top overscroll, so chrome dissolves in place while only the card follows the drag.
- Container pages (series/season) previously had no remote button at all; they now cast the same next-up episode their Play button targets.

**Detail hero (`PhoneDetailHero`)**
- Card overlay badges leaked onto the detail hero whenever the payload carried an OverlaySummary; removed along with the dead plumbing.

**Player launch (`PlayerView`, `MobilePlayerControls`, `PlayerOrientationCoordinator`, `ContentView`)**
- The presenting screen fades to black as the cover starts, so the spring's slow tail slides black-over-black instead of creeping over the hero artwork in the top safe area.
- Status-bar hide and landscape rotation defer until the presentation transition completes (via transitionCoordinator) instead of fighting the cover animation.
- The HUD stays unmounted until the frame is landscape (landscape-locked iPhone only), then fades in at its final position.
- Late-resolving controls get reserved slots: PiP/AirPlay in the top strip, the Chapters pill (disabled while empty), and the title eyebrow line.

## Testing

- Verified on device: zoom pull-down dismiss, remote button on series/season/episode pages, player launch sequence (cover wipe, rotation, HUD fade-in)
- `xcodebuild` iOS Simulator build passes per commit
