### PR TITLE
Preserve byte ranges in hosted diagnostics

### DIFF
--- a/iosApp/Tests/HostedDiagnosticsAPITests.swift
+++ b/iosApp/Tests/HostedDiagnosticsAPITests.swift
@@ -555,7 +555,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
             level: .info,
             category: .playback,
             tag: "CMP playback_session_id=\(privateLogSessionID) file_abcdefgh",
-            message: "[CMP-ROUTE] playbackSessionId=\(privateLogSessionID) fileId=private-file-log planId=private-plan-log media=5.700124438 wss://[host:0123456789ab]/items/42 http://127.0.0.1:49152/master.m3u8 host=127.0.0.1 http://127.42.7.9:49153/playlist.m3u8 \"host\":\"127.42.7.9\" \"playback_session_id\":\"private-json-session\" request \(privateBareUUID) compact (\(privateCompactUUID)), uppercase \(privateUppercaseCompactUUID); item_42 plan_abcdefgh item_count request_cancelled peer 127.42.7.8 file /Users/alice/private-title.mkv route selected",
+            message: "[CMP-ROUTE] playbackSessionId=\(privateLogSessionID) fileId=private-file-log planId=private-plan-log media=5.700124438 range=bytes=0-1023 bytes=67108864 wss://[host:0123456789ab]/items/42 http://127.0.0.1:49152/master.m3u8 host=127.0.0.1 http://127.42.7.9:49153/playlist.m3u8 \"host\":\"127.42.7.9\" \"playback_session_id\":\"private-json-session\" request \(privateBareUUID) compact (\(privateCompactUUID)), uppercase \(privateUppercaseCompactUUID); item_42 plan_abcdefgh item_count request_cancelled peer 127.42.7.8 file /Users/alice/private-title.mkv route selected",
             attrs: [
                 "sink": .string("HDMI"),
                 "fmt": .string("content_abcdefgh"),
@@ -731,6 +731,8 @@ final class HostedDiagnosticsAPITests: XCTestCase {
         XCTAssertTrue(hostedLog.msg.contains("[redacted_private_id]"))
         XCTAssertTrue(hostedLog.msg.contains("mediaSeconds=5p700124438s"))
         XCTAssertFalse(hostedLog.msg.contains("media=5.700124438"))
+        XCTAssertTrue(hostedLog.msg.contains("range=bytes=0-1023"))
+        XCTAssertTrue(hostedLog.msg.contains("bytes=67108864B"))
         XCTAssertTrue(hostedLog.msg.contains("item_count"))
         XCTAssertTrue(hostedLog.msg.contains("request_cancelled"))
         XCTAssertEqual(hostedLog.run, canonicalRunID)

--- a/iosApp/iosApp/Shared/Diagnostics/Bundle/DiagnosticsBundleBuilder.swift
+++ b/iosApp/iosApp/Shared/Diagnostics/Bundle/DiagnosticsBundleBuilder.swift
@@ -572,6 +572,10 @@ struct DiagnosticsBundleBuilder {
             for match in regex.matches(in: rendered, range: range).reversed() {
                 guard match.numberOfRanges == 4 else { continue }
                 let key = source.substring(with: match.range(at: 1))
+                if key.caseInsensitiveCompare("bytes") == .orderedSame,
+                   isHostedByteRangeValue(in: source, before: match.range.location) {
+                    continue
+                }
                 let delimiter = source.substring(with: match.range(at: 2))
                 let numeric = source.substring(with: match.range(at: 3))
                     .replacingOccurrences(of: ".", with: "p")
@@ -582,6 +586,12 @@ struct DiagnosticsBundleBuilder {
             }
         }
         return rendered
+    }
+
+    private static func isHostedByteRangeValue(in source: NSString, before location: Int) -> Bool {
+        let prefix = source.substring(to: location)
+        let range = NSRange(location: 0, length: (prefix as NSString).length)
+        return hostedByteRangeAssignmentPrefixRegex.firstMatch(in: prefix, range: range) != nil
     }
 
     private static func redactHostedAbsolutePaths(in value: String) -> String {
@@ -751,6 +761,9 @@ struct DiagnosticsBundleBuilder {
             pattern: #"(?i)\b(rate)(\s*[:=]\s*)(-?(?:[0-9]+(?:\.[0-9]+)?|\.[0-9]+))(?![0-9A-Za-z.])"#
         ), "x"),
     ]
+    private static let hostedByteRangeAssignmentPrefixRegex = try! NSRegularExpression(
+        pattern: #"(?i)\brange\s*[:=]\s*$"#
+    )
     private static let hostedBarePrivateIdentifierRegex = try! NSRegularExpression(
         pattern: #"(?i)(?<![A-Za-z0-9])((?:ps|playback|session|file|item|media|plan|attempt|profile|account|user|device|content|library|request|req|correlation|server|subtitle|track|run)[_-](?:[0-9]+|[A-Za-z0-9][A-Za-z0-9_-]{7,}))(?![A-Za-z0-9_-])"#
     )


### PR DESCRIPTION
## What changed

- Preserve HTTP byte-range evidence such as `range=bytes=0-1023` during hosted diagnostics sanitization.
- Continue adding explicit units to standalone `bytes=<count>` telemetry.
- Add a hosted bundle regression that covers both forms in the same log line.

## Why

Follow-up to #155. Its numeric telemetry normalizer could interpret the nested `bytes=` token in an HTTP Range value as standalone byte-count telemetry and rewrite it to `bytes=0B-1023`.

## Validation

- Direct Swift sanitizer runtime check passed for `range=bytes=0-1023 bytes=67108864`.
- Changed Swift sources parse successfully.
- `git diff --check` passes.
- Full Xcode tests remain unavailable locally because the required `/Volumes/NVMe` DerivedData volume is not mounted; CI should run the complete suite.

## Review thread

Addresses the unresolved byte-range review comment on #155.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d055425ec15910b7c10c5b822285c63fefb44016. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->