### PR TITLE
Clarify Apple TV profile pairing

### DIFF
--- a/iosApp/iosApp/Screens/Profiles/ProfileSelectionView.swift
+++ b/iosApp/iosApp/Screens/Profiles/ProfileSelectionView.swift
@@ -267,7 +267,7 @@ struct ProfileSelectionView: View {
                 #if os(tvOS)
                 TVProfileTile(
                     profile: profile,
-                    isLastUsed: profile.id == rememberedProfileID,
+                    isRemembered: profile.id == rememberedProfileID,
                     prefersDefaultFocus: profile.id == preferredProfileID,
                     defaultFocusNamespace: profileFocusNamespace
                 ) {
@@ -276,7 +276,7 @@ struct ProfileSelectionView: View {
                 #else
                 ProfileTile(
                     profile: profile,
-                    isLastUsed: profile.id == rememberedProfileID
+                    isRemembered: profile.id == rememberedProfileID
                 ) {
                     handleProfileTap(profile)
                 }

--- a/iosApp/iosApp/Screens/Profiles/ProfileTile.swift
+++ b/iosApp/iosApp/Screens/Profiles/ProfileTile.swift
@@ -49,7 +49,7 @@ private let focusScale: CGFloat = 1.05
 /// tile lifts with a white ring and a colored halo matching its tint.
 struct ProfileTile: View {
     let profile: UserProfile
-    var isLastUsed: Bool = false
+    var isRemembered: Bool = false
     let action: () -> Void
 
     @FocusState private var isFocused: Bool
@@ -135,12 +135,14 @@ struct ProfileTile: View {
                 .padding(12)
             }
 
-            if isLastUsed {
+            if isRemembered {
                 VStack {
                     Spacer()
                     HStack {
-                        Text("LAST USED")
+                        Text(rememberedBadgeLabel)
                             .font(.caption.bold())
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.75)
                             .foregroundStyle(.white)
                             .padding(.horizontal, 10)
                             .padding(.vertical, 6)
@@ -196,10 +198,26 @@ struct ProfileTile: View {
 
     private var accessibilityValue: String {
         var values: [String] = []
-        if isLastUsed { values.append("Last used") }
+        if isRemembered { values.append(rememberedAccessibilityValue) }
         if profile.hasPin { values.append("PIN protected") }
         if profile.isChild { values.append("Child profile") }
         return values.joined(separator: ", ")
+    }
+
+    private var rememberedBadgeLabel: String {
+        #if os(tvOS)
+        "APPLE TV USER"
+        #else
+        "LAST USED"
+        #endif
+    }
+
+    private var rememberedAccessibilityValue: String {
+        #if os(tvOS)
+        "Paired with this Apple TV user"
+        #else
+        "Last used"
+        #endif
     }
 }
 

--- a/iosApp/iosApp/tvOS/Profiles/AppleTVUserContext.swift
+++ b/iosApp/iosApp/tvOS/Profiles/AppleTVUserContext.swift
@@ -5,21 +5,21 @@ import TVServices
 ///
 /// tvOS 16 deprecated the APIs that exposed system-user identifiers and the
 /// all-users profile mapping panel. Runs-as-Current-User now owns that
-/// separation, while this remaining signal tells us whether the Apple TV has
-/// multiple users for whom separate preferences should be explained.
+/// separation, while this remaining signal tells us whether apps should retain
+/// preferences for the current user context.
 struct AppleTVUserContext: Equatable, Sendable {
     static let current = AppleTVUserContext(
-        storesSeparateUserPreferences: TVUserManager()
+        shouldStorePreferencesForCurrentUser: TVUserManager()
             .shouldStorePreferencesForCurrentUser
     )
 
-    let storesSeparateUserPreferences: Bool
+    let shouldStorePreferencesForCurrentUser: Bool
 
     var pairingDescription: String {
-        if storesSeparateUserPreferences {
-            "Silo keeps a separate profile pairing for each Apple TV user. Switch users in Control Center to view or change another pairing."
+        if shouldStorePreferencesForCurrentUser {
+            "Silo keeps a separate profile pairing for this Apple TV user. Switch users in Control Center to view or change the pairing available to another user."
         } else {
-            "This Apple TV currently has one user. Add users in Apple TV Settings to give each person a separate Silo profile pairing."
+            "This Apple TV user context is not set to keep separate app preferences. Silo uses the profile pairing available to the current app context, and you can change it here at any time."
         }
     }
 }

--- a/iosApp/iosApp/tvOS/Profiles/AppleTVUserContext.swift
+++ b/iosApp/iosApp/tvOS/Profiles/AppleTVUserContext.swift
@@ -1,0 +1,26 @@
+#if os(tvOS)
+import TVServices
+
+/// User-facing context for the current tvOS storage persona.
+///
+/// tvOS 16 deprecated the APIs that exposed system-user identifiers and the
+/// all-users profile mapping panel. Runs-as-Current-User now owns that
+/// separation, while this remaining signal tells us whether the Apple TV has
+/// multiple users for whom separate preferences should be explained.
+struct AppleTVUserContext: Equatable, Sendable {
+    static let current = AppleTVUserContext(
+        storesSeparateUserPreferences: TVUserManager()
+            .shouldStorePreferencesForCurrentUser
+    )
+
+    let storesSeparateUserPreferences: Bool
+
+    var pairingDescription: String {
+        if storesSeparateUserPreferences {
+            "Silo keeps a separate profile pairing for each Apple TV user. Switch users in Control Center to view or change another pairing."
+        } else {
+            "This Apple TV currently has one user. Add users in Apple TV Settings to give each person a separate Silo profile pairing."
+        }
+    }
+}
+#endif

--- a/iosApp/iosApp/tvOS/Screens/Components/TVProfileTile.swift
+++ b/iosApp/iosApp/tvOS/Screens/Components/TVProfileTile.swift
@@ -4,7 +4,7 @@ import SwiftUI
 /// tvOS focus behavior for the shared profile presentation.
 struct TVProfileTile: View {
     let profile: UserProfile
-    var isLastUsed: Bool = false
+    var isRemembered: Bool = false
     var prefersDefaultFocus: Bool = false
     var defaultFocusNamespace: Namespace.ID? = nil
     let action: () -> Void
@@ -12,7 +12,7 @@ struct TVProfileTile: View {
     var body: some View {
         ProfileTile(
             profile: profile,
-            isLastUsed: isLastUsed,
+            isRemembered: isRemembered,
             action: action
         )
         // Lets the first profile tile claim initial focus instead of the

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVGeneralSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVGeneralSettingsView.swift
@@ -13,12 +13,26 @@ struct TVGeneralSettingsPane: View {
     @State private var showsMenuEditor = false
     @State private var registry = ServerRegistry.shared
     @State private var librarySnapshot = MainTabLibrarySnapshot.cachedForCurrentAuthority()
+    let activeProfile: UserProfile?
     let detailFocus: FocusState<TVSettingsDetailFocus?>.Binding
+    let changePairedProfile: () -> Void
+    private let appleTVUserContext = AppleTVUserContext.current
     @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            TVSettingsSectionHeader("PROFILE")
+            TVSettingsSectionHeader("APPLE TV USER")
+
+            TVSettingsPickerRow(
+                title: "Paired Silo Profile",
+                value: pairedProfileName,
+                action: changePairedProfile
+            )
+            .focused(detailFocus, equals: .generalAppleTVUser)
+
+            TVSettingsFooter(pairingDescription)
+
+            TVSettingsSectionHeader("PROFILE AT LAUNCH")
 
             TVSettingsPickerRow(
                 title: "Profile at Launch",
@@ -141,6 +155,24 @@ struct TVGeneralSettingsPane: View {
             in: preferences.resolvedPrimaryMenuItems(),
             libraries: libraries
         ).count
+    }
+
+    private var pairedProfileName: String {
+        guard let serverID = registry.activeServerId,
+              let remembered = launchPreferences.rememberedProfile(for: serverID) else {
+            return "Not paired"
+        }
+        guard let activeProfile,
+              activeProfile.id == remembered.profileID else {
+            return "Saved profile"
+        }
+        return activeProfile.name
+    }
+
+    private var pairingDescription: String {
+        let base = appleTVUserContext.pairingDescription
+        guard launchPreferences.behavior == .askEveryLaunch else { return base }
+        return "\(base) Ask Every Time is on, so Silo will still show Who's Watching at launch."
     }
 
     @ViewBuilder

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsView.swift
@@ -304,7 +304,7 @@ struct TVSettingsView: View {
 
     private func initialDetailFocus(for category: TVSettingsCategory) -> TVSettingsDetailFocus {
         if category == .general {
-            return .generalProfileLaunch
+            return .generalAppleTVUser
         }
         if category == .subtitles,
            viewModel.settingsServerUpgradeRequired || viewModel.subtitleMatchesSystemAppearance {
@@ -448,7 +448,11 @@ struct TVSettingsView: View {
     private var paneContent: some View {
         switch selectedCategory {
         case .general:
-            TVGeneralSettingsPane(detailFocus: $detailFocus)
+            TVGeneralSettingsPane(
+                activeProfile: viewModel.activeProfile,
+                detailFocus: $detailFocus,
+                changePairedProfile: switchProfile
+            )
         case .playback:
             TVPlaybackSettingsPane(
                 viewModel: viewModel,
@@ -541,6 +545,7 @@ struct TVSettingsView: View {
 
 enum TVSettingsDetailFocus: Hashable {
     case top
+    case generalAppleTVUser
     case generalProfileLaunch
     case generalCardPreset
     case generalTopMenu


### PR DESCRIPTION
## Summary

- add an Apple TV User section to tvOS General settings
- show the Silo profile paired with the current Apple TV user and reuse the existing transactional profile picker to change it
- label the remembered tvOS tile as Apple TV User, including an explicit accessibility value
- explain whether tvOS currently recommends separate per-user preferences

## Platform behavior

tvOS 16 deprecated the APIs that enumerate system-user identifiers and present an all-users mapping panel. This keeps Silo on Apple's supported Runs-as-Current-User model: the OS owns user separation, while Silo makes the current user's pairing visible and editable.

## Validation

- Xcode 26.4: tvOS 26.4 simulator build, install, and launch succeeded
- exercised Settings focus from the General rail into Paired Silo Profile
- selecting the pairing row opened the existing profile picker
- runtime accessibility snapshot reported `admin, Paired with this Apple TV user`
- final remembered-profile badge rendered on one line
- iOS 26.4 simulator build succeeded for the shared profile-tile rename
- `git diff --check` passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Apple TV user pairing status and guidance in General Settings.
  * Added a “Profile at Launch” settings section with profile-switching support.
  * Improved profile tiles with remembered-profile badges and platform-specific accessibility text.
  * Updated Apple TV settings focus to prioritize the paired-user control.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->