### PR TITLE
fix(apple): scale poster overlays with card width

### DIFF
--- a/iosApp/iosApp/Overlays/CardOverlays.swift
+++ b/iosApp/iosApp/Overlays/CardOverlays.swift
@@ -13,6 +13,9 @@ import SwiftUI
 /// }
 /// ```
 struct CardOverlays: View {
+    /// Matches the measured poster overlay layer on the web Home carousel.
+    private static let posterReferenceWidth: CGFloat = 185
+
     let data: OverlayData
     let prefs: CardOverlayPrefs
     var variant: Variant = .poster
@@ -26,30 +29,39 @@ struct CardOverlays: View {
 
     var body: some View {
         let preset = OverlayPresets.preset(prefs.preset)
-        ZStack(alignment: .topLeading) {
-            cornerStack(.topLeft, preset: preset)
-            cornerStack(.topRight, preset: preset)
-            cornerStack(.bottomLeft, preset: preset)
-            cornerStack(.bottomRight, preset: preset)
+        GeometryReader { proxy in
+            let scale = variant == .poster
+                ? proxy.size.width / Self.posterReferenceWidth
+                : 1
+            ZStack(alignment: .topLeading) {
+                cornerStack(.topLeft, preset: preset, scale: scale)
+                cornerStack(.topRight, preset: preset, scale: scale)
+                cornerStack(.bottomLeft, preset: preset, scale: scale)
+                cornerStack(.bottomRight, preset: preset, scale: scale)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .allowsHitTesting(false)
     }
 
     @ViewBuilder
-    private func cornerStack(_ position: OverlayPosition, preset: OverlayPreset) -> some View {
+    private func cornerStack(
+        _ position: OverlayPosition,
+        preset: OverlayPreset,
+        scale: CGFloat
+    ) -> some View {
         let badges = OverlayRegistry
             .enabled(at: position, in: prefs)
             .compactMap { OverlayBadgeRenderState.resolve(def: $0, data: data, prefs: prefs, preset: preset) }
         if badges.isEmpty {
             EmptyView()
         } else {
-            VStack(alignment: alignment(for: position), spacing: preset.gap) {
+            VStack(alignment: alignment(for: position), spacing: preset.gap * scale) {
                 ForEach(badges, id: \.id) { state in
-                    OverlayBadgeView(state: state, preset: preset)
+                    OverlayBadgeView(state: state, preset: preset, scale: scale)
                 }
             }
-            .padding(insets(for: position))
+            .padding(insets(for: position, scale: scale))
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: anchor(for: position))
         }
     }
@@ -70,18 +82,18 @@ struct CardOverlays: View {
         }
     }
 
-    private func insets(for position: OverlayPosition) -> EdgeInsets {
+    private func insets(for position: OverlayPosition, scale: CGFloat) -> EdgeInsets {
         // `wide` and `hero` variants leave more bottom room because a
         // title block / progress bar typically sits under the image.
         let bottomInset: CGFloat = {
             switch variant {
-            case .poster: return 8
+            case .poster: return 8 * scale
             case .wide:   return 24
             case .hero:   return 16
             }
         }()
-        let sideInset: CGFloat = variant == .hero ? 16 : 8
-        let topInset: CGFloat  = variant == .hero ? 16 : 8
+        let sideInset: CGFloat = variant == .hero ? 16 : 8 * scale
+        let topInset: CGFloat  = variant == .hero ? 16 : 8 * scale
         switch position {
         case .topLeft:
             return EdgeInsets(top: topInset, leading: sideInset, bottom: 0, trailing: 0)
@@ -161,13 +173,14 @@ struct OverlayBadgeRenderState: Equatable {
 struct OverlayBadgeView: View {
     let state: OverlayBadgeRenderState
     let preset: OverlayPreset
+    let scale: CGFloat
 
     var body: some View {
-        HStack(spacing: 4) {
+        HStack(spacing: 4 * scale) {
             if let iconId = state.iconId {
                 OverlayIcon(
                     iconId: iconId,
-                    size: preset.iconSize,
+                    size: preset.iconSize * scale,
                     tint: preset.foregroundColor(state.accentColor)
                 )
             }
@@ -175,8 +188,8 @@ struct OverlayBadgeView: View {
                 badgeText
             }
         }
-        .padding(.horizontal, preset.horizontalPadding)
-        .padding(.vertical, preset.verticalPadding)
+        .padding(.horizontal, preset.horizontalPadding * scale)
+        .padding(.vertical, preset.verticalPadding * scale)
         .background(background)
         .overlay(border)
         .clipShape(shape)
@@ -195,8 +208,8 @@ struct OverlayBadgeView: View {
     @ViewBuilder
     private var badgeText: some View {
         let text = Text(state.label)
-            .font(preset.font.weight(preset.textWeight))
-            .tracking(preset.tracking)
+            .font(.system(size: preset.fontSize * scale, weight: preset.textWeight))
+            .tracking(preset.tracking * scale)
             .foregroundColor(preset.foregroundColor(state.accentColor))
         Group {
             if let textCase = preset.textCase {
@@ -205,7 +218,7 @@ struct OverlayBadgeView: View {
                 text
             }
         }
-        .modifier(BadgeShadow(enabled: preset.textShadow))
+        .modifier(BadgeShadow(enabled: preset.textShadow, scale: scale))
     }
 
     @ViewBuilder
@@ -223,7 +236,7 @@ struct OverlayBadgeView: View {
     @ViewBuilder
     private var border: some View {
         if let stroke = preset.borderColor(state.accentColor) {
-            shape.stroke(stroke, lineWidth: 1)
+            shape.stroke(stroke, lineWidth: scale)
         }
     }
 
@@ -236,16 +249,17 @@ struct OverlayBadgeView: View {
         case .capsule:
             return AnyShape(Capsule(style: .continuous))
         case .rounded(let radius):
-            return AnyShape(RoundedRectangle(cornerRadius: radius, style: .continuous))
+            return AnyShape(RoundedRectangle(cornerRadius: radius * scale, style: .continuous))
         }
     }
 }
 
 private struct BadgeShadow: ViewModifier {
     let enabled: Bool
+    let scale: CGFloat
     func body(content: Content) -> some View {
         if enabled {
-            content.shadow(color: Color.black.opacity(0.85), radius: 1, y: 1)
+            content.shadow(color: Color.black.opacity(0.85), radius: scale, y: scale)
         } else {
             content
         }

--- a/iosApp/iosApp/Overlays/OverlayPresets.swift
+++ b/iosApp/iosApp/Overlays/OverlayPresets.swift
@@ -19,7 +19,7 @@ enum OverlayPresets {
 
     private static let minimal = OverlayPreset(
         id: .minimal,
-        font: .system(size: 9),
+        fontSize: 9,
         textWeight: .semibold,
         textCase: .uppercase,
         tracking: 1.2,
@@ -39,7 +39,7 @@ enum OverlayPresets {
 
     private static let classic = OverlayPreset(
         id: .classic,
-        font: .system(size: 10),
+        fontSize: 10,
         textWeight: .semibold,
         textCase: .uppercase,
         tracking: 0.6,
@@ -62,7 +62,7 @@ enum OverlayPresets {
 
     private static let vibrant = OverlayPreset(
         id: .vibrant,
-        font: .system(size: 10),
+        fontSize: 10,
         textWeight: .bold,
         textCase: .uppercase,
         tracking: 0.6,
@@ -82,7 +82,7 @@ enum OverlayPresets {
 
     private static let pill = OverlayPreset(
         id: .pill,
-        font: .system(size: 10),
+        fontSize: 10,
         textWeight: .semibold,
         textCase: .uppercase,
         tracking: 0.6,
@@ -106,7 +106,7 @@ enum OverlayPresets {
 
     private static let square = OverlayPreset(
         id: .square,
-        font: .system(size: 9),
+        fontSize: 9,
         textWeight: .bold,
         textCase: .uppercase,
         tracking: 1.2,

--- a/iosApp/iosApp/Overlays/OverlayTypes.swift
+++ b/iosApp/iosApp/Overlays/OverlayTypes.swift
@@ -280,7 +280,7 @@ enum AccentStrategy: String {
 /// comes from the registry (icon) and the user's `accentColor`.
 struct OverlayPreset {
     let id: PresetId
-    let font: Font
+    let fontSize: CGFloat
     let textWeight: Font.Weight
     let textCase: Text.Case?
     let tracking: CGFloat


### PR DESCRIPTION
## What changed

Poster overlay pills on iOS and tvOS used fixed geometry, so compact cards and larger layouts did not keep the same proportions as the Web Home cards.

I helped work out that sizing against the Web UI and confirmed the Web version live. This applies the same rule in the shared Apple renderer: poster overlays use the actual rendered card width as their reference, while wide and hero overlays keep their current optical sizing.

Type, tracking, padding, icons, gaps, insets, radii, borders, and shadows all scale together. Because the renderer is shared, the change follows card presentation sizes on iPhone and iPad and the poster widths used on tvOS.

## Validation

- `xcrun swiftc -parse` passed for all three changed Swift files on current upstream main.
- The same implementation produced both unsigned iOS and tvOS IPAs in the [fork build](https://github.com/blurbery/silo-apple/releases/tag/v1.0.0-build.1).
- The complete diff and iOS/tvOS call sites were reviewed with no unresolved material findings.
- A signed Xcode or store build was not run locally because signing infrastructure is not available in the fork.

Related issue: N/A — narrow cross-platform UI fix.

## AI disclosure

OpenAI Codex desktop app (GPT-5) assisted with the implementation and review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved badge scaling on poster-style cards so overlays remain proportional across different poster sizes.
  * Preserved consistent sizing for wide and hero card variants.
  * Refined badge typography, spacing, borders, corner rounding, padding, and shadows for clearer visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->