### PR TITLE
Add privacy policy access on Apple platforms

### DIFF
--- a/iosApp/iosApp/Screens/Settings/IOSSettingsOverview.swift
+++ b/iosApp/iosApp/Screens/Settings/IOSSettingsOverview.swift
@@ -251,6 +251,18 @@ struct IOSSettingsOverview: View {
                 value: versionString,
                 showsChevron: false
             )
+
+            SettingsOverviewDivider()
+
+            Link(destination: SiloLegalLinks.privacyPolicy) {
+                SettingsOverviewRow(
+                    title: "Privacy Policy",
+                    subtitle: "Learn how Silo handles your information",
+                    systemImage: "hand.raised.fill",
+                    tint: .teal
+                )
+            }
+            .buttonStyle(.plain)
         }
     }
 
@@ -358,7 +370,7 @@ struct IOSSettingsOverview: View {
     }
 
     private var matchesAboutSection: Bool {
-        matches("about", "version", versionString)
+        matches("about", "version", versionString, "privacy", "policy", "information")
     }
 
     private var matchesSignOut: Bool {

--- a/iosApp/iosApp/Screens/Settings/SiloLegalLinks.swift
+++ b/iosApp/iosApp/Screens/Settings/SiloLegalLinks.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+enum SiloLegalLinks {
+    static let privacyPolicy = URL(string: "https://siloserver.org/privacy/")!
+}

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsComponents.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsComponents.swift
@@ -541,6 +541,78 @@ struct TVSettingsConfirmationOverlay: View {
     }
 }
 
