### PR TITLE
Add App Store / DRM additional permission under AGPL section 7

### DIFF
--- a/APPSTORE-EXCEPTION.md
+++ b/APPSTORE-EXCEPTION.md
@@ -1,0 +1,49 @@
+# Silo Apple App Store / DRM Exception
+
+Copyright (C) 2026 Silo Media L.L.C. and contributors
+
+Silo Apple is licensed under the GNU Affero General Public License,
+version 3 or (at your option) any later version — see [LICENSE](LICENSE) —
+with the following additional permission.
+
+## Additional permission under AGPL v3 section 7
+
+As an additional permission under section 7 of the GNU Affero General
+Public License v3 (incorporated by section 7 of any later version the
+recipient elects), the copyright holders grant permission to distribute,
+install, and use this Program — and any modified versions thereof —
+through application stores and beta-distribution platforms operated by
+third parties (including but not limited to the Apple App Store and
+Apple TestFlight), even where the platform's terms impose restrictions
+on:
+
+- signing or re-signing of the binary by anyone other than the original
+  developer or the platform operator;
+- tamper protection, FairPlay-style DRM, or similar integrity controls
+  applied to the binary by the platform;
+- end-user redistribution of the installed binary outside the platform's
+  own channels;
+- end-user re-linking of the installed binary against modified versions
+  of the Program,
+
+even where such restrictions would otherwise be incompatible with
+sections 4 through 6 of AGPL v3.
+
+This permission applies solely to the binary distribution path. It does
+not waive any obligation under the License regarding source code: the
+complete corresponding source for the Program, including any
+modifications, remains available under AGPL v3, and recipients retain
+every right that license grants with respect to that source — they may
+obtain it, study it, modify it, build their own copy, and distribute
+their modified version under the same license, outside the constraints
+of any application store.
+
+As provided by section 7 of AGPL v3, any recipient redistributing the
+Program may remove this additional permission from their copy.
+
+## Trademark note
+
+This permission covers copyright only. The Silo name, logo, and wordmark
+are trademarks of Silo Media L.L.C. and are not licensed by it:
+publishing a Silo-branded build to an app store additionally requires
+written trademark permission. See [TRADEMARK.md](TRADEMARK.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing
+
+Thanks for contributing to Silo Apple.
+
+## Licensing of contributions
+
+This project is licensed under `AGPL-3.0-or-later` with the App Store /
+DRM additional permission in
+[APPSTORE-EXCEPTION.md](APPSTORE-EXCEPTION.md).
+
+By submitting a contribution, you agree that it is licensed under those
+same terms — the AGPL *including* the App Store additional permission —
+and that the project may distribute builds containing your contribution
+through application stores such as the Apple App Store and TestFlight as
+that permission describes. If you cannot agree to the additional
+permission, say so in your pull request before it is merged.
+
+You retain copyright in your contribution; no assignment is requested.
+
+## Practical notes
+
+- Repository layout, build commands, and coding conventions are in
+  [CLAUDE.md](CLAUDE.md) and the docs under `docs/`.
+- Third-party components and their licenses are inventoried in
+  [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md); update it when a
+  dependency changes.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,11 @@ Fastlane lanes are defined in `fastlane/Fastfile`. All Apple IDs, team IDs, sign
 
 ## License & Trademarks
 
-Silo Apple is licensed under `AGPL-3.0-or-later`. See [LICENSE](LICENSE).
+Silo Apple is licensed under `AGPL-3.0-or-later` with an additional
+permission under AGPL section 7 allowing distribution through the Apple App
+Store and TestFlight despite those platforms' signing, DRM, and
+redistribution terms. See [LICENSE](LICENSE) and
+[APPSTORE-EXCEPTION.md](APPSTORE-EXCEPTION.md).
 
 The **Silo name, logo, and wordmark are trademarks of Silo Media L.L.C.** and
 are **not** covered by the AGPL. You're free to fork and redistribute the code,


### PR DESCRIPTION
The Apple clients are heading for TestFlight and the App Store, and plain AGPL sits badly with store distribution: the FSF reads Apple's platform terms as "further restrictions" under section 10, and Apple's history (GNU Go, VLC) is to pull an app when any copyright holder complains rather than argue the point.

This adopts the fix the rest of our stack already uses. AetherEngine ships LGPL-3.0 with an App Store / DRM exception, and its author's own client (Sodalite) ships GPLv3 with the same clause. We stay `AGPL-3.0-or-later` and add the equivalent additional permission under AGPL section 7.

- **APPSTORE-EXCEPTION.md** — the additional permission: distribution through app stores and beta platforms (App Store and TestFlight named) is allowed despite platform signing, DRM, redistribution, and re-linking terms that would otherwise conflict with AGPL sections 4–6. Source obligations are explicitly untouched, and downstream redistributors may remove the permission, which is what keeps it a valid section 7 grant. Trademark permission for Silo-branded store builds stays a separate requirement per TRADEMARK.md.
- **CONTRIBUTING.md** — new. States that contributions are accepted under the AGPL including the exception, so future PRs carry consent automatically. Contributors keep their copyright.
- **README.md** — License section now describes the combined terms and links the exception.

`LICENSE` is untouched (verbatim AGPL text), so GitHub keeps detecting the repo as AGPL-3.0 instead of "Other".

Deliberately out of scope: retroactive sign-off from the five past external contributors. The exception cleanly covers Silo Media's code and everything merged after this lands; earlier external contributions are in the same position they were before this file existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contribution guidelines covering licensing, copyright, and repository resources.
  * Documented permissions for distributing the app through the Apple App Store and TestFlight.
  * Added details about platform signing, DRM, redistribution, and source-code obligations.
  * Updated the README with the new licensing exception and supporting documentation link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->