### PR TITLE
Use server-resolved profile images across Apple clients

### DIFF
--- a/iosApp/iosApp/Components/ProfileAvatarView.swift
+++ b/iosApp/iosApp/Components/ProfileAvatarView.swift
@@ -5,6 +5,11 @@ struct ProfileAvatarView: View {
     private static let diceBearBaseURL = "https://api.dicebear.com/9.x"
 
     let avatar: String?
+    /// Server-resolved avatar URL (`avatar_url`). When present it wins over
+    /// the client-side resolution of ``avatar``, which cannot resolve opaque
+    /// `upload:` refs. Absolute URLs are used verbatim; a leading-slash path
+    /// is resolved against the active server.
+    var imageUrl: String? = nil
     let name: String
     var size: CGFloat
     var backgroundColor: Color = .continuumSurfaceVariant
@@ -37,6 +42,7 @@ struct ProfileAvatarView: View {
     }
 
     private var displayAvatarText: String? {
+        guard resolvedServerImageURL == nil else { return nil }
         guard let trimmedAvatar = avatar?.trimmingCharacters(in: .whitespacesAndNewlines),
               !trimmedAvatar.isEmpty,
               !isImageAvatar(trimmedAvatar) else {
@@ -45,7 +51,13 @@ struct ProfileAvatarView: View {
         return trimmedAvatar
     }
 
+    private var resolvedServerImageURL: String? {
+        ProfileAvatarResolver.serverResolvedImageURL(imageUrl)
+    }
+
     private var resolvedImageURL: String? {
+        if let serverURL = resolvedServerImageURL { return serverURL }
+
         guard let trimmedAvatar = avatar?.trimmingCharacters(in: .whitespacesAndNewlines),
               !trimmedAvatar.isEmpty,
               isImageAvatar(trimmedAvatar) else {

--- a/iosApp/iosApp/Components/ProfileAvatarView.swift
+++ b/iosApp/iosApp/Components/ProfileAvatarView.swift
@@ -21,11 +21,11 @@ struct ProfileAvatarView: View {
                 .fill(backgroundColor)
                 .frame(width: size, height: size)
 
-            if let imageURL = resolvedImageURL {
-                AsyncImageView(url: imageURL, contentMode: .fill)
-                    .frame(width: size, height: size)
-                    .clipShape(Circle())
-            } else if let displayAvatar = displayAvatarText {
+            // The text/initial fallback is layered beneath the image so that a
+            // failed load — e.g. an expired presigned `avatar_url` — degrades
+            // to it instead of an error placeholder: `.clear` style renders
+            // nothing on both the loading and error branches.
+            if let displayAvatar = displayAvatarText {
                 Text(displayAvatar)
                     .font(.system(size: fontSize))
             } else if !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -37,14 +37,20 @@ struct ProfileAvatarView: View {
                     .font(.system(size: size * 0.36))
                     .foregroundColor(.continuumSecondaryText)
             }
+
+            if let imageURL = resolvedImageURL {
+                AsyncImageView(url: imageURL, contentMode: .fill, placeholderStyle: .clear)
+                    .frame(width: size, height: size)
+                    .clipShape(Circle())
+            }
         }
         .frame(width: size, height: size)
     }
 
     private var displayAvatarText: String? {
-        guard resolvedServerImageURL == nil else { return nil }
         guard let trimmedAvatar = avatar?.trimmingCharacters(in: .whitespacesAndNewlines),
               !trimmedAvatar.isEmpty,
+              !trimmedAvatar.lowercased().hasPrefix("upload:"),
               !isImageAvatar(trimmedAvatar) else {
             return nil
         }

--- a/iosApp/iosApp/Components/TabTopBarActions.swift
+++ b/iosApp/iosApp/Components/TabTopBarActions.swift
@@ -112,6 +112,7 @@ private struct ProfileAvatarMenu: View {
         } label: {
             ProfileAvatarView(
                 avatar: profile?.avatarEmoji,
+                imageUrl: profile?.avatarImageUrl,
                 name: profile?.name ?? "",
                 size: 36
             )

--- a/iosApp/iosApp/Networking/WireFormatModels.swift
+++ b/iosApp/iosApp/Networking/WireFormatModels.swift
@@ -12,6 +12,13 @@ struct Profile: Codable {
     let id: String
     let name: String
     let avatar: String?
+    /// Server-resolved avatar URL (`avatar_url`). For uploads this is a
+    /// short-lived presigned object-store URL that changes on every fetch, so
+    /// it must not be persisted long-term. For presets it is a DiceBear URL or
+    /// a server-relative `/profile-avatars/{id}.svg` path.
+    let avatarUrl: String?
+    /// `avatar_source`: "upload", "preset", or "none".
+    let avatarSource: String?
     let hasPin: Bool?
     let isChild: Bool?
     let isPrimary: Bool?
@@ -40,6 +47,7 @@ struct Profile: Codable {
             id: id,
             name: name,
             avatarEmoji: avatar,
+            avatarImageUrl: avatarUrl,
             hasPin: hasPin ?? false,
             isChild: isChild ?? false,
             isPrimary: isPrimary ?? false,

--- a/iosApp/iosApp/Screens/Profiles/PINEntryView.swift
+++ b/iosApp/iosApp/Screens/Profiles/PINEntryView.swift
@@ -96,6 +96,7 @@ struct PINEntryView: View {
         VStack(spacing: 10) {
             ProfileAvatarView(
                 avatar: profile.avatarEmoji,
+                imageUrl: profile.avatarImageUrl,
                 name: profile.name,
                 size: avatarSize
             )

--- a/iosApp/iosApp/Screens/Profiles/ProfileModels.swift
+++ b/iosApp/iosApp/Screens/Profiles/ProfileModels.swift
@@ -9,6 +9,12 @@ struct UserProfile: Codable, Identifiable, Hashable {
     let id: String
     let name: String
     let avatarEmoji: String?
+    /// Server-resolved avatar image URL (`avatar_url`). Absolute for uploads
+    /// (short-lived presigned object-store URL) and DiceBear presets, or a
+    /// server-relative path for locally hosted preset art. Preferred over the
+    /// client-side resolution of ``avatarEmoji`` when present; optional so
+    /// cached payloads written before this field existed still decode.
+    let avatarImageUrl: String?
     let hasPin: Bool
     let isChild: Bool
     let isPrimary: Bool
@@ -23,6 +29,7 @@ struct UserProfile: Codable, Identifiable, Hashable {
         id: String,
         name: String,
         avatarEmoji: String?,
+        avatarImageUrl: String? = nil,
         hasPin: Bool,
         isChild: Bool,
         isPrimary: Bool = false,
@@ -34,6 +41,7 @@ struct UserProfile: Codable, Identifiable, Hashable {
         self.id = id
         self.name = name
         self.avatarEmoji = avatarEmoji
+        self.avatarImageUrl = avatarImageUrl
         self.hasPin = hasPin
         self.isChild = isChild
         self.isPrimary = isPrimary

--- a/iosApp/iosApp/Screens/Profiles/ProfileTile.swift
+++ b/iosApp/iosApp/Screens/Profiles/ProfileTile.swift
@@ -294,6 +294,14 @@ enum ProfileAvatarResolver {
         }
 
         let lowercased = trimmed.lowercased()
+
+        // The Nuke pipeline registers no SVG decoder, so the server's legacy
+        // `/profile-avatars/{id}.svg` preset URLs cannot be rendered here.
+        // Decline them and let the caller's raw-ref fallback chain apply.
+        // Uploads are .webp and DiceBear presets are PNG, so both pass.
+        let pathOnly = lowercased.split(separator: "?", maxSplits: 1)[0]
+        if pathOnly.hasSuffix(".svg") { return nil }
+
         if lowercased.hasPrefix("http://")
             || lowercased.hasPrefix("https://")
             || lowercased.hasPrefix("data:image/")

--- a/iosApp/iosApp/Screens/Profiles/ProfileTile.swift
+++ b/iosApp/iosApp/Screens/Profiles/ProfileTile.swift
@@ -159,7 +159,10 @@ struct ProfileTile: View {
     @ViewBuilder
     private var avatarContent: some View {
         let avatar = profile.avatarEmoji?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        if ProfileAvatarResolver.isImage(avatar) {
+        if let serverURL = ProfileAvatarResolver.serverResolvedImageURL(profile.avatarImageUrl) {
+            AsyncImageView(url: serverURL, contentMode: .fill)
+                .frame(width: tileSize, height: tileSize)
+        } else if ProfileAvatarResolver.isImage(avatar) {
             // Image avatars (DiceBear preset or URL) clip to the full tile
             // bounds for a cinematic poster effect.
             if let url = ProfileAvatarResolver.imageURL(for: avatar) {
@@ -280,6 +283,32 @@ struct AddProfileTile: View {
 /// avatars in a tile shape rather than a circle. Kept as a small local
 /// utility rather than adjusting the shared view's API surface.
 enum ProfileAvatarResolver {
+    /// Resolve the server-supplied `avatar_url`. Absolute URLs (presigned
+    /// upload URLs, DiceBear) are used verbatim; a server-relative path is
+    /// prefixed with the active server URL. Returns nil when absent or when
+    /// no active server is known for a relative path.
+    static func serverResolvedImageURL(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+
+        let lowercased = trimmed.lowercased()
+        if lowercased.hasPrefix("http://")
+            || lowercased.hasPrefix("https://")
+            || lowercased.hasPrefix("data:image/")
+            || lowercased.hasPrefix("file://") {
+            return trimmed
+        }
+
+        guard trimmed.hasPrefix("/") else { return nil }
+        let serverURL = ServerRegistry.shared.activeServerUrl
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        guard !serverURL.isEmpty else { return nil }
+        return serverURL + trimmed
+    }
+
     static func isImage(_ value: String) -> Bool {
         let lowercased = value.lowercased()
         return lowercased.hasPrefix("preset:dicebear:")
@@ -331,6 +360,6 @@ enum ProfileAvatarResolver {
         guard !style.isEmpty, !seed.isEmpty else { return nil }
         let s = style.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? style
         let d = seed.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? seed
-        return "https://api.dicebear.com/9.x/\(s)/png?seed=\(d)&size=512"
+        return "https://api.dicebear.com/9.x/\(s)/png?seed=\(d)&size=256"
     }
 }

--- a/iosApp/iosApp/Screens/Settings/IOSSettingsOverview.swift
+++ b/iosApp/iosApp/Screens/Settings/IOSSettingsOverview.swift
@@ -25,6 +25,7 @@ struct IOSSettingsOverview: View {
 
                     SettingsAccountCard(
                         avatar: viewModel.activeProfile?.avatarEmoji,
+                        avatarImageUrl: viewModel.activeProfile?.avatarImageUrl,
                         name: displayName,
                         subtitle: subtitleLine,
                         isAdministrator: viewModel.userInfo?.isAdmin == true,

--- a/iosApp/iosApp/Screens/Settings/SettingsAccountCard.swift
+++ b/iosApp/iosApp/Screens/Settings/SettingsAccountCard.swift
@@ -3,6 +3,9 @@ import SwiftUI
 
 struct SettingsAccountCard: View {
     let avatar: String?
+    /// Server-resolved avatar image URL (`avatar_url`), preferred over the
+    /// raw `avatar` ref when present.
+    var avatarImageUrl: String? = nil
     let name: String
     let subtitle: String
     let isAdministrator: Bool
@@ -11,7 +14,7 @@ struct SettingsAccountCard: View {
     var body: some View {
         Button(action: action) {
             HStack(spacing: 14) {
-                ProfileAvatarView(avatar: avatar, name: name, size: 54)
+                ProfileAvatarView(avatar: avatar, imageUrl: avatarImageUrl, name: name, size: 54)
 
                 VStack(alignment: .leading, spacing: 3) {
                     Text("Current profile")

--- a/iosApp/iosApp/Screens/Settings/SettingsView.swift
+++ b/iosApp/iosApp/Screens/Settings/SettingsView.swift
@@ -84,6 +84,7 @@ struct SettingsView: View {
                 HStack(spacing: 14) {
                     ProfileAvatarView(
                         avatar: viewModel.activeProfile?.avatarEmoji,
+                        imageUrl: viewModel.activeProfile?.avatarImageUrl,
                         name: viewModel.activeProfile?.name
                             ?? viewModel.userInfo?.username
                             ?? "",

--- a/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
+++ b/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
@@ -729,10 +729,21 @@ enum StartupContentPrefetcher {
         var seen = Set<String>()
 
         for profile in profiles {
-            guard urls.count < maxProfileArtworkURLs,
-                  let avatar = profile.avatarEmoji?.trimmingCharacters(in: .whitespacesAndNewlines),
-                  ProfileAvatarResolver.isImage(avatar),
-                  let urlString = ProfileAvatarResolver.imageURL(for: avatar),
+            guard urls.count < maxProfileArtworkURLs else { continue }
+
+            // Mirror the view-side precedence: server-resolved `avatar_url`
+            // first, then the client-side resolution of the raw ref.
+            let resolved: String?
+            if let serverURL = ProfileAvatarResolver.serverResolvedImageURL(profile.avatarImageUrl) {
+                resolved = serverURL
+            } else if let avatar = profile.avatarEmoji?.trimmingCharacters(in: .whitespacesAndNewlines),
+                      ProfileAvatarResolver.isImage(avatar) {
+                resolved = ProfileAvatarResolver.imageURL(for: avatar)
+            } else {
+                resolved = nil
+            }
+
+            guard let urlString = resolved,
                   let url = normalizedURL(from: urlString) else {
                 continue
             }

--- a/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
@@ -600,6 +600,7 @@ struct TVMainTabView: View {
         TVProfileDropdown(
             profileName: currentProfile?.name ?? "Profile",
             avatar: currentProfile?.avatarEmoji,
+            avatarImageUrl: currentProfile?.avatarImageUrl,
             serverHost: ServerRegistry.shared.activeServer?.displayName,
             entersPanel: isActive && panelEntersFocus,
             focusEntryGeneration: panelFocusEntryGeneration,

--- a/iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift
@@ -557,6 +557,7 @@ struct TVTopMenuBar: View {
         } label: {
             ProfileAvatarView(
                 avatar: currentProfile?.avatarEmoji,
+                imageUrl: currentProfile?.avatarImageUrl,
                 name: currentProfile?.name ?? "",
                 size: ContinuumTheme.Skyline.barIconSize,
                 backgroundColor: Color.white.opacity(0.18),
@@ -1088,6 +1089,9 @@ private enum TVProfileAction: Hashable {
 struct TVProfileDropdown: View {
     let profileName: String
     let avatar: String?
+    /// Server-resolved avatar image URL (`avatar_url`), preferred over the
+    /// raw `avatar` ref when present.
+    var avatarImageUrl: String? = nil
     /// Display name of the active server, shown under the profile name in
     /// the §5.8 mono header style.
     let serverHost: String?
@@ -1185,6 +1189,7 @@ struct TVProfileDropdown: View {
         HStack(spacing: 14) {
             ProfileAvatarView(
                 avatar: avatar,
+                imageUrl: avatarImageUrl,
                 name: profileName,
                 size: 44,
                 backgroundColor: Color.white.opacity(0.16),

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsView.swift
@@ -237,6 +237,7 @@ struct TVSettingsView: View {
             HStack(spacing: 18) {
                 ProfileAvatarView(
                     avatar: viewModel.profileAvatar,
+                    imageUrl: viewModel.profileAvatarImageUrl,
                     name: viewModel.displayName,
                     size: 68
                 )

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsViewModel.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsViewModel.swift
@@ -154,6 +154,11 @@ final class TVSettingsViewModel {
         activeProfile?.avatarEmoji
     }
 
+    /// Server-resolved avatar image URL, preferred over ``profileAvatar``.
+    var profileAvatarImageUrl: String? {
+        activeProfile?.avatarImageUrl
+    }
+
     // MARK: - Load / save
 
     /// Main-actor isolated: it publishes into observable state the settings


### PR DESCRIPTION
## Summary

- Decode server-provided profile image URLs and sources.
- Prefer resolved upload or preset URLs across iOS and tvOS profile, settings, PIN, and navigation views.
- Update startup artwork prefetching and reduce DiceBear fallback output size.

## Testing

- Not run (source change only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Profile avatars now use server-provided images across iOS and tvOS profile menus, settings, PIN entry, and profile tiles.
  * Supports absolute and server-relative avatar image URLs.
  * Existing emoji, text, and client-resolved avatar fallbacks remain available when images are unavailable.
  * Improved avatar loading and prefetching, including clearer fallback behavior for failed images.
  * Reduced generated avatar image sizes for improved efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->