+// MARK: - Privacy policy handoff
+
+/// Apple TV has no general-purpose web browser, so HTTPS links have no system
+/// destination. Present the public policy URL as a QR handoff instead.
+struct TVPrivacyPolicyOverlay: View {
+    let dismiss: () -> Void
+
+    @FocusState private var isDoneFocused: Bool
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.76)
+                .ignoresSafeArea()
+
+            HStack(spacing: 54) {
+                QRCodeView(
+                    content: SiloLegalLinks.privacyPolicy.absoluteString,
+                    size: 320
+                )
+                .padding(22)
+                .background(Color.white, in: RoundedRectangle(cornerRadius: 24))
+                .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 22) {
+                    Image(systemName: "hand.raised.fill")
+                        .font(.system(size: 38, weight: .semibold))
+                        .foregroundStyle(Color.continuumAccent)
+                        .accessibilityHidden(true)
+
+                    Text("Privacy Policy")
+                        .font(.system(size: 42, weight: .bold))
+                        .foregroundStyle(Color.continuumOnSurface)
+
+                    Text("Scan this code with your phone or tablet to read Silo's privacy policy.")
+                        .font(.system(size: 23))
+                        .foregroundStyle(Color.continuumSecondaryText)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    Text(SiloLegalLinks.privacyPolicy.absoluteString)
+                        .font(.system(size: 20, weight: .medium, design: .monospaced))
+                        .foregroundStyle(Color.continuumAccent)
+                        .accessibilityLabel("Privacy policy URL")
+                        .accessibilityValue(SiloLegalLinks.privacyPolicy.absoluteString)
+
+                    Button(action: dismiss) {
+                        Text("Done")
+                            .font(.system(size: 24, weight: .semibold))
+                            .frame(maxWidth: .infinity, alignment: .center)
+                    }
+                    .buttonStyle(TVSettingsPaneRowStyle())
+                    .focused($isDoneFocused)
+                }
+                .frame(width: 560, alignment: .leading)
+            }
+            .padding(.horizontal, 64)
+            .padding(.vertical, 52)
+            .background(
+                RoundedRectangle(cornerRadius: 32, style: .continuous)
+                    .fill(Color.continuumSurfaceElevated)
+            )
+            .overlay {
+                RoundedRectangle(cornerRadius: 32, style: .continuous)
+                    .strokeBorder(Color.continuumChromeRestingBorder, lineWidth: 1)
+            }
+            .focusSection()
+            .defaultFocus($isDoneFocused, true, priority: .userInitiated)
+        }
+        .onAppear { isDoneFocused = true }
+        .onExitCommand(perform: dismiss)
+    }
+}
+
 // MARK: - Picker sheet
 
 /// Compact modal option menu mounted by the root Settings view.

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsView.swift
@@ -351,11 +351,15 @@ struct TVSettingsView: View {
         preferredDetailFocus = .serverPrivacyPolicy
         railFocus = nil
         detailFocus = nil
-        showPrivacyPolicy = true
+        withAnimation(.easeOut(duration: ContinuumTheme.fastDuration)) {
+            showPrivacyPolicy = true
+        }
     }
 
     private func dismissPrivacyPolicy() {
-        showPrivacyPolicy = false
+        withAnimation(.easeOut(duration: ContinuumTheme.fastDuration)) {
+            showPrivacyPolicy = false
+        }
         preferredFocusOwner = .detail
         preferredDetailFocus = .serverPrivacyPolicy
         isRestoringDetailFocus = true

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsView.swift
@@ -20,6 +20,7 @@ struct TVSettingsView: View {
     @State private var viewModel = TVSettingsViewModel()
     @State private var diagnosticsModel = DiagnosticsViewModel()
     @State private var showSignOutConfirm = false
+    @State private var showPrivacyPolicy = false
     @State private var selectedCategory: TVSettingsCategory = .general
     @State private var activePicker: TVSettingsPickerRequest?
     @State private var pendingPickerFocus: TVSettingsDetailFocus?
@@ -65,6 +66,12 @@ struct TVSettingsView: View {
                 .onDisappear(perform: restorePickerFocus)
                 .zIndex(2)
             }
+
+            if showPrivacyPolicy {
+                TVPrivacyPolicyOverlay(dismiss: dismissPrivacyPolicy)
+                    .transition(.opacity)
+                    .zIndex(3)
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: showSignOutConfirm)
@@ -76,6 +83,7 @@ struct TVSettingsView: View {
             if focus != nil,
                activePicker == nil,
                !showSignOutConfirm,
+               !showPrivacyPolicy,
                !isRestoringDetailFocus {
                 preferredFocusOwner = .rail
             }
@@ -95,6 +103,7 @@ struct TVSettingsView: View {
             if let focus,
                activePicker == nil,
                !showSignOutConfirm,
+               !showPrivacyPolicy,
                !isRestoringDetailFocus {
                 preferredDetailFocus = focus
                 preferredFocusOwner = .detail
@@ -134,6 +143,7 @@ struct TVSettingsView: View {
                 .frame(width: 490)
                 .disabled(
                     showSignOutConfirm
+                        || showPrivacyPolicy
                         || activePicker != nil
                         || isRestoringDetailFocus
                 )
@@ -149,7 +159,7 @@ struct TVSettingsView: View {
 
             detailPane
                 .frame(maxWidth: .infinity, alignment: .topLeading)
-                .disabled(showSignOutConfirm || activePicker != nil)
+                .disabled(showSignOutConfirm || showPrivacyPolicy || activePicker != nil)
                 .defaultFocus(
                     $detailFocus,
                     preferredDetailFocus,
@@ -336,6 +346,29 @@ struct TVSettingsView: View {
         }
     }
 
+    private func presentPrivacyPolicy() {
+        preferredFocusOwner = .detail
+        preferredDetailFocus = .serverPrivacyPolicy
+        railFocus = nil
+        detailFocus = nil
+        showPrivacyPolicy = true
+    }
+
+    private func dismissPrivacyPolicy() {
+        showPrivacyPolicy = false
+        preferredFocusOwner = .detail
+        preferredDetailFocus = .serverPrivacyPolicy
+        isRestoringDetailFocus = true
+        Task { @MainActor in
+            await Task.yield()
+            resetFocus(in: settingsFocusScope)
+            resetFocus(in: detailFocusScope)
+            detailFocus = .serverPrivacyPolicy
+            try? await Task.sleep(for: .milliseconds(120))
+            isRestoringDetailFocus = false
+        }
+    }
+
     private func presentPicker(_ request: TVSettingsPickerRequest) {
         // Remove every underlying focus candidate in the same update that
         // mounts the modal. The picker then becomes the sole focus owner.
@@ -509,6 +542,20 @@ struct TVSettingsView: View {
 
             TVSettingsInfoRow(title: "App Version", value: Self.versionString)
 
+            Button(action: presentPrivacyPolicy) {
+                HStack(spacing: 16) {
+                    Image(systemName: "hand.raised.fill")
+                        .font(.system(size: 22, weight: .medium))
+                    Text("Privacy Policy")
+                        .font(.system(size: 26))
+                    Spacer(minLength: 0)
+                    Image(systemName: "qrcode")
+                        .font(.system(size: 18, weight: .semibold))
+                        .opacity(0.55)
+                }
+            }
+            .buttonStyle(TVSettingsPaneRowStyle())
+            .focused($detailFocus, equals: .serverPrivacyPolicy)
         }
     }
 
@@ -562,6 +609,7 @@ enum TVSettingsDetailFocus: Hashable {
     case subtitleBackgroundOpacity
     case subtitleBackgroundColor
     case subtitlePosition
+    case serverPrivacyPolicy
 }
 
 // MARK: - Categories


### PR DESCRIPTION
## Summary

- add one canonical public privacy-policy URL for the Apple clients
- add a searchable Privacy Policy row to the iOS Settings About section that opens the published policy
- add a tvOS Privacy Policy row that presents a focused QR-code handoff, with Done/Menu dismissal and focus restoration

## Why

The public release audit requires the privacy policy to be easily accessible from the apps. A normal HTTPS `Link` works on iOS, but the live Apple TV simulator confirmed that the same control has no usable browser destination on tvOS. The QR handoff gives Apple TV users a working path to the public policy without duplicating policy content in the app.

## User impact

iPhone and iPad users can open the policy directly from Settings. Apple TV users can scan the displayed URL with a phone or tablet, dismiss the handoff, and continue from the same focused row.

## Validation

- XcodeGen project regeneration completed
- Xcode 26.5 iOS simulator build passed
- Xcode 26.5 tvOS simulator build passed
- visually verified the iOS row and published policy opening in Safari
- visually verified the tvOS row, QR handoff, centered Done action, dismissal, and focus restoration on an authenticated simulator
- `git diff --check` passed

A final physical phone/tablet scan of the tvOS QR code remains a release smoke-test item.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Privacy Policy link to the About section on iOS.
  * Added a Privacy Policy option in tvOS Settings.
  * Added a tvOS privacy-policy overlay with a QR code, explanatory text, and dismissal controls.
  * Improved settings search to recognize privacy-related terms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->