### PR TITLE
fix(home): stop stripping library suffix from home section titles

### DIFF
--- a/iosApp/iosApp/Screens/Home/Feed/HomeFeedRow.swift
+++ b/iosApp/iosApp/Screens/Home/Feed/HomeFeedRow.swift
@@ -40,7 +40,7 @@ struct HomeFeedRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: HomeFeedMetrics.headerGap) {
             HomeSectionHeader(
-                title: displayTitle,
+                title: section.title,
                 icon: isResume ? "play.circle.fill" : nil,
                 style: headerStyle
             )
@@ -99,26 +99,6 @@ struct HomeFeedRow: View {
     private func watchedAction(for item: SectionItem) -> ((Bool) async -> Bool)? {
         guard let onSetWatched else { return nil }
         return { played in await onSetWatched(item, played) }
-    }
-
-    /// Server section titles read like query descriptions — "Recently
-    /// Released in Movies", "Recently Added in TV Shows". Trimming the
-    /// "in <library>" tail leaves a curated-sounding label without needing
-    /// a server change, and the library context is already implied by the
-    /// artwork in the row.
-    ///
-    /// Only generated titles are trimmed: an admin-named custom section
-    /// ("Made in Britain") is someone's deliberate choice, and cutting at
-    /// the *last* " in " keeps a generated title whose label itself contains
-    /// "in" from losing more than the library tail. `customized` is not a
-    /// useful guard here — the server sets it for any profile override
-    /// (position, item limit), not just a renamed title.
-    private var displayTitle: String {
-        guard section.isCustom != true,
-              let range = section.title.range(of: " in ", options: [.caseInsensitive, .backwards]) else {
-            return section.title
-        }
-        return String(section.title[..<range.lowerBound])
     }
 }
 #endif


### PR DESCRIPTION
## Summary

Fixes #136.

The iOS home feed's `HomeFeedRow.displayTitle` trimmed everything after the last case-insensitive `" in "` from generated section titles. With libraries producing sections like `Recently Added in Movies` and `Recently Added in Series`, both rows rendered as an identical "Recently Added" heading, making them impossible to tell apart. The web client shows the full configured titles.

## Change

- Remove the `displayTitle` trimming helper in `HomeFeedRow` and render `section.title` as supplied by the server, matching the web client.

This also removes the residual risk of truncating any title that merely contains `" in "`, and keeps section naming consistent across clients.

## Testing

- `xcodebuild build` for the `Silo` iOS scheme (iPhone 17 Pro simulator) succeeds.
- No tests added: the change deletes a display-only transform and renders the server string verbatim (per repo guidance to skip tests for small UI changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Section headers now display their titles consistently without automatically trimming generated text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->