### PR TITLE
feat(playback): let Aether declare Apple TV capabilities

### DIFF
--- a/docs/tvos-player/README.md
+++ b/docs/tvos-player/README.md
@@ -1,7 +1,10 @@
 # Apple Library Playback Documentation
 
-Current architecture as of 2026-08-22: Silo's library-media implementation is
-being replaced by one AetherEngine route across iOS, tvOS, and macOS. The
+Current architecture as of 2026-08-23: Silo's library-media implementation is
+one AetherEngine route across iOS, tvOS, and macOS. Apple TV 4K online playback
+declares the pinned engine/build manifest and lets Aether probe each source;
+offline downloads and conservative Apple surfaces retain bounded decoder
+attestation. The
 canonical product, ownership, deletion, capability, privacy, legal, and
 validation contract is the
 [AetherEngine-only replacement specification](aetherengine-replacement-spec.md).

--- a/docs/tvos-player/aetherengine-replacement-spec.md
+++ b/docs/tvos-player/aetherengine-replacement-spec.md
@@ -1,7 +1,7 @@
 # AetherEngine-Only Playback Replacement
 
-Status: Aether-only source migration, coordinated transport/software-decode contracts, Apple builds, shared-dev and isolated-fixture direct-play proof, and final Fable review complete; Opus rerun, hardware breadth, and release gates pending
-Date: 2026-08-22
+Status: Aether-only source migration and Apple TV 4K engine-declared streaming capabilities implemented; physical hardware breadth and release gates pending
+Date: 2026-08-23
 Silo Apple baseline: `4910372c2ccb34d0f6bbde9419b6806e3971ff3f`
 AetherEngine pin: `6.34.0` / `0ae80496ab6f3fda135f43ef195ff10961c0e625`
 
@@ -47,8 +47,9 @@ explicitly.
   `IOReader` to conceal a missing Aether API.
 - Reimplementing Aether's codec routing, recovery, demux, decode, remux,
   buffering, cache, local HLS, or AVPlayer/sample-buffer hosting.
-- Expanding Apple capabilities merely because upstream documentation lists a
-  format. Capability growth requires Silo fixture and device proof.
+- Recreating Aether's per-stream routing decision in the app. The online
+  manifest must match the exact pinned engine/build, while the engine probes
+  the actual source and device at load time.
 
 ## Ownership boundary
 
@@ -69,8 +70,8 @@ Silo controls, settings, queue, progress, realtime, downloads
 ### Silo owns
 
 - Playback V3 start, replan, renewal, stop, progress, and attempt identity.
-- User quality intent, server-delivery policy, and conservative capability
-  advertisement.
+- User quality intent, server-delivery/output policy, and Protocol V3
+  capability assembly.
 - Resume, Next Up, intro/credits, markers, queueing, and exactly-once end work.
 - Realtime commands and SiloControl behavior.
 - Download lifecycle, persistent storage, and offline item metadata.
@@ -235,10 +236,25 @@ snapshots:
 
 The audiobook snapshot is included in this cleanup.
 
-The first Aether-only build deliberately underclaims. It starts with the
-smallest delivery/codec/subtitle set needed by the controlled fixtures and
-shared-development validation. Later Aether-only builds add claims one proven
-slice at a time.
+The first Aether-only build deliberately underclaimed with handwritten,
+fixture-bounded decoder envelopes. That was safe for migration but could make
+the server reject a source before Aether's runtime probe saw it. The current
+Apple TV policy separates an engine/build declaration from device/output and
+persistent-artifact constraints:
+
+- a physical Apple TV 4K sends `video_evidence: declared`, the flat decoder and
+  demuxer manifest of pinned AetherEngine 6.34.0 plus FFmpegBuild 2.4.3, and no
+  per-profile/bit-depth/performance `video_decode[]` envelope;
+- Aether probes the actual source and exact device during `load`, selects its
+  native or software path, and a typed load failure enters Silo's bounded V3
+  replan path;
+- Apple TV HD stays on the bounded `platform_attested` policy because it has
+  materially less software-decode headroom and Aether does not yet emit a
+  typed decoder-underperforming signal;
+- simulators, iOS, and macOS also retain `platform_attested` until their rollout
+  policy is changed explicitly;
+- downloads retain the bounded attestation because an offline artifact cannot
+  ask the server for a different plan.
 
 Rules:
 
@@ -254,21 +270,39 @@ Rules:
 - `software_video_decode_v1` is an engine-neutral, explicit opt-in that lets a
   strict evidence-tier client qualify bounded `hardware: false`
   `video_decode` entries. Without it, exact/platform-attested planning retains
-  its historical hardware-only behavior;
-- Apple advertises software decode only for original-file delivery. Packaged
-  progressive/HLS delivery stays on the conservative VideoToolbox codec list;
-  the audio-only audiobook request does not advertise the video feature;
-- download creation sends the same detailed decoder entries and feature opt-in
-  rather than flattening the 1080p software limit into the device-wide 2160p
-  ceiling. This preserves hardware 4K originals while forcing out-of-bounds
-  software sources through the compatibility-artifact policy. Its legacy flat
-  list stays hardware-only, so older servers that ignore the additive fields
-  also fail safely;
-- old client Dolby Vision transformations are dropped until their exact
-  Aether outcome and display-dependent claims are re-derived and proven;
+  its historical hardware-only behavior. It remains relevant to downloads and
+  conservative streaming surfaces; `declared` Apple TV 4K planning uses the
+  flat engine list by definition;
+- only `original_http` receives the broad Aether manifest and its
+  `client_managed_dynamic_range_v1` validated claim. That claim lets the
+  server deliver an HDR/Dolby Vision source even when the current output does
+  not advertise the source range, because Aether owns the post-delivery
+  display handshake and local presentation. Packaged progressive/HLS delivery
+  stays on the VideoToolbox-backed codec list and remains gated by the live
+  output snapshot;
+- download creation sends detailed decoder entries and the feature opt-in
+  rather than inheriting the online declaration. Its legacy flat list stays
+  hardware-only, so older servers that ignore additive fields fail safely;
+- Dolby Vision client transformations remain scoped to `original_http` and to
+  the same live display/output evidence used by the server. They are preferred
+  when the server can describe an exact Profile 7 outcome; the managed-range
+  claim is the engine-owned fallback and does not invent a selectable recipe;
 - `authHeaderRefresh` is `false` in the first Aether snapshot. Protocol V3
   defines it as refreshing credentials without restarting playback; a fresh
-  Aether load does not satisfy that contract.
+  Aether load does not satisfy that contract;
+- codec, audio, container, hardware-probe, device-generation, and bounded
+  fallback logic live in `AppleDecodeCapabilities`; diagnostics, downloads,
+  and V3 shape adapters consume that owner instead of maintaining independent
+  lists.
+
+The claim changes admission, not ownership. Protocol V3 still supplies the
+authenticated original URL, freezes attempt identity, records the output
+snapshot, and excludes a failed plan key on replan. Aether probes the received
+file and may demux, locally repackage, bridge audio, switch the panel, or map
+the source onto SDR without a server-selected transformation. If that load
+returns a typed failure, the server tries a different version or delivery; an
+exhausted HDR route remains terminal until a real server tone-map recipe is
+installed.
 
 The migration justified coordinated server changes only where direct evidence
 showed an engine-neutral contract gap. First, signed media URLs can
@@ -282,22 +316,16 @@ development and has been validated through the exact Apple build's Aether
 boundary.
 
 Second, the pinned Aether stack successfully software-decoded five otherwise
