### PR TITLE
fix(subtitles): thin outline stroke and honor font choice for Arabic cues

### DIFF
--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleAppearancePreview.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleAppearancePreview.swift
@@ -66,8 +66,13 @@ struct SubtitleAppearancePreview: View {
             || systemEdge == .uniform
         let outlineColor = hasOutline ? Color(hex: appearance.textOutlineColor) : .clear
         // Four hard directional shadows fake libass's uniform glyph
-        // outline; a soft radius reads as a glow instead.
-        let outlineOffset: CGFloat = max(1, sampleFontSize * 0.04)
+        // outline; a soft radius reads as a glow instead. The shared
+        // formula's 1-2 clamp is calibrated for the 1080-line playfield,
+        // so feed it the unscaled size and scale the result into preview
+        // space — clamping post-scale would flatten the whole ladder.
+        let outlineOffset = CGFloat(
+            SubtitleStylingOverride.Parameters.outlineSize(for: Double(playfieldFontSize))
+        ) * Self.fontScale
 
         let raisedColor = systemEdge == .raised ? Color.white.opacity(0.8) : .clear
         let depressedColor = systemEdge == .depressed ? Color.black.opacity(0.9) : .clear
@@ -113,10 +118,17 @@ struct SubtitleAppearancePreview: View {
         }
     }
 
