### PR TITLE
Improve tvOS card focus styling and restoration

### DIFF
--- a/iosApp/iosApp/Components/EpisodeThumbCard.swift
+++ b/iosApp/iosApp/Components/EpisodeThumbCard.swift
@@ -23,6 +23,9 @@ struct EpisodeThumbCard: View {
     @State private var playedOverride: Bool?
     @State private var uiCustomization = UICustomizationPreferences.shared
     @EnvironmentObject private var overlayStore: OverlayPrefsStore
+    #if os(tvOS)
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    #endif
     /// iOS 26 zoom transition namespace, shared from `MainTabView`. Lets the
     /// tapped thumbnail act as the `.matchedTransitionSource` for the zoom into
     /// the episode's item detail, keyed on `item.contentId`. `nil` (tvOS/macOS
@@ -43,7 +46,12 @@ struct EpisodeThumbCard: View {
     }
 
     #if os(tvOS)
-    @FocusState private var isFocused: Bool
+    @FocusState private var standaloneFocused: Bool
+
+    private var isFocused: Bool {
+        guard let focusedItemId else { return standaloneFocused }
+        return focusedItemId.wrappedValue == item.contentId
+    }
     #endif
 
     var body: some View {
@@ -320,14 +328,20 @@ struct EpisodeThumbCard: View {
     private var thumbnailButton: some View {
         let button = Button(action: action) {
             thumbnail
-                .tvFocusRing(
-                    isFocused: isFocused,
-                    cornerRadius: ContinuumTheme.cornerRadius
-                )
         }
-        .buttonStyle(TVCardFocusButtonStyle())
-        .focused($isFocused)
-        .applyRowFocus(focusedItemId, itemId: item.contentId)
+        .buttonStyle(.card)
+        .applyEpisodeFocus(
+            focusedItemId,
+            itemId: item.contentId,
+            standaloneBinding: $standaloneFocused
+        )
+        .scaleEffect(isFocused && !reduceMotion ? 1.025 : 1)
+        .shadow(
+            color: .black.opacity(isFocused ? 0.5 : 0.2),
+            radius: isFocused ? 20 : 8,
+            y: isFocused ? 10 : 4
+        )
+        .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: isFocused)
         .applyEpisodePlayPauseAction(playAction)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityDescription)
@@ -392,17 +406,18 @@ private extension View {
         }
     }
 
-    /// Mirrors `MediaCard.applyRowFocus` so episode thumbs participate
-    /// in the row's `defaultFocus(... priority: .userInitiated)` mechanism.
+    /// A card must have one focus binding. Inside a managed row, that binding
+    /// is the row's item ID; standalone usage falls back to a local Boolean.
     @ViewBuilder
-    func applyRowFocus(
+    func applyEpisodeFocus(
         _ binding: FocusState<String?>.Binding?,
-        itemId: String?
+        itemId: String,
+        standaloneBinding: FocusState<Bool>.Binding
     ) -> some View {
-        if let binding, let itemId {
+        if let binding {
             self.focused(binding, equals: itemId)
         } else {
-            self
+            self.focused(standaloneBinding)
         }
     }
 }

--- a/iosApp/iosApp/Components/EpisodeThumbCard.swift
+++ b/iosApp/iosApp/Components/EpisodeThumbCard.swift
@@ -320,8 +320,12 @@ struct EpisodeThumbCard: View {
     private var thumbnailButton: some View {
         let button = Button(action: action) {
             thumbnail
+                .tvFocusRing(
+                    isFocused: isFocused,
+                    cornerRadius: ContinuumTheme.cornerRadius
+                )
         }
-        .buttonStyle(.card)
+        .buttonStyle(TVCardFocusButtonStyle())
         .focused($isFocused)
         .applyRowFocus(focusedItemId, itemId: item.contentId)
         .applyEpisodePlayPauseAction(playAction)

--- a/iosApp/iosApp/Components/MediaCard.swift
+++ b/iosApp/iosApp/Components/MediaCard.swift
@@ -519,7 +519,12 @@ private struct FocusableMediaCard<Content: View>: View {
     let personalItems: PersonalListMenuItems?
     @ViewBuilder var content: () -> Content
 
-    @FocusState private var isFocused: Bool
+    @FocusState private var standaloneFocused: Bool
+
+    private var isFocused: Bool {
+        guard let focusedItemId, let itemId else { return standaloneFocused }
+        return focusedItemId.wrappedValue == itemId
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 22) {
@@ -558,8 +563,11 @@ private struct FocusableMediaCard<Content: View>: View {
             content()
         }
         .buttonStyle(.card)
-        .focused($isFocused)
-        .applyRowFocus(focusedItemId, itemId: itemId)
+        .applyCardFocus(
+            focusedItemId,
+            itemId: itemId,
+            standaloneBinding: $standaloneFocused
+        )
         .applyPlayPauseAction(playAction)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityDescription)
@@ -630,19 +638,18 @@ private extension View {
         }
     }
 
-    /// Conditionally binds this view to the parent row's `@FocusState`
-    /// so `defaultFocus(... priority: .userInitiated)` upstream can land
-    /// focus on it. No-op when either argument is nil (e.g., on iOS or
-    /// when this card isn't inside a row that manages focus).
+    /// Use exactly one focus binding: the parent row's item ID when managed,
+    /// otherwise the card's local Boolean for standalone grids.
     @ViewBuilder
-    func applyRowFocus(
+    func applyCardFocus(
         _ binding: FocusState<String?>.Binding?,
-        itemId: String?
+        itemId: String?,
+        standaloneBinding: FocusState<Bool>.Binding
     ) -> some View {
         if let binding, let itemId {
             self.focused(binding, equals: itemId)
         } else {
-            self
+            self.focused(standaloneBinding)
         }
     }
 }

--- a/iosApp/iosApp/Components/MediaRow.swift
+++ b/iosApp/iosApp/Components/MediaRow.swift
@@ -62,6 +62,11 @@ struct MediaRow: View {
     /// Down at the row's boundary — used by the Skyline section pager to
     /// page to the next section (there is no row geometrically below).
     var onMoveDown: (() -> Void)? = nil
+    /// tvOS-only ownership gate for focus restoration after membership
+    /// mutations. The host keeps this true while this row owns focus (including
+    /// its context-menu flow) and clears it when focus moves to chrome or a
+    /// different row.
+    var focusRestorationOwner: Binding<Bool>? = nil
 
     @FocusState private var focusedItemId: String?
     #if os(tvOS)
@@ -100,6 +105,10 @@ struct MediaRow: View {
         }
         .onChange(of: items.map(\.contentId)) { oldIds, newIds in
             restoreFocusAfterItemRemoval(from: oldIds, to: newIds)
+        }
+        .onChange(of: focusRestorationOwner?.wrappedValue ?? false) { _, ownsRestoration in
+            guard !ownsRestoration else { return }
+            focusRestorationGeneration += 1
         }
         #endif
     }
@@ -149,7 +158,8 @@ struct MediaRow: View {
     /// position and claim the card that slid into that slot, falling back to
     /// the preceding card when the removed item was last.
     private func restoreFocusAfterItemRemoval(from oldIds: [String], to newIds: [String]) {
-        guard let removedId = lastFocusedItemId,
+        guard focusRestorationOwner?.wrappedValue == true,
+              let removedId = lastFocusedItemId,
               let removedIndex = oldIds.firstIndex(of: removedId),
               !newIds.contains(removedId),
               !newIds.isEmpty else { return }
@@ -177,6 +187,7 @@ struct MediaRow: View {
     ) {
         DispatchQueue.main.asyncAfter(deadline: .now() + (attempt == 0 ? 0 : 0.08)) {
             guard generation == focusRestorationGeneration,
+                  focusRestorationOwner?.wrappedValue == true,
                   focusedItemId == nil || focusedItemId == removedId else { return }
 
             focusedItemId = replacementId
@@ -185,6 +196,7 @@ struct MediaRow: View {
             guard attempt < 8 else { return }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
                 guard generation == focusRestorationGeneration,
+                      focusRestorationOwner?.wrappedValue == true,
                       focusedItemId != replacementId else { return }
                 Self.focusLogger.debug(
                     "mediaRow.reclaimReplacementFocus attempt=\(attempt + 1, privacy: .public)"

--- a/iosApp/iosApp/Components/MediaRow.swift
+++ b/iosApp/iosApp/Components/MediaRow.swift
@@ -70,6 +70,11 @@ struct MediaRow: View {
     /// identity per page, so the kick has to land on `onAppear`, not only
     /// on a `focusRequest` change).
     @State private var lastAppliedFocusRequest = 0
+    /// Survives the brief nil produced when a context menu dismisses or its
+    /// focused card is removed, so a membership refresh can hand focus to a
+    /// neighboring card instead of leaving the row without an owner.
+    @State private var lastFocusedItemId: String?
+    @State private var focusRestorationGeneration = 0
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     private static let focusLogger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "com.continuum.app",
@@ -89,8 +94,12 @@ struct MediaRow: View {
         .onChange(of: focusedItemId) { _, newValue in
             guard let newValue,
                   let item = items.first(where: { $0.contentId == newValue }) else { return }
+            lastFocusedItemId = newValue
             Self.focusLogger.debug("mediaRow.focus changed")
             onItemFocus?(item)
+        }
+        .onChange(of: items.map(\.contentId)) { oldIds, newIds in
+            restoreFocusAfterItemRemoval(from: oldIds, to: newIds)
         }
         #endif
     }
@@ -123,6 +132,7 @@ struct MediaRow: View {
     /// a different value — retry until the scroll settles and ours is last.
     private func claimFirstItemFocus(_ firstItem: SectionItem, attempt: Int = 0) {
         focusedItemId = firstItem.contentId
+        lastFocusedItemId = firstItem.contentId
         onItemFocus?(firstItem)
         // Window must outlast the ~300ms animated ride home plus the engine's
         // settling repairs, or the last mid-flight repair wins after all.
@@ -131,6 +141,61 @@ struct MediaRow: View {
             guard focusedItemId != firstItem.contentId else { return }
             Self.focusLogger.debug("mediaRow.reclaimFocus attempt=\(attempt + 1, privacy: .public)")
             claimFirstItemFocus(firstItem, attempt: attempt + 1)
+        }
+    }
+
+    /// Context-menu mutations can immediately remove the focused card from a
+    /// membership-driven row (Continue Watching, Next Up). Preserve its old
+    /// position and claim the card that slid into that slot, falling back to
+    /// the preceding card when the removed item was last.
+    private func restoreFocusAfterItemRemoval(from oldIds: [String], to newIds: [String]) {
+        guard let removedId = lastFocusedItemId,
+              let removedIndex = oldIds.firstIndex(of: removedId),
+              !newIds.contains(removedId),
+              !newIds.isEmpty else { return }
+
+        let replacementId = newIds[min(removedIndex, newIds.count - 1)]
+        focusRestorationGeneration += 1
+        let generation = focusRestorationGeneration
+        Self.focusLogger.debug("mediaRow.restoreFocus after removal")
+        claimReplacementFocus(
+            replacementId,
+            removedId: removedId,
+            generation: generation
+        )
+    }
+
+    /// Defer until the refreshed LazyHStack has mounted the replacement, then
+    /// verify on a later turn after the focus engine has processed the write.
+    /// A bounded retry covers the context-menu dismissal repair without
+    /// fighting a legitimate focus move to another card.
+    private func claimReplacementFocus(
+        _ replacementId: String,
+        removedId: String,
+        generation: Int,
+        attempt: Int = 0
+    ) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + (attempt == 0 ? 0 : 0.08)) {
+            guard generation == focusRestorationGeneration,
+                  focusedItemId == nil || focusedItemId == removedId else { return }
+
+            focusedItemId = replacementId
+            lastFocusedItemId = replacementId
+
+            guard attempt < 8 else { return }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
+                guard generation == focusRestorationGeneration,
+                      focusedItemId != replacementId else { return }
+                Self.focusLogger.debug(
+                    "mediaRow.reclaimReplacementFocus attempt=\(attempt + 1, privacy: .public)"
+                )
+                claimReplacementFocus(
+                    replacementId,
+                    removedId: removedId,
+                    generation: generation,
+                    attempt: attempt + 1
+                )
+            }
         }
     }
     #endif

--- a/iosApp/iosApp/Screens/Home/SectionRow.swift
+++ b/iosApp/iosApp/Screens/Home/SectionRow.swift
@@ -29,6 +29,8 @@ struct SectionRow: View {
     var cardVerticalPadding: CGFloat? = nil
     /// Down at the row boundary — forwarded to `MediaRow` for the section pager.
     var onMoveDown: (() -> Void)? = nil
+    /// Live tvOS ownership gate for context-menu focus restoration.
+    var focusRestorationOwner: Binding<Bool>? = nil
 
     #if os(tvOS)
     @Environment(AppRouter.self) private var router
@@ -102,7 +104,8 @@ struct SectionRow: View {
             onItemFocus: onItemFocus,
             cardWidth: cardWidth,
             cardVerticalPadding: cardVerticalPadding,
-            onMoveDown: onMoveDown
+            onMoveDown: onMoveDown,
+            focusRestorationOwner: focusRestorationOwner
         )
     }
 

--- a/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
+++ b/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
@@ -45,6 +45,9 @@ struct TVSkylineSectionFeed: View {
     /// async, so the initial hand-down would land on nothing.
     @State private var pendingFocusRequest: Int?
     @State private var lastAppliedRequest = 0
+    /// The row that owns card focus or its context-menu dismissal flow. Unlike
+    /// the marquee preview, this is cleared when focus moves into chrome.
+    @State private var focusRestorationOwnerSectionId: String?
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -78,6 +81,11 @@ struct TVSkylineSectionFeed: View {
             requestEntryFocus(focusRequest)
         }
         .onChange(of: focusRequest) { _, request in requestEntryFocus(request) }
+        .onChange(of: isTopMenuFocused) { _, isFocused in
+            if isFocused {
+                focusRestorationOwnerSectionId = nil
+            }
+        }
         // Rows mount only after the async section load; a deferred entry
         // token re-fires once they exist.
         .onChange(of: sections.map(\.id)) { _, _ in
@@ -150,11 +158,16 @@ struct TVSkylineSectionFeed: View {
             focusRequest: isFirstRow ? contentFocusToken : 0,
             onMoveUp: isFirstRow ? onTopMenuFocusRequest : nil,
             onItemFocus: { item in
+                focusRestorationOwnerSectionId = section.id
                 previewFocusedItem(item, in: section)
             },
             cardWidth: ContinuumTheme.Skyline.densePosterCardWidth,
             cardVerticalPadding: ContinuumTheme.Skyline.rowBandCardVerticalPadding,
-            onMoveDown: nil
+            onMoveDown: nil,
+            focusRestorationOwner: Binding(
+                get: { focusRestorationOwnerSectionId == section.id },
+                set: { _ in }
+            )
         )
     }
 

--- a/iosApp/iosApp/tvOS/Screens/Components/TVCardFocusStyle.swift
+++ b/iosApp/iosApp/tvOS/Screens/Components/TVCardFocusStyle.swift
@@ -1,0 +1,76 @@
+#if os(tvOS)
+import SwiftUI
+
+struct TVCardFocusButtonStyle: ButtonStyle {
+    var scale: CGFloat = 1.05
+    var focusedShadowOpacity: Double = 0.45
+    var focusedShadowRadius: CGFloat = 18
+    var focusedShadowY: CGFloat = 8
+    var unfocusedShadowOpacity: Double = 0.3
+    var unfocusedShadowRadius: CGFloat = 8
+    var unfocusedShadowY: CGFloat = 4
+
+    func makeBody(configuration: Configuration) -> some View {
+        TVCardFocusButtonStyleBody(
+            configuration: configuration,
+            focusedScale: scale,
+            focusedShadowOpacity: focusedShadowOpacity,
+            focusedShadowRadius: focusedShadowRadius,
+            focusedShadowY: focusedShadowY,
+            unfocusedShadowOpacity: unfocusedShadowOpacity,
+            unfocusedShadowRadius: unfocusedShadowRadius,
+            unfocusedShadowY: unfocusedShadowY
+        )
+    }
+}
+
+private struct TVCardFocusButtonStyleBody: View {
+    let configuration: ButtonStyleConfiguration
+    let focusedScale: CGFloat
+    let focusedShadowOpacity: Double
+    let focusedShadowRadius: CGFloat
+    let focusedShadowY: CGFloat
+    let unfocusedShadowOpacity: Double
+    let unfocusedShadowRadius: CGFloat
+    let unfocusedShadowY: CGFloat
+
+    @Environment(\.isFocused) private var isFocused
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        configuration.label
+            .scaleEffect(currentScale)
+            .shadow(
+                color: .black.opacity(isFocused ? focusedShadowOpacity : unfocusedShadowOpacity),
+                radius: isFocused ? focusedShadowRadius : unfocusedShadowRadius,
+                y: isFocused ? focusedShadowY : unfocusedShadowY
+            )
+            .focusEffectDisabled()
+            .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: isFocused)
+            .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: configuration.isPressed)
+    }
+
+    private var currentScale: CGFloat {
+        guard !reduceMotion else { return 1 }
+        let base = isFocused ? focusedScale : 1
+        return configuration.isPressed ? base * 0.97 : base
+    }
+}
+
+extension View {
+    func tvFocusRing(
+        isFocused: Bool,
+        cornerRadius: CGFloat,
+        lineWidth: CGFloat = 3
+    ) -> some View {
+        overlay(
+            RoundedRectangle(cornerRadius: cornerRadius)
+                .stroke(
+                    Color.white.opacity(isFocused ? 0.9 : 0),
+                    lineWidth: isFocused ? lineWidth : 0
+                )
+        )
+        .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: isFocused)
+    }
+}
+#endif

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVDetailCastRail.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVDetailCastRail.swift
@@ -64,7 +64,17 @@ private struct TVCastCard: View {
         } label: {
             CastCardLabel(member: member, photoSize: photoSize)
         }
-        .buttonStyle(CastCardStyle(photoSize: photoSize))
+        .buttonStyle(
+            TVCardFocusButtonStyle(
+                scale: 1.05,
+                focusedShadowOpacity: 0.35,
+                focusedShadowRadius: 14,
+                focusedShadowY: 6,
+                unfocusedShadowOpacity: 0,
+                unfocusedShadowRadius: 0,
+                unfocusedShadowY: 0
+            )
+        )
     }
 }
 
@@ -123,36 +133,4 @@ private struct CastCardLabel: View {
     }
 }
 
-/// Custom style so the system doesn't paint its default focus halo on
-/// top. Scale + shadow only — the portrait ring handles the focus cue.
-private struct CastCardStyle: ButtonStyle {
-    let photoSize: CGSize
-
-    func makeBody(configuration: Configuration) -> some View {
-        CastCardBody(configuration: configuration)
-    }
-}
-
-private struct CastCardBody: View {
-    let configuration: ButtonStyleConfiguration
-
-    @Environment(\.isFocused) private var isFocused
-
-    var body: some View {
-        configuration.label
-            .scaleEffect(scale)
-            .shadow(
-                color: .black.opacity(isFocused ? 0.35 : 0.0),
-                radius: isFocused ? 14 : 0,
-                y: isFocused ? 6 : 0
-            )
-            .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: isFocused)
-            .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: configuration.isPressed)
-    }
-
-    private var scale: CGFloat {
-        let base: CGFloat = isFocused ? 1.05 : 1.0
-        return configuration.isPressed ? base * 0.97 : base
-    }
-}
 #endif

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
@@ -121,7 +121,7 @@ struct TVEpisodeCard: View {
                 captionStyle: captionStyle
             )
         }
