### PR TITLE
feat(player): show subtitle search as unavailable when unconfigured

### DIFF
--- a/iosApp/Tests/AIModelDecodingTests.swift
+++ b/iosApp/Tests/AIModelDecodingTests.swift
@@ -214,6 +214,58 @@ final class AIModelDecodingTests: XCTestCase {
         XCTAssertTrue(empty.onView == .off)
     }
 
+    // MARK: - Subtitle provider status (fail-OPEN, unlike every other status)
+
+    /// The full server shape, feature on.
+    func testSubtitleProvidersStatusEnabled() {
+        let status = decode(SubtitleProvidersStatus.self, """
+        {
+          "schema_version": 1,
+          "enabled": true,
+          "providers": ["opensubtitles", "subdl"]
+        }
+        """)
+        XCTAssertTrue(status.enabled)
+        XCTAssertTrue(status.providers == ["opensubtitles", "subdl"])
+    }
+
+    /// Only an affirmative `false` may disable the entry point.
+    func testSubtitleProvidersStatusExplicitlyDisabled() {
+        let status = decode(SubtitleProvidersStatus.self, """
+        { "schema_version": 1, "enabled": false, "providers": [] }
+        """)
+        XCTAssertFalse(status.enabled)
+        XCTAssertTrue(status.providers.isEmpty)
+    }
+
+    /// **The load-bearing case.** Unlike `SubtitleAIStatus` / `MetadataAIStatus`
+    /// — where an omitted `enabled` means "off" — this model must default to
+    /// `true`. Subtitle provider search shipped long before its status
+    /// endpoint, so a server answering without the key (or an older one whose
+    /// 404 the store also reads as "assume enabled") still has working search.
+    /// Flipping this default to `false` would disable the feature on every
+    /// server that hasn't updated yet, which is precisely the regression this
+    /// probe exists to avoid.
+    func testSubtitleProvidersStatusOmittedDefaultsEnabled() {
+        let status = decode(SubtitleProvidersStatus.self, "{}")
+        XCTAssertTrue(status.enabled)
+        XCTAssertTrue(status.providers.isEmpty)
+    }
+
+    /// A partial body (providers listed, `enabled` absent) also fails open,
+    /// and an absent `providers` list is not an error.
+    func testSubtitleProvidersStatusPartialBodyFailsOpen() {
+        let providersOnly = decode(SubtitleProvidersStatus.self, """
+        { "providers": ["opensubtitles"] }
+        """)
+        XCTAssertTrue(providersOnly.enabled)
+
+        let enabledOnly = decode(SubtitleProvidersStatus.self, """
+        { "enabled": true }
+        """)
+        XCTAssertTrue(enabledOnly.providers.isEmpty)
+    }
+
     // MARK: - Downloaded subtitles (handoff source)
 
     /// Decodes the REAL server shape (`internal/subtitles.DownloadedSubtitle`):

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -175,6 +175,7 @@ struct ContentView: View {
                 // failure-tolerant, so double-calling with `selectProfile` is safe.
                 await AICapabilities.shared.refresh()
                 await RequestsFeatureStore.shared.refresh()
+                await SubtitleProvidersStore.shared.refresh()
                 await uiCustomization.refresh()
                 #if os(iOS)
                 await ApplePushRegistrationCoordinator.shared.prepareForAuthenticatedProfile()
@@ -285,6 +286,7 @@ struct ContentView: View {
             // happy path costs nothing.
             Task { await AICapabilities.shared.refresh() }
             Task { await RequestsFeatureStore.shared.refresh() }
+            Task { await SubtitleProvidersStore.shared.refresh() }
             Task { await uiCustomization.refresh() }
             #if os(iOS)
             Task {

--- a/iosApp/iosApp/Control/tvOS/RemotePlaybackIdentityManager.swift
+++ b/iosApp/iosApp/Control/tvOS/RemotePlaybackIdentityManager.swift
@@ -246,7 +246,12 @@ final class RemotePlaybackIdentityManager {
         }
         activeIdentity = nil
         AuthService.shared.clearCachesForTemporaryIdentityChange()
-        return await releaseIdentityTransition(transitionLease, returning: true)
+        let ended = await releaseIdentityTransition(transitionLease, returning: true)
+        // The persistent scope owns the credential slot again and the gate is
+        // open, so this probes the restored identity. See the helper for why
+        // it can't be folded into `clearCachesForTemporaryIdentityChange()`.
+        refreshSubtitleProvidersAfterIdentityChange()
+        return ended
     }
 
     private func activate(
@@ -297,7 +302,11 @@ final class RemotePlaybackIdentityManager {
                 activationGenerationPending = nil
             }
             AuthService.shared.clearCachesForTemporaryIdentityChange()
-            return await releaseIdentityTransition(transitionLease, returning: false)
+            let rolledBack = await releaseIdentityTransition(transitionLease, returning: false)
+            // Rollback restored (or cleared) the previous scope above, so the
+            // identity that is live now is whatever `activeIdentity` reflects.
+            refreshSubtitleProvidersAfterIdentityChange()
+            return rolledBack
         }
         activeIdentity = ActiveIdentity(
             generationID: generationID,
@@ -312,7 +321,44 @@ final class RemotePlaybackIdentityManager {
             sessionExpiresAt: scope.expiresAt
         )
         activationGenerationPending = nil
-        return await releaseIdentityTransition(transitionLease, returning: true)
+        let activated = await releaseIdentityTransition(transitionLease, returning: true)
+        // Only now — identity published, pending marker cleared, gate open —
+        // does a request carry the temporary scope's credentials. Probing any
+        // earlier (e.g. at the `clearCachesForTemporaryIdentityChange()` call
+        // above, which runs *before* `beginTemporaryScope`) would answer for
+        // the outgoing identity and cache that answer against the new one.
+        refreshSubtitleProvidersAfterIdentityChange()
+        return activated
+    }
+
+    /// Re-probe the subtitle-provider capability after a temporary-identity
+    /// transition settles.
+    ///
+    /// Needed because `clearCachesForTemporaryIdentityChange()` calls
+    /// `SubtitleProvidersStore.reset()`, and that store fails *open*: reset
+    /// restores `isAvailable = true`. So an affirmative "no providers here"
+    /// learned about the current server is thrown away on every handoff, and
+    /// — unlike sign-in — a temporary-identity swap changes no auth state, so
+    /// no other probe fires. Without this the "Search Subtitles…" row silently
+    /// re-enables and can run the empty 20–30s search this gate exists to
+    /// prevent.
+    ///
+    /// Same shape as `ServerRegistry.refreshFeaturesAfterServerSwitch()`,
+    /// which re-probes after a switch between already-signed-in servers for
+    /// exactly this reason.
+    ///
+    /// Deliberately *not* called from every
+    /// `clearCachesForTemporaryIdentityChange()` site: two of the three run
+    /// while the scope is mid-swap (before `beginTemporaryScope`), where a
+    /// probe would be answered by the outgoing identity. Each call site below
+    /// instead fires this once its scope is fully installed or restored and
+    /// the HTTP identity-transition lease has been released, so the request
+    /// isn't gated shut either. Fire-and-forget: any failure leaves the
+    /// optimistic `true` in place, which is the fail-open contract — including
+    /// the case where a queued transition takes the lease first and blocks
+    /// this probe, since that transition fires its own once it settles.
+    private func refreshSubtitleProvidersAfterIdentityChange() {
+        Task { await SubtitleProvidersStore.shared.refresh() }
     }
 
     private func releaseIdentityTransition(

--- a/iosApp/iosApp/Networking/AIModels.swift
+++ b/iosApp/iosApp/Networking/AIModels.swift
@@ -105,6 +105,31 @@ struct SubtitleAIStatus: Codable {
     }
 }
 
+/// `GET /api/v1/subtitles/providers/status`. Whether the server has any
+/// external subtitle providers (OpenSubtitles / SubDL / Subsource)
+/// configured, so the client can disable the in-player "Search Subtitles…"
+/// entry point instead of running a fan-out search that can only return
+/// nothing.
+///
+/// **The decoder defaults `enabled` to `true`, not `false`** — unlike every
+/// other status model in this file. Subtitle search shipped long before this
+/// endpoint did, so anything short of an affirmative "no providers" must
+/// leave the feature usable or every not-yet-updated server regresses. Same
+/// rule as ``SubtitleProvidersStore``, which owns the full rationale.
+///
+/// `providers` is informational (the configured provider ids); nothing gates
+/// on it today.
+struct SubtitleProvidersStatus: Codable {
+    let enabled: Bool
+    let providers: [String]
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        enabled = try c.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
+        providers = try c.decodeIfPresent([String].self, forKey: .providers) ?? []
+    }
+}
+
 /// `GET /api/v1/subtitles/ai/quota`. The per-user ASR allowance. When
 /// `limited` is false the remaining fields are typically absent and the
 /// feature is effectively unmetered.

--- a/iosApp/iosApp/Networking/ContinuumAI.swift
+++ b/iosApp/iosApp/Networking/ContinuumAI.swift
@@ -85,6 +85,18 @@ actor ContinuumAI {
 
     // MARK: - Subtitle provider search
 
+    /// Whether the server has any external subtitle providers configured.
+    ///
+    /// Available to any authenticated user, and answered `200` by every
+    /// server that implements it (there is a fallback registration so it
+    /// never 404s on an instance where the feature is unwired). Servers
+    /// that predate the endpoint DO 404 — and those have working search, so
+    /// the caller must treat a thrown error as "assume enabled". See
+    /// ``SubtitleProvidersStore`` for that fail-open contract.
+    func subtitleProvidersStatus() async throws -> SubtitleProvidersStatus {
+        try await http.get("/api/v1/subtitles/providers/status")
+    }
+
     /// Synchronous fan-out search across the server's configured external
     /// subtitle providers. Can legitimately take 20–30s (per-provider
     /// timeouts), so it opts out of the fail-fast timeout via `.extended`.

--- a/iosApp/iosApp/Networking/ServerRegistry.swift
+++ b/iosApp/iosApp/Networking/ServerRegistry.swift
@@ -383,6 +383,7 @@ final class ServerRegistry {
         await MainActor.run {
             AICapabilities.shared.reset()
             RequestsFeatureStore.shared.reset()
+            SubtitleProvidersStore.shared.reset()
             RequestsEventBus.shared.reset()
             // Re-probe against the just-activated server: a switch between
             // signed-in servers can keep authState at .authenticated, so
@@ -390,6 +391,10 @@ final class ServerRegistry {
             // until the next foreground. Fire-and-forget — the probe
             // degrades to disabled on any failure.
             Task { await RequestsFeatureStore.shared.refresh() }
+            // Same reason, opposite default: the reset above restored
+            // "available", so this re-probe is what *dims* the search row on
+            // a destination server that has no providers configured.
+            Task { await SubtitleProvidersStore.shared.refresh() }
         }
     }
 
@@ -537,11 +542,13 @@ final class ServerRegistry {
             await MainActor.run {
                 AICapabilities.shared.reset()
                 RequestsFeatureStore.shared.reset()
+                SubtitleProvidersStore.shared.reset()
                 RequestsEventBus.shared.reset()
                 // Same rationale as `switchTo`: the fallback server may
                 // already be signed in, with no auth-state change to
                 // trigger the usual probe.
                 Task { await RequestsFeatureStore.shared.refresh() }
+                Task { await SubtitleProvidersStore.shared.refresh() }
             }
         }
         return true

--- a/iosApp/iosApp/Networking/SubtitleProvidersStore.swift
+++ b/iosApp/iosApp/Networking/SubtitleProvidersStore.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+/// Cached holder for whether the server has any external subtitle providers
+/// configured (`GET /api/v1/subtitles/providers/status`), used to render the
+/// in-player "Search Subtitles…" entry point as *disabled with a reason*
+/// rather than letting it run a search that can only ever come back empty.
+///
+/// Without this probe, a server with no providers wired up answers
+/// `POST /api/v1/subtitles/search` with `200 {"results": null}` — so the user
+/// picks a language, waits out the 20–30s provider fan-out timeout, and gets
+/// "No subtitles found for English.", which is indistinguishable from a real
+/// empty result. That has already been reported as a broken feature when it
+/// was only ever an unconfigured one.
+///
+/// Structurally this follows the ``AICapabilities`` / ``RequestsFeatureStore``
+/// precedent: a `@MainActor` `@Observable` singleton, probed once per session,
+/// reset on sign-out and profile/server switch, with a `generation` counter so
+/// a probe that lands after a switch discards its result instead of
+/// repopulating the next account's flag.
+///
+/// ## It FAILS OPEN — deliberately inverting the sibling stores' convention
+///
+/// `AICapabilities` and `RequestsFeatureStore` both treat a probe failure as
+/// "feature off": a 404 there means an older server that genuinely lacks the
+/// feature, so hiding the entry point is correct.
+///
+/// **This store must do the opposite.** Subtitle provider search shipped long
+/// before its status endpoint did, so every server that predates the endpoint
+/// 404s here while having a perfectly working search. Defaulting to disabled
+/// would regress all of them at once. Therefore:
+///
+///   - ``isAvailable`` starts `true`, before any probe has run.
+///   - A 404, a network error, a decode failure — anything short of an
+///     affirmative answer — leaves it `true`.
+///   - Only an explicit `{"enabled": false}` from a server that *does*
+///     implement the endpoint may turn the entry point off.
+///
+/// The wire model (``SubtitleProvidersStatus``) carries the same bias: a
+/// missing `enabled` key decodes to `true`, not `false`.
+///
+/// Reset + refresh hooks live in `AuthService`/`ServerRegistry`/`ContentView`
+/// next to the existing `AICapabilities` calls.
+@MainActor
+@Observable
+final class SubtitleProvidersStore {
+    static let shared = SubtitleProvidersStore()
+
+    /// Whether the "Search Subtitles…" entry point should be *enabled*.
+    ///
+    /// Starts `true` and only ever goes `false` on an affirmative
+    /// `{"enabled": false}` — see the fail-open rationale in the type doc.
+    /// The optimistic default also means there is no visible flicker during
+    /// the startup probe: the row is enabled, and at worst it dims a moment
+    /// later on a server that really has no providers.
+    private(set) var isAvailable = true
+
+    /// Bumped on every `reset()` so a probe that finishes after a sign-out
+    /// or profile switch discards its result instead of repopulating the
+    /// next account's flag.
+    private var generation = 0
+
+    private let api: ContinuumAI
+
+    init(api: ContinuumAI = .shared) {
+        self.api = api
+    }
+
+    func refresh() async {
+        let gen = generation
+        let status = try? await api.subtitleProvidersStatus()
+        guard gen == generation else { return }
+        guard let status else {
+            // Fail open. A thrown error here is overwhelmingly likely to be a
+            // 404 from a server that predates the endpoint (where search
+            // works fine), or a transient network blip. Neither is evidence
+            // that providers are unconfigured, so leave the previous value —
+            // which, absent an affirmative answer, is `true`.
+            return
+        }
+        isAvailable = status.enabled
+    }
+
+    /// Drop the cached probe on sign-out and profile/server switch.
+    ///
+    /// Note the restore value is `true`, **not** `false` as in the sibling
+    /// stores: the next server is presumed capable until it says otherwise,
+    /// for the same reason the initial value is `true`. Resetting to `false`
+    /// would leave the row disabled on every older server between the switch
+    /// and the (never-succeeding) probe.
+    func reset() {
+        generation &+= 1
+        isAvailable = true
+    }
+}

--- a/iosApp/iosApp/Screens/Auth/AuthService.swift
+++ b/iosApp/iosApp/Screens/Auth/AuthService.swift
@@ -297,6 +297,10 @@ final class AuthService: @unchecked Sendable {
         Task { @MainActor in
             await AICapabilities.shared.refresh()
             await RequestsFeatureStore.shared.refresh()
+            // Unlike the two above, this one gates *enablement* of an entry
+            // point that stays visible either way, and it defaults to
+            // available — so a slow or failing probe never hides anything.
+            await SubtitleProvidersStore.shared.refresh()
         }
     }
 
@@ -589,6 +593,7 @@ final class AuthService: @unchecked Sendable {
         // profile switch; `selectProfile` re-fetches after the switch lands.
         AICapabilities.shared.reset()
         RequestsFeatureStore.shared.reset()
+        SubtitleProvidersStore.shared.reset()
         RequestsEventBus.shared.reset()
         #if os(tvOS)
         ItemDetailCache.shared.clearAll()
@@ -750,6 +755,7 @@ final class AuthService: @unchecked Sendable {
         ProfilePrefsStore.shared.clear()
         AICapabilities.shared.reset()
         RequestsFeatureStore.shared.reset()
+        SubtitleProvidersStore.shared.reset()
         RequestsEventBus.shared.reset()
         #if os(tvOS)
         ItemDetailCache.shared.clearAll()

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -5833,15 +5833,47 @@ class PlayerViewModel {
 
     // MARK: - Subtitle provider search (synchronous, no job machinery)
 
-    /// Whether in-player subtitle search is available: an active playback
-    /// session (the synthesized stream URL is session-scoped), a known media
-    /// file, and a backend that can host downloaded sidecars. False for
-    /// offline/local playback. Gates the "Search Subtitles…" entry row.
+    /// **Visibility** predicate for the "Search Subtitles…" entry row: an
+    /// active playback session (the synthesized stream URL is session-scoped),
+    /// a known media file, and a backend that can host downloaded sidecars.
+    /// False for offline/local playback, where the row is meaningless and is
+    /// hidden outright.
+    ///
+    /// This is the client-side half of the gate — it says nothing about
+    /// whether the *server* can actually service a search. See
+    /// ``subtitleSearchEnabled``.
     @MainActor
-    var subtitleSearchAvailable: Bool {
+    var subtitleSearchVisible: Bool {
         activePlaybackSessionId != nil
             && currentSelectedVersion?.fileId != nil
             && backendCapabilities.supportsExternalPrimarySubtitles
+    }
+
+    /// **Enablement** predicate: visible *and* the server actually has
+    /// external subtitle providers configured.
+    ///
+    /// The split exists because a server with no providers answers the search
+    /// endpoint `200 {"results": null}` — so without this the user picks a
+    /// language, waits out the 20–30s provider fan-out, and gets "No subtitles
+    /// found", which reads as a broken feature rather than an unconfigured
+    /// one. The row instead renders disabled with
+    /// ``subtitleSearchUnavailableReason``.
+    ///
+    /// ``SubtitleProvidersStore/isAvailable`` fails **open**: older servers
+    /// that 404 the provider-status probe keep a fully enabled row.
+    @MainActor
+    var subtitleSearchEnabled: Bool {
+        subtitleSearchVisible && SubtitleProvidersStore.shared.isAvailable
+    }
+
+    /// Why the visible "Search Subtitles…" row is disabled, or `nil` when it
+    /// is enabled (or not shown at all). Rendered in the row's value slot on
+    /// tvOS and as the menu-item subtitle on iOS, so the disabled state is
+    /// self-explaining rather than a mystery grey row.
+    @MainActor
+    var subtitleSearchUnavailableReason: String? {
+        guard subtitleSearchVisible, !subtitleSearchEnabled else { return nil }
+        return "Not set up on this server"
     }
 
     /// Run a provider search for the current media file. Synchronous on the

--- a/iosApp/iosApp/Screens/Player/Sheets/SubtitleSearchMenu.swift
+++ b/iosApp/iosApp/Screens/Player/Sheets/SubtitleSearchMenu.swift
@@ -10,9 +10,15 @@
 //  and auto-selects with no session restart (the same sidecar handoff the AI
 //  flow uses; see `PlayerViewModel.downloadSearchedSubtitle`).
 //
-//  Presented from ``TrackSelectionSheet`` next to the "AI Subtitles…" entry
-//  and gated on ``PlayerViewModel/subtitleSearchAvailable`` (needs an active
-//  server session — hidden for offline/local playback).
+//  Presented next to the "AI Subtitles…" entry — from the Audio & Subtitles
+//  menu in ``MobilePlayerControls`` (iOS) and the Subtitles pane's options
+//  column in ``TVPlayerInfoHUD`` (tvOS).
+//  The entry row is shown per ``PlayerViewModel/subtitleSearchVisible`` (needs
+//  an active server session — hidden for offline/local playback) and is only
+//  actionable per ``PlayerViewModel/subtitleSearchEnabled``, which additionally
+//  requires the server to have external providers configured; otherwise the row
+//  renders disabled with ``PlayerViewModel/subtitleSearchUnavailableReason``
+//  rather than running a search that can only come back empty.
 //
 //  Two-platform split mirrors ``SubtitleTranslateMenu``: iOS renders a
 //  sectioned `List` in a sheet; tvOS renders a centered floating panel with a

--- a/iosApp/iosApp/Screens/Player/Sheets/SubtitleSearchMenu.swift
+++ b/iosApp/iosApp/Screens/Player/Sheets/SubtitleSearchMenu.swift
@@ -81,6 +81,29 @@ struct SubtitleSearchMenu: View {
     }
 
     var body: some View {
+        platformBody
+            // The provider probe is async and fails open, so this menu can
+            // already be on screen when the server's "no providers configured"
+            // answer lands — the entry row's `.disabled(...)` only gates
+            // *opening* it. Catch the flip here so an idle language list stops
+            // inviting a search that can't work; `search(language:)` guards the
+            // action itself for the narrower race where the pick beats this.
+            //
+            // Keyed on the reason rather than `subtitleSearchEnabled` because
+            // the reason is non-nil for exactly the unconfigured-provider case:
+            // the *visibility* half of that predicate also drops when the
+            // playback session momentarily has no id, and hijacking the menu
+            // for that would be a false positive.
+            .onChange(of: viewModel.subtitleSearchUnavailableReason) { _, _ in
+                reflectUnavailabilityIfIdle()
+            }
+            // Covers the sliver where the probe lands between the row's tap
+            // and this view appearing, which `onChange` would never see.
+            .onAppear { reflectUnavailabilityIfIdle() }
+    }
+
+    @ViewBuilder
+    private var platformBody: some View {
         #if os(tvOS)
         tvOSPanel
         #else
@@ -146,10 +169,49 @@ struct SubtitleSearchMenu: View {
 
     // MARK: - Actions
 
+    /// Terminal copy for a search the server can't service. Reuses the entry
+    /// row's own string so the two surfaces can't drift. The fallback covers
+    /// only the case where the *visibility* half of the gate dropped too (the
+    /// playback session went away under an open sheet), which nils the reason
+    /// while leaving search just as unrunnable.
+    private var unavailableMessage: String {
+        viewModel.subtitleSearchUnavailableReason ?? "Subtitle search isn't available right now."
+    }
+
+    /// Show the unavailable state if the server has since told us it has no
+    /// providers. Only rewrites an *idle* language list: an in-flight search
+    /// or a result list the user is reading is left alone, since yanking
+    /// either away mid-read is more disruptive than the stale state — and
+    /// `search(language:)` guards the action, so nothing new can be launched
+    /// from them either.
+    private func reflectUnavailabilityIfIdle() {
+        guard phase == .picking,
+              let reason = viewModel.subtitleSearchUnavailableReason else { return }
+        searchedLanguage = nil
+        phase = .failed(reason)
+    }
+
     /// Selecting a language IS the search trigger (one-tap, like the AI
     /// menu routes on language pick) — no separate Search button.
     private func search(language: String) {
         guard downloadingId == nil, phase != .searching else { return }
+        // The entry row's `.disabled(...)` gates opening this menu, not acting
+        // inside it: `SubtitleProvidersStore` fails open, so the sheet can be
+        // presented before the probe returns `{"enabled": false}`. Without
+        // this the pick would still start the provider fan-out and deliver the
+        // 20–30s empty search this feature exists to avoid. Route it to the
+        // menu's existing terminal failure state instead of silently ignoring
+        // the press, which on both platforms would read as a dead row.
+        //
+        // `searchedLanguage` stays nil deliberately: it is what makes the
+        // failure panel offer "Try Again", and retrying is pointless here —
+        // only "Back" applies.
+        guard viewModel.subtitleSearchEnabled else {
+            selectedLanguage = language
+            searchedLanguage = nil
+            phase = .failed(unavailableMessage)
+            return
+        }
         selectedLanguage = language
         searchedLanguage = language
         phase = .searching

--- a/iosApp/iosApp/Screens/Player/iOS/MobilePlayerControls.swift
+++ b/iosApp/iosApp/Screens/Player/iOS/MobilePlayerControls.swift
@@ -512,7 +512,17 @@ struct MobilePlayerControls: View {
     }
 
     private func actionRowContent(style: ActionRowStyle) -> some View {
-        let noTracks = viewModel.audioTracks.isEmpty && viewModel.subtitleTracks.isEmpty
+        // The Audio & Subtitles pill is only inert when the menu would have
+        // nothing at all in it. A track-less file can still offer subtitle
+        // search (and the explanation when search isn't configured), so those
+        // entry points keep the menu open. This also closes a pre-existing
+        // reachability gap: before, a file with no audio and no subtitle
+        // tracks disabled the pill outright, making subtitle search — the one
+        // feature that could fix exactly that file — impossible to reach.
+        let noTracks = viewModel.audioTracks.isEmpty
+            && viewModel.subtitleTracks.isEmpty
+            && !viewModel.subtitleSearchVisible
+            && !aiSubtitlesAvailable
         return HStack(spacing: 8) {
             qualityMenu(compact: style != .full)
 
@@ -677,7 +687,11 @@ struct MobilePlayerControls: View {
                     secondarySubtitlesSubmenu
                 }
             }
-            if aiSubtitlesAvailable || viewModel.subtitleSearchAvailable {
+            // The search term is the VISIBLE predicate, not the enabled one:
+            // the disabled row and its explanation live inside this section,
+            // so gating the section on enablement would hide the very thing
+            // that tells the user why search isn't offered.
+            if aiSubtitlesAvailable || viewModel.subtitleSearchVisible {
                 Section {
                     if aiSubtitlesAvailable {
                         Button {
@@ -686,12 +700,26 @@ struct MobilePlayerControls: View {
                             Label("AI Subtitles…", systemImage: "sparkles")
                         }
                     }
-                    if viewModel.subtitleSearchAvailable {
+                    if viewModel.subtitleSearchVisible {
                         Button {
                             activeSheet = .subtitleSearch
                         } label: {
-                            Label("Search Subtitles…", systemImage: "magnifyingglass")
+                            // Closure form so the reason can ride along as a
+                            // second `Text` — UIKit renders it as the menu
+                            // item's subtitle, the same pattern `trackMenuRow`
+                            // uses for track attributes. `.disabled` greys the
+                            // item natively via
+                            // `UIMenuElement.Attributes.disabled`.
+                            Label {
+                                Text("Search Subtitles…")
+                                if let reason = viewModel.subtitleSearchUnavailableReason {
+                                    Text(reason)
+                                }
+                            } icon: {
+                                Image(systemName: "magnifyingglass")
+                            }
                         }
+                        .disabled(!viewModel.subtitleSearchEnabled)
                     }
                 }
             }

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPlayerInfoHUD.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPlayerInfoHUD.swift
@@ -81,15 +81,33 @@ struct TVPlayerInfoHUD: View {
             Spacer(minLength: 0)
         }
         .onAppear {
-            if !availableTabs.contains(activeTab), let first = availableTabs.first {
-                activeTab = first
-            }
+            repairActiveTabIfUnavailable()
             // If the parent didn't seed focus (edge case on re-present), at
             // least make sure focus lands on the active tab so Menu has a
             // handler to bubble to.
             if focusedTab == nil {
                 focusedTab = activeTab
             }
+        }
+        // The tab set is not static for the lifetime of the HUD: the subtitle
+        // provider probe is async and fails open, so on a track-less,
+        // non-AI session the Subtitles tab starts present (optimistic
+        // `isAvailable`) and can drop out mid-session when the server answers
+        // "no providers". If that happens while Subtitles is the active tab,
+        // repairing only in `onAppear` would leave the panel rendering a pane
+        // whose pill — and whose focus owner — no longer exists, which on
+        // tvOS means focus can land nowhere at all (docs/tvos-focus.md).
+        //
+        // Repair-on-change rather than pinning `activeTab` into
+        // `availableTabs`: keeping the active tab mounted unconditionally
+        // would make the tab set depend on state this handler writes (a
+        // derived-state feedback loop, the hazard this codebase has been
+        // bitten by), it would defeat the `onAppear` repair entirely, and
+        // because `TVPlayerControls` remembers `activeHUDTab` across HUD
+        // presentations it would strand a Subtitles pill holding nothing but
+        // a greyed-out row for the rest of the session.
+        .onChange(of: availableTabs) { _, _ in
+            repairActiveTabIfUnavailable()
         }
         .onChange(of: activeTab) { _, _ in
             readOnlyPaneIsAtTop = true
@@ -169,6 +187,26 @@ struct TVPlayerInfoHUD: View {
 
     private var isReadOnlyPaneScrolled: Bool {
         (activeTab == .info || activeTab == .stats) && !readOnlyPaneIsAtTop
+    }
+
+    /// Move off a tab that is no longer in `availableTabs`, taking focus with
+    /// it. Run on appear (a remembered `activeHUDTab` may not apply to this
+    /// stream) and whenever the tab set changes underneath us.
+    ///
+    /// Focus is reseeded, not just the selection: whatever owned focus — the
+    /// vanished pill, or a row inside the pane it selected — is leaving the
+    /// hierarchy in this same update, and a tvOS view with no reachable focus
+    /// target also has nothing for Menu to bubble `onExitCommand` from, which
+    /// strands the user in the HUD. `.defaultFocus` only seeds on first
+    /// appearance of the focus scope, so it cannot cover this.
+    ///
+    /// `availableTabs` always contains `.info`, so `first` is effectively
+    /// non-nil; it stays optional to keep this honest if that ever changes.
+    private func repairActiveTabIfUnavailable() {
+        guard !availableTabs.contains(activeTab),
+              let first = availableTabs.first else { return }
+        activeTab = first
+        focusedTab = first
     }
 
     /// Used by the composite Info/Stats panes when Up is pressed at the top
@@ -1655,13 +1693,19 @@ private struct SubtitlesPane: View {
         focusedOption = .translate
     }
 
-    /// Restoring focus to `.search` stays correct now that the row has a
-    /// disabled variant with no `.focused(...)` binding: the only way to open
-    /// this menu is the *enabled* row's action, so whenever this runs the
-    /// focusable row is the one on screen.
+    /// Restore focus to the "Search Subtitles…" row — unless the provider
+    /// probe answered "unavailable" while the menu was open, which swaps that
+    /// row for the disabled variant that carries no `.focused(...)` binding.
+    /// Returning focus to an unreachable target would leave the pane with
+    /// nothing focused, so fall back to the Tracks column's "Off" row, which
+    /// is always present (docs/tvos-focus.md).
     private func closeSubtitleSearchMenu() {
         showSubtitleSearchMenu = false
-        focusedOption = .search
+        if viewModel.subtitleSearchEnabled {
+            focusedOption = .search
+        } else {
+            entryTrackFocused = true
+        }
     }
 
     /// Whether the server's AI capabilities + the current track list offer any

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPlayerInfoHUD.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPlayerInfoHUD.swift
@@ -46,18 +46,26 @@ struct TVPlayerInfoHUD: View {
     /// Audio / Subtitles / Chapters disappear when the stream has none of
     /// those — Infuse hides rather than disables, which keeps the bar tidy.
     ///
-    /// Subtitles also appear when the stream has *no* tracks but the server's
-    /// AI can produce them (ASR transcription, or translating an existing text
-    /// track). Without this, a file with no subtitles would hide the Subtitles
-    /// tab entirely — and with it the only entry point to "AI Subtitles…",
-    /// which is exactly the case where transcription is most useful. Uses the
-    /// same `hasActionableSource` probe the pane gates its AI row on.
+    /// Subtitles also appear when the stream has *no* tracks but the server
+    /// can still produce them: AI (ASR transcription, or translating an
+    /// existing text track), or a provider search. Without this, a file with
+    /// no subtitles would hide the Subtitles tab entirely — and with it the
+    /// only entry point to "AI Subtitles…" / "Search Subtitles…", which is
+    /// exactly the case where they are most useful. Uses the same
+    /// `hasActionableSource` probe the pane gates its AI row on.
+    ///
+    /// The search term is deliberately the **enabled** predicate, not the
+    /// visible one: a row that can't be acted on must never be the sole
+    /// reason its tab exists, or a track-less file on a server with no
+    /// providers would open a Subtitles tab containing one greyed-out row.
+    /// When the tab is present for another reason, the disabled row still
+    /// renders inside it and explains itself.
     private var availableTabs: [Tab] {
         var tabs: [Tab] = [.info, .stats, .video]
         if !viewModel.audioTracks.isEmpty { tabs.append(.audio) }
         if !viewModel.subtitleTracks.isEmpty
             || SubtitleTranslateMenu.hasActionableSource(viewModel)
-            || viewModel.subtitleSearchAvailable {
+            || viewModel.subtitleSearchEnabled {
             tabs.append(.subtitles)
         }
         if !viewModel.chapters.isEmpty { tabs.append(.chapters) }
@@ -431,6 +439,10 @@ private struct HUDRowButtonBody: View {
 private struct HUDSettingRow: View {
     let label: String
     let value: String
+    /// Optional secondary line under the label. Used to explain a disabled
+    /// row ("Not set up on this server") — the trailing `value` slot is only
+    /// ~165pt wide at 22pt semibold, which truncates any real sentence.
+    var detail: String? = nil
     var colorHex: String? = nil
     var systemImage: String? = nil
     let action: () -> Void
@@ -440,6 +452,7 @@ private struct HUDSettingRow: View {
             HUDSettingRowLabel(
                 label: label,
                 value: value,
+                detail: detail,
                 colorHex: colorHex,
                 systemImage: systemImage,
                 showsChevron: true
@@ -476,6 +489,7 @@ private struct HUDToggleRow: View {
 private struct HUDSettingRowLabel: View {
     let label: String
     let value: String
+    var detail: String? = nil
     var colorHex: String? = nil
     var systemImage: String? = nil
     let showsChevron: Bool
@@ -488,9 +502,20 @@ private struct HUDSettingRowLabel: View {
                 Image(systemName: systemImage)
                     .font(.system(size: 20, weight: .semibold))
             }
-            Text(label)
-                .font(.system(size: 22, weight: .medium))
-                .lineLimit(1)
+            // Second line mirrors `HUDTrackRowLabel`'s attributes line: 17pt,
+            // dimmed, focus-inverted. Only rendered when a `detail` is given,
+            // so ordinary rows keep their exact single-line metrics.
+            VStack(alignment: .leading, spacing: 3) {
+                Text(label)
+                    .font(.system(size: 22, weight: .medium))
+                    .lineLimit(1)
+                if let detail {
+                    Text(detail)
+                        .font(.system(size: 17))
+                        .foregroundStyle(isFocused ? .black.opacity(0.62) : .white.opacity(0.55))
+                        .lineLimit(1)
+                }
+            }
             Spacer(minLength: 18)
             HStack(spacing: 10) {
                 if let colorHex {
@@ -1630,6 +1655,10 @@ private struct SubtitlesPane: View {
         focusedOption = .translate
     }
 
+    /// Restoring focus to `.search` stays correct now that the row has a
+    /// disabled variant with no `.focused(...)` binding: the only way to open
+    /// this menu is the *enabled* row's action, so whenever this runs the
+    /// focusable row is the one on screen.
     private func closeSubtitleSearchMenu() {
         showSubtitleSearchMenu = false
         focusedOption = .search
@@ -1759,16 +1788,41 @@ private struct SubtitlesPane: View {
                 .focused($focusedOption, equals: .translate)
                 .id(Option.translate)
             }
-            if viewModel.subtitleSearchAvailable {
-                HUDSettingRow(
-                    label: "Search Subtitles…",
-                    value: "",
-                    systemImage: "magnifyingglass"
-                ) {
-                    showSubtitleSearchMenu = true
+            if viewModel.subtitleSearchVisible {
+                // Two mutually-exclusive variants rather than one row with
+                // modifiers applied conditionally: a non-focusable row must
+                // not carry a `.focused(...)` binding (same idiom as
+                // `TVGeneralSettingsView.presetRow`), or the focus engine
+                // holds a binding for a target it can never reach.
+                //
+                // The disabled variant also needs the explicit `.opacity`:
+                // `HUDSettingRowLabel` derives every color from
+                // `@Environment(\.isFocused)`, so `.disabled(true)` alone
+                // would render pixel-identical to an enabled unfocused row.
+                // Same treatment `HUDTrackRow` uses for its disabled rows.
+                if let reason = viewModel.subtitleSearchUnavailableReason {
+                    HUDSettingRow(
+                        label: "Search Subtitles…",
+                        value: "",
+                        detail: reason,
+                        systemImage: "magnifyingglass",
+                        action: {}
+                    )
+                    .disabled(true)
+                    .opacity(0.35)
+                    .accessibilityHint(reason)
+                    .id(Option.search)
+                } else {
+                    HUDSettingRow(
+                        label: "Search Subtitles…",
+                        value: "",
+                        systemImage: "magnifyingglass"
+                    ) {
+                        showSubtitleSearchMenu = true
+                    }
+                    .focused($focusedOption, equals: .search)
+                    .id(Option.search)
                 }
-                .focused($focusedOption, equals: .search)
-                .id(Option.search)
             }
             if viewModel.backendCapabilities.supportsSubtitleDelay {
                 HUDSettingRow(label: "Delay", value: delayText) {


### PR DESCRIPTION
## Why

The in-player "Search Subtitles…" entry point rendered whenever there was an active playback session, regardless of whether the server could actually service a search.

On a server with no external subtitle providers configured (which is the case on production today), the search endpoint answers `200` with an empty result set. So the user picked a language, waited out the 20–30s provider fan-out, and got **"No subtitles found for English."** — indistinguishable from a genuine empty result. This was reported as a broken feature when it was only ever an unconfigured one.

## What

Gates the row on `GET /api/v1/subtitles/providers/status` (Silo-Server/silo-server#618) and renders it **disabled, with "Not set up on this server"**, instead of letting it run a query that cannot succeed.

| | Before | After |
|---|---|---|
| Providers configured | Row enabled | Row enabled (unchanged) |
| No providers | Row enabled → 30s wait → "No subtitles found" | Row greyed, "Not set up on this server" |
| Server predates the probe | Row enabled | Row enabled (unchanged) |

## ⚠️ The probe fails OPEN — please don't "fix" this

This deliberately inverts the `AICapabilities` / `RequestsFeatureStore` convention, where a 404 means "feature off".

Subtitle search shipped long before its status endpoint did, so **every server that predates the endpoint 404s here while having perfectly working search.** Defaulting to disabled would regress all of them at once. Only an affirmative `{"enabled": false}` disables the row; the wire model defaults `enabled` to `true` on a missing key.

`testSubtitleProvidersStatusOmittedDefaultsEnabled` pins this so a future consistency cleanup trips a red test rather than shipping the regression. The rationale is documented in three places (store type doc, `reset()`, wire model).

## Structure

`subtitleSearchAvailable` splits into two predicates:

- `subtitleSearchVisible` — session + file + backend capability (unchanged logic). Decides whether the row **exists**.
- `subtitleSearchEnabled` — adds the server probe. Decides whether it's **actionable**.

On tvOS the Subtitles *tab* keys off `subtitleSearchEnabled`, not visible — a disabled row must never be the sole reason its tab exists, or a track-less file on a provider-less server would open a tab containing exactly one greyed row.

## tvOS focus notes (per docs/tvos-focus.md)

Two **mutually-exclusive row variants** rather than one row with conditional modifiers: a non-focusable row must not carry a `.focused(...)` binding, or the focus engine holds a binding for a target it can never reach. Same idiom as `TVGeneralSettingsView.presetRow`.

The disabled variant also needs an explicit `.opacity(0.35)` — `HUDSettingRowLabel` derives every color from `@Environment(\.isFocused)`, so `.disabled(true)` alone renders **pixel-identical to an enabled unfocused row**. Same treatment `HUDTrackRow` already uses.

`HUDSettingRow` gained an optional `detail:` second line (17pt, mirroring `HUDTrackRowLabel`) because the trailing `value` slot is only ~165pt at 22pt semibold and truncates any real sentence.

## Drive-by fix

The iOS Audio & Subtitles pill's `noTracks` predicate now accounts for search and AI. This closes a **pre-existing** reachability gap: a file with no audio and no subtitle tracks disabled the pill outright, making subtitle search — the one feature that could fix exactly that file — impossible to reach.

macOS has no subtitle-search surface and is untouched.

## Testing

- iOS (`Silo`, iPhone 17 Pro sim) — **BUILD SUCCEEDED**
- tvOS (`SiloTV`, Apple TV 4K sim) — **BUILD SUCCEEDED**
- `AIModelDecodingTests` — 24/24 pass, incl. 4 new fail-open decoder cases

**Not yet validated against a live provider-less server.** Worth a d-pad pass on tvOS confirming focus skips the greyed row cleanly, and an iOS check of the menu-item subtitle rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)