### PR TITLE
feat(images): request large artwork variants on tvOS

### DIFF
--- a/iosApp/Tests/ImageSizeCapabilityTests.swift
+++ b/iosApp/Tests/ImageSizeCapabilityTests.swift
@@ -174,4 +174,78 @@ final class ImageSizeCapabilityTests: XCTestCase {
         XCTAssertTrue(capability.requestQuery.isEmpty)
         XCTAssertFalse(capability.isAvailable)
     }
+
+    func testSuccessfulRefreshIsCachedForSession() async throws {
+        let response = try decodedCapability()
+        let stub = ImageSizeCapabilityFetchStub(response: response)
+        let capability = ImageSizeCapability(platformPrefersLargeImages: true) {
+            try await stub.fetch()
+        }
+
+        await capability.refresh()
+        await capability.refresh()
+
+        let callCount = await stub.callCount
+        XCTAssertEqual(callCount, 1)
+        XCTAssertEqual(capability.requestQuery, ["image_size": "large"])
+    }
+
+    func testFailedRefreshRetriesAndThenCachesSuccess() async throws {
+        let response = try decodedCapability()
+        let stub = ImageSizeCapabilityFetchStub(
+            response: response,
+            failuresBeforeSuccess: 1
+        )
+        let capability = ImageSizeCapability(platformPrefersLargeImages: true) {
+            try await stub.fetch()
+        }
+
+        await capability.refresh()
+        XCTAssertTrue(capability.requestQuery.isEmpty)
+
+        await capability.refresh()
+        await capability.refresh()
+
+        let callCount = await stub.callCount
+        XCTAssertEqual(callCount, 2)
+        XCTAssertEqual(capability.requestQuery, ["image_size": "large"])
+    }
+
+    func testResetRequiresCapabilityProbeForNewIdentity() async throws {
+        let response = try decodedCapability()
+        let stub = ImageSizeCapabilityFetchStub(response: response)
+        let capability = ImageSizeCapability(platformPrefersLargeImages: true) {
+            try await stub.fetch()
+        }
+
+        await capability.refresh()
+        capability.reset()
+        await capability.refresh()
+
+        let callCount = await stub.callCount
+        XCTAssertEqual(callCount, 2)
+        XCTAssertEqual(capability.requestQuery, ["image_size": "large"])
+    }
+}
+
+private actor ImageSizeCapabilityFetchStub {
+    private(set) var callCount = 0
+    private let response: ImageSizeCapabilityResponse
+    private let failuresBeforeSuccess: Int
+
+    init(
+        response: ImageSizeCapabilityResponse,
+        failuresBeforeSuccess: Int = 0
+    ) {
+        self.response = response
+        self.failuresBeforeSuccess = failuresBeforeSuccess
+    }
+
+    func fetch() throws -> ImageSizeCapabilityResponse {
+        callCount += 1
+        if callCount <= failuresBeforeSuccess {
+            throw URLError(.cannotConnectToHost)
+        }
+        return response
+    }
 }

--- a/iosApp/Tests/ImageSizeCapabilityTests.swift
+++ b/iosApp/Tests/ImageSizeCapabilityTests.swift
@@ -1,0 +1,177 @@
+//
+//  ImageSizeCapabilityTests.swift
+//  SiloTests
+//
+//  Wire-decoding + query-injection tests for image-size selection.
+//  Decodes raw snake_case JSON exactly as `HTTPClient` does
+//  (`.convertFromSnakeCase`), and covers the gating matrix for the
+//  query entries the networking layer merges into image-bearing
+//  requests.
+//
+//  The `platformPrefersLargeImages` flag is passed explicitly rather
+//  than read from `#if os(tvOS)`: the test target is hosted by the iOS
+//  app, so the tvOS branch is otherwise unreachable from a test.
+//
+
+import XCTest
+import Foundation
+@testable import Silo
+
+final class ImageSizeCapabilityTests: XCTestCase {
+
+    private func decoder() -> JSONDecoder {
+        let d = JSONDecoder()
+        d.keyDecodingStrategy = .convertFromSnakeCase
+        return d
+    }
+
+    /// The capability payload as the server documents it.
+    private let capabilityJSON = """
+    {
+      "schema_version": 1,
+      "param": "image_size",
+      "sizes": ["small", "medium", "large", "original"],
+      "widths": {
+        "poster": {"small": 300, "medium": 500, "large": 780},
+        "still": {"small": 300, "medium": 500, "large": 780},
+        "logo": {"small": 300, "medium": 500, "large": 1280},
+        "backdrop": {"small": 300, "medium": 780, "large": 1920}
+      },
+      "original_max_width_px": 1920
+    }
+    """
+
+    private func decodedCapability() throws -> ImageSizeCapabilityResponse {
+        try decoder().decode(
+            ImageSizeCapabilityResponse.self,
+            from: Data(capabilityJSON.utf8)
+        )
+    }
+
+    // MARK: - Decoding
+
+    func testCapabilityDecodesServerPayload() throws {
+        let capability = try decodedCapability()
+        XCTAssertEqual(capability.schemaVersion, 1)
+        XCTAssertEqual(capability.param, "image_size")
+        XCTAssertEqual(capability.sizes, ["small", "medium", "large", "original"])
+        XCTAssertEqual(capability.originalMaxWidthPx, 1920)
+        XCTAssertEqual(capability.widths["poster"]?["large"], 780)
+        XCTAssertEqual(capability.widths["logo"]?["large"], 1280)
+        XCTAssertEqual(capability.widths["backdrop"]?["large"], 1920)
+    }
+
+    /// Roles the client doesn't know about must not fail the decode —
+    /// the server is free to add image roles without a client release.
+    func testCapabilityDecodesUnknownImageRole() throws {
+        let json = """
+        {
+          "schema_version": 1,
+          "param": "image_size",
+          "sizes": ["small", "large"],
+          "widths": {"thumb": {"small": 120, "large": 480}},
+          "original_max_width_px": 1920
+        }
+        """
+        let capability = try decoder().decode(
+            ImageSizeCapabilityResponse.self,
+            from: Data(json.utf8)
+        )
+        XCTAssertEqual(capability.widths["thumb"]?["large"], 480)
+    }
+
+    // MARK: - Query injection
+
+    func testQueryEntriesAddLargeWhenSupportedOnTV() throws {
+        let entries = ImageSizeCapability.queryEntries(
+            capability: try decodedCapability(),
+            platformPrefersLargeImages: true
+        )
+        XCTAssertEqual(entries, ["image_size": "large"])
+    }
+
+    /// iOS and macOS must keep sending byte-identical requests.
+    func testQueryEntriesEmptyOffTV() throws {
+        let entries = ImageSizeCapability.queryEntries(
+            capability: try decodedCapability(),
+            platformPrefersLargeImages: false
+        )
+        XCTAssertTrue(entries.isEmpty)
+    }
+
+    /// Older server: the probe 404s, the capability stays nil, and the
+    /// client sends nothing rather than risking a 400.
+    func testQueryEntriesEmptyWithoutCapability() {
+        let entries = ImageSizeCapability.queryEntries(
+            capability: nil,
+            platformPrefersLargeImages: true
+        )
+        XCTAssertTrue(entries.isEmpty)
+    }
+
+    /// A schema the client doesn't understand is treated as "off".
+    func testQueryEntriesEmptyForUnknownSchemaVersion() {
+        let capability = ImageSizeCapabilityResponse(
+            schemaVersion: 2,
+            param: "image_size",
+            sizes: ["small", "large"],
+            widths: [:],
+            originalMaxWidthPx: 1920
+        )
+        XCTAssertTrue(
+            ImageSizeCapability.queryEntries(
+                capability: capability,
+                platformPrefersLargeImages: true
+            ).isEmpty
+        )
+    }
+
+    /// A server that doesn't advertise `large` gets no parameter at all,
+    /// because an unadvertised value is a 400.
+    func testQueryEntriesEmptyWhenLargeNotAdvertised() {
+        let capability = ImageSizeCapabilityResponse(
+            schemaVersion: 1,
+            param: "image_size",
+            sizes: ["small", "medium"],
+            widths: [:],
+            originalMaxWidthPx: 1920
+        )
+        XCTAssertTrue(
+            ImageSizeCapability.queryEntries(
+                capability: capability,
+                platformPrefersLargeImages: true
+            ).isEmpty
+        )
+    }
+
+    /// The parameter name comes from the payload, not a hardcoded string.
+    func testQueryEntriesUseServerSuppliedParamName() {
+        let capability = ImageSizeCapabilityResponse(
+            schemaVersion: 1,
+            param: "img_size",
+            sizes: ["large"],
+            widths: [:],
+            originalMaxWidthPx: 1920
+        )
+        XCTAssertEqual(
+            ImageSizeCapability.queryEntries(
+                capability: capability,
+                platformPrefersLargeImages: true
+            ),
+            ["img_size": "large"]
+        )
+    }
+
+    // MARK: - Lifecycle
+
+    /// `reset()` drops the probe so a later profile/server never inherits
+    /// the previous one's capability.
+    func testResetClearsCapability() {
+        let capability = ImageSizeCapability()
+        XCTAssertNil(capability.capability)
+        capability.reset()
+        XCTAssertNil(capability.capability)
+        XCTAssertTrue(capability.requestQuery.isEmpty)
+        XCTAssertFalse(capability.isAvailable)
+    }
+}