-        .buttonStyle(EpisodeCardStyle())
+        .buttonStyle(TVCardFocusButtonStyle())
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityDescription)
 
@@ -344,22 +344,14 @@ private struct EpisodeCardLabel: View {
         }
         .frame(width: cardWidth, height: stillHeight)
         .clipShape(RoundedRectangle(cornerRadius: stillCornerRadius))
+        .tvFocusRing(isFocused: isFocused, cornerRadius: stillCornerRadius)
         .overlay(
             RoundedRectangle(cornerRadius: stillCornerRadius)
-                .stroke(borderColor, lineWidth: borderWidth)
+                .stroke(
+                    Color.white.opacity(isCurrent && !isFocused ? 0.7 : 0),
+                    lineWidth: isCurrent && !isFocused ? 2 : 0
+                )
         )
-    }
-
-    private var borderColor: Color {
-        if isFocused { return Color.white.opacity(0.9) }
-        if isCurrent { return Color.white.opacity(0.7) }
-        return .clear
-    }
-
-    private var borderWidth: CGFloat {
-        if isFocused { return 3 }
-        if isCurrent { return 2 }
-        return 0
     }
 
     private var watchedBadge: some View {
@@ -405,35 +397,4 @@ private struct EpisodeCardLabel: View {
     }
 }
 
