### PR TITLE
Fix resilient Apple TV companion setup

### DIFF
--- a/iosApp/Tests/PairingCoordinatorTests.swift
+++ b/iosApp/Tests/PairingCoordinatorTests.swift
@@ -27,6 +27,10 @@ private final class FakePairingChannel: PairingChannel {
         sent.append(message)
     }
 
+    func queue(_ message: PairingMessage) async {
+        sent.append(message)
+    }
+
     func close() async {
         closeCount += 1
         feed.finish()
@@ -53,9 +57,11 @@ private final class FakePairingAPI: PairingDeviceAuthorizing, @unchecked Sendabl
     var approveError: Error?
     var startError: Error?
     var pollResponse: DeviceLoginPollResponse?
+    var pollResults: [Result<DeviceLoginPollResponse, Error>] = []
 
     private(set) var startedServers: [String] = []
     private(set) var approvedCodes: [String] = []
+    private(set) var pollCount = 0
 
     func start(serverURL: String, deviceName: String, devicePlatform: String) async throws -> DeviceLoginStartResponse {
         if let startError { throw startError }
@@ -75,6 +81,10 @@ private final class FakePairingAPI: PairingDeviceAuthorizing, @unchecked Sendabl
     }
 
     func poll(serverURL: String, deviceCode: String) async throws -> DeviceLoginPollResponse {
+        pollCount += 1
+        if !pollResults.isEmpty {
+            return try pollResults.removeFirst().get()
+        }
         if let pollResponse { return pollResponse }
         throw PairingDeviceAPI.APIError.http(500)
     }
@@ -387,6 +397,29 @@ final class ReceiverPairingCoordinatorTests: XCTestCase {
         var persisted: [Persisted] = []
     }
 
+    @MainActor
+    private final class PersistGate {
+        var started = false
+        var cancelled = false
+        private var continuation: CheckedContinuation<Void, Never>?
+
+        func wait() async {
+            await withTaskCancellationHandler {
+                await withCheckedContinuation {
+                    continuation = $0
+                    started = true
+                }
+            } onCancel: {
+                Task { @MainActor in self.cancelled = true }
+            }
+        }
+
+        func release() {
+            continuation?.resume()
+            continuation = nil
+        }
+    }
+
     private func makeCoordinator(api: FakePairingAPI, recorder: PersistRecorder) -> ReceiverPairingCoordinator {
         ReceiverPairingCoordinator(api: api) { url, _, access, _ in
             recorder.persisted.append(Persisted(url: url, access: access))
@@ -444,6 +477,173 @@ final class ReceiverPairingCoordinatorTests: XCTestCase {
         XCTAssertEqual(coordinator.state, .idle)
         XCTAssertEqual(channel.lastSent, .cancel(reason: "consent_denied"))
         XCTAssertTrue(api.startedServers.isEmpty)
+    }
+
+    /// Regression: the server can restart or a reverse proxy can briefly
+    /// return an error while a valid device-login request is pending. Keep
+    /// polling the same request instead of making the whole companion setup
+    /// terminal after that single transient response.
+    func testTransientPollFailureRetriesAndEventuallySignsIn() async {
+        let channel = FakePairingChannel()
+        let api = FakePairingAPI()
+        api.pollResults = [
+            .failure(PairingDeviceAPI.APIError.http(502)),
+            .success(approvedPoll),
+        ]
+        let recorder = PersistRecorder()
+        let coordinator = makeCoordinator(api: api, recorder: recorder)
+        let runTask = Task { await coordinator.run(session: channel, stream: channel.stream) }
+
+        channel.deliver(.pushServer(serverURL: "https://home.example", serverName: "Home"))
+        await expectEventually("consent prompt") {
+            if case .consentRequested = coordinator.state { return true }
+            return false
+        }
+        coordinator.allowPendingServer()
+        await expectEventually("signed in after retry") {
+            if case .signedIn(let count) = coordinator.state { return count == 1 }
+            return false
+        }
+
+        XCTAssertEqual(api.pollCount, 2)
+        XCTAssertEqual(recorder.persisted.map(\.access), ["ACCESS"])
+        XCTAssertTrue(channel.sent.contains {
+            if case .serverResult(_, .signedIn, _) = $0 { return true }
+            return false
+        })
+
+        channel.deliver(.done)
+        await runTask.value
+    }
+
+    func testMissingPollRequestFailsWithoutRetrying() async {
+        let channel = FakePairingChannel()
+        let api = FakePairingAPI()
+        api.pollResults = [.failure(PairingDeviceAPI.APIError.http(404))]
+        let recorder = PersistRecorder()
+        let coordinator = makeCoordinator(api: api, recorder: recorder)
+        let runTask = Task { await coordinator.run(session: channel, stream: channel.stream) }
+
+        channel.deliver(.pushServer(serverURL: "https://home.example", serverName: "Home"))
+        await expectEventually("consent prompt") {
+            if case .consentRequested = coordinator.state { return true }
+            return false
+        }
+        coordinator.allowPendingServer()
+        await expectEventually("missing request failure") {
+            if case .failed(let name) = coordinator.state { return name == "Home" }
+            return false
+        }
+
+        XCTAssertEqual(api.pollCount, 1)
+        XCTAssertTrue(recorder.persisted.isEmpty)
+        channel.deliver(.done)
+        await runTask.value
+    }
+
+    func testCancellationDuringTransientPollBackoffDoesNotPublishFailure() async {
+        let channel = FakePairingChannel()
+        let api = FakePairingAPI()
+        api.pollResults = [.failure(PairingDeviceAPI.APIError.http(502))]
+        let recorder = PersistRecorder()
+        let coordinator = makeCoordinator(api: api, recorder: recorder)
+        let runTask = Task { await coordinator.run(session: channel, stream: channel.stream) }
+
+        channel.deliver(.pushServer(serverURL: "https://home.example", serverName: "Home"))
+        await expectEventually("consent prompt") {
+            if case .consentRequested = coordinator.state { return true }
+            return false
+        }
+        coordinator.allowPendingServer()
+        await expectEventually("first transient poll failure") { api.pollCount == 1 }
+
+        channel.deliver(.cancel(reason: "test_cancel"))
+        await runTask.value
+        XCTAssertEqual(coordinator.state, .idle)
+        XCTAssertTrue(recorder.persisted.isEmpty)
+        XCTAssertFalse(channel.sent.contains {
+            if case .serverResult(_, .failed, _) = $0 { return true }
+            return false
+        })
+    }
+
+    /// Regression: leaving the setup screen can race the non-cancellable
+    /// persistence boundary. A committed sign-in result must reach the phone
+    /// before the TV sends its teardown cancellation.
+    func testCancellationAfterPersistenceStartsPublishesSuccessFirst() async {
+        let channel = FakePairingChannel()
+        let api = FakePairingAPI()
+        api.pollResponse = approvedPoll
+        let recorder = PersistRecorder()
+        let gate = PersistGate()
+        let coordinator = ReceiverPairingCoordinator(api: api) { url, _, access, _ in
+            await gate.wait()
+            recorder.persisted.append(Persisted(url: url, access: access))
+            return true
+        }
+        let runTask = Task { await coordinator.run(session: channel, stream: channel.stream) }
+
+        channel.deliver(.pushServer(serverURL: "https://home.example", serverName: "Home"))
+        await expectEventually("consent prompt") {
+            if case .consentRequested = coordinator.state { return true }
+            return false
+        }
+        coordinator.allowPendingServer()
+        await expectEventually("persistence started") { gate.started }
+
+        let cancelTask = Task { await coordinator.cancel() }
+        await expectEventually("attempt cancelled at persistence boundary") { gate.cancelled }
+        gate.release()
+        await cancelTask.value
+
+        let resultIndex = channel.sent.firstIndex {
+            if case .serverResult(_, .signedIn, _) = $0 { return true }
+            return false
+        }
+        let cancelIndex = channel.sent.firstIndex(of: .cancel(reason: "receiver_cancelled"))
+        XCTAssertNotNil(resultIndex)
+        XCTAssertNotNil(cancelIndex)
+        if let resultIndex, let cancelIndex {
+            XCTAssertLessThan(resultIndex, cancelIndex)
+        }
+        XCTAssertEqual(recorder.persisted.map(\.access), ["ACCESS"])
+        await runTask.value
+    }
+
+    /// A phone-side timeout at the same boundary must not return the TV to
+    /// setup after its credentials have already committed.
+    func testPeerCancellationAfterPersistenceStartsPreservesCommittedSignIn() async {
+        let channel = FakePairingChannel()
+        let api = FakePairingAPI()
+        api.pollResponse = approvedPoll
+        let recorder = PersistRecorder()
+        let gate = PersistGate()
+        let coordinator = ReceiverPairingCoordinator(api: api) { url, _, access, _ in
+            await gate.wait()
+            recorder.persisted.append(Persisted(url: url, access: access))
+            return true
+        }
+        let runTask = Task { await coordinator.run(session: channel, stream: channel.stream) }
+
+        channel.deliver(.pushServer(serverURL: "https://home.example", serverName: "Home"))
+        await expectEventually("consent prompt") {
+            if case .consentRequested = coordinator.state { return true }
+            return false
+        }
+        coordinator.allowPendingServer()
+        await expectEventually("persistence started") { gate.started }
+
+        channel.deliver(.cancel(reason: "phone_timeout"))
+        await expectEventually("attempt cancelled at persistence boundary") { gate.cancelled }
+        gate.release()
+        await runTask.value
+
+        XCTAssertEqual(coordinator.state, .completed(serverNames: ["Home"]))
+        XCTAssertEqual(recorder.persisted.map(\.access), ["ACCESS"])
+        XCTAssertTrue(channel.sent.contains {
+            if case .serverResult(_, .signedIn, _) = $0 { return true }
+            return false
+        })
     }
 
     /// Regression: the phone's `done` after a failed-only session must not

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -123,6 +123,19 @@ struct ContentView: View {
             ) else { return }
             router.showProfileSelection()
         }
+        .onChange(of: serverRegistry.activeServerId) { previousServerID, activeServerID in
+            guard previousServerID != activeServerID,
+                  router.authState == .needsServerSetup,
+                  shouldPresentProfileSelectionAfterRecovery(
+                      isLoggedIn: AuthService.shared.isLoggedIn,
+                      activeProfileID: AuthService.shared.profileId
+                  ) else { return }
+            // Companion setup adds the server and account atomically. The
+            // active-server change intentionally re-keys `authContent`, which
+            // otherwise replaces the receiver's success screen with a fresh
+            // setup view before its delayed navigation can run.
+            router.showProfileSelection()
+        }
         #if os(iOS) || os(tvOS)
         .onReceive(NotificationCenter.default.publisher(for: .diagnosticsPendingReportCreated)) { _ in
             guard router.authState == .authenticated else { return }

--- a/iosApp/iosApp/Pairing/PairingSession.swift
+++ b/iosApp/iosApp/Pairing/PairingSession.swift
@@ -26,10 +26,18 @@ extension FramedJSONSession where Message == PairingMessage {
 /// real socket.
 protocol PairingChannel: Sendable {
     func send(_ message: PairingMessage) async throws
+    /// Queue an ordered best-effort frame without waiting for the transport
+    /// write to complete. Used once a sign-in is already committed, where a
+    /// stalled socket must not hold teardown open indefinitely.
+    func queue(_ message: PairingMessage) async
     func close() async
     /// Best-effort goodbye frame ahead of the FIN, bounded by a watchdog so a
     /// wedged connection can never hang the caller.
     func closeGracefully(goodbye: PairingMessage) async
 }
 
-extension FramedJSONSession: PairingChannel where Message == PairingMessage {}
+extension FramedJSONSession: PairingChannel where Message == PairingMessage {
+    func queue(_ message: PairingMessage) async {
+        enqueue(message)
+    }
+}

--- a/iosApp/iosApp/Pairing/Receiver/ReceiverPairingCoordinator.swift
+++ b/iosApp/iosApp/Pairing/Receiver/ReceiverPairingCoordinator.swift
@@ -62,6 +62,10 @@ final class ReceiverPairingCoordinator {
     /// cancellable task so the stream reader below is NEVER blocked by polling.
     private var pollTask: Task<Void, Never>?
     private var idleTask: Task<Void, Never>?
+    /// Prevent the stream reader from starting replacement work while an
+    /// explicit TV-side teardown is waiting for the current attempt to reach
+    /// its cancellation-safe boundary.
+    private var isCancelling = false
     private static let logger = Logger(subsystem: "com.continuum.app", category: "pairing.receiver")
 
     init(
@@ -77,6 +81,7 @@ final class ReceiverPairingCoordinator {
     /// message or a dropped connection aborts the attempt immediately rather
     /// than after the poll loop finishes (design spec §7).
     func run(session: any PairingChannel, stream: AsyncThrowingStream<PairingMessage, Error>) async {
+        isCancelling = false
         signedInNames = []
         consented = false
         pendingPush = nil
@@ -93,6 +98,7 @@ final class ReceiverPairingCoordinator {
             state = .linked
             armIdleTimer(session)
             for try await message in stream {
+                guard !isCancelling else { continue }
                 armIdleTimer(session)
                 switch message {
                 case let .pushServer(serverURL, serverName):
@@ -101,6 +107,7 @@ final class ReceiverPairingCoordinator {
                     // previous server — supersede it, don't ignore the push.
                     pollTask?.cancel()
                     await pollTask?.value
+                    guard !isCancelling else { return }
                     if consented {
                         beginAttempt(serverURL: serverURL, serverName: serverName, session: session)
                     } else {
@@ -117,15 +124,24 @@ final class ReceiverPairingCoordinator {
                     Self.logger.notice("peer cancelled: \(reason, privacy: .public)")
                     pollTask?.cancel()
                     await pollTask?.value
-                    await teardown(session: session, resetState: true)
+                    if signedInNames.isEmpty {
+                        await teardown(session: session, resetState: true)
+                    } else {
+                        // A peer timeout can race the persistence boundary.
+                        // Never discard a sign-in that already committed.
+                        state = .completed(serverNames: signedInNames)
+                        await teardown(session: session, resetState: false)
+                    }
                     return
                 case .hello, .deviceStarted, .serverResult:
                     break // TV → phone kinds; a conforming phone never sends these
                 }
             }
             // Stream ended without a Done (peer closed the connection).
+            guard !isCancelling else { return }
             await onStreamClosed(session)
         } catch {
+            guard !isCancelling else { return }
             // Stream threw: the connection dropped mid-session.
             Self.logger.error("session error: \(String(describing: error), privacy: .public)")
             await onStreamClosed(session)
@@ -180,13 +196,24 @@ final class ReceiverPairingCoordinator {
     /// the failure screen, or leaving the setup screen). The phone is told
     /// this was a deliberate TV-side cancel, not a dropped connection.
     func cancel() async {
-        pollTask?.cancel()
+        guard !isCancelling else { return }
+        isCancelling = true
+        let session = activeSession
+        activeSession = nil
+        let task = pollTask
+        pollTask = nil
+        task?.cancel()
+        // A cancellation can race the non-cancellable half of persistence
+        // after tokens have committed. Let that task publish its signed-in
+        // result before sending the cancel frame, so the phone cannot repaint
+        // a successful setup as cancelled.
+        await task?.value
         idleTask?.cancel()
-        state = .idle
-        if let session = activeSession {
+        idleTask = nil
+        if let session {
             await session.closeGracefully(goodbye: .cancel(reason: "receiver_cancelled"))
         }
-        activeSession = nil
+        state = .idle
     }
 
     /// Cancel any in-flight poll, close the session, and (optionally) return
@@ -250,9 +277,24 @@ final class ReceiverPairingCoordinator {
 
             // 2. Poll until approved or the device code expires.
             let deadline = Date().addingTimeInterval(TimeInterval(started.expiresIn))
+            var pollInterval = max(1, started.interval)
             while Date() < deadline {
                 try Task.checkCancellation() // abort promptly on peer cancel / drop
-                let poll = try await api.poll(serverURL: normalized, deviceCode: started.deviceCode)
+                let poll: DeviceLoginPollResponse
+                do {
+                    poll = try await api.poll(serverURL: normalized, deviceCode: started.deviceCode)
+                } catch {
+                    try Task.checkCancellation()
+                    if case PairingDeviceAPI.APIError.http(404) = error {
+                        throw error // the server has expired and removed this request
+                    }
+                    // Match the ordinary device-login flow and Android TV:
+                    // a deploy, proxy hiccup, or brief network loss must not
+                    // invalidate a still-live device code.
+                    Self.logger.notice("transient device-login poll failure; retrying")
+                    try await Task.sleep(for: .seconds(pollInterval))
+                    continue
+                }
                 try Task.checkCancellation() // a cancel that raced the network must win — persist nothing
                 switch poll.status {
                 case "approved":
@@ -268,12 +310,13 @@ final class ReceiverPairingCoordinator {
                     // confirmation frame must not repaint a real sign-in as a
                     // failure. If the send is lost the phone may undercount,
                     // but EOF-after-success still completes on both ends.
-                    try? await session.send(.serverResult(serverURL: normalized, status: .signedIn, error: nil))
+                    await session.queue(.serverResult(serverURL: normalized, status: .signedIn, error: nil))
                     return
                 case "denied", "expired", "consumed":
                     throw PairingDeviceAPI.APIError.http(409)
                 default: // "pending"
-                    try await Task.sleep(for: .seconds(max(1, poll.pollAfter ?? started.interval)))
+                    pollInterval = max(1, poll.pollAfter ?? pollInterval)
+                    try await Task.sleep(for: .seconds(pollInterval))
                 }
             }
             throw PairingDeviceAPI.APIError.http(408) // local timeout


### PR DESCRIPTION
## Summary

- retry transient Apple TV device-login poll failures while the server-issued request remains valid, while keeping a missing request (404) terminal
- serialize teardown behind any in-flight credential commit so a real sign-in cannot be repainted as cancelled
- preserve committed sign-ins across peer cancellation and route an atomic companion sign-in straight to profile selection when the active-server boundary re-keys the auth view

## Diagnosis

The baseline iPhone-to-tvOS simulator flow failed when a brief server restart produced one transient 502 during the Apple TV poll. The tvOS receiver treated every thrown poll as terminal, unlike Android TV and the ordinary Apple device-login flow. Reproduction also exposed two related Apple lifecycle races: setup-view teardown could send `cancel` after credentials committed but before the success frame, and the active-server identity re-key could recreate the setup view before its delayed success navigation ran.

## Validation

- exact head: `5277c213b568c8ea74e83f519c37d8ed2d4078ac`
- iOS simulator build and launch: `Silo` — passed
- tvOS simulator build and launch: `SiloTV` — passed
- focused pairing, persistence, and profile-routing suites: 36 passed, 0 failed
- end-to-end iPhone → Apple TV simulator setup: consent and match-code flow completed; iPhone reached `Done`; Apple TV advanced directly to `Who's watching?`; the account remained present after relaunch
- shared development server identity, API, app, database, and authenticated health checks — passed

No server or Android change is required; their device-login semantics already match the intended retry behavior.