--- a/iosApp/Tests/TVHeroArtworkResolverTests.swift
+++ b/iosApp/Tests/TVHeroArtworkResolverTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+@testable import Silo
+
+final class TVHeroArtworkResolverTests: XCTestCase {
+    private let poster = TVHeroArtwork(url: "https://example.test/poster.jpg", thumbhash: "poster")!
+    private let sectionBackdrop = TVHeroArtwork(
+        url: "https://example.test/section-backdrop.jpg",
+        thumbhash: "section"
+    )!
+    private let detailBackdrop = TVHeroArtwork(
+        url: "https://example.test/detail-backdrop.jpg",
+        thumbhash: "detail"
+    )!
+
+    func testEpisodeDoesNotFlashPosterBeforeDetailBackdropLoads() {
+        let artwork = TVHeroArtworkResolver.resolve(
+            sectionBackdrop: nil,
+            fallback: poster,
+            prefersEnrichedBackdrop: true,
+            canLoadEnrichment: true,
+            enrichmentLoaded: false,
+            enrichedBackdrop: nil
+        )
+
+        XCTAssertNil(artwork)
+    }
+
+    func testEpisodeShowsDetailBackdropAsFirstArtwork() {
+        let artwork = TVHeroArtworkResolver.resolve(
+            sectionBackdrop: nil,
+            fallback: poster,
+            prefersEnrichedBackdrop: true,
+            canLoadEnrichment: true,
+            enrichmentLoaded: true,
+            enrichedBackdrop: detailBackdrop
+        )
+
+        XCTAssertEqual(artwork, detailBackdrop)
+    }
+
+    func testEpisodeFallsBackOnlyAfterDetailConfirmsNoBackdrop() {
+        let artwork = TVHeroArtworkResolver.resolve(
+            sectionBackdrop: nil,
+            fallback: poster,
+            prefersEnrichedBackdrop: true,
+            canLoadEnrichment: true,
+            enrichmentLoaded: true,
+            enrichedBackdrop: nil
+        )
+
+        XCTAssertEqual(artwork, poster)
+    }
+
+    func testNonEpisodeUsesSectionBackdropImmediately() {
+        let artwork = TVHeroArtworkResolver.resolve(
+            sectionBackdrop: sectionBackdrop,
+            fallback: poster,
+            prefersEnrichedBackdrop: false,
+            canLoadEnrichment: true,
+            enrichmentLoaded: false,
+            enrichedBackdrop: nil
+        )
+
+        XCTAssertEqual(artwork, sectionBackdrop)
+    }
+
+    func testCollectionWithoutDetailUsesPosterFallbackImmediately() {
+        let artwork = TVHeroArtworkResolver.resolve(
+            sectionBackdrop: nil,
+            fallback: poster,
+            prefersEnrichedBackdrop: true,
+            canLoadEnrichment: false,
+            enrichmentLoaded: false,
+            enrichedBackdrop: nil
+        )
+
+        XCTAssertEqual(artwork, poster)
+    }
+}

--- a/iosApp/Tests/TVHeroArtworkResolverTests.swift
+++ b/iosApp/Tests/TVHeroArtworkResolverTests.swift
@@ -18,7 +18,7 @@ final class TVHeroArtworkResolverTests: XCTestCase {
             fallback: poster,
             prefersEnrichedBackdrop: true,
             canLoadEnrichment: true,
-            enrichmentLoaded: false,
+            enrichmentState: .loading,
             enrichedBackdrop: nil
         )
 
@@ -31,7 +31,7 @@ final class TVHeroArtworkResolverTests: XCTestCase {
             fallback: poster,
             prefersEnrichedBackdrop: true,
             canLoadEnrichment: true,
-            enrichmentLoaded: true,
+            enrichmentState: .completed,
             enrichedBackdrop: detailBackdrop
         )
 
@@ -44,7 +44,7 @@ final class TVHeroArtworkResolverTests: XCTestCase {
             fallback: poster,
             prefersEnrichedBackdrop: true,
             canLoadEnrichment: true,
-            enrichmentLoaded: true,
+            enrichmentState: .completed,
             enrichedBackdrop: nil
         )
 
@@ -57,7 +57,7 @@ final class TVHeroArtworkResolverTests: XCTestCase {
             fallback: poster,
             prefersEnrichedBackdrop: false,
             canLoadEnrichment: true,
-            enrichmentLoaded: false,
+            enrichmentState: .loading,
             enrichedBackdrop: nil
         )
 
