### PR TITLE
feat: add profile selection timeout policies

### DIFF
--- a/docs/superpowers/specs/2026-08-11-profile-launch-and-tvos-user-mapping-design.md
+++ b/docs/superpowers/specs/2026-08-11-profile-launch-and-tvos-user-mapping-design.md
@@ -34,6 +34,32 @@ tags:
 - Physical Apple TV validation remains required for switching between multiple real tvOS users;
   the simulator cannot establish that OS-level isolation boundary.
 
+## 2026-08-12 follow-up: return timeout policy
+
+The device-local setting is now named **Profile Selection** and offers four choices:
+
+| Setting | Cold launch | Return from a real background interval |
+|---|---|---|
+| **Automatic** | Restore the last valid profile | Keep the active profile |
+| **Every Time** | Show “Who’s Watching?” | Show “Who’s Watching?” |
+| **After 1 Hour** | Show the picker if the persisted away interval has expired | Show the picker after one hour away |
+| **After 12 Hours** | Show the picker if the persisted away interval has expired | Show the picker after twelve hours away |
+
+This controls the active profile session, not the server account session. When a policy expires,
+Silo keeps the account signed in, retires the old profile identity and profile-scoped work, and asks
+for the selected profile's PIN through the existing picker when required. Automatic remains the
+migration and new-install default.
+
+Only a real `.background` transition starts the persisted clock; `.inactive` transitions do not.
+Background audio and Picture in Picture keep the profile session active, and a clock starts if that
+playback ends while Silo remains backgrounded. Content deep links stay queued until a new profile is
+active, and personalized Top Shelf content is unavailable after the policy requires selection. The
+preference remains local to the device or current Apple TV user and requires no server change.
+
+The follow-up validation adds exact one-hour/twelve-hour boundary tests, persisted-state and legacy
+decoding coverage, a signed iOS Every Time background/return flow, and signed iOS/tvOS visual checks.
+The tvOS four-option sheet was also verified with every wrapped description visible and stable focus.
+
 ## 1. Summary
 
 Give people an explicit choice for what happens when a new Silo app session starts:
@@ -102,7 +128,8 @@ to authenticate the same Silo account again.
 - No cloud-synced launch preference. This is a local device/viewer policy.
 - No manual map from deprecated `TVUserIdentifier` values to Silo profile IDs.
 - No changes to profile CRUD, household permissions, or PIN rules.
-- No timeout-based “lock after N minutes” in v1. That is a separate privacy-lock feature.
+- No timeout-based “lock after N minutes” in v1. The 2026-08-12 follow-up above supersedes this
+  original scope boundary.
 - No Android implementation in this repository.
 
 ## 4. Product Decisions

