### PR TITLE
Sanitize compact identifiers in hosted diagnostics

### DIFF
--- a/iosApp/Tests/HostedDiagnosticsAPITests.swift
+++ b/iosApp/Tests/HostedDiagnosticsAPITests.swift
@@ -549,11 +549,13 @@ final class HostedDiagnosticsAPITests: XCTestCase {
         let privateBreadcrumbSessionID = "private-server-playback-session-breadcrumb"
         let canonicalRunID = "0198a8f8-6c2d-7e31-8f44-62d198a10111"
         let privateBareUUID = "1198a8f8-6c2d-7e31-8f44-62d198a10112"
+        let privateCompactUUID = "5e884898da28047151d0e56f8dc62927"
+        let privateUppercaseCompactUUID = "5E884898DA28047151D0E56F8DC62927"
         let logLine = try XCTUnwrap(DiagLog.renderedLine(
             level: .info,
             category: .playback,
             tag: "CMP playback_session_id=\(privateLogSessionID) file_abcdefgh",
-            message: "[CMP-ROUTE] playbackSessionId=\(privateLogSessionID) fileId=private-file-log planId=private-plan-log wss://[host:0123456789ab]/items/42 http://127.0.0.1:49152/master.m3u8 host=127.0.0.1 http://127.42.7.9:49153/playlist.m3u8 \"host\":\"127.42.7.9\" \"playback_session_id\":\"private-json-session\" request \(privateBareUUID) item_42 plan_abcdefgh item_count request_cancelled peer 127.42.7.8 file /Users/alice/private-title.mkv route selected",
+            message: "[CMP-ROUTE] playbackSessionId=\(privateLogSessionID) fileId=private-file-log planId=private-plan-log media=5.700124438 wss://[host:0123456789ab]/items/42 http://127.0.0.1:49152/master.m3u8 host=127.0.0.1 http://127.42.7.9:49153/playlist.m3u8 \"host\":\"127.42.7.9\" \"playback_session_id\":\"private-json-session\" request \(privateBareUUID) compact (\(privateCompactUUID)), uppercase \(privateUppercaseCompactUUID); item_42 plan_abcdefgh item_count request_cancelled peer 127.42.7.8 file /Users/alice/private-title.mkv route selected",
             attrs: [
                 "sink": .string("HDMI"),
                 "fmt": .string("content_abcdefgh"),
@@ -714,6 +716,8 @@ final class HostedDiagnosticsAPITests: XCTestCase {
             "127.42.7.9",
             "127.42.7.8",
             privateBareUUID,
+            privateCompactUUID,
+            privateUppercaseCompactUUID,
             "file_abcdefgh",
             "item_42",
             "plan_abcdefgh",
@@ -725,6 +729,8 @@ final class HostedDiagnosticsAPITests: XCTestCase {
         }
         XCTAssertTrue(renderedEvidence.contains("[redacted_path]"))
         XCTAssertTrue(hostedLog.msg.contains("[redacted_private_id]"))
+        XCTAssertTrue(hostedLog.msg.contains("mediaSeconds=5p700124438s"))
+        XCTAssertFalse(hostedLog.msg.contains("media=5.700124438"))
         XCTAssertTrue(hostedLog.msg.contains("item_count"))
         XCTAssertTrue(hostedLog.msg.contains("request_cancelled"))
         XCTAssertEqual(hostedLog.run, canonicalRunID)
@@ -767,6 +773,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
         let privateBarePlanID = "plan_abcdefgh"
         let privateManifestID = "content_abcdefgh"
         let privateDeviceSummaryID = "device_abcdefgh"
+        let privateCompactUUIDKey = "5e884898da28047151d0e56f8dc62927"
         let metricKitBinaryUUID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
         let privatePath = "/private/var/mobile/Containers/Data/Application/\(privateContainerID)/Silo.app/Silo"
         let rawStack = Data(
@@ -776,6 +783,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
             "diagnosticMetaData": [
                 "virtualMemoryRegionInfo": "mapped image \(privatePath)",
                 "exceptionReason": "container[\(privatePath)] loopback request http://127.0.0.1:49152/items/42 failed for \(privateBareUUID) \(privateBareItemID) \(privateBarePlanID)",
+                privateCompactUUIDKey: "private-keyed-value",
             ],
             "callStacks": [
                 "callStackRootFrames": [[
@@ -883,6 +891,8 @@ final class HostedDiagnosticsAPITests: XCTestCase {
             privateBarePlanID,
             privateManifestID,
             privateDeviceSummaryID,
+            privateCompactUUIDKey,
+            "private-keyed-value",
         ] {
             XCTAssertFalse(hostedEvidence.contains(forbidden), forbidden)
         }
@@ -930,12 +940,14 @@ final class HostedDiagnosticsAPITests: XCTestCase {
 
     func testHostedDeviceSnapshotRedactsBarePrivateIdentifiersInNestedValues() throws {
         let privateUUID = "1198a8f8-6c2d-7e31-8f44-62d198a10112"
+        let privateCompactUUIDKey = "5e884898da28047151d0e56f8dc62927"
         let snapshot = DeviceSnapshotPayload(
             capturedAt: DiagnosticsTimestamp.string(from: Date(timeIntervalSince1970: 1_700_200_000)),
             provenance: .preFailure,
             identity: .object([
                 "manufacturer": .string("Apple"),
                 "model": .string("iPhone item_42"),
+                privateCompactUUIDKey: .string("private-keyed-value"),
             ]),
             display: .object([
                 "mode": .string("request_cancelled"),
@@ -952,12 +964,20 @@ final class HostedDiagnosticsAPITests: XCTestCase {
         let sanitized = try DiagnosticsBundleBuilder.sanitizeHostedDeviceJSON(raw)
         let rendered = String(decoding: sanitized, as: UTF8.self)
 
-        for forbidden in [privateUUID, "item_42", "plan_abcdefgh", "file_abcdefgh"] {
+        for forbidden in [
+            privateUUID,
+            privateCompactUUIDKey,
+            "private-keyed-value",
+            "item_42",
+            "plan_abcdefgh",
+            "file_abcdefgh",
+        ] {
             XCTAssertFalse(rendered.contains(forbidden), forbidden)
         }
         XCTAssertTrue(rendered.contains("[redacted_private_id]"))
         XCTAssertTrue(rendered.contains("request_cancelled"))
         XCTAssertTrue(String(decoding: raw, as: UTF8.self).contains(privateUUID))
+        XCTAssertTrue(String(decoding: raw, as: UTF8.self).contains(privateCompactUUIDKey))
     }
 
     func testManualHostedBundleIsDeterministicAcrossLiveRingAndDebugChanges() async throws {

--- a/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
+++ b/iosApp/iosApp/Screens/Player/AVPlayerRoute/AVPlayerBackend.swift
@@ -2306,7 +2306,7 @@ final class AVPlayerBackend {
             toleranceBefore: .zero,
             toleranceAfter: .zero
         )
-        cmpLog("[CMP-AVP] vod resume pre-seek player=\(target) media=\(pendingStartTime) context=\(context)")
+        cmpLog("[CMP-AVP] vod resume pre-seek player=\(target) mediaSeconds=\(pendingStartTime) context=\(context)")
     }
 
     private func prepareAssetPlayback(

--- a/iosApp/iosApp/Shared/Diagnostics/Bundle/DiagnosticsBundleBuilder.swift
+++ b/iosApp/iosApp/Shared/Diagnostics/Bundle/DiagnosticsBundleBuilder.swift
@@ -351,7 +351,8 @@ struct DiagnosticsBundleBuilder {
                 // hosted reports omit it and the collector can reject this
                 // otherwise ambiguous network-identity key globally.
                 guard normalizedKey != "virtualmemoryregioninfo",
-                      normalizedKey != "address" else { return }
+                      normalizedKey != "address",
+                      !hasHostedBareUUID(in: entry.key) else { return }
                 if normalizedKey == "binaryuuid",
                    let binaryUUID = entry.value as? String,
                    isHostedMetricKitBinaryUUID(binaryUUID) {
@@ -449,7 +450,8 @@ struct DiagnosticsBundleBuilder {
         case .object(let object):
             return .object(object.reduce(into: [:]) { result, entry in
                 let normalizedKey = entry.key.lowercased().filter { $0.isLetter || $0.isNumber }
-                guard !hostedDevicePrivateFieldKeys.contains(normalizedKey) else { return }
+                guard !hostedDevicePrivateFieldKeys.contains(normalizedKey),
+                      !hasHostedBareUUID(in: entry.key) else { return }
                 result[entry.key] = removeHostedDevicePrivateFields(from: entry.value)
             })
         default:
@@ -513,9 +515,17 @@ struct DiagnosticsBundleBuilder {
         let networkAssignmentsRemoved = sanitizeHostedNetworkIdentityAssignments(
             in: identifiersRemoved
         )
+        let numericMediaNormalized = replaceMatches(
+            of: hostedNumericMediaAssignmentRegex,
+            in: networkAssignmentsRemoved,
+            with: "mediaSeconds"
+        )
+        let numericTelemetryNormalized = normalizeHostedNumericTelemetryAssignments(
+            in: numericMediaNormalized
+        )
         let loopbackNormalized = replaceMatches(
             of: hostedLoopbackHostRegex,
-            in: networkAssignmentsRemoved,
+            in: numericTelemetryNormalized,
             with: "redacted.invalid"
         )
         return templateHostedURLPaths(in: loopbackNormalized)
@@ -525,6 +535,11 @@ struct DiagnosticsBundleBuilder {
         var rendered = replaceMatches(
             of: hostedBareUUIDRegex,
             in: value,
+            with: "[redacted_private_id]"
+        )
+        rendered = replaceMatches(
+            of: hostedBareCompactUUIDRegex,
+            in: rendered,
             with: "[redacted_private_id]"
         )
         let source = rendered as NSString
@@ -539,6 +554,32 @@ struct DiagnosticsBundleBuilder {
                 in: match.range(at: 1),
                 with: "[redacted_private_id]"
             )
+        }
+        return rendered
+    }
+
+    private static func hasHostedBareUUID(in value: String) -> Bool {
+        let range = NSRange(location: 0, length: (value as NSString).length)
+        return hostedBareUUIDRegex.firstMatch(in: value, range: range) != nil
+            || hostedBareCompactUUIDRegex.firstMatch(in: value, range: range) != nil
+    }
+
+    private static func normalizeHostedNumericTelemetryAssignments(in value: String) -> String {
+        var rendered = value
+        for (regex, suffix) in hostedNumericTelemetryAssignmentRegexes {
+            let source = rendered as NSString
+            let range = NSRange(location: 0, length: source.length)
+            for match in regex.matches(in: rendered, range: range).reversed() {
+                guard match.numberOfRanges == 4 else { continue }
+                let key = source.substring(with: match.range(at: 1))
+                let delimiter = source.substring(with: match.range(at: 2))
+                let numeric = source.substring(with: match.range(at: 3))
+                    .replacingOccurrences(of: ".", with: "p")
+                rendered = (rendered as NSString).replacingCharacters(
+                    in: match.range,
+                    with: key + delimiter + numeric + suffix
+                )
+            }
         }
         return rendered
     }
@@ -690,6 +731,26 @@ struct DiagnosticsBundleBuilder {
     private static let hostedBareUUIDRegex = try! NSRegularExpression(
         pattern: #"(?i)[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"#
     )
+    private static let hostedBareCompactUUIDRegex = try! NSRegularExpression(
+        pattern: #"(?i)(?<![0-9a-f])[0-9a-f]{32}(?![0-9a-f])"#
+    )
+    private static let hostedNumericMediaAssignmentRegex = try! NSRegularExpression(
+        pattern: #"(?i)\bmedia(?=\s*[:=]\s*-?(?:[0-9]+(?:\.[0-9]+)?|\.[0-9]+)(?:$|[\s,;)\]}]))"#
+    )
+    private static let hostedNumericTelemetryAssignmentRegexes: [(NSRegularExpression, String)] = [
+        (try! NSRegularExpression(
+            pattern: #"(?i)\b(budgetBytes|bytes)(\s*[:=]\s*)(-?[0-9]+)(?![0-9A-Za-z.])"#
+        ), "B"),
+        (try! NSRegularExpression(
+            pattern: #"(?i)\b(elapsedMs)(\s*[:=]\s*)(-?(?:[0-9]+(?:\.[0-9]+)?|\.[0-9]+))(?![0-9A-Za-z.])"#
+        ), "ms"),
+        (try! NSRegularExpression(
+            pattern: #"(?i)\b(current|mediaSeconds|start|startTime)(\s*[:=]\s*)(-?(?:[0-9]+(?:\.[0-9]+)?|\.[0-9]+))(?![0-9A-Za-z.])"#
+        ), "s"),
+        (try! NSRegularExpression(
+            pattern: #"(?i)\b(rate)(\s*[:=]\s*)(-?(?:[0-9]+(?:\.[0-9]+)?|\.[0-9]+))(?![0-9A-Za-z.])"#
+        ), "x"),
+    ]
     private static let hostedBarePrivateIdentifierRegex = try! NSRegularExpression(
         pattern: #"(?i)(?<![A-Za-z0-9])((?:ps|playback|session|file|item|media|plan|attempt|profile|account|user|device|content|library|request|req|correlation|server|subtitle|track|run)[_-](?:[0-9]+|[A-Za-z0-9][A-Za-z0-9_-]{7,}))(?![A-Za-z0-9_-])"#
     )


### PR DESCRIPTION
## What changed

- Redact standalone compact 32-character UUIDs from hosted diagnostic strings.
- Drop arbitrary MetricKit/device JSON entries whose keys contain dashed or compact UUIDs.
- Rename the ambiguous playback telemetry key from `media` to `mediaSeconds`.
- Normalize known numeric playback telemetry into explicit, non-IP unit-bearing hosted representations.
- Add hosted bundle regressions for lowercase, uppercase, punctuated compact UUIDs, arbitrary UUID keys, and media telemetry.

## Why

The TestFlight report `SILO-HFME3S4B` was rejected by the public diagnostics collector as `privacy_value_rejected`. The retained report on the connected iPhone proved that a compact UUID escaped the hosted sanitizer. Replaying the full report also exposed ambiguous numeric playback telemetry that could resemble network identity under the collector's fail-closed policy.

All transformations remain destination-specific: self-hosted/raw diagnostic evidence is unchanged.

## Validation

- Swift sanitizer regex/runtime checks passed.
- All changed Swift files parse successfully.
- The reconstructed retained report produced zero privacy validation failures with this PR and the coordinated server PR.
- Independent privacy-focused code review found no remaining Critical or Important issues.
- Full Xcode tests were not run locally because the required `/Volumes/NVMe` DerivedData volume was not mounted; CI should run the complete suite.

## Coordination

Merge with the corresponding `silo-diagnostics` privacy validator PR. No Android change is required: Android already redacts compact UUIDs and legacy network forms and does not emit the affected Apple playback fields.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 6b006caafae2164dc1a5e161eba6a91a95ba2a86. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved privacy protection in hosted diagnostics by removing UUID-like identifiers from logs, metadata, device snapshots, and JSON keys.
  * Standardized redaction of media duration and telemetry values with explicit units.
  * Updated playback diagnostics to clearly label resume positions as media time.
  * Expanded diagnostic coverage to verify sensitive identifiers remain excluded from hosted evidence while preserved in raw inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->