-transcode-only opaque fixtures, but Protocol V3 intentionally ignored
-`hardware: false` entries. The server now accepts those entries only with
-`software_video_decode_v1` and enforces their codec, exercised profile,
-bit-depth, frame size, frame-rate, and bitrate bounds. The first claims are
-deliberately fixture-bounded: 1080p30 at rounded 10/3/3/32 Mbps ceilings for
-H.264/AV1/VP9/VC-1, and 720x480 at a rounded 31 fps and 7 Mbps for MPEG-2
-(the nominally NTSC fixture's server probe reports 30.303 fps). The Apple snapshot advertises exercised H.264
-High 10, AV1 Main 10, VP9 Profile 0, interlaced MPEG-2 Main, and VC-1 Advanced
-software routes, while
-keeping H.264/HEVC VideoToolbox entries separate. Legacy clients and clients
-without the feature retain the prior planner behavior. Broader delivery,
-renewal, and physical-hardware validation is still required before release.
-The initial AV1 and H.264 software entries intentionally claim only their
-exercised 10-bit profiles; unproved 8-bit AV1 and non-VideoToolbox H.264
-variants continue through server adaptation rather than being inferred from
-codec-family support.
+transcode-only opaque fixtures, which established the strict fallback and
+download envelopes. The server accepts those `hardware: false` entries only
+with `software_video_decode_v1` and enforces their profile, bit depth, frame
+size, frame rate, and bitrate bounds. Those bounds remain deliberately narrow:
+1080p30 at rounded 10/3/3/32 Mbps ceilings for H.264/AV1/VP9/VC-1, and 720x480
+at 31 fps and 7 Mbps for MPEG-2. They no longer constrain online Apple TV 4K
+`original_http`; there, the pinned engine manifest gets the source to Aether's
+own probe. Broader physical-hardware validation is still required before
+release, especially for sustained software decode where a load can succeed
+but fail to maintain real-time playback.
 
 ## Tracks and subtitles
 

--- a/iosApp/Tests/AetherPlaybackBoundaryTests.swift
+++ b/iosApp/Tests/AetherPlaybackBoundaryTests.swift
@@ -15,6 +15,79 @@ final class AetherPlaybackBoundaryTests: XCTestCase {
         let streams: [LiveStreamFixture]
     }
 
+    func testExplicitV3AudioSelectionOverridesProfileLanguageForInitialLoad() {
+        let languages = AetherInitialAudioPreference.languages(
+            selectedOrdinal: 0,
+            tracks: [
+                makeAudioTrack(language: "pt", isDefault: true),
+                makeAudioTrack(language: "en", isDefault: false),
+            ],
+            fallbackLanguage: "en"
+        )
+
+        XCTAssertEqual(languages, ["pt"])
+    }
+
+    func testUnlabeledExplicitAudioSelectionDoesNotFallBackToProfileLanguage() {
+        let languages = AetherInitialAudioPreference.languages(
+            selectedOrdinal: 0,
+            tracks: [makeAudioTrack(language: nil, isDefault: false)],
+            fallbackLanguage: "en"
+        )
+
+        XCTAssertEqual(languages, [])
+    }
+
+    func testUnavailableExplicitAudioInventoryDoesNotResurrectProfileLanguage() {
+        for tracks in [
+            [AudioTrack](),
+            [makeAudioTrack(language: "pt", isDefault: true)],
+        ] {
+            let languages = AetherInitialAudioPreference.languages(
+                selectedOrdinal: 1,
+                tracks: tracks,
+                fallbackLanguage: "en"
+            )
+
+            XCTAssertEqual(languages, [])
+        }
+    }
+
+    func testWhitespaceOnlyExplicitAudioLanguageDoesNotBecomeAnAetherHint() {
+        let languages = AetherInitialAudioPreference.languages(
+            selectedOrdinal: 0,
+            tracks: [makeAudioTrack(language: "  ", isDefault: false)],
+            fallbackLanguage: "en"
+        )
+
+        XCTAssertEqual(languages, [])
+    }
+
+    func testProfileAudioLanguageRemainsFallbackWithoutExplicitSelection() {
+        let languages = AetherInitialAudioPreference.languages(
+            selectedOrdinal: nil,
+            tracks: [makeAudioTrack(language: "pt", isDefault: true)],
+            fallbackLanguage: " en "
+        )
+
+        XCTAssertEqual(languages, ["en"])
+    }
+
+    private func makeAudioTrack(language: String?, isDefault: Bool) -> AudioTrack {
+        AudioTrack(
+            index: nil,
+            codec: "eac3",
+            channels: 6,
+            channelLayout: "5.1(side)",
+            bitrate: 640,
+            sampleRate: 48_000,
+            language: language,
+            title: nil,
+            embeddedTitle: nil,
+            isDefault: isDefault
+        )
+    }
+
     func testHeaderAuthenticatedStreamResolutionStaysOnAPIMediaOrigin() throws {
         let request = try XCTUnwrap(StreamRequest.resolve(
             rawURL: "/playback/transcode/session-1/master.m3u8?seek=12",

--- a/iosApp/Tests/AppleDecodeCapabilitiesTests.swift
+++ b/iosApp/Tests/AppleDecodeCapabilitiesTests.swift
@@ -1,17 +1,17 @@
 import XCTest
 @testable import Silo
 
-/// Playback and downloads must describe the same stack while retaining the
-/// evidence each wire contract can safely understand.
+/// Online playback may trust Aether's load-time probe; downloads must retain
+/// enough bounded evidence to be safe without a server replan.
 final class AppleDecodeCapabilitiesTests: XCTestCase {
 
     // MARK: - The surfaces agree
 
     func testV3SnapshotReportsTheSharedVocabulary() {
         let capabilities = ApplePlaybackV3Capabilities.snapshot().capabilities
-        XCTAssertEqual(capabilities.codecsAudio, AppleDecodeCapabilities.audioCodecs)
-        XCTAssertEqual(capabilities.containers, AppleDecodeCapabilities.containers)
-        XCTAssertEqual(capabilities.codecsVideo, AppleDecodeCapabilities.videoCodecs)
+        XCTAssertEqual(capabilities.codecsAudio, AppleDecodeCapabilities.streamingAudioCodecs)
+        XCTAssertEqual(capabilities.containers, AppleDecodeCapabilities.streamingContainers)
+        XCTAssertEqual(capabilities.codecsVideo, AppleDecodeCapabilities.streamingVideoCodecs)
     }
 
     func testDownloadCapsReportTheSharedVocabulary() {
@@ -23,7 +23,7 @@ final class AppleDecodeCapabilitiesTests: XCTestCase {
         XCTAssertEqual(caps.videoEvidence, PlaybackProtocolV3.Evidence.platformAttested)
         XCTAssertEqual(
             caps.videoDecode,
-            ApplePlaybackV3Capabilities.snapshot().capabilities.videoDecode
+            AppleDecodeCapabilities.playbackV3VideoDecodeAttestation()
         )
         XCTAssertEqual(caps.clientFeatures, [PlaybackProtocolV3.softwareVideoDecodeFeature])
         XCTAssertTrue(
@@ -84,9 +84,10 @@ final class AppleDecodeCapabilitiesTests: XCTestCase {
         XCTAssertNil(object["videoDecode"])
     }
 
-    func testEveryAudioSurfaceCarriesTheSameCodecs() {
-        // The concrete regression: one list gaining a codec the others miss.
-        let v3 = Set(ApplePlaybackV3Capabilities.snapshot().capabilities.codecsAudio)
+    func testConservativeStreamingAndDownloadsShareAudioCodecs() {
+        let v3 = Set(ApplePlaybackV3Capabilities.snapshot(
+            videoCapabilityMode: .platformAttested
+        ).capabilities.codecsAudio)
         let downloads = Set(DownloadCaps.current().codecsAudio)
         XCTAssertEqual(v3, downloads)
         XCTAssertEqual(v3, Set(AppleDecodeCapabilities.audioCodecs))
@@ -98,12 +99,191 @@ final class AppleDecodeCapabilitiesTests: XCTestCase {
         XCTAssertTrue(expected.isSubset(of: Set(AppleDecodeCapabilities.containers)))
 
         let originalHTTP = try XCTUnwrap(
-            ApplePlaybackV3Capabilities.snapshot().context.deliveries[
+            ApplePlaybackV3Capabilities.snapshot(
+                videoCapabilityMode: .platformAttested
+            ).context.deliveries[
                 PlaybackProtocolV3.DeliveryClass.originalHTTP
             ]
         )
         XCTAssertTrue(expected.isSubset(of: Set(originalHTTP.containers)))
         XCTAssertFalse(originalHTTP.containers.contains("ogg"))
+    }
+
+    func testAppleTV4KUsesTheAetherBuildDeclaration() throws {
+        let snapshot = ApplePlaybackV3Capabilities.snapshot(
+            videoCapabilityMode: .aetherDeclared
+        )
+        XCTAssertEqual(snapshot.capabilities.videoEvidence, PlaybackProtocolV3.Evidence.declared)
+        XCTAssertEqual(snapshot.capabilities.videoDecode, [])
+        XCTAssertEqual(
+            snapshot.capabilities.codecsVideoHardware,
+            AppleDecodeCapabilities.hardwareVideoCodecs
+        )
+        XCTAssertEqual(
+            snapshot.capabilities.codecsVideo,
+            AppleDecodeCapabilities.aetherOriginalHTTPVideoCodecs
+        )
+        XCTAssertEqual(
+            snapshot.capabilities.codecsAudio,
+            AppleDecodeCapabilities.aetherOriginalHTTPAudioCodecs
+        )
+        XCTAssertEqual(
+            snapshot.capabilities.containers,
+            AppleDecodeCapabilities.aetherOriginalHTTPContainers
+        )
+        XCTAssertEqual(snapshot.capabilities.maxResolution, "2160p")
+
+        let originalHTTP = try XCTUnwrap(
+            snapshot.context.deliveries[PlaybackProtocolV3.DeliveryClass.originalHTTP]
+        )
+        XCTAssertEqual(
+            originalHTTP.videoCodecs,
+            AppleDecodeCapabilities.aetherOriginalHTTPVideoCodecs
+        )
+        XCTAssertEqual(
+            originalHTTP.audioDecodeCodecs,
+            AppleDecodeCapabilities.aetherOriginalHTTPAudioCodecs
+        )
+        XCTAssertEqual(
+            originalHTTP.containers,
+            AppleDecodeCapabilities.aetherOriginalHTTPContainers
+        )
+        XCTAssertTrue(
+            originalHTTP.validatedClaims.contains(
+                PlaybackProtocolV3.clientManagedDynamicRangeClaim
+            ),
+            "The Aether original-file executor must declare that display adaptation happens after delivery."
+        )
+        XCTAssertTrue(
+            originalHTTP.validatedClaims.contains(
+                PlaybackProtocolV3.clientSelectedAudioTrackClaim
+            ),
+            "The Aether original-file executor maps the plan's selected audio ordinal after probing."
+        )
+
+        let progressive = try XCTUnwrap(
+            snapshot.context.deliveries[PlaybackProtocolV3.DeliveryClass.progressive]
+        )
+        XCTAssertEqual(progressive.videoCodecs, AppleDecodeCapabilities.packagedVideoCodecs)
+        XCTAssertEqual(progressive.containers, ["mp4", "mov", "m4v"])
+        XCTAssertEqual(progressive.audioDecodeCodecs, ["aac", "ac3", "eac3", "alac", "mp3"])
+
+        let hls = try XCTUnwrap(
+            snapshot.context.deliveries[PlaybackProtocolV3.DeliveryClass.hls]
+        )
+        XCTAssertEqual(hls.videoCodecs, AppleDecodeCapabilities.packagedVideoCodecs)
+        XCTAssertEqual(hls.containers, ["hls", "mpegts", "fmp4", "mp4"])
+        XCTAssertEqual(hls.audioDecodeCodecs, ["aac", "ac3", "eac3"])
+    }
+
+    func testConservativeAndAudioOnlySnapshotsDoNotClaimClientManagedDynamicRange() throws {
+        let conservativeOriginal = try XCTUnwrap(
+            ApplePlaybackV3Capabilities.snapshot(
+                videoCapabilityMode: .platformAttested
+            ).context.deliveries[PlaybackProtocolV3.DeliveryClass.originalHTTP]
+        )
+        XCTAssertFalse(
+            conservativeOriginal.validatedClaims.contains(
+                PlaybackProtocolV3.clientManagedDynamicRangeClaim
+            )
+        )
+        XCTAssertFalse(
+            conservativeOriginal.validatedClaims.contains(
+                PlaybackProtocolV3.clientSelectedAudioTrackClaim
+            )
+        )
+
+        let audiobookOriginal = try XCTUnwrap(
+            ApplePlaybackV3Capabilities.audiobookSnapshot(
+                videoCapabilityMode: .aetherDeclared
+            ).context.deliveries[PlaybackProtocolV3.DeliveryClass.originalHTTP]
+        )
+        XCTAssertFalse(
+            audiobookOriginal.validatedClaims.contains(
+                PlaybackProtocolV3.clientManagedDynamicRangeClaim
+            )
+        )
+        XCTAssertFalse(
+            audiobookOriginal.validatedClaims.contains(
+                PlaybackProtocolV3.clientSelectedAudioTrackClaim
+            )
+        )
+    }
+
+    func testAetherDeclarationKeepsV3WireShapeWithoutDetailedPredictions() throws {
+        let capabilities = ApplePlaybackV3Capabilities.snapshot(
+            videoCapabilityMode: .aetherDeclared
+        ).capabilities
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: encoder.encode(capabilities))
+                as? [String: Any]
+        )
+
+        XCTAssertEqual(
+            object["video_evidence"] as? String,
+            PlaybackProtocolV3.Evidence.declared
+        )
+        XCTAssertEqual((object["video_decode"] as? [[String: Any]])?.count, 0)
+        XCTAssertEqual(
+            object["codecs_video"] as? [String],
+            AppleDecodeCapabilities.aetherOriginalHTTPVideoCodecs
+        )
+        XCTAssertNil(object["videoEvidence"])
+        XCTAssertNil(object["videoDecode"])
+    }
+
+    func testEngineDeclarationCoversPinnedAetherFFmpegManifest() {
+        let video = Set(AppleDecodeCapabilities.aetherOriginalHTTPVideoCodecs)
+        let audio = Set(AppleDecodeCapabilities.aetherOriginalHTTPAudioCodecs)
+        let containers = Set(AppleDecodeCapabilities.aetherOriginalHTTPContainers)
+
+        XCTAssertEqual(video, Set([
+            "h264", "hevc", "av1", "vp9", "vp8", "mpeg4", "mpeg2video", "vc1",
+            "qtrle", "msmpeg4v1", "msmpeg4v2", "msmpeg4v3", "wmv1", "wmv2", "wmv3",
+        ]))
+        XCTAssertEqual(audio, Set([
+            "aac", "ac3", "eac3", "mp3", "mp2", "flac", "opus", "vorbis", "alac",
+            "truehd", "mlp", "dts", "dca", "dts-hd", "dtshd", "pcm", "pcm_s16le",
+            "pcm_s24le", "pcm_f32le",
+        ]))
+        XCTAssertEqual(containers, Set([
+            "mp4", "m4v", "mov", "mkv", "matroska", "avi", "mpegts", "ts", "m2ts",
+            "mts", "3gp", "3g2", "vob", "ogg", "webm", "flv", "mp3", "aac", "m4a",
+            "m4b", "flac", "alac", "wav", "opus",
+        ]))
+        XCTAssertFalse(containers.contains("asf"))
+    }
+
+    func testPersistentDownloadsDoNotInheritOptimisticEngineClaims() {
+        let caps = DownloadCaps.current()
+        XCTAssertFalse(caps.codecsVideo.contains("qtrle"))
+        XCTAssertFalse(caps.codecsAudio.contains("mlp"))
+        XCTAssertFalse(caps.containers.contains("flv"))
+        XCTAssertFalse(caps.videoDecode.isEmpty)
+    }
+
+    func testStreamingPolicyTrustsAppleTV4KButNotAppleTVHDOrSimulators() {
+        func mode(
+            _ isTVOS: Bool,
+            _ isSimulator: Bool,
+            _ machineIdentifier: String
+        ) -> AppleDecodeCapabilities.StreamingVideoCapabilityMode {
+            AppleDecodeCapabilities.streamingVideoCapabilityModeForDevice(
+                isTVOS: isTVOS,
+                isSimulator: isSimulator,
+                machineIdentifier: machineIdentifier
+            )
+        }
+        XCTAssertEqual(mode(true, false, "AppleTV5,3"), .platformAttested)
+        XCTAssertEqual(mode(true, false, "AppleTV6,2"), .aetherDeclared)
+        XCTAssertEqual(mode(true, false, "AppleTV11,1"), .aetherDeclared)
+        XCTAssertEqual(mode(true, false, "AppleTV14,1"), .aetherDeclared)
+        XCTAssertEqual(mode(true, false, "AppleTV99,1"), .aetherDeclared)
+        XCTAssertEqual(mode(true, true, "arm64"), .platformAttested)
+        XCTAssertEqual(mode(false, false, "iPhone19,1"), .platformAttested)
+        XCTAssertEqual(mode(true, false, "unknown"), .platformAttested)
     }
 
     // MARK: - The vocabulary itself
@@ -127,12 +307,13 @@ final class AppleDecodeCapabilitiesTests: XCTestCase {
     }
 
     func testHardwareCodecsAreASubsetOfClaimedCodecs() {
-        let claimed = Set(AppleDecodeCapabilities.videoCodecs)
-        XCTAssertTrue(Set(AppleDecodeCapabilities.hardwareVideoCodecs).isSubset(of: claimed))
+        let hardware = Set(AppleDecodeCapabilities.hardwareVideoCodecs)
+        XCTAssertTrue(hardware.isSubset(of: Set(AppleDecodeCapabilities.attestedVideoCodecs)))
+        XCTAssertTrue(hardware.isSubset(of: Set(AppleDecodeCapabilities.aetherOriginalHTTPVideoCodecs)))
     }
 
     func testDecodeEntriesNameTheDecoderTheyActuallyUse() {
-        for entry in ApplePlaybackV3Capabilities.snapshot().capabilities.videoDecode {
+        for entry in AppleDecodeCapabilities.videoDecodeAttestation() {
             XCTAssertEqual(entry.hardware ? "VideoToolbox" : (entry.codec == "av1" ? "dav1d" : "libavcodec"), entry.decoderName)
         }
     }
@@ -142,7 +323,7 @@ final class AppleDecodeCapabilitiesTests: XCTestCase {
     func testSimulatorClaimStaysConservative() throws {
         try XCTSkipUnless(AppleDecodeCapabilities.isSimulator)
         XCTAssertEqual(
-            AppleDecodeCapabilities.videoCodecs,
+            AppleDecodeCapabilities.streamingVideoCodecs,
             ["h264", "av1", "vp9", "mpeg2video", "vc1"]
         )
         XCTAssertEqual(AppleDecodeCapabilities.maxResolution, "1080p")

--- a/iosApp/Tests/DeviceSnapshotBuilderTests.swift
+++ b/iosApp/Tests/DeviceSnapshotBuilderTests.swift
@@ -74,6 +74,33 @@ final class DeviceSnapshotBuilderTests: XCTestCase {
         XCTAssertEqual(display["supports_ten_bit"], .bool(true))
     }
 
+    func testDeclaredEngineDiagnosticsDoNotInventPerCodecDisplayFacts() {
+        let snapshot = DiagnosticsCapabilityProbe.snapshot(
+            displayCapabilities: ApplePlaybackDisplayCapabilities(
+                hdrPlaybackEligible: true,
+                supportsDolbyVision: true,
+                supportsHDR10: true,
+                supportsHLG: true,
+                supportsAtmos: false,
+                maxResolution: .uhd4K,
+                supportsTenBit: true
+            ),
+            videoCapabilityMode: .aetherDeclared
+        )
+
+        guard case .array(let codecs) = snapshot.videoCodecs else {
+            return XCTFail("video codec diagnostics were not an array")
+        }
+        XCTAssertEqual(codecs.count, AppleDecodeCapabilities.aetherOriginalHTTPVideoCodecs.count)
+        for codec in codecs {
+            guard case .object(let fields) = codec else {
+                return XCTFail("video codec diagnostic was not an object")
+            }
+            XCTAssertEqual(fields["max"], .string("not_collected"))
+            XCTAssertEqual(fields["hdr"], .string("not_collected"))
+        }
+    }
+
     private func makeBuilder(
         audio: DiagnosticsCapabilityProbe.AudioOutputSnapshot,
         date: Date = Date(timeIntervalSince1970: 100)

--- a/iosApp/Tests/Fixtures/PlaybackV3/SOURCE
+++ b/iosApp/Tests/Fixtures/PlaybackV3/SOURCE
@@ -1,7 +1,7 @@
 Source: silo-server internal/playback/testdata/protocol_v3
-Server ref: codex/aether-tokenless-playback-v3
-Server commit: d76226449a0aa0667ef916b8238d6afe6a7d082f
-Vendored: 2026-08-22
+Server ref: codex/aether-managed-original
+Server commit: ccdf703c1adb84146eb6b09657eb36a73144600a
+Vendored: 2026-08-23
 
 All nine files come from internal/playback/testdata/protocol_v3. Six of them are
 also published byte-identically under docs/design/schemas/playback-v3/v3/fixtures/valid;

--- a/iosApp/Tests/Fixtures/PlaybackV3/capability_response.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/capability_response.json
@@ -13,6 +13,7 @@
     "output_change_v1",
     "direct_stream_resume_v1",
     "header_authenticated_media_v1",
+    "authorized_media_origins_v1",
     "software_video_decode_v1",
     "plan_source_duration_v1"
   ],

--- a/iosApp/Tests/Fixtures/PlaybackV3/conformance_matrix.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/conformance_matrix.json
@@ -1974,6 +1974,243 @@
       }
     },
     {
+      "name": "client_managed_hdr_selected_audio",
+      "category": "hdr_dv_matrix",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "file_id": 42,
+        "profile_id": "profile-1",
+        "playback_attempt_id": "attempt-client-managed-original",
+        "quality_preference": "original",
+        "subtitle_fidelity_preference": "compatible",
+        "start_position": 12.5,
+        "progress_persistence": "client",
+        "audio_track_id": "file:42:audio:1",
+        "audio_track_index": 1,
+        "metered": false,
+        "client_capabilities": {
+          "video_evidence": "exact",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "hevc"
+          ],
+          "codecs_video_hardware": [
+            "hevc"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mkv"
+          ],
+          "max_resolution": "2160p",
+          "hdr": false,
+          "hdr_details": {
+            "hdr10": false,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision_profiles": []
+          },
+          "video_decode": [
+            {
+              "codec": "hevc",
+              "profiles": [
+                "main 10"
+              ],
+              "levels": [
+                153
+              ],
+              "bit_depths": [
+                10
+              ],
+              "max_width": 3840,
+              "max_height": 2160,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 80000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "fixture"
+          },
+          "output": {
+            "hdr_details": {
+              "hdr10": false,
+              "hdr10_plus": false,
+              "hlg": false,
+              "dolby_vision_profiles": []
+            },
+            "output_context_id": "output-a"
+          },
+          "deliveries": {
+            "hls": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "hls"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mkv",
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "hdr_details": {
+                "hdr10": false,
+                "hdr10_plus": false,
+                "hlg": false,
+                "dolby_vision_profiles": []
+              },
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [
+                "client_managed_dynamic_range_v1",
+                "client_selected_audio_track_v1"
+              ],
+              "transformations": []
+            },
+            "progressive": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "source": {
+        "media_file_id": 42,
+        "duration_seconds": 7200,
+        "container": "mkv",
+        "video_codec": "hevc",
+        "video_profile": "main 10",
+        "video_level": 153,
+        "bit_depth": 10,
+        "color_range": "tv",
+        "width": 3840,
+        "height": 2160,
+        "frame_rate": 23.976023976023978,
+        "bitrate_kbps": 60000,
+        "dynamic_range": "hdr10",
+        "hdr10_plus": false,
+        "dv_enhancement_layer": "none",
+        "audio_codec": "aac",
+        "audio_channels": 2,
+        "audio_layout": "stereo"
+      },
+      "expected": {
+        "outcome": "playable",
+        "delivery": "original_http",
+        "decision_reason": "client_managed_dynamic_range",
+        "plan_id": "plan:880cfe7954be7aff16c5d89d2b2a09bd",
+        "plan_attempt_key": "v3:b020c19644d2bb36",
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:1",
+            "index": 1
+          }
+        },
+        "subtitle": {
+          "mode": "off",
+          "inventory": []
+        },
+        "claims": {
+          "video": {
+            "hdr10": false,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision": false
+          },
+          "audio": {
+            "codec": "aac",
+            "passthrough": false,
+            "atmos_preserved": false,
+            "reason": "client_decode_supported"
+          },
+          "subtitles": {
+            "ass_styling_preserved": false,
+            "bitmap_overlay": false,
+            "bitmap_sidecar": false
+          }
+        },
+        "available_qualities": [
+          {
+            "label": "original",
+            "height": 2160,
+            "bitrate_kbps": 60000,
+            "preserves_source": true
+          }
+        ]
+      }
+    },
+    {
       "name": "dolby_vision_8_exact_direct",
       "category": "hdr_dv_matrix",
       "request": {
@@ -5409,6 +5646,8 @@
             "output_change_v1",
             "direct_stream_resume_v1",
             "header_authenticated_media_v1",
+            "authorized_media_origins_v1",
+            "software_video_decode_v1",
             "plan_source_duration_v1"
           ],
           "outcome": "adaptation_unavailable",

--- a/iosApp/Tests/Fixtures/PlaybackV3/decision_response.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/decision_response.json
@@ -10,6 +10,7 @@
     "output_change_v1",
     "direct_stream_resume_v1",
     "header_authenticated_media_v1",
+    "authorized_media_origins_v1",
     "software_video_decode_v1",
     "plan_source_duration_v1"
   ],

--- a/iosApp/Tests/PlaybackProtocolV3ConformanceFixtureTests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3ConformanceFixtureTests.swift
@@ -21,7 +21,7 @@ final class PlaybackProtocolV3ConformanceFixtureTests: XCTestCase {
             bundleClass: Self.self
         )
         XCTAssertEqual(matrix.schemaVersion, 1)
-        XCTAssertEqual(matrix.plannerScenarios.count, 17)
+        XCTAssertEqual(matrix.plannerScenarios.count, 18)
         XCTAssertEqual(matrix.replanScenarios.count, 10)
         XCTAssertEqual(matrix.protocolScenarios.count, 8)
 
@@ -73,6 +73,20 @@ final class PlaybackProtocolV3ConformanceFixtureTests: XCTestCase {
         XCTAssertEqual(hdr10.source.dynamicRange, "hdr10")
         XCTAssertEqual(hdr10.expected.delivery, "original_http")
         XCTAssertEqual(hdr10.expected.claims?.video.hdr10, true)
+
+        let clientManaged = try plannerScenario(named: "client_managed_hdr_selected_audio", in: matrix)
+        XCTAssertEqual(clientManaged.source.dynamicRange, "hdr10")
+        XCTAssertEqual(clientManaged.request.audioTrackIndex, 1)
+        XCTAssertEqual(
+            Set(clientManaged.request.clientPlaybackContext.deliveries["original_http"]?.validatedClaims ?? []),
+            Set([
+                PlaybackProtocolV3.clientManagedDynamicRangeClaim,
+                PlaybackProtocolV3.clientSelectedAudioTrackClaim
+            ])
+        )
+        XCTAssertEqual(clientManaged.expected.delivery, "original_http")
+        XCTAssertEqual(clientManaged.expected.decisionReason, "client_managed_dynamic_range")
+        XCTAssertEqual(clientManaged.expected.selectedTracks?.audio?.index, 1)
 
         let dolbyVision = try plannerScenario(named: "dolby_vision_8_exact_direct", in: matrix)
         XCTAssertEqual(dolbyVision.source.dolbyVisionProfile, 8)
@@ -237,6 +251,7 @@ private struct PlaybackV3ConformanceStartRequest: Decodable {
     let qualityPreference: String
     let progressPersistence: String?
     let startPosition: Double?
+    let audioTrackIndex: Int?
     let subtitleTrackId: String?
     let subtitleTrackIndex: Int?
     let clientCapabilities: PlaybackV3ConformanceCapabilities
@@ -265,6 +280,7 @@ private struct PlaybackV3ConformanceDevice: Decodable {
 private struct PlaybackV3ConformanceDelivery: Decodable {
     let enabled: Bool
     let supportedOnDevice: Bool
+    let validatedClaims: [String]?
     let transformations: [PlaybackV3Transformation]?
 }
 

--- a/iosApp/Tests/PlaybackProtocolV3Tests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3Tests.swift
@@ -1203,10 +1203,21 @@ final class PlaybackProtocolV3Tests: XCTestCase {
     }
 
     func testAudiobookSnapshotOnlyAdvertisesAudioOnlyAetherRoutes() throws {
-        let snapshot = ApplePlaybackV3Capabilities.audiobookSnapshot()
+        let snapshot = ApplePlaybackV3Capabilities.audiobookSnapshot(
+            videoCapabilityMode: .aetherDeclared
+        )
+        XCTAssertEqual(snapshot.capabilities.videoEvidence, PlaybackProtocolV3.Evidence.declared)
         XCTAssertEqual(snapshot.capabilities.codecsVideo, [])
         XCTAssertEqual(snapshot.capabilities.codecsVideoHardware, [])
         XCTAssertEqual(snapshot.capabilities.videoDecode, [])
+        XCTAssertEqual(
+            snapshot.capabilities.codecsAudio,
+            ["aac", "ac3", "eac3", "alac", "mp3", "flac", "pcm", "pcm_s16le", "pcm_s24le"]
+        )
+        XCTAssertEqual(
+            snapshot.capabilities.containers,
+            ["mp4", "mp3", "m4a", "m4b", "aac", "flac", "wav"]
+        )
         XCTAssertFalse(snapshot.capabilities.codecsAudio.contains("dts"))
         XCTAssertFalse(snapshot.capabilities.codecsAudio.contains("truehd"))
         XCTAssertFalse(snapshot.capabilities.codecsAudio.contains("vorbis"))

--- a/iosApp/iosApp/Downloads/DownloadModels.swift
+++ b/iosApp/iosApp/Downloads/DownloadModels.swift
@@ -231,7 +231,7 @@ struct DownloadCaps: Encodable, Sendable {
             // to preserve safe 4K originals on physical devices.
             maxResolution: "1080p",
             hdr: !isSimulator,
-            videoDecode: ApplePlaybackV3Capabilities.videoDecodeAttestation()
+            videoDecode: AppleDecodeCapabilities.playbackV3VideoDecodeAttestation()
         )
     }
 }

--- a/iosApp/iosApp/Screens/Player/AetherLoadSpec.swift
+++ b/iosApp/iosApp/Screens/Player/AetherLoadSpec.swift
@@ -1,6 +1,33 @@
 import AetherEngine
 import Foundation
 
+/// Resolves the language hint Aether uses for its initial audio pick.
+///
+/// A Protocol V3 plan's selected audio ordinal is authoritative. Feeding the
+/// user's broader profile preference to Aether in that case can start a
+/// different track, publish first frame, and then force a full pipeline reload
+/// when the exact ordinal is applied after inventory arrives. Prefer the
+/// selected track's language for the first open; the existing post-probe
+/// ordinal reconciliation remains the exact fallback for unlabeled or
+/// same-language tracks.
+enum AetherInitialAudioPreference {
+    static func languages(
+        selectedOrdinal: Int?,
+        tracks: [AudioTrack],
+        fallbackLanguage: String
+    ) -> [String] {
+        if let selectedOrdinal {
+            guard tracks.indices.contains(selectedOrdinal) else { return [] }
+            let selectedLanguage = tracks[selectedOrdinal].language?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return selectedLanguage.isEmpty ? [] : [selectedLanguage]
+        }
+
+        let fallback = fallbackLanguage.trimmingCharacters(in: .whitespacesAndNewlines)
+        return fallback.isEmpty ? [] : [fallback]
+    }
+}
+
 /// Immutable inputs for one Aether load generation.
 ///
 /// The initialisers are main-actor isolated because they sample the display
@@ -222,10 +249,11 @@ struct AetherLoadSpec {
         let effectiveHeaders = requestHeaders ?? plan.stream.headers
 
         // Protocol V3's selected audio index is an ordinal in the server's
-        // audio-track list, not an FFmpeg AVStream index. Original HTTP is
-        // offered only for the container default; remux/transcode outputs are
-        // already packaged with the selected track. Let Aether choose the
-        // default/output stream rather than passing a different index space.
+        // audio-track list, not an FFmpeg AVStream index. Keep it out of
+        // LoadOptions: after Aether publishes its probed inventory,
+        // PlayerViewModel maps that ordinal to Aether's stream id and applies
+        // the plan-authoritative selection. This lets original HTTP remain a
+        // byte-for-byte source while still honoring a non-default track.
         if let selectedIndex = plan.selectedTracks.audio?.index {
             guard selectedIndex >= 0 else {
                 throw ValidationError.invalidAudioTrackIndex(selectedIndex)

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -2293,7 +2293,11 @@ class PlayerViewModel {
     ) async throws {
         try requireCurrentStreamLoad(expectedStreamLoadGeneration)
         let preferredSubtitles = subtitleOrderingLanguage.map { [$0] } ?? []
-        let preferredAudio = settings.audioLanguage.isEmpty ? [] : [settings.audioLanguage]
+        let preferredAudio = AetherInitialAudioPreference.languages(
+            selectedOrdinal: prepared.protocolV3?.plan.selectedTracks.audio?.index,
+            tracks: prepared.selectedVersion.audioTracks ?? [],
+            fallbackLanguage: settings.audioLanguage
+        )
         // The explicit Buffer Ahead choice wins; `automatic` has no count of
         // its own and keeps the historical mapping from the synced Seek Cache
         // toggle, so a device that never touches this picker behaves exactly as

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3Capabilities.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3Capabilities.swift
@@ -1,8 +1,6 @@
 import AVFoundation
-import CoreMedia
 import CryptoKit
 import Foundation
-import VideoToolbox
 
 struct ApplePlaybackV3CapabilitySnapshot: Equatable {
     let capabilities: PlaybackV3CodecCapabilities
@@ -109,29 +107,33 @@ enum ApplePlaybackV3Capabilities {
         )
     ]
 
-    static func snapshot() -> ApplePlaybackV3CapabilitySnapshot {
+    static func snapshot(
+        videoCapabilityMode requestedMode: AppleDecodeCapabilities.StreamingVideoCapabilityMode? = nil
+    ) -> ApplePlaybackV3CapabilitySnapshot {
         let hdrAvailability = ApplePlaybackHDRAvailability.probe()
         let output = outputSnapshot(hdrAvailability: hdrAvailability)
-        let videoDecode = videoDecodeAttestation()
-        var seenVideoCodecs = Set<String>()
-        let videoCodecs = videoDecode.map(\.codec).filter {
-            seenVideoCodecs.insert($0).inserted
-        }
-        let hardwareVideoCodecs = videoDecode.filter(\.hardware).map(\.codec)
+        let videoCapabilityMode = requestedMode ?? AppleDecodeCapabilities.streamingVideoCapabilityMode
+        let usesAetherDeclaration = videoCapabilityMode == .aetherDeclared
+        let videoDecode = usesAetherDeclaration
+            ? []
+            : AppleDecodeCapabilities.playbackV3VideoDecodeAttestation()
+        let videoCodecs = AppleDecodeCapabilities.streamingVideoCodecs(for: videoCapabilityMode)
+        let hardwareVideoCodecs = AppleDecodeCapabilities.hardwareVideoCodecs
 
-        // Aether owns demux/decode on original HTTP. The narrower packaged
-        // delivery lists below describe the formats the server may emit.
-        let audioCodecs = AppleDecodeCapabilities.audioCodecs
-        let containers = AppleDecodeCapabilities.containers
+        // Aether owns demux/decode on original HTTP. On Apple TV 4K this is a
+        // build declaration, not a prediction about the exact source: Aether's
+        // load-time probe chooses native or software decode and a typed load
+        // failure enters the existing bounded V3 replan path. The narrower
+        // packaged delivery lists below still describe what the server may
+        // emit directly to the native receiver path.
+        let audioCodecs = AppleDecodeCapabilities.streamingAudioCodecs(for: videoCapabilityMode)
+        let containers = AppleDecodeCapabilities.streamingContainers(for: videoCapabilityMode)
         let hdr = output.hdrDetails.map { $0.hdr10 || $0.hlg || !$0.dolbyVisionProfiles.isEmpty } ?? false
 
         let capabilities = PlaybackV3CodecCapabilities(
-            // VideoToolbox attests that a codec family is hardware-decodable;
-            // it cannot enumerate the profiles and levels a decoder accepts.
-            // The server skips those fields only for hardware entries at this
-            // tier and still applies every bound we do supply. Software
-            // entries carry profiles the server enforces.
-            videoEvidence: PlaybackProtocolV3.Evidence.platformAttested,
+            videoEvidence: usesAetherDeclaration
+                ? PlaybackProtocolV3.Evidence.declared
+                : PlaybackProtocolV3.Evidence.platformAttested,
             // These are the exact codecs accepted by the pinned Aether build,
             // not codecs attested by an Apple audio-decoder probe.
             audioEvidence: PlaybackProtocolV3.Evidence.declared,
@@ -139,7 +141,7 @@ enum ApplePlaybackV3Capabilities {
             codecsVideoHardware: hardwareVideoCodecs,
             codecsAudio: audioCodecs,
             containers: containers,
-            maxResolution: AppleDecodeCapabilities.maxResolutionToken,
+            maxResolution: AppleDecodeCapabilities.streamingMaxResolutionToken(for: videoCapabilityMode),
             hdr: hdr,
             hdrDetails: output.hdrDetails,
             // No passthrough entries: Apple routes audio through the system
@@ -174,6 +176,14 @@ enum ApplePlaybackV3Capabilities {
             sidecarBitmap: false,
             fontAttachments: false
         )
+        let originalHTTPClaims = commonClaims
+            + ["client_subtitle_overlay"]
+            + (usesAetherDeclaration
+                ? [
+                    PlaybackProtocolV3.clientManagedDynamicRangeClaim,
+                    PlaybackProtocolV3.clientSelectedAudioTrackClaim,
+                ]
+                : [])
         let packagedSubtitles = PlaybackV3DeliverySubtitleCapabilities(
             embeddedText: true,
             sidecarText: true,
@@ -196,7 +206,7 @@ enum ApplePlaybackV3Capabilities {
                 subtitles: aetherSubtitles,
                 features: [],
                 authHeaderRefresh: false,
-                validatedClaims: commonClaims + ["client_subtitle_overlay"],
+                validatedClaims: originalHTTPClaims,
                 transformations: clientTransformations
             ),
             PlaybackProtocolV3.DeliveryClass.progressive: PlaybackV3DeliveryCapability(
@@ -254,8 +264,10 @@ enum ApplePlaybackV3Capabilities {
 
     /// Capability evidence for Aether's audio-only execution mode. Keep every
     /// advertised delivery executable without relying on a video surface.
-    static func audiobookSnapshot() -> ApplePlaybackV3CapabilitySnapshot {
-        let base = snapshot()
+    static func audiobookSnapshot(
+        videoCapabilityMode requestedMode: AppleDecodeCapabilities.StreamingVideoCapabilityMode? = nil
+    ) -> ApplePlaybackV3CapabilitySnapshot {
+        let base = snapshot(videoCapabilityMode: requestedMode)
         let noSubtitles = PlaybackV3DeliverySubtitleCapabilities(
             embeddedText: false,
             sidecarText: false,
@@ -349,94 +361,6 @@ enum ApplePlaybackV3Capabilities {
             context: context,
             hdrAvailability: base.hdrAvailability
         )
-    }
-
-    /// The hardware attestations VideoToolbox supplies, followed by the
-    /// narrower software envelopes proven with Aether fixtures.
-    ///
-    /// Hardware profiles and levels stay empty because VideoToolbox cannot
-    /// enumerate them; under `platform_attested` the server skips both only
-    /// for `hardware: true` entries. Software entries carry and enforce the
-    /// exact exercised profiles plus fixture-bounded performance ceilings.
-    static func videoDecodeAttestation() -> [PlaybackV3VideoDecodeCapability] {
-        let codecTypes: [(String, CMVideoCodecType)] = [
-            ("h264", kCMVideoCodecType_H264),
-            ("hevc", kCMVideoCodecType_HEVC)
-        ]
-        let hardwareCapabilities: [PlaybackV3VideoDecodeCapability] = codecTypes.compactMap { codec, codecType in
-            guard hardwareDecodeSupported(codecType) else {
-                return nil
-            }
-            return PlaybackV3VideoDecodeCapability(
-                codec: codec,
-                decoderName: "VideoToolbox",
-                profiles: [],
-                levels: [],
-                // Apple hardware decodes HEVC Main and Main10; H.264 High 10
-                // has no hardware path on any supported device.
-                bitDepths: codec == "hevc" ? [8, 10] : [8],
-                maxWidth: maxDecodeHeight >= 2_160 ? 3_840 : 1_920,
-                maxHeight: maxDecodeHeight,
-                // Every device that reaches the minimum OS decodes 4K60. Higher
-                // frame rates are only guaranteed below 4K, and the contract has
-                // no way to express a rate that depends on resolution, so the
-                // lower of the two is the bound we can stand behind.
-                maxFrameRate: 60,
-                maxBitrateKbps: maxDecodeHeight >= 2_160 ? 120_000 : 25_000,
-                hardware: true
-            )
-        }
-        let softwareCapabilities: [(
-            codec: String, decoder: String, profiles: [String], bitDepths: [Int],
-            maxWidth: Int, maxHeight: Int, maxFrameRate: Double, maxBitrateKbps: Int
-        )] = [
-            // H.264 remains a duplicate on purpose: the hardware entry covers
-            // ordinary 8-bit streams, while this entry is the exercised High
-            // 10 software route. MPEG-2 carries the interlaced proof.
-            ("h264", "libavcodec", ["high 10"], [10], 1_920, 1_080, 30, 10_000),
-            ("av1", "dav1d", ["main"], [10], 1_920, 1_080, 30, 3_000),
-            ("vp9", "libavcodec", ["profile 0"], [8], 1_920, 1_080, 30, 3_000),
-            // The exercised NTSC fixture's server probe reports 30.303 fps,
-            // so its rounded source-rate ceiling must be 31 rather than 30.
-            ("mpeg2video", "libavcodec", ["main"], [8], 720, 480, 31, 7_000),
-            ("vc1", "libavcodec", ["advanced"], [8], 1_920, 1_080, 30, 32_000),
-        ]
-        return hardwareCapabilities + softwareCapabilities.map { capability in
-            PlaybackV3VideoDecodeCapability(
-                codec: capability.codec,
-                decoderName: capability.decoder,
-                profiles: capability.profiles,
-                levels: [],
-                bitDepths: capability.bitDepths,
-                maxWidth: capability.maxWidth,
-                maxHeight: capability.maxHeight,
-                maxFrameRate: capability.maxFrameRate,
-                maxBitrateKbps: capability.maxBitrateKbps,
-                hardware: false
-            )
-        }
-    }
-
-    /// Whether the platform routes this codec to an accelerated decoder.
-    private static func hardwareDecodeSupported(_ codecType: CMVideoCodecType) -> Bool {
-        #if targetEnvironment(simulator)
-        // The simulator services VideoToolbox through the host Mac, so
-        // `VTIsHardwareDecodeSupported` answers for the host GPU rather than
-        // for any device we could ship to. H.264 is accelerated on every host
-        // that can run the simulator; nothing else is worth attesting.
-        return codecType == kCMVideoCodecType_H264
-        #else
-        return VTIsHardwareDecodeSupported(codecType)
-        #endif
-    }
-
-    /// The tallest frame this build's decoders are guaranteed to accept.
-    private static var maxDecodeHeight: Int {
-        #if targetEnvironment(simulator)
-        1_080
-        #else
-        2_160
-        #endif
     }
 
     private static func outputSnapshot(
@@ -550,13 +474,7 @@ enum ApplePlaybackV3Capabilities {
     }
 
     private static var deviceContext: PlaybackV3DeviceContext {
-        var systemInfo = utsname()
-        uname(&systemInfo)
-        let mirror = Mirror(reflecting: systemInfo.machine)
-        let machine = mirror.children.reduce(into: "") { result, element in
-            guard let value = element.value as? Int8, value != 0 else { return }
-            result.append(Character(UnicodeScalar(UInt8(value))))
-        }
+        let machine = AppleDecodeCapabilities.machineIdentifier
         let version = ProcessInfo.processInfo.operatingSystemVersion
         var details = ["os_name": platformName]
         if !machine.isEmpty {

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/PlaybackProtocolV3Models.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/PlaybackProtocolV3Models.swift
@@ -32,6 +32,14 @@ enum PlaybackProtocolV3 {
     /// hardware-only strict-tier behavior.
     static let softwareVideoDecodeFeature = "software_video_decode_v1"
     static let planSourceDurationFeature = "plan_source_duration_v1"
+    /// Scoped to `original_http`: the Aether executor accepts the declared
+    /// source dynamic range and resolves HDR/Dolby Vision presentation against
+    /// the live output after delivery. It is not a promise that packaged
+    /// server streams can present the same range natively.
+    static let clientManagedDynamicRangeClaim = "client_managed_dynamic_range_v1"
+    /// Scoped to `original_http`: after probing the complete source, Aether
+    /// maps the plan's selected audio ordinal to its concrete stream id.
+    static let clientSelectedAudioTrackClaim = "client_selected_audio_track_v1"
 
     /// Delivery classes are the unit a client negotiates in
     /// `client_playback_context.deliveries`. They are deliberately coarser than
@@ -121,12 +129,33 @@ struct PlaybackV3VideoDecodeCapability: Codable, Equatable, Sendable {
     let hardware: Bool
 }
 
+extension AppleDecodeCapabilities {
+    /// The neutral decoder facts above adapted once into the Protocol V3 wire
+    /// model. Keeping this adapter beside the model lets shared capability code
+    /// compile in extensions that do not carry the playback protocol.
+    static func playbackV3VideoDecodeAttestation() -> [PlaybackV3VideoDecodeCapability] {
+        videoDecodeAttestation().map { capability in
+            PlaybackV3VideoDecodeCapability(
+                codec: capability.codec,
+                decoderName: capability.decoderName,
+                profiles: capability.profiles,
+                levels: capability.levels,
+                bitDepths: capability.bitDepths,
+                maxWidth: capability.maxWidth,
+                maxHeight: capability.maxHeight,
+                maxFrameRate: capability.maxFrameRate,
+                maxBitrateKbps: capability.maxBitrateKbps,
+                hardware: capability.hardware
+            )
+        }
+    }
+}
+
 struct PlaybackV3CodecCapabilities: Codable, Equatable {
-    /// How this client knows what it can decode. Apple's platform-backed
-    /// Aether stack claims `platform_attested`: codec, bit depth and dimension
-    /// bounds are exercised facts, while profile/level are not enumerable and
-    /// the server skips matching them. Software entries participate only with
-    /// the explicit software-video feature token.
+    /// How this client knows what it can decode. Online Apple TV 4K playback
+    /// uses `declared` for the pinned Aether/FFmpeg manifest and lets Aether
+    /// probe the exact stream at load time. Persistent downloads and the
+    /// conservative Apple surfaces retain bounded `platform_attested` entries.
     let videoEvidence: String
     let audioEvidence: String
     let codecsVideo: [String]

--- a/iosApp/iosApp/Shared/AppleDecodeCapabilities.swift
+++ b/iosApp/iosApp/Shared/AppleDecodeCapabilities.swift
@@ -1,33 +1,99 @@
+import CoreMedia
 import Foundation
+import VideoToolbox
 
-/// What this Apple client can actually decode, stated once.
+struct AppleVideoDecodeCapability: Equatable, Sendable {
+    let codec: String
+    let decoderName: String?
+    let profiles: [String]
+    let levels: [Int]
+    let bitDepths: [Int]
+    let maxWidth: Int
+    let maxHeight: Int
+    let maxFrameRate: Double
+    let maxBitrateKbps: Int
+    let hardware: Bool
+}
+
+/// What the pinned Apple playback stack can actually open, stated once.
 ///
-/// Playback and download surfaces report the same underlying stack using
-/// different wire shapes: V3 can describe every detailed decoder, while the
-/// legacy portion of download creation must remain hardware-only so an older
-/// server that ignores additive decoder evidence fails safely. The codec and
-/// container vocabulary still lives here so spelling cannot drift silently.
+/// Online playback and persistent downloads deliberately use different
+/// policies. Aether probes each online source and chooses its native or
+/// libavcodec path at load time, so supported Apple TV 4K hardware reports the
+/// pinned engine/build manifest without predicting profiles, bit depths, or
+/// performance in app code. Downloads have no server replan available when
+/// they are played offline, so they retain the bounded platform attestation.
 ///
-/// What differs between surfaces is policy and evidence shape, kept at the
-/// call site where its safety reason can be stated. Only the underlying "the
-/// stack can open this" vocabulary is shared.
+/// This is intentionally the only codec/container inventory in the app. Wire
+/// surfaces may narrow it for their delivery contract, but must not recreate
+/// their own decoder tables.
 enum AppleDecodeCapabilities {
+    enum StreamingVideoCapabilityMode: Equatable {
+        case aetherDeclared
+        case platformAttested
+    }
+
     #if targetEnvironment(simulator)
     static let isSimulator = true
     #else
     static let isSimulator = false
     #endif
 
-    /// Video codecs the pinned media stack has exercised end to end. H.264
-    /// includes the software High-10 path; MPEG-2 includes the interlaced path.
-    /// The remaining non-Apple codecs are bounded software claims in the V3
-    /// snapshot rather than pretending VideoToolbox supplied them.
-    static let softwareVideoCodecs = ["av1", "vp9", "mpeg2video", "vc1"]
-    static let videoCodecs: [String] = (isSimulator ? ["h264"] : ["h264", "hevc"])
-        + softwareVideoCodecs
+    static let machineIdentifier: String = {
+        var systemInfo = utsname()
+        uname(&systemInfo)
+        return withUnsafeBytes(of: &systemInfo.machine) { raw in
+            String(decoding: raw.prefix(while: { $0 != 0 }), as: UTF8.self)
+        }
+    }()
 
-    /// The subset of `videoCodecs` VideoToolbox decodes in hardware.
-    static let hardwareVideoCodecs: [String] = isSimulator ? ["h264"] : ["h264", "hevc"]
+    /// Keep the optimistic engine declaration off Apple TV HD. It has much
+    /// less software-decode headroom than every Apple TV 4K generation and no
+    /// online performance signal exists yet that can trigger a typed replan.
+    static func streamingVideoCapabilityModeForDevice(
+        isTVOS: Bool,
+        isSimulator: Bool,
+        machineIdentifier: String
+    ) -> StreamingVideoCapabilityMode {
+        guard isTVOS,
+              !isSimulator,
+              machineIdentifier.hasPrefix("AppleTV"),
+              machineIdentifier != "AppleTV5,3" else {
+            return .platformAttested
+        }
+        return .aetherDeclared
+    }
+
+    static var streamingVideoCapabilityMode: StreamingVideoCapabilityMode {
+        #if os(tvOS)
+        let isTVOS = true
+        #else
+        let isTVOS = false
+        #endif
+        return streamingVideoCapabilityModeForDevice(
+            isTVOS: isTVOS,
+            isSimulator: isSimulator,
+            machineIdentifier: machineIdentifier
+        )
+    }
+
+    private static var isAppleTVHD: Bool {
+        machineIdentifier == "AppleTV5,3"
+    }
+
+    /// The narrower, fixture-bounded software set retained for downloads and
+    /// conservative streaming clients. H.264 High 10 is added as a separate
+    /// detailed entry below because ordinary H.264 is also hardware-backed.
+    static let softwareVideoCodecs = ["av1", "vp9", "mpeg2video", "vc1"]
+
+    /// The complete online video manifest of AetherEngine 6.34.0 at
+    /// 0ae80496 with FFmpegBuild 2.4.3. Aether routes H.264, HEVC, and
+    /// hardware-decodable AV1 natively when the exact probed stream permits;
+    /// every other decoder present in the build goes through libavcodec.
+    static let aetherOriginalHTTPVideoCodecs = [
+        "h264", "hevc", "av1", "vp9", "vp8", "mpeg4", "mpeg2video", "vc1",
+        "qtrle", "msmpeg4v1", "msmpeg4v2", "msmpeg4v3", "wmv1", "wmv2", "wmv3"
+    ]
 
     /// Server-packaged progressive/HLS routes remain on their native codec
     /// vocabulary. The software claims above describe Aether's original-file
@@ -44,6 +110,14 @@ enum AppleDecodeCapabilities {
             "opus", "vorbis", "pcm", "pcm_s16le", "pcm_s24le"
         ]
 
+    /// Audio decoders present in the same Aether/FFmpeg build. Aliases are
+    /// intentional because scanners do not all spell DTS-HD or PCM alike.
+    static let aetherOriginalHTTPAudioCodecs = [
+        "aac", "ac3", "eac3", "mp3", "mp2", "flac", "opus", "vorbis", "alac",
+        "truehd", "mlp", "dts", "dca", "dts-hd", "dtshd", "pcm", "pcm_s16le",
+        "pcm_s24le", "pcm_f32le"
+    ]
+
     /// Video containers the client demuxes. Both spellings of the two aliased
     /// ones (`mkv`/`matroska`, `ts`/`mpegts`) are listed: the server sends
     /// whichever its scanner recorded, and a claim it cannot match reads as
@@ -57,24 +131,163 @@ enum AppleDecodeCapabilities {
     /// aliases remain honest for legacy metadata and future scanner changes.
     ///
     /// Aether supports additional containers, including Ogg. They stay out of
-    /// this server-facing flat vocabulary until Silo has exercised every
-    /// codec/container pairing that the cross-product would authorize.
+    /// the conservative/download vocabulary; online Apple TV 4K playback uses
+    /// the engine manifest below and relies on its per-source probe.
     static let audioContainers = ["mp3", "m4a", "m4b", "aac", "flac", "wav"]
+
+    /// Demuxers used by the pinned Aether build for online original HTTP.
+    /// ASF/WMV stays absent even though WMV elementary streams in Matroska are
+    /// supported; FFmpegBuild does not ship the corresponding container path.
+    private static let aetherVideoContainers = [
+        "mp4", "m4v", "mov", "mkv", "matroska", "avi", "mpegts", "ts", "m2ts",
+        "mts", "3gp", "3g2", "vob", "ogg", "webm", "flv"
+    ]
+    private static let aetherAudioContainers = [
+        "mp3", "aac", "m4a", "m4b", "flac", "alac", "wav", "opus", "ogg"
+    ]
+
+    static let aetherOriginalHTTPContainers: [String] = {
+        var seen = Set<String>()
+        return (aetherVideoContainers + aetherAudioContainers).filter {
+            seen.insert($0).inserted
+        }
+    }()
 
     /// The full direct-play container vocabulary used by flat capability
     /// surfaces and by the `original_http` V3 delivery.
     static let containers = videoContainers + audioContainers
 
-    /// The resolution ceiling to claim, or nil for "no client-imposed cap".
-    /// The simulator renders at 1080p; on device the ceiling is the display
-    /// pipeline's own, which the flat caps leave unstated.
-    static let maxResolution: String? = isSimulator ? "1080p" : nil
+    static func streamingVideoCodecs(for mode: StreamingVideoCapabilityMode) -> [String] {
+        switch mode {
+        case .aetherDeclared:
+            return aetherOriginalHTTPVideoCodecs
+        case .platformAttested:
+            return attestedVideoCodecs
+        }
+    }
+
+    static func streamingAudioCodecs(for mode: StreamingVideoCapabilityMode) -> [String] {
+        mode == .aetherDeclared
+            ? aetherOriginalHTTPAudioCodecs
+            : audioCodecs
+    }
+
+    static func streamingContainers(for mode: StreamingVideoCapabilityMode) -> [String] {
+        mode == .aetherDeclared
+            ? aetherOriginalHTTPContainers
+            : containers
+    }
+
+    static var streamingVideoCodecs: [String] {
+        streamingVideoCodecs(for: streamingVideoCapabilityMode)
+    }
+
+    static var streamingAudioCodecs: [String] {
+        streamingAudioCodecs(for: streamingVideoCapabilityMode)
+    }
+
+    static var streamingContainers: [String] {
+        streamingContainers(for: streamingVideoCapabilityMode)
+    }
+
+    /// The conservative resolution ceiling, or nil for "no client-imposed
+    /// cap". The simulator and Apple TV HD stop at 1080p; other device
+    /// surfaces retain the existing 2160p fallback token.
+    static var maxResolution: String? {
+        isSimulator || isAppleTVHD ? "1080p" : nil
+    }
 
     /// `maxResolution` for surfaces that need it spelled out rather than left
     /// open — the V3 snapshot's per-codec decode entries pair it with
     /// explicit pixel dimensions, so "no cap" has nothing to mean there.
-    static let maxResolutionToken: String = maxResolution ?? "2160p"
+    static var maxResolutionToken: String { maxResolution ?? "2160p" }
 
-    static let maxDecodeWidth: Int = isSimulator ? 1_920 : 3_840
-    static let maxDecodeHeight: Int = isSimulator ? 1_080 : 2_160
+    static func streamingMaxResolutionToken(for mode: StreamingVideoCapabilityMode) -> String {
+        mode == .aetherDeclared ? "2160p" : maxResolutionToken
+    }
+
+    static var streamingMaxResolutionToken: String {
+        streamingMaxResolutionToken(for: streamingVideoCapabilityMode)
+    }
+
+    static var maxDecodeWidth: Int { maxDecodeHeight >= 2_160 ? 3_840 : 1_920 }
+    static var maxDecodeHeight: Int { isSimulator || isAppleTVHD ? 1_080 : 2_160 }
+
+    /// The hardware attestations VideoToolbox supplies, followed by the
+    /// narrower software envelopes proven with Aether fixtures. This is the
+    /// persistent-download safety contract and the fallback for Apple TV HD,
+    /// simulators, iOS, and macOS; online Apple TV 4K playback does not send
+    /// these predictions.
+    static func videoDecodeAttestation() -> [AppleVideoDecodeCapability] {
+        videoDecodeAttestationValue
+    }
+
+    private static let videoDecodeAttestationValue = makeVideoDecodeAttestation()
+
+    private static func makeVideoDecodeAttestation() -> [AppleVideoDecodeCapability] {
+        let codecTypes: [(String, CMVideoCodecType)] = [
+            ("h264", kCMVideoCodecType_H264),
+            ("hevc", kCMVideoCodecType_HEVC)
+        ]
+        let hardwareCapabilities: [AppleVideoDecodeCapability] = codecTypes.compactMap { codec, codecType in
+            guard hardwareDecodeSupported(codecType) else {
+                return nil
+            }
+            return AppleVideoDecodeCapability(
+                codec: codec,
+                decoderName: "VideoToolbox",
+                profiles: [],
+                levels: [],
+                bitDepths: codec == "hevc" ? [8, 10] : [8],
+                maxWidth: maxDecodeWidth,
+                maxHeight: maxDecodeHeight,
+                maxFrameRate: 60,
+                maxBitrateKbps: maxDecodeHeight >= 2_160 ? 120_000 : 25_000,
+                hardware: true
+            )
+        }
+        let softwareCapabilities: [(
+            codec: String, decoder: String, profiles: [String], bitDepths: [Int],
+            maxWidth: Int, maxHeight: Int, maxFrameRate: Double, maxBitrateKbps: Int
+        )] = [
+            ("h264", "libavcodec", ["high 10"], [10], 1_920, 1_080, 30, 10_000),
+            ("av1", "dav1d", ["main"], [10], 1_920, 1_080, 30, 3_000),
+            ("vp9", "libavcodec", ["profile 0"], [8], 1_920, 1_080, 30, 3_000),
+            // The exercised NTSC fixture reports 30.303 fps.
+            ("mpeg2video", "libavcodec", ["main"], [8], 720, 480, 31, 7_000),
+            ("vc1", "libavcodec", ["advanced"], [8], 1_920, 1_080, 30, 32_000),
+        ]
+        return hardwareCapabilities + softwareCapabilities.map { capability in
+            AppleVideoDecodeCapability(
+                codec: capability.codec,
+                decoderName: capability.decoder,
+                profiles: capability.profiles,
+                levels: [],
+                bitDepths: capability.bitDepths,
+                maxWidth: capability.maxWidth,
+                maxHeight: capability.maxHeight,
+                maxFrameRate: capability.maxFrameRate,
+                maxBitrateKbps: capability.maxBitrateKbps,
+                hardware: false
+            )
+        }
+    }
+
+    static let hardwareVideoCodecs = videoDecodeAttestationValue.filter(\.hardware).map(\.codec)
+
+    static let attestedVideoCodecs: [String] = {
+        var seen = Set<String>()
+        return videoDecodeAttestationValue.map(\.codec).filter {
+            seen.insert($0).inserted
+        }
+    }()
+
+    private static func hardwareDecodeSupported(_ codecType: CMVideoCodecType) -> Bool {
+        #if targetEnvironment(simulator)
+        // The simulator answers for the host GPU, not a shippable device.
+        return codecType == kCMVideoCodecType_H264
+        #else
+        return VTIsHardwareDecodeSupported(codecType)
+        #endif
+    }
 }

--- a/iosApp/iosApp/Shared/Diagnostics/DiagnosticsCapabilityProbe.swift
+++ b/iosApp/iosApp/Shared/Diagnostics/DiagnosticsCapabilityProbe.swift
@@ -35,11 +35,16 @@ enum DiagnosticsCapabilityProbe {
     }
 
     static func snapshot(
-        displayCapabilities: ApplePlaybackDisplayCapabilities = .probe()
+        displayCapabilities: ApplePlaybackDisplayCapabilities = .probe(),
+        videoCapabilityMode requestedMode: AppleDecodeCapabilities.StreamingVideoCapabilityMode? = nil
     ) -> Snapshot {
-        Snapshot(
+        let videoCapabilityMode = requestedMode ?? AppleDecodeCapabilities.streamingVideoCapabilityMode
+        return Snapshot(
             display: displaySnapshot(displayCapabilities),
-            videoCodecs: videoCodecSnapshot(displayCapabilities),
+            videoCodecs: videoCodecSnapshot(
+                displayCapabilities,
+                videoCapabilityMode: videoCapabilityMode
+            ),
             network: .object(["transport": .string("not_collected")])
         )
     }
@@ -94,25 +99,43 @@ enum DiagnosticsCapabilityProbe {
         ])
     }
 
-    private static func videoCodecSnapshot(_ capabilities: ApplePlaybackDisplayCapabilities) -> DiagnosticsJSONValue {
+    private static func videoCodecSnapshot(
+        _ capabilities: ApplePlaybackDisplayCapabilities,
+        videoCapabilityMode: AppleDecodeCapabilities.StreamingVideoCapabilityMode
+    ) -> DiagnosticsJSONValue {
         // Which codecs is the shared client answer; the rest of each entry is
-        // this probe's own (display-derived resolution, HDR from the panel).
-        let codecs = AppleDecodeCapabilities.videoCodecs.map(diagnosticsMIME(for:))
-        #if targetEnvironment(simulator)
-        let maxResolution = "1080p"
-        let hdr = false
-        #else
-        let maxResolution = capabilities.maxResolution?.rawValue ?? "unknown"
-        let hdr = capabilities.supportsHDR10 || capabilities.supportsHLG || capabilities.supportsDolbyVision
-        #endif
+        // this probe's own. Declared evidence intentionally carries no
+        // per-codec performance or HDR prediction: the display section still
+        // records panel facts, while Aether probes the exact source at load.
+        let codecs = AppleDecodeCapabilities.streamingVideoCodecs(
+            for: videoCapabilityMode
+        ).map(diagnosticsMIME(for:))
+        let maxResolution: DiagnosticsJSONValue
+        let hdr: DiagnosticsJSONValue
+        if videoCapabilityMode == .aetherDeclared {
+            maxResolution = .string("not_collected")
+            hdr = .string("not_collected")
+        } else {
+            #if targetEnvironment(simulator)
+            maxResolution = .string("1080p")
+            hdr = .bool(false)
+            #else
+            maxResolution = .string(capabilities.maxResolution?.rawValue ?? "unknown")
+            hdr = .bool(
+                capabilities.supportsHDR10
+                    || capabilities.supportsHLG
+                    || capabilities.supportsDolbyVision
+            )
+            #endif
+        }
 
         return .array(codecs.map { codec in
             .object([
                 "mime": .string(codec),
                 "hw": .string("unknown"),
                 "profiles": .string("not_collected"),
-                "max": .string(maxResolution),
-                "hdr": .bool(hdr),
+                "max": maxResolution,
+                "hdr": hdr,
             ])
         })
     }


### PR DESCRIPTION
## Summary

- centralize Apple codec, container, hardware-probe, and device-generation policy in `AppleDecodeCapabilities`
- let physical Apple TV 4K clients advertise the pinned AetherEngine/FFmpeg build manifest for `original_http`, while retaining bounded platform attestation for downloads, Apple TV HD, simulators, iOS, and macOS
- add explicit V3 claims for Aether-managed dynamic range and client-selected audio without broadening packaged progressive/HLS routes
- make the V3-selected audio track authoritative for Aether's initial open so a global language preference cannot override a manual pre-play selection
- align diagnostics, tests, and the Aether migration documentation with the consolidated ownership boundary

## Why

The Apple client had multiple handwritten capability tables that could reject a source before Aether's runtime probe saw it. The split also allowed Aether to open with the profile-level audio language and only apply the V3-selected ordinal afterward, producing a wrong-language first frame followed by a disruptive pipeline reload.

This change keeps the V3 protocol shape and server fallback ladder, but moves source-specific decode and presentation decisions to Aether where they can be made from the actual file and device.

## Companion server

- Silo-Server/silo-server#737 teaches the V3 planner to honor the two delivery-scoped claims and publishes the generated managed-HDR selected-audio conformance scenario
- the server change is required for these claims to alter route selection; an older server ignores them and retains its previous fallback behavior

## Validation

- `AetherPlaybackBoundaryTests`, `AppleDecodeCapabilitiesTests`, `DeviceSnapshotBuilderTests`, and `PlaybackProtocolV3Tests`: 93 tests executed, 1 fixture-dependent test skipped, 0 failures
- exact server conformance corpus plus Apple fixture/player suites: 75 tests executed, 1 live-fixture skip, 0 failures
- signed generic tvOS device build: succeeded on the rebased head
- pre-publication physical tvOS smoke: signed install, metadata verification, launch, and on-device process verification succeeded; the rebased head differs only by the upstream runpath fix and received a fresh signed build
- full `SiloTests` attempt: 1,104 tests executed with 1 skip and 3 failures in `UICustomizationPreferencesTests`; the same three failures reproduced when that unrelated suite was run alone
- independent read-only review completed; no blocking finding

## Follow-up

- confirm the manual non-default audio selection flow on the published build
- duplicate-language or unlabeled tracks still rely on the existing exact post-probe ordinal reconciliation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved online playback capability reporting for Apple TV 4K, including broader codec and container support.
  - Added dynamic-range handling and client-selected audio track mapping for supported streaming playback.
  - Improved initial audio-language selection using available track information, with profile-language fallback.
  - Enhanced playback diagnostics to distinguish declared capabilities from device-attested capabilities.

- **Bug Fixes**
  - Preserved conservative decoding limits for downloads, Apple TV HD, simulators, and other platform-attested playback scenarios.
  - Improved handling of unavailable, unlabeled, or blank audio-language selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