--- a/iosApp/Tests/ProfileLaunchPolicyTests.swift
+++ b/iosApp/Tests/ProfileLaunchPolicyTests.swift
@@ -5,6 +5,18 @@ final class ProfileLaunchPolicyTests: XCTestCase {
     private let serverID = "server-a"
     private let accountEpoch = "account-a"
 
+    func testProfileSelectionPoliciesKeepStableOrderAndLegacyEveryTimeRawValue() {
+        XCTAssertEqual(
+            ProfileLaunchBehavior.allCases,
+            [.automatic, .askEveryLaunch, .afterOneHour, .afterTwelveHours]
+        )
+        XCTAssertEqual(ProfileLaunchBehavior.askEveryLaunch.rawValue, "askEveryLaunch")
+        XCTAssertNil(ProfileLaunchBehavior.automatic.awayTimeout)
+        XCTAssertNil(ProfileLaunchBehavior.askEveryLaunch.awayTimeout)
+        XCTAssertEqual(ProfileLaunchBehavior.afterOneHour.awayTimeout, 60 * 60)
+        XCTAssertEqual(ProfileLaunchBehavior.afterTwelveHours.awayTimeout, 12 * 60 * 60)
+    }
+
     func testDefaultStateUsesAutomaticAndRequiresAProfile() {
         let state = ProfileLaunchState()
 
@@ -39,6 +51,91 @@ final class ProfileLaunchPolicyTests: XCTestCase {
             .needsSelection
         )
         XCTAssertEqual(state.rememberedByServerID[serverID], remembered)
+    }
+
+    func testEveryTimeRequiresARealBackgroundIntervalOnWarmReturn() {
+        let start = Date(timeIntervalSinceReferenceDate: 1_000)
+        var state = ProfileLaunchState(behavior: .askEveryLaunch)
+
+        XCTAssertFalse(state.requiresSelectionAfterBackground(at: start))
+
+        state.backgroundedAt = start
+        XCTAssertTrue(state.requiresSelectionAfterBackground(at: start))
+    }
+
+    func testTimedPoliciesRestoreBeforeAndRequireAtTimeout() {
+        let start = Date(timeIntervalSinceReferenceDate: 1_000)
+        let remembered = RememberedProfile(
+            profileID: "profile-a",
+            requiredPINAtSelection: false,
+            accountEpoch: accountEpoch
+        )
+        var oneHour = ProfileLaunchState(
+            behavior: .afterOneHour,
+            rememberedByServerID: [serverID: remembered],
+            backgroundedAt: start
+        )
+
+        XCTAssertEqual(
+            oneHour.resolution(
+                for: serverID,
+                accountEpoch: accountEpoch,
+                hasStoredProfileToken: false,
+                now: start.addingTimeInterval(3_599)
+            ),
+            .restore(remembered)
+        )
+        XCTAssertEqual(
+            oneHour.resolution(
+                for: serverID,
+                accountEpoch: accountEpoch,
+                hasStoredProfileToken: false,
+                now: start.addingTimeInterval(3_600)
+            ),
+            .needsSelection
+        )
+
+        oneHour.behavior = .afterTwelveHours
+        XCTAssertFalse(
+            oneHour.requiresSelectionAtLaunch(
+                at: start.addingTimeInterval((12 * 60 * 60) - 1)
+            )
+        )
+        XCTAssertTrue(
+            oneHour.requiresSelectionAtLaunch(
+                at: start.addingTimeInterval(12 * 60 * 60)
+            )
+        )
+    }
+
+    func testAutomaticIgnoresAStaleBackgroundMarker() {
+        let start = Date(timeIntervalSinceReferenceDate: 1_000)
+        let state = ProfileLaunchState(
+            behavior: .automatic,
+            backgroundedAt: start
+        )
+
+        XCTAssertFalse(
+            state.requiresSelectionAtLaunch(
+                at: start.addingTimeInterval(24 * 60 * 60)
+            )
+        )
+        XCTAssertFalse(
+            state.requiresSelectionAfterBackground(
+                at: start.addingTimeInterval(24 * 60 * 60)
+            )
+        )
+    }
+
+    func testLegacyLaunchStateWithoutBackgroundMarkerStillDecodes() throws {
+        let legacy = Data(
+            #"{"behavior":"automatic","rememberedByServerID":{},"selectionRequiredServerIDs":[]}"#.utf8
+        )
+
+        let decoded = try JSONDecoder().decode(ProfileLaunchState.self, from: legacy)
+
+        XCTAssertEqual(decoded.behavior, .automatic)
+        XCTAssertNil(decoded.backgroundedAt)
     }
 
     func testAutomaticRestoresPINlessProfileOffline() {
@@ -138,6 +235,9 @@ final class ProfileLaunchPolicyTests: XCTestCase {
 
         let preferences = ProfileLaunchPreferences(defaults: defaults)
         preferences.behavior = .askEveryLaunch
+        XCTAssertTrue(preferences.markBackgrounded(
+            at: Date(timeIntervalSinceReferenceDate: 1_000)
+        ))
         XCTAssertTrue(preferences.markSelectionRequired(for: serverID))
         preferences.remember(
             profileID: "profile-a",
@@ -157,6 +257,26 @@ final class ProfileLaunchPolicyTests: XCTestCase {
             )
         )
         XCTAssertFalse(restored.state.selectionRequiredServerIDs.contains(serverID))
+        XCTAssertNil(restored.state.backgroundedAt)
+    }
+
+    func testBackgroundMarkerPersistsAndClearsAcrossProcessRestores() throws {
+        let suiteName = "ProfileLaunchPolicyTests.\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let defaults = SharedDefaults(suite: suite, standard: suite)
+        defer { suite.removePersistentDomain(forName: suiteName) }
+        let start = Date(timeIntervalSinceReferenceDate: 2_000)
+
+        let preferences = ProfileLaunchPreferences(defaults: defaults)
+        preferences.behavior = .afterOneHour
+        XCTAssertTrue(preferences.markBackgrounded(at: start))
+        XCTAssertEqual(
+            ProfileLaunchPreferences(defaults: defaults).state.backgroundedAt,
+            start
+        )
+
+        XCTAssertTrue(preferences.clearBackgroundedAt())
+        XCTAssertNil(ProfileLaunchPreferences(defaults: defaults).state.backgroundedAt)
     }
 
     func testBehaviorRollsBackWhenPersistenceFails() throws {
@@ -191,7 +311,7 @@ final class ProfileLaunchPolicyTests: XCTestCase {
         ))
     }
 
-    func testTopShelfRequiresAutomaticMatchingCurrentUserIdentity() {
+    func testTopShelfRespectsProfileSelectionPolicyAndMatchingCurrentUserIdentity() {
         let pinless = RememberedProfile(
             profileID: "profile-a",
             requiredPINAtSelection: false,
@@ -226,6 +346,27 @@ final class ProfileLaunchPolicyTests: XCTestCase {
             activeProfileID: "profile-a",
             accountEpoch: accountEpoch,
             hasStoredProfileToken: true
+        ))
+
+        let start = Date(timeIntervalSinceReferenceDate: 3_000)
+        state.behavior = .afterOneHour
+        state.selectionRequiredServerIDs.remove(serverID)
+        state.backgroundedAt = start
+        XCTAssertTrue(TopShelfProfilePolicy.allowsPersonalizedContent(
+            state: state,
+            serverID: serverID,
+            activeProfileID: "profile-a",
+            accountEpoch: accountEpoch,
+            hasStoredProfileToken: false,
+            now: start.addingTimeInterval(3_599)
+        ))
+        XCTAssertFalse(TopShelfProfilePolicy.allowsPersonalizedContent(
+            state: state,
+            serverID: serverID,
+            activeProfileID: "profile-a",
+            accountEpoch: accountEpoch,
+            hasStoredProfileToken: false,
+            now: start.addingTimeInterval(3_600)
         ))
     }
 

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 #if os(iOS) || os(tvOS)
 import UIKit
+#elseif os(macOS)
+import AppKit
 #endif
 
 struct ContentView: View {
@@ -129,6 +131,11 @@ struct ContentView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.willTerminateNotification)) { _ in
             ExitSentinel.shared.appWillTerminate()
+        }
+        #endif
+        #if os(macOS)
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)) { _ in
+            markProfileAwayStartForTermination()
         }
         #endif
         .task {
@@ -346,6 +353,15 @@ struct ContentView: View {
         }
     }
 
