### PR TITLE
Fix framework runpaths for Apple targets

### DIFF
--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -96,6 +96,7 @@ targets:
         SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD: "NO"
         SDKROOT: iphoneos
         SUPPORTED_PLATFORMS: "iphoneos iphonesimulator"
+        LD_RUNPATH_SEARCH_PATHS: "$(inherited) @executable_path/Frameworks"
       configs:
         Debug:
           APS_ENVIRONMENT: development
@@ -148,6 +149,7 @@ targets:
         SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD: "NO"
         SDKROOT: appletvos
         SUPPORTED_PLATFORMS: "appletvos appletvsimulator"
+        LD_RUNPATH_SEARCH_PATHS: "$(inherited) @executable_path/Frameworks"
     dependencies:
       - package: AetherEngine
         product: AetherEngine
@@ -193,6 +195,7 @@ targets:
         ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
         SDKROOT: macosx
         SUPPORTED_PLATFORMS: "macosx"
+        LD_RUNPATH_SEARCH_PATHS: "$(inherited) @executable_path/../Frameworks"
     dependencies:
       - package: AetherEngine
         product: AetherEngine


### PR DESCRIPTION
## Summary

- restore the executable framework runpath for the iOS and tvOS app targets
- restore the bundle-relative framework runpath for the macOS app target
- keep the settings in `project.yml`, the XcodeGen source of truth

## Validation

- `xcodegen generate`
- iOS Debug simulator build succeeded
- tvOS Debug simulator build succeeded
- generated project contains the expected runpaths for Debug and Release
- built tvOS executable contains `@executable_path/Frameworks` as an `LC_RPATH`

## Additional validation note

The macOS build currently stops during Swift module resolution because AetherEngine and Nuke are reported as built for an incompatible target, before linking the app. That is separate from this runpath setting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved framework loading and runtime reliability across iOS, tvOS, and macOS applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->