### PR TITLE
fix(detail): restore portrait layout after iPhone rotation

### DIFF
--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneDetailHero.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneDetailHero.swift
@@ -31,6 +31,7 @@ struct PhoneDetailHero<Actions: View, BelowOverview: View>: View {
     @ViewBuilder let belowOverview: () -> BelowOverview
 
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Environment(\.verticalSizeClass) private var verticalSizeClass
     @State private var availableWidth: CGFloat = 0
     @State private var showFullOverview = false
     @EnvironmentObject private var overlayStore: OverlayPrefsStore
@@ -58,6 +59,13 @@ struct PhoneDetailHero<Actions: View, BelowOverview: View>: View {
     }
 
     private var usesExpandedLayout: Bool {
+        // The expanded branch can keep reporting its landscape width for one
+        // more layout pass after an iPhone rotates back to portrait. Let the
+        // updated size classes break that feedback loop immediately so the
+        // poster and two-column composition cannot survive in portrait.
+        if horizontalSizeClass == .compact, verticalSizeClass == .regular {
+            return false
+        }
         if availableWidth > 0 {
             return availableWidth >= expandedLayoutBreakpoint
         }


### PR DESCRIPTION
## What changed

- Observe the vertical size class in the shared iPhone/iPad detail hero.
- Force the compact hero whenever an iPhone has returned to compact-width, regular-height portrait.
- Prevent the stale landscape geometry value from keeping the poster and two-column layout alive for an extra layout pass.

## Root cause

`availableWidth` can retain the previous landscape width briefly after rotation. Because `usesExpandedLayout` preferred that cached geometry value, the expanded poster layout could remain selected after the device was back in portrait.

## User impact

Movie and series detail pages now return immediately to the backdrop-first compact layout after rotating from landscape back to portrait, instead of continuing to show the landscape poster card.

## Validation

- `git diff --check origin/main...HEAD`
- XcodeGen generation from commit `5aaedbd`
- Signed iOS 26.4 simulator build and launch on iPhone 17 Pro: succeeded
- Movie detail: verified portrait → landscape poster layout → portrait compact layout
- Series detail: verified portrait → landscape poster layout → portrait compact layout

The build reports eight existing warnings in unrelated files; the changed file introduces no warnings.