-    private var sampleFontSize: CGFloat {
-        (appearance.systemRelativeFontScale.map {
+    /// The size playback would use in the 1080-line ASS playfield, before
+    /// the preview's own downscale. Shared styling formulas are calibrated
+    /// against this, not against `sampleFontSize`.
+    private var playfieldFontSize: CGFloat {
+        appearance.systemRelativeFontScale.map {
             SubtitleStylingOverride.Parameters.referenceFontSize * $0
-        } ?? appearance.fontSize.pointSize) * Self.fontScale
+        } ?? appearance.fontSize.pointSize
+    }
+
+    private var sampleFontSize: CGFloat {
+        playfieldFontSize * Self.fontScale
     }
 
     private var sampleFont: Font {

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleRenderer.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleRenderer.swift
@@ -48,11 +48,18 @@ final class ASSTrackHandle {
     let ptr: UnsafeMutablePointer<ASS_Track>
     let isNativeASS: Bool   // true iff codec is ASS/SSA (author-styled)
     let flushesOnSeek: Bool
+    let preservesScriptSpecificFonts: Bool
 
-    init(ptr: UnsafeMutablePointer<ASS_Track>, isNativeASS: Bool, flushesOnSeek: Bool) {
+    init(
+        ptr: UnsafeMutablePointer<ASS_Track>,
+        isNativeASS: Bool,
+        flushesOnSeek: Bool,
+        preservesScriptSpecificFonts: Bool = false
+    ) {
         self.ptr = ptr
         self.isNativeASS = isNativeASS
         self.flushesOnSeek = flushesOnSeek
+        self.preservesScriptSpecificFonts = preservesScriptSpecificFonts
     }
 
     deinit {
@@ -288,7 +295,8 @@ final class SubtitleRenderer {
     func installFullASS(
         slot: SubtitleSlot,
         assDocument: String,
-        isNativeASS: Bool
+        isNativeASS: Bool,
+        preservesScriptSpecificFonts: Bool = false
     ) {
         sessionQueue.async { [weak self] in
             guard let self, let lib = self.library else { return }
@@ -312,7 +320,12 @@ final class SubtitleRenderer {
             )
             ass_set_check_readorder(track, 0)
 
-            let handle = ASSTrackHandle(ptr: track, isNativeASS: isNativeASS, flushesOnSeek: false)
+            let handle = ASSTrackHandle(
+                ptr: track,
+                isNativeASS: isNativeASS,
+                flushesOnSeek: false,
+                preservesScriptSpecificFonts: preservesScriptSpecificFonts
+            )
             self.handleLock.lock()
             switch slot {
             case .primary:   self.primary = handle
@@ -325,7 +338,8 @@ final class SubtitleRenderer {
                 params: self.currentParams,
                 isNativeASS: isNativeASS,
                 slot: slot,
-                fontScaleCompensation: self.fontScaleCompensation
+                fontScaleCompensation: self.fontScaleCompensation,
+                preservesScriptSpecificFonts: preservesScriptSpecificFonts
             )
         }
     }
@@ -497,14 +511,16 @@ final class SubtitleRenderer {
             params: currentParams,
             isNativeASS: primaryHandle?.isNativeASS ?? false,
             slot: .primary,
-            fontScaleCompensation: fontScaleCompensation
+            fontScaleCompensation: fontScaleCompensation,
+            preservesScriptSpecificFonts: primaryHandle?.preservesScriptSpecificFonts ?? false
         )
         SubtitleStylingOverride.apply(
             renderer: secondaryRenderer,
             params: currentParams,
             isNativeASS: secondaryHandle?.isNativeASS ?? false,
             slot: .secondary,
-            fontScaleCompensation: fontScaleCompensation
+            fontScaleCompensation: fontScaleCompensation,
+            preservesScriptSpecificFonts: secondaryHandle?.preservesScriptSpecificFonts ?? false
         )
     }
 

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleScriptFont.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleScriptFont.swift
@@ -184,13 +184,23 @@ enum SubtitleScriptFont {
         }
     }
 
+    /// The Arabic-script blocks whose letters or decimal digits can occur in
+    /// subtitle prose. Deliberately not every block Scripts.txt assigns to
+    /// Arabic: the remaining ones (Mathematical Alphabetic Symbols, the Siyaq
+    /// and Rumi number sets, Coptic Epact) are notation whose glyphs the
+    /// fallback faces don't cover, so classifying on them would switch the
+    /// style without improving rendering. Extended-B/-C letters only ever
+    /// appear alongside core U+06xx text, so their inclusion is completeness,
+    /// not a behavior change.
     private static func isInArabicBlock(_ scalar: Unicode.Scalar) -> Bool {
         switch scalar.value {
-        case 0x0600...0x06FF,
-             0x0750...0x077F,
-             0x08A0...0x08FF,
-             0xFB50...0xFDFF,
-             0xFE70...0xFEFF:
+        case 0x0600...0x06FF,      // Arabic
+             0x0750...0x077F,      // Arabic Supplement
+             0x0870...0x089F,      // Arabic Extended-B
+             0x08A0...0x08FF,      // Arabic Extended-A
+             0xFB50...0xFDFF,      // Arabic Presentation Forms-A
+             0xFE70...0xFEFF,      // Arabic Presentation Forms-B
+             0x10EC0...0x10EFF:    // Arabic Extended-C
             return true
         default:
             return false

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleScriptFont.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleScriptFont.swift
@@ -15,14 +15,18 @@ import Foundation
 
 enum SubtitleScriptFont {
     private static let arabicAlef: UniChar = 0x0627
+    /// Face to try when the category-mapped one is missing. Ships on every
+    /// Apple platform that carries Arabic at all, unlike Damascus (absent
+    /// on tvOS).
+    private static let universalArabicFamily = "Geeza Pro"
     private static let cacheLock = NSLock()
     private static var resolvedArabicFamilies: [String: String] = [:]
 
-    /// True when the cue carries any Arabic letter. The fallback faces
-    /// (Geeza Pro, Damascus) cover Latin too, so a mixed cue such as
-    /// `NARRATOR: مرحبا` costs nothing by taking the Arabic style, while
-    /// a majority test would send it down the Latin path and flatten the
-    /// Arabic run.
+    /// True when the cue carries any Arabic letter or Arabic-Indic digit.
+    /// The fallback faces (Geeza Pro, Damascus) cover Latin too, so a mixed
+    /// cue such as `NARRATOR: مرحبا` costs nothing by taking the Arabic
+    /// style, while a majority test would send it down the Latin path and
+    /// flatten the Arabic run.
     static func containsArabicLetters(_ text: String) -> Bool {
         // ASS override blocks (`{\i1}`) are markup, not cue text. A cue can
         // still contain a literal unmatched `{` — `translateCueBody` drops
@@ -35,7 +39,7 @@ enum SubtitleScriptFont {
         return scanForArabic(text, honoringOverrideBraces: false) ?? false
     }
 
-    /// Scan `text` for Arabic letters. Returns nil when
+    /// Scan `text` for Arabic-script content. Returns nil when
     /// `honoringOverrideBraces` is set and the braces never balanced,
     /// meaning the result would be based on a truncated scan.
     private static func scanForArabic(
@@ -65,7 +69,7 @@ enum SubtitleScriptFont {
                     continue
                 }
             }
-            guard !insideASSOverride, isLetter(scalar), isArabic(scalar) else { continue }
+            guard !insideASSOverride, isArabicScript(scalar) else { continue }
             containsArabic = true
         }
 
@@ -91,11 +95,20 @@ enum SubtitleScriptFont {
                 for: chosenFamily,
                 chosenFont: chosenFont
             )
-            if let mappedFont = availableFont(named: mappedFamily), coversArabic(mappedFont) {
-                resolved = mappedFamily
+            // The category-mapped face is a style preference, not a
+            // guarantee: Damascus is absent on tvOS, where
+            // `CTFontCreateWithName` silently substitutes Helvetica and
+            // `availableFont` rejects it. Fall through to the universal
+            // face before giving up, otherwise no ArabicFallback style is
+            // emitted and the FONT_NAME override flattens Arabic cues.
+            if let covering = coveringArabicFamily(mappedFamily) {
+                resolved = covering
+            } else if mappedFamily != universalArabicFamily,
+                      let covering = coveringArabicFamily(universalArabicFamily) {
+                resolved = covering
             } else {
                 // Preserve CoreText/libass's existing per-glyph fallback if
-                // the expected platform face is unavailable.
+                // no expected platform face is available.
                 resolved = chosenFamily
             }
         }
@@ -104,6 +117,12 @@ enum SubtitleScriptFont {
         resolvedArabicFamilies[chosenFamily] = resolved
         cacheLock.unlock()
         return resolved
+    }
+
+    /// `family` if it both resolves to itself and covers Arabic, else nil.
+    private static func coveringArabicFamily(_ family: String) -> String? {
+        guard let font = availableFont(named: family), coversArabic(font) else { return nil }
+        return family
     }
 
     private static func availableFont(named family: String) -> CTFont? {
@@ -128,7 +147,7 @@ enum SubtitleScriptFont {
         if let chosenFont, isSerif(chosenFont) {
             return "Damascus"
         }
-        return "Geeza Pro"
+        return universalArabicFamily
     }
 
     private static func isSerif(_ font: CTFont) -> Bool {
@@ -147,17 +166,25 @@ enum SubtitleScriptFont {
         CFCharacterSetIsCharacterMember(CTFontCopyCharacterSet(font), arabicAlef)
     }
 
-    private static func isLetter(_ scalar: Unicode.Scalar) -> Bool {
+    /// A scalar that needs an Arabic-capable face: inside an Arabic block
+    /// and either a letter or a decimal digit. Digits matter because the
+    /// Arabic-Indic sets (U+0660–0669, U+06F0–06F9) live in those blocks —
+    /// a digits-only cue such as `٢٠٢٦` would otherwise stay on `Default`
+    /// and be flattened onto a Latin family by the `FONT_NAME` override.
+    /// Punctuation and marks are excluded: they carry no script identity
+    /// on their own.
+    private static func isArabicScript(_ scalar: Unicode.Scalar) -> Bool {
+        guard isInArabicBlock(scalar) else { return false }
         switch scalar.properties.generalCategory {
         case .uppercaseLetter, .lowercaseLetter, .titlecaseLetter,
-             .modifierLetter, .otherLetter:
+             .modifierLetter, .otherLetter, .decimalNumber:
             return true
         default:
             return false
         }
     }
 
-    private static func isArabic(_ scalar: Unicode.Scalar) -> Bool {
+    private static func isInArabicBlock(_ scalar: Unicode.Scalar) -> Bool {
         switch scalar.value {
         case 0x0600...0x06FF,
              0x0750...0x077F,

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleScriptFont.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleScriptFont.swift
@@ -1,0 +1,172 @@
+//
+//  SubtitleScriptFont.swift
+//  Continuum (iOS + tvOS + macOS)
+//
+//  Script-aware font fallback for generated ASS documents. The user's
+//  chosen subtitle family is often Latin-only, so Arabic cues would
+//  otherwise render through libass's per-glyph fallback (or, worse, be
+//  flattened onto the Latin family by the renderer-wide `FONT_NAME`
+//  override). Resolves an Arabic-capable companion family for a chosen
+//  family, and classifies cue text so the converter can select it.
+//
+
+import CoreText
+import Foundation
+
+enum SubtitleScriptFont {
+    private static let arabicAlef: UniChar = 0x0627
+    private static let cacheLock = NSLock()
+    private static var resolvedArabicFamilies: [String: String] = [:]
+
+    /// True when the cue carries any Arabic letter. The fallback faces
+    /// (Geeza Pro, Damascus) cover Latin too, so a mixed cue such as
+    /// `NARRATOR: مرحبا` costs nothing by taking the Arabic style, while
+    /// a majority test would send it down the Latin path and flatten the
+    /// Arabic run.
+    static func containsArabicLetters(_ text: String) -> Bool {
+        // ASS override blocks (`{\i1}`) are markup, not cue text. A cue can
+        // still contain a literal unmatched `{` — `translateCueBody` drops
+        // raw braces but the `&#123;` entity path resolves one back in —
+        // which would latch the scanner and swallow the rest of the line.
+        // Fall back to a brace-blind scan when that happens.
+        if let balanced = scanForArabic(text, honoringOverrideBraces: true) {
+            return balanced
+        }
+        return scanForArabic(text, honoringOverrideBraces: false) ?? false
+    }
+
+    /// Scan `text` for Arabic letters. Returns nil when
+    /// `honoringOverrideBraces` is set and the braces never balanced,
+    /// meaning the result would be based on a truncated scan.
+    private static func scanForArabic(
+        _ text: String,
+        honoringOverrideBraces: Bool
+    ) -> Bool? {
+        var containsArabic = false
+        var insideASSOverride = false
+        var escaped = false
+
+        for scalar in text.unicodeScalars {
+            if escaped {
+                escaped = false
+                continue
+            }
+            if scalar.value == 0x5C {
+                escaped = true
+                continue
+            }
+            if honoringOverrideBraces {
+                if scalar.value == 0x7B {
+                    insideASSOverride = true
+                    continue
+                }
+                if scalar.value == 0x7D {
+                    insideASSOverride = false
+                    continue
+                }
+            }
+            guard !insideASSOverride, isLetter(scalar), isArabic(scalar) else { continue }
+            containsArabic = true
+        }
+
+        if honoringOverrideBraces, insideASSOverride { return nil }
+        return containsArabic
+    }
+
+    static func arabicFontFamily(for chosenFamily: String) -> String {
+        cacheLock.lock()
+        let cached = resolvedArabicFamilies[chosenFamily]
+        cacheLock.unlock()
+        if let cached { return cached }
+
+        // CoreText resolution loads cmaps; keep it off the lock and accept
+        // that two callers may resolve the same family concurrently — the
+        // result is deterministic, so the duplicate work is benign.
+        let chosenFont = availableFont(named: chosenFamily)
+        let resolved: String
+        if let chosenFont, coversArabic(chosenFont) {
+            resolved = chosenFamily
+        } else {
+            let mappedFamily = mappedArabicFamily(
+                for: chosenFamily,
+                chosenFont: chosenFont
+            )
+            if let mappedFont = availableFont(named: mappedFamily), coversArabic(mappedFont) {
+                resolved = mappedFamily
+            } else {
+                // Preserve CoreText/libass's existing per-glyph fallback if
+                // the expected platform face is unavailable.
+                resolved = chosenFamily
+            }
+        }
+
+        cacheLock.lock()
+        resolvedArabicFamilies[chosenFamily] = resolved
+        cacheLock.unlock()
+        return resolved
+    }
+
+    private static func availableFont(named family: String) -> CTFont? {
+        let font = CTFontCreateWithName(family as CFString, 16, nil)
+        let resolvedFamily = CTFontCopyFamilyName(font) as String
+        guard resolvedFamily.compare(
+            family,
+            options: [.caseInsensitive, .diacriticInsensitive]
+        ) == .orderedSame else {
+            return nil
+        }
+        return font
+    }
+
+    private static func mappedArabicFamily(
+        for chosenFamily: String,
+        chosenFont: CTFont?
+    ) -> String {
+        if chosenFamily.compare("Times New Roman", options: .caseInsensitive) == .orderedSame {
+            return "Damascus"
+        }
+        if let chosenFont, isSerif(chosenFont) {
+            return "Damascus"
+        }
+        return "Geeza Pro"
+    }
+
+    private static func isSerif(_ font: CTFont) -> Bool {
+        // CoreText stores the OpenType stylistic class in the upper four
+        // bits: 1-5 and 7 are its serif classifications.
+        let stylisticClass = CTFontGetSymbolicTraits(font).rawValue >> 28
+        switch stylisticClass {
+        case 1...5, 7:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func coversArabic(_ font: CTFont) -> Bool {
+        CFCharacterSetIsCharacterMember(CTFontCopyCharacterSet(font), arabicAlef)
+    }
+
+    private static func isLetter(_ scalar: Unicode.Scalar) -> Bool {
+        switch scalar.properties.generalCategory {
+        case .uppercaseLetter, .lowercaseLetter, .titlecaseLetter,
+             .modifierLetter, .otherLetter:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func isArabic(_ scalar: Unicode.Scalar) -> Bool {
+        switch scalar.value {
+        case 0x0600...0x06FF,
+             0x0750...0x077F,
+             0x08A0...0x08FF,
+             0xFB50...0xFDFF,
+             0xFE70...0xFEFF:
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleSession.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleSession.swift
@@ -69,9 +69,27 @@ final class SubtitleSession {
     private let renderer: SubtitleRenderer
     private let fetcher: SidecarSubtitleFetcher
 
+    private struct InstalledConvertedSidecar {
+        let urlIndex: Int
+        let format: SubtitleFormat
+        /// Whether the installed document actually carries `ArabicFallback`
+        /// Dialogue lines (drives the renderer's `FONT_NAME` suppression).
+        let usedArabicFallbackStyle: Bool
+        /// Whether the track has Arabic cues at all. Only these need
+        /// regenerating on a font-family change: a Latin-only track tracks
+        /// the new family through the live `FONT_NAME` override, while an
+        /// Arabic track may need a fallback style the old family didn't.
+        let containsArabicCues: Bool
+        /// Value of `installedSidecarGeneration` when this entry was
+        /// written. A reinstall that reconverted outside the lock must
+        /// re-check it before installing (see `installSidecarContent`).
+        let generation: UInt64
+    }
+
     /// Guards the lock-free mutable session state (`sidecarDescriptors`,
-    /// `sidecarCache`, `fetchTasks`, `liveSlots`, `stylingParams`). Mirrors
-    /// the `handleLock` idiom in `SubtitleRenderer`.
+    /// `sidecarCache`, `fetchTasks`, `installedConvertedSidecars`,
+    /// `liveSlots`, `stylingParams`). Mirrors the `handleLock` idiom in
+    /// `SubtitleRenderer`.
     ///
     /// The two playback backends call into this session from different
     /// queues — the CoreMedia route from `PlayerCore.controlQueue`, the
@@ -90,6 +108,22 @@ final class SubtitleSession {
         lock.lock()
         defer { lock.unlock() }
         return body()
+    }
+
+    /// Bump the slot's generation and return the new value. Call for every
+    /// change to what occupies the slot, clears included, so an in-flight
+    /// reinstall can detect that its target is gone. Caller holds `lock`.
+    @discardableResult
+    private func bumpInstalledGenerationLocked(_ slot: SubtitleSlot) -> UInt64 {
+        let next = (installedSidecarGeneration[slot] ?? 0) &+ 1
+        installedSidecarGeneration[slot] = next
+        return next
+    }
+
+    /// Forget the converted sidecar occupying the slot. Caller holds `lock`.
+    private func clearInstalledSidecarLocked(_ slot: SubtitleSlot) {
+        installedConvertedSidecars.removeValue(forKey: slot)
+        bumpInstalledGenerationLocked(slot)
     }
 
     /// Sidecar descriptors keyed by their server-assigned URL index.
@@ -113,6 +147,16 @@ final class SubtitleSession {
     /// Active per-slot fetch Task so switching tracks cancels the
     /// previous fetch cleanly. Guarded by `lock`.
     private var fetchTasks: [SubtitleSlot: Task<Void, Never>] = [:]
+
+    /// Converted sidecar currently installed in each libass slot. This is
+    /// enough to regenerate its synthetic styles from `sidecarCache` when
+    /// the user changes font family without refetching the track.
+    /// Guarded by `lock`.
+    private var installedConvertedSidecars: [SubtitleSlot: InstalledConvertedSidecar] = [:]
+
+    /// Monotonic per-slot counter, bumped on every mutation of the slot's
+    /// installed-track state — installs and clears alike. Guarded by `lock`.
+    private var installedSidecarGeneration: [SubtitleSlot: UInt64] = [:]
 
     /// Slots currently driven by a live AI subtitle track (cues streamed
     /// in via `feedLiveCue`). A live track must NOT be flushed on seek —
@@ -157,8 +201,36 @@ final class SubtitleSession {
     // MARK: - Configuration
 
     func applyStyling(_ params: SubtitleStylingOverride.Parameters) {
-        withLock { stylingParams = params }
+        let reinstallations: [(
+            slot: SubtitleSlot,
+            sidecar: InstalledConvertedSidecar,
+            content: String
+        )] = withLock {
+            let fontFamilyChanged = stylingParams.fontFamilyName != params.fontFamilyName
+            stylingParams = params
+            guard fontFamilyChanged else { return [] }
+            return installedConvertedSidecars.compactMap { slot, sidecar in
+                // Latin-only tracks track the new family through the live
+                // FONT_NAME override. A track with Arabic cues always needs
+                // reconversion: the new family may need a fallback style the
+                // old one didn't (or vice versa), and the override would
+                // otherwise flatten Arabic onto a non-covering family.
+                guard sidecar.containsArabicCues,
+                      let content = sidecarCache[sidecar.urlIndex] else { return nil }
+                return (slot, sidecar, content)
+            }
+        }
         renderer.applySettings(params)
+        for reinstallation in reinstallations {
+            installSidecarContent(
+                content: reinstallation.content,
+                codecHint: nil,
+                urlIndex: reinstallation.sidecar.urlIndex,
+                slot: reinstallation.slot,
+                knownFormat: reinstallation.sidecar.format,
+                requiredGeneration: reinstallation.sidecar.generation
+            )
+        }
     }
 
     var currentParams: SubtitleStylingOverride.Parameters {
@@ -205,6 +277,7 @@ final class SubtitleSession {
         withLock {
             _ = liveSlots.remove(slot)
             bitmapCueStores.removeValue(forKey: slot)
+            clearInstalledSidecarLocked(slot)
         }
         if isNativeASS {
             renderer.createTrack(
@@ -253,6 +326,7 @@ final class SubtitleSession {
         withLock {
             _ = liveSlots.remove(slot)
             bitmapCueStores.removeValue(forKey: slot)
+            clearInstalledSidecarLocked(slot)
         }
         publishStatus(slot: slot, .fetching)
 
@@ -305,7 +379,7 @@ final class SubtitleSession {
                 self.installSidecarContent(
                     content: result.content,
                     codecHint: descriptor.codec,
-                    url: descriptor.url,
+                    urlIndex: urlIndex,
                     slot: slot,
                     knownFormat: result.format
                 )
@@ -339,6 +413,7 @@ final class SubtitleSession {
         withLock {
             _ = liveSlots.remove(slot)
             bitmapCueStores.removeValue(forKey: slot)
+            clearInstalledSidecarLocked(slot)
         }
         renderer.dropTrack(slot: slot)
         publishStatus(slot: slot, .idle)
@@ -398,6 +473,7 @@ final class SubtitleSession {
         cancelFetchTask(for: slot)
         withLock {
             _ = liveSlots.remove(slot)
+            clearInstalledSidecarLocked(slot)
             bitmapCueStores[slot] = BitmapSubtitleCueStore(
                 retentionSeconds: retentionSeconds,
                 maxCueCount: maxCueCount
@@ -487,7 +563,10 @@ final class SubtitleSession {
     ///   - language: optional ISO language tag (also informational).
     func openLive(slot: SubtitleSlot, label: String? = nil, language: String? = nil) {
         cancelFetchTask(for: slot)
-        withLock { bitmapCueStores.removeValue(forKey: slot) }
+        withLock {
+            bitmapCueStores.removeValue(forKey: slot)
+            clearInstalledSidecarLocked(slot)
+        }
         let params = withLock { stylingParams }
         let header = SubtitleStylingOverride.syntheticHeader(
             params: params,
@@ -531,7 +610,10 @@ final class SubtitleSession {
     /// Close the live track in the given slot. Drops the libass track and
     /// clears the live-slot flag. Safe to call on a slot that isn't live.
     func closeLive(slot: SubtitleSlot) {
-        withLock { _ = liveSlots.remove(slot) }
+        withLock {
+            _ = liveSlots.remove(slot)
+            clearInstalledSidecarLocked(slot)
+        }
         renderer.dropTrack(slot: slot)
         publishStatus(slot: slot, .idle)
     }
@@ -552,6 +634,7 @@ final class SubtitleSession {
             fetchTasks.removeAll()
             sidecarCache.removeAll()
             sidecarDescriptors.removeAll()
+            for slot in SubtitleSlot.allCases { clearInstalledSidecarLocked(slot) }
             liveSlots.removeAll()
             bitmapCueStores.removeAll()
             return snapshot
@@ -577,36 +660,88 @@ final class SubtitleSession {
         }
     }
 
+    /// Convert (if needed) and install sidecar content into a slot.
+    ///
+    /// - Parameter requiredGeneration: set by the font-change reinstall
+    ///   path, which reconverts outside the lock. The install is abandoned
+    ///   unless the slot still holds the same installed entry it did when
+    ///   the reinstall was planned — otherwise a concurrent
+    ///   `closeSlot`/`openSidecar`/`openLive`/`openBitmapTrack`/
+    ///   `openEmbedded` would be undone by a late install.
     private func installSidecarContent(
         content: String,
         codecHint: String?,
-        url: URL,
+        urlIndex: Int,
         slot: SubtitleSlot,
-        knownFormat: SubtitleFormat? = nil
+        knownFormat: SubtitleFormat? = nil,
+        requiredGeneration: UInt64? = nil
     ) {
         let format = knownFormat ?? Self.codecToFormat(codecHint) ?? .vtt
         let isNativeASS = (format == .ass)
 
         let assDocument: String
+        let preservesScriptSpecificFonts: Bool
+        let containsArabicCues: Bool
         switch format {
         case .ass:
             assDocument = content
+            preservesScriptSpecificFonts = false
+            containsArabicCues = false
         case .vtt, .srt:
             let params = withLock { stylingParams }
-            assDocument = VTTToASSConverter.convert(
+            let hasArabicFallbackStyle = SubtitleStylingOverride
+                .arabicFallbackFontName(params: params) != nil
+            let conversion = VTTToASSConverter.convert(
                 vtt: content,
                 header: SubtitleStylingOverride.syntheticHeader(
                     params: params,
                     slot: slot
-                )
+                ),
+                hasArabicFallbackStyle: hasArabicFallbackStyle
             )
+            assDocument = conversion.assDocument
+            preservesScriptSpecificFonts = conversion.usedArabicFallbackStyle
+            containsArabicCues = conversion.containsArabicCues
         }
 
-        renderer.installFullASS(
-            slot: slot,
-            assDocument: assDocument,
-            isNativeASS: isNativeASS
-        )
+        // Bookkeeping, staleness check, and the install must be atomic with
+        // respect to slot changes: releasing the lock first would let a
+        // concurrent close/open slip between them and be resurrected by this
+        // install. Safe to hold `lock` here specifically because
+        // `installFullASS` only enqueues onto the renderer's serial
+        // `sessionQueue` and never calls back into the session — unlike the
+        // `.sync` renderer calls the lock's contract warns about. Ordering
+        // then follows from that queue: any later user action enqueues its
+        // renderer work after ours.
+        let installed = withLock { () -> Bool in
+            if let requiredGeneration,
+               installedSidecarGeneration[slot] != requiredGeneration
+                || installedConvertedSidecars[slot] == nil {
+                return false
+            }
+
+            if isNativeASS {
+                clearInstalledSidecarLocked(slot)
+            } else {
+                installedConvertedSidecars[slot] = InstalledConvertedSidecar(
+                    urlIndex: urlIndex,
+                    format: format,
+                    usedArabicFallbackStyle: preservesScriptSpecificFonts,
+                    containsArabicCues: containsArabicCues,
+                    generation: bumpInstalledGenerationLocked(slot)
+                )
+            }
+
+            renderer.installFullASS(
+                slot: slot,
+                assDocument: assDocument,
+                isNativeASS: isNativeASS,
+                preservesScriptSpecificFonts: preservesScriptSpecificFonts
+            )
+            return true
+        }
+        guard installed else { return }
+
         let stats = Self.dialogueStats(in: assDocument)
         let nowSeconds = currentPositionSecondsProvider?() ?? -1
         Self.logger.info(

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleSession.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleSession.swift
@@ -169,6 +169,23 @@ final class SubtitleSession {
     /// when `applySubtitleStyling` is called. Guarded by `lock`.
     private var stylingParams: SubtitleStylingOverride.Parameters = .default
 
+    /// Monotonic counter bumped on every `stylingParams` change. A
+    /// conversion runs off a snapshot taken outside `lock`, so the install
+    /// gate re-checks this to reject a document generated from styling the
+    /// user has since replaced. Guarded by `lock`.
+    private var stylingGeneration: UInt64 = 0
+
+    /// Serial queue for font-change reinstalls. Reconverting a
+    /// feature-length sidecar is O(cues) and must not run on the settings
+    /// caller's queue. Serial rather than concurrent so a rapid sequence of
+    /// font changes across both slots can't fan out into simultaneous
+    /// whole-file conversions; slot independence makes the ordering
+    /// immaterial either way.
+    private let reinstallQueue = DispatchQueue(
+        label: "com.continuum.subtitle-session.reinstall",
+        qos: .userInitiated
+    )
+
     /// Per-slot cue stores for bitmap subtitle tracks (PGS/DVD). Bitmap
     /// tracks bypass libass entirely: the extractor feeds ready CGImage
     /// cues into the slot's store and the backend's display-link pump
@@ -207,7 +224,10 @@ final class SubtitleSession {
             content: String
         )] = withLock {
             let fontFamilyChanged = stylingParams.fontFamilyName != params.fontFamilyName
-            stylingParams = params
+            if stylingParams != params {
+                stylingParams = params
+                stylingGeneration &+= 1
+            }
             guard fontFamilyChanged else { return [] }
             return installedConvertedSidecars.compactMap { slot, sidecar in
                 // Latin-only tracks track the new family through the live
@@ -221,15 +241,22 @@ final class SubtitleSession {
             }
         }
         renderer.applySettings(params)
+        // Reconversion is unbounded work on the caller's queue (player
+        // settings / UI), so it lands on `reinstallQueue`. Arriving late is
+        // safe: the install gate rejects the document if the slot's
+        // generation moved (track switched or closed) or if the styling
+        // generation moved (a newer conversion supersedes this one).
         for reinstallation in reinstallations {
-            installSidecarContent(
-                content: reinstallation.content,
-                codecHint: nil,
-                urlIndex: reinstallation.sidecar.urlIndex,
-                slot: reinstallation.slot,
-                knownFormat: reinstallation.sidecar.format,
-                requiredGeneration: reinstallation.sidecar.generation
-            )
+            reinstallQueue.async { [weak self] in
+                self?.installSidecarContent(
+                    content: reinstallation.content,
+                    codecHint: nil,
+                    urlIndex: reinstallation.sidecar.urlIndex,
+                    slot: reinstallation.slot,
+                    knownFormat: reinstallation.sidecar.format,
+                    requiredGeneration: reinstallation.sidecar.generation
+                )
+            }
         }
     }
 
@@ -676,78 +703,115 @@ final class SubtitleSession {
         knownFormat: SubtitleFormat? = nil,
         requiredGeneration: UInt64? = nil
     ) {
+        enum InstallOutcome {
+            case installed
+            /// The slot no longer holds the entry this install targeted.
+            case abandoned
+            /// Styling changed under the conversion; convert again.
+            case restyled
+        }
+
         let format = knownFormat ?? Self.codecToFormat(codecHint) ?? .vtt
         let isNativeASS = (format == .ass)
 
-        let assDocument: String
-        let preservesScriptSpecificFonts: Bool
-        let containsArabicCues: Bool
-        switch format {
-        case .ass:
-            assDocument = content
-            preservesScriptSpecificFonts = false
-            containsArabicCues = false
-        case .vtt, .srt:
-            let params = withLock { stylingParams }
-            let hasArabicFallbackStyle = SubtitleStylingOverride
-                .arabicFallbackFontName(params: params) != nil
-            let conversion = VTTToASSConverter.convert(
-                vtt: content,
-                header: SubtitleStylingOverride.syntheticHeader(
-                    params: params,
-                    slot: slot
-                ),
-                hasArabicFallbackStyle: hasArabicFallbackStyle
-            )
-            assDocument = conversion.assDocument
-            preservesScriptSpecificFonts = conversion.usedArabicFallbackStyle
-            containsArabicCues = conversion.containsArabicCues
-        }
-
-        // Bookkeeping, staleness check, and the install must be atomic with
-        // respect to slot changes: releasing the lock first would let a
-        // concurrent close/open slip between them and be resurrected by this
-        // install. Safe to hold `lock` here specifically because
-        // `installFullASS` only enqueues onto the renderer's serial
-        // `sessionQueue` and never calls back into the session — unlike the
-        // `.sync` renderer calls the lock's contract warns about. Ordering
-        // then follows from that queue: any later user action enqueues its
-        // renderer work after ours.
-        let installed = withLock { () -> Bool in
-            if let requiredGeneration,
-               installedSidecarGeneration[slot] != requiredGeneration
-                || installedConvertedSidecars[slot] == nil {
-                return false
-            }
-
-            if isNativeASS {
-                clearInstalledSidecarLocked(slot)
-            } else {
-                installedConvertedSidecars[slot] = InstalledConvertedSidecar(
-                    urlIndex: urlIndex,
-                    format: format,
-                    usedArabicFallbackStyle: preservesScriptSpecificFonts,
-                    containsArabicCues: containsArabicCues,
-                    generation: bumpInstalledGenerationLocked(slot)
+        // Conversion bakes the styling snapshot into the document's header
+        // and style selection, and it runs outside `lock`. A font change
+        // landing in that window would otherwise install a document carrying
+        // the old families — permanently, since this is a fresh install with
+        // no reinstall scheduled for it, and the live FONT_NAME override is
+        // suppressed while `preservesScriptSpecificFonts` is set. Reconvert
+        // instead. Terminates because each retry requires the user to have
+        // changed styling again, and those changes are human-paced.
+        while true {
+            let assDocument: String
+            let preservesScriptSpecificFonts: Bool
+            let containsArabicCues: Bool
+            /// nil for authored ASS: it is passed through unmodified, so no
+            /// styling snapshot is embedded in it.
+            let conversionStylingGeneration: UInt64?
+            switch format {
+            case .ass:
+                assDocument = content
+                preservesScriptSpecificFonts = false
+                containsArabicCues = false
+                conversionStylingGeneration = nil
+            case .vtt, .srt:
+                let (params, generation) = withLock { (stylingParams, stylingGeneration) }
+                let hasArabicFallbackStyle = SubtitleStylingOverride
+                    .arabicFallbackFontName(params: params) != nil
+                let conversion = VTTToASSConverter.convert(
+                    vtt: content,
+                    header: SubtitleStylingOverride.syntheticHeader(
+                        params: params,
+                        slot: slot
+                    ),
+                    hasArabicFallbackStyle: hasArabicFallbackStyle
                 )
+                assDocument = conversion.assDocument
+                preservesScriptSpecificFonts = conversion.usedArabicFallbackStyle
+                containsArabicCues = conversion.containsArabicCues
+                conversionStylingGeneration = generation
             }
 
-            renderer.installFullASS(
-                slot: slot,
-                assDocument: assDocument,
-                isNativeASS: isNativeASS,
-                preservesScriptSpecificFonts: preservesScriptSpecificFonts
-            )
-            return true
-        }
-        guard installed else { return }
+            // Bookkeeping, staleness checks, and the install must be atomic
+            // with respect to slot changes: releasing the lock first would let
+            // a concurrent close/open slip between them and be resurrected by
+            // this install. Safe to hold `lock` here specifically because
+            // `installFullASS` only enqueues onto the renderer's serial
+            // `sessionQueue` and never calls back into the session — unlike the
+            // `.sync` renderer calls the lock's contract warns about. Ordering
+            // then follows from that queue: any later user action enqueues its
+            // renderer work after ours.
+            let outcome = withLock { () -> InstallOutcome in
+                if let requiredGeneration,
+                   installedSidecarGeneration[slot] != requiredGeneration
+                    || installedConvertedSidecars[slot] == nil {
+                    return .abandoned
+                }
+                if let conversionStylingGeneration,
+                   conversionStylingGeneration != stylingGeneration {
+                    return .restyled
+                }
 
-        let stats = Self.dialogueStats(in: assDocument)
-        let nowSeconds = currentPositionSecondsProvider?() ?? -1
-        Self.logger.info(
-            "[CMP-SUB] installed sidecar slot=\(slot.rawValue, privacy: .public) format=\(String(describing: format), privacy: .public) nativeASS=\(isNativeASS, privacy: .public) assChars=\(assDocument.count, privacy: .public) dialogueCount=\(stats.count, privacy: .public) first=\(stats.first ?? "nil", privacy: .public) last=\(stats.last ?? "nil", privacy: .public) now=\(nowSeconds, privacy: .public)"
-        )
-        publishStatus(slot: slot, .ready)
+                if isNativeASS {
+                    clearInstalledSidecarLocked(slot)
+                } else {
+                    installedConvertedSidecars[slot] = InstalledConvertedSidecar(
+                        urlIndex: urlIndex,
+                        format: format,
+                        usedArabicFallbackStyle: preservesScriptSpecificFonts,
+                        containsArabicCues: containsArabicCues,
+                        generation: bumpInstalledGenerationLocked(slot)
+                    )
+                }
+
+                renderer.installFullASS(
+                    slot: slot,
+                    assDocument: assDocument,
+                    isNativeASS: isNativeASS,
+                    preservesScriptSpecificFonts: preservesScriptSpecificFonts
+                )
+                return .installed
+            }
+            switch outcome {
+            case .abandoned:
+                return
+            case .restyled:
+                // The slot generation is untouched by a rejected install, so
+                // `requiredGeneration` stays valid for the next pass.
+                continue
+            case .installed:
+                break
+            }
+
+            let stats = Self.dialogueStats(in: assDocument)
+            let nowSeconds = currentPositionSecondsProvider?() ?? -1
+            Self.logger.info(
+                "[CMP-SUB] installed sidecar slot=\(slot.rawValue, privacy: .public) format=\(String(describing: format), privacy: .public) nativeASS=\(isNativeASS, privacy: .public) assChars=\(assDocument.count, privacy: .public) dialogueCount=\(stats.count, privacy: .public) first=\(stats.first ?? "nil", privacy: .public) last=\(stats.last ?? "nil", privacy: .public) now=\(nowSeconds, privacy: .public)"
+            )
+            publishStatus(slot: slot, .ready)
+            return
+        }
     }
 
     private static func dialogueStats(in assDocument: String) -> (count: Int, first: String?, last: String?) {

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleSession.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleSession.swift
@@ -723,6 +723,22 @@ final class SubtitleSession {
         // instead. Terminates because each retry requires the user to have
         // changed styling again, and those changes are human-paced.
         while true {
+            // Cheap pre-gate: a reinstall whose target entry is already gone
+            // has nothing to install, so skip the O(cues) conversion below.
+            // This does not replace the identical check inside the install
+            // block — that one is the authoritative one, because the slot can
+            // still be closed or reinstalled while the conversion runs outside
+            // `lock`. This only avoids paying for work that is already known
+            // to be wasted, which is the common case when styling changes
+            // arrive faster than conversions finish.
+            if let requiredGeneration {
+                let stillCurrent = withLock {
+                    installedSidecarGeneration[slot] == requiredGeneration
+                        && installedConvertedSidecars[slot] != nil
+                }
+                if !stillCurrent { return }
+            }
+
             let assDocument: String
             let preservesScriptSpecificFonts: Bool
             let containsArabicCues: Bool

--- a/iosApp/iosApp/Screens/Player/Subtitles/SubtitleStylingOverride.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/SubtitleStylingOverride.swift
@@ -7,8 +7,9 @@
 //
 //    1. `syntheticHeader(...)` — produces an ASS `[Script Info]` +
 //       `[V4+ Styles]` block with the user's preferences baked into the
-//       Default style. Used by `VTTToASSConverter` and by synthesized
-//       SRT→ASS wraps when we don't have an authored header.
+//       Default style plus an optional script-aware Arabic style. Used by
+//       `VTTToASSConverter` and by synthesized SRT→ASS wraps when we don't
+//       have an authored header.
 //
 //    2. `apply(to:isNativeASS:)` — applies `ass_set_selective_style_override`,
 //       `ass_set_font_scale`, and `ass_set_line_position` to a live
@@ -55,12 +56,19 @@ enum SubtitleStylingOverride {
         /// later; negative = earlier.
         var syncOffsetMs: Int
 
+        /// Thin user-requested outline in the 1080-line ASS playfield.
+        /// The 1-2 range keeps small text legible without producing a
+        /// sticker-like edge at larger sizes.
         var effectiveBorderSize: Double {
             if borderSize > 0 || systemTextEdgeStyle == .uniform
                 || systemTextEdgeStyle == .raised || systemTextEdgeStyle == .depressed {
-                return max(2, min(4, fontSize * 0.08))
+                return Self.outlineSize(for: fontSize)
             }
             return 0
+        }
+
+        static func outlineSize(for fontSize: Double) -> Double {
+            max(1, min(2, fontSize * 0.03))
         }
 
         /// The user's outline color applies to every outline the user asked
@@ -253,9 +261,10 @@ enum SubtitleStylingOverride {
     // MARK: - Synthetic ASS header
 
     /// Build a complete ASS script header with the user's preferences
-    /// applied to a `Default` style. Callers append an `[Events]` header
-    /// plus their own Dialogue lines. Used by `VTTToASSConverter` and by
-    /// the SRT-fallback path.
+    /// applied to a `Default` style and, when needed, an Arabic-capable
+    /// companion style. Callers append Dialogue lines to the included
+    /// `[Events]` section. Used by `VTTToASSConverter` and by the
+    /// SRT-fallback path.
     ///
     /// - Parameter params: user preferences snapshot.
     /// - Parameter slot: primary slot places subtitles near the bottom
@@ -302,26 +311,37 @@ enum SubtitleStylingOverride {
         s += "\n"
         s += "[V4+ Styles]\n"
         s += "Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding\n"
-        s += "Style: Default,"
-        s += "\(params.fontFamilyName),"                       // Fontname
-        s += "\(Int(Parameters.referenceFontSize.rounded()))," // Fontsize
-        s += "\(primary),"                                     // PrimaryColour
-        s += "&H00FFFFFF,"                                     // SecondaryColour (karaoke flash)
-        s += "\(outline),"                                     // OutlineColour
-        s += "\(back),"                                        // BackColour
-        s += "0,0,0,0,"                                        // Bold, Italic, Underline, StrikeOut
-        s += "100,100,"                                        // ScaleX, ScaleY
-        s += "0,0,"                                            // Spacing, Angle
-        s += "\(borderStyle),"                                 // BorderStyle
-        s += "\(borderSize),"                                  // Outline / box padding
-        s += "\(shadow),"                                      // Shadow
-        s += "\(alignment),"                                   // Alignment
-        s += "60,60,\(marginV),"                               // MarginL, MarginR, MarginV
-        s += "1\n"                                             // Encoding
+        func appendStyle(named name: String, fontFamilyName: String) {
+            s += "Style: \(name),"
+            s += "\(fontFamilyName),"                              // Fontname
+            s += "\(Int(Parameters.referenceFontSize.rounded()))," // Fontsize
+            s += "\(primary),"                                     // PrimaryColour
+            s += "&H00FFFFFF,"                                     // SecondaryColour (karaoke flash)
+            s += "\(outline),"                                     // OutlineColour
+            s += "\(back),"                                        // BackColour
+            s += "0,0,0,0,"                                        // Bold, Italic, Underline, StrikeOut
+            s += "100,100,"                                        // ScaleX, ScaleY
+            s += "0,0,"                                            // Spacing, Angle
+            s += "\(borderStyle),"                                 // BorderStyle
+            s += "\(borderSize),"                                  // Outline / box padding
+            s += "\(shadow),"                                      // Shadow
+            s += "\(alignment),"                                   // Alignment
+            s += "60,60,\(marginV),"                               // MarginL, MarginR, MarginV
+            s += "1\n"                                             // Encoding
+        }
+        appendStyle(named: "Default", fontFamilyName: params.fontFamilyName)
+        if let arabicFallbackFontName = arabicFallbackFontName(params: params) {
+            appendStyle(named: "ArabicFallback", fontFamilyName: arabicFallbackFontName)
+        }
         s += "\n"
         s += "[Events]\n"
         s += "Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text\n"
         return s
+    }
+
+    static func arabicFallbackFontName(params: Parameters) -> String? {
+        let resolved = SubtitleScriptFont.arabicFontFamily(for: params.fontFamilyName)
+        return resolved == params.fontFamilyName ? nil : resolved
     }
 
     // MARK: - Live renderer overrides
@@ -345,12 +365,16 @@ enum SubtitleStylingOverride {
     ///   physical size regardless of the content's aspect ratio. 1.0 when
     ///   the overlay is video-rect sized (no margins). Native ASS is never
     ///   compensated — authored typesetting must keep tracking the picture.
+    /// - Parameter preservesScriptSpecificFonts: true when a generated ASS
+    ///   document contains per-script font styles that must not be flattened
+    ///   by the renderer-wide Fontname override.
     static func apply(
         renderer: OpaquePointer?,
         params: Parameters,
         isNativeASS: Bool,
         slot: SubtitleSlot,
-        fontScaleCompensation: Double = 1.0
+        fontScaleCompensation: Double = 1.0,
+        preservesScriptSpecificFonts: Bool = false
     ) {
         guard let renderer else { return }
 
@@ -414,10 +438,9 @@ enum SubtitleStylingOverride {
         style.ScaleY = 1.0
         style.Spacing = 0
         style.Blur = 0
-        // Outline + shadow: both scale with `ScaledBorderAndShadow: yes`
-        // in the authored header, so keep them small relative to the
-        // authored FontSize=16 grid. Default 0.5 outline + 1.5 shadow
-        // matches the web player's "shadow" default (no heavy outline).
+        // Outline + shadow both scale with `ScaledBorderAndShadow: yes`.
+        // User-requested outlines stay within 1-2 points in the controlled
+        // 1080-line playfield so they remain an edge rather than a glyph box.
         style.Outline = params.effectiveBorderSize
         style.Shadow = params.assShadow
         style.BorderStyle = Int32(params.assBorderStyle)
@@ -454,14 +477,17 @@ enum SubtitleStylingOverride {
             // from glyph masks after rendering instead of enabling this bit.
             bits = systemBits
         } else {
-            bits =
-                Int32(ASS_OVERRIDE_BIT_FONT_NAME.rawValue) |
+            var controlledBits =
                 Int32(ASS_OVERRIDE_BIT_SELECTIVE_FONT_SCALE.rawValue) |
                 Int32(ASS_OVERRIDE_BIT_COLORS.rawValue) |
                 Int32(ASS_OVERRIDE_BIT_ATTRIBUTES.rawValue) |
                 Int32(ASS_OVERRIDE_BIT_BORDER.rawValue) |
                 Int32(ASS_OVERRIDE_BIT_ALIGNMENT.rawValue) |
                 Int32(ASS_OVERRIDE_BIT_MARGINS.rawValue)
+            if !preservesScriptSpecificFonts {
+                controlledBits |= Int32(ASS_OVERRIDE_BIT_FONT_NAME.rawValue)
+            }
+            bits = controlledBits
         }
         ass_set_selective_style_override_enabled(renderer, bits)
     }

--- a/iosApp/iosApp/Screens/Player/Subtitles/VTTToASSConverter.swift
+++ b/iosApp/iosApp/Screens/Player/Subtitles/VTTToASSConverter.swift
@@ -20,6 +20,19 @@ import Foundation
 
 enum VTTToASSConverter {
 
+    struct ConversionResult {
+        let assDocument: String
+        /// Whether any Dialogue actually selected `ArabicFallback`. Drives
+        /// the renderer's `FONT_NAME`-override suppression.
+        let usedArabicFallbackStyle: Bool
+        /// Whether any cue carries Arabic at all, independent of whether
+        /// the header offered a fallback style. Drives the session's
+        /// font-change reinstall: a track with Arabic cues must be
+        /// reconverted for the new family even when the old family covered
+        /// Arabic itself (no fallback style emitted).
+        let containsArabicCues: Bool
+    }
+
     /// Convert a WebVTT document body to a full ASS document.
     ///
     /// - Parameter vtt: the raw WebVTT content as served by the Continuum
@@ -28,11 +41,21 @@ enum VTTToASSConverter {
     ///   `[V4+ Styles]` + `[Events] Format:` header. Supplied by the
     ///   caller (`SubtitleStylingOverride.syntheticHeader`) so the user's
     ///   styling preferences are embedded at conversion time.
-    /// - Returns: a full ASS document. Always syntactically valid; returns
-    ///   just the header + empty Events section on catastrophic parse
-    ///   failure (never throws).
-    static func convert(vtt: String, header: String) -> String {
+    /// - Parameter hasArabicFallbackStyle: whether `header` contains the
+    ///   script-aware `ArabicFallback` style.
+    /// - Returns: the full ASS document, whether any emitted Dialogue
+    ///   selected `ArabicFallback`, and whether any cue contained Arabic.
+    ///   The document is always syntactically valid; catastrophic parse
+    ///   failure produces just the header and empty Events section
+    ///   (never throws).
+    static func convert(
+        vtt: String,
+        header: String,
+        hasArabicFallbackStyle: Bool
+    ) -> ConversionResult {
         var out = header
+        var usedArabicFallbackStyle = false
+        var containsArabicCues = false
         if !out.hasSuffix("\n") { out.append("\n") }
 
         // Normalise line endings so the scanner only has to handle `\n`.
@@ -106,12 +129,25 @@ enum VTTToASSConverter {
 
             let startTs = assTimestamp(millis: startMs)
             let endTs = assTimestamp(millis: endMs)
+            // Classify every cue regardless of header contents: the session
+            // needs `containsArabicCues` even when no fallback style exists.
+            let cueHasArabic = SubtitleScriptFont.containsArabicLetters(cueText)
+            if cueHasArabic { containsArabicCues = true }
+            let usesArabicFallback = hasArabicFallbackStyle && cueHasArabic
+            if usesArabicFallback {
+                usedArabicFallbackStyle = true
+            }
+            let style = usesArabicFallback ? "ArabicFallback" : "Default"
             // ASS Dialogue format:
             //   Dialogue: Layer,Start,End,Style,Name,MarginL,MarginR,MarginV,Effect,Text
-            out.append("Dialogue: 0,\(startTs),\(endTs),Default,,0,0,0,,\(cueText)\n")
+            out.append("Dialogue: 0,\(startTs),\(endTs),\(style),,0,0,0,,\(cueText)\n")
         }
 
-        return out
+        return ConversionResult(
+            assDocument: out,
+            usedArabicFallbackStyle: usedArabicFallbackStyle,
+            containsArabicCues: containsArabicCues
+        )
     }
 
     // MARK: - Block classification


### PR DESCRIPTION
Fixes #148 — two subtitle appearance defects reported by a user (internal Discord thread).

## What changed

### 1. Outline thickness
- `SubtitleStylingOverride.Parameters.effectiveBorderSize` dropped from `max(2, min(4, fontSize * 0.08))` to a shared `outlineSize(for:)` = `max(1, min(2, fontSize * 0.03))` — at the iOS default size (48) that's 1.44 instead of 3.84, in line with the renderer's normal 0.5-edge baseline instead of ~8x it.
- The device-caption uniform-edge compositor path picks up the same value automatically.
- `SubtitleAppearancePreview` now feeds the **unscaled playfield size** through the same shared formula and scales the result into preview space, so the preview finally tracks playback across the whole size ladder (previously the clamp floor flattened it to a constant, too-thick edge).

### 2. Arabic text ignoring the chosen font
Converted VTT/SRT tracks emitted every cue in the user's chosen face; Latin-only faces have no Arabic glyphs, so CoreText substituted a system face per glyph run and the selection appeared dead for Arabic.

- New `SubtitleScriptFont` helper: detects Arabic-bearing cues (ASS override-tag aware, robust to unbalanced literal braces from the `&#123;` entity path) and resolves an Arabic-capable companion family for the chosen one — verified via an actual CoreText coverage check, mapped by category (serif → Damascus, otherwise Geeza Pro), with a safe fall-through when the platform lacks the mapped face (e.g. Damascus doesn't exist on tvOS; CoreText's silent Helvetica substitution is caught and Geeza Pro used instead).
- `SubtitleStylingOverride.syntheticHeader` emits an `ArabicFallback` companion style when the resolved family differs; `VTTToASSConverter` routes Arabic-bearing cues to it.
- The libass renderer-wide `FONT_NAME` override is suppressed **only** for tracks that actually used the fallback style, so Latin-only tracks keep live mid-playback font switching exactly as before.
- Mid-playback font changes regenerate installed Arabic-bearing sidecar tracks from the in-memory cache (no refetch), guarded by a per-slot generation counter so a reinstall racing a close/track-switch can't resurrect a track the user just turned off.

Empirical note from simulator probing (iOS/tvOS 26.4): Arial and Times New Roman report native Arabic coverage on Apple platforms, so for those faces the coverage check keeps the chosen family and its own Arabic glyphs render (consistent styling). The dedicated fallback engages for Menlo and any non-covering system family. If the reporter's complaint under the default face persists on-device, forcing the category mapping regardless of self-coverage is a one-line follow-up in `SubtitleScriptFont.mappedArabicFamily`.

## Verification
- `xcodegen generate` + `Silo` (iPhone 17 Pro sim), `SiloTV` (Apple TV sim), and `SiloMac` (macOS) builds all pass with `CODE_SIGNING_ALLOWED=NO`.
- Font-coverage behavior validated by compiling and running a CoreText probe on booted iOS/tvOS 26.4 simulators.
- On-device visual validation (outline weight, Arabic rendering with each font preset, mid-playback font switching on an Arabic track) still pending — screenshots from the reporter's scenario would close the loop.

## AI disclosure
Implementation was drafted by OpenAI Codex (gpt-5.6-sol) and revised by Claude Opus agents; reviewed, verified, and committed by Claude Fable 5 under human direction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Arabic subtitle rendering with automatic font selection and script-specific font support.
  * Arabic subtitle cues now use appropriate fallback styling when needed.
  * Cached subtitle files can be reprocessed after font changes without being downloaded again.

* **Bug Fixes**
  * Corrected subtitle outline sizing in appearance previews.
  * Improved subtitle replacement, live-track, and slot-switching behavior.
  * Prevented outdated subtitle conversions from being applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->