@@ -70,7 +70,20 @@ final class TVHeroArtworkResolverTests: XCTestCase {
             fallback: poster,
             prefersEnrichedBackdrop: true,
             canLoadEnrichment: false,
-            enrichmentLoaded: false,
+            enrichmentState: .notStarted,
+            enrichedBackdrop: nil
+        )
+
+        XCTAssertEqual(artwork, poster)
+    }
+
+    func testFailedDetailLookupFallsBackInsteadOfStayingBlank() {
+        let artwork = TVHeroArtworkResolver.resolve(
+            sectionBackdrop: nil,
+            fallback: poster,
+            prefersEnrichedBackdrop: true,
+            canLoadEnrichment: true,
+            enrichmentState: .failed,
             enrichedBackdrop: nil
         )
 

--- a/iosApp/TopShelf/ContentProvider.swift
+++ b/iosApp/TopShelf/ContentProvider.swift
@@ -32,8 +32,9 @@ final class ContentProvider: TVTopShelfContentProvider {
             return nil
         }
         let response: TopShelfSectionsResponse
+        let imageSizeQuery = await http.fetchImageSizeQuery()
         do {
-            response = try await http.fetchHomeSections()
+            response = try await http.fetchHomeSections(imageSizeQuery: imageSizeQuery)
         } catch {
             defaults.set(
                 "fetch-failed: \(error)",
@@ -46,7 +47,8 @@ final class ContentProvider: TVTopShelfContentProvider {
         let nuItems = items(from: response, matching: Self.isNextUp)
         let seriesPosters = await fetchSeriesPosters(
             for: cwItems + nuItems,
-            using: http
+            using: http,
+            imageSizeQuery: imageSizeQuery
         )
 
         let continueWatching = collection(
@@ -107,7 +109,8 @@ final class ContentProvider: TVTopShelfContentProvider {
     /// still instead.
     private func fetchSeriesPosters(
         for items: [TopShelfItem],
-        using http: TopShelfHTTPClient
+        using http: TopShelfHTTPClient,
+        imageSizeQuery: [String: String]
     ) async -> EpisodePosters {
         let seriesIds = Set(items.compactMap { item -> String? in
             guard item.type == "episode" else { return nil }
@@ -120,7 +123,13 @@ final class ContentProvider: TVTopShelfContentProvider {
         ) { group in
             for seriesId in seriesIds {
                 group.addTask {
-                    (seriesId, try? await http.fetchSeasons(seriesId: seriesId))
+                    (
+                        seriesId,
+                        try? await http.fetchSeasons(
+                            seriesId: seriesId,
+                            imageSizeQuery: imageSizeQuery
+                        )
+                    )
                 }
             }
             var acc = EpisodePosters()
@@ -147,7 +156,13 @@ final class ContentProvider: TVTopShelfContentProvider {
         ) { group in
             for seriesId in seriesMissingPoster {
                 group.addTask {
-                    (seriesId, (try? await http.fetchItemDetail(contentId: seriesId))?.posterUrl)
+                    (
+                        seriesId,
+                        (try? await http.fetchItemDetail(
+                            contentId: seriesId,
+                            imageSizeQuery: imageSizeQuery
+                        ))?.posterUrl
+                    )
                 }
             }
             for await (seriesId, poster) in group {

--- a/iosApp/TopShelf/TopShelfHTTPClient.swift
+++ b/iosApp/TopShelf/TopShelfHTTPClient.swift
@@ -52,21 +52,49 @@ struct TopShelfHTTPClient {
         )
     }
 
-    func fetchHomeSections() async throws -> TopShelfSectionsResponse {
-        try await get("/api/v1/home/sections")
+    /// Negotiate the same large-image contract as the main tvOS app. Older
+    /// servers and transient failures return an empty query, preserving the
+    /// extension's existing fallback behavior.
+    func fetchImageSizeQuery() async -> [String: String] {
+        let capability: ImageSizeCapabilityResponse? = try? await get(
+            "/api/v1/images/capability"
+        )
+        return ImageSizeSelection.queryEntries(
+            capability: capability,
+            prefersLargeImages: true
+        )
     }
 
-    func fetchSeasons(seriesId: String) async throws -> TopShelfSeasonsResponse {
-        try await get("/api/v1/catalog/series/\(seriesId)/seasons")
+    func fetchHomeSections(imageSizeQuery: [String: String]) async throws -> TopShelfSectionsResponse {
+        try await get("/api/v1/home/sections", query: imageSizeQuery)
     }
 
-    func fetchItemDetail(contentId: String) async throws -> TopShelfItemDetail {
-        try await get("/api/v1/catalog/items/\(contentId)")
+    func fetchSeasons(
+        seriesId: String,
+        imageSizeQuery: [String: String]
+    ) async throws -> TopShelfSeasonsResponse {
+        try await get(
+            "/api/v1/catalog/series/\(seriesId)/seasons",
+            query: imageSizeQuery
+        )
+    }
+
+    func fetchItemDetail(
+        contentId: String,
+        imageSizeQuery: [String: String]
+    ) async throws -> TopShelfItemDetail {
+        try await get(
+            "/api/v1/catalog/items/\(contentId)",
+            query: imageSizeQuery
+        )
     }
 
     // MARK: - Private
 
-    private func get<T: Decodable>(_ path: String) async throws -> T {
+    private func get<T: Decodable>(
+        _ path: String,
+        query: [String: String] = [:]
+    ) async throws -> T {
         guard let serverID = defaults.string(forKey: SharedStorage.activeServerIdKey),
               isPersonalizedContentAllowed,
               let serverUrl = defaults.string(forKey: SharedStorage.serverUrlKey),
@@ -84,6 +112,9 @@ struct TopShelfHTTPClient {
         let base = components.percentEncodedPath
         let trimmed = base.hasSuffix("/") ? String(base.dropLast()) : base
         components.percentEncodedPath = trimmed + path
+        components.queryItems = query
+            .sorted { $0.key < $1.key }
+            .map { URLQueryItem(name: $0.key, value: $0.value) }
         guard let url = components.url else { throw Error.invalidURL }
 
         var request = URLRequest(url: url, timeoutInterval: 5)

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -226,6 +226,10 @@ struct ContentView: View {
                 // features stay hidden until a profile switch. Idempotent and
                 // failure-tolerant, so double-calling with `selectProfile` is safe.
                 await AICapabilities.shared.refresh()
+                // Same cold-relaunch reasoning: without this, a restored
+                // session on tvOS would request default-size images until
+                // the next profile switch.
+                await ImageSizeCapability.shared.refresh()
                 await RequestsFeatureStore.shared.refresh()
                 await SubtitleProvidersStore.shared.refresh()
                 await uiCustomization.refresh()
@@ -361,6 +365,7 @@ struct ContentView: View {
             // natural retry on foreground. `refresh()` is idempotent, so the
             // happy path costs nothing.
             Task { await AICapabilities.shared.refresh() }
+            Task { await ImageSizeCapability.shared.refresh() }
             Task { await RequestsFeatureStore.shared.refresh() }
             Task { await SubtitleProvidersStore.shared.refresh() }
             Task { await uiCustomization.refresh() }

--- a/iosApp/iosApp/Networking/ContinuumAPI.swift
+++ b/iosApp/iosApp/Networking/ContinuumAPI.swift
@@ -42,6 +42,32 @@ actor ContinuumAPI {
         await tokenStore.getProfileId()
     }
 
+    // MARK: - Image size selection
+
+    /// Extra query entries asking the server to bake a larger image
+    /// variant into every image URL in the response.
+    ///
+    /// One place decides this for every image-bearing endpoint, so call
+    /// sites just merge it in. Empty off tvOS, and empty until (or
+    /// unless) the capability probe in ``ImageSizeCapability`` lands —
+    /// which makes iOS and macOS requests byte-identical to before.
+    private var imageSizeQuery: [String: String] {
+        ImageSizeCapability.shared.requestQuery
+    }
+
+    /// Merge ``imageSizeQuery`` into a caller-built query. Caller-supplied
+    /// values win, so an explicit size is never overwritten.
+    private func withImageSize(_ query: [String: String]) -> [String: String] {
+        query.merging(imageSizeQuery) { caller, _ in caller }
+    }
+
+    /// `GET /api/v1/images/capability`. Throws `HTTPError.http(404, _)`
+    /// on servers that predate image-size selection; the caller treats
+    /// that as "feature off".
+    func imageSizeCapability() async throws -> ImageSizeCapabilityResponse {
+        try await http.get("/api/v1/images/capability")
+    }
+
     // MARK: - Path-based dispatcher (legacy)
 
     func get<T: Decodable>(_ path: String, query: [String: String] = [:]) async throws -> T {
@@ -422,7 +448,7 @@ actor ContinuumAPI {
     // --- Home / sections ---
 
     func homeSections() async throws -> SectionsResponse {
-        try await http.get("/api/v1/home/sections")
+        try await http.get("/api/v1/home/sections", query: imageSizeQuery)
     }
 
     func dismissContinueWatchingItem(contentId: String, progressUpdatedAt: String) async throws {
@@ -437,7 +463,7 @@ actor ContinuumAPI {
     }
 
     func librarySections(libraryId: Int) async throws -> SectionsResponse {
-        try await http.get("/api/v1/library/\(libraryId)/sections")
+        try await http.get("/api/v1/library/\(libraryId)/sections", query: imageSizeQuery)
     }
 
     /// Fetch the IDs of items the recommendation engine considers
@@ -494,8 +520,11 @@ actor ContinuumAPI {
 
     // --- Catalog ---
 
+    /// Every catalog-shaped list (browse, search, person credits,
+    /// collection items, section paging) funnels through here, so the
+    /// image-size entry only has to be merged in once.
     func catalog(query: [String: String]) async throws -> CatalogResponse {
-        try await http.get("/api/v1/catalog", query: query)
+        try await http.get("/api/v1/catalog", query: withImageSize(query))
     }
 
     func historyCatalog(
@@ -515,7 +544,7 @@ actor ContinuumAPI {
     }
 
     func itemDetail(contentId: String) async throws -> ItemDetail {
-        try await http.get("/api/v1/catalog/items/\(contentId)")
+        try await http.get("/api/v1/catalog/items/\(contentId)", query: imageSizeQuery)
     }
 
     func catalogFilters(libraryId: Int?, includeTechnical: Bool = true) async throws -> CatalogFilters {
@@ -527,15 +556,18 @@ actor ContinuumAPI {
     }
 
     func seasons(seriesId: String) async throws -> SeasonsResponse {
-        try await http.get("/api/v1/catalog/series/\(seriesId)/seasons")
+        try await http.get("/api/v1/catalog/series/\(seriesId)/seasons", query: imageSizeQuery)
     }
 
     func episodes(seriesId: String, seasonNumber: Int) async throws -> EpisodesResponse {
-        try await http.get("/api/v1/catalog/series/\(seriesId)/seasons/\(seasonNumber)/episodes")
+        try await http.get(
+            "/api/v1/catalog/series/\(seriesId)/seasons/\(seasonNumber)/episodes",
+            query: imageSizeQuery
+        )
     }
 
     func watchDetail(contentId: String) async throws -> WatchDetail {
-        try await http.get("/api/v1/watch/\(contentId)")
+        try await http.get("/api/v1/watch/\(contentId)", query: imageSizeQuery)
     }
 
     func person(id: Int) async throws -> Person {
@@ -725,25 +757,31 @@ actor ContinuumAPI {
 
     // --- Personal data ---
 
+    // These three build their own query rather than routing through
+    // `catalog(query:)`, so each merges the image-size entry itself.
+    // They back real poster grids on TV, and `historyCatalog` — the
+    // entry point the history screen actually uses — is already covered
+    // by `catalog(query:)`.
+
     func favorites(offset: Int, limit: Int) async throws -> CatalogResponse {
-        try await http.get("/api/v1/favorites", query: [
+        try await http.get("/api/v1/favorites", query: withImageSize([
             "offset": String(offset),
             "limit": String(limit),
-        ])
+        ]))
     }
 
     func watchlist(offset: Int, limit: Int) async throws -> CatalogResponse {
-        try await http.get("/api/v1/watchlist", query: [
+        try await http.get("/api/v1/watchlist", query: withImageSize([
             "offset": String(offset),
             "limit": String(limit),
-        ])
+        ]))
     }
 
     func history(offset: Int, limit: Int) async throws -> CatalogResponse {
-        try await http.get("/api/v1/history", query: [
+        try await http.get("/api/v1/history", query: withImageSize([
             "offset": String(offset),
             "limit": String(limit),
-        ])
+        ]))
     }
 
     /// Server returns 204 when the item is a favorite and 404 otherwise.

--- a/iosApp/iosApp/Networking/ContinuumAPI.swift
+++ b/iosApp/iosApp/Networking/ContinuumAPI.swift
@@ -52,13 +52,19 @@ actor ContinuumAPI {
     /// unless) the capability probe in ``ImageSizeCapability`` lands —
     /// which makes iOS and macOS requests byte-identical to before.
     private var imageSizeQuery: [String: String] {
-        ImageSizeCapability.shared.requestQuery
+        get async {
+            // Gate only the artwork request, never launch/profile navigation.
+            // Concurrent startup prefetches join one probe, and older or
+            // unreachable servers fall back to an empty query.
+            await ImageSizeCapability.shared.refresh()
+            return ImageSizeCapability.shared.requestQuery
+        }
     }
 
     /// Merge ``imageSizeQuery`` into a caller-built query. Caller-supplied
     /// values win, so an explicit size is never overwritten.
-    private func withImageSize(_ query: [String: String]) -> [String: String] {
-        query.merging(imageSizeQuery) { caller, _ in caller }
+    private func withImageSize(_ query: [String: String]) async -> [String: String] {
+        query.merging(await imageSizeQuery) { caller, _ in caller }
     }
 
     /// `GET /api/v1/images/capability`. Throws `HTTPError.http(404, _)`
@@ -448,7 +454,7 @@ actor ContinuumAPI {
     // --- Home / sections ---
 
     func homeSections() async throws -> SectionsResponse {
-        try await http.get("/api/v1/home/sections", query: imageSizeQuery)
+        try await http.get("/api/v1/home/sections", query: await imageSizeQuery)
     }
 
     func dismissContinueWatchingItem(contentId: String, progressUpdatedAt: String) async throws {
@@ -463,7 +469,7 @@ actor ContinuumAPI {
     }
 
     func librarySections(libraryId: Int) async throws -> SectionsResponse {
-        try await http.get("/api/v1/library/\(libraryId)/sections", query: imageSizeQuery)
+        try await http.get("/api/v1/library/\(libraryId)/sections", query: await imageSizeQuery)
     }
 
     /// Fetch the IDs of items the recommendation engine considers
@@ -524,7 +530,7 @@ actor ContinuumAPI {
     /// collection items, section paging) funnels through here, so the
     /// image-size entry only has to be merged in once.
     func catalog(query: [String: String]) async throws -> CatalogResponse {
-        try await http.get("/api/v1/catalog", query: withImageSize(query))
+        try await http.get("/api/v1/catalog", query: await withImageSize(query))
     }
 
     func historyCatalog(
@@ -544,7 +550,7 @@ actor ContinuumAPI {
     }
 
     func itemDetail(contentId: String) async throws -> ItemDetail {
-        try await http.get("/api/v1/catalog/items/\(contentId)", query: imageSizeQuery)
+        try await http.get("/api/v1/catalog/items/\(contentId)", query: await imageSizeQuery)
     }
 
     func catalogFilters(libraryId: Int?, includeTechnical: Bool = true) async throws -> CatalogFilters {
@@ -556,18 +562,21 @@ actor ContinuumAPI {
     }
 
     func seasons(seriesId: String) async throws -> SeasonsResponse {
-        try await http.get("/api/v1/catalog/series/\(seriesId)/seasons", query: imageSizeQuery)
+        try await http.get(
+            "/api/v1/catalog/series/\(seriesId)/seasons",
+            query: await imageSizeQuery
+        )
     }
 
     func episodes(seriesId: String, seasonNumber: Int) async throws -> EpisodesResponse {
         try await http.get(
             "/api/v1/catalog/series/\(seriesId)/seasons/\(seasonNumber)/episodes",
-            query: imageSizeQuery
+            query: await imageSizeQuery
         )
     }
 
     func watchDetail(contentId: String) async throws -> WatchDetail {
-        try await http.get("/api/v1/watch/\(contentId)", query: imageSizeQuery)
+        try await http.get("/api/v1/watch/\(contentId)", query: await imageSizeQuery)
     }
 
     func person(id: Int) async throws -> Person {
@@ -764,21 +773,21 @@ actor ContinuumAPI {
     // by `catalog(query:)`.
 
     func favorites(offset: Int, limit: Int) async throws -> CatalogResponse {
-        try await http.get("/api/v1/favorites", query: withImageSize([
+        try await http.get("/api/v1/favorites", query: await withImageSize([
             "offset": String(offset),
             "limit": String(limit),
         ]))
     }
 
     func watchlist(offset: Int, limit: Int) async throws -> CatalogResponse {
-        try await http.get("/api/v1/watchlist", query: withImageSize([
+        try await http.get("/api/v1/watchlist", query: await withImageSize([
             "offset": String(offset),
             "limit": String(limit),
         ]))
     }
 
     func history(offset: Int, limit: Int) async throws -> CatalogResponse {
-        try await http.get("/api/v1/history", query: withImageSize([
+        try await http.get("/api/v1/history", query: await withImageSize([
             "offset": String(offset),
             "limit": String(limit),
         ]))

--- a/iosApp/iosApp/Networking/ImageSizeCapability.swift
+++ b/iosApp/iosApp/Networking/ImageSizeCapability.swift
@@ -1,30 +1,5 @@
 import Foundation
 
-/// `GET /api/v1/images/capability`.
-///
-/// Servers that predate image-size selection return `404`, which the
-/// probe treats as "feature unavailable" — see ``ImageSizeCapability``.
-struct ImageSizeCapabilityResponse: Codable, Equatable {
-    /// Wire-format version. Only `1` is understood; anything else is
-    /// treated as unsupported rather than guessed at.
-    let schemaVersion: Int
-    /// The query parameter the server wants the size on. Always
-    /// `image_size` for schema 1, but read from the payload rather than
-    /// hardcoded so a future rename is a server-side decision.
-    let param: String
-    /// Size tokens the server accepts, e.g. `["small", "medium",
-    /// "large", "original"]`. Sending a value that isn't in here is a
-    /// `400`, so the client only sends tokens it saw advertised.
-    let sizes: [String]
-    /// Pixel widths per image role (`poster`, `still`, `logo`,
-    /// `backdrop`) per size token. Informational — the client picks a
-    /// token, not a width — but decoded so it stays available for
-    /// diagnostics and future per-surface selection.
-    let widths: [String: [String: Int]]
-    /// Longest-edge cap the `original` variant is bounded by.
-    let originalMaxWidthPx: Int
-}
-
 /// Cached holder for the server's image-size capability probe, used to
 /// decide whether catalog/section/detail requests may ask for a larger
 /// baked-in image variant.
@@ -54,7 +29,7 @@ final class ImageSizeCapability: @unchecked Sendable {
     /// `large` is a deliberate stop short of `original`: TV posters and
     /// stills render at w780 without paying for full-size art on every
     /// card in a shelf.
-    static let requestedSize = "large"
+    static let requestedSize = ImageSizeSelection.requestedSize
 
     /// Whether this platform wants larger images at all. tvOS renders
     /// full-screen shelves and detail art on a 4K panel; iOS and macOS
@@ -75,31 +50,47 @@ final class ImageSizeCapability: @unchecked Sendable {
         capability: ImageSizeCapabilityResponse?,
         platformPrefersLargeImages: Bool
     ) -> [String: String] {
-        guard platformPrefersLargeImages,
-              let capability,
-              capability.schemaVersion == 1,
-              !capability.param.isEmpty,
-              capability.sizes.contains(requestedSize)
-        else { return [:] }
-        return [capability.param: requestedSize]
+        ImageSizeSelection.queryEntries(
+            capability: capability,
+            prefersLargeImages: platformPrefersLargeImages
+        )
     }
 
-    private let api: ContinuumAPI
+    private struct Probe {
+        let id: Int
+        let generation: Int
+        let task: Task<ImageSizeCapabilityResponse?, Never>
+    }
+
+    private let fetchCapability: @Sendable () async throws -> ImageSizeCapabilityResponse
+    private let prefersLargeImages: Bool
     private let lock = NSLock()
     private var storedCapability: ImageSizeCapabilityResponse?
     private var generation = 0
+    private var nextProbeID = 0
+    private var inFlightProbe: Probe?
 
-    init(api: ContinuumAPI = .shared) {
-        self.api = api
+    init(
+        api: ContinuumAPI = .shared,
+        platformPrefersLargeImages: Bool = ImageSizeCapability.platformPrefersLargeImages
+    ) {
+        self.prefersLargeImages = platformPrefersLargeImages
+        self.fetchCapability = { try await api.imageSizeCapability() }
+    }
+
+    init(
+        platformPrefersLargeImages: Bool,
+        fetchCapability: @escaping @Sendable () async throws -> ImageSizeCapabilityResponse
+    ) {
+        self.prefersLargeImages = platformPrefersLargeImages
+        self.fetchCapability = fetchCapability
     }
 
     // MARK: - Gating convenience
 
     /// The decoded probe, or `nil` before it lands / after `reset()`.
     var capability: ImageSizeCapabilityResponse? {
-        lock.lock()
-        defer { lock.unlock() }
-        return storedCapability
+        lock.withLock { storedCapability }
     }
 
     /// Whether this client will actually send a size on this platform.
@@ -111,7 +102,7 @@ final class ImageSizeCapability: @unchecked Sendable {
     var requestQuery: [String: String] {
         Self.queryEntries(
             capability: capability,
-            platformPrefersLargeImages: Self.platformPrefersLargeImages
+            platformPrefersLargeImages: prefersLargeImages
         )
     }
 
@@ -125,32 +116,45 @@ final class ImageSizeCapability: @unchecked Sendable {
     /// Skipped entirely on platforms that wouldn't send the parameter,
     /// so iOS and macOS don't pay for a request they can't use.
     func refresh() async {
-        guard Self.platformPrefersLargeImages else { return }
-        let gen = currentGeneration()
-        guard let probed = try? await api.imageSizeCapability() else { return }
-        lock.lock()
-        defer { lock.unlock() }
-        // Discard if a reset (sign-out / profile or server switch)
-        // happened while the probe was in flight.
-        guard gen == generation else { return }
-        storedCapability = probed
+        guard prefersLargeImages else { return }
+        guard let probe = lock.withLock({ () -> Probe? in
+            if storedCapability != nil { return nil }
+            if let inFlightProbe, inFlightProbe.generation == generation {
+                return inFlightProbe
+            }
+            nextProbeID &+= 1
+            let probe = Probe(
+                id: nextProbeID,
+                generation: generation,
+                task: Task { [fetchCapability] in try? await fetchCapability() }
+            )
+            inFlightProbe = probe
+            return probe
+        }) else { return }
+
+        let probed = await probe.task.value
+        lock.withLock {
+            // Discard if a reset happened while the probe was in flight, or a
+            // newer probe superseded this one. A nil result remains retryable
+            // on the next foreground; successful results are cached.
+            guard generation == probe.generation,
+                  inFlightProbe?.id == probe.id else { return }
+            inFlightProbe = nil
+            storedCapability = probed
+        }
     }
 
     /// Drop the cached probe so capabilities don't leak across accounts
     /// or servers. Bumps `generation` first so any in-flight refresh
     /// discards its result instead of clobbering this reset.
     func reset() {
-        lock.lock()
-        defer { lock.unlock() }
-        generation &+= 1
-        storedCapability = nil
-    }
-
-    // MARK: - Internals
-
-    private func currentGeneration() -> Int {
-        lock.lock()
-        defer { lock.unlock() }
-        return generation
+        let task = lock.withLock { () -> Task<ImageSizeCapabilityResponse?, Never>? in
+            generation &+= 1
+            storedCapability = nil
+            let task = inFlightProbe?.task
+            inFlightProbe = nil
+            return task
+        }
+        task?.cancel()
     }
 }

--- a/iosApp/iosApp/Networking/ImageSizeCapability.swift
+++ b/iosApp/iosApp/Networking/ImageSizeCapability.swift
@@ -1,0 +1,156 @@
+import Foundation
+
+/// `GET /api/v1/images/capability`.
+///
+/// Servers that predate image-size selection return `404`, which the
+/// probe treats as "feature unavailable" — see ``ImageSizeCapability``.
+struct ImageSizeCapabilityResponse: Codable, Equatable {
+    /// Wire-format version. Only `1` is understood; anything else is
+    /// treated as unsupported rather than guessed at.
+    let schemaVersion: Int
+    /// The query parameter the server wants the size on. Always
+    /// `image_size` for schema 1, but read from the payload rather than
+    /// hardcoded so a future rename is a server-side decision.
+    let param: String
+    /// Size tokens the server accepts, e.g. `["small", "medium",
+    /// "large", "original"]`. Sending a value that isn't in here is a
+    /// `400`, so the client only sends tokens it saw advertised.
+    let sizes: [String]
+    /// Pixel widths per image role (`poster`, `still`, `logo`,
+    /// `backdrop`) per size token. Informational — the client picks a
+    /// token, not a width — but decoded so it stays available for
+    /// diagnostics and future per-surface selection.
+    let widths: [String: [String: Int]]
+    /// Longest-edge cap the `original` variant is bounded by.
+    let originalMaxWidthPx: Int
+}
+
+/// Cached holder for the server's image-size capability probe, used to
+/// decide whether catalog/section/detail requests may ask for a larger
+/// baked-in image variant.
+///
+/// Follows the ``AICapabilities`` precedent: a `.shared` singleton
+/// fetched once per session and reset on sign-out and profile/server
+/// switch, with a generation counter so a probe still in flight across
+/// a reset discards its result instead of repopulating the next
+/// account's capabilities. A `404`/network error leaves the slot `nil`,
+/// which ``isAvailable`` reads as "feature off", so older servers
+/// degrade silently.
+///
+/// Unlike `AICapabilities` this is **not** `@MainActor @Observable`: no
+/// view observes it, and its one consumer is the `ContinuumAPI` actor,
+/// which needs a synchronous read while building a request. State is
+/// guarded by a lock instead — same shape as `ServerRegistry`'s
+/// `ActiveServerIDSnapshot`.
+///
+/// Image URLs stay opaque: the server bakes the chosen variant into the
+/// URLs it returns and the client never rewrites them. A larger variant
+/// simply arrives as a different URL, which `CachedAsyncImage` /
+/// `PosterImageCache` cache independently.
+final class ImageSizeCapability: @unchecked Sendable {
+    static let shared = ImageSizeCapability()
+
+    /// The query parameter name and size token this client asks for.
+    /// `large` is a deliberate stop short of `original`: TV posters and
+    /// stills render at w780 without paying for full-size art on every
+    /// card in a shelf.
+    static let requestedSize = "large"
+
+    /// Whether this platform wants larger images at all. tvOS renders
+    /// full-screen shelves and detail art on a 4K panel; iOS and macOS
+    /// keep the server's default sizes, so their requests are unchanged.
+    static var platformPrefersLargeImages: Bool {
+        #if os(tvOS)
+        true
+        #else
+        false
+        #endif
+    }
+
+    /// The extra query entries to merge into an image-bearing request.
+    ///
+    /// Pure and parameterized so both branches are testable from the
+    /// iOS-hosted test target, which cannot exercise `#if os(tvOS)`.
+    static func queryEntries(
+        capability: ImageSizeCapabilityResponse?,
+        platformPrefersLargeImages: Bool
+    ) -> [String: String] {
+        guard platformPrefersLargeImages,
+              let capability,
+              capability.schemaVersion == 1,
+              !capability.param.isEmpty,
+              capability.sizes.contains(requestedSize)
+        else { return [:] }
+        return [capability.param: requestedSize]
+    }
+
+    private let api: ContinuumAPI
+    private let lock = NSLock()
+    private var storedCapability: ImageSizeCapabilityResponse?
+    private var generation = 0
+
+    init(api: ContinuumAPI = .shared) {
+        self.api = api
+    }
+
+    // MARK: - Gating convenience
+
+    /// The decoded probe, or `nil` before it lands / after `reset()`.
+    var capability: ImageSizeCapabilityResponse? {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedCapability
+    }
+
+    /// Whether this client will actually send a size on this platform.
+    var isAvailable: Bool { !requestQuery.isEmpty }
+
+    /// Query entries for the current platform and probe state. `[:]`
+    /// when the probe hasn't landed, the server doesn't support the
+    /// feature, or this isn't tvOS.
+    var requestQuery: [String: String] {
+        Self.queryEntries(
+            capability: capability,
+            platformPrefersLargeImages: Self.platformPrefersLargeImages
+        )
+    }
+
+    // MARK: - Lifecycle
+
+    /// Probe the server once per session. Failure-tolerant and
+    /// idempotent: a `404` from an older server, or any transport
+    /// error, leaves the feature off and is retried on the next
+    /// foreground refresh.
+    ///
+    /// Skipped entirely on platforms that wouldn't send the parameter,
+    /// so iOS and macOS don't pay for a request they can't use.
+    func refresh() async {
+        guard Self.platformPrefersLargeImages else { return }
+        let gen = currentGeneration()
+        guard let probed = try? await api.imageSizeCapability() else { return }
+        lock.lock()
+        defer { lock.unlock() }
+        // Discard if a reset (sign-out / profile or server switch)
+        // happened while the probe was in flight.
+        guard gen == generation else { return }
+        storedCapability = probed
+    }
+
+    /// Drop the cached probe so capabilities don't leak across accounts
+    /// or servers. Bumps `generation` first so any in-flight refresh
+    /// discards its result instead of clobbering this reset.
+    func reset() {
+        lock.lock()
+        defer { lock.unlock() }
+        generation &+= 1
+        storedCapability = nil
+    }
+
+    // MARK: - Internals
+
+    private func currentGeneration() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return generation
+    }
+}

--- a/iosApp/iosApp/Networking/ServerRegistry.swift
+++ b/iosApp/iosApp/Networking/ServerRegistry.swift
@@ -462,6 +462,7 @@ final class ServerRegistry {
         // foreground refresh observes one consistent server context.
         await MainActor.run {
             AICapabilities.shared.reset()
+            ImageSizeCapability.shared.reset()
             RequestsFeatureStore.shared.reset()
             SubtitleProvidersStore.shared.reset()
             RequestsEventBus.shared.reset()
@@ -471,6 +472,10 @@ final class ServerRegistry {
             // until the next foreground. Fire-and-forget — the probe
             // degrades to disabled on any failure.
             Task { await RequestsFeatureStore.shared.refresh() }
+            // Same shape: without a re-probe the destination server's
+            // image-size support would stay unknown, and TV requests would
+            // silently fall back to the server's default image variants.
+            Task { await ImageSizeCapability.shared.refresh() }
             // Same reason, opposite default: the reset above restored
             // "available", so this re-probe is what *dims* the search row on
             // a destination server that has no providers configured.
@@ -741,6 +746,7 @@ final class ServerRegistry {
         if removesActiveServer {
             await MainActor.run {
                 AICapabilities.shared.reset()
+                ImageSizeCapability.shared.reset()
                 RequestsFeatureStore.shared.reset()
                 SubtitleProvidersStore.shared.reset()
                 RequestsEventBus.shared.reset()
@@ -748,6 +754,7 @@ final class ServerRegistry {
                 // already be signed in, with no auth-state change to
                 // trigger the usual probe.
                 Task { await RequestsFeatureStore.shared.refresh() }
+                Task { await ImageSizeCapability.shared.refresh() }
                 Task { await SubtitleProvidersStore.shared.refresh() }
             }
         }

--- a/iosApp/iosApp/Screens/Auth/AuthService.swift
+++ b/iosApp/iosApp/Screens/Auth/AuthService.swift
@@ -203,9 +203,10 @@ final class AuthService: @unchecked Sendable {
             rememberSelection: rememberSelection,
             expectedAccount: expectedAccount
         )
-        // Re-probe AI capabilities for the newly-selected profile. Fire and
-        // forget — gating defaults to "unavailable" until the probes land,
-        // so nothing blocks on this.
+        // Re-probe capabilities for the newly-selected profile. Fire and
+        // forget so profile navigation is never held behind an optional
+        // feature probe. Artwork-bearing API methods await the coalesced image
+        // probe at their own request boundary before dispatching.
         Task { @MainActor in
             await AICapabilities.shared.refresh()
             await ImageSizeCapability.shared.refresh()

--- a/iosApp/iosApp/Screens/Auth/AuthService.swift
+++ b/iosApp/iosApp/Screens/Auth/AuthService.swift
@@ -208,6 +208,7 @@ final class AuthService: @unchecked Sendable {
         // so nothing blocks on this.
         Task { @MainActor in
             await AICapabilities.shared.refresh()
+            await ImageSizeCapability.shared.refresh()
             await RequestsFeatureStore.shared.refresh()
             // Unlike the two above, this one gates *enablement* of an entry
             // point that stays visible either way, and it defaults to
@@ -524,6 +525,7 @@ final class AuthService: @unchecked Sendable {
         // Server-wide AI capability + per-user ASR quota are reset on every
         // profile switch; `selectProfile` re-fetches after the switch lands.
         AICapabilities.shared.reset()
+        ImageSizeCapability.shared.reset()
         RequestsFeatureStore.shared.reset()
         SubtitleProvidersStore.shared.reset()
         RequestsEventBus.shared.reset()
@@ -692,6 +694,7 @@ final class AuthService: @unchecked Sendable {
         OverlayPrefsStore.shared.clear()
         ProfilePrefsStore.shared.clear()
         AICapabilities.shared.reset()
+        ImageSizeCapability.shared.reset()
         RequestsFeatureStore.shared.reset()
         SubtitleProvidersStore.shared.reset()
         RequestsEventBus.shared.reset()

--- a/iosApp/iosApp/Shared/ImageSizeSelection.swift
+++ b/iosApp/iosApp/Shared/ImageSizeSelection.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Shared wire contract for `GET /api/v1/images/capability`. The main app and
+/// Top Shelf extension both decode this lightweight model so every tvOS
+/// artwork surface negotiates the same server-advertised query parameter.
+struct ImageSizeCapabilityResponse: Codable, Equatable {
+    let schemaVersion: Int
+    let param: String
+    let sizes: [String]
+    let widths: [String: [String: Int]]
+    let originalMaxWidthPx: Int
+}
+
+enum ImageSizeSelection {
+    static let requestedSize = "large"
+
+    static func queryEntries(
+        capability: ImageSizeCapabilityResponse?,
+        prefersLargeImages: Bool
+    ) -> [String: String] {
+        guard prefersLargeImages,
+              let capability,
+              capability.schemaVersion == 1,
+              !capability.param.isEmpty,
+              capability.sizes.contains(requestedSize)
+        else { return [:] }
+        return [capability.param: requestedSize]
+    }
+}

--- a/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
+++ b/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
@@ -14,13 +14,24 @@ struct TVHeroArtwork: Equatable {
     }
 }
 
+enum TVHeroEnrichmentState: Equatable {
+    case notStarted
+    case loading
+    case completed
+    case failed
+
+    var permitsFallback: Bool {
+        self == .completed || self == .failed
+    }
+}
+
 enum TVHeroArtworkResolver {
     static func resolve(
         sectionBackdrop: TVHeroArtwork?,
         fallback: TVHeroArtwork?,
         prefersEnrichedBackdrop: Bool,
         canLoadEnrichment: Bool,
-        enrichmentLoaded: Bool,
+        enrichmentState: TVHeroEnrichmentState,
         enrichedBackdrop: TVHeroArtwork?
     ) -> TVHeroArtwork? {
         if !prefersEnrichedBackdrop, let sectionBackdrop {
@@ -30,7 +41,7 @@ enum TVHeroArtworkResolver {
         guard canLoadEnrichment else {
             return sectionBackdrop ?? fallback
         }
-        guard enrichmentLoaded else {
+        guard enrichmentState.permitsFallback else {
             // Do not paint the poster while detail enrichment is in flight:
             // that creates a conspicuous portrait-to-landscape flash. The
             // first image displayed should be the real backdrop.
@@ -318,7 +329,7 @@ final class TVFocusMarqueeModel {
             ),
             prefersEnrichedBackdrop: content.isEpisode || content.backdropUrl?.isEmpty != false,
             canLoadEnrichment: content.contentId != nil,
-            enrichmentLoaded: enrichment != nil,
+            enrichmentState: enrichmentState,
             enrichedBackdrop: TVHeroArtwork(
                 url: enrichment?.backdropUrl,
                 thumbhash: enrichment?.backdropThumbhash
@@ -333,6 +344,7 @@ final class TVFocusMarqueeModel {
     private var debounceTask: Task<Void, Never>?
     private var tintTask: Task<Void, Never>?
     private var enrichTask: Task<Void, Never>?
+    private var enrichmentState: TVHeroEnrichmentState = .notStarted
     private var lastSampledTintURL: String?
     /// Per-item enrichment cache so scrubbing back over a row never
     /// refetches details.
@@ -375,22 +387,34 @@ final class TVFocusMarqueeModel {
         enrichTask?.cancel()
         guard let contentId = candidate.contentId else {
             enrichment = nil
+            enrichmentState = .completed
             return
         }
         if let cached = enrichmentCache[contentId] {
             enrichment = cached
+            enrichmentState = .completed
             sampleTintIfNeeded(for: backdropURL)
             return
         }
 
         enrichment = nil
+        enrichmentState = .loading
         enrichTask = Task { [weak self] in
-            guard let detail = try? await ContinuumAPI.shared.itemDetail(contentId: contentId) else { return }
-            guard !Task.isCancelled, let self else { return }
-            let enrichment = TVMarqueeEnrichment(detail: detail)
-            self.enrichmentCache[contentId] = enrichment
-            if self.content?.contentId == contentId {
-                self.enrichment = enrichment
+            do {
+                let detail = try await ContinuumAPI.shared.itemDetail(contentId: contentId)
+                guard !Task.isCancelled, let self else { return }
+                let enrichment = TVMarqueeEnrichment(detail: detail)
+                self.enrichmentCache[contentId] = enrichment
+                if self.content?.contentId == contentId {
+                    self.enrichment = enrichment
+                    self.enrichmentState = .completed
+                    self.sampleTintIfNeeded(for: self.backdropURL)
+                }
+            } catch {
+                guard !Task.isCancelled, let self,
+                      self.content?.contentId == contentId else { return }
+                self.enrichment = nil
+                self.enrichmentState = .failed
                 self.sampleTintIfNeeded(for: self.backdropURL)
             }
         }

--- a/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
+++ b/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
@@ -1,3 +1,45 @@
+import Foundation
+
+/// Pure artwork selection for the tvOS focus hero. Kept outside the tvOS
+/// compilation guard so the iOS-hosted unit tests can exercise the transition
+/// from section data to detail enrichment.
+struct TVHeroArtwork: Equatable {
+    let url: String
+    let thumbhash: String?
+
+    init?(url: String?, thumbhash: String?) {
+        guard let url, !url.isEmpty else { return nil }
+        self.url = url
+        self.thumbhash = thumbhash
+    }
+}
+
+enum TVHeroArtworkResolver {
+    static func resolve(
+        sectionBackdrop: TVHeroArtwork?,
+        fallback: TVHeroArtwork?,
+        prefersEnrichedBackdrop: Bool,
+        canLoadEnrichment: Bool,
+        enrichmentLoaded: Bool,
+        enrichedBackdrop: TVHeroArtwork?
+    ) -> TVHeroArtwork? {
+        if !prefersEnrichedBackdrop, let sectionBackdrop {
+            return sectionBackdrop
+        }
+
+        guard canLoadEnrichment else {
+            return sectionBackdrop ?? fallback
+        }
+        guard enrichmentLoaded else {
+            // Do not paint the poster while detail enrichment is in flight:
+            // that creates a conspicuous portrait-to-landscape flash. The
+            // first image displayed should be the real backdrop.
+            return nil
+        }
+        return enrichedBackdrop ?? sectionBackdrop ?? fallback
+    }
+}
+
 #if os(tvOS)
 import SwiftUI
 import Nuke
@@ -29,8 +71,13 @@ struct TVMarqueeContent: Equatable {
     /// or `S2 E7 · episode title · 45 min · 23 min left` for episodes.
     let metaParts: [String]
     let synopsis: String?
+    /// A genuine landscape backdrop from the section payload. This must stay
+    /// separate from the poster fallback so the hero can wait for detail
+    /// enrichment without briefly painting a portrait poster first.
     let backdropUrl: String?
     let backdropThumbhash: String?
+    let fallbackArtworkUrl: String?
+    let fallbackArtworkThumbhash: String?
     /// Episodes carry only their low-res still in the section payload, so the
     /// root hero upgrades to the series backdrop from detail enrichment rather
     /// than blowing the still up full-width.
@@ -78,10 +125,10 @@ extension TVMarqueeContent {
             badges: badges,
             metaParts: meta,
             synopsis: item.overview,
-            backdropUrl: Self.nonEmpty(item.backdropUrl) ?? item.posterUrl,
-            backdropThumbhash: Self.nonEmpty(item.backdropUrl) != nil
-                ? item.backdropThumbhash
-                : item.posterThumbhash,
+            backdropUrl: Self.nonEmpty(item.backdropUrl),
+            backdropThumbhash: item.backdropThumbhash,
+            fallbackArtworkUrl: Self.nonEmpty(item.posterUrl),
+            fallbackArtworkThumbhash: item.posterThumbhash,
             isEpisode: isEpisode
         )
     }
@@ -105,8 +152,10 @@ extension TVMarqueeContent {
             badges: [],
             metaParts: meta,
             synopsis: nil,
-            backdropUrl: collection.posterUrl,
-            backdropThumbhash: collection.posterThumbhash,
+            backdropUrl: nil,
+            backdropThumbhash: nil,
+            fallbackArtworkUrl: collection.posterUrl,
+            fallbackArtworkThumbhash: collection.posterThumbhash,
             isEpisode: false
         )
     }
@@ -250,25 +299,36 @@ final class TVFocusMarqueeModel {
     /// backdrop (same palette pipeline the hero carousel used).
     private(set) var tintColor: Color = .continuumBackground
 
-    /// Backdrop art for the root hero. Episodes carry only their low-res still
-    /// in the section payload (§9); once detail enrichment lands we upgrade to
-    /// the series backdrop it provides rather than blowing the still up
-    /// full-width. Non-episodes always use their own section backdrop.
-    var backdropURL: String? {
-        if content?.isEpisode == true,
-           let enriched = enrichment?.backdropUrl, !enriched.isEmpty {
-            return enriched
-        }
-        return content?.backdropUrl
+    /// Backdrop art for the root hero. Episodes need their detail-level series
+    /// backdrop, and any item missing a section backdrop gets one chance to
+    /// obtain the real backdrop from detail. While that request is in flight
+    /// the hero stays artwork-free instead of flashing the poster. Poster/still
+    /// fallback is used only after detail confirms no backdrop exists (or for
+    /// collections, which have no detail lookup).
+    private var resolvedArtwork: TVHeroArtwork? {
+        guard let content else { return nil }
+        return TVHeroArtworkResolver.resolve(
+            sectionBackdrop: TVHeroArtwork(
+                url: content.backdropUrl,
+                thumbhash: content.backdropThumbhash
+            ),
+            fallback: TVHeroArtwork(
+                url: content.fallbackArtworkUrl,
+                thumbhash: content.fallbackArtworkThumbhash
+            ),
+            prefersEnrichedBackdrop: content.isEpisode || content.backdropUrl?.isEmpty != false,
+            canLoadEnrichment: content.contentId != nil,
+            enrichmentLoaded: enrichment != nil,
+            enrichedBackdrop: TVHeroArtwork(
+                url: enrichment?.backdropUrl,
+                thumbhash: enrichment?.backdropThumbhash
+            )
+        )
     }
 
-    var backdropThumbhash: String? {
-        if content?.isEpisode == true,
-           let enriched = enrichment?.backdropUrl, !enriched.isEmpty {
-            return enrichment?.backdropThumbhash ?? content?.backdropThumbhash
-        }
-        return content?.backdropThumbhash
-    }
+    var backdropURL: String? { resolvedArtwork?.url }
+
+    var backdropThumbhash: String? { resolvedArtwork?.thumbhash }
 
     private var debounceTask: Task<Void, Never>?
     private var tintTask: Task<Void, Never>?
@@ -303,8 +363,8 @@ final class TVFocusMarqueeModel {
 
     private func display(_ candidate: TVMarqueeContent) {
         content = candidate
-        sampleTintIfNeeded(for: candidate.backdropUrl)
         loadEnrichment(for: candidate)
+        sampleTintIfNeeded(for: backdropURL)
     }
 
     /// The §9 backfill: fields the section payload doesn't carry (air


### PR DESCRIPTION
## Problem

Posters and backdrops look blurry on Apple TV: the server previously returned fixed small variants (w300 cards / w500 posters), and the Nuke pipeline deliberately never upscales, so quality was bounded by what the server sent.

## Approach

Adopts the server's new `image_size` contract (Silo-Server/silo-server#742):

- `ImageSizeCapability` probes `GET /api/v1/images/capability` once per session (404 or error → feature silently off, older servers unaffected), resetting on sign-out and profile/server switch with a generation guard.
- On tvOS only, `ContinuumAPI` merges `image_size=large` into the artwork-bearing requests — home/library sections, catalog query (covering browse, search, person credits, collection items, history catalog), item detail, seasons, episodes, watch detail, favorites, watchlist, history. iOS/macOS requests are unchanged.
- Gating requires `schema_version == 1` and the server actually advertising `large`; the parameter name is taken from the capability payload. Image URLs stay opaque; no Nuke/pipeline changes.

## Verification

- `xcodebuild` SiloTV (generic/tvOS) and Silo (generic/iOS): both **BUILD SUCCEEDED**.
- `ImageSizeCapabilityTests`: 9 tests, 0 failures — payload decode, forward-compat decode, and the full gating matrix.

Follow-up worth noting: `recommendationsDiscover` renders on the TV home surface but is not yet covered by the server parameter.

Related issue: N/A — coordinated client half of Silo-Server/silo-server#742.

## AI-use disclosure

Implemented by Claude Code (maintainer-directed) with human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved image delivery on supported TV platforms by requesting larger image sizes when available.
  * Image-size support is automatically detected per server and applied across major content views.
  * Support refreshes when switching servers, changing profiles, signing in, or returning to the app.
  * Improved TV hero artwork selection with enriched backdrops and appropriate poster fallbacks.

* **Bug Fixes**
  * Safely falls back to existing image requests when image-size selection is unavailable.
  * Prevented incorrect hero artwork and tinting while detail artwork loads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->