### PR TITLE
fix(playback): bound conditional origin chunks

### DIFF
--- a/iosApp/Tests/PlaybackOriginStreamResumeTests.swift
+++ b/iosApp/Tests/PlaybackOriginStreamResumeTests.swift
@@ -208,13 +208,30 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
 
     private final class ChunkRecorder {
         private let lock = NSLock()
-        private var storedCount = 0
+        private var storedByteCounts: [Int] = []
+        private var deliveredRanges: [ClosedRange<Int64>] = []
         private var failureCauses: [PlaybackOriginReconnectPolicy.EndCause] = []
+        private var failureStatuses: [Int?] = []
+        private var sessionMissingCount = 0
+        private var requestBeginCount = 0
+        private var requestEndCount = 0
 
         var stores: Int {
             lock.lock()
             defer { lock.unlock() }
-            return storedCount
+            return storedByteCounts.count
+        }
+
+        var storedBytes: [Int] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storedByteCounts
+        }
+
+        var ranges: [ClosedRange<Int64>] {
+            lock.lock()
+            defer { lock.unlock() }
+            return deliveredRanges
         }
 
         var causes: [PlaybackOriginReconnectPolicy.EndCause] {
@@ -223,16 +240,89 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
             return failureCauses
         }
 
-        func recordStore() {
+        var statuses: [Int?] {
             lock.lock()
-            storedCount += 1
+            defer { lock.unlock() }
+            return failureStatuses
+        }
+
+        var missingSessions: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return sessionMissingCount
+        }
+
+        var requestCounts: (began: Int, ended: Int) {
+            lock.lock()
+            defer { lock.unlock() }
+            return (requestBeginCount, requestEndCount)
+        }
+
+        func recordStore(_ data: Data = Data()) {
+            lock.lock()
+            storedByteCounts.append(data.count)
             lock.unlock()
         }
 
-        func recordFailure(_ cause: PlaybackOriginReconnectPolicy.EndCause) {
+        func recordRange(_ range: ClosedRange<Int64>) {
+            lock.lock()
+            deliveredRanges.append(range)
+            lock.unlock()
+        }
+
+        func recordFailure(
+            _ cause: PlaybackOriginReconnectPolicy.EndCause,
+            statusCode: Int? = nil
+        ) {
             lock.lock()
             failureCauses.append(cause)
+            failureStatuses.append(statusCode)
             lock.unlock()
+        }
+
+        func recordSessionMissing() {
+            lock.lock()
+            sessionMissingCount += 1
+            lock.unlock()
+        }
+
+        func recordBegin() {
+            lock.lock()
+            requestBeginCount += 1
+            lock.unlock()
+        }
+
+        func recordEnd() {
+            lock.lock()
+            requestEndCount += 1
+            lock.unlock()
+        }
+    }
+
+    private final class ChunkCallbackRaceRecorder: @unchecked Sendable {
+        let storeEntered = DispatchSemaphore(value: 0)
+        let releaseStore = DispatchSemaphore(value: 0)
+        private let lock = NSLock()
+        private var events: [String] = []
+
+        var snapshot: [String] {
+            lock.lock()
+            defer { lock.unlock() }
+            return events
+        }
+
+        func record(_ event: String) {
+            lock.lock()
+            events.append(event)
+            lock.unlock()
+        }
+
+        func blockInStore() -> PlaybackOriginReconnectPolicy.EndCause? {
+            record("store-enter")
+            storeEntered.signal()
+            _ = releaseStore.wait(timeout: .now() + 2)
+            record("store-exit")
+            return nil
         }
     }
 
@@ -252,11 +342,24 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
             case fullResponseAfterWeakETag
             case partialChangedAfterWeakETag
             case alwaysFullChangedEntity
+            case chunkFullChangedHeadersOnly
+            case chunkFullMatchingHeadersOnly
+            case chunkByteZeroFullBody
+            case chunkByteZeroShortFullBody
+            case chunkPreconditionFailed
+            case chunkSessionMissing404
+            case chunkMalformed206Unit
+            case chunkMalformed206Ordering
+            case chunkMalformed206Total
+            case chunkOversized206
+            case chunkShort206OversizedBody
+            case chunkShortEOF206
         }
 
         struct Request: Equatable {
             let range: String?
             let ifRange: String?
+            let ifMatch: String?
         }
 
         private let totalBytes: Int64 = 64 * 1024 * 1024
@@ -266,6 +369,7 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
         private let lock = NSLock()
         private var connections: [ObjectIdentifier: NWConnection] = [:]
         private var requests: [Request] = []
+        private var bodyBytesSent = 0
         private(set) var port: UInt16 = 0
 
         init(behavior: ReopenBehavior) throws {
@@ -284,6 +388,12 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
             lock.lock()
             defer { lock.unlock() }
             return requests
+        }
+
+        func observedBodyBytesSent() -> Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return bodyBytesSent
         }
 
         func start() async throws {
@@ -350,8 +460,9 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
         private func respond(_ connection: NWConnection, request: String) {
             let range = header("range", in: request)
             let ifRange = header("if-range", in: request)
+            let ifMatch = header("if-match", in: request)
             lock.lock()
-            requests.append(Request(range: range, ifRange: ifRange))
+            requests.append(Request(range: range, ifRange: ifRange, ifMatch: ifMatch))
             let requestNumber = requests.count
             lock.unlock()
 
@@ -360,10 +471,184 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
                     Int64(value[marker.upperBound...].split(separator: "-")[0])
                 } ?? 0
             } ?? 0
+            let requestedEnd = range.flatMap { value -> Int64? in
+                guard let marker = value.range(of: "bytes=") else { return nil }
+                let bounds = value[marker.upperBound...].split(
+                    separator: "-",
+                    omittingEmptySubsequences: false
+                )
+                guard bounds.count == 2, !bounds[1].isEmpty else { return nil }
+                return Int64(bounds[1])
+            }
+            if behavior == .chunkFullChangedHeadersOnly
+                || behavior == .chunkFullMatchingHeadersOnly {
+                let responseETag = behavior == .chunkFullChangedHeadersOnly
+                    ? "\"entity-v2\""
+                    : "\"entity-v1\""
+                let header = [
+                    "HTTP/1.1 200 OK",
+                    "Content-Length: \(totalBytes)",
+                    "ETag: \(responseETag)",
+                    "Content-Type: application/octet-stream",
+                    "Connection: keep-alive",
+                    "",
+                    ""
+                ].joined(separator: "\r\n")
+                // CFNetwork does not publish this loopback response until the
+                // first body frame arrives. Send one byte, then deliberately
+                // keep the response open. A completion-handler fetcher still
+                // cannot classify it until its idle timeout; a delegate
+                // rejects it as soon as the headers are published.
+                connection.send(content: Data(header.utf8), completion: .contentProcessed {
+                    error in
+                    guard error == nil else { return }
+                    connection.send(content: Data([0xEE]), completion: .idempotent)
+                })
+                return
+            }
+            if behavior == .chunkByteZeroFullBody
+                || behavior == .chunkByteZeroShortFullBody {
+                let responseBytes = behavior == .chunkByteZeroShortFullBody
+                    ? Int64(64 * 1024)
+                    : totalBytes
+                let header = [
+                    "HTTP/1.1 200 OK",
+                    "Content-Length: \(responseBytes)",
+                    "ETag: \"entity-v1\"",
+                    "Content-Type: application/octet-stream",
+                    "Connection: close",
+                    "",
+                    ""
+                ].joined(separator: "\r\n")
+                connection.send(content: Data(header.utf8), completion: .contentProcessed {
+                    [weak self] error in
+                    guard let self, error == nil else { return }
+                    self.sendBody(connection, remaining: responseBytes)
+                })
+                return
+            }
+            if behavior == .chunkPreconditionFailed {
+                let header = [
+                    "HTTP/1.1 412 Precondition Failed",
+                    "Content-Length: 0",
+                    "ETag: \"entity-v2\"",
+                    "Connection: close",
+                    "",
+                    ""
+                ].joined(separator: "\r\n")
+                connection.send(
+                    content: Data(header.utf8),
+                    contentContext: .finalMessage,
+                    isComplete: true,
+                    completion: .idempotent
+                )
+                return
+            }
+            if behavior == .chunkSessionMissing404 {
+                let prefix = Data(
+                    "{\"code\":\"playback_session_not_found\"}".utf8
+                ) + Data(repeating: 0x20, count: 4096)
+                let header = [
+                    "HTTP/1.1 404 Not Found",
+                    "Content-Length: \(totalBytes)",
+                    "Content-Type: application/json",
+                    "Connection: close",
+                    "",
+                    ""
+                ].joined(separator: "\r\n")
+                connection.send(content: Data(header.utf8), completion: .contentProcessed {
+                    [weak self] error in
+                    guard let self, error == nil else { return }
+                    self.sendBody(
+                        connection,
+                        firstChunk: prefix,
+                        remaining: self.totalBytes - Int64(prefix.count)
+                    )
+                })
+                return
+            }
+            if behavior == .chunkMalformed206Unit
+                || behavior == .chunkMalformed206Ordering
+                || behavior == .chunkMalformed206Total
+                || behavior == .chunkOversized206 {
+                let requestedEnd = requestedEnd ?? offset
+                let contentRange: String
+                switch behavior {
+                case .chunkMalformed206Unit:
+                    contentRange = "items \(offset)-\(requestedEnd)/\(totalBytes)"
+                case .chunkMalformed206Ordering:
+                    contentRange = "bytes \(offset + 1)-\(offset)/\(totalBytes)"
+                case .chunkMalformed206Total:
+                    contentRange = "bytes \(offset)-\(requestedEnd)/\(requestedEnd)"
+                case .chunkOversized206:
+                    contentRange = "bytes \(offset)-\(requestedEnd + 1)/\(totalBytes)"
+                default:
+                    fatalError("unreachable")
+                }
+                let header = [
+                    "HTTP/1.1 206 Partial Content",
+                    "Content-Range: \(contentRange)",
+                    "Content-Length: \(totalBytes - offset)",
+                    "ETag: \"entity-v1\"",
+                    "Content-Type: application/octet-stream",
+                    "Connection: keep-alive",
+                    "",
+                    ""
+                ].joined(separator: "\r\n")
+                connection.send(content: Data(header.utf8), completion: .contentProcessed {
+                    error in
+                    guard error == nil else { return }
+                    connection.send(content: Data([0xEE]), completion: .idempotent)
+                })
+                return
+            }
+            if behavior == .chunkShort206OversizedBody {
+                let declaredBytes: Int64 = 64 * 1024
+                let declaredEnd = offset + declaredBytes - 1
+                let header = [
+                    "HTTP/1.1 206 Partial Content",
+                    "Content-Range: bytes \(offset)-\(declaredEnd)/\(totalBytes)",
+                    "Content-Length: \(totalBytes - offset)",
+                    "ETag: \"entity-v1\"",
+                    "Content-Type: application/octet-stream",
+                    "Connection: close",
+                    "",
+                    ""
+                ].joined(separator: "\r\n")
+                connection.send(content: Data(header.utf8), completion: .contentProcessed {
+                    [weak self] error in
+                    guard let self, error == nil else { return }
+                    self.sendBody(connection, remaining: self.totalBytes - offset)
+                })
+                return
+            }
+            if behavior == .chunkShortEOF206 {
+                let declaredBytes: Int64 = 64 * 1024
+                let entityTotal = offset + declaredBytes
+                let declaredEnd = entityTotal - 1
+                let header = [
+                    "HTTP/1.1 206 Partial Content",
+                    "Content-Range: bytes \(offset)-\(declaredEnd)/\(entityTotal)",
+                    "Content-Length: \(declaredBytes)",
+                    "ETag: \"entity-v1\"",
+                    "Content-Type: application/octet-stream",
+                    "Connection: close",
+                    "",
+                    ""
+                ].joined(separator: "\r\n")
+                connection.send(content: Data(header.utf8), completion: .contentProcessed {
+                    [weak self] error in
+                    guard let self, error == nil else { return }
+                    self.sendBody(connection, remaining: declaredBytes)
+                })
+                return
+            }
             if behavior == .delayedInitialWindow
                 || behavior == .delayedInitialWindowWithoutValidator {
-                let byteCount = 64 * 1024
                 let isWindow = requestNumber == 1
+                let byteCount = isWindow
+                    ? 64 * 1024
+                    : Int((requestedEnd ?? (offset + 64 * 1024 - 1)) - offset + 1)
                 let end = isWindow
                     ? totalBytes - 1
                     : offset + Int64(byteCount) - 1
@@ -463,7 +748,19 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
                  .partialMissingETag,
                  .partialChangedAfterWeakETag,
                  .alwaysChangedEntity,
-                 .invalidContentRange:
+                 .invalidContentRange,
+                 .chunkFullChangedHeadersOnly,
+                 .chunkFullMatchingHeadersOnly,
+                 .chunkByteZeroFullBody,
+                 .chunkByteZeroShortFullBody,
+                 .chunkPreconditionFailed,
+                 .chunkSessionMissing404,
+                 .chunkMalformed206Unit,
+                 .chunkMalformed206Ordering,
+                 .chunkMalformed206Total,
+                 .chunkOversized206,
+                 .chunkShort206OversizedBody,
+                 .chunkShortEOF206:
                 fullResponse = false
             }
             if fullResponse {
@@ -491,7 +788,7 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
                 return
             }
 
