### PR TITLE
Harden YouTube trailer handoffs across Apple platforms

### DIFF
--- a/iosApp/Tests/TrailerRailModelTests.swift
+++ b/iosApp/Tests/TrailerRailModelTests.swift
@@ -169,6 +169,10 @@ final class TrailerRailModelTests: XCTestCase {
             TrailerRail.youtubeDeepLinkURL(siteKey: key)?.absoluteString,
             "youtube://www.youtube.com/watch?v=tFMo3UJ4B4g"
         )
+        XCTAssertEqual(
+            TrailerRail.youtubeWatchURL(siteKey: key)?.absoluteString,
+            "https://www.youtube.com/watch?v=tFMo3UJ4B4g"
+        )
     }
 
     func testKeysWithUnderscoresAndHyphensSurviveURLConstruction() {
@@ -181,6 +185,10 @@ final class TrailerRailModelTests: XCTestCase {
         XCTAssertEqual(
             TrailerRail.thumbnailURL(siteKey: key)?.absoluteString,
             "https://i.ytimg.com/vi/a-B_c1D2e3F/hqdefault.jpg"
+        )
+        XCTAssertEqual(
+            TrailerRail.youtubeWatchURL(siteKey: key)?.absoluteString,
+            "https://www.youtube.com/watch?v=a-B_c1D2e3F"
         )
     }
 }

