### PR TITLE
Fix hosted diagnostics rejection for playback telemetry

### DIFF
--- a/iosApp/Tests/HostedDiagnosticsAPITests.swift
+++ b/iosApp/Tests/HostedDiagnosticsAPITests.swift
@@ -555,7 +555,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
             level: .info,
             category: .playback,
             tag: "CMP playback_session_id=\(privateLogSessionID) file_abcdefgh",
-            message: "[CMP-ROUTE] playbackSessionId=\(privateLogSessionID) fileId=private-file-log planId=private-plan-log media=5.700124438 range=bytes=0-1023 bytes=67108864 wss://[host:0123456789ab]/items/42 http://127.0.0.1:49152/master.m3u8 host=127.0.0.1 http://127.42.7.9:49153/playlist.m3u8 \"host\":\"127.42.7.9\" \"playback_session_id\":\"private-json-session\" request \(privateBareUUID) compact (\(privateCompactUUID)), uppercase \(privateUppercaseCompactUUID); item_42 plan_abcdefgh item_count request_cancelled peer 127.42.7.8 file /Users/alice/private-title.mkv route selected",
+            message: "[CMP-ROUTE] playbackSessionId=\(privateLogSessionID) fileId=private-file-log planId=private-plan-log media=5.700124438 range=bytes=0-1023 bytes=67108864 anchorPlayer=0.0 bufAhead=0.0 generatedAhead=0.0 stationaryFor=0.0 cachedAheadBytes=67108864 maxLegacy=4294967295 mixedRadix=127.0x000001 hexDotted=0x7f.1 hexCode=0x7f000001 octalCode=017700000001 \"quotedMetric\":\"0.0\" quotedOctal='017700000001' publicVersion=8.8.8 ac.cur=0.0 ac.pts=0.0 ac.cur=017700000001 ac.pts=0x7f000001 ac.cur=127.0x000001 \"ac.cur\":\"0.0\" ac.pts : 0.0 ac.cur=-0.0 ac.pts=+127.1 shortCount=123456 tooLargeLegacy=4294967296 overflowHex=0x100000000 badOctal=018 wss://[host:0123456789ab]/items/42 http://127.0.0.1:49152/master.m3u8 host=127.0.0.1 http://127.42.7.9:49153/playlist.m3u8 \"host\":\"127.42.7.9\" \"playback_session_id\":\"private-json-session\" request \(privateBareUUID) compact (\(privateCompactUUID)), uppercase \(privateUppercaseCompactUUID); item_42 plan_abcdefgh item_count request_cancelled peer 127.42.7.8 file /Users/alice/private-title.mkv route selected",
             attrs: [
                 "sink": .string("HDMI"),
                 "fmt": .string("content_abcdefgh"),
@@ -660,6 +660,10 @@ final class HostedDiagnosticsAPITests: XCTestCase {
         let localDeviceData = try Data(
             contentsOf: report.directoryURL.appendingPathComponent("device.json")
         )
+        let localLogData = try Data(
+            contentsOf: report.directoryURL.appendingPathComponent("logs.jsonl")
+        )
+        XCTAssertTrue(String(decoding: localLogData, as: UTF8.self).contains("anchorPlayer=0.0"))
         XCTAssertTrue(String(decoding: localDeviceData, as: UTF8.self).contains("uid_hash"))
         XCTAssertTrue(String(decoding: localDeviceData, as: UTF8.self).contains("route_hashes"))
         XCTAssertTrue(String(decoding: localDeviceData, as: UTF8.self).contains("server_url"))
@@ -733,6 +737,44 @@ final class HostedDiagnosticsAPITests: XCTestCase {
         XCTAssertFalse(hostedLog.msg.contains("media=5.700124438"))
         XCTAssertTrue(hostedLog.msg.contains("range=bytes=0-1023"))
         XCTAssertTrue(hostedLog.msg.contains("bytes=67108864B"))
+        for key in [
+            "anchorPlayer", "bufAhead", "generatedAhead", "stationaryFor",
+            "cachedAheadBytes", "maxLegacy", "hexCode", "octalCode", "mixedRadix",
+            "hexDotted",
+        ] {
+            XCTAssertTrue(
+                hostedLog.msg.contains("\(key)=[redacted_network_identity]"),
+                hostedLog.msg
+            )
+        }
+        XCTAssertTrue(
+            hostedLog.msg.contains(#""quotedMetric":"[redacted_network_identity]""#),
+            hostedLog.msg
+        )
+        XCTAssertTrue(
+            hostedLog.msg.contains("quotedOctal='[redacted_network_identity]'"),
+            hostedLog.msg
+        )
+        for preserved in [
+            "publicVersion=8.8.8", "ac.cur=0.0", "ac.pts=0.0", "shortCount=123456",
+            "tooLargeLegacy=4294967296", "overflowHex=0x100000000", "badOctal=018",
+        ] {
+            XCTAssertTrue(hostedLog.msg.contains(preserved), hostedLog.msg)
+        }
+        for removed in [
+            "ac.cur=017700000001", "ac.pts=0x7f000001", "ac.cur=127.0x000001",
+            #""ac.cur":"0.0""#, "ac.pts : 0.0", "ac.cur=-0.0", "ac.pts=+127.1",
+        ] {
+            XCTAssertFalse(hostedLog.msg.contains(removed), hostedLog.msg)
+        }
+        XCTAssertTrue(
+            hostedLog.msg.contains(#""ac.cur":"[redacted_network_identity]""#),
+            hostedLog.msg
+        )
+        XCTAssertTrue(
+            hostedLog.msg.contains("ac.pts : [redacted_network_identity]"),
+            hostedLog.msg
+        )
         XCTAssertTrue(hostedLog.msg.contains("item_count"))
         XCTAssertTrue(hostedLog.msg.contains("request_cancelled"))
         XCTAssertEqual(hostedLog.run, canonicalRunID)

--- a/iosApp/iosApp/Shared/Diagnostics/Bundle/DiagnosticsBundleBuilder.swift
+++ b/iosApp/iosApp/Shared/Diagnostics/Bundle/DiagnosticsBundleBuilder.swift
@@ -528,7 +528,100 @@ struct DiagnosticsBundleBuilder {
             in: numericTelemetryNormalized,
             with: "redacted.invalid"
         )
-        return templateHostedURLPaths(in: loopbackNormalized)
+        let ambiguousLegacyNumbersRemoved = sanitizeHostedAmbiguousLegacyNumericAssignments(
+            in: loopbackNormalized
+        )
+        return templateHostedURLPaths(in: ambiguousLegacyNumbersRemoved)
+    }
+
+    private static func sanitizeHostedAmbiguousLegacyNumericAssignments(
+        in value: String
+    ) -> String {
+        let source = value as NSString
+        let range = NSRange(location: 0, length: source.length)
+        let matches = hostedAmbiguousLegacyNumericAssignmentRegex.matches(
+            in: value,
+            options: [],
+            range: range
+        )
+        var rendered = value
+        for match in matches.reversed() {
+            let prefix = source.substring(with: match.range(at: 1))
+            let sign = source.substring(with: match.range(at: 2))
+            let token = source.substring(with: match.range(at: 3))
+            let parts = token.split(separator: ".", omittingEmptySubsequences: false)
+            let isExactSafeClockAssignment =
+                sign.isEmpty &&
+                (prefix.lowercased() == "ac.cur=" || prefix.lowercased() == "ac.pts=") &&
+                (2...4).contains(parts.count) &&
+                parts.allSatisfy { !$0.isEmpty && $0.allSatisfy(\.isNumber) }
+            guard !isExactSafeClockAssignment,
+                  isHostedRejectedLegacyNumericToken(token) else { continue }
+            rendered = (rendered as NSString).replacingCharacters(
+                in: match.range,
+                with: "\(prefix)[redacted_network_identity]"
+            )
+        }
+        return rendered
+    }
+
+    /// Mirrors the collector's legacy IPv4 parsing and rejection boundary for
+    /// free-text numeric assignments. Public decimal multipart values remain
+    /// useful telemetry; explicit radix syntax, integer IPv4, and non-public
+    /// multipart values are ambiguous network identities and fail closed.
+    private static func isHostedRejectedLegacyNumericToken(_ token: String) -> Bool {
+        let parts = token.split(separator: ".", omittingEmptySubsequences: false).map(String.init)
+        guard (1...4).contains(parts.count) else { return false }
+        var numbers: [UInt64] = []
+        for component in parts {
+            guard !component.isEmpty, component.count <= 16 else { return false }
+            let lowercased = component.lowercased()
+            let radix: Int
+            let digits: String
+            if lowercased.hasPrefix("0x") {
+                radix = 16
+                digits = String(lowercased.dropFirst(2))
+                guard !digits.isEmpty,
+                      digits.allSatisfy({ $0.isHexDigit }) else { return false }
+            } else if component.count > 1, component.hasPrefix("0") {
+                radix = 8
+                digits = String(component.dropFirst())
+                guard digits.allSatisfy({ ("0"..."7").contains(String($0)) }) else {
+                    return false
+                }
+            } else {
+                radix = 10
+                digits = component
+                guard digits.allSatisfy(\.isNumber) else { return false }
+            }
+            guard let number = UInt64(digits.isEmpty ? "0" : digits, radix: radix),
+                  number <= UInt64(UInt32.max) else { return false }
+            numbers.append(number)
+        }
+        guard numbers.dropLast().allSatisfy({ $0 <= 255 }) else { return false }
+        let lastLimits: [UInt64] = [UInt64(UInt32.max), 0x00ff_ffff, 0x0000_ffff, 0xff]
+        guard let last = numbers.last, last <= lastLimits[parts.count - 1] else { return false }
+
+        let address = numbers.dropLast().enumerated().reduce(last) { result, entry in
+            result + (entry.element << UInt64(24 - (entry.offset * 8)))
+        }
+        let first = address >> 24
+        let second = (address >> 16) & 0xff
+        let isNonPublic = first == 0 || first == 10 ||
+            (first == 100 && (64...127).contains(second)) ||
+            first == 127 ||
+            (first == 169 && second == 254) ||
+            (first == 172 && (16...31).contains(second)) ||
+            (first == 192 && (second == 0 || second == 168)) ||
+            (first == 198 && (second == 18 || second == 19)) ||
+            first >= 224
+        let explicitLegacySyntax = parts.contains { component in
+            component.lowercased().hasPrefix("0x") ||
+                (component.count > 1 && component.hasPrefix("0"))
+        }
+        let longIntegerSyntax = parts.count == 1 &&
+            (7...10).contains(token.count) && token.allSatisfy(\.isNumber)
+        return explicitLegacySyntax || longIntegerSyntax || (parts.count > 1 && isNonPublic)
     }
 
     private static func sanitizeHostedBarePrivateIdentifiers(in value: String) -> String {
@@ -763,6 +856,16 @@ struct DiagnosticsBundleBuilder {
     ]
     private static let hostedByteRangeAssignmentPrefixRegex = try! NSRegularExpression(
         pattern: #"(?i)\brange\s*[:=]\s*$"#
+    )
+    private static let hostedAmbiguousLegacyNumericAssignmentRegex = try! NSRegularExpression(
+        // Playback telemetry such as `bufAhead=0.0` and
+        // `cachedAheadBytes=67108864` is indistinguishable from shortened,
+        // integer, octal, hexadecimal, or mixed-radix IPv4 syntax at the
+        // public collector. Preserve the explicitly unit-normalized keys
+        // above, but fail closed for every remaining numeric assignment,
+        // including quoted JSON-style fields, instead of maintaining an
+        // incomplete free-text key allowlist.
+        pattern: #"(?i)(?<![A-Za-z0-9_.-])((?:\"[A-Za-z][A-Za-z0-9_.-]{0,95}\"|'[A-Za-z][A-Za-z0-9_.-]{0,95}'|[A-Za-z][A-Za-z0-9_.-]{0,95})\s*[:=]\s*(?:[\"'])?)([-+]?)((?:(?:0x[0-9a-f]{1,16}|0[0-7]{1,15}|[0-9]{1,16})\.){1,3}(?:0x[0-9a-f]{1,16}|0[0-7]{1,15}|[0-9]{1,16})|0x[0-9a-f]{1,16}|0[0-7]+|[0-9]{7,10})(?![0-9A-Za-z.])"#
     )
     private static let hostedBarePrivateIdentifierRegex = try! NSRegularExpression(
         pattern: #"(?i)(?<![A-Za-z0-9])((?:ps|playback|session|file|item|media|plan|attempt|profile|account|user|device|content|library|request|req|correlation|server|subtitle|track|run)[_-](?:[0-9]+|[A-Za-z0-9][A-Za-z0-9_-]{7,}))(?![A-Za-z0-9_-])"#


### PR DESCRIPTION
## Summary

- Redact hosted-only playback telemetry values that are indistinguishable from legacy IPv4 syntax at the diagnostics collector.
- Mirror the collector's decimal/octal/hex and one-to-four-part parsing boundary, including quoted assignments and mixed-radix forms.
- Preserve public decimal multipart telemetry, exact safe `ac.cur=`/`ac.pts=` clock values, known unit-normalized fields, and all raw/self-hosted evidence.

## Root cause

iOS build 29 still emits untyped playback values such as `anchorPlayer=0.0`, `bufAhead=0.0`, and large byte counters. The collector intentionally interprets those shapes as shortened or integer IPv4 identities and rejects the entire hosted bundle. The earlier client normalization covered only a small known-key list, so real playback logs could still reach the Worker unchanged.

## Validation

- Reproduced the build-29 shape in the simulator before the fix.
- Focused hosted-bundle regression covers decimal, octal, hex, mixed-radix, quoted/spaced assignments, integer boundaries, and safe public/clock telemetry.
- 126 diagnostics XCTest cases pass on the iPhone 17 simulator.
- Simulator-generated bundles containing the full adversarial corpus, including signed clock near-misses, reached `ready` at the live Worker. Final proof: [SILO-RFQ9MSL6](https://diagnostics.siloserver.org/admin/reports/f309daa0-3f57-4a10-893e-1ed8ea7c3f03), with all six validation checks passing, including `privacy_fields`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3af85aa0e1cf5f5f311b6e081baef1e9156d8f8b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved privacy protection for hosted diagnostic logs by redacting sensitive numeric and network-like identifiers.
  - Added coverage for decimal, hexadecimal, octal, mixed-format, quoted, and alternate representations that could expose identities.
  - Preserved approved diagnostic values, including safe clock assignments, while retaining original metrics in local diagnostic artifacts.
  - Replaced rejected values with a clear redaction marker in hosted output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->