-            let end = totalBytes - 1
+            let end = requestedEnd ?? totalBytes - 1
             let responseETag: String?
             if behavior == .fullResponseAfterWeakETag {
                 responseETag = "W/\"entity-v1\""
@@ -516,7 +813,7 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
             var headerLines = [
                 "HTTP/1.1 206 Partial Content",
                 "Content-Range: \(contentRange)",
-                "Content-Length: \(totalBytes - offset)",
+                "Content-Length: \(end - offset + 1)",
                 "Content-Type: application/octet-stream",
                 "Connection: close",
                 "",
@@ -528,7 +825,7 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
             let header = headerLines.joined(separator: "\r\n")
             connection.send(content: Data(header.utf8), completion: .contentProcessed { [weak self] error in
                 guard let self, error == nil else { return }
-                self.sendBody(connection, remaining: self.totalBytes - offset)
+                self.sendBody(connection, remaining: end - offset + 1)
             })
         }
 
@@ -559,9 +856,29 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
                 content: Data(repeating: 0xAB, count: count),
                 completion: .contentProcessed { [weak self] error in
                     guard error == nil else { return }
+                    self?.recordBodyBytesSent(count)
                     self?.sendBody(connection, remaining: remaining - Int64(count))
                 }
             )
+        }
+
+        private func sendBody(
+            _ connection: NWConnection,
+            firstChunk: Data,
+            remaining: Int64
+        ) {
+            connection.send(content: firstChunk, completion: .contentProcessed {
+                [weak self] error in
+                guard let self, error == nil else { return }
+                self.recordBodyBytesSent(firstChunk.count)
+                self.sendBody(connection, remaining: remaining)
+            })
+        }
+
+        private func recordBodyBytesSent(_ count: Int) {
+            lock.lock()
+            bodyBytesSent += count
+            lock.unlock()
         }
     }
 
@@ -902,7 +1219,8 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
         XCTAssertEqual(cache.stats().originBytesTransferred, transferredBeforeChunk)
         let requests = origin.observedRequests()
         XCTAssertEqual(requests.count, 2)
-        XCTAssertEqual(requests[1].ifRange, "\"entity-v1\"")
+        XCTAssertNil(requests[1].ifRange)
+        XCTAssertEqual(requests[1].ifMatch, "\"entity-v1\"")
     }
 
     func testEarlyChunkWaitsForWindowEntityBeforeCaching() async throws {
@@ -938,7 +1256,7 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
         let fetchedWithWindowEntity = await waitUntil {
             origin.observedRequests().contains {
                 $0.range?.hasPrefix("bytes=\(farOffset)-") == true
-                    && $0.ifRange == "\"entity-v2\""
+                    && $0.ifMatch == "\"entity-v2\""
             }
         }
         XCTAssertTrue(fetchedWithWindowEntity)
@@ -946,7 +1264,8 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
             $0.range?.hasPrefix("bytes=\(farOffset)-") == true
         }
         XCTAssertEqual(chunkRequests.count, 1)
-        XCTAssertEqual(chunkRequests[0].ifRange, "\"entity-v2\"")
+        XCTAssertNil(chunkRequests[0].ifRange)
+        XCTAssertEqual(chunkRequests[0].ifMatch, "\"entity-v2\"")
         let completed = await waitUntil { reader.result.completed }
         XCTAssertTrue(completed)
         XCTAssertNil(reader.result.error)
@@ -1031,7 +1350,444 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
             $0.range?.hasPrefix("bytes=\(farOffset)-") == true
         }
         XCTAssertEqual(chunkRequests.count, 1)