+    /// macOS does not reliably publish a background scene phase before Cmd-Q.
+    /// Termination always ends active playback, so it starts an away interval
+    /// even when media was still playing at the time of the notification.
+    private func markProfileAwayStartForTermination(at date: Date = .now) {
+        guard AuthService.shared.isLoggedIn,
+              AuthService.shared.profileId != nil else { return }
+        launchPreferences.markBackgrounded(at: date)
+    }
+
     /// If background playback starts, stop the away clock. If it later stops
     /// while Silo is still hidden, begin a fresh interval at that point.
     private func updateProfileAwayStartForBackgroundPlayback() {
@@ -380,11 +396,31 @@ struct ContentView: View {
               launchPreferences.requiresSelectionAfterBackground() else {
             return
         }
-        let deactivated = await AuthService.shared.deactivateProfile(
+        var deactivated = await AuthService.shared.deactivateProfile(
             preserveRememberedProfile: true,
             markSelectionRequired: true,
             expectedProfileID: expectedProfileID
         )
+        #if os(tvOS)
+        if !deactivated {
+            let endedTemporaryIdentity = await RemotePlaybackIdentityManager.shared.end()
+            let hasTemporaryIdentity = await TokenStore.shared.hasTemporaryScope()
+            guard endedTemporaryIdentity || !hasTemporaryIdentity else {
+                return
+            }
+            guard router.authState == .authenticated,
+                  !keepsProfileActiveInBackground,
+                  launchPreferences.requiresSelectionAfterBackground(),
+                  AuthService.shared.profileId == expectedProfileID else {
+                return
+            }
+            deactivated = await AuthService.shared.deactivateProfile(
+                preserveRememberedProfile: true,
+                markSelectionRequired: true,
+                expectedProfileID: expectedProfileID
+            )
+        }
+        #endif
         guard deactivated else { return }
         router.showProfileSelection()
     }

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -7,8 +7,11 @@ struct ContentView: View {
     @State private var router = AppRouter()
     @State private var serverRegistry = ServerRegistry.shared
     @State private var audioStore = AudioPlaybackStore()
+    @State private var launchPreferences = ProfileLaunchPreferences.shared
+    @State private var isApplyingProfileReturnPolicy = false
     #if os(iOS)
     @State private var siloControl = SiloControlClient()
+    @State private var pictureInPicture = PictureInPictureCoordinator.shared
     #endif
     @State private var debugPlayContentId: String?
     @State private var didAttemptDebugAutoPlay = false
@@ -259,6 +262,20 @@ struct ContentView: View {
             }
             #endif
 
+            if newPhase == .background {
+                markProfileAwayStartIfNeeded()
+            } else if newPhase == .active,
+                      router.authState == .authenticated {
+                if keepsProfileActiveInBackground {
+                    launchPreferences.clearBackgroundedAt()
+                } else if launchPreferences.requiresSelectionAfterBackground() {
+                    Task { await applyProfileReturnPolicy() }
+                    return
+                } else {
+                    launchPreferences.clearBackgroundedAt()
+                }
+            }
+
             // Cover the transient-failure case Codex flagged on #41:
             // initial overlay hydration runs once in the auth-state
             // task above. If that fetch transiently failed and the
@@ -299,6 +316,77 @@ struct ContentView: View {
             Task { await DownloadManager.shared.onAppActive() }
             #endif
         }
+        .onChange(of: audioStore.player.isPlaying) { _, _ in
+            updateProfileAwayStartForBackgroundPlayback()
+        }
+        #if os(iOS)
+        .onChange(of: pictureInPicture.isEngaged) { _, _ in
+            updateProfileAwayStartForBackgroundPlayback()
+        }
+        #endif
+    }
+
+    /// Background audio and PiP are still active use of the selected profile,
+    /// so their running time does not count toward a profile-selection timeout.
+    private var keepsProfileActiveInBackground: Bool {
+        if audioStore.player.isPlaying { return true }
+        #if os(iOS)
+        if pictureInPicture.isEngaged { return true }
+        #endif
+        return false
+    }
+
+    private func markProfileAwayStartIfNeeded(at date: Date = .now) {
+        guard router.authState == .authenticated,
+              AuthService.shared.profileId != nil else { return }
+        if keepsProfileActiveInBackground {
+            launchPreferences.clearBackgroundedAt()
+        } else {
+            launchPreferences.markBackgrounded(at: date)
+        }
+    }
+
+    /// If background playback starts, stop the away clock. If it later stops
+    /// while Silo is still hidden, begin a fresh interval at that point.
+    private func updateProfileAwayStartForBackgroundPlayback() {
+        guard scenePhase == .background else { return }
+        markProfileAwayStartIfNeeded()
+    }
+
+    /// Turn an expired away interval into the same durable identity boundary
+    /// as an explicit profile switch. The account and remembered-profile hint
+    /// remain available to Who's Watching.
+    @MainActor
+    private func applyProfileReturnPolicy() async {
+        guard !isApplyingProfileReturnPolicy,
+              router.authState == .authenticated,
+              !keepsProfileActiveInBackground,
+              launchPreferences.requiresSelectionAfterBackground(),
+              let expectedProfileID = AuthService.shared.profileId else {
+            return
+        }
+        isApplyingProfileReturnPolicy = true
+        defer { isApplyingProfileReturnPolicy = false }
+
+        // Retire player UI and audio state while the old profile still owns
+        // request identity, then close the HTTP dispatch gate and clear every
+        // profile-scoped cache through AuthService.
+        router.presentedPlayer = nil
+        audioStore.dismissFullPlayer()
+        await audioStore.player.close()
+
+        guard router.authState == .authenticated,
+              !keepsProfileActiveInBackground,
+              launchPreferences.requiresSelectionAfterBackground() else {
+            return
+        }
+        let deactivated = await AuthService.shared.deactivateProfile(
+            preserveRememberedProfile: true,
+            markSelectionRequired: true,
+            expectedProfileID: expectedProfileID
+        )
+        guard deactivated else { return }
+        router.showProfileSelection()
     }
 
     #if os(iOS) || os(tvOS)
@@ -408,6 +496,14 @@ struct ContentView: View {
 
         guard url.scheme?.lowercased() == "continuum",
               let host = url.host?.lowercased() else { return }
+
+        // A content link received while the app is returning must not race the
+        // timeout lock and briefly open data for the previous profile. The
+        // authenticated-state task drains it after profile selection succeeds.
+        guard !launchPreferences.requiresSelectionAfterBackground() else {
+            pendingDeepLink = url
+            return
+        }
 
         if host == "downloads" {
             guard router.authState == .authenticated else {

--- a/iosApp/iosApp/Screens/Auth/AuthService.swift
+++ b/iosApp/iosApp/Screens/Auth/AuthService.swift
@@ -367,6 +367,14 @@ final class AuthService: @unchecked Sendable {
                 expectedAccount: expectedAccount
             )
             if committed {
+                guard launchPreferences.clearBackgroundedAt() else {
+                    _ = await TokenStore.shared.deactivateProfile(
+                        expectedAccount: expectedAccount,
+                        expectedProfileID: remembered.profileID
+                    )
+                    await clearPerProfileCaches()
+                    return false
+                }
                 await clearPerProfileCaches()
                 return true
             } else {

--- a/iosApp/iosApp/Screens/Profiles/ProfileLaunchPreferences.swift
+++ b/iosApp/iosApp/Screens/Profiles/ProfileLaunchPreferences.swift
@@ -30,6 +30,9 @@ final class ProfileLaunchPreferences {
             guard state.behavior != newValue else { return }
             let previousState = state
             state.behavior = newValue
+            if newValue == .automatic {
+                state.backgroundedAt = nil
+            }
             if !persist() {
                 state = previousState
                 _ = persist()
@@ -54,14 +57,20 @@ final class ProfileLaunchPreferences {
         for serverID: String,
         accountEpoch: String?,
         hasStoredProfileToken: Bool,
-        knownProfileIDs: Set<String>? = nil
+        knownProfileIDs: Set<String>? = nil,
+        now: Date = .now
     ) -> ProfileLaunchResolution {
         state.resolution(
             for: serverID,
             accountEpoch: accountEpoch,
             hasStoredProfileToken: hasStoredProfileToken,
-            knownProfileIDs: knownProfileIDs
+            knownProfileIDs: knownProfileIDs,
+            now: now
         )
+    }
+
+    func requiresSelectionAfterBackground(at now: Date = .now) -> Bool {
+        state.requiresSelectionAfterBackground(at: now)
     }
 
     @discardableResult
@@ -78,6 +87,37 @@ final class ProfileLaunchPreferences {
             accountEpoch: accountEpoch
         )
         state.selectionRequiredServerIDs.remove(serverID)
+        state.backgroundedAt = nil
+        guard persist() else {
+            state = previousState
+            return false
+        }
+        return true
+    }
+
+    /// Persist the start of a real background interval. Inactive transitions
+    /// such as alerts and Control Center never call this path.
+    @discardableResult
+    func markBackgrounded(at date: Date = .now) -> Bool {
+        guard behavior != .automatic else {
+            return clearBackgroundedAt()
+        }
+        let previousState = state
+        state.backgroundedAt = date
+        guard persist() else {
+            state = previousState
+            return false
+        }
+        return true
+    }
+
+    /// End the current away interval after a non-expired foreground return or
+    /// when background playback means the profile is still actively in use.
+    @discardableResult
+    func clearBackgroundedAt() -> Bool {
+        guard state.backgroundedAt != nil else { return true }
+        let previousState = state
+        state.backgroundedAt = nil
         guard persist() else {
             state = previousState
             return false

--- a/iosApp/iosApp/Screens/Settings/GeneralSettingsView.swift
+++ b/iosApp/iosApp/Screens/Settings/GeneralSettingsView.swift
@@ -10,7 +10,7 @@ struct GeneralSettingsView: View {
         List {
             SettingsPageHeader(
                 title: "General",
-                subtitle: "Choose how Silo starts on this device.",
+                subtitle: "Choose what happens when you open Silo on this device.",
                 systemImage: "gearshape.fill",
                 tint: .purple
             )
@@ -26,9 +26,11 @@ struct GeneralSettingsView: View {
 
     private var profileSection: some View {
         Section {
-            Picker("Profile at Launch", selection: $launchPreferences.behavior) {
+            Picker("Profile Selection", selection: $launchPreferences.behavior) {
                 ForEach(ProfileLaunchBehavior.allCases) { behavior in
-                    Text(behavior.title).tag(behavior)
+                    Text(behavior.title)
+                        .accessibilityHint(behavior.standardDescription)
+                        .tag(behavior)
                 }
             }
             .foregroundStyle(Color.continuumOnSurface)
@@ -37,6 +39,7 @@ struct GeneralSettingsView: View {
             #else
             .pickerStyle(.navigationLink)
             #endif
+            .accessibilityValue(launchPreferences.behavior.title)
             .accessibilityHint(launchPreferences.behavior.standardDescription)
         } header: {
             Text("Profiles")

--- a/iosApp/iosApp/Screens/Settings/IOSSettingsOverview.swift
+++ b/iosApp/iosApp/Screens/Settings/IOSSettingsOverview.swift
@@ -333,7 +333,7 @@ struct IOSSettingsOverview: View {
     }
 
     private var matchesGeneral: Bool {
-        matches("general", "profile", "launch", "startup", "automatic", "ask every time", "who's watching")
+        matches("general", "profile", "selection", "launch", "startup", "automatic", "every time", "hours", "who's watching", "pin")
     }
 
     private var matchesSubtitles: Bool {

--- a/iosApp/iosApp/Shared/ProfileLaunchBehavior.swift
+++ b/iosApp/iosApp/Shared/ProfileLaunchBehavior.swift
@@ -2,16 +2,36 @@ import Foundation
 
 enum ProfileLaunchBehavior: String, Codable, CaseIterable, Identifiable, Sendable {
     case automatic
+    // Raw value predates the timed options; kept for persisted-state compatibility.
     case askEveryLaunch
+    case afterOneHour
+    case afterTwelveHours
 
     var id: String { rawValue }
+
+    /// How long Silo can be away before Who's Watching is shown again.
+    /// `nil` for the untimed behaviors.
+    var awayTimeout: TimeInterval? {
+        switch self {
+        case .automatic, .askEveryLaunch:
+            return nil
+        case .afterOneHour:
+            return 3600
+        case .afterTwelveHours:
+            return 43200
+        }
+    }
 
     var title: String {
         switch self {
         case .automatic:
             return "Automatic"
         case .askEveryLaunch:
-            return "Ask Every Time"
+            return "Every Time"
+        case .afterOneHour:
+            return "After 1 Hour"
+        case .afterTwelveHours:
+            return "After 12 Hours"
         }
     }
 
@@ -20,7 +40,11 @@ enum ProfileLaunchBehavior: String, Codable, CaseIterable, Identifiable, Sendabl
         case .automatic:
             return "Use the last profile selected on this device. A protected profile can reopen without asking for its PIN."
         case .askEveryLaunch:
-            return "Show Who's Watching when Silo starts."
+            return "Show Who's Watching whenever you return to Silo."
+        case .afterOneHour:
+            return "Show Who's Watching when you've been away from Silo for 1 hour."
+        case .afterTwelveHours:
+            return "Show Who's Watching when you've been away from Silo for 12 hours."
         }
     }
 
@@ -28,8 +52,8 @@ enum ProfileLaunchBehavior: String, Codable, CaseIterable, Identifiable, Sendabl
         switch self {
         case .automatic:
             return "Use the profile selected for the current Apple TV user. A protected profile can reopen without asking for its PIN."
-        case .askEveryLaunch:
-            return "Show Who's Watching when Silo starts."
+        case .askEveryLaunch, .afterOneHour, .afterTwelveHours:
+            return standardDescription
         }
     }
 }

--- a/iosApp/iosApp/Shared/ProfileLaunchState.swift
+++ b/iosApp/iosApp/Shared/ProfileLaunchState.swift
@@ -4,14 +4,19 @@ struct ProfileLaunchState: Codable, Equatable, Sendable {
     var behavior: ProfileLaunchBehavior = .automatic
     var rememberedByServerID: [String: RememberedProfile] = [:]
     var selectionRequiredServerIDs: Set<String> = []
+    /// The start of the current interval away from Silo. Persisting this in
+    /// the current device-user domain makes timed policies independent of
+    /// whether the process survives in the background.
+    var backgroundedAt: Date? = nil
 
     func resolution(
         for serverID: String,
         accountEpoch: String?,
         hasStoredProfileToken: Bool,
-        knownProfileIDs: Set<String>? = nil
+        knownProfileIDs: Set<String>? = nil,
+        now: Date = .now
     ) -> ProfileLaunchResolution {
-        guard behavior == .automatic,
+        guard !requiresSelectionAtLaunch(at: now),
               !selectionRequiredServerIDs.contains(serverID),
               let remembered = rememberedByServerID[serverID],
               let accountEpoch,
@@ -24,11 +29,35 @@ struct ProfileLaunchState: Codable, Equatable, Sendable {
         return .restore(remembered)
     }
 
+    /// Cold starts preserve the original Every Time contract even when the
+    /// previous process never recorded a background transition. Timed modes
+    /// only expire when a persisted away interval has actually elapsed.
+    func requiresSelectionAtLaunch(at now: Date = .now) -> Bool {
+        if behavior == .askEveryLaunch { return true }
+        return hasExpiredAwayInterval(at: now)
+    }
+
+    /// Warm foreground returns require an actual background marker, avoiding
+    /// false locks for inactive-only interruptions such as system prompts.
+    func requiresSelectionAfterBackground(at now: Date = .now) -> Bool {
+        guard backgroundedAt != nil else { return false }
+        if behavior == .askEveryLaunch { return true }
+        return hasExpiredAwayInterval(at: now)
+    }
+
     static func load(from defaults: SharedDefaults) -> ProfileLaunchState {
         guard let data = defaults.data(forKey: SharedStorage.profileLaunchStateKey),
               let decoded = try? JSONDecoder().decode(ProfileLaunchState.self, from: data) else {
             return ProfileLaunchState()
         }
         return decoded
+    }
+
+    private func hasExpiredAwayInterval(at now: Date) -> Bool {
+        guard let backgroundedAt,
+              let timeout = behavior.awayTimeout else {
+            return false
+        }
+        return now.timeIntervalSince(backgroundedAt) >= timeout
     }
 }

--- a/iosApp/iosApp/Shared/TopShelfProfilePolicy.swift
+++ b/iosApp/iosApp/Shared/TopShelfProfilePolicy.swift
@@ -6,12 +6,14 @@ enum TopShelfProfilePolicy {
         serverID: String?,
         activeProfileID: String?,
         accountEpoch: String?,
-        hasStoredProfileToken: Bool
+        hasStoredProfileToken: Bool,
+        now: Date = .now
     ) -> Bool {
         guard let serverID,
               let activeProfileID,
               let remembered = state.rememberedByServerID[serverID],
-              state.behavior == .automatic,
+              state.behavior != .askEveryLaunch,
+              !state.requiresSelectionAfterBackground(at: now),
               !state.selectionRequiredServerIDs.contains(serverID),
               remembered.profileID == activeProfileID,
               remembered.accountEpoch == accountEpoch,

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVGeneralSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVGeneralSettingsView.swift
@@ -35,10 +35,11 @@ struct TVGeneralSettingsPane: View {
             TVSettingsSectionHeader("PROFILE AT LAUNCH")
 
             TVSettingsPickerRow(
-                title: "Profile at Launch",
+                title: "Profile Selection",
                 value: launchPreferences.behavior.title
             ) { activePicker = .profileLaunch }
             .focused(detailFocus, equals: .generalProfileLaunch)
+            .accessibilityHint(launchPreferences.behavior.tvDescription)
 
             TVSettingsFooter(launchPreferences.behavior.tvDescription)
 
@@ -202,7 +203,7 @@ struct TVGeneralSettingsPane: View {
         switch picker {
         case .profileLaunch:
             TVSettingsPickerSheet(
-                title: "Profile at Launch",
+                title: "Profile Selection",
                 options: TVSettingsOptions.profileLaunch,
                 selection: $launchPreferences.behaviorID
             )

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsComponents.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsComponents.swift
@@ -7,6 +7,7 @@ import SwiftUI
 struct TVSettingsOption: Identifiable, Hashable {
     let id: String
     let label: String
+    var detail: String? = nil
     var previewFontName: String? = nil
 }
 
@@ -18,7 +19,7 @@ enum TVSettingsOptions {
 
     static let profileLaunch: [TVSettingsOption] =
         ProfileLaunchBehavior.allCases.map {
-            .init(id: $0.rawValue, label: $0.title)
+            .init(id: $0.rawValue, label: $0.title, detail: $0.tvDescription)
         }
 
     /// The shared cross-client quality presets, optionally led by a
@@ -712,10 +713,22 @@ struct TVSettingsPickerSheet: View {
     }
 
     private var preferredCardHeight: CGFloat {
-        let rowHeight: CGFloat = options.contains { $0.previewFontName != nil } ? 88 : 72
         let chromeHeight: CGFloat = subtitlePreviewAppearance == nil ? 158 : 344
         let disabledMessageHeight: CGFloat = disabledMessage == nil ? 0 : 72
-        return chromeHeight + disabledMessageHeight + CGFloat(options.count) * rowHeight
+        let rowsHeight = options.reduce(CGFloat(0)) { $0 + estimatedRowHeight(for: $1) }
+        return chromeHeight + disabledMessageHeight + rowsHeight
+    }
+
+    /// Per-row height estimate including the list gap. Detail text wraps at
+    /// the card's fixed ~590pt text column, roughly 54 characters of 20pt
+    /// system text per line; rounding lines up leaves breathing room below
+    /// the last row instead of clipping a wrapped description.
+    private func estimatedRowHeight(for option: TVSettingsOption) -> CGFloat {
+        if let detail = option.detail {
+            let detailLines = max(1.0, (Double(detail.count) / 54).rounded(.up))
+            return 88 + CGFloat(detailLines) * 26
+        }
+        return option.previewFontName != nil ? 88 : 72
     }
 
     private func focusSelection() {
@@ -781,6 +794,13 @@ private struct TVSettingsPickerOptionRow: View {
                         .font(.system(size: 27, weight: isSelected ? .semibold : .medium))
                         .lineLimit(1)
 
+                    if let detail = option.detail {
+                        Text(detail)
+                            .font(.system(size: 20))
+                            .opacity(0.72)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
                     if let previewFontName = option.previewFontName {
                         Text("Subtitle sample")
                             .font(.custom(previewFontName, size: 22))
@@ -799,6 +819,7 @@ private struct TVSettingsPickerOptionRow: View {
         .buttonStyle(TVSettingsPaneRowStyle(isSelected: isSelected))
         .focused($focusedOptionID, equals: option.id)
         .accessibilityLabel(option.label)
+        .accessibilityHint(option.detail ?? "")
         .accessibilityValue(isSelected ? "Selected" : "")
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #142 that expands the device-local Profile Selection policy to four choices:

- **Automatic** keeps using the last valid profile
- **Every Time** shows Who's Watching after cold launches and real background returns
- **After 1 Hour** and **After 12 Hours** show the picker after the persisted away interval expires

The account remains signed in when a policy expires. Silo retires the active profile identity and profile-scoped work, preserves the remembered profile as a focus hint, and requests the PIN again through the existing picker when required.

## Behavior and UX

- starts the away clock only for real background transitions, not inactive-only interruptions
- pauses the clock while background audio or Picture in Picture remains active
- consumes the away interval after a successful cold restore
- records macOS termination as the start of an away interval
- safely retires temporary tvOS playback identity before enforcing an expired policy
- queues content deep links until a profile is active
- suppresses personalized Top Shelf content once selection is required
- adds explanatory and accessible iOS, macOS, and tvOS settings copy
- sizes the tvOS option sheet from wrapped detail content so all four choices remain visible without clipping

## Validation

- 23 focused signed iOS simulator tests covering launch policy, identity, migration, persistence, exact timeout boundaries, legacy decoding, and Top Shelf gating on `ee0996d`
- tvOS simulator build on `ee0996d`
- macOS build on `ee0996d`
- `git diff --check`
- signed iOS simulator Every Time background/return flow
- signed iOS Profile Selection visual and accessibility inspection
- signed tvOS Profile Selection sheet and focus inspection, including After 12 Hours without clipping or scroll movement

Physical Apple TV validation is still required to prove isolation between multiple real Apple TV system users; this change preserves the existing current-user storage boundary.