-/// Custom style so the system doesn't paint its default focus halo over
-/// the card. Scale + drop shadow only; the white overlay ring on the
-/// still (driven by `isFocused` in the label) is the focus cue.
-private struct EpisodeCardStyle: ButtonStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        EpisodeCardStyleBody(configuration: configuration)
-    }
-}
-
-private struct EpisodeCardStyleBody: View {
-    let configuration: ButtonStyleConfiguration
-
-    @Environment(\.isFocused) private var isFocused
-
-    var body: some View {
-        configuration.label
-            .scaleEffect(scale)
-            .shadow(
-                color: .black.opacity(isFocused ? 0.45 : 0.3),
-                radius: isFocused ? 18 : 8,
-                y: isFocused ? 8 : 4
-            )
-            .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: isFocused)
-            .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: configuration.isPressed)
-    }
-
-    private var scale: CGFloat {
-        let base: CGFloat = isFocused ? 1.04 : 1.0
-        return configuration.isPressed ? base * 0.97 : base
-    }
-}
 #endif

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVTrailersRail.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVTrailersRail.swift
@@ -100,7 +100,7 @@ private struct TVTrailerCard: View {
                 thumbCornerRadius: thumbCornerRadius
             )
         }
-        .buttonStyle(TrailerCardStyle())
+        .buttonStyle(TVCardFocusButtonStyle())
     }
 }
 
