### PR TITLE
tvOS: detect and repair total focus loss; dedupe Settings-exit popToRoot

### DIFF
--- a/iosApp/iosApp/tvOS/Navigation/TVFocusWatchdog.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVFocusWatchdog.swift
@@ -1,0 +1,148 @@
+#if os(tvOS)
+import SwiftUI
+import UIKit
+
+/// Reads and nudges the live focus engine for the app's key window.
+///
+/// SwiftUI exposes no way to ask "does anything on screen currently hold
+/// focus?", and `@FocusState` is not an answer: the engine can drop focus
+/// without writing `nil` back into a binding, which is exactly the wedge this
+/// watchdog exists to catch. `UIFocusSystem` is the only source of truth.
+enum TVFocusSystemProbe {
+    @MainActor
+    private static var keyWindow: UIWindow? {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .filter { $0.activationState == .foregroundActive }
+            .flatMap(\.windows)
+            .first(where: \.isKeyWindow)
+    }
+
+    /// The focused item's *type* name, or `nil` when nothing is focused. Only
+    /// the type is returned: a focused item's description can carry item
+    /// titles, and breadcrumbs must stay free of library content.
+    @MainActor
+    static func focusedItemTypeName() -> String? {
+        guard let window = keyWindow,
+              let item = UIFocusSystem.focusSystem(for: window)?.focusedItem
+        else { return nil }
+        return String(describing: type(of: item))
+    }
+
+    /// Ask the engine to re-resolve focus from the window root. Used only on
+    /// pushed routes, where the tvOS shell owns no focus target it could
+    /// legitimately pin.
+    @MainActor
+    static func requestFocusUpdate() {
+        guard let window = keyWindow else { return }
+        window.setNeedsFocusUpdate()
+        window.updateFocusIfNeeded()
+    }
+}
+
+/// Watches for the focus engine losing focus entirely — no focused item, so no
+/// control reacts to the remote and the app reads as hard-frozen — and fires a
+/// single repair nudge per detection.
+///
+/// Field reports of this wedge showed the main thread alive and the top bar's
+/// `@FocusState` stale at a non-nil item, so the bar's own compensating re-pin
+/// never ran. Detection therefore cannot be derived from app state; it has to
+/// come from the engine (`TVFocusSystemProbe`).
+///
+/// Per docs/tvos-focus.md the repair must not fight the engine: one nudge per
+/// detected outage, rate-limited, and never a retry loop.
+struct TVFocusWatchdogModifier: ViewModifier {
+    /// False whenever something other than the shell legitimately owns (or
+    /// suspends) focus — a presented cover, a system dialog, the background.
+    /// A "no focused item" reading is not actionable in those states.
+    let isActive: Bool
+    let onRepair: () -> Void
+
+    private static let checkInterval = Duration.seconds(2)
+    /// Two consecutive misses (~4 s) before acting. One miss is routinely seen
+    /// mid-transition, while a cover dismisses or content swaps in.
+    private static let missesBeforeRepair = 2
+    private static let minimumSecondsBetweenRepairs: TimeInterval = 5
+    private static let maximumRepairsPerOutage = 3
+
+    @State private var consecutiveMisses = 0
+    @State private var repairsThisOutage = 0
+    @State private var lastRepairAt: Date?
+    @State private var repairPending = false
+
+    func body(content: Content) -> some View {
+        content
+            .task(id: isActive) {
+                guard isActive else {
+                    resetOutageState()
+                    return
+                }
+                while !Task.isCancelled {
+                    try? await Task.sleep(for: Self.checkInterval)
+                    guard !Task.isCancelled else { return }
+                    check()
+                }
+            }
+    }
+
+    @MainActor
+    private func check() {
+        if let focused = TVFocusSystemProbe.focusedItemTypeName() {
+            recordRecoveryIfNeeded(focused: focused)
+            resetOutageState()
+            return
+        }
+
+        consecutiveMisses += 1
+        guard consecutiveMisses >= Self.missesBeforeRepair else { return }
+        guard repairsThisOutage < Self.maximumRepairsPerOutage else { return }
+        if let lastRepairAt, Date().timeIntervalSince(lastRepairAt) < Self.minimumSecondsBetweenRepairs {
+            return
+        }
+
+        repairsThisOutage += 1
+        lastRepairAt = Date()
+        repairPending = true
+        DiagnosticsCoordinator.recordBreadcrumb(
+            level: .warning,
+            category: .focus,
+            tag: "FocusRepair",
+            message: "no focused item; repairing",
+            attrs: [
+                "misses": .int(consecutiveMisses),
+                "attempt": .int(repairsThisOutage),
+            ]
+        )
+        onRepair()
+    }
+
+    @MainActor
+    private func recordRecoveryIfNeeded(focused: String) {
+        guard consecutiveMisses >= Self.missesBeforeRepair else { return }
+        // Distinguishing repaired from self-healing outages is the point of
+        // this line: it tells a field report how often the wedge is real
+        // versus a transient the engine would have resolved on its own.
+        DiagnosticsCoordinator.recordBreadcrumb(
+            category: .focus,
+            tag: "FocusRepair",
+            message: repairPending ? "focus restored after repair" : "focus recovered unaided",
+            attrs: [
+                "misses": .int(consecutiveMisses),
+                "focused": .string(focused),
+            ]
+        )
+    }
+
+    private func resetOutageState() {
+        consecutiveMisses = 0
+        repairsThisOutage = 0
+        repairPending = false
+    }
+}
+
+extension View {
+    func tvFocusWatchdog(isActive: Bool, onRepair: @escaping () -> Void) -> some View {
+        modifier(TVFocusWatchdogModifier(isActive: isActive, onRepair: onRepair))
+    }
+}
+#endif

