### PR TITLE
Fix iOS detail playback pickers in compact landscape

### DIFF
--- a/iosApp/iosApp/Screens/Detail/Phone/PhonePlaybackSelectorRow.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhonePlaybackSelectorRow.swift
@@ -40,6 +40,7 @@ struct PhonePlaybackSelectorRow: View {
 
     #if os(iOS)
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Environment(\.verticalSizeClass) private var verticalSizeClass
     #endif
     @State private var activeSelector: PhonePlaybackSelectorKind?
 
@@ -50,14 +51,21 @@ struct PhonePlaybackSelectorRow: View {
     var body: some View {
         if currentVersion != nil, !selectorKinds.isEmpty {
             #if os(iOS)
-            selectorCard
-                .popover(
-                    item: $activeSelector,
-                    attachmentAnchor: .rect(.bounds),
-                    arrowEdge: .top
-                ) { kind in
-                    selectorPresentation(for: kind)
-                }
+            if usesPopoverLayout {
+                selectorCard
+                    .popover(
+                        item: $activeSelector,
+                        attachmentAnchor: .rect(.bounds),
+                        arrowEdge: .top
+                    ) { kind in
+                        selectorPresentation(for: kind)
+                    }
+            } else {
+                selectorCard
+                    .sheet(item: $activeSelector) { kind in
+                        selectorPresentation(for: kind)
+                    }
+            }
             #else
             selectorCard
                 .sheet(item: $activeSelector) { kind in
@@ -86,7 +94,7 @@ struct PhonePlaybackSelectorRow: View {
 
     private var usesPopoverLayout: Bool {
         #if os(iOS)
-        horizontalSizeClass == .regular
+        horizontalSizeClass == .regular && verticalSizeClass == .regular
         #else
         false
         #endif


### PR DESCRIPTION
## Summary

- present detail-page playback selectors as sheets whenever either size axis is compact
- keep anchored popovers for regular-width, regular-height iPad layouts
- prevent compact-height iPhone landscape presentations from collapsing into an unusable sliver

## Validation

- iOS 26.4, iPhone 17 Pro simulator: reproduced the landscape audio picker collapse on `main`, with no selectable rows exposed
- patched landscape build: the sheet exposed every audio choice and selecting another track updated the detail row
- patched portrait build: the sheet exposed every audio choice and remained selectable
- independently exercised the existing in-player track sheet with 24 subtitle rows in landscape; it scrolled to later rows without snapping back and accepted a selection
- iOS simulator build succeeded

The in-player scrolling/selection portion of the report was already addressed by #189. This PR fixes the remaining detail-page landscape presentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the playback selector’s presentation across different iPhone and iPad screen orientations.
  * The selector now automatically uses a popover or sheet layout based on available screen space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->