@@ -178,10 +178,7 @@ private struct TrailerCardLabel: View {
         }
         .frame(width: cardWidth, height: thumbHeight)
         .clipShape(RoundedRectangle(cornerRadius: thumbCornerRadius))
-        .overlay(
-            RoundedRectangle(cornerRadius: thumbCornerRadius)
-                .stroke(Color.white.opacity(isFocused ? 0.9 : 0), lineWidth: isFocused ? 3 : 0)
-        )
+        .tvFocusRing(isFocused: isFocused, cornerRadius: thumbCornerRadius)
     }
 
     /// YouTube stills exist for every remote video; local extras have no
@@ -217,39 +214,6 @@ private struct TrailerCardLabel: View {
                 .foregroundColor(.white)
         }
         .shadow(color: .black.opacity(0.35), radius: 8, y: 3)
-    }
-}
-
-/// Custom style so the system doesn't paint its default focus halo over
-/// the card. Scale + drop shadow only; the white ring on the thumbnail
-/// (driven by `isFocused` in the label) is the focus cue — matching
-/// `TVEpisodeCard`.
-private struct TrailerCardStyle: ButtonStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        TrailerCardStyleBody(configuration: configuration)
-    }
-}
-
-private struct TrailerCardStyleBody: View {
-    let configuration: ButtonStyleConfiguration
-
-    @Environment(\.isFocused) private var isFocused
-
-    var body: some View {
-        configuration.label
-            .scaleEffect(scale)
-            .shadow(
-                color: .black.opacity(isFocused ? 0.45 : 0.3),
-                radius: isFocused ? 18 : 8,
-                y: isFocused ? 8 : 4
-            )
-            .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: isFocused)
-            .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: configuration.isPressed)
-    }
-
-    private var scale: CGFloat {
-        let base: CGFloat = isFocused ? 1.04 : 1.0
-        return configuration.isPressed ? base * 0.97 : base
     }
 }
 


### PR DESCRIPTION
## Summary

- consolidate custom focus styling used by tvOS detail-rail cards
- restore the native tvOS card hover treatment for episode thumbnails, with a slightly stronger scale and depth shadow
- give each card a single focus binding so logical focus and visual hover state cannot diverge
- move focus to the nearest surviving card when a watched-state refresh removes the focused item

## Validation

- signed `SiloTV` physical-device build succeeded
- installed and launched on a physical Apple TV; running process verified
- Appium D-pad movement produced a visible focus-state change on the device
- marking an item watched restored the visible hover effect on the replacement card during physical-device testing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved tvOS card focus visuals with consistent scaling, shadows, press feedback, focus rings, animations, and reduced-motion support.
  - Restores focus to an appropriate replacement card when content is removed from a media row.
  - Preserves standalone card focus behavior when cards are not part of a managed row.
- **Bug Fixes**
  - Improved focus ownership and restoration across sections, context menus, and top-level navigation.
  - Standardized focus behavior across episode, cast, trailer, and media cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->