### PR TITLE
feat(client-identity): report app name, version, build, and channel to the server

### DIFF
--- a/.github/workflows/sideload-ipa.yml
+++ b/.github/workflows/sideload-ipa.yml
@@ -59,8 +59,12 @@ jobs:
   # Create the GitHub Release ONCE before the platform builds fan out, so the
   # matrix jobs only upload assets (no create race). Tag pushes release under
   # the pushed tag; dispatch runs mirror the TestFlight flow by minting the
-  # next v<version>-build.N tag from existing releases and stamping that build
-  # number into the IPAs via BUILD_NUMBER.
+  # next v<version>-build.N tag from existing releases.
+  #
+  # BOTH paths get a build number stamped into the IPAs via BUILD_NUMBER.
+  # Tag pushes used to leave it empty, so every tag-built sideload IPA shipped
+  # CFBundleVersion=1 (the project.yml literal) and two builds of the same
+  # marketing version were indistinguishable in the server's Activity page.
   release:
     runs-on: ubuntu-latest
     permissions:
@@ -80,23 +84,39 @@ jobs:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
+          # Validates the resolved version is a plain dotted version before it
+          # is embedded in a tag name / shell strings. Runs for both events:
+          # a tag push resolves v1.4.0-beta.2 -> 1.4.0.
+          V="$(scripts/ci/resolve-marketing-version.sh \
+                "$GH_EVENT_NAME" "$GH_REF_NAME" "$INPUT_VERSION")"
+          # Build number for this marketing version = highest already-used
+          # build + 1, over BOTH event types so a dispatch run and a tag push
+          # can never mint the same CFBundleVersion for the same marketing
+          # version. A v<V>-build.N release contributes N; a plain v<V> (or
+          # v<V>-beta.2 / v<V>+ios) release contributes 1, since a tag-push
+          # build occupies the first slot for its version.
+          #
+          # Deliberately max-based, not a count: deleting an old release must
+          # not walk the sequence backwards and let two different IPAs ship as
+          # the same version+build, which is exactly what the server's Activity
+          # page relies on being unambiguous.
+          TAGS="$(gh release list --limit 1000 --json tagName -q '.[].tagName')"
+          LAST="$(printf '%s\n' "$TAGS" \
+                    | { grep -E "^v${V//./\\.}-build\.[0-9]+$" || true; } \
+                    | sed -E 's/.*build\.([0-9]+)$/\1/' | sort -n | tail -n 1)"
+          LAST="${LAST:-0}"
+          if (( LAST < 1 )) \
+             && printf '%s\n' "$TAGS" | grep -qE "^v${V//./\\.}([-+].*)?$"; then
+            LAST=1
+          fi
+          BUILD=$(( LAST + 1 ))
+          echo "build_number=$BUILD" >> "$GITHUB_OUTPUT"
           if [[ "$GH_EVENT_NAME" == "workflow_dispatch" ]]; then
-            # Validates the dispatch input is a plain dotted version before it
-            # is embedded in a tag name / shell strings.
-            V="$(scripts/ci/resolve-marketing-version.sh \
-                  "$GH_EVENT_NAME" "$GH_REF_NAME" "$INPUT_VERSION")"
-            # Next build number for this version = highest existing
-            # v<V>-build.N release + 1 (starts at 1).
-            LAST="$(gh release list --limit 1000 --json tagName -q '.[].tagName' \
-                      | { grep -E "^v${V//./\\.}-build\.[0-9]+$" || true; } \
-                      | sed -E 's/.*build\.([0-9]+)$/\1/' | sort -n | tail -n 1)"
-            BUILD=$(( ${LAST:-0} + 1 ))
             TAG="v${V}-build.${BUILD}"
             TITLE="v${V} (Build ${BUILD})"
-            echo "build_number=$BUILD" >> "$GITHUB_OUTPUT"
           else
             TAG="$GH_REF_NAME"
-            TITLE="$GH_REF_NAME"
+            TITLE="$GH_REF_NAME (Build ${BUILD})"
           fi
           # Tag pushes can already have a release (created manually or by a
           # previous run); only create when missing.
@@ -161,7 +181,8 @@ jobs:
         run: bundle exec fastlane ios ${{ matrix.lane }}
         env:
           MARKETING_VERSION: ${{ steps.ver.outputs.value }}
-          # Set for dispatch runs only; tag builds keep the project.yml value.
+          # Always set (dispatch and tag push alike) so no sideload IPA ever
+          # ships the project.yml CURRENT_PROJECT_VERSION placeholder.
           BUILD_NUMBER: ${{ needs.release.outputs.build_number }}
 
       - name: Upload ${{ matrix.platform }} IPA artifact

--- a/.github/workflows/sideload-ipa.yml
+++ b/.github/workflows/sideload-ipa.yml
@@ -28,8 +28,9 @@ on:
 env:
   XCODEGEN_VERSION: "2.43.0"
 
-# Serialize runs: dispatch builds compute the next v<version>-build.N number
-# from existing releases, so overlapping runs could pick the same number.
+# Serialize runs: build numbers are unique per run (see the release job), but
+# two runs targeting the same tag would still race each other's `gh release`
+# asset uploads, and one sideload build already occupies two macOS runners.
 concurrency:
   group: sideload-ipa
   cancel-in-progress: false
@@ -58,13 +59,24 @@ jobs:
 
   # Create the GitHub Release ONCE before the platform builds fan out, so the
   # matrix jobs only upload assets (no create race). Tag pushes release under
-  # the pushed tag; dispatch runs mirror the TestFlight flow by minting the
-  # next v<version>-build.N tag from existing releases.
+  # the pushed tag; dispatch runs mint a v<version>-build.N tag.
   #
   # BOTH paths get a build number stamped into the IPAs via BUILD_NUMBER.
   # Tag pushes used to leave it empty, so every tag-built sideload IPA shipped
   # CFBundleVersion=1 (the project.yml literal) and two builds of the same
   # marketing version were indistinguishable in the server's Activity page.
+  #
+  # The number is github.run_number, NOT a max or count over existing
+  # releases. A release-derived counter cannot survive the cases that matter:
+  #   - Prerelease tags carry no build number to read back, so v1.4.0-beta.1,
+  #     -beta.2, -rc.1 and the final v1.4.0 all collapse onto the same value.
+  #   - Deleting a release walks the sequence backwards.
+  # Either one lets two different IPAs ship as the same version+build, which
+  # is exactly what the server's Activity page relies on being unambiguous.
+  # run_number is monotonic, never reused, and unaffected by release deletion.
+  # It is also stable across a re-run (a re-run bumps run_attempt, not
+  # run_number), so re-running a failed matrix leg reproduces the same build
+  # instead of quietly republishing a different binary under the same tag.
   release:
     runs-on: ubuntu-latest
     permissions:
@@ -81,6 +93,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_EVENT_NAME: ${{ github.event_name }}
           GH_REF_NAME: ${{ github.ref_name }}