-        XCTAssertEqual(chunkRequests[0].ifRange, "\"entity-v1\"")
+        XCTAssertNil(chunkRequests[0].ifRange)
+        XCTAssertEqual(chunkRequests[0].ifMatch, "\"entity-v1\"")
+    }
+
+    func testChunkFetcherRejectsChangedFullResponseAtHeaders() async throws {
+        let origin = try StubOrigin(behavior: .chunkFullChangedHeadersOnly)
+        try await origin.start()
+        defer { origin.stop() }
+        let recorder = ChunkRecorder()
+        let fetcher = PlaybackOriginChunkFetcher(
+            originURL: origin.url,
+            originHeaders: [:],
+            entityETagProvider: { "\"entity-v1\"" },
+            requiresEntityValidation: true,
+            callbacks: PlaybackOriginChunkFetcher.Callbacks(
+                store: { _, data, _, _ in
+                    recorder.recordStore(data)
+                    return nil
+                },
+                didStore: { recorder.recordRange($0) },
+                didReceiveResponse: { _ in },
+                didDetectSessionMissing: {},
+                didFail: { _, cause, _ in recorder.recordFailure(cause) },
+                beginRequest: { recorder.recordBegin() },
+                endRequest: { recorder.recordEnd() }
+            )
+        )
+        defer { fetcher.cancel() }
+
+        let offset: Int64 = 8 * 1024 * 1024
+        fetcher.ensureFetch(covering: offset, totalLength: offset + 1)
+
+        let rejected = await waitUntil(timeout: 1) {
+            recorder.causes == [.entityChanged]
+        }
+        XCTAssertTrue(rejected, "changed 200 headers must be rejected before its body or idle timeout")
+        XCTAssertEqual(recorder.stores, 0)
+        XCTAssertTrue(recorder.ranges.isEmpty)
+        XCTAssertEqual(recorder.requestCounts.began, 1)
+        XCTAssertEqual(recorder.requestCounts.ended, 1)
+        let request = try XCTUnwrap(origin.observedRequests().first)
+        XCTAssertEqual(request.range, "bytes=\(offset)-\(offset)")
+        XCTAssertNil(request.ifRange)
+        XCTAssertEqual(request.ifMatch, "\"entity-v1\"")
+    }
+
+    func testChunkFetcherRejectsRangeIgnoredFullResponseAtHeaders() async throws {
+        let origin = try StubOrigin(behavior: .chunkFullMatchingHeadersOnly)
+        try await origin.start()
+        defer { origin.stop() }
+        let recorder = ChunkRecorder()
+        let fetcher = PlaybackOriginChunkFetcher(
+            originURL: origin.url,
+            originHeaders: [:],
+            entityETagProvider: { "\"entity-v1\"" },
+            requiresEntityValidation: true,
+            callbacks: PlaybackOriginChunkFetcher.Callbacks(
+                store: { _, data, _, _ in
+                    recorder.recordStore(data)
+                    return nil
+                },
+                didStore: { recorder.recordRange($0) },
+                didReceiveResponse: { _ in },
+                didDetectSessionMissing: {},
+                didFail: { _, cause, _ in recorder.recordFailure(cause) },
+                beginRequest: { recorder.recordBegin() },
+                endRequest: { recorder.recordEnd() }
+            )
+        )
+        defer { fetcher.cancel() }
+
+        let offset: Int64 = 8 * 1024 * 1024
+        fetcher.ensureFetch(covering: offset, totalLength: offset + 1)
+
+        let rejected = await waitUntil(timeout: 1) {
+            recorder.causes == [.rangeIgnored]
+        }
+        XCTAssertTrue(rejected, "matching 200 headers must be rejected before its body or idle timeout")
+        XCTAssertEqual(recorder.stores, 0)
+        XCTAssertTrue(recorder.ranges.isEmpty)
+        XCTAssertEqual(recorder.requestCounts.began, 1)
+        XCTAssertEqual(recorder.requestCounts.ended, 1)
+        let request = try XCTUnwrap(origin.observedRequests().first)
+        XCTAssertEqual(request.range, "bytes=\(offset)-\(offset)")
+        XCTAssertNil(request.ifRange)
+        XCTAssertEqual(request.ifMatch, "\"entity-v1\"")
+    }
+
+    func testChunkFetcherBoundsByteZeroFullResponseToRequestedRange() async throws {
+        let origin = try StubOrigin(behavior: .chunkByteZeroFullBody)
+        try await origin.start()
+        defer { origin.stop() }
+        let recorder = ChunkRecorder()
+        let fetcher = PlaybackOriginChunkFetcher(
+            originURL: origin.url,
+            originHeaders: [:],
+            entityETagProvider: { "\"entity-v1\"" },
+            requiresEntityValidation: true,
+            callbacks: PlaybackOriginChunkFetcher.Callbacks(
+                store: { _, data, _, _ in
+                    recorder.recordStore(data)
+                    return nil
+                },
+                didStore: { recorder.recordRange($0) },
+                didReceiveResponse: { _ in },
+                didDetectSessionMissing: {},
+                didFail: { _, cause, _ in recorder.recordFailure(cause) },
+                beginRequest: { recorder.recordBegin() },
+                endRequest: { recorder.recordEnd() }
+            )
+        )
+        defer { fetcher.cancel() }
+
+        let requestedBytes = PlaybackOriginRoutingPolicy.chunkBytes
+        fetcher.ensureFetch(covering: 0, totalLength: requestedBytes)
+
+        let stored = await waitUntil(timeout: 5) {
+            recorder.storedBytes == [Int(requestedBytes)]
+        }
+        XCTAssertTrue(stored)
+        XCTAssertEqual(recorder.ranges, [0...(requestedBytes - 1)])
+        XCTAssertTrue(recorder.causes.isEmpty)
+        XCTAssertEqual(recorder.requestCounts.began, 1)
+        XCTAssertEqual(recorder.requestCounts.ended, 1)
+        let request = try XCTUnwrap(origin.observedRequests().first)
+        XCTAssertEqual(request.range, "bytes=0-\(requestedBytes - 1)")
+        XCTAssertNil(request.ifRange)
+        XCTAssertEqual(request.ifMatch, "\"entity-v1\"")
+        try? await Task.sleep(for: .milliseconds(100))
+        XCTAssertLessThan(origin.observedBodyBytesSent(), 64 * 1024 * 1024)
+    }
+
+    func testChunkFetcherCancelWaitsForCallbackQuiescenceAndBalancesRequests() async throws {
+        let origin = try StubOrigin(behavior: .partialSameEntity)
+        try await origin.start()
+        defer { origin.stop() }
+        let recorder = ChunkCallbackRaceRecorder()
+        let fetcher = PlaybackOriginChunkFetcher(
+            originURL: origin.url,
+            originHeaders: [:],
+            entityETagProvider: { "\"entity-v1\"" },
+            requiresEntityValidation: true,
+            callbacks: PlaybackOriginChunkFetcher.Callbacks(
+                store: { _, _, _, _ in recorder.blockInStore() },
+                didStore: { _ in recorder.record("did-store") },
+                didReceiveResponse: { _ in recorder.record("response") },
+                didDetectSessionMissing: { recorder.record("session-missing") },
+                didFail: { _, _, _ in recorder.record("failure") },
+                beginRequest: { recorder.record("begin") },
+                endRequest: { recorder.record("end") }
+            )
+        )
+        defer { fetcher.cancel() }
+
+        let offset: Int64 = 8 * 1024 * 1024
+        fetcher.ensureFetch(covering: offset, totalLength: offset + 1)
+        XCTAssertEqual(recorder.storeEntered.wait(timeout: .now() + 2), .success)
+
+        let cancelStarted = DispatchSemaphore(value: 0)
+        let cancelReturned = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            cancelStarted.signal()
+            fetcher.cancel()
+            recorder.record("cancel-return")
+            cancelReturned.signal()
+        }
+        XCTAssertEqual(cancelStarted.wait(timeout: .now() + 1), .success)
+        XCTAssertEqual(cancelReturned.wait(timeout: .now() + 0.1), .timedOut)
+
+        recorder.releaseStore.signal()
+        XCTAssertEqual(cancelReturned.wait(timeout: .now() + 2), .success)
+        let eventsAtReturn = recorder.snapshot
+        XCTAssertEqual(
+            eventsAtReturn,
+            ["begin", "store-enter", "store-exit", "response", "end", "did-store", "cancel-return"]
+        )
+        try? await Task.sleep(for: .milliseconds(100))
+        XCTAssertEqual(recorder.snapshot, eventsAtReturn, "late transport callbacks must remain silent")
+        fetcher.ensureFetch(covering: offset + 1, totalLength: offset + 2)
+        XCTAssertEqual(recorder.snapshot, eventsAtReturn, "cancelled fetcher must reject new admission")
+    }
+
+    func testChunkFetcherMapsBodylessIfMatch412ToEntityChanged() async throws {
+        let origin = try StubOrigin(behavior: .chunkPreconditionFailed)
+        try await origin.start()
+        defer { origin.stop() }
+        let recorder = ChunkRecorder()
+        let fetcher = PlaybackOriginChunkFetcher(
+            originURL: origin.url,
+            originHeaders: [:],
+            entityETagProvider: { "\"entity-v1\"" },
+            requiresEntityValidation: true,
+            callbacks: PlaybackOriginChunkFetcher.Callbacks(
+                store: { _, data, _, _ in
+                    recorder.recordStore(data)
+                    return nil
+                },
+                didStore: { recorder.recordRange($0) },
+                didReceiveResponse: { _ in },
+                didDetectSessionMissing: { recorder.recordSessionMissing() },
+                didFail: { _, cause, status in
+                    recorder.recordFailure(cause, statusCode: status)
+                },
+                beginRequest: { recorder.recordBegin() },
+                endRequest: { recorder.recordEnd() }
+            )
+        )
+        defer { fetcher.cancel() }
+
+        let offset: Int64 = 8 * 1024 * 1024
+        fetcher.ensureFetch(covering: offset, totalLength: offset + 1)
+
+        let changed = await waitUntil { recorder.causes == [.entityChanged] }
+        XCTAssertTrue(changed)
+        XCTAssertEqual(recorder.statuses, [412])
+        XCTAssertEqual(recorder.stores, 0)
+        XCTAssertEqual(recorder.missingSessions, 0)
+        XCTAssertEqual(recorder.requestCounts.began, 1)
+        XCTAssertEqual(recorder.requestCounts.ended, 1)
+        XCTAssertEqual(origin.observedBodyBytesSent(), 0)
+        let request = try XCTUnwrap(origin.observedRequests().first)
+        XCTAssertEqual(request.ifMatch, "\"entity-v1\"")
+    }
+
+    func testChunkFetcherBounds404DiagnosticAndDetectsSessionMissingSentinel() async throws {
+        let origin = try StubOrigin(behavior: .chunkSessionMissing404)
+        try await origin.start()
+        defer { origin.stop() }
+        let recorder = ChunkRecorder()
+        let fetcher = PlaybackOriginChunkFetcher(
+            originURL: origin.url,
+            originHeaders: [:],
+            callbacks: PlaybackOriginChunkFetcher.Callbacks(
+                store: { _, data, _, _ in
+                    recorder.recordStore(data)
+                    return nil
+                },
+                didStore: { recorder.recordRange($0) },
+                didReceiveResponse: { _ in },
+                didDetectSessionMissing: { recorder.recordSessionMissing() },
+                didFail: { _, cause, status in
+                    recorder.recordFailure(cause, statusCode: status)
+                },
+                beginRequest: { recorder.recordBegin() },
+                endRequest: { recorder.recordEnd() }
+            )
+        )
+        defer { fetcher.cancel() }
+
+        let offset: Int64 = 8 * 1024 * 1024
+        fetcher.ensureFetch(covering: offset, totalLength: offset + 1)
+
+        let failed = await waitUntil { recorder.causes == [.httpFatal(404)] }
+        XCTAssertTrue(failed)
+        XCTAssertEqual(recorder.statuses, [404])
+        XCTAssertEqual(recorder.missingSessions, 1)
+        XCTAssertEqual(recorder.stores, 0)
+        XCTAssertEqual(recorder.requestCounts.began, 1)
+        XCTAssertEqual(recorder.requestCounts.ended, 1)
+        try? await Task.sleep(for: .milliseconds(100))
+        XCTAssertGreaterThanOrEqual(origin.observedBodyBytesSent(), 4096)
+        XCTAssertLessThan(origin.observedBodyBytesSent(), 64 * 1024 * 1024)
+    }
+
+    func testChunkFetcherRejectsMalformedAndOversizedContentRanges() async throws {
+        let behaviors: [StubOrigin.ReopenBehavior] = [
+            .chunkMalformed206Unit,
+            .chunkMalformed206Ordering,
+            .chunkMalformed206Total,
+            .chunkOversized206,
+        ]
+        let offset: Int64 = 8 * 1024 * 1024
+
+        for behavior in behaviors {
+            let origin = try StubOrigin(behavior: behavior)
+            try await origin.start()
+            let recorder = ChunkRecorder()
+            let fetcher = PlaybackOriginChunkFetcher(
+                originURL: origin.url,
+                originHeaders: [:],
+                entityETagProvider: { "\"entity-v1\"" },
+                requiresEntityValidation: true,
+                callbacks: PlaybackOriginChunkFetcher.Callbacks(
+                    store: { _, data, _, _ in
+                        recorder.recordStore(data)
+                        return nil
+                    },
+                    didStore: { recorder.recordRange($0) },
+                    didReceiveResponse: { _ in },
+                    didDetectSessionMissing: { recorder.recordSessionMissing() },
+                    didFail: { _, cause, status in
+                        recorder.recordFailure(cause, statusCode: status)
+                    },
+                    beginRequest: { recorder.recordBegin() },
+                    endRequest: { recorder.recordEnd() }
+                )
+            )
+
+            fetcher.ensureFetch(covering: offset, totalLength: offset + 1)
+            let rejected = await waitUntil { recorder.causes == [.rangeIgnored] }
+            XCTAssertTrue(rejected, "behavior \(behavior)")
+            XCTAssertEqual(recorder.statuses, [206], "behavior \(behavior)")
+            XCTAssertEqual(recorder.stores, 0, "behavior \(behavior)")
+            XCTAssertEqual(recorder.requestCounts.began, 1, "behavior \(behavior)")
+            XCTAssertEqual(recorder.requestCounts.ended, 1, "behavior \(behavior)")
+            fetcher.cancel()
+            origin.stop()
+        }
+    }
+
+    func testChunkFetcherRejectsShortNonEOF206() async throws {
+        let origin = try StubOrigin(behavior: .chunkShort206OversizedBody)
+        try await origin.start()
+        defer { origin.stop() }
+        let recorder = ChunkRecorder()
+        let fetcher = PlaybackOriginChunkFetcher(
+            originURL: origin.url,
+            originHeaders: [:],
+            entityETagProvider: { "\"entity-v1\"" },
+            requiresEntityValidation: true,
+            callbacks: PlaybackOriginChunkFetcher.Callbacks(
+                store: { _, data, _, _ in
+                    recorder.recordStore(data)
+                    return nil
+                },
+                didStore: { recorder.recordRange($0) },
+                didReceiveResponse: { _ in },
+                didDetectSessionMissing: { recorder.recordSessionMissing() },
+                didFail: { _, cause, status in
+                    recorder.recordFailure(cause, statusCode: status)
+                },
+                beginRequest: { recorder.recordBegin() },
+                endRequest: { recorder.recordEnd() }
+            )
+        )
+        defer { fetcher.cancel() }
+
+        let offset: Int64 = 8 * 1024 * 1024
+        let requestedBytes = PlaybackOriginRoutingPolicy.chunkBytes
+        fetcher.ensureFetch(covering: offset, totalLength: offset + requestedBytes)
+
+        let rejected = await waitUntil { recorder.causes == [.rangeIgnored] }
+        XCTAssertTrue(rejected)
+        XCTAssertEqual(recorder.statuses, [206])
+        XCTAssertEqual(recorder.stores, 0)
+        XCTAssertTrue(recorder.ranges.isEmpty)
+        XCTAssertEqual(recorder.requestCounts.began, 1)
+        XCTAssertEqual(recorder.requestCounts.ended, 1)
+    }
+
+    func testChunkFetcherAcceptsShort206OnlyAtEntityEOF() async throws {
+        let origin = try StubOrigin(behavior: .chunkShortEOF206)
+        try await origin.start()
+        defer { origin.stop() }
+        let recorder = ChunkRecorder()
+        let fetcher = PlaybackOriginChunkFetcher(
+            originURL: origin.url,
+            originHeaders: [:],
+            entityETagProvider: { "\"entity-v1\"" },
+            requiresEntityValidation: true,
+            callbacks: PlaybackOriginChunkFetcher.Callbacks(
+                store: { _, data, _, _ in
+                    recorder.recordStore(data)
+                    return nil
+                },
+                didStore: { recorder.recordRange($0) },
+                didReceiveResponse: { _ in },
+                didDetectSessionMissing: { recorder.recordSessionMissing() },
+                didFail: { _, cause, status in
+                    recorder.recordFailure(cause, statusCode: status)
+                },
+                beginRequest: { recorder.recordBegin() },
+                endRequest: { recorder.recordEnd() }
+            )
+        )
+        defer { fetcher.cancel() }
+
+        let offset: Int64 = 8 * 1024 * 1024
+        let requestedBytes = PlaybackOriginRoutingPolicy.chunkBytes
+        fetcher.ensureFetch(covering: offset, totalLength: offset + requestedBytes)
+
+        let declaredBytes: Int64 = 64 * 1024
+        let stored = await waitUntil { recorder.storedBytes == [Int(declaredBytes)] }
+        XCTAssertTrue(stored)
+        XCTAssertEqual(recorder.ranges, [offset...(offset + declaredBytes - 1)])
+        XCTAssertTrue(recorder.causes.isEmpty)
+        XCTAssertEqual(recorder.requestCounts.began, 1)
+        XCTAssertEqual(recorder.requestCounts.ended, 1)
+        let transmitted = await waitUntil {
+            origin.observedBodyBytesSent() == Int(declaredBytes)
+        }
+        XCTAssertTrue(transmitted)
+    }
+
+    func testChunkFetcherBoundsShortByteZero200ToContentLength() async throws {
+        let origin = try StubOrigin(behavior: .chunkByteZeroShortFullBody)
+        try await origin.start()
+        defer { origin.stop() }
+        let recorder = ChunkRecorder()
+        let fetcher = PlaybackOriginChunkFetcher(
+            originURL: origin.url,
+            originHeaders: [:],
+            entityETagProvider: { "\"entity-v1\"" },
+            requiresEntityValidation: true,
+            callbacks: PlaybackOriginChunkFetcher.Callbacks(
+                store: { _, data, _, _ in
+                    recorder.recordStore(data)
+                    return nil
+                },
+                didStore: { recorder.recordRange($0) },
+                didReceiveResponse: { _ in },
+                didDetectSessionMissing: { recorder.recordSessionMissing() },
+                didFail: { _, cause, status in
+                    recorder.recordFailure(cause, statusCode: status)
+                },
+                beginRequest: { recorder.recordBegin() },
+                endRequest: { recorder.recordEnd() }
+            )
+        )
+        defer { fetcher.cancel() }
+
+        let requestedBytes = PlaybackOriginRoutingPolicy.chunkBytes
+        fetcher.ensureFetch(covering: 0, totalLength: requestedBytes)
+
+        let entityBytes: Int64 = 64 * 1024
+        let stored = await waitUntil { recorder.storedBytes == [Int(entityBytes)] }
+        XCTAssertTrue(stored)
+        XCTAssertEqual(recorder.ranges, [0...(entityBytes - 1)])
+        XCTAssertTrue(recorder.causes.isEmpty)
+        XCTAssertEqual(recorder.requestCounts.began, 1)
+        XCTAssertEqual(recorder.requestCounts.ended, 1)
+        let transmitted = await waitUntil {
+            origin.observedBodyBytesSent() == Int(entityBytes)
+        }
+        XCTAssertTrue(transmitted)
+        let request = try XCTUnwrap(origin.observedRequests().first)
+        XCTAssertEqual(request.range, "bytes=0-\(requestedBytes - 1)")
+        XCTAssertEqual(request.ifMatch, "\"entity-v1\"")
     }
 
     func testChunkFetcherUsesValidatorLearnedAfterConstruction() async throws {
@@ -1077,8 +1833,8 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
         let validatedRequest = requests.first {
             $0.range == "bytes=\(validatedOffset)-\(validatedOffset)"
         }
-        XCTAssertNil(unvalidatedRequest?.ifRange)
-        XCTAssertEqual(validatedRequest?.ifRange, "\"entity-v1\"")
+        XCTAssertNil(unvalidatedRequest?.ifMatch)
+        XCTAssertEqual(validatedRequest?.ifMatch, "\"entity-v1\"")
     }
 
     func testResumeCapableChunkFetcherRejectsResponsesWithoutEstablishedValidator() async throws {
@@ -1120,6 +1876,7 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
         XCTAssertEqual(recorder.stores, 0)
         XCTAssertEqual(origin.observedRequests().count, 2)
         XCTAssertTrue(origin.observedRequests().allSatisfy { $0.ifRange == nil })
+        XCTAssertTrue(origin.observedRequests().allSatisfy { $0.ifMatch == nil })
     }
 
     func testWeakETagIsNotSentAsIfRangeOrMisclassifiedAsEntityChange() async throws {

--- a/iosApp/Tests/PlaybackOriginStreamResumeTests.swift
+++ b/iosApp/Tests/PlaybackOriginStreamResumeTests.swift
@@ -209,6 +209,8 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
     private final class ChunkRecorder {
         private let lock = NSLock()
         private var storedByteCounts: [Int] = []
+        private var storedEntityTotals: [Int64?] = []
+        private var receivedEntityTotals: [Int64?] = []
         private var deliveredRanges: [ClosedRange<Int64>] = []
         private var failureCauses: [PlaybackOriginReconnectPolicy.EndCause] = []
         private var failureStatuses: [Int?] = []
@@ -226,6 +228,18 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
             lock.lock()
             defer { lock.unlock() }
             return storedByteCounts
+        }
+
+        var storedTotals: [Int64?] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storedEntityTotals
+        }
+
+        var responseTotals: [Int64?] {
+            lock.lock()
+            defer { lock.unlock() }
+            return receivedEntityTotals
         }
 
         var ranges: [ClosedRange<Int64>] {
@@ -258,9 +272,16 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
             return (requestBeginCount, requestEndCount)
         }
 