--- a/iosApp/Tests/TrailerReturnPolicyTests.swift
+++ b/iosApp/Tests/TrailerReturnPolicyTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+import Foundation
+@testable import Silo
+
+final class TrailerReturnPolicyTests: XCTestCase {
+
+    private func record(
+        savedAt: Date,
+        serverId: String = "server-1",
+        profileId: String = "profile-1"
+    ) -> TrailerReturnRecord {
+        TrailerReturnRecord(
+            contentId: "movie-42",
+            serverId: serverId,
+            profileId: profileId,
+            savedAt: savedAt
+        )
+    }
+
+    func testFreshMatchingRecordRestores() {
+        let now = Date()
+        XCTAssertTrue(TrailerReturnPolicy.shouldRestore(
+            record: record(savedAt: now.addingTimeInterval(-120)),
+            now: now,
+            activeServerId: "server-1",
+            activeProfileId: "profile-1"
+        ))
+    }
+
+    func testRecordAtExactWindowBoundaryRestores() {
+        let now = Date()
+        XCTAssertTrue(TrailerReturnPolicy.shouldRestore(
+            record: record(savedAt: now.addingTimeInterval(-TrailerReturnPolicy.maxRecordAge)),
+            now: now,
+            activeServerId: "server-1",
+            activeProfileId: "profile-1"
+        ))
+    }
+
+    func testExpiredRecordDoesNotRestore() {
+        let now = Date()
+        XCTAssertFalse(TrailerReturnPolicy.shouldRestore(
+            record: record(savedAt: now.addingTimeInterval(-TrailerReturnPolicy.maxRecordAge - 1)),
+            now: now,
+            activeServerId: "server-1",
+            activeProfileId: "profile-1"
+        ))
+    }
+
+    func testFutureSavedAtDoesNotRestore() {
+        // A clock that went backwards must invalidate, not extend, the record.
+        let now = Date()
+        XCTAssertFalse(TrailerReturnPolicy.shouldRestore(
+            record: record(savedAt: now.addingTimeInterval(60)),
+            now: now,
+            activeServerId: "server-1",
+            activeProfileId: "profile-1"
+        ))
+    }
+
+    func testServerMismatchDoesNotRestore() {
+        let now = Date()
+        XCTAssertFalse(TrailerReturnPolicy.shouldRestore(
+            record: record(savedAt: now),
+            now: now,
+            activeServerId: "server-2",
+            activeProfileId: "profile-1"
+        ))
+    }
+
+    func testProfileMismatchDoesNotRestore() {
+        let now = Date()
+        XCTAssertFalse(TrailerReturnPolicy.shouldRestore(
+            record: record(savedAt: now),
+            now: now,
+            activeServerId: "server-1",
+            activeProfileId: "profile-2"
+        ))
+    }
+
+    func testMissingIdentityDoesNotRestore() {
+        let now = Date()
+        XCTAssertFalse(TrailerReturnPolicy.shouldRestore(
+            record: record(savedAt: now),
+            now: now,
+            activeServerId: nil,
+            activeProfileId: nil
+        ))
+    }
+}

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -192,11 +192,13 @@ struct ContentView: View {
             #endif
             await maybeAutoPlayForDebug()
             if router.authState == .authenticated {
+                let hasPendingDeepLink = pendingDeepLink != nil
                 if let pending = pendingDeepLink {
                     pendingDeepLink = nil
                     handleDeepLink(pending)
                 }
                 #if os(tvOS)
+                restoreTrailerReturnIfNeeded(hasPriorityLaunchIntent: hasPendingDeepLink)
                 await ExitSentinel.shared.captureLeftoverIfNeeded()
                 #endif
                 #if os(iOS) || os(tvOS)
@@ -640,6 +642,21 @@ struct ContentView: View {
             break
         }
     }
+
+    #if os(tvOS)
+    /// Consumes a fresh trailer handoff as soon as authentication resolves,
+    /// before unrelated startup hydration can delay navigation. A queued deep
+    /// link remains the priority launch intent, but the trailer record is still
+    /// consumed so it cannot ghost-navigate a later launch.
+    private func restoreTrailerReturnIfNeeded(hasPriorityLaunchIntent: Bool) {
+        guard let contentId = TVTrailerReturnStore.shared.consumeColdLaunchRestore(),
+              !hasPriorityLaunchIntent,
+              router.path.isEmpty else {
+            return
+        }
+        router.navigate(to: .itemDetail(contentId: contentId))
+    }
+    #endif
 
     @MainActor
     private func routePlayDeepLink(contentId: String) async {

--- a/iosApp/iosApp/Screens/Auth/AuthService.swift
+++ b/iosApp/iosApp/Screens/Auth/AuthService.swift
@@ -273,7 +273,12 @@ final class AuthService: @unchecked Sendable {
             let committed = await TokenStore.shared.deactivateProfile(
                 expectedAccount: expectedAccount
             )
-            if committed { await clearPerProfileCaches() }
+            if committed {
+                // A cold trailer return may require the profile picker. Keep
+                // the record until the selected identity can validate it;
+                // explicit in-app profile changes clear it before this path.
+                await clearPerProfileCaches(preservingTrailerReturn: true)
+            }
             return false
 
         case .restore(let remembered):
@@ -422,7 +427,11 @@ final class AuthService: @unchecked Sendable {
                 throw ProfileTransitionError.accountEpochUnavailable
             }
         }
-        await clearPerProfileCaches()
+        // Preserve a cold trailer return through the picker. Once the router
+        // becomes authenticated, ContentView consumes it and the identity
+        // policy either restores the matching page or rejects the record.
+        // Explicit profile switches already clear it during deactivation.
+        await clearPerProfileCaches(preservingTrailerReturn: true)
         await HTTPClient.shared.endIdentityTransition(transitionLease)
         #if os(iOS) || os(tvOS)
         DiagnosticsCoordinator.activeProfileDidChange()

--- a/iosApp/iosApp/Screens/Auth/AuthService.swift
+++ b/iosApp/iosApp/Screens/Auth/AuthService.swift
@@ -291,7 +291,10 @@ final class AuthService: @unchecked Sendable {
                     await clearPerProfileCaches()
                     return false
                 }
-                await clearPerProfileCaches()
+                // This is launch restoration of the same remembered identity,
+                // not a profile boundary. Keep a matching trailer handoff
+                // alive until ContentView can consume it after authentication.
+                await clearPerProfileCaches(preservingTrailerReturn: true)
                 return true
             } else {
                 _ = await TokenStore.shared.deactivateProfile(
@@ -487,11 +490,11 @@ final class AuthService: @unchecked Sendable {
         }
     }
 
-    /// Drop every cached response that's profile-scoped. Called on
-    /// profile switch and sign-out so userData (watched, favorites,
+    /// Drop every cached response that's profile-scoped. Called while
+    /// restoring or changing profile identity so userData (watched, favorites,
     /// watchlist, home recommendations) doesn't leak between accounts.
     @MainActor
-    private func clearPerProfileCaches() {
+    private func clearPerProfileCaches(preservingTrailerReturn: Bool = false) {
         StartupContentPrefetcher.resetProfileScopedPrefetches()
         for prefix in CacheKey.perProfilePrefixes {
             ResponseCache.shared.removeAll(withPrefix: prefix)
@@ -517,10 +520,12 @@ final class AuthService: @unchecked Sendable {
         RequestsEventBus.shared.reset()
         #if os(tvOS)
         ItemDetailCache.shared.clearAll()
-        // The identity check in TrailerReturnPolicy already refuses a record
-        // across identities; deleting here keeps the outgoing identity's
-        // browsing out of plaintext defaults on a shared device.
-        TVTrailerReturnStore.shared.clear()
+        if !preservingTrailerReturn {
+            // The identity check in TrailerReturnPolicy already refuses a record
+            // across identities; deleting here keeps the outgoing identity's
+            // browsing out of plaintext defaults on a shared device.
+            TVTrailerReturnStore.shared.clear()
+        }
         #endif
     }
 

--- a/iosApp/iosApp/Screens/Auth/AuthService.swift
+++ b/iosApp/iosApp/Screens/Auth/AuthService.swift
@@ -517,6 +517,10 @@ final class AuthService: @unchecked Sendable {
         RequestsEventBus.shared.reset()
         #if os(tvOS)
         ItemDetailCache.shared.clearAll()
+        // The identity check in TrailerReturnPolicy already refuses a record
+        // across identities; deleting here keeps the outgoing identity's
+        // browsing out of plaintext defaults on a shared device.
+        TVTrailerReturnStore.shared.clear()
         #endif
     }
 
@@ -679,6 +683,10 @@ final class AuthService: @unchecked Sendable {
         RequestsEventBus.shared.reset()
         #if os(tvOS)
         ItemDetailCache.shared.clearAll()
+        // The identity check in TrailerReturnPolicy already refuses a record
+        // across identities; deleting here keeps the outgoing identity's
+        // browsing out of plaintext defaults on a shared device.
+        TVTrailerReturnStore.shared.clear()
         #endif
     }
 

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneTrailersRail.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneTrailersRail.swift
@@ -55,7 +55,8 @@ struct PhoneTrailersRail: View {
 ///
 /// Both phone detail screens embed this instead of `PhoneTrailersRail`
 /// directly: a remote trailer is handed to the YouTube app with the same
-/// deep link used on tvOS, and that branch would otherwise be copied into
+/// deep link used on tvOS, then falls back to the public watch page when no
+/// app accepts it. That branch would otherwise be copied into
 /// `MovieDetailContent` and `SeriesDetailContent` verbatim. Local extras are
 /// ordinary playback targets, so those taps continue up to the detail view
 /// that owns the player presentation.
@@ -74,9 +75,19 @@ struct PhoneTrailersSection: View {
         case .local(let extra):
             onPlayExtra(extra.contentId)
         case .remote(let video):
-            if let url = TrailerRail.youtubeDeepLinkURL(siteKey: video.siteKey) {
-                openURL(url)
-            }
+            openRemoteTrailer(siteKey: video.siteKey)
+        }
+    }
+
+    private func openRemoteTrailer(siteKey: String) {
+        guard let appURL = TrailerRail.youtubeDeepLinkURL(siteKey: siteKey),
+              let webURL = TrailerRail.youtubeWatchURL(siteKey: siteKey) else {
+            return
+        }
+
+        openURL(appURL) { accepted in
+            guard !accepted else { return }
+            openURL(webURL)
         }
     }
 }

--- a/iosApp/iosApp/Screens/Detail/TrailerRail.swift
+++ b/iosApp/iosApp/Screens/Detail/TrailerRail.swift
@@ -104,4 +104,10 @@ enum TrailerRail {
     static func youtubeDeepLinkURL(siteKey: String) -> URL? {
         URL(string: "youtube://www.youtube.com/watch?v=\(siteKey)")
     }
+
+    /// Public watch page used when no installed app accepts the YouTube
+    /// custom scheme. The system opens this in the default browser.
+    static func youtubeWatchURL(siteKey: String) -> URL? {
+        URL(string: "https://www.youtube.com/watch?v=\(siteKey)")
+    }
 }

--- a/iosApp/iosApp/Screens/Detail/TrailerReturnPolicy.swift
+++ b/iosApp/iosApp/Screens/Detail/TrailerReturnPolicy.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Record of a remote-trailer handoff to the YouTube app on tvOS, persisted
+/// so a cold launch can put the user back on the detail page they left from.
+///
+/// tvOS has no way to programmatically return from the YouTube app, so the
+/// warm path relies on the system keeping Silo suspended. This record exists
+/// solely to survive the one case that breaks: Silo is jetsammed while the
+/// trailer plays, and the user relaunches into Home with the detail page gone.
+struct TrailerReturnRecord: Codable, Equatable {
+    let contentId: String
+    /// Identity at handoff time. A record from another server or profile is
+    /// never honored — restoring it would surface one profile's browsing to
+    /// another on a shared living-room device.
+    let serverId: String
+    let profileId: String
+    let savedAt: Date
+}
+
+/// Pure decision rule for honoring a persisted handoff record, kept free of
+/// SwiftUI and platform conditionals (like `TrailerRail`) so it is testable
+/// headless from the iOS test bundle.
+enum TrailerReturnPolicy {
+    /// How long a handoff record stays eligible for cold-launch restore.
+    ///
+    /// The record covers exactly one story: "I was watching a trailer and
+    /// came back." Thirty minutes comfortably exceeds a trailer plus some
+    /// YouTube drift while staying well inside the same sitting — an older
+    /// record restored the next day reads as a bug, and on a shared device
+    /// quietly reveals what someone else was browsing. Erring short is
+    /// cheap: the user just lands on Home, which is today's behavior.
+    static let maxRecordAge: TimeInterval = 30 * 60
+
+    /// Whether a persisted record should restore its detail page now.
+    ///
+    /// Age is the last line of defense, not the primary guard: identity must
+    /// match exactly, and a clock that has gone backwards (negative age)
+    /// invalidates rather than extends the record.
+    static func shouldRestore(
+        record: TrailerReturnRecord,
+        now: Date,
+        activeServerId: String?,
+        activeProfileId: String?
+    ) -> Bool {
+        guard record.serverId == activeServerId,
+              record.profileId == activeProfileId else {
+            return false
+        }
+        let age = now.timeIntervalSince(record.savedAt)
+        return age >= 0 && age <= maxRecordAge
+    }
+}

--- a/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
@@ -220,6 +220,7 @@ struct TVMainTabView: View {
             await uiCustomization.refresh()
             controlReceiver.start(router: router)
             await loadCurrentProfile()
+            restoreTrailerReturnIfNeeded()
         }
         .task(id: currentLibraryAuthority) {
             await loadLibraries(for: currentLibraryAuthority)
@@ -1098,6 +1099,22 @@ struct TVMainTabView: View {
 
     private func switchProfile() {
         router.switchProfile()
+    }
+
+    /// Cold-launch tail of a remote-trailer handoff: if Silo was jetsammed
+    /// while the YouTube app played a trailer, put the user back on the
+    /// detail page they left from instead of stranding them on Home. The
+    /// store consumes its record on first call (and the eligibility rules
+    /// live in `TrailerReturnPolicy`), so this is a plain push when a fresh,
+    /// identity-matching record exists and a no-op otherwise. Guarded on an
+    /// empty stack: if something else already navigated (deep link, control
+    /// receiver), that intent wins.
+    private func restoreTrailerReturnIfNeeded() {
+        guard let contentId = TVTrailerReturnStore.shared.consumeColdLaunchRestore(),
+              router.path.isEmpty else {
+            return
+        }
+        router.navigate(to: .itemDetail(contentId: contentId))
     }
 
     private func loadCurrentProfile() async {

--- a/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
@@ -220,7 +220,6 @@ struct TVMainTabView: View {
             await uiCustomization.refresh()
             controlReceiver.start(router: router)
             await loadCurrentProfile()
-            restoreTrailerReturnIfNeeded()
         }
         .task(id: currentLibraryAuthority) {
             await loadLibraries(for: currentLibraryAuthority)
@@ -1099,22 +1098,6 @@ struct TVMainTabView: View {
 
     private func switchProfile() {
         router.switchProfile()
-    }
-
-    /// Cold-launch tail of a remote-trailer handoff: if Silo was jetsammed
-    /// while the YouTube app played a trailer, put the user back on the
-    /// detail page they left from instead of stranding them on Home. The
-    /// store consumes its record on first call (and the eligibility rules
-    /// live in `TrailerReturnPolicy`), so this is a plain push when a fresh,
-    /// identity-matching record exists and a no-op otherwise. Guarded on an
-    /// empty stack: if something else already navigated (deep link, control
-    /// receiver), that intent wins.
-    private func restoreTrailerReturnIfNeeded() {
-        guard let contentId = TVTrailerReturnStore.shared.consumeColdLaunchRestore(),
-              router.path.isEmpty else {
-            return
-        }
-        router.navigate(to: .itemDetail(contentId: contentId))
     }
 
     private func loadCurrentProfile() async {

--- a/iosApp/iosApp/tvOS/Navigation/TVTrailerReturnStore.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVTrailerReturnStore.swift
@@ -1,0 +1,89 @@
+#if os(tvOS)
+import Foundation
+
+/// Persists the one `TrailerReturnRecord` written when a detail page hands a
+/// remote trailer off to the YouTube app, so a cold relaunch can restore the
+/// detail page the user left from (see the record's doc comment for why only
+/// the jetsam case needs this).
+///
+/// Lifecycle is deliberately narrow:
+/// - Written at handoff, just before the deep link opens.
+/// - Consumed (read + deleted) exactly once per process, at the cold-launch
+///   authenticated landing in `TVMainTabView` — whether or not the restore
+///   happens, so a stale record can never linger across sittings.
+/// - Cleared on any warm return to the detail page (`scenePhase` → active
+///   while the page is alive): the page survived suspension, so there is
+///   nothing to restore and the record must not outlive its story.
+///
+/// Eligibility (freshness window, server/profile identity) is decided by
+/// `TrailerReturnPolicy`, which stays platform-free and unit-tested; this
+/// store owns only persistence and the process-once gate.
+///
+/// Plain `UserDefaults.standard`: nothing outside the app process (Top
+/// Shelf) reads this, so the App Group suite mirroring that
+/// `TVLibraryScopeStore` does is not needed. Identity lives inside the
+/// record rather than the key, so a profile switch invalidates by
+/// comparison instead of by key bookkeeping.
+struct TVTrailerReturnStore {
+    static let shared = TVTrailerReturnStore()
+
+    private static let recordKey = "trailerReturn.record"
+
+    /// Process-wide gate so the cold-launch restore runs once even if the
+    /// authenticated shell re-mounts (sign-out → sign-in) in the same run.
+    /// A re-mount is not a cold launch, and restoring there would replay a
+    /// consumed story.
+    @MainActor private static var didAttemptColdLaunchRestore = false
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    /// Record a handoff from the detail page for `contentId`. No-op when no
+    /// profile is active — an anonymous record could be honored by whoever
+    /// signs in next.
+    func saveHandoff(contentId: String) {
+        guard let profileId = AuthService.shared.profileId, !profileId.isEmpty,
+              let serverId = ServerRegistry.shared.activeServerId else {
+            return
+        }
+        let record = TrailerReturnRecord(
+            contentId: contentId,
+            serverId: serverId,
+            profileId: profileId,
+            savedAt: Date()
+        )
+        guard let data = try? JSONEncoder().encode(record) else { return }
+        defaults.set(data, forKey: Self.recordKey)
+    }
+
+    func clear() {
+        defaults.removeObject(forKey: Self.recordKey)
+    }
+
+    /// The contentId to restore on this cold launch, or nil. First call per
+    /// process does the work; every call deletes any stored record.
+    @MainActor
+    func consumeColdLaunchRestore(now: Date = Date()) -> String? {
+        defer { clear() }
+        guard !Self.didAttemptColdLaunchRestore else { return nil }
+        Self.didAttemptColdLaunchRestore = true
+
+        guard let data = defaults.data(forKey: Self.recordKey),
+              let record = try? JSONDecoder().decode(TrailerReturnRecord.self, from: data) else {
+            return nil
+        }
+        guard TrailerReturnPolicy.shouldRestore(
+            record: record,
+            now: now,
+            activeServerId: ServerRegistry.shared.activeServerId,
+            activeProfileId: AuthService.shared.profileId
+        ) else {
+            return nil
+        }
+        return record.contentId
+    }
+}
+#endif

--- a/iosApp/iosApp/tvOS/Navigation/TVTrailerReturnStore.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVTrailerReturnStore.swift
@@ -8,8 +8,9 @@ import Foundation
 ///
 /// Lifecycle is deliberately narrow:
 /// - Written at handoff, just before the deep link opens.
+/// - Cleared immediately if the system rejects that launch.
 /// - Consumed (read + deleted) exactly once per process, at the cold-launch
-///   authenticated landing in `TVMainTabView` — whether or not the restore
+///   authenticated landing in `ContentView` — whether or not the restore
 ///   happens, so a stale record can never linger across sittings.
 /// - Cleared on any warm return to the detail page (`scenePhase` → active
 ///   while the page is alive): the page survived suspension, so there is

--- a/iosApp/iosApp/tvOS/Navigation/TVTrailerReturnStore.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVTrailerReturnStore.swift
@@ -42,11 +42,12 @@ struct TVTrailerReturnStore {
     }
 
     /// Record a handoff from the detail page for `contentId`. No-op when no
-    /// profile is active — an anonymous record could be honored by whoever
-    /// signs in next.
+    /// profile or server is active — an anonymous record could be honored by
+    /// whoever signs in next, and an empty serverId would match an equally
+    /// degenerate active server at consume time instead of failing closed.
     func saveHandoff(contentId: String) {
         guard let profileId = AuthService.shared.profileId, !profileId.isEmpty,
-              let serverId = ServerRegistry.shared.activeServerId else {
+              let serverId = ServerRegistry.shared.activeServerId, !serverId.isEmpty else {
             return
         }
         let record = TrailerReturnRecord(

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
@@ -23,9 +23,10 @@ struct TVItemDetailView: View {
     @State private var isLoadingNextUpPlaybackDetail = false
     @State private var didLoadNextUpPlaybackDetail = false
     /// Whether the YouTube app is installed, probed once per page appearance.
-    /// Remote trailer cards are hidden entirely when it isn't — tvOS has no
-    /// in-app web fallback, so a card that cannot open must not exist.
-    /// Always false on the simulator, which has no YouTube app.
+    /// Remote trailer cards and the "Find Trailers" action are hidden when it
+    /// isn't — tvOS has no in-app web fallback, so content that cannot open
+    /// must not be offered. Always false on the simulator, which has no
+    /// YouTube app.
     @State private var allowRemoteTrailers = false
     @Environment(AppRouter.self) private var router
     private static let focusLogger = Logger(
@@ -297,7 +298,7 @@ struct TVItemDetailView: View {
                 nextUpSubtitleOverrideCleared: didClearNextUpSubtitleOverride,
                 trailerEntries: trailerEntries(for: detail),
                 onSelectTrailer: playTrailer,
-                supportsTrailerFetch: viewModel.supportsTrailerFetch,
+                supportsTrailerFetch: viewModel.supportsTrailerFetch && allowRemoteTrailers,
                 onFindTrailers: {
                     // Without the YouTube app the rail hides remote cards, so
                     // new remote videos must not be reported as a find.
@@ -422,7 +423,7 @@ struct TVItemDetailView: View {
                 isLoadingEpisodes: viewModel.isLoadingEpisodes,
                 trailerEntries: trailerEntries(for: detail),
                 onSelectTrailer: playTrailer,
-                supportsTrailerFetch: viewModel.supportsTrailerFetch,
+                supportsTrailerFetch: viewModel.supportsTrailerFetch && allowRemoteTrailers,
                 onFindTrailers: {
                     // Without the YouTube app the rail hides remote cards, so
                     // new remote videos must not be reported as a find.

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
@@ -29,6 +29,7 @@ struct TVItemDetailView: View {
     /// YouTube app.
     @State private var allowRemoteTrailers = false
     @Environment(AppRouter.self) private var router
+    @Environment(\.scenePhase) private var scenePhase
     private static let focusLogger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "com.continuum.app",
         category: "TVFocus"
@@ -75,6 +76,14 @@ struct TVItemDetailView: View {
             // otherwise keep running (and retaining the view model) after
             // this route pops.
             viewModel.stopTrailerFetch()
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            // A warm return from the YouTube app lands here with the page
+            // still alive — nothing to restore, so the handoff record must
+            // not survive to be replayed on some later cold launch.
+            if newPhase == .active {
+                TVTrailerReturnStore.shared.clear()
+            }
         }
         .task(id: contentId) {
             didClearSubtitleOverride = false
@@ -139,6 +148,12 @@ struct TVItemDetailView: View {
     private func playTrailer(_ entry: TrailerRailEntry) {
         switch entry {
         case .remote(let video):
+            // Recorded before the deep link so a jetsam during the trailer
+            // can restore this page on the next cold launch (see
+            // `TVTrailerReturnStore`). tvOS cannot bring the user back from
+            // YouTube; this is the fallback for when suspension doesn't
+            // preserve the page either.
+            TVTrailerReturnStore.shared.saveHandoff(contentId: contentId)
             TVTrailerLaunch.open(siteKey: video.siteKey)
         case .local(let extra):
             router.navigate(

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
@@ -165,7 +165,10 @@ struct TVItemDetailView: View {
             // YouTube; this is the fallback for when suspension doesn't
             // preserve the page either.
             TVTrailerReturnStore.shared.saveHandoff(contentId: contentId)
-            TVTrailerLaunch.open(siteKey: video.siteKey)
+            TVTrailerLaunch.open(siteKey: video.siteKey) { didOpen in
+                guard !didOpen else { return }
+                TVTrailerReturnStore.shared.clear()
+            }
         case .local(let extra):
             router.navigate(
                 to: .player(

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
@@ -76,6 +76,14 @@ struct TVItemDetailView: View {
             // otherwise keep running (and retaining the view model) after
             // this route pops.
             viewModel.stopTrailerFetch()
+            // A pop proves the user is navigating in-app, so any handoff
+            // record is dead: if the YouTube launch had actually taken over
+            // the screen, this page could not be popping. Without this, a
+            // failed `open` (app deleted after the probe) leaves a live
+            // record that would ghost-navigate a later cold launch. The
+            // jetsam case this store exists for never pops, so it is
+            // unaffected.
+            TVTrailerReturnStore.shared.clear()
         }
         .onChange(of: scenePhase) { _, newPhase in
             // A warm return from the YouTube app lands here with the page

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
@@ -88,8 +88,11 @@ struct TVItemDetailView: View {
         .onChange(of: scenePhase) { _, newPhase in
             // A warm return from the YouTube app lands here with the page
             // still alive — nothing to restore, so the handoff record must
-            // not survive to be replayed on some later cold launch.
+            // not survive to be replayed on some later cold launch. Re-probe
+            // YouTube as well because its installation can change while Silo
+            // is suspended.
             if newPhase == .active {
+                allowRemoteTrailers = TVTrailerLaunch.isYouTubeAppInstalled()
                 TVTrailerReturnStore.shared.clear()
             }
         }

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
@@ -29,8 +29,8 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
     /// whether remote cards exist at all). Empty hides the rail.
     let trailerEntries: [TrailerRailEntry]
     let onSelectTrailer: (TrailerRailEntry) -> Void
-    /// Whether the manual "Find Trailers" action applies to this item —
-    /// false on episode pages, which never carry videos.
+    /// Whether the manual "Find Trailers" action can be offered — false on
+    /// episode pages and when the YouTube app is unavailable.
     let supportsTrailerFetch: Bool
     let onFindTrailers: () -> Void
     /// Copy from the fetch coordinator; nil while idle.

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -30,7 +30,8 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     /// whether remote cards exist at all). Empty hides the rail.
     let trailerEntries: [TrailerRailEntry]
     let onSelectTrailer: (TrailerRailEntry) -> Void
-    /// Whether the manual "Find Trailers" action applies to this item.
+    /// Whether the manual "Find Trailers" action can be offered. The caller
+    /// also requires the YouTube app because tvOS has no browser fallback.
     let supportsTrailerFetch: Bool
     let onFindTrailers: () -> Void
     /// Copy from the fetch coordinator; nil while idle.

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVTrailersRail.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVTrailersRail.swift
@@ -323,8 +323,8 @@ struct TVTrailerStatusPill: View {
 // MARK: - YouTube app bridge
 
 /// Deep-link bridge to the installed YouTube app — the only remote-trailer
-/// playback path on tvOS, which has no in-app web view to fall back on
-/// (iOS uses a `WKWebView` sheet instead).
+/// playback path on tvOS, which has no browser to fall back on (iOS falls
+/// back to the public watch page in the default browser).
 ///
 /// Plain (non-isolated) statics, matching `PlatformScreen` and
 /// `TVFocusDebugOverlay`'s `UIApplication` accessors; every call site is a

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVTrailersRail.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVTrailersRail.swift
@@ -341,11 +341,16 @@ enum TVTrailerLaunch {
         return UIApplication.shared.canOpenURL(probe)
     }
 
-    /// Hand a video off to the YouTube app. Only ever called for cards that
-    /// exist, i.e. after ``isYouTubeAppInstalled()`` returned true.
-    static func open(siteKey: String) {
-        guard let url = TrailerRail.youtubeDeepLinkURL(siteKey: siteKey) else { return }
-        UIApplication.shared.open(url, options: [:], completionHandler: nil)
+    /// Hand a video off to the YouTube app and report whether the system
+    /// accepted the launch. Only ever called for cards that exist, i.e. after
+    /// ``isYouTubeAppInstalled()`` returned true, but the app can disappear
+    /// or reject the URL between that probe and this request.
+    static func open(siteKey: String, completion: @escaping (Bool) -> Void) {
+        guard let url = TrailerRail.youtubeDeepLinkURL(siteKey: siteKey) else {
+            completion(false)
+            return
+        }
+        UIApplication.shared.open(url, options: [:], completionHandler: completion)
     }
 }
 #endif


### PR DESCRIPTION
## Summary

- fall back to the public YouTube watch page on iOS and macOS when no installed app accepts the YouTube deep link
- hide remote trailer cards and the manual **Find Trailers** action on tvOS when the YouTube app is unavailable
- preserve local-extra playback inside Silo
- record tvOS trailer handoffs so a fresh, identity-matching cold launch can restore the detail page if Silo is jetsammed while YouTube is playing
- expire and consume restoration records defensively to avoid replaying stale or cross-profile navigation

## Why

Remote trailer taps previously did nothing on iOS/macOS when YouTube was not installed. On tvOS, offering trailer discovery without YouTube exposed content that could not be played. A separate tvOS lifecycle edge case could also strand users on Home if Silo was jetsammed during a YouTube handoff.

## Validation

- regenerated the Xcode project with XcodeGen after adding source files
- signed tvOS 26.5 simulator build, install, and launch passed on Xcode 26.5
- visually verified movie and series detail pages hide **Find Trailers** when YouTube is unavailable
- iOS 26.5 simulator, tvOS 26.5 simulator, and arm64 macOS builds passed for the trailer fallback
- `git diff --check` passed
- added URL-construction and trailer-return policy coverage

The focused XCTest run is currently blocked by unrelated existing `DiagnosticsCoordinator` test-hook compile failures elsewhere in `SiloTests`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved trailer playback across iOS and tvOS with YouTube app launching and browser fallback on iOS.
  * tvOS now returns viewers to the relevant title after returning from YouTube.
  * Trailer discovery options now reflect YouTube availability and supported content types.

* **Bug Fixes**
  * Improved handling of trailer return state across sign-in, profile changes, and app launches.
  * Expired, mismatched, or incomplete trailer return information is no longer restored.

* **Documentation**
  * Clarified trailer playback and discovery behavior across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->