+          GH_RUN_NUMBER: ${{ github.run_number }}
           INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
@@ -89,27 +102,7 @@ jobs:
           # a tag push resolves v1.4.0-beta.2 -> 1.4.0.
           V="$(scripts/ci/resolve-marketing-version.sh \
                 "$GH_EVENT_NAME" "$GH_REF_NAME" "$INPUT_VERSION")"
-          # Build number for this marketing version = highest already-used
-          # build + 1, over BOTH event types so a dispatch run and a tag push
-          # can never mint the same CFBundleVersion for the same marketing
-          # version. A v<V>-build.N release contributes N; a plain v<V> (or
-          # v<V>-beta.2 / v<V>+ios) release contributes 1, since a tag-push
-          # build occupies the first slot for its version.
-          #
-          # Deliberately max-based, not a count: deleting an old release must
-          # not walk the sequence backwards and let two different IPAs ship as
-          # the same version+build, which is exactly what the server's Activity
-          # page relies on being unambiguous.
-          TAGS="$(gh release list --limit 1000 --json tagName -q '.[].tagName')"
-          LAST="$(printf '%s\n' "$TAGS" \
-                    | { grep -E "^v${V//./\\.}-build\.[0-9]+$" || true; } \
-                    | sed -E 's/.*build\.([0-9]+)$/\1/' | sort -n | tail -n 1)"
-          LAST="${LAST:-0}"
-          if (( LAST < 1 )) \
-             && printf '%s\n' "$TAGS" | grep -qE "^v${V//./\\.}([-+].*)?$"; then
-            LAST=1
-          fi
-          BUILD=$(( LAST + 1 ))
+          BUILD="$GH_RUN_NUMBER"
           echo "build_number=$BUILD" >> "$GITHUB_OUTPUT"
           if [[ "$GH_EVENT_NAME" == "workflow_dispatch" ]]; then
             TAG="v${V}-build.${BUILD}"
@@ -119,15 +112,19 @@ jobs:
             TITLE="$GH_REF_NAME (Build ${BUILD})"
           fi
           # Tag pushes can already have a release (created manually or by a
-          # previous run); only create when missing.
-          if ! gh release view "$TAG" >/dev/null 2>&1; then
+          # previous run); only create when missing. Re-title an existing one
+          # either way: the build step uploads with --clobber, so a stale
+          # title would advertise a different build than the attached IPAs.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" --title "$TITLE"
+          else
             gh release create "$TAG" \
               --target "$GITHUB_SHA" \
               --title "$TITLE" \
               --notes "Unsigned iOS/tvOS IPAs for third-party signing / sideloading. See docs/release/sideloading.md."
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "Releasing as $TAG"
+          echo "Releasing as $TAG (build $BUILD)"
 
   build:
     needs: [setup, release]

--- a/docs/release/ci-release.md
+++ b/docs/release/ci-release.md
@@ -11,8 +11,7 @@
 - Manual: Actions tab → "TestFlight Release" → Run workflow → enter `version`
   and pick `platform` (`both` / `ios` / `tvos`).
 
-On a both-platform run, tvOS is skipped if the iOS job fails (build-number
-ordering); a tvOS-only run builds tvOS on its own.
+A single-platform selection builds only that platform; the other job is skipped.
 
 The git tag is the marketing version. A preflight `build-numbers` job reserves
 the next per-platform build number from App Store Connect once, then the iOS and

--- a/docs/release/sideloading.md
+++ b/docs/release/sideloading.md
@@ -16,15 +16,30 @@ or similar. This is separate from the TestFlight pipeline
   run and, on tag builds, attached to the GitHub Release.
 
 ## How it triggers
-- Push tag `vX.Y.Z` → builds both IPAs and attaches them to that release.
+- Push tag `vX.Y.Z` → builds both IPAs and attaches them to that tag's release.
 - Manual: Actions → "Sideload IPA Build" → Run workflow → enter `version` and
-  pick `platform` (`both` / `ios` / `tvos`); artifacts only, nothing attached to
-  a release. Tag pushes always build both platforms.
+  pick `platform` (`both` / `ios` / `tvos`); the run mints a
+  `v<version>-build.<run>` tag and attaches the IPAs to it. Tag pushes always
+  build both platforms.
 
 The marketing version resolves the same way as the TestFlight workflow
-(`scripts/ci/resolve-marketing-version.sh`). The archives are unsigned, so no
-build-number sequencing against App Store Connect is needed and the two jobs
-run in parallel.
+(`scripts/ci/resolve-marketing-version.sh`). The archives are unsigned, so
+nothing is sequenced against App Store Connect and the two jobs run in
+parallel.
+
+## Telling two sideload builds apart
+Both trigger paths stamp `CFBundleVersion` from the workflow's
+`github.run_number`, so every sideloaded IPA is distinguishable from every
+other build of the same marketing version — including several prerelease tags
+of one version, which carry no build number of their own to count from.
+Re-running a workflow run reproduces its build number rather than minting a
+new one, so a re-run cannot republish a different binary under a number that
+already shipped.
+
+The unsigned lanes additionally set `SILO_BUILD_CHANNEL=sideload`, which the
+app reports to the server as `X-Silo-Client-Channel`. That is what separates a
+re-signed sideload build from the TestFlight build of the same marketing
+version and build number in the server's Activity page.
 
 ## Fastlane lanes
     bundle exec fastlane ios ipa_ios_unsigned    # -> build/ios-unsigned/Silo-unsigned.ipa

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -93,6 +93,14 @@ def build_number_xcarg
   "CURRENT_PROJECT_VERSION=#{value} "
 end
 
+# Overrides the SILO_BUILD_CHANNEL build setting (project.yml default: release)
+# for the unsigned sideload lanes. It reaches the app as the SiloBuildChannel
+# Info.plist key and is reported to the server as X-Silo-Client-Channel, so an
+# operator can tell a re-signed sideload build from the TestFlight build of the
+# same marketing version + build number. Constant, not env-derived: there is no
+# untrusted input to validate.
+SIDELOAD_CHANNEL_XCARG = "SILO_BUILD_CHANNEL=sideload ".freeze
+
 # Returns the build number to stamp on a TestFlight build.
 #
 # In CI the reserve_build_numbers job computes the next number per platform once
@@ -598,6 +606,7 @@ platform :ios do
       destination:  "generic/platform=iOS",
       archive_path: archive_path,
       xcargs:       "#{marketing_version_xcarg}#{build_number_xcarg}" \
+                    "#{SIDELOAD_CHANNEL_XCARG}" \
                     "CODE_SIGNING_ALLOWED=NO " \
                     "CODE_SIGNING_REQUIRED=NO " \
                     "CODE_SIGN_IDENTITY='' " \
@@ -628,6 +637,7 @@ platform :ios do
       destination:  "generic/platform=tvOS",
       archive_path: archive_path,
       xcargs:       "#{marketing_version_xcarg}#{build_number_xcarg}" \
+                    "#{SIDELOAD_CHANNEL_XCARG}" \
                     "CODE_SIGNING_ALLOWED=NO " \
                     "CODE_SIGNING_REQUIRED=NO " \
                     "CODE_SIGN_IDENTITY='' " \

--- a/iosApp/DownloadsActivity/Info.plist
+++ b/iosApp/DownloadsActivity/Info.plist
@@ -25,5 +25,7 @@
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.widgetkit-extension</string>
 	</dict>
+	<key>SiloBuildChannel</key>
+	<string>$(SILO_BUILD_CHANNEL)</string>
 </dict>
 </plist>

--- a/iosApp/NotificationService/Info.plist
+++ b/iosApp/NotificationService/Info.plist
@@ -34,5 +34,7 @@
 		<key>NSExtensionPrincipalClass</key>
 		<string>$(PRODUCT_MODULE_NAME).NotificationService</string>
 	</dict>
+	<key>SiloBuildChannel</key>
+	<string>$(SILO_BUILD_CHANNEL)</string>
 </dict>
 </plist>

--- a/iosApp/TopShelf/Info.plist
+++ b/iosApp/TopShelf/Info.plist
@@ -36,6 +36,8 @@
 		<key>NSExtensionPrincipalClass</key>
 		<string>$(PRODUCT_MODULE_NAME).ContentProvider</string>
 	</dict>
+	<key>SiloBuildChannel</key>
+	<string>$(SILO_BUILD_CHANNEL)</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>arm64</string>

--- a/iosApp/iosApp/Downloads/DownloadSessionDelegate.swift
+++ b/iosApp/iosApp/Downloads/DownloadSessionDelegate.swift
@@ -201,11 +201,7 @@ enum DownloadAuthHeaders {
         if let profileToken = await TokenStore.shared.getProfileToken() {
             request.setValue(profileToken, forHTTPHeaderField: "X-Profile-Token")
         }
-        let device = AppleDeviceIdentity.current
-        request.setValue(device.id, forHTTPHeaderField: "X-Silo-Device-Id")
-        request.setValue(device.name, forHTTPHeaderField: "X-Silo-Device-Name")
-        request.setValue(device.platform, forHTTPHeaderField: "X-Silo-Device-Platform")
-        request.setValue(device.clientFamily, forHTTPHeaderField: "X-Silo-Client-Family")
+        AppleDeviceIdentity.current.applyHeaders(to: &request)
         return request
     }
 }

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -64,6 +64,8 @@
 		<string>_silopair._tcp</string>
 		<string>_silocast._tcp</string>
 	</array>
+	<key>SiloBuildChannel</key>
+	<string>$(SILO_BUILD_CHANNEL)</string>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UIBackgroundModes</key>

--- a/iosApp/iosApp/Networking/HTTPClient.swift
+++ b/iosApp/iosApp/Networking/HTTPClient.swift
@@ -1080,11 +1080,9 @@ actor HTTPClient {
             attached.append("profileToken")
         }
         let device = AppleDeviceIdentity.current
-        request.setValue(device.id, forHTTPHeaderField: "X-Silo-Device-Id")
-        request.setValue(device.name, forHTTPHeaderField: "X-Silo-Device-Name")
-        request.setValue(device.platform, forHTTPHeaderField: "X-Silo-Device-Platform")
-        request.setValue(device.clientFamily, forHTTPHeaderField: "X-Silo-Client-Family")
+        device.applyHeaders(to: &request)
         attached.append("device=\(device.platform)/\(device.clientFamily)")
+        attached.append("client=\(device.clientName) \(device.appVersion) (\(device.appBuild))")
         let method = request.httpMethod ?? ""
         let attachedDesc = attached.joined(separator: ", ")
         Self.logger.debug("→ \(method, privacy: .public) \(path, privacy: .public) headers=[\(attachedDesc, privacy: .public)]")
@@ -1116,11 +1114,9 @@ actor HTTPClient {
             attached.append("profileToken")
         }
         let device = AppleDeviceIdentity.current
-        request.setValue(device.id, forHTTPHeaderField: "X-Silo-Device-Id")
-        request.setValue(device.name, forHTTPHeaderField: "X-Silo-Device-Name")
-        request.setValue(device.platform, forHTTPHeaderField: "X-Silo-Device-Platform")
-        request.setValue(device.clientFamily, forHTTPHeaderField: "X-Silo-Client-Family")
+        device.applyHeaders(to: &request)
         attached.append("device=\(device.platform)/\(device.clientFamily)")
+        attached.append("client=\(device.clientName) \(device.appVersion) (\(device.appBuild))")
         let method = request.httpMethod ?? ""
         let attachedDesc = attached.joined(separator: ", ")
         Self.logger.debug("→ \(method, privacy: .public) \(path, privacy: .public) headers=[\(attachedDesc, privacy: .public)]")
@@ -1140,11 +1136,7 @@ actor HTTPClient {
         if let profileToken = auth.profileToken {
             request.setValue(profileToken, forHTTPHeaderField: "X-Profile-Token")
         }
-        let device = AppleDeviceIdentity.current
-        request.setValue(device.id, forHTTPHeaderField: "X-Silo-Device-Id")
-        request.setValue(device.name, forHTTPHeaderField: "X-Silo-Device-Name")
-        request.setValue(device.platform, forHTTPHeaderField: "X-Silo-Device-Platform")
-        request.setValue(device.clientFamily, forHTTPHeaderField: "X-Silo-Client-Family")
+        AppleDeviceIdentity.current.applyHeaders(to: &request)
     }
 
     // MARK: - Response handling

--- a/iosApp/iosApp/Networking/HTTPClient.swift
+++ b/iosApp/iosApp/Networking/HTTPClient.swift
@@ -1079,13 +1079,7 @@ actor HTTPClient {
             request.setValue(profileToken, forHTTPHeaderField: "X-Profile-Token")
             attached.append("profileToken")
         }
-        let device = AppleDeviceIdentity.current
-        device.applyHeaders(to: &request)
-        attached.append("device=\(device.platform)/\(device.clientFamily)")
-        attached.append("client=\(device.clientName) \(device.appVersion) (\(device.appBuild))")
-        let method = request.httpMethod ?? ""
-        let attachedDesc = attached.joined(separator: ", ")
-        Self.logger.debug("→ \(method, privacy: .public) \(path, privacy: .public) headers=[\(attachedDesc, privacy: .public)]")
+        attachIdentityAndTrace(&request, path: path, credentials: attached)
     }
 
     /// Attach the immutable account-owner/profile snapshot captured before the
@@ -1113,12 +1107,34 @@ actor HTTPClient {
             request.setValue(profileToken, forHTTPHeaderField: "X-Profile-Token")
             attached.append("profileToken")
         }
+        attachIdentityAndTrace(&request, path: path, credentials: attached)
+    }
+
+    /// Attaches the shared device/client identity headers and emits the
+    /// one-line request trace. Both the ordinary and legacy auth paths end
+    /// here so a field added to either the header set or the trace reaches
+    /// both instead of drifting between two copies.
+    ///
+    /// `credentials` is what the caller already attached (auth, profile,
+    /// profileToken); nothing here is user data, so the whole line is
+    /// logged `.public`.
+    private func attachIdentityAndTrace(
+        _ request: inout URLRequest,
+        path: String,
+        credentials: [String]
+    ) {
         let device = AppleDeviceIdentity.current
         device.applyHeaders(to: &request)
-        attached.append("device=\(device.platform)/\(device.clientFamily)")
-        attached.append("client=\(device.clientName) \(device.appVersion) (\(device.appBuild))")
+        let trace = credentials + [
+            "device=\(device.platform)/\(device.clientFamily)",
+            // Channel included deliberately: it is the only field that
+            // separates a re-signed sideload build from the TestFlight build
+            // of the same version+build, which is exactly the question a
+            // user-supplied log has to answer.
+            "client=\(device.clientName) \(device.appVersion) (\(device.appBuild)) \(device.channel)"
+        ]
         let method = request.httpMethod ?? ""
-        let attachedDesc = attached.joined(separator: ", ")
+        let attachedDesc = trace.joined(separator: ", ")
         Self.logger.debug("→ \(method, privacy: .public) \(path, privacy: .public) headers=[\(attachedDesc, privacy: .public)]")
     }
 

--- a/iosApp/iosApp/Networking/HostedDiagnosticsAPI.swift
+++ b/iosApp/iosApp/Networking/HostedDiagnosticsAPI.swift
@@ -362,8 +362,8 @@ actor HostedDiagnosticsAPI {
         let body = HostedInstallationRequest(
             platform: platform,
             appID: Bundle.main.bundleIdentifier ?? "org.siloserver.silo",
-            appVersion: Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown",
-            appBuild: Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "unknown"
+            appVersion: AppleDeviceIdentity.bundleAppVersion,
+            appBuild: AppleDeviceIdentity.bundleAppBuild
         )
         var request = try request(path: "v1/installations", method: "POST")
         request.timeoutInterval = 10

--- a/iosApp/iosApp/Pairing/PairingDeviceAPI.swift
+++ b/iosApp/iosApp/Pairing/PairingDeviceAPI.swift
@@ -165,11 +165,7 @@ struct PairingDeviceAPI: PairingDeviceAuthorizing {
         if let bearer { request.setValue("Bearer \(bearer)", forHTTPHeaderField: "Authorization") }
         if let profileId { request.setValue(profileId, forHTTPHeaderField: "X-Profile-Id") }
         if let profileToken { request.setValue(profileToken, forHTTPHeaderField: "X-Profile-Token") }
-        let device = AppleDeviceIdentity.current
-        request.setValue(device.id, forHTTPHeaderField: "X-Silo-Device-Id")
-        request.setValue(device.name, forHTTPHeaderField: "X-Silo-Device-Name")
-        request.setValue(device.platform, forHTTPHeaderField: "X-Silo-Device-Platform")
-        request.setValue(device.clientFamily, forHTTPHeaderField: "X-Silo-Client-Family")
+        AppleDeviceIdentity.current.applyHeaders(to: &request)
     }
 
     private func send<R: Decodable>(_ request: URLRequest) async throws -> R {

--- a/iosApp/iosApp/Screens/Player/PlaybackRealtimeProtocol.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackRealtimeProtocol.swift
@@ -448,8 +448,16 @@ private struct PlaybackRealtimeBaseEnvelope: Decodable {
     let type: PlaybackRealtimeMessageType
 }
 
+// Stable protocol-level client ids, deliberately NOT the human-facing
+// `X-Silo-Client` product names: the server has stored these since Continuum
+// and only checks that they are non-empty. macOS previously fell through to
+// the iOS id, so a Mac session announced itself as iOS on the realtime socket
+// while its HTTP headers said `Silo Mac` — the same session named two
+// contradictory ways.
 #if os(tvOS)
 private let applePlaybackRealtimeClientName = "continuum-tvos"
+#elseif os(macOS)
+private let applePlaybackRealtimeClientName = "continuum-macos"
 #else
 private let applePlaybackRealtimeClientName = "continuum-ios"
 #endif

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3Capabilities.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3Capabilities.swift
@@ -477,20 +477,22 @@ enum ApplePlaybackV3Capabilities {
         #endif
     }
 
-    // Version/build/channel come from the one identity snapshot the HTTP
-    // headers also use, so the two carriers cannot disagree about the same
-    // running binary. A missing Info.plist key reports `unknown` rather than a
-    // plausible-looking "0".
+    // Version/build/channel come from the same readers the HTTP headers use,
+    // so the two carriers cannot disagree about the same running binary. They
+    // deliberately do NOT go through `AppleDeviceIdentity.current`: that
+    // initializer also resolves the keychain-backed device id, and a capability
+    // snapshot has no need to block on the keychain. A missing Info.plist key
+    // reports `unknown` rather than a plausible-looking "0".
     private static var appVersion: String {
-        AppleDeviceIdentity.current.appVersion
+        AppleDeviceIdentity.bundleAppVersion
     }
 
     private static var appBuild: String {
-        AppleDeviceIdentity.current.appBuild
+        AppleDeviceIdentity.bundleAppBuild
     }
 
     private static var appChannel: String {
-        AppleDeviceIdentity.current.channel
+        AppleDeviceIdentity.buildChannel
     }
 
     private static var deviceContext: PlaybackV3DeviceContext {

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3Capabilities.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3Capabilities.swift
@@ -187,6 +187,8 @@ enum ApplePlaybackV3Capabilities {
             protocolVersion: PlaybackProtocolV3.version,
             formFactor: formFactor,
             appVersion: appVersion,
+            appBuild: appBuild,
+            appChannel: appChannel,
             device: deviceContext,
             output: output,
             deliveries: deliveries
@@ -281,6 +283,8 @@ enum ApplePlaybackV3Capabilities {
             protocolVersion: base.context.protocolVersion,
             formFactor: base.context.formFactor,
             appVersion: base.context.appVersion,
+            appBuild: base.context.appBuild,
+            appChannel: base.context.appChannel,
             device: base.context.device,
             output: output,
             deliveries: deliveries
@@ -473,8 +477,20 @@ enum ApplePlaybackV3Capabilities {
         #endif
     }
 
+    // Version/build/channel come from the one identity snapshot the HTTP
+    // headers also use, so the two carriers cannot disagree about the same
+    // running binary. A missing Info.plist key reports `unknown` rather than a
+    // plausible-looking "0".
     private static var appVersion: String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0"
+        AppleDeviceIdentity.current.appVersion
+    }
+
+    private static var appBuild: String {
+        AppleDeviceIdentity.current.appBuild
+    }
+
+    private static var appChannel: String {
+        AppleDeviceIdentity.current.channel
     }
 
     private static var deviceContext: PlaybackV3DeviceContext {

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/PlaybackProtocolV3Models.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/PlaybackProtocolV3Models.swift
@@ -173,6 +173,10 @@ struct PlaybackV3ClientContext: Codable, Equatable {
     let protocolVersion: Int
     let formFactor: String
     let appVersion: String
+    /// `CFBundleVersion`. Optional so older/foreign contexts still decode.
+    let appBuild: String?
+    /// `dev` / `sideload` / `release`.
+    let appChannel: String?
     let device: PlaybackV3DeviceContext
     let output: PlaybackV3OutputContext
     /// Keyed by delivery class, never by an engine name.

--- a/iosApp/iosApp/Shared/AppleDeviceIdentity.swift
+++ b/iosApp/iosApp/Shared/AppleDeviceIdentity.swift
@@ -15,19 +15,50 @@ struct AppleDeviceIdentity: Sendable {
     /// metadata (`iOS`, `tvOS`, `macOS`), while this intentionally groups
     /// interchangeable form factors across operating systems.
     let clientFamily: String
+    /// Product name the server shows in admin Activity (e.g. `Silo Apple TV`).
+    /// Deliberately human-facing and stable per product, not per device.
+    let clientName: String
+    /// `CFBundleShortVersionString` (marketing version), or `unknown`.
+    let appVersion: String
+    /// `CFBundleVersion` (build number), or `unknown`. Reported separately so
+    /// operators can tell two builds of the same marketing version apart.
+    let appBuild: String
+    /// How this binary was produced: `dev`, `sideload`, or `release`.
+    let channel: String
 
-    init(id: String, name: String, platform: String, clientFamily: String) {
+    /// The new client-identity fields default to visibly-unresolved
+    /// placeholders. Only `current` is a real snapshot of this process; any
+    /// other construction (tests, synthetic identities) is not expected to
+    /// describe a shipped build.
+    init(
+        id: String,
+        name: String,
+        platform: String,
+        clientFamily: String,
+        clientName: String = "Silo",
+        appVersion: String = "unknown",
+        appBuild: String = "unknown",
+        channel: String = "unknown"
+    ) {
         self.id = id
         self.name = name
         self.platform = platform
         self.clientFamily = clientFamily
+        self.clientName = clientName
+        self.appVersion = appVersion
+        self.appBuild = appBuild
+        self.channel = channel
     }
 
     static let current = AppleDeviceIdentity(
         id: AppleDeviceIdentity.loadOrCreateID(),
         name: AppleDeviceIdentity.currentName(),
         platform: AppleDeviceIdentity.currentPlatform(),
-        clientFamily: AppleDeviceIdentity.currentClientFamily()
+        clientFamily: AppleDeviceIdentity.currentClientFamily(),
+        clientName: AppleDeviceIdentity.currentClientName(),
+        appVersion: AppleDeviceIdentity.bundleString("CFBundleShortVersionString"),
+        appBuild: AppleDeviceIdentity.bundleString("CFBundleVersion"),
+        channel: AppleDeviceIdentity.currentChannel()
     )
 
     private static let keychainAccount = "com.continuum.device.identity"
@@ -74,5 +105,61 @@ struct AppleDeviceIdentity: Sendable {
         #else
         return "desktop"
         #endif
+    }
+
+    /// Mirrors `currentClientFamily()`'s idiom split so an iPad and an iPhone
+    /// running the same binary are distinguishable in admin Activity.
+    private static func currentClientName() -> String {
+        #if os(tvOS)
+        return "Silo Apple TV"
+        #elseif os(macOS)
+        return "Silo Mac"
+        #elseif os(iOS)
+        return UIDevice.current.userInterfaceIdiom == .pad ? "Silo iPad" : "Silo iPhone"
+        #else
+        return "Silo"
+        #endif
+    }
+
+    /// A missing version/build reports as `unknown` rather than a plausible
+    /// number: an unreadable Info.plist should look broken, not like 1.0.
+    private static func bundleString(_ key: String) -> String {
+        let raw = Bundle.main.object(forInfoDictionaryKey: key) as? String
+        let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? "unknown" : trimmed
+    }
+
+    /// `SiloBuildChannel` is fed by the `SILO_BUILD_CHANNEL` build setting
+    /// (see project.yml), which the unsigned sideload lanes override. An
+    /// absent or unexpanded value means an ordinary release build.
+    private static func currentChannel() -> String {
+        #if DEBUG
+        return "dev"
+        #else
+        let raw = Bundle.main.object(forInfoDictionaryKey: "SiloBuildChannel") as? String
+        let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? "release" : trimmed
+        #endif
+    }
+}
+
+extension AppleDeviceIdentity {
+    /// The device + client identity headers every Silo request carries.
+    /// Kept here so no call site drifts from the others; empty values are
+    /// omitted rather than sent as blank headers.
+    func applyHeaders(to request: inout URLRequest) {
+        let headers: [(String, String)] = [
+            ("X-Silo-Device-Id", id),
+            ("X-Silo-Device-Name", name),
+            ("X-Silo-Device-Platform", platform),
+            ("X-Silo-Client-Family", clientFamily),
+            ("X-Silo-Client", clientName),
+            ("X-Silo-Client-Version", appVersion),
+            ("X-Silo-Client-Build", appBuild),
+            ("X-Silo-Client-Channel", channel)
+        ]
+        for (field, value) in headers where !value.isEmpty {
+            request.setValue(value, forHTTPHeaderField: field)
+        }
     }
 }

--- a/iosApp/iosApp/Shared/AppleDeviceIdentity.swift
+++ b/iosApp/iosApp/Shared/AppleDeviceIdentity.swift
@@ -23,7 +23,9 @@ struct AppleDeviceIdentity: Sendable {
     /// `CFBundleVersion` (build number), or `unknown`. Reported separately so
     /// operators can tell two builds of the same marketing version apart.
     let appBuild: String
-    /// How this binary was produced: `dev`, `sideload`, or `release`.
+    /// How this binary was produced: `dev`, `sideload`, or `release` for a
+    /// real build, or `unknown` for a synthetic identity that does not
+    /// describe a running binary (see the memberwise init below).
     let channel: String
 
     /// The new client-identity fields default to visibly-unresolved
@@ -56,9 +58,9 @@ struct AppleDeviceIdentity: Sendable {
         platform: AppleDeviceIdentity.currentPlatform(),
         clientFamily: AppleDeviceIdentity.currentClientFamily(),
         clientName: AppleDeviceIdentity.currentClientName(),
-        appVersion: AppleDeviceIdentity.bundleString("CFBundleShortVersionString"),
-        appBuild: AppleDeviceIdentity.bundleString("CFBundleVersion"),
-        channel: AppleDeviceIdentity.currentChannel()
+        appVersion: AppleDeviceIdentity.bundleAppVersion,
+        appBuild: AppleDeviceIdentity.bundleAppBuild,
+        channel: AppleDeviceIdentity.buildChannel
     )
 
     private static let keychainAccount = "com.continuum.device.identity"
@@ -121,18 +123,28 @@ struct AppleDeviceIdentity: Sendable {
         #endif
     }
 
-    /// A missing version/build reports as `unknown` rather than a plausible
-    /// number: an unreadable Info.plist should look broken, not like 1.0.
-    private static func bundleString(_ key: String) -> String {
-        let raw = Bundle.main.object(forInfoDictionaryKey: key) as? String
-        let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return trimmed.isEmpty ? "unknown" : trimmed
-    }
+    /// `CFBundleShortVersionString` (marketing version), or `unknown`.
+    ///
+    /// Exposed apart from ``current`` because it reads nothing but the bundle.
+    /// Callers that want the app version but have no use for the rest of the
+    /// identity — diagnostics report headers, playback capability snapshots —
+    /// should use this rather than `current`, whose initializer additionally
+    /// resolves the keychain-backed device id. Both routes funnel through the
+    /// same reader, so a version reported in a request body can never disagree
+    /// with the one reported in the headers of the same running binary.
+    static var bundleAppVersion: String { bundleString("CFBundleShortVersionString") }
 
+    /// `CFBundleVersion` (build number), or `unknown`. See ``bundleAppVersion``.
+    static var bundleAppBuild: String { bundleString("CFBundleVersion") }
+
+    /// How this binary was produced: `dev`, `sideload`, or `release`.
+    ///
     /// `SiloBuildChannel` is fed by the `SILO_BUILD_CHANNEL` build setting
     /// (see project.yml), which the unsigned sideload lanes override. An
-    /// absent or unexpanded value means an ordinary release build.
-    private static func currentChannel() -> String {
+    /// absent or unexpanded value means an ordinary release build — so every
+    /// target carrying that build setting must also declare the Info.plist
+    /// key, or it silently reports `release`.
+    static var buildChannel: String {
         #if DEBUG
         return "dev"
         #else
@@ -140,6 +152,14 @@ struct AppleDeviceIdentity: Sendable {
         let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         return trimmed.isEmpty ? "release" : trimmed
         #endif
+    }
+
+    /// A missing version/build reports as `unknown` rather than a plausible
+    /// number: an unreadable Info.plist should look broken, not like 1.0.
+    private static func bundleString(_ key: String) -> String {
+        let raw = Bundle.main.object(forInfoDictionaryKey: key) as? String
+        let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? "unknown" : trimmed
     }
 }
 

--- a/iosApp/iosApp/Shared/Diagnostics/DiagnosticsCoordinator.swift
+++ b/iosApp/iosApp/Shared/Diagnostics/DiagnosticsCoordinator.swift
@@ -1831,11 +1831,11 @@ actor DiagnosticsCoordinator {
     }
 
     private static func appVersion() -> String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
+        AppleDeviceIdentity.bundleAppVersion
     }
 
     private static func appBuild() -> String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "unknown"
+        AppleDeviceIdentity.bundleAppBuild
     }
 
     private static func platform() -> Platform {

--- a/iosApp/iosApp/tvOS-Info.plist
+++ b/iosApp/iosApp/tvOS-Info.plist
@@ -57,6 +57,8 @@
 	</array>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>Silo uses your local network to find, set up, and control Silo on your Apple TV.</string>
+	<key>SiloBuildChannel</key>
+	<string>$(SILO_BUILD_CHANNEL)</string>
 	<key>TVTopShelfImage</key>
 	<dict>
 		<key>TVTopShelfPrimaryImage</key>

--- a/iosApp/macOS-Info.plist
+++ b/iosApp/macOS-Info.plist
@@ -36,6 +36,8 @@
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
+	<key>SiloBuildChannel</key>
+	<string>$(SILO_BUILD_CHANNEL)</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>

--- a/iosApp/macOS-Info.plist
+++ b/iosApp/macOS-Info.plist
@@ -36,11 +36,11 @@
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
-	<key>SiloBuildChannel</key>
-	<string>$(SILO_BUILD_CHANNEL)</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>
 	<true/>
+	<key>SiloBuildChannel</key>
+	<string>$(SILO_BUILD_CHANNEL)</string>
 </dict>
 </plist>

--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -17,16 +17,6 @@ settings:
   base:
     SWIFT_VERSION: "5"
     ENABLE_USER_SCRIPT_SANDBOXING: false
-    # One committed baseline for every target (app + extensions must ship the
-    # same CFBundleVersion). CI overrides both through xcodebuild xcargs, which
-    # outrank project-level settings; none of the Signing/*.xcconfig files set
-    # them, so nothing shadows these locally either.
-    MARKETING_VERSION: "1.0.0"
-    CURRENT_PROJECT_VERSION: 1
-    # Surfaced to the app as the `SiloBuildChannel` Info.plist key and reported
-    # to the server as X-Silo-Client-Channel. The unsigned sideload lanes
-    # override this to `sideload`; DEBUG builds report `dev` regardless.
-    SILO_BUILD_CHANNEL: release
     # DEVELOPMENT_TEAM is intentionally omitted — set via the DEVELOPMENT_TEAM env var locally
     # or injected by the CI pipeline.
     CODE_SIGN_STYLE: Automatic
@@ -35,6 +25,33 @@ settings:
     # the missing slice.
     EXCLUDED_ARCHS[sdk=appletvsimulator*]: x86_64
     EXCLUDED_ARCHS[sdk=iphonesimulator*]: x86_64
+
+# One committed version/channel baseline for every shippable target: the app
+# and its embedded extensions must ship the same CFBundleVersion, and six
+# copies of the same three lines drift.
+#
+# This is a target template, NOT the project-level `settings.base`, and that
+# distinction is load-bearing. Xcode resolves build settings target settings >
+# target xcconfig > project settings > project xcconfig. Every target below
+# carries a Signing/<Target>.xcconfig that ends with
+# `#include? "Local.xcconfig"` — a gitignored file contributors are told to
+# create. At project level a stray MARKETING_VERSION in someone's
+# Local.xcconfig would silently outrank the committed value; template settings
+# are merged into the target, where they win, which is the same guarantee the
+# per-target blocks used to provide. CI still outranks everything via
+# xcodebuild xcargs (command-line settings beat xcconfigs too).
+targetTemplates:
+  ShippableProduct:
+    settings:
+      base:
+        MARKETING_VERSION: "1.0.0"
+        CURRENT_PROJECT_VERSION: 1
+        # Surfaced to the app as the `SiloBuildChannel` Info.plist key and
+        # reported to the server as X-Silo-Client-Channel. The unsigned
+        # sideload lanes override this to `sideload`; DEBUG builds report
+        # `dev` regardless. Every target using this template must declare the
+        # key in its Info.plist or it reports `release` no matter what.
+        SILO_BUILD_CHANNEL: release
 
 packages:
   # FFmpeg xcframeworks (LGPL). Provides the Libavcodec / Libavformat /
@@ -54,6 +71,7 @@ packages:
 
 targets:
   Silo:
+    templates: [ShippableProduct]
     type: application
     platform: iOS
     sources:
@@ -105,6 +123,7 @@ targets:
   # by #if os(tvOS) so they compile out on the iOS target even though the
   # directory is included in both targets' source tree.
   SiloTV:
+    templates: [ShippableProduct]
     type: application
     platform: tvOS
     sources:
@@ -147,6 +166,7 @@ targets:
         embed: true
 
   SiloMac:
+    templates: [ShippableProduct]
     type: application
     platform: macOS
     sources:
@@ -198,6 +218,7 @@ targets:
   # shared Keychain access group. Compiles `iosApp/Shared/` for the
   # SharedStorage helpers used on both sides.
   SiloTVTopShelf:
+    templates: [ShippableProduct]
     type: app-extension
     platform: tvOS
     sources:
@@ -227,6 +248,7 @@ targets:
   # Shares active server/profile/token state via the App Group + shared
   # Keychain access group, but does not link the main app's AuthService.
   SiloNotificationService:
+    templates: [ShippableProduct]
     type: app-extension
     platform: iOS
     sources:
@@ -253,6 +275,7 @@ targets:
   # them, so it compiles just the shared attributes schema and needs no
   # entitlements or shared storage.
   SiloDownloadsActivity:
+    templates: [ShippableProduct]
     type: app-extension
     platform: iOS
     sources:

--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -17,6 +17,16 @@ settings:
   base:
     SWIFT_VERSION: "5"
     ENABLE_USER_SCRIPT_SANDBOXING: false
+    # One committed baseline for every target (app + extensions must ship the
+    # same CFBundleVersion). CI overrides both through xcodebuild xcargs, which
+    # outrank project-level settings; none of the Signing/*.xcconfig files set
+    # them, so nothing shadows these locally either.
+    MARKETING_VERSION: "1.0.0"
+    CURRENT_PROJECT_VERSION: 1
+    # Surfaced to the app as the `SiloBuildChannel` Info.plist key and reported
+    # to the server as X-Silo-Client-Channel. The unsigned sideload lanes
+    # override this to `sideload`; DEBUG builds report `dev` regardless.
+    SILO_BUILD_CHANNEL: release
     # DEVELOPMENT_TEAM is intentionally omitted — set via the DEVELOPMENT_TEAM env var locally
     # or injected by the CI pipeline.
     CODE_SIGN_STYLE: Automatic
@@ -66,8 +76,6 @@ targets:
       base:
         PRODUCT_NAME: Silo
         INFOPLIST_FILE: iosApp/Info.plist
-        MARKETING_VERSION: "1.0.0"
-        CURRENT_PROJECT_VERSION: 1
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
         TARGETED_DEVICE_FAMILY: "1,2"
@@ -120,8 +128,6 @@ targets:
       base:
         PRODUCT_NAME: SiloTV
         INFOPLIST_FILE: iosApp/tvOS-Info.plist
-        MARKETING_VERSION: "1.0.0"
-        CURRENT_PROJECT_VERSION: 1
         ASSETCATALOG_COMPILER_APPICON_NAME: TVAppIcon
         ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
         SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD: "NO"
@@ -173,8 +179,6 @@ targets:
       base:
         PRODUCT_NAME: Silo
         INFOPLIST_FILE: macOS-Info.plist
-        MARKETING_VERSION: "1.0.0"
-        CURRENT_PROJECT_VERSION: 1
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
         SDKROOT: macosx
@@ -213,8 +217,6 @@ targets:
       base:
         PRODUCT_NAME: SiloTVTopShelf
         INFOPLIST_FILE: TopShelf/Info.plist
-        MARKETING_VERSION: "1.0.0"
-        CURRENT_PROJECT_VERSION: 1
         SDKROOT: appletvos
         SUPPORTED_PLATFORMS: "appletvos appletvsimulator"
     dependencies:
@@ -239,8 +241,6 @@ targets:
       base:
         PRODUCT_NAME: SiloNotificationService
         INFOPLIST_FILE: NotificationService/Info.plist
-        MARKETING_VERSION: "1.0.0"
-        CURRENT_PROJECT_VERSION: 1
         SDKROOT: iphoneos
         SUPPORTED_PLATFORMS: "iphoneos iphonesimulator"
     dependencies:
@@ -265,8 +265,6 @@ targets:
       base:
         PRODUCT_NAME: SiloDownloadsActivity
         INFOPLIST_FILE: DownloadsActivity/Info.plist
-        MARKETING_VERSION: "1.0.0"
-        CURRENT_PROJECT_VERSION: 1
         TARGETED_DEVICE_FAMILY: "1,2"
         SDKROOT: iphoneos
         SUPPORTED_PLATFORMS: "iphoneos iphonesimulator"


### PR DESCRIPTION
Server companion: Silo-Server/silo-server#631 · Scope: Silo-Server/silo-server#630

## Problem

The Apple apps sent **no client name and no app version** to the Silo server on ordinary requests — only `X-Silo-Device-Id`, `-Name`, `-Platform`, and `X-Silo-Client-Family`. Every iOS, tvOS, and macOS session therefore fell back to user-agent sniffing on the admin Activity page, and the server could not name the app at all, let alone the build.

The one app version that did reach the server, `PlaybackV3ClientContext.appVersion`, was discarded on arrival — and it dropped the build and defaulted to `"0"` anyway.

## Changes

**`AppleDeviceIdentity`** gains `clientName`, `appVersion` (`CFBundleShortVersionString`), `appBuild` (`CFBundleVersion`), and `channel`, plus an `applyHeaders(to:)` extension that writes the whole identity set.

Version/build/channel are additionally exposed as `bundleAppVersion` / `bundleAppBuild` / `buildChannel`: bundle-only readers that skip `current`'s keychain-backed device id. Everything that reports a version to the server now funnels through them — the HTTP headers, the playback capability snapshot, the diagnostics report header, and the hosted-installation registration — so no two carriers can disagree about the same running binary, and a capability snapshot never blocks on the Keychain to read a plist key. The three Settings screens still read `Bundle.main` directly; they are display-only and keep their own `1.0` / `1.0.0` UI fallbacks.

**Five request paths, not four.** `HTTPClient`'s three attach sites, `PairingDeviceAPI`, and `DownloadSessionDelegate` — the last was carrying the identical 4-header block and, left alone, would have been the one Apple path still reporting no client version. Centralizing them is what stops that from recurring. `HTTPClient`'s two near-identical attach functions now share one `attachIdentityAndTrace` tail, so the header set and the request trace cannot drift apart either.

**Client names** keep the `Silo ` prefix to match what the Android client already sends:

| Platform | `X-Silo-Client` |
|---|---|
| tvOS | `Silo Apple TV` |
| macOS | `Silo Mac` |
| iOS, `.pad` | `Silo iPad` |
| iOS, otherwise | `Silo iPhone` |

The iPhone/iPad split reuses the `userInterfaceIdiom` check `currentClientFamily()` already does.

**A missing version key reports `"unknown"`, not `"0"`** — a broken build should look broken rather than look like version 0.

**`channel`** is `dev` under `#if DEBUG`, else the `SiloBuildChannel` Info.plist key (fed by the new `SILO_BUILD_CHANNEL` build setting), else `release`. All six shippable targets declare the key, extensions included: the build setting alone is not enough, and a target that carries it without the plist key silently reports `release`.

**Realtime hello.** The hello's `version: "1"` is the *protocol* version, not an app version, and is deliberately left alone (flagged in the server PR so it does not get "helpfully" wired up later). Its `client.name`, however, had no macOS branch, so a Mac announced itself as `continuum-ios` on the realtime socket while its headers said `Silo Mac` — the same session named two contradictory ways. Added `continuum-macos`. These stay protocol-level ids rather than the human-facing product names; the server has stored them since Continuum and only checks they are non-empty.

**`project.yml` hygiene:** `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` (and the new `SILO_BUILD_CHANNEL`) are hoisted out of six identical per-target blocks into a `ShippableProduct` target template. A template rather than the project-level `settings.base`, and that distinction is load-bearing: Xcode resolves target settings > target xcconfig > project settings, and all six targets carry a `Signing/*.xcconfig` ending in `#include? "Local.xcconfig"`. At project level a contributor's gitignored `Local.xcconfig` silently outranks the committed version — verified, it resolves to the xcconfig value — whereas template settings land at target level where they win, the same guarantee the per-target blocks provided. CI's `xcodebuild` xcargs still outrank everything.

## CI

**TestFlight and App Store versioning is untouched.** `reserve_build_numbers` already queries `latest_testflight_build_number + 1` per platform in a preflight job and stamps it via `build_app` xcargs — that is already a real monotonic number matching TestFlight exactly. iOS and tvOS running independent ASC sequences is by design.

Two gaps fixed:

1. **Tag-push sideload builds shipped `CFBundleVersion = 1`.** `BUILD_NUMBER` was set only on `workflow_dispatch` runs; on tag push it was empty, `build_number_xcarg` returned `""`, and the `project.yml` literal survived. Both event types now compute one.

   The counter is **`github.run_number`**, not a max or count over existing releases. A release-derived counter cannot survive the cases that matter. Prerelease tags carry no build number to read back, so `v1.4.0-beta.1`, `-beta.2`, `-rc.1` and the final `v1.4.0` all collapse onto the same value; and deleting a release walks the sequence backwards. Either one lets two different IPAs ship as the same version+build, which is exactly what the Activity page relies on being unambiguous. `run_number` is monotonic, never reused, unaffected by release deletion, and stable across a re-run (a re-run bumps `run_attempt`, not `run_number`) — so re-running a failed matrix leg reproduces the same build instead of republishing a different binary under a number that already shipped. An existing release is also re-titled each run, so the release page can never advertise a different build than the IPAs `--clobber` just replaced.

2. **Sideload builds now self-mark** via `SILO_BUILD_CHANNEL=sideload` on the two unsigned lanes only, so a re-signed sideload build is distinguishable from the TestFlight build of the same version+build. The channel is also included in the client's own request log, since that is the question a user-supplied log has to answer.

Also removed a stale line in `docs/release/ci-release.md` claiming tvOS is skipped when iOS fails, which contradicts `release.yml`, and corrected `docs/release/sideloading.md`, which still claimed dispatch runs attach nothing to a release.

## Known gap: macOS

`SiloMac` has **no release lane** — `release.yml` has exactly four jobs (`setup`, `build-numbers`, `ios`, `tvos`) and the Fastfile six lanes, none of which archive, stamp, or upload it. Mac builds will report `1.0.0 (build 1)` until one exists.

Deferred deliberately rather than bolted on here: `SiloMac` has no entitlements file at all, and the Mac App Store path requires App Sandbox around bundled FFmpeg frameworks and arbitrary local-server access. Developer ID + notarized DMG is the lighter path if revisited. The `channel` field at least separates a developer's `dev` build from a Release one. Tracked in Silo-Server/silo-server#630.

## Verification

```
xcodegen generate
xcodebuild -scheme Silo   -destination 'platform=iOS Simulator,name=iPhone 17 Pro'         ** BUILD SUCCEEDED **
xcodebuild -scheme SiloTV -destination 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation)'  ** BUILD SUCCEEDED **
xcodebuild -scheme SiloMac -destination 'platform=macOS'                                    ** BUILD SUCCEEDED **
```

Verified in the built products that all six bundles (three apps + Top Shelf, Notification Service, Downloads Activity) carry `SiloBuildChannel`, and that `-showBuildSettings` resolves `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` / `SILO_BUILD_CHANNEL` on all six targets.

The xcconfig precedence claim was tested rather than reasoned about: with a `Signing/Local.xcconfig` containing `MARKETING_VERSION = 9.9.9`, the project-level layout resolved to `9.9.9` and the target-template layout holds at `1.0.0`, while `xcodebuild MARKETING_VERSION=1.4.0` still overrides both.

`sideload-ipa.yml` and `project.yml` parse as YAML; `ruby -c fastlane/Fastfile` is Syntax OK.

## Risks

- `app_version` now defaults to `"unknown"` instead of `"0"` when the plist key is missing; the server treats it as an opaque string, so this is safe, and it is called out in the server PR.
- New `app_build`/`app_channel` are optional and omitted (not null) by older clients.
- Sideload `CFBundleVersion` values are now sparse (they follow the workflow's run counter rather than counting 1, 2, 3 per version). They are unique and increasing, which is what the Activity page needs; they are never uploaded to App Store Connect, so no ASC sequencing constraint applies.
- `run_number` resets if the workflow file is ever deleted and recreated. It is currently well above the highest published sideload build (1), and a rename does not reset it.

### AI Disclosure
- Tool(s): Claude Code
- Model(s): claude-opus-5
- Involvement: fully AI-generated
- Adversarial review: a first review pass caught that the sideload build-number counter had been rewritten as a count of existing releases, which regresses when a release is deleted; it was reverted to a max-based counter. A second, deeper review then showed the max-based counter was *also* wrong — its clamp for non-`build.N` tags is a flat ceiling, so `v1.4.0-beta.2`, `-rc.1` and `v1.4.0` all mint build 2 (reproduced against fixtures: 1, 2, 2, 2). That is what drove the switch to `run_number`. The same pass found that hoisting the version settings into `settings.base` had inverted their precedence against the per-target xcconfigs (confirmed experimentally, then fixed with a target template); that `SILO_BUILD_CHANNEL` was set on all six targets but declared in only three Info.plists; that the capability snapshot had picked up a Keychain dependency for a plist read; and that the realtime hello still identified macOS as iOS.