-        func recordStore(_ data: Data = Data()) {
+        func recordStore(_ data: Data = Data(), total: Int64? = nil) {
             lock.lock()
             storedByteCounts.append(data.count)
+            storedEntityTotals.append(total)
+            lock.unlock()
+        }
+
+        func recordResponse(total: Int64?) {
+            lock.lock()
+            receivedEntityTotals.append(total)
             lock.unlock()
         }
 
@@ -346,6 +367,7 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
             case chunkFullMatchingHeadersOnly
             case chunkByteZeroFullBody
             case chunkByteZeroShortFullBody
+            case chunkByteZeroUnknownLengthShortBody
             case chunkPreconditionFailed
             case chunkSessionMissing404
             case chunkMalformed206Unit
@@ -514,6 +536,23 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
                 let header = [
                     "HTTP/1.1 200 OK",
                     "Content-Length: \(responseBytes)",
+                    "ETag: \"entity-v1\"",
+                    "Content-Type: application/octet-stream",
+                    "Connection: close",
+                    "",
+                    ""
+                ].joined(separator: "\r\n")
+                connection.send(content: Data(header.utf8), completion: .contentProcessed {
+                    [weak self] error in
+                    guard let self, error == nil else { return }
+                    self.sendBody(connection, remaining: responseBytes)
+                })
+                return
+            }
+            if behavior == .chunkByteZeroUnknownLengthShortBody {
+                let responseBytes: Int64 = 64 * 1024
+                let header = [
+                    "HTTP/1.1 200 OK",
                     "ETag: \"entity-v1\"",
                     "Content-Type: application/octet-stream",
                     "Connection: close",
@@ -753,6 +792,7 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
                  .chunkFullMatchingHeadersOnly,
                  .chunkByteZeroFullBody,
                  .chunkByteZeroShortFullBody,
+                 .chunkByteZeroUnknownLengthShortBody,
                  .chunkPreconditionFailed,
                  .chunkSessionMissing404,
                  .chunkMalformed206Unit,
@@ -1755,12 +1795,12 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
             entityETagProvider: { "\"entity-v1\"" },
             requiresEntityValidation: true,
             callbacks: PlaybackOriginChunkFetcher.Callbacks(
-                store: { _, data, _, _ in
-                    recorder.recordStore(data)
+                store: { _, data, total, _ in
+                    recorder.recordStore(data, total: total)
                     return nil
                 },
                 didStore: { recorder.recordRange($0) },
-                didReceiveResponse: { _ in },
+                didReceiveResponse: { recorder.recordResponse(total: $0) },
                 didDetectSessionMissing: { recorder.recordSessionMissing() },
                 didFail: { _, cause, status in
                     recorder.recordFailure(cause, statusCode: status)
@@ -1775,9 +1815,14 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
         fetcher.ensureFetch(covering: 0, totalLength: requestedBytes)
 
         let entityBytes: Int64 = 64 * 1024
-        let stored = await waitUntil { recorder.storedBytes == [Int(entityBytes)] }
+        let stored = await waitUntil {
+            recorder.storedBytes == [Int(entityBytes)]
+                && recorder.responseTotals == [entityBytes]
+        }
         XCTAssertTrue(stored)
         XCTAssertEqual(recorder.ranges, [0...(entityBytes - 1)])
+        XCTAssertEqual(recorder.storedTotals, [entityBytes])
+        XCTAssertEqual(recorder.responseTotals, [entityBytes])
         XCTAssertTrue(recorder.causes.isEmpty)
         XCTAssertEqual(recorder.requestCounts.began, 1)
         XCTAssertEqual(recorder.requestCounts.ended, 1)
@@ -1785,6 +1830,54 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
             origin.observedBodyBytesSent() == Int(entityBytes)
         }
         XCTAssertTrue(transmitted)
+        let request = try XCTUnwrap(origin.observedRequests().first)
+        XCTAssertEqual(request.range, "bytes=0-\(requestedBytes - 1)")
+        XCTAssertEqual(request.ifMatch, "\"entity-v1\"")
+    }
+
+    func testChunkFetcherAcceptsShortUnknownLengthByteZero200AtEOF() async throws {
+        let origin = try StubOrigin(behavior: .chunkByteZeroUnknownLengthShortBody)
+        try await origin.start()
+        defer { origin.stop() }
+        let recorder = ChunkRecorder()
+        let fetcher = PlaybackOriginChunkFetcher(
+            originURL: origin.url,
+            originHeaders: [:],
+            entityETagProvider: { "\"entity-v1\"" },
+            requiresEntityValidation: true,
+            callbacks: PlaybackOriginChunkFetcher.Callbacks(
+                store: { _, data, total, _ in
+                    recorder.recordStore(data, total: total)
+                    return nil
+                },
+                didStore: { recorder.recordRange($0) },
+                didReceiveResponse: { recorder.recordResponse(total: $0) },
+                didDetectSessionMissing: { recorder.recordSessionMissing() },
+                didFail: { _, cause, status in
+                    recorder.recordFailure(cause, statusCode: status)
+                },
+                beginRequest: { recorder.recordBegin() },
+                endRequest: { recorder.recordEnd() }
+            )
+        )
+        defer { fetcher.cancel() }
+
+        let requestedBytes = PlaybackOriginRoutingPolicy.chunkBytes
+        fetcher.ensureFetch(covering: 0, totalLength: requestedBytes)
+
+        let entityBytes: Int64 = 64 * 1024
+        let stored = await waitUntil {
+            recorder.storedBytes == [Int(entityBytes)]
+                && recorder.responseTotals == [entityBytes]
+        }
+        XCTAssertTrue(stored)
+        XCTAssertEqual(recorder.ranges, [0...(entityBytes - 1)])
+        XCTAssertEqual(recorder.storedTotals, [entityBytes])
+        XCTAssertEqual(recorder.responseTotals, [entityBytes])
+        XCTAssertTrue(recorder.causes.isEmpty)
+        XCTAssertEqual(recorder.requestCounts.began, 1)
+        XCTAssertEqual(recorder.requestCounts.ended, 1)
+        XCTAssertEqual(origin.observedBodyBytesSent(), Int(entityBytes))
         let request = try XCTUnwrap(origin.observedRequests().first)
         XCTAssertEqual(request.range, "bytes=0-\(requestedBytes - 1)")
         XCTAssertEqual(request.ifMatch, "\"entity-v1\"")

--- a/iosApp/Tests/PlaybackOriginStreamResumeTests.swift
+++ b/iosApp/Tests/PlaybackOriginStreamResumeTests.swift
@@ -376,6 +376,8 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
             case chunkOversized206
             case chunkShort206OversizedBody
             case chunkShortEOF206
+            case chunkWildcardTotal206
+            case chunkTruncated206ThenComplete
         }
 
         struct Request: Equatable {
@@ -682,6 +684,38 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
                 })
                 return
             }
+            if behavior == .chunkWildcardTotal206
+                || behavior == .chunkTruncated206ThenComplete {
+                let end = requestedEnd ?? (offset + 64 * 1024 - 1)
+                let fullByteCount = end - offset + 1
+                let truncatesThisAttempt = behavior == .chunkTruncated206ThenComplete
+                    && requestNumber == 1
+                let responseByteCount = truncatesThisAttempt
+                    ? max(1, fullByteCount / 2)
+                    : fullByteCount
+                let total = behavior == .chunkWildcardTotal206
+                    ? "*"
+                    : String(totalBytes)
+                var headerLines = [
+                    "HTTP/1.1 206 Partial Content",
+                    "Content-Range: bytes \(offset)-\(end)/\(total)",
+                    "ETag: \"entity-v1\"",
+                    "Content-Type: application/octet-stream",
+                    "Connection: close",
+                    "",
+                    ""
+                ]
+                if !truncatesThisAttempt {
+                    headerLines.insert("Content-Length: \(fullByteCount)", at: 2)
+                }
+                let header = headerLines.joined(separator: "\r\n")
+                connection.send(content: Data(header.utf8), completion: .contentProcessed {
+                    [weak self] error in
+                    guard let self, error == nil else { return }
+                    self.sendBody(connection, remaining: responseByteCount)
+                })
+                return
+            }
             if behavior == .delayedInitialWindow
                 || behavior == .delayedInitialWindowWithoutValidator {
                 let isWindow = requestNumber == 1
@@ -800,7 +834,9 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
                  .chunkMalformed206Total,
                  .chunkOversized206,
                  .chunkShort206OversizedBody,
-                 .chunkShortEOF206:
+                 .chunkShortEOF206,
+                 .chunkWildcardTotal206,
+                 .chunkTruncated206ThenComplete:
                 fullResponse = false
             }
             if fullResponse {
@@ -1782,6 +1818,99 @@ final class PlaybackOriginStreamResumeTests: XCTestCase {
             origin.observedBodyBytesSent() == Int(declaredBytes)
         }
         XCTAssertTrue(transmitted)
+    }
+
+    func testChunkFetcherAcceptsFullRequested206WithWildcardTotal() async throws {
+        let origin = try StubOrigin(behavior: .chunkWildcardTotal206)
+        try await origin.start()
+        defer { origin.stop() }
+        let recorder = ChunkRecorder()
+        let fetcher = PlaybackOriginChunkFetcher(
+            originURL: origin.url,
+            originHeaders: [:],
+            entityETagProvider: { "\"entity-v1\"" },
+            requiresEntityValidation: true,
+            callbacks: PlaybackOriginChunkFetcher.Callbacks(
+                store: { _, data, total, _ in
+                    recorder.recordStore(data, total: total)
+                    return nil
+                },
+                didStore: { recorder.recordRange($0) },
+                didReceiveResponse: { recorder.recordResponse(total: $0) },
+                didDetectSessionMissing: { recorder.recordSessionMissing() },
+                didFail: { _, cause, status in
+                    recorder.recordFailure(cause, statusCode: status)
+                },
+                beginRequest: { recorder.recordBegin() },
+                endRequest: { recorder.recordEnd() }
+            )
+        )
+        defer { fetcher.cancel() }
+
+        let offset: Int64 = 8 * 1024 * 1024
+        let requestedBytes: Int64 = 64 * 1024
+        fetcher.ensureFetch(covering: offset, totalLength: offset + requestedBytes)
+
+        let stored = await waitUntil {
+            recorder.storedBytes == [Int(requestedBytes)]
+                && recorder.responseTotals.count == 1
+        }
+        XCTAssertTrue(stored)
+        XCTAssertEqual(recorder.ranges, [offset...(offset + requestedBytes - 1)])
+        XCTAssertEqual(recorder.storedTotals.count, 1)
+        XCTAssertNil(recorder.storedTotals[0])
+        XCTAssertEqual(recorder.responseTotals.count, 1)
+        XCTAssertNil(recorder.responseTotals[0])
+        XCTAssertTrue(recorder.causes.isEmpty)
+        XCTAssertEqual(recorder.requestCounts.began, 1)
+        XCTAssertEqual(recorder.requestCounts.ended, 1)
+        XCTAssertEqual(origin.observedBodyBytesSent(), Int(requestedBytes))
+    }
+
+    func testChunkFetcherRetriesCleanlyTruncated206BeforeStoring() async throws {
+        let origin = try StubOrigin(behavior: .chunkTruncated206ThenComplete)
+        try await origin.start()
+        defer { origin.stop() }
+        let recorder = ChunkRecorder()
+        let fetcher = PlaybackOriginChunkFetcher(
+            originURL: origin.url,
+            originHeaders: [:],
+            entityETagProvider: { "\"entity-v1\"" },
+            requiresEntityValidation: true,
+            callbacks: PlaybackOriginChunkFetcher.Callbacks(
+                store: { _, data, _, _ in
+                    recorder.recordStore(data)
+                    return nil
+                },
+                didStore: { recorder.recordRange($0) },
+                didReceiveResponse: { _ in },
+                didDetectSessionMissing: { recorder.recordSessionMissing() },
+                didFail: { _, cause, status in
+                    recorder.recordFailure(cause, statusCode: status)
+                },
+                beginRequest: { recorder.recordBegin() },
+                endRequest: { recorder.recordEnd() }
+            )
+        )
+        defer { fetcher.cancel() }
+
+        let offset: Int64 = 8 * 1024 * 1024
+        let requestedBytes: Int64 = 64 * 1024
+        fetcher.ensureFetch(covering: offset, totalLength: offset + requestedBytes)
+
+        let stored = await waitUntil(timeout: 3) {
+            recorder.storedBytes == [Int(requestedBytes)]
+        }
+        XCTAssertTrue(stored)
+        XCTAssertEqual(recorder.ranges, [offset...(offset + requestedBytes - 1)])
+        XCTAssertTrue(recorder.causes.isEmpty)
+        XCTAssertEqual(recorder.requestCounts.began, 1)
+        XCTAssertEqual(recorder.requestCounts.ended, 1)
+        let requests = origin.observedRequests()
+        XCTAssertEqual(requests.count, 2)
+        XCTAssertEqual(requests.map(\.range), Array(repeating: "bytes=\(offset)-\(offset + requestedBytes - 1)", count: 2))
+        XCTAssertEqual(requests.map(\.ifMatch), Array(repeating: "\"entity-v1\"", count: 2))
+        XCTAssertEqual(origin.observedBodyBytesSent(), Int(requestedBytes + requestedBytes / 2))
     }
 
     func testChunkFetcherBoundsShortByteZero200ToContentLength() async throws {

--- a/iosApp/iosApp/Screens/Player/PlaybackOriginChunkFetcher.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackOriginChunkFetcher.swift
@@ -52,7 +52,7 @@ final class PlaybackOriginChunkFetcher: @unchecked Sendable {
     private struct ContentRange {
         let start: Int64
         let end: Int64
-        let total: Int64
+        let total: Int64?
 
         var count: Int64 { end - start + 1 }
     }
@@ -288,8 +288,9 @@ final class PlaybackOriginChunkFetcher: @unchecked Sendable {
             // when the changed origin also returns less than the requested
             // interval. Only a response from the expected entity reaches this
             // coverage check.
+            let reachesEntityEOF = parsed.total.map { parsed.end == $0 - 1 } ?? false
             guard parsed.end == state.range.upperBound - 1
-                    || parsed.end == parsed.total - 1 else {
+                    || reachesEntityEOF else {
                 let receivedRange = contentRange ?? "missing"
                 Self.logger.warning(
                     "[CMP-SOURCE-CACHE] chunk incomplete content-range expected=\(state.range.lowerBound, privacy: .public)-\(state.range.upperBound - 1, privacy: .public) received=\(receivedRange, privacy: .public)"
@@ -377,9 +378,10 @@ final class PlaybackOriginChunkFetcher: @unchecked Sendable {
         }
     }
 
-    /// Parses exactly `bytes start-end/total`. A satisfiable 206 cannot use a
-    /// wildcard total, negative positions, an inverted interval, or an end at
-    /// or beyond the complete representation length.
+    /// Parses exactly `bytes start-end/total`, including the RFC-permitted
+    /// wildcard when the complete representation length is unknown. A
+    /// satisfiable 206 cannot use negative positions, an inverted interval,
+    /// or (when known) an end at or beyond the complete length.
     private static func parseContentRange(_ header: String?) -> ContentRange? {
         guard let header else { return nil }
         let trimmed = header.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -390,10 +392,15 @@ final class PlaybackOriginChunkFetcher: @unchecked Sendable {
         guard unit.lowercased() == "bytes" else { return nil }
         let value = trimmed[separator...].trimmingCharacters(in: .whitespaces)
         let slashParts = value.split(separator: "/", omittingEmptySubsequences: false)
-        guard slashParts.count == 2,
-              slashParts[1] != "*",
-              let total = Int64(slashParts[1]),
-              total > 0 else {
+        guard slashParts.count == 2 else {
+            return nil
+        }
+        let total: Int64?
+        if slashParts[1] == "*" {
+            total = nil
+        } else if let parsedTotal = Int64(slashParts[1]), parsedTotal > 0 {
+            total = parsedTotal
+        } else {
             return nil
         }
         let bounds = slashParts[0].split(separator: "-", omittingEmptySubsequences: false)
@@ -401,8 +408,10 @@ final class PlaybackOriginChunkFetcher: @unchecked Sendable {
               let start = Int64(bounds[0]),
               let end = Int64(bounds[1]),
               start >= 0,
-              start <= end,
-              end < total else {
+              start <= end else {
+            return nil
+        }
+        if let total, end >= total {
             return nil
         }
         return ContentRange(start: start, end: end, total: total)
@@ -433,7 +442,14 @@ final class PlaybackOriginChunkFetcher: @unchecked Sendable {
 
     /// Must run on `stateQueue`.
     private func handleDataLocked(_ data: Data, taskID: Int) -> Bool {
-        guard var state = attempts[taskID], state.response != nil else {
+        // Remove before mutation so the dictionary does not retain another
+        // reference to the Data buffer and force a full copy-on-write for
+        // every delegate delivery.
+        guard var state = attempts.removeValue(forKey: taskID) else {
+            return true
+        }
+        guard state.response != nil else {
+            attempts[taskID] = state
             return true
         }
         switch state.response {
@@ -443,7 +459,6 @@ final class PlaybackOriginChunkFetcher: @unchecked Sendable {
                 state.body.append(contentsOf: data.prefix(remaining))
             }
             if state.body.count == byteLimit {
-                attempts.removeValue(forKey: taskID)
                 completeMediaLocked(state)
                 return true
             } else {
@@ -455,7 +470,6 @@ final class PlaybackOriginChunkFetcher: @unchecked Sendable {
                 state.body.append(contentsOf: data.prefix(remaining))
             }
             if state.body.count == 4096 {
-                attempts.removeValue(forKey: taskID)
                 completeNotFoundLocked(state)
                 return true
             } else {
@@ -498,9 +512,10 @@ final class PlaybackOriginChunkFetcher: @unchecked Sendable {
         case .media(_, _, let byteLimit, let acceptsShortEOF):
             guard state.body.count == byteLimit
                     || (acceptsShortEOF && !state.body.isEmpty) else {
-                failLocked(
+                retryOrFailLocked(
                     id: state.id,
                     range: state.range,
+                    attempt: state.attempt,
                     cause: .prematureEOF,
                     statusCode: nil
                 )

--- a/iosApp/iosApp/Screens/Player/PlaybackOriginChunkFetcher.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackOriginChunkFetcher.swift
@@ -40,7 +40,12 @@ final class PlaybackOriginChunkFetcher: @unchecked Sendable {
     )
 
     private enum AcceptedResponse {
-        case media(total: Int64?, entityETag: String?, byteLimit: Int)
+        case media(
+            total: Int64?,
+            entityETag: String?,
+            byteLimit: Int,
+            acceptsShortEOF: Bool
+        )
         case notFound
     }
 
@@ -298,7 +303,8 @@ final class PlaybackOriginChunkFetcher: @unchecked Sendable {
                     entityETag: PlaybackOriginStream.strongETag(
                         http.value(forHTTPHeaderField: "ETag")
                     ),
-                    byteLimit: Int(min(parsed.count, Int64(state.range.count)))
+                    byteLimit: Int(min(parsed.count, Int64(state.range.count))),
+                    acceptsShortEOF: false
                 ),
                 taskID: taskID
             )
@@ -324,7 +330,8 @@ final class PlaybackOriginChunkFetcher: @unchecked Sendable {
                     entityETag: PlaybackOriginStream.strongETag(
                         http.value(forHTTPHeaderField: "ETag")
                     ),
-                    byteLimit: byteLimit
+                    byteLimit: byteLimit,
+                    acceptsShortEOF: http.expectedContentLength < 0
                 ),
                 taskID: taskID
             )
@@ -406,7 +413,7 @@ final class PlaybackOriginChunkFetcher: @unchecked Sendable {
         guard var state = attempts[taskID] else { return }
         state.response = response
         switch response {
-        case .media(_, _, let byteLimit):
+        case .media(_, _, let byteLimit, _):
             state.body.reserveCapacity(byteLimit)
         case .notFound:
             state.body.reserveCapacity(4096)
@@ -430,7 +437,7 @@ final class PlaybackOriginChunkFetcher: @unchecked Sendable {
             return true
         }
         switch state.response {
-        case .media(_, _, let byteLimit):
+        case .media(_, _, let byteLimit, _):
             let remaining = max(0, byteLimit - state.body.count)
             if remaining > 0 {
                 state.body.append(contentsOf: data.prefix(remaining))
@@ -488,8 +495,9 @@ final class PlaybackOriginChunkFetcher: @unchecked Sendable {
             return
         }
         switch state.response {
-        case .media(_, _, let byteLimit):
-            guard state.body.count == byteLimit else {
+        case .media(_, _, let byteLimit, let acceptsShortEOF):
+            guard state.body.count == byteLimit
+                    || (acceptsShortEOF && !state.body.isEmpty) else {
                 failLocked(
                     id: state.id,
                     range: state.range,
@@ -498,7 +506,10 @@ final class PlaybackOriginChunkFetcher: @unchecked Sendable {
                 )
                 return
             }
-            completeMediaLocked(state)
+            let inferredTotal = acceptsShortEOF && state.body.count < byteLimit
+                ? Int64(state.body.count)
+                : nil
+            completeMediaLocked(state, inferredTotal: inferredTotal)
         case .notFound:
             completeNotFoundLocked(state)
         case nil:
@@ -512,14 +523,14 @@ final class PlaybackOriginChunkFetcher: @unchecked Sendable {
         }
     }
 
-    private func completeMediaLocked(_ state: AttemptState) {
-        guard case .media(let total, let responseETag, _) = state.response else { return }
+    private func completeMediaLocked(_ state: AttemptState, inferredTotal: Int64? = nil) {
+        guard case .media(let total, let responseETag, _, _) = state.response else { return }
         storeAndFinishLocked(
             id: state.id,
             range: state.range,
             attempt: state.attempt,
             body: state.body,
-            total: total,
+            total: inferredTotal ?? total,
             responseETag: responseETag
         )
     }

--- a/iosApp/iosApp/Screens/Player/PlaybackOriginChunkFetcher.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackOriginChunkFetcher.swift
@@ -6,8 +6,8 @@ import OSLog
 /// extractor reads, and far seeks are served with exact `Range` GETs over
 /// one shared keep-alive URLSession instead of retargeting the streaming
 /// window connection. Each chunk is stored (and its waiters woken) when the
-/// response body completes — at most one chunk of latency for a probe read.
-final class PlaybackOriginChunkFetcher {
+/// requested interval completes — at most one chunk of latency for a probe read.
+final class PlaybackOriginChunkFetcher: @unchecked Sendable {
     /// Interactive detour/probe fetches must fail fast enough for the source
     /// window or outage coordinator to recover. Long outage survival is owned
     /// by `PlaybackOriginReconnectPolicy`, not by one blocked range request.
@@ -39,6 +39,28 @@ final class PlaybackOriginChunkFetcher {
         category: "PlaybackOriginChunkFetcher"
     )
 
+    private enum AcceptedResponse {
+        case media(total: Int64?, entityETag: String?, byteLimit: Int)
+        case notFound
+    }
+
+    private struct ContentRange {
+        let start: Int64
+        let end: Int64
+        let total: Int64
+
+        var count: Int64 { end - start + 1 }
+    }
+
+    private struct AttemptState {
+        let id: UUID
+        let range: Range<Int64>
+        let attempt: Int
+        let expectedEntityETag: String?
+        var response: AcceptedResponse?
+        var body = Data()
+    }
+
     private let originURL: URL
     private let originHeaders: [String: String]
     /// Resolved for every request and response rather than captured at
@@ -50,9 +72,24 @@ final class PlaybackOriginChunkFetcher {
     private let requiresEntityValidation: Bool
     private let callbacks: Callbacks
 
-    private let lock = NSLock()
+    /// State transitions and every externally supplied callback share this
+    /// executor. An external `cancel()` synchronously joins it, so once cancel
+    /// returns no callback can still be running and late delegate events cannot
+    /// start another one. The queue-specific fast path avoids self-deadlock
+    /// when a callback synchronously invalidates its owning source resource.
+    private let stateQueue = DispatchQueue(
+        label: "com.continuum.PlaybackOriginChunkFetcher.state",
+        qos: .userInitiated
+    )
+    private let stateQueueKey = DispatchSpecificKey<UInt8>()
+    /// `PlaybackSourceResource` queries coverage while holding its own state
+    /// lock. Publish only this callback-free snapshot behind a tiny lock so it
+    /// never waits for `stateQueue`, whose callbacks may need that outer lock.
+    private let coverageLock = NSLock()
+    private var publishedInFlight: [UUID: Range<Int64>] = [:]
     private var cancelled = false
     private var inFlight: [UUID: Range<Int64>] = [:]
+    private var attempts: [Int: AttemptState] = [:]
     private var session: URLSession?
 
     init(
@@ -67,27 +104,34 @@ final class PlaybackOriginChunkFetcher {
         self.entityETagProvider = entityETagProvider
         self.requiresEntityValidation = requiresEntityValidation
         self.callbacks = callbacks
+        stateQueue.setSpecific(key: stateQueueKey, value: 1)
     }
 
     func cancel() {
-        lock.lock()
-        cancelled = true
-        let open = inFlight.count
-        inFlight.removeAll()
-        let session = self.session
-        self.session = nil
-        lock.unlock()
-        session?.invalidateAndCancel()
-        for _ in 0..<open {
-            callbacks.endRequest()
+        let session: URLSession? = withState {
+            guard !cancelled else { return nil }
+            cancelled = true
+            attempts.removeAll()
+            let open = inFlight.count
+            inFlight.removeAll()
+            coverageLock.lock()
+            publishedInFlight.removeAll()
+            coverageLock.unlock()
+            let session = self.session
+            self.session = nil
+            for _ in 0..<open {
+                callbacks.endRequest()
+            }
+            return session
         }
+        session?.invalidateAndCancel()
     }
 
     /// Whether an in-flight chunk will (eventually) deliver `offset`.
     func coversInFlight(offset: Int64) -> Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        return inFlight.values.contains { $0.contains(offset) }
+        coverageLock.lock()
+        defer { coverageLock.unlock() }
+        return publishedInFlight.values.contains { $0.contains(offset) }
     }
 
     /// Fetch `chunkBytes` starting at `offset` unless an in-flight chunk
@@ -101,22 +145,22 @@ final class PlaybackOriginChunkFetcher {
         guard end > start else { return }
         let range = start..<end
 
-        let id = UUID()
-        lock.lock()
-        guard !cancelled else {
-            lock.unlock()
-            return
+        withState {
+            guard !cancelled,
+                  !inFlight.values.contains(where: { $0.contains(offset) }) else {
+                return
+            }
+            let id = UUID()
+            inFlight[id] = range
+            coverageLock.lock()
+            publishedInFlight[id] = range
+            coverageLock.unlock()
+            // Begin is serialized with admission. Cancellation therefore can
+            // neither observe this request before begin nor deliver end first.
+            callbacks.beginRequest()
+            Self.logger.info("[CMP-SOURCE-CACHE] chunk fetch start=\(start, privacy: .public) len=\(end - start, privacy: .public)")
+            runLocked(id: id, range: range, attempt: 1)
         }
-        if inFlight.values.contains(where: { $0.contains(offset) }) {
-            lock.unlock()
-            return
-        }
-        inFlight[id] = range
-        lock.unlock()
-
-        callbacks.beginRequest()
-        Self.logger.info("[CMP-SOURCE-CACHE] chunk fetch start=\(start, privacy: .public) len=\(end - start, privacy: .public)")
-        run(id: id, range: range, attempt: 1)
     }
 
     private func makeSessionLocked() -> URLSession {
@@ -125,7 +169,14 @@ final class PlaybackOriginChunkFetcher {
         // fresh TCP+TLS handshake per probe, which is the cost this class
         // exists to avoid.
         let config = Self.makeSessionConfiguration()
-        let created = URLSession(configuration: config)
+        let delegateQueue = OperationQueue()
+        delegateQueue.maxConcurrentOperationCount = 1
+        delegateQueue.qualityOfService = .userInitiated
+        let created = URLSession(
+            configuration: config,
+            delegate: ConnectionDelegate(fetcher: self),
+            delegateQueue: delegateQueue
+        )
         session = created
         return created
     }
@@ -140,13 +191,15 @@ final class PlaybackOriginChunkFetcher {
     }
 
     private func run(id: UUID, range: Range<Int64>, attempt: Int) {
-        lock.lock()
-        guard !cancelled, inFlight[id] != nil else {
-            lock.unlock()
-            return
+        withState {
+            runLocked(id: id, range: range, attempt: attempt)
         }
+    }
+
+    /// Must run on `stateQueue`.
+    private func runLocked(id: UUID, range: Range<Int64>, attempt: Int) {
+        guard !cancelled, inFlight[id] != nil else { return }
         let session = makeSessionLocked()
-        lock.unlock()
 
         var request = URLRequest(url: originURL)
         request.httpMethod = "GET"
@@ -154,147 +207,378 @@ final class PlaybackOriginChunkFetcher {
             request.setValue(value, forHTTPHeaderField: key)
         }
         request.setValue("bytes=\(range.lowerBound)-\(range.upperBound - 1)", forHTTPHeaderField: "Range")
-        if range.lowerBound > 0, let entityETag = entityETagProvider() {
-            request.setValue(entityETag, forHTTPHeaderField: "If-Range")
+        // Unlike If-Range, If-Match never turns a stale validator into a
+        // potentially multi-gigabyte 200 response. A changed entity fails as
+        // a bodyless 412 before the origin sends any file bytes.
+        let expectedEntityETag = entityETagProvider()
+        if let expectedEntityETag {
+            request.setValue(expectedEntityETag, forHTTPHeaderField: "If-Match")
         }
 
-        let task = session.dataTask(with: request) { [weak self] data, response, error in
-            self?.handleResult(id: id, range: range, attempt: attempt, data: data, response: response, error: error)
+        let task = session.dataTask(with: request)
+        guard !cancelled, inFlight[id] != nil else {
+            task.cancel()
+            return
         }
+        attempts[task.taskIdentifier] = AttemptState(
+            id: id,
+            range: range,
+            attempt: attempt,
+            expectedEntityETag: expectedEntityETag,
+            response: nil
+        )
         task.resume()
     }
 
-    private func handleResult(
-        id: UUID,
-        range: Range<Int64>,
-        attempt: Int,
-        data: Data?,
-        response: URLResponse?,
-        error: Error?
-    ) {
-        lock.lock()
-        let stillWanted = !cancelled && inFlight[id] != nil
-        lock.unlock()
-        guard stillWanted else { return }
+    private func withState<T>(_ body: () -> T) -> T {
+        if DispatchQueue.getSpecific(key: stateQueueKey) != nil {
+            return body()
+        }
+        return stateQueue.sync(execute: body)
+    }
 
-        if let error {
-            if (error as NSError).domain == NSURLErrorDomain,
-               (error as NSError).code == NSURLErrorCancelled {
-                finish(id: id)
-                return
-            }
-            retryOrFail(id: id, range: range, attempt: attempt, cause: .network, statusCode: nil)
-            return
+    /// Validate headers before URLSession is allowed to deliver body bytes.
+    /// Returning false causes the delegate to cancel the response; the attempt
+    /// has already been removed so its cancellation completion is a no-op.
+    fileprivate func handleResponse(_ response: URLResponse, taskID: Int) -> Bool {
+        withState {
+            handleResponseLocked(response, taskID: taskID)
+        }
+    }
+
+    /// Must run on `stateQueue`.
+    private func handleResponseLocked(_ response: URLResponse, taskID: Int) -> Bool {
+        guard let state = attempts[taskID],
+              !cancelled,
+              inFlight[state.id] != nil else {
+            return false
         }
         guard let http = response as? HTTPURLResponse else {
-            retryOrFail(id: id, range: range, attempt: attempt, cause: .network, statusCode: nil)
-            return
+            rejectAttemptLocked(taskID: taskID, cause: .network, statusCode: nil, retryable: true)
+            return false
         }
 
         switch http.statusCode {
         case 206:
             let contentRange = http.value(forHTTPHeaderField: "Content-Range")
-            let total = PlaybackOriginStream.totalLength(fromContentRange: contentRange)
-            guard let rangeStart = PlaybackOriginStream.rangeStart(fromContentRange: contentRange),
-                  rangeStart == range.lowerBound else {
+            guard let parsed = Self.parseContentRange(contentRange),
+                  parsed.start == state.range.lowerBound,
+                  parsed.end < state.range.upperBound else {
                 let receivedRange = contentRange ?? "missing"
                 Self.logger.warning(
-                    "[CMP-SOURCE-CACHE] chunk invalid content-range expectedStart=\(range.lowerBound, privacy: .public) received=\(receivedRange, privacy: .public)"
+                    "[CMP-SOURCE-CACHE] chunk invalid content-range expected=\(state.range.lowerBound, privacy: .public)-\(state.range.upperBound - 1, privacy: .public) received=\(receivedRange, privacy: .public)"
                 )
-                fail(id: id, range: range, cause: .rangeIgnored, statusCode: 206)
-                return
+                rejectAttemptLocked(taskID: taskID, cause: .rangeIgnored, statusCode: 206, retryable: false)
+                return false
             }
-            if let cause = entityValidationFailure(for: http) {
-                retryOrFail(
-                    id: id,
-                    range: range,
-                    attempt: attempt,
-                    cause: cause,
-                    statusCode: 206
-                )
-                return
+            if let cause = entityValidationFailure(
+                for: http,
+                expectedEntityETag: state.expectedEntityETag
+            ) {
+                rejectAttemptLocked(taskID: taskID, cause: cause, statusCode: 206, retryable: true)
+                return false
             }
-            storeAndFinish(
-                id: id,
-                range: range,
-                attempt: attempt,
-                body: data ?? Data(),
-                total: total,
-                responseETag: PlaybackOriginStream.strongETag(
-                    http.value(forHTTPHeaderField: "ETag")
+            // Preserve entity-change precedence for a syntactically safe
+            // partial response: callers must invalidate the old resource even
+            // when the changed origin also returns less than the requested
+            // interval. Only a response from the expected entity reaches this
+            // coverage check.
+            guard parsed.end == state.range.upperBound - 1
+                    || parsed.end == parsed.total - 1 else {
+                let receivedRange = contentRange ?? "missing"
+                Self.logger.warning(
+                    "[CMP-SOURCE-CACHE] chunk incomplete content-range expected=\(state.range.lowerBound, privacy: .public)-\(state.range.upperBound - 1, privacy: .public) received=\(receivedRange, privacy: .public)"
                 )
+                rejectAttemptLocked(taskID: taskID, cause: .rangeIgnored, statusCode: 206, retryable: false)
+                return false
+            }
+            acceptResponseLocked(
+                .media(
+                    total: parsed.total,
+                    entityETag: PlaybackOriginStream.strongETag(
+                        http.value(forHTTPHeaderField: "ETag")
+                    ),
+                    byteLimit: Int(min(parsed.count, Int64(state.range.count)))
+                ),
+                taskID: taskID
             )
-        case 200 where range.lowerBound == 0:
-            if let cause = entityValidationFailure(for: http) {
-                retryOrFail(
-                    id: id,
-                    range: range,
-                    attempt: attempt,
-                    cause: cause,
-                    statusCode: 200
-                )
-                return
+            return true
+        case 200 where state.range.lowerBound == 0:
+            if let cause = entityValidationFailure(
+                for: http,
+                expectedEntityETag: state.expectedEntityETag
+            ) {
+                rejectAttemptLocked(taskID: taskID, cause: cause, statusCode: 200, retryable: true)
+                return false
             }
             // Origin ignored the Range but the chunk starts at 0, so a
-            // truncated prefix of the body is exactly the requested bytes
-            // (Data's prefix is a no-copy slice).
+            // bounded prefix of the body is exactly the requested bytes. The
+            // delegate cancels as soon as that prefix is complete.
             let total = http.expectedContentLength > 0 ? http.expectedContentLength : nil
-            let body = (data ?? Data()).prefix(Int(range.upperBound - range.lowerBound))
-            storeAndFinish(
-                id: id,
-                range: range,
-                attempt: attempt,
-                body: body,
-                total: total,
-                responseETag: PlaybackOriginStream.strongETag(
-                    http.value(forHTTPHeaderField: "ETag")
-                )
+            let byteLimit = http.expectedContentLength > 0
+                ? Int(min(Int64(state.range.count), http.expectedContentLength))
+                : state.range.count
+            acceptResponseLocked(
+                .media(
+                    total: total,
+                    entityETag: PlaybackOriginStream.strongETag(
+                        http.value(forHTTPHeaderField: "ETag")
+                    ),
+                    byteLimit: byteLimit
+                ),
+                taskID: taskID
             )
+            return true
         case 200:
             // Accepting head bytes at a nonzero offset would corrupt the cache.
-            let cause = entityValidationFailure(for: http) ?? .rangeIgnored
-            fail(id: id, range: range, cause: cause, statusCode: 200)
+            let cause = entityValidationFailure(
+                for: http,
+                expectedEntityETag: state.expectedEntityETag
+            ) ?? .rangeIgnored
+            rejectAttemptLocked(taskID: taskID, cause: cause, statusCode: 200, retryable: false)
+            return false
+        case 412:
+            // If-Match failed. The origin guarantees no representation body
+            // was selected, so invalidate the resource immediately.
+            rejectAttemptLocked(taskID: taskID, cause: .entityChanged, statusCode: 412, retryable: false)
+            return false
         case 404:
-            let body = data.flatMap { String(data: $0.prefix(4096), encoding: .utf8) }
-            if PlaybackOriginStream.isPlaybackSessionMissing(statusCode: 404, body: body) {
-                callbacks.didDetectSessionMissing()
-            }
-            fail(id: id, range: range, cause: .httpFatal(404), statusCode: 404)
+            acceptResponseLocked(.notFound, taskID: taskID)
+            return true
         case 502, 503, 504:
-            retryOrFail(id: id, range: range, attempt: attempt, cause: .httpOutage(http.statusCode), statusCode: http.statusCode)
+            rejectAttemptLocked(
+                taskID: taskID,
+                cause: .httpOutage(http.statusCode),
+                statusCode: http.statusCode,
+                retryable: true
+            )
+            return false
         case 416:
             if let total = PlaybackOriginStream.totalLength(fromContentRange: http.value(forHTTPHeaderField: "Content-Range")) {
                 callbacks.didReceiveResponse(total)
             }
-            fail(id: id, range: range, cause: .httpFatal(416), statusCode: 416)
+            rejectAttemptLocked(taskID: taskID, cause: .httpFatal(416), statusCode: 416, retryable: false)
+            return false
         default:
-            fail(id: id, range: range, cause: .httpFatal(http.statusCode), statusCode: http.statusCode)
+            rejectAttemptLocked(
+                taskID: taskID,
+                cause: .httpFatal(http.statusCode),
+                statusCode: http.statusCode,
+                retryable: false
+            )
+            return false
+        }
+    }
+
+    /// Parses exactly `bytes start-end/total`. A satisfiable 206 cannot use a
+    /// wildcard total, negative positions, an inverted interval, or an end at
+    /// or beyond the complete representation length.
+    private static func parseContentRange(_ header: String?) -> ContentRange? {
+        guard let header else { return nil }
+        let trimmed = header.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let separator = trimmed.firstIndex(where: { $0.isWhitespace }) else {
+            return nil
+        }
+        let unit = trimmed[..<separator]
+        guard unit.lowercased() == "bytes" else { return nil }
+        let value = trimmed[separator...].trimmingCharacters(in: .whitespaces)
+        let slashParts = value.split(separator: "/", omittingEmptySubsequences: false)
+        guard slashParts.count == 2,
+              slashParts[1] != "*",
+              let total = Int64(slashParts[1]),
+              total > 0 else {
+            return nil
+        }
+        let bounds = slashParts[0].split(separator: "-", omittingEmptySubsequences: false)
+        guard bounds.count == 2,
+              let start = Int64(bounds[0]),
+              let end = Int64(bounds[1]),
+              start >= 0,
+              start <= end,
+              end < total else {
+            return nil
+        }
+        return ContentRange(start: start, end: end, total: total)
+    }
+
+    /// Must run on `stateQueue`.
+    private func acceptResponseLocked(_ response: AcceptedResponse, taskID: Int) {
+        guard var state = attempts[taskID] else { return }
+        state.response = response
+        switch response {
+        case .media(_, _, let byteLimit):
+            state.body.reserveCapacity(byteLimit)
+        case .notFound:
+            state.body.reserveCapacity(4096)
+        }
+        attempts[taskID] = state
+    }
+
+    /// Append one delegate delivery while enforcing a strict per-response
+    /// memory ceiling. Returns true when the URLSession task should be
+    /// cancelled because the requested prefix (or 404 diagnostic prefix) is
+    /// complete and all callbacks have already been delivered.
+    fileprivate func handleData(_ data: Data, taskID: Int) -> Bool {
+        withState {
+            handleDataLocked(data, taskID: taskID)
+        }
+    }
+
+    /// Must run on `stateQueue`.
+    private func handleDataLocked(_ data: Data, taskID: Int) -> Bool {
+        guard var state = attempts[taskID], state.response != nil else {
+            return true
+        }
+        switch state.response {
+        case .media(_, _, let byteLimit):
+            let remaining = max(0, byteLimit - state.body.count)
+            if remaining > 0 {
+                state.body.append(contentsOf: data.prefix(remaining))
+            }
+            if state.body.count == byteLimit {
+                attempts.removeValue(forKey: taskID)
+                completeMediaLocked(state)
+                return true
+            } else {
+                attempts[taskID] = state
+            }
+        case .notFound:
+            let remaining = max(0, 4096 - state.body.count)
+            if remaining > 0 {
+                state.body.append(contentsOf: data.prefix(remaining))
+            }
+            if state.body.count == 4096 {
+                attempts.removeValue(forKey: taskID)
+                completeNotFoundLocked(state)
+                return true
+            } else {
+                attempts[taskID] = state
+            }
+        case nil:
+            break
+        }
+        return false
+    }
+
+    fileprivate func handleCompletion(error: Error?, taskID: Int) {
+        withState {
+            handleCompletionLocked(error: error, taskID: taskID)
+        }
+    }
+
+    /// Must run on `stateQueue`.
+    private func handleCompletionLocked(error: Error?, taskID: Int) {
+        guard let state = attempts.removeValue(forKey: taskID),
+              !cancelled,
+              inFlight[state.id] != nil else { return }
+
+        if let error {
+            if (error as NSError).domain == NSURLErrorDomain,
+               (error as NSError).code == NSURLErrorCancelled {
+                finishLocked(id: state.id)
+                return
+            }
+            retryOrFailLocked(
+                id: state.id,
+                range: state.range,
+                attempt: state.attempt,
+                cause: .network,
+                statusCode: nil
+            )
+            return
+        }
+        switch state.response {
+        case .media(_, _, let byteLimit):
+            guard state.body.count == byteLimit else {
+                failLocked(
+                    id: state.id,
+                    range: state.range,
+                    cause: .prematureEOF,
+                    statusCode: nil
+                )
+                return
+            }
+            completeMediaLocked(state)
+        case .notFound:
+            completeNotFoundLocked(state)
+        case nil:
+            retryOrFailLocked(
+                id: state.id,
+                range: state.range,
+                attempt: state.attempt,
+                cause: .network,
+                statusCode: nil
+            )
+        }
+    }
+
+    private func completeMediaLocked(_ state: AttemptState) {
+        guard case .media(let total, let responseETag, _) = state.response else { return }
+        storeAndFinishLocked(
+            id: state.id,
+            range: state.range,
+            attempt: state.attempt,
+            body: state.body,
+            total: total,
+            responseETag: responseETag
+        )
+    }
+
+    private func completeNotFoundLocked(_ state: AttemptState) {
+        let body = String(data: state.body, encoding: .utf8)
+        if PlaybackOriginStream.isPlaybackSessionMissing(statusCode: 404, body: body) {
+            callbacks.didDetectSessionMissing()
+            guard !cancelled else { return }
+        }
+        failLocked(id: state.id, range: state.range, cause: .httpFatal(404), statusCode: 404)
+    }
+
+    private func rejectAttemptLocked(
+        taskID: Int,
+        cause: PlaybackOriginReconnectPolicy.EndCause,
+        statusCode: Int?,
+        retryable: Bool
+    ) {
+        let state = attempts.removeValue(forKey: taskID)
+        guard let state else { return }
+        if retryable {
+            retryOrFailLocked(
+                id: state.id,
+                range: state.range,
+                attempt: state.attempt,
+                cause: cause,
+                statusCode: statusCode
+            )
+        } else {
+            failLocked(id: state.id, range: state.range, cause: cause, statusCode: statusCode)
         }
     }
 
     private func entityValidationFailure(
-        for response: HTTPURLResponse
+        for response: HTTPURLResponse,
+        expectedEntityETag: String?
     ) -> PlaybackOriginReconnectPolicy.EndCause? {
-        guard let entityETag = entityETagProvider() else {
+        guard let expectedEntityETag else {
             return requiresEntityValidation ? .rangeIgnored : nil
         }
         let responseETagHeader = response.value(forHTTPHeaderField: "ETag")
         guard let responseETag = PlaybackOriginStream.strongETag(responseETagHeader) else {
             Self.logger.warning(
-                "[CMP-SOURCE-CACHE] chunk entity-unverifiable expectedETag=\(entityETag, privacy: .public) responseETag=\(responseETagHeader ?? "missing", privacy: .public)"
+                "[CMP-SOURCE-CACHE] chunk entity-unverifiable expectedETag=\(expectedEntityETag, privacy: .public) responseETag=\(responseETagHeader ?? "missing", privacy: .public)"
             )
             return .rangeIgnored
         }
-        guard responseETag == entityETag else {
+        guard responseETag == expectedEntityETag else {
             Self.logger.error(
-                "[CMP-SOURCE-CACHE] chunk entity-changed expectedETag=\(entityETag, privacy: .public) responseETag=\(responseETagHeader ?? "missing", privacy: .public)"
+                "[CMP-SOURCE-CACHE] chunk entity-changed expectedETag=\(expectedEntityETag, privacy: .public) responseETag=\(responseETagHeader ?? "missing", privacy: .public)"
             )
             return .entityChanged
         }
         return nil
     }
 
-    private func storeAndFinish(
+    /// Must run on `stateQueue`.
+    private func storeAndFinishLocked(
         id: UUID,
         range: Range<Int64>,
         attempt: Int,
@@ -305,7 +589,7 @@ final class PlaybackOriginChunkFetcher {
         guard !body.isEmpty else {
             // A 206 with an empty body is an origin bug; a repeat request
             // will not do better.
-            fail(id: id, range: range, cause: .prematureEOF, statusCode: nil)
+            failLocked(id: id, range: range, cause: .prematureEOF, statusCode: nil)
             return
         }
         if let cause = callbacks.store(
@@ -314,7 +598,8 @@ final class PlaybackOriginChunkFetcher {
             total,
             responseETag
         ) {
-            retryOrFail(
+            guard !cancelled else { return }
+            retryOrFailLocked(
                 id: id,
                 range: range,
                 attempt: attempt,
@@ -323,8 +608,11 @@ final class PlaybackOriginChunkFetcher {
             )
             return
         }
+        guard !cancelled else { return }
         callbacks.didReceiveResponse(total)
-        finish(id: id)
+        guard !cancelled else { return }
+        finishLocked(id: id)
+        guard !cancelled else { return }
         callbacks.didStore(range.lowerBound...(range.lowerBound + Int64(body.count) - 1))
     }
 
@@ -332,7 +620,8 @@ final class PlaybackOriginChunkFetcher {
     /// (`PlaybackOriginReconnectPolicy`) so "how often and how long to retry
     /// an origin read" has one definition. Chunks are never "productive" in
     /// the streak sense — each is a fresh short request.
-    private func retryOrFail(
+    /// Must run on `stateQueue`.
+    private func retryOrFailLocked(
         id: UUID,
         range: Range<Int64>,
         attempt: Int,
@@ -345,7 +634,7 @@ final class PlaybackOriginChunkFetcher {
             everProductive: false
         ) {
         case .giveUp:
-            fail(id: id, range: range, cause: cause, statusCode: statusCode)
+            failLocked(id: id, range: range, cause: cause, statusCode: statusCode)
         case .retry(let delay):
             Self.logger.info("[CMP-SOURCE-CACHE] chunk retry start=\(range.lowerBound, privacy: .public) attempt=\(attempt + 1, privacy: .public) cause=\(String(describing: cause), privacy: .public)")
             Task.detached(priority: .userInitiated) { [weak self] in
@@ -355,23 +644,59 @@ final class PlaybackOriginChunkFetcher {
         }
     }
 
-    private func fail(
+    /// Must run on `stateQueue`.
+    private func failLocked(
         id: UUID,
         range: Range<Int64>,
         cause: PlaybackOriginReconnectPolicy.EndCause,
         statusCode: Int?
     ) {
         Self.logger.warning("[CMP-SOURCE-CACHE] chunk failed start=\(range.lowerBound, privacy: .public) cause=\(String(describing: cause), privacy: .public) status=\(statusCode ?? 0, privacy: .public)")
-        finish(id: id)
+        finishLocked(id: id)
+        guard !cancelled else { return }
         callbacks.didFail(range, cause, statusCode)
     }
 
-    private func finish(id: UUID) {
-        lock.lock()
+    /// Must run on `stateQueue`.
+    private func finishLocked(id: UUID) {
         let removed = inFlight.removeValue(forKey: id) != nil
-        lock.unlock()
         if removed {
+            coverageLock.lock()
+            publishedInFlight.removeValue(forKey: id)
+            coverageLock.unlock()
             callbacks.endRequest()
+        }
+    }
+
+    private final class ConnectionDelegate: NSObject, URLSessionDataDelegate {
+        private weak var fetcher: PlaybackOriginChunkFetcher?
+
+        init(fetcher: PlaybackOriginChunkFetcher) {
+            self.fetcher = fetcher
+        }
+
+        func urlSession(
+            _ session: URLSession,
+            dataTask: URLSessionDataTask,
+            didReceive response: URLResponse,
+            completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+        ) {
+            guard let fetcher,
+                  fetcher.handleResponse(response, taskID: dataTask.taskIdentifier) else {
+                completionHandler(.cancel)
+                return
+            }
+            completionHandler(.allow)
+        }
+
+        func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+            if fetcher?.handleData(data, taskID: dataTask.taskIdentifier) == true {
+                dataTask.cancel()
+            }
+        }
+
+        func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+            fetcher?.handleCompletion(error: error, taskID: task.taskIdentifier)
         }
     }
 }

--- a/iosApp/iosApp/Screens/Player/PlaybackSourceProxy.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSourceProxy.swift
@@ -1850,9 +1850,9 @@ private final class PlaybackSourceResource {
             // later claim into chunks with no window left to protect.
             windowOwnerServeID = nil
         }
-        // Safe lock nesting: the fetcher never calls back into the resource
-        // while holding its own lock, so stateLock → fetcher.lock is the
-        // only order that ever occurs.
+        // Safe lock nesting: coversInFlight reads a callback-free published
+        // snapshot. Its tiny lock never waits on the fetcher's state queue,
+        // whose callbacks may need this resource lock.
         let fetcher = chunkFetcher
         for (id, waiter) in dataWaiters {
             if cause == nil || fetcher?.coversInFlight(offset: waiter.offset) == true {


### PR DESCRIPTION
## Problem

Fixes #138.

Companion server contract/diagnostics: Silo-Server/silo-server#594.

An internal TestFlight report showed bounded direct-stream chunk requests receiving full `200 OK` responses after conditional range validation failed. `PlaybackOriginChunkFetcher` used a completion-handler data task, so it could not inspect the status until Foundation had accumulated the entire response in one `Data`. The captured responses were hundreds of MiB to multiple GiB, making memory-pressure termination the likely playback failure.

## Approach

- Move discrete chunk reads to a serial `URLSessionDataDelegate` and validate status, `Content-Range`, and the strong ETag at response headers.
- Send `If-Match` for validator-bound bounded reads so a stale entity receives a bodyless `412`, while leaving the sequential stream's standard `If-Range` behavior unchanged.
- Reject unexpected nonzero `200` responses before their bodies are delivered.
- Bound accepted media to the requested/declared interval and 404 diagnostics to 4 KiB, cancelling transport as soon as the bound is reached.
- Serialize admission, accounting, callbacks, and cancellation so `cancel()` is a callback-quiescence barrier and begin/end counts remain exact.
- Strictly validate partial intervals, including short non-EOF and EOF cases, without losing changed-entity precedence.
- Accept a shorter connection-close-delimited byte-zero `200` only at clean EOF and publish the observed entity length, while retaining the requested-byte streaming cap.

## Testing

- `xcodegen generate`: passed.
- `PlaybackOriginStreamResumeTests`: 31 passed, 0 failed on an iPhone 17 Pro simulator (iOS 26.4).
- Cancellation-race regression repeated 10 times: 10 passed, 0 failed.
- Broader `SiloTests` run before the final focused edge-case additions: 1,255 passed; the same eight unrelated settings/UI tests failed and were reproduced against a clean detached `origin/main` build.
- Final signed iOS simulator build, install, and two terminate/launch cycles: passed.
- Final `SiloTV` simulator build and `SiloMac` arm64 build: passed.
- Final adversarial review: clean; the initial callback-quiescence race, malformed/short `206` handling, and small full-response edge cases were fixed and covered.

The remaining coverage gap is a real-device stream of the reported multi-GiB media. Simulator tests deterministically prove header-time rejection and bounded transport, but cannot prove physical-device jetsam behavior.

### AI Disclosure
- Tool(s): Codex harness
- Model(s): gpt-5.6-sol
- Involvement: fully AI-generated, human-directed
- Adversarial review: independent agents reproduced the transport behavior, rejected an unsafe server-validator change, found cancellation and partial-range edge cases, and verified their fixes in the final diff. The automated PR review found one additional unknown-length EOF case, which is fixed in the follow-up commit and covered by the 31-test focused suite.