--- a/iosApp/iosApp/tvOS/Navigation/TVFocusWatchdog.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVFocusWatchdog.swift
@@ -62,12 +62,14 @@ struct TVFocusWatchdogModifier: ViewModifier {
     /// Two consecutive misses (~4 s) before acting. One miss is routinely seen
     /// mid-transition, while a cover dismisses or content swaps in.
     private static let missesBeforeRepair = 2
-    private static let minimumSecondsBetweenRepairs: TimeInterval = 5
+    /// Monotonic: a wall-clock step (NTP, manual date change) must not be able
+    /// to read as "the last repair was in the future" and gate repair off.
+    private static let minimumTimeBetweenRepairs = Duration.seconds(5)
     private static let maximumRepairsPerOutage = 3
 
     @State private var consecutiveMisses = 0
     @State private var repairsThisOutage = 0
-    @State private var lastRepairAt: Date?
+    @State private var lastRepairAt: ContinuousClock.Instant?
     @State private var repairPending = false
 
     func body(content: Content) -> some View {
@@ -96,12 +98,13 @@ struct TVFocusWatchdogModifier: ViewModifier {
         consecutiveMisses += 1
         guard consecutiveMisses >= Self.missesBeforeRepair else { return }
         guard repairsThisOutage < Self.maximumRepairsPerOutage else { return }
-        if let lastRepairAt, Date().timeIntervalSince(lastRepairAt) < Self.minimumSecondsBetweenRepairs {
+        let now = ContinuousClock.now
+        if let lastRepairAt, now - lastRepairAt < Self.minimumTimeBetweenRepairs {
             return
         }
 
         repairsThisOutage += 1
-        lastRepairAt = Date()
+        lastRepairAt = now
         repairPending = true
         DiagnosticsCoordinator.recordBreadcrumb(
             level: .warning,

--- a/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
@@ -307,9 +307,13 @@ struct TVMainTabView: View {
     /// stale focus state and re-arm content entry focus — the same path a tab
     /// selection uses. On a pushed route the shell owns no focus target, so ask
     /// the engine to re-resolve from the window instead of pinning one.
+    ///
+    /// `rootContent` blocks hit testing while a panel is open, so an open panel
+    /// has to come down first or the content focus hand-down lands on nothing.
     private func repairLostFocus() {
         topMenuFocusResetRequest += 1
         if router.path.isEmpty {
+            closePanelForContentHandoff()
             suppressTopMenuFocusForContentHandoff()
             contentFocusRequest += 1
         } else {

--- a/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
@@ -94,6 +94,11 @@ struct TVMainTabView: View {
     /// this, so their pops keep the engine's restore-to-card behavior.
     @State private var barOwnsFocusOnPopToRoot = false
     @State private var topMenuFocusRequest = 0
+    /// Bumped by the focus watchdog to drop the bar's `@FocusState` when the
+    /// engine has already dropped focus without telling it. Re-suppressing is
+    /// not enough: the bar nils on the *transition* into suppression, and the
+    /// wedge is observed while suppression is already true.
+    @State private var topMenuFocusResetRequest = 0
     /// Active focus hand-down generation. Incremented whenever a root is
     /// selected so the freshly-swapped-in content imperatively claims
     /// focus, instead of relying on `prefersDefaultFocus` (which can lose
@@ -125,6 +130,7 @@ struct TVMainTabView: View {
                     isMenuFocused: $isTopMenuFocused,
                     isFocusSuppressed: isTopMenuFocusSuppressed,
                     focusRequest: topMenuFocusRequest,
+                    focusResetRequest: topMenuFocusResetRequest,
                     focusRequestTarget: panelReturnFocus,
                     openPanel: openPanel,
                     panelHasFocus: panelHasFocus,
@@ -279,6 +285,35 @@ struct TVMainTabView: View {
                 let authority = currentLibraryAuthority
                 Task { await loadLibraries(for: authority) }
             }
+        }
+        .tvFocusWatchdog(isActive: focusWatchdogIsActive, onRepair: repairLostFocus)
+    }
+
+    /// The watchdog's reading is only actionable while this shell's focus graph
+    /// is the one on screen. Covers, dialogs, and the standby overlay own (or
+    /// legitimately suspend) focus themselves, and a backgrounded scene has no
+    /// focused item by definition.
+    private var focusWatchdogIsActive: Bool {
+        scenePhase == .active
+            && router.presentedPlayer == nil
+            && !audioStore.isShowingFullPlayer
+            && !showSignOutConfirm
+            && !showServerPicker
+            && controlReceiver.standbyState == nil
+    }
+
+    /// One nudge per detected focus outage (docs/tvos-focus.md: do not fight
+    /// the engine). At root the shell owns the hand-down, so clear the bar's
+    /// stale focus state and re-arm content entry focus — the same path a tab
+    /// selection uses. On a pushed route the shell owns no focus target, so ask
+    /// the engine to re-resolve from the window instead of pinning one.
+    private func repairLostFocus() {
+        topMenuFocusResetRequest += 1
+        if router.path.isEmpty {
+            suppressTopMenuFocusForContentHandoff()
+            contentFocusRequest += 1
+        } else {
+            TVFocusSystemProbe.requestFocusUpdate()
         }
     }
 

--- a/iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift
@@ -314,6 +314,18 @@ struct TVTopMenuBar: View {
             // one main-queue turn leaves a visible frame where tvOS repairs
             // focus back to Home. A legit leave (down into the page, Menu out)
             // has neither flag, so it falls through and focus is allowed to go.
+            // A suppressed bar must never take focus back. The shell suppresses
+            // before handing focus down, and the watchdog's reset arrives while
+            // suppression is already true with a passive preview still open —
+            // exactly the `spuriousFromOpenPreview` shape — so an ungated re-pin
+            // would undo the repair and re-strand the remote. Drop the re-pin
+            // flag with it so it can't fire on a later legitimate nil write.
+            if isFocusSuppressed {
+                isMenuFocused = false
+                refocusAfterClose = false
+                dwellTask?.cancel()
+                return
+            }
             let spuriousFromOpenPreview = openPanel != nil && !panelHasFocus
             if (spuriousFromOpenPreview || refocusAfterClose), let target = lastBarFocus {
                 refocusAfterClose = false

--- a/iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift
@@ -139,6 +139,11 @@ struct TVTopMenuBar: View {
     @Binding var isMenuFocused: Bool
     let isFocusSuppressed: Bool
     let focusRequest: Int
+    /// Bumped when the shell has determined the bar's `@FocusState` is stale —
+    /// the engine dropped focus without the bar observing it, so no suppression
+    /// transition will clear it. Drops the bar's focus state without asking for
+    /// focus back.
+    var focusResetRequest: Int = 0
     /// Bar element to focus on the next `focusRequest` bump, overriding the
     /// default of the selected tab. The shell sets this so Menu-ing out of a
     /// panel returns focus to the *panel's* tab/avatar (§7), not whatever
@@ -247,6 +252,15 @@ struct TVTopMenuBar: View {
                 // should dwell-open normally, so drop any close-suppression.
                 dwellSuppressedElement = nil
             }
+        }
+        .onChange(of: focusResetRequest) { _, _ in
+            // Clear the re-pin flags first: the bar has no focus to defend
+            // here, and letting the nil write below take the re-pin branch
+            // would have the bar grab focus the shell is handing elsewhere.
+            refocusAfterClose = false
+            dwellSuppressedElement = nil
+            dwellTask?.cancel()
+            focusedItem = nil
         }
         .onChange(of: focusRequest) { _, _ in
             let target = focusRequestTarget.map { String(describing: $0) } ?? "nil"

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsView.swift
@@ -468,8 +468,12 @@ struct TVSettingsView: View {
         }
     }
 
+    /// The tab request is the only action needed: TVMainTabView's
+    /// `requestedTab` handler routes `.home` through `selectRoot`, which pops
+    /// to root itself (unconditionally, including when Home is already the
+    /// selected root). Popping here too produced a second `popToRoot` and a
+    /// duplicate navigation breadcrumb for one exit.
     private func exitSettingsToHome() {
-        router.popToRoot()
         router.switchTab(to: .home)
     }
 


### PR DESCRIPTION
## Summary

Fixes the tvOS "app freezes while navigating" report (internal Discord thread; hosted diagnostics SILO-CKL2YPFD, SILO-4LUBC6XL, SILO-5STFTL9M, SILO-J7ZGNDH3, SILO-EWKFMYZM).

On-device investigation with an instrumented build proved the app never actually deadlocks: the main thread stays alive while the tvOS focus engine silently drops focus entirely — no element on screen is focused, so every remote press lands on nothing and the app reads as hard-frozen until force-killed. The top menu bar's `@FocusState` is left stale at a non-nil item, so its existing compensating re-pin never runs. Two earlier hypotheses were refuted with direct evidence: the `canOpenURL("youtube://")` probe on item-detail entry is ~1 ms every time, and the bar's `focusedItem` handler never storms (41/41 paired enter/exit, <1 ms each).

## Changes

- **`TVFocusWatchdog.swift`** (new): while the shell is active (foreground, no player cover, no dialog, no standby overlay), poll `UIFocusSystem` every 2 s. After two consecutive "nothing focused" readings (~4 s) record a `FocusRepair` diagnostics breadcrumb and fire one rate-limited repair nudge (≥5 s apart, max 3 per outage): clear the bar's stale `@FocusState` and re-arm content entry focus at root, or request an engine re-resolve (`setNeedsFocusUpdate`) on pushed routes. Recovery breadcrumbs distinguish "focus restored after repair" from "focus recovered unaided" so future field reports quantify the wedge and prove/disprove the repair.
- **`TVMainTabView` / `TVTopMenuBar`**: `focusResetRequest` plumbing so the shell can drop the bar's stale focus state without asking for focus back (re-suppressing alone cannot — the bar only nils on the transition into suppression).
- **`TVSettingsView`**: Settings exit now emits exactly one `popToRoot` (previously two ~60 ms apart — `exitSettingsToHome` popped and then `selectRoot(.home)` popped again).

## Validation (physical Apple TV, tvOS 26.6)

- 10/10 scripted detail-open/back cycles and 2/2 Settings→exit→detail cycles pass; breadcrumbs confirm exactly one `popToRoot` per Settings exit.
- Zero spurious watchdog fires across 365 checks; a single transient nil reading mid-push was correctly ignored; backgrounding suspends the poll entirely.
- The pre-fix wedge was observed twice (unresponsive UI, live main thread) but did not recur during 8 rounds of post-fix provocation, so the repair path is wired and built but not yet exercised against a live wedge — the breadcrumb pair is the mechanism to confirm from the field. Reporter-side manual validation on tvOS 27 is in progress.
- tvOS and iOS schemes both build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tvOS focus recovery when focus is lost or becomes stuck.
  * Reduced duplicate navigation when exiting Settings to return Home.
  * Reset top-menu focus state more reliably during recovery.
  * Improved focus handling across root and pushed screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->