### PR TITLE
fix(ios): prevent detail page scaling after rotation

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -1303,15 +1303,17 @@ struct MainTabView: View {
             )
         case .itemDetail(let contentId):
             ItemDetailView(contentId: contentId)
-                #if os(iOS)
-                // Destination half of the iOS 26 poster → detail zoom. Keys off
-                // the unique per-card source id the tapped card recorded in
-                // `pendingZoomSourceID` (falling back to `contentId`), so the
-                // zoom animates from the exact card even when the same item is
-                // visible in two rows. SwiftUI falls back to a normal push when
-                // no matching source is on screen.
-                .navigationTransition(.zoom(sourceID: router.pendingZoomSourceID ?? contentId, in: zoomNamespace))
-                #endif
+                // The iOS 26 poster → detail zoom transition
+                // (`.navigationTransition(.zoom(sourceID:in:))`, keyed off
+                // `pendingZoomSourceID`) is intentionally NOT applied here.
+                // On iOS 26 the zoom transition keeps the pushed detail bound
+                // to the source card's portal geometry; rotating the device
+                // while the detail is up recomputes that transform against
+                // stale geometry, leaving the whole page scaled up ("zoomed
+                // in") after rotating back and the source card stuck on
+                // screen. Deep-linked pushes (no zoom source) never showed
+                // the bug. Restore the modifier once Apple fixes the
+                // regression (see forums thread 807208).
         case .personDetail(let personId):
             PersonDetailView(personId: personId)
         case .player(let contentId, let startFromBeginning, let resumePosition):


### PR DESCRIPTION
## Summary

- Prevent iOS detail pages from retaining an incorrect scale after device rotation.
- Keep detail content sized to the current viewport when orientation changes.

## Testing

- Not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated item detail navigation to use the standard push transition.
  * Removed the zoom animation when opening item details for a more consistent navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->