### PR TITLE
feat(playback): surface server tone mapping metadata

### DIFF
--- a/iosApp/Tests/AetherPlaybackStatsProjectionTests.swift
+++ b/iosApp/Tests/AetherPlaybackStatsProjectionTests.swift
@@ -161,6 +161,29 @@ final class AetherPlaybackStatsProjectionTests: XCTestCase {
         XCTAssertFalse(stats.engineRows.contains { $0.0 == "Producer restarts" })
     }
 
+    func testServerToneMapPlanPreservesOriginalDynamicRangeInStats() {
+        let stats = AetherPlaybackStatsProjection.make(
+            snapshot: AetherPlaybackStatsSnapshot(
+                route: .remoteBypass,
+                phase: .playing,
+                sourceVideoFormat: .sdr,
+                outputVideoFormat: .sdr,
+                sourceVideoWidth: 1_920,
+                sourceVideoHeight: 1_080
+            ),
+            source: AetherPlaybackStatsSourceMetadata(
+                sourceURL: URL(string: "https://media.example.test/transcode/master.m3u8"),
+                delivery: PlaybackProtocolV3.PlanDelivery.transcodeHLS,
+                container: "hls",
+                playbackRate: 1,
+                plannedSourceDynamicRange: "hdr10",
+                plannedOutputDynamicRange: "sdr"
+            )
+        )
+
+        XCTAssertEqual(stats.dynamicRange, "HDR10 → SDR")
+    }
+
     func testIdleSnapshotProducesNoSyntheticEngineRows() {
         let stats = AetherPlaybackStatsProjection.make(
             snapshot: AetherPlaybackStatsSnapshot(route: .none, phase: .idle),

--- a/iosApp/Tests/Fixtures/PlaybackV3/SOURCE
+++ b/iosApp/Tests/Fixtures/PlaybackV3/SOURCE
@@ -1,7 +1,7 @@
 Source: silo-server internal/playback/testdata/protocol_v3
 Server ref: main
-Server commit: 820eef7792d24e2b5af789e448906481bd560296
-Vendored: 2026-08-23
+Server commit: 745b767f73088309953972de9ea23f33d854496e
+Vendored: 2026-08-25
 
 All nine files come from internal/playback/testdata/protocol_v3. Six of them are
 also published byte-identically under docs/design/schemas/playback-v3/v3/fixtures/valid;

--- a/iosApp/Tests/Fixtures/PlaybackV3/attempt_keys.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/attempt_keys.json
@@ -1,10 +1,10 @@
 [
   {
     "name": "hls_burn_in_sorted_transformations_and_pcm_mutations",
-    "server_plan_attempt_key": "v3:a90828494166fe72",
-    "replan_echo": "v3:a90828494166fe72",
+    "server_plan_attempt_key": "v3:27ee8bdc3ff5b1d7",
+    "replan_echo": "v3:27ee8bdc3ff5b1d7",
     "attempted_plan_keys": [
-      "v3:a90828494166fe72"
+      "v3:27ee8bdc3ff5b1d7"
     ],
     "expected_server_action": "reject_already_attempted_plan"
   },

--- a/iosApp/Tests/Fixtures/PlaybackV3/capability_response.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/capability_response.json
@@ -28,9 +28,18 @@
     {
       "name": "audio_to_aac",
       "executor": "server",
-      "recipe_version": "1",
+      "recipe_version": "2",
       "validated_claims": [
         "audio_decode"
+      ]
+    },
+    {
+      "name": "hdr_to_sdr_tonemap",
+      "executor": "server",
+      "recipe_version": "1",
+      "validated_claims": [
+        "hdr_metadata_removed",
+        "sdr_bt709_output"
       ]
     },
     {

--- a/iosApp/Tests/Fixtures/PlaybackV3/conformance_matrix.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/conformance_matrix.json
@@ -175,8 +175,8 @@
         "outcome": "playable",
         "delivery": "server_transcode_hls",
         "decision_reason": "quality_original",
-        "plan_id": "plan:7b3b4cdf37a1a1084395bc810c9ac179",
-        "plan_attempt_key": "v3:5f2c9f8566a979cc",
+        "plan_id": "plan:1496ada4f9ff74754e2f14031f86fb21",
+        "plan_attempt_key": "v3:4db9d7afc07c1655",
         "selected_tracks": {
           "audio": {
             "id": "file:42:audio:0",
@@ -218,7 +218,7 @@
           {
             "name": "audio_to_aac",
             "executor": "server",
-            "recipe_version": "1",
+            "recipe_version": "2",
             "validated_claims": [
               "audio_decode"
             ]
@@ -232,13 +232,43 @@
             "preserves_source": true
           },
           {
-            "label": "720p",
+            "label": "1080p-medium",
+            "display_name": "1080p Medium",
+            "height": 1080,
+            "bitrate_kbps": 6000,
+            "preserves_source": false
+          },
+          {
+            "label": "1080p-low",
+            "display_name": "1080p Low",
+            "height": 1080,
+            "bitrate_kbps": 3000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-high",
+            "display_name": "720p High",
+            "height": 720,
+            "bitrate_kbps": 4000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-medium",
+            "display_name": "720p Medium",
             "height": 720,
             "bitrate_kbps": 2000,
             "preserves_source": false
           },
           {
+            "label": "720p-low",
+            "display_name": "720p Low",
+            "height": 720,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          },
+          {
             "label": "480p",
+            "display_name": "480p",
             "height": 480,
             "bitrate_kbps": 1500,
             "preserves_source": false
@@ -459,13 +489,43 @@
             "preserves_source": true
           },
           {
-            "label": "720p",
+            "label": "1080p-medium",
+            "display_name": "1080p Medium",
+            "height": 1080,
+            "bitrate_kbps": 6000,
+            "preserves_source": false
+          },
+          {
+            "label": "1080p-low",
+            "display_name": "1080p Low",
+            "height": 1080,
+            "bitrate_kbps": 3000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-high",
+            "display_name": "720p High",
+            "height": 720,
+            "bitrate_kbps": 4000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-medium",
+            "display_name": "720p Medium",
             "height": 720,
             "bitrate_kbps": 2000,
             "preserves_source": false
           },
           {
+            "label": "720p-low",
+            "display_name": "720p Low",
+            "height": 720,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          },
+          {
             "label": "480p",
+            "display_name": "480p",
             "height": 480,
             "bitrate_kbps": 1500,
             "preserves_source": false
@@ -667,13 +727,43 @@
             "preserves_source": true
           },
           {
-            "label": "720p",
+            "label": "1080p-medium",
+            "display_name": "1080p Medium",
+            "height": 1080,
+            "bitrate_kbps": 6000,
+            "preserves_source": false
+          },
+          {
+            "label": "1080p-low",
+            "display_name": "1080p Low",
+            "height": 1080,
+            "bitrate_kbps": 3000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-high",
+            "display_name": "720p High",
+            "height": 720,
+            "bitrate_kbps": 4000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-medium",
+            "display_name": "720p Medium",
             "height": 720,
             "bitrate_kbps": 2000,
             "preserves_source": false
           },
           {
+            "label": "720p-low",
+            "display_name": "720p Low",
+            "height": 720,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          },
+          {
             "label": "480p",
+            "display_name": "480p",
             "height": 480,
             "bitrate_kbps": 1500,
             "preserves_source": false
@@ -875,13 +965,43 @@
             "preserves_source": true
           },
           {
-            "label": "720p",
+            "label": "1080p-medium",
+            "display_name": "1080p Medium",
+            "height": 1080,
+            "bitrate_kbps": 6000,
+            "preserves_source": false
+          },
+          {
+            "label": "1080p-low",
+            "display_name": "1080p Low",
+            "height": 1080,
+            "bitrate_kbps": 3000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-high",
+            "display_name": "720p High",
+            "height": 720,
+            "bitrate_kbps": 4000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-medium",
+            "display_name": "720p Medium",
             "height": 720,
             "bitrate_kbps": 2000,
             "preserves_source": false
           },
           {
+            "label": "720p-low",
+            "display_name": "720p Low",
+            "height": 720,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          },
+          {
             "label": "480p",
+            "display_name": "480p",
             "height": 480,
             "bitrate_kbps": 1500,
             "preserves_source": false
@@ -1086,13 +1206,43 @@
             "preserves_source": true
           },
           {
-            "label": "720p",
+            "label": "1080p-medium",
+            "display_name": "1080p Medium",
+            "height": 1080,
+            "bitrate_kbps": 6000,
+            "preserves_source": false
+          },
+          {
+            "label": "1080p-low",
+            "display_name": "1080p Low",
+            "height": 1080,
+            "bitrate_kbps": 3000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-high",
+            "display_name": "720p High",
+            "height": 720,
+            "bitrate_kbps": 4000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-medium",
+            "display_name": "720p Medium",
             "height": 720,
             "bitrate_kbps": 2000,
             "preserves_source": false
           },
           {
+            "label": "720p-low",
+            "display_name": "720p Low",
+            "height": 720,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          },
+          {
             "label": "480p",
+            "display_name": "480p",
             "height": 480,
             "bitrate_kbps": 1500,
             "preserves_source": false
@@ -1298,13 +1448,43 @@
             "preserves_source": true
           },
           {
-            "label": "720p",
+            "label": "1080p-medium",
+            "display_name": "1080p Medium",
+            "height": 1080,
+            "bitrate_kbps": 6000,
+            "preserves_source": false
+          },
+          {
+            "label": "1080p-low",
+            "display_name": "1080p Low",
+            "height": 1080,
+            "bitrate_kbps": 3000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-high",
+            "display_name": "720p High",
+            "height": 720,
+            "bitrate_kbps": 4000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-medium",
+            "display_name": "720p Medium",
             "height": 720,
             "bitrate_kbps": 2000,
             "preserves_source": false
           },
           {
+            "label": "720p-low",
+            "display_name": "720p Low",
+            "height": 720,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          },
+          {
             "label": "480p",
+            "display_name": "480p",
             "height": 480,
             "bitrate_kbps": 1500,
             "preserves_source": false
@@ -1467,8 +1647,8 @@
         "outcome": "playable",
         "delivery": "server_transcode_hls",
         "decision_reason": "quality_fixed_rung",
-        "plan_id": "plan:36db80a93b9d295f44c2c3be6a7cb0ce",
-        "plan_attempt_key": "v3:aad5ccea009fea2a",
+        "plan_id": "plan:e8ddb06ffa481d3561b07cef06a91ec5",
+        "plan_attempt_key": "v3:4830f767fa704f38",
         "selected_tracks": {
           "audio": {
             "id": "file:42:audio:0",
@@ -1510,7 +1690,7 @@
           {
             "name": "audio_to_aac",
             "executor": "server",
-            "recipe_version": "1",
+            "recipe_version": "2",
             "validated_claims": [
               "audio_decode"
             ]
@@ -1524,13 +1704,43 @@
             "preserves_source": true
           },
           {
-            "label": "720p",
+            "label": "1080p-medium",
+            "display_name": "1080p Medium",
+            "height": 1080,
+            "bitrate_kbps": 6000,
+            "preserves_source": false
+          },
+          {
+            "label": "1080p-low",
+            "display_name": "1080p Low",
+            "height": 1080,
+            "bitrate_kbps": 3000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-high",
+            "display_name": "720p High",
+            "height": 720,
+            "bitrate_kbps": 4000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-medium",
+            "display_name": "720p Medium",
             "height": 720,
             "bitrate_kbps": 2000,
             "preserves_source": false
           },
           {
+            "label": "720p-low",
+            "display_name": "720p Low",
+            "height": 720,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          },
+          {
             "label": "480p",
+            "display_name": "480p",
             "height": 480,
             "bitrate_kbps": 1500,
             "preserves_source": false
@@ -1969,6 +2179,319 @@
             "height": 2160,
             "bitrate_kbps": 60000,
             "preserves_source": true
+          }
+        ]
+      }
+    },
+    {
+      "name": "hdr10_to_sdr_tone_map",
+      "category": "hdr_dv_matrix",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "file_id": 42,
+        "profile_id": "profile-1",
+        "playback_attempt_id": "attempt-hdr10-tone-map",
+        "quality_preference": "1080p",
+        "subtitle_fidelity_preference": "compatible",
+        "start_position": 12.5,
+        "progress_persistence": "client",
+        "audio_track_id": "file:42:audio:0",
+        "audio_track_index": 0,
+        "metered": false,
+        "client_capabilities": {
+          "video_evidence": "exact",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "hevc"
+          ],
+          "codecs_video_hardware": [
+            "hevc"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mkv"
+          ],
+          "max_resolution": "1080p",
+          "hdr": false,
+          "video_decode": [
+            {
+              "codec": "hevc",
+              "profiles": [
+                "main 10"
+              ],
+              "levels": [
+                41
+              ],
+              "bit_depths": [
+                8
+              ],
+              "max_width": 1920,
+              "max_height": 1080,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 20000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "fixture"
+          },
+          "output": {
+            "output_context_id": "output-a"
+          },
+          "deliveries": {
+            "hls": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "hls"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mkv",
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "progressive": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "source": {
+        "media_file_id": 42,
+        "duration_seconds": 7200,
+        "container": "mkv",
+        "video_codec": "hevc",
+        "video_profile": "main 10",
+        "video_level": 153,
+        "bit_depth": 10,
+        "color_range": "tv",
+        "width": 3840,
+        "height": 2160,
+        "frame_rate": 23.976023976023978,
+        "bitrate_kbps": 60000,
+        "dynamic_range": "hdr10",
+        "hdr10_plus": false,
+        "dv_enhancement_layer": "none",
+        "audio_codec": "aac",
+        "audio_channels": 2,
+        "audio_layout": "stereo"
+      },
+      "expected": {
+        "outcome": "playable",
+        "delivery": "server_transcode_hls",
+        "decision_reason": "quality_fixed_rung",
+        "plan_id": "plan:23105e95d0363c4627ab0f60ed0bfa96",
+        "plan_attempt_key": "v3:8a4c0deb6795be69",
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:0",
+            "index": 0
+          }
+        },
+        "subtitle": {
+          "mode": "off",
+          "inventory": []
+        },
+        "claims": {
+          "video": {
+            "hdr10": false,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision": false
+          },
+          "audio": {
+            "codec": "aac",
+            "passthrough": false,
+            "atmos_preserved": false,
+            "reason": "server_audio_adaptation"
+          },
+          "subtitles": {
+            "ass_styling_preserved": false,
+            "bitmap_overlay": false,
+            "bitmap_sidecar": false
+          }
+        },
+        "transformations": [
+          {
+            "name": "video_to_h264",
+            "executor": "server",
+            "recipe_version": "2",
+            "validated_claims": [
+              "h264_decode"
+            ]
+          },
+          {
+            "name": "audio_to_aac",
+            "executor": "server",
+            "recipe_version": "2",
+            "validated_claims": [
+              "audio_decode"
+            ]
+          },
+          {
+            "name": "hdr_to_sdr_tonemap",
+            "executor": "server",
+            "recipe_version": "1",
+            "validated_claims": [
+              "hdr_metadata_removed",
+              "sdr_bt709_output"
+            ]
+          }
+        ],
+        "available_qualities": [
+          {
+            "label": "original",
+            "height": 2160,
+            "bitrate_kbps": 60000,
+            "preserves_source": true
+          },
+          {
+            "label": "2160p-high",
+            "display_name": "4K High",
+            "height": 2160,
+            "bitrate_kbps": 40000,
+            "preserves_source": false
+          },
+          {
+            "label": "2160p-medium",
+            "display_name": "4K Medium",
+            "height": 2160,
+            "bitrate_kbps": 20000,
+            "preserves_source": false
+          },
+          {
+            "label": "2160p-low",
+            "display_name": "4K Low",
+            "height": 2160,
+            "bitrate_kbps": 10000,
+            "preserves_source": false
+          },
+          {
+            "label": "1080p-high",
+            "display_name": "1080p High",
+            "height": 1080,
+            "bitrate_kbps": 10000,
+            "preserves_source": false
+          },
+          {
+            "label": "1080p-medium",
+            "display_name": "1080p Medium",
+            "height": 1080,
+            "bitrate_kbps": 6000,
+            "preserves_source": false
+          },
+          {
+            "label": "1080p-low",
+            "display_name": "1080p Low",
+            "height": 1080,
+            "bitrate_kbps": 3000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-high",
+            "display_name": "720p High",
+            "height": 720,
+            "bitrate_kbps": 4000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-medium",
+            "display_name": "720p Medium",
+            "height": 720,
+            "bitrate_kbps": 2000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-low",
+            "display_name": "720p Low",
+            "height": 720,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          },
+          {
+            "label": "480p",
+            "display_name": "480p",
+            "height": 480,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
           }
         ]
       }
@@ -2688,6 +3211,321 @@
       }
     },
     {
+      "name": "dolby_vision_7_id6_to_sdr_tone_map",
+      "category": "hdr_dv_matrix",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "file_id": 42,
+        "profile_id": "profile-1",
+        "playback_attempt_id": "attempt-dv7-id6-tone-map",
+        "quality_preference": "1080p",
+        "subtitle_fidelity_preference": "compatible",
+        "start_position": 12.5,
+        "progress_persistence": "client",
+        "audio_track_id": "file:42:audio:0",
+        "audio_track_index": 0,
+        "metered": false,
+        "client_capabilities": {
+          "video_evidence": "exact",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "hevc"
+          ],
+          "codecs_video_hardware": [
+            "hevc"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mkv"
+          ],
+          "max_resolution": "1080p",
+          "hdr": false,
+          "video_decode": [
+            {
+              "codec": "hevc",
+              "profiles": [
+                "main 10"
+              ],
+              "levels": [
+                41
+              ],
+              "bit_depths": [
+                8
+              ],
+              "max_width": 1920,
+              "max_height": 1080,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 20000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "fixture"
+          },
+          "output": {
+            "output_context_id": "output-a"
+          },
+          "deliveries": {
+            "hls": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "hls"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mkv",
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "progressive": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "source": {
+        "media_file_id": 42,
+        "duration_seconds": 7200,
+        "container": "mkv",
+        "video_codec": "hevc",
+        "video_profile": "main 10",
+        "video_level": 153,
+        "bit_depth": 10,
+        "color_range": "tv",
+        "width": 3840,
+        "height": 2160,
+        "frame_rate": 23.976023976023978,
+        "bitrate_kbps": 60000,
+        "dynamic_range": "dolby_vision",
+        "hdr10_plus": false,
+        "dolby_vision_profile": 7,
+        "dv_bl_compat_id": 6,
+        "dv_enhancement_layer": "unknown",
+        "audio_codec": "aac",
+        "audio_channels": 2,
+        "audio_layout": "stereo"
+      },
+      "expected": {
+        "outcome": "playable",
+        "delivery": "server_transcode_hls",
+        "decision_reason": "quality_fixed_rung",
+        "plan_id": "plan:48fee96902632f7f3b70e8e5dd0669f3",
+        "plan_attempt_key": "v3:f7602afa81a3eee0",
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:0",
+            "index": 0
+          }
+        },
+        "subtitle": {
+          "mode": "off",
+          "inventory": []
+        },
+        "claims": {
+          "video": {
+            "hdr10": false,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision": false
+          },
+          "audio": {
+            "codec": "aac",
+            "passthrough": false,
+            "atmos_preserved": false,
+            "reason": "server_audio_adaptation"
+          },
+          "subtitles": {
+            "ass_styling_preserved": false,
+            "bitmap_overlay": false,
+            "bitmap_sidecar": false
+          }
+        },
+        "transformations": [
+          {
+            "name": "video_to_h264",
+            "executor": "server",
+            "recipe_version": "2",
+            "validated_claims": [
+              "h264_decode"
+            ]
+          },
+          {
+            "name": "audio_to_aac",
+            "executor": "server",
+            "recipe_version": "2",
+            "validated_claims": [
+              "audio_decode"
+            ]
+          },
+          {
+            "name": "hdr_to_sdr_tonemap",
+            "executor": "server",
+            "recipe_version": "1",
+            "validated_claims": [
+              "hdr_metadata_removed",
+              "sdr_bt709_output"
+            ]
+          }
+        ],
+        "available_qualities": [
+          {
+            "label": "original",
+            "height": 2160,
+            "bitrate_kbps": 60000,
+            "preserves_source": true
+          },
+          {
+            "label": "2160p-high",
+            "display_name": "4K High",
+            "height": 2160,
+            "bitrate_kbps": 40000,
+            "preserves_source": false
+          },
+          {
+            "label": "2160p-medium",
+            "display_name": "4K Medium",
+            "height": 2160,
+            "bitrate_kbps": 20000,
+            "preserves_source": false
+          },
+          {
+            "label": "2160p-low",
+            "display_name": "4K Low",
+            "height": 2160,
+            "bitrate_kbps": 10000,
+            "preserves_source": false
+          },
+          {
+            "label": "1080p-high",
+            "display_name": "1080p High",
+            "height": 1080,
+            "bitrate_kbps": 10000,
+            "preserves_source": false
+          },
+          {
+            "label": "1080p-medium",
+            "display_name": "1080p Medium",
+            "height": 1080,
+            "bitrate_kbps": 6000,
+            "preserves_source": false
+          },
+          {
+            "label": "1080p-low",
+            "display_name": "1080p Low",
+            "height": 1080,
+            "bitrate_kbps": 3000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-high",
+            "display_name": "720p High",
+            "height": 720,
+            "bitrate_kbps": 4000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-medium",
+            "display_name": "720p Medium",
+            "height": 720,
+            "bitrate_kbps": 2000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-low",
+            "display_name": "720p Low",
+            "height": 720,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          },
+          {
+            "label": "480p",
+            "display_name": "480p",
+            "height": 480,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          }
+        ]
+      }
+    },
+    {
       "name": "truehd_audio_conversion",
       "category": "audio_matrix",
       "request": {
@@ -2874,8 +3712,8 @@
         "outcome": "playable",
         "delivery": "server_remux_progressive",
         "decision_reason": "audio_adaptation",
-        "plan_id": "plan:cccf704a0487d09d54a95b51d095c474",
-        "plan_attempt_key": "v3:8a79df3157b88939",
+        "plan_id": "plan:7ae72046390c9f41614fc8a0e7465089",
+        "plan_attempt_key": "v3:8e3e32c8e2e5b895",
         "selected_tracks": {
           "audio": {
             "id": "file:42:audio:0",
@@ -2909,7 +3747,7 @@
           {
             "name": "audio_to_aac",
             "executor": "server",
-            "recipe_version": "1",
+            "recipe_version": "2",
             "validated_claims": [
               "audio_decode"
             ]
@@ -3848,8 +4686,8 @@
         "outcome": "playable",
         "delivery": "server_transcode_hls",
         "decision_reason": "subtitle_burn_in_required",
-        "plan_id": "plan:67e9593ed921a129645e41427a081943",
-        "plan_attempt_key": "v3:4d2de636abf938b1",
+        "plan_id": "plan:3fbb45a597dbfeb7ec62888782109a50",
+        "plan_attempt_key": "v3:09c05142189931a3",
         "selected_tracks": {
           "audio": {
             "id": "file:42:audio:0",
@@ -3910,7 +4748,7 @@
           {
             "name": "audio_to_aac",
             "executor": "server",
-            "recipe_version": "1",
+            "recipe_version": "2",
             "validated_claims": [
               "audio_decode"
             ]
@@ -3924,13 +4762,43 @@
             "preserves_source": true
           },
           {
-            "label": "720p",
+            "label": "1080p-medium",
+            "display_name": "1080p Medium",
+            "height": 1080,
+            "bitrate_kbps": 6000,
+            "preserves_source": false
+          },
+          {
+            "label": "1080p-low",
+            "display_name": "1080p Low",
+            "height": 1080,
+            "bitrate_kbps": 3000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-high",
+            "display_name": "720p High",
+            "height": 720,
+            "bitrate_kbps": 4000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-medium",
+            "display_name": "720p Medium",
             "height": 720,
             "bitrate_kbps": 2000,
             "preserves_source": false
           },
           {
+            "label": "720p-low",
+            "display_name": "720p Low",
+            "height": 720,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          },
+          {
             "label": "480p",
+            "display_name": "480p",
             "height": 480,
             "bitrate_kbps": 1500,
             "preserves_source": false
@@ -4132,13 +5000,43 @@
             "preserves_source": true
           },
           {
-            "label": "720p",
+            "label": "1080p-medium",
+            "display_name": "1080p Medium",
+            "height": 1080,
+            "bitrate_kbps": 6000,
+            "preserves_source": false
+          },
+          {
+            "label": "1080p-low",
+            "display_name": "1080p Low",
+            "height": 1080,
+            "bitrate_kbps": 3000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-high",
+            "display_name": "720p High",
+            "height": 720,
+            "bitrate_kbps": 4000,
+            "preserves_source": false
+          },
+          {
+            "label": "720p-medium",
+            "display_name": "720p Medium",
             "height": 720,
             "bitrate_kbps": 2000,
             "preserves_source": false
           },
           {
+            "label": "720p-low",
+            "display_name": "720p Low",
+            "height": 720,
+            "bitrate_kbps": 1500,
+            "preserves_source": false
+          },
+          {
             "label": "480p",
+            "display_name": "480p",
             "height": 480,
             "bitrate_kbps": 1500,
             "preserves_source": false

--- a/iosApp/Tests/PlaybackProtocolV3ConformanceFixtureTests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3ConformanceFixtureTests.swift
@@ -21,7 +21,7 @@ final class PlaybackProtocolV3ConformanceFixtureTests: XCTestCase {
             bundleClass: Self.self
         )
         XCTAssertEqual(matrix.schemaVersion, 1)
-        XCTAssertEqual(matrix.plannerScenarios.count, 18)
+        XCTAssertEqual(matrix.plannerScenarios.count, 20)
         XCTAssertEqual(matrix.replanScenarios.count, 10)
         XCTAssertEqual(matrix.protocolScenarios.count, 8)
 
@@ -97,6 +97,37 @@ final class PlaybackProtocolV3ConformanceFixtureTests: XCTestCase {
         XCTAssertEqual(fallback.source.dolbyVisionProfile, 7)
         XCTAssertEqual(fallback.expected.delivery, "server_remux_progressive")
         XCTAssertEqual(fallback.expected.transformations?.map(\.executor), ["server"])
+
+        let hdrToneMap = try plannerScenario(named: "hdr10_to_sdr_tone_map", in: matrix)
+        XCTAssertEqual(hdrToneMap.source.dynamicRange, "hdr10")
+        XCTAssertEqual(hdrToneMap.expected.delivery, "server_transcode_hls")
+        XCTAssertEqual(
+            hdrToneMap.expected.transformations?.last,
+            PlaybackV3Transformation(
+                name: "hdr_to_sdr_tonemap",
+                executor: "server",
+                recipeVersion: "1",
+                validatedClaims: ["hdr_metadata_removed", "sdr_bt709_output"]
+            )
+        )
+        XCTAssertEqual(
+            hdrToneMap.expected.availableQualities?.first {
+                $0.label == "1080p-medium"
+            }?.displayName,
+            "1080p Medium"
+        )
+
+        let dolbyVisionToneMap = try plannerScenario(
+            named: "dolby_vision_7_id6_to_sdr_tone_map",
+            in: matrix
+        )
+        XCTAssertEqual(dolbyVisionToneMap.source.dolbyVisionProfile, 7)
+        XCTAssertEqual(dolbyVisionToneMap.source.dvBlCompatId, 6)
+        XCTAssertEqual(dolbyVisionToneMap.expected.delivery, "server_transcode_hls")
+        XCTAssertEqual(
+            dolbyVisionToneMap.expected.transformations?.last?.name,
+            "hdr_to_sdr_tonemap"
+        )
 
         let audioConversion = try plannerScenario(named: "truehd_audio_conversion", in: matrix)
         XCTAssertEqual(audioConversion.source.audioCodec, "truehd")

--- a/iosApp/Tests/PlaybackProtocolV3Tests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3Tests.swift
@@ -1287,22 +1287,40 @@ final class PlaybackProtocolV3Tests: XCTestCase {
     }
 
     func testServerQualityDisplayNameWinsForCompoundRungs() {
+        let serverQualities = [
+            PlaybackV3AvailableQuality(
+                label: "1080p-medium",
+                displayName: "1080p Medium",
+                height: 1_080,
+                bitrateKbps: 6_000,
+                preservesSource: false
+            )
+        ]
         let options = ApplePlaybackQuality.playbackOptions(
-            serverQualities: [
-                PlaybackV3AvailableQuality(
-                    label: "1080p-medium",
-                    displayName: "1080p Medium",
-                    height: 1_080,
-                    bitrateKbps: 6_000,
-                    preservesSource: false
-                )
-            ],
+            serverQualities: serverQualities,
             fallbackVersion: nil
         )
 
         XCTAssertEqual(options.last?.id, "1080p-medium")
         XCTAssertEqual(options.last?.label, "1080p Medium")
         XCTAssertEqual(options.last?.subtitle, "Maximum bitrate: 6 Mbps")
+
+        let selection = ApplePlaybackQuality.protocolV3Selection(
+            requestedQualityId: "1080p-medium",
+            availableQualities: serverQualities
+        )
+        XCTAssertEqual(selection.clientQualityId, "1080p-medium")
+        XCTAssertEqual(selection.serverPreference, "1080p-medium")
+        XCTAssertEqual(selection.bandwidthCapKbps, 6_000)
+        XCTAssertTrue(selection.isServerOwned)
+
+        let settingsFallback = ApplePlaybackQuality.protocolV3Selection(
+            requestedQualityId: "1080p-medium",
+            availableQualities: []
+        )
+        XCTAssertEqual(settingsFallback.serverPreference, "1080p")
+        XCTAssertEqual(settingsFallback.bandwidthCapKbps, 12_000)
+        XCTAssertFalse(settingsFallback.isServerOwned)
     }
 
     func testEmptyServerQualityCatalogOnlyOffersAuto() {

--- a/iosApp/Tests/PlaybackProtocolV3Tests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3Tests.swift
@@ -103,6 +103,15 @@ final class PlaybackProtocolV3Tests: XCTestCase {
                 "server_transcode_hls"
             ]
         )
+        XCTAssertEqual(
+            capability.transformations.first { $0.name == "hdr_to_sdr_tonemap" },
+            PlaybackV3Transformation(
+                name: "hdr_to_sdr_tonemap",
+                executor: "server",
+                recipeVersion: "1",
+                validatedClaims: ["hdr_metadata_removed", "sdr_bt709_output"]
+            )
+        )
 
         let start = try PlaybackV3FixtureTestSupport.decode(
             PlaybackV3StartRequest.self,
@@ -598,6 +607,23 @@ final class PlaybackProtocolV3Tests: XCTestCase {
                 makePlan(streamProtocol: "dash")
             )
         )
+    }
+
+    func testServerToneMapTransformationIsAcceptedAsPackagedHLS() {
+        let plan = makePlan(
+            delivery: PlaybackProtocolV3.PlanDelivery.transcodeHLS,
+            streamProtocol: "hls",
+            transformations: [
+                PlaybackV3Transformation(
+                    name: "hdr_to_sdr_tonemap",
+                    executor: "server",
+                    recipeVersion: "1",
+                    validatedClaims: ["hdr_metadata_removed", "sdr_bt709_output"]
+                )
+            ]
+        )
+
+        XCTAssertNoThrow(try ApplePlaybackV3PlanAdapter.validate(plan))
     }
 
     func testSubtitleIdentityUsesDenseServerCombinedOrdinals() {
@@ -1247,6 +1273,7 @@ final class PlaybackProtocolV3Tests: XCTestCase {
             serverQualities: [
                 PlaybackV3AvailableQuality(
                     label: "audio_high",
+                    displayName: nil,
                     height: nil,
                     bitrateKbps: 320,
                     preservesSource: false
@@ -1257,6 +1284,25 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         XCTAssertEqual(options.map(\.id), ["auto", "audio_high"])
         XCTAssertEqual(options.last?.resolution, "")
         XCTAssertEqual(options.last?.bitrateKbps, 320)
+    }
+
+    func testServerQualityDisplayNameWinsForCompoundRungs() {
+        let options = ApplePlaybackQuality.playbackOptions(
+            serverQualities: [
+                PlaybackV3AvailableQuality(
+                    label: "1080p-medium",
+                    displayName: "1080p Medium",
+                    height: 1_080,
+                    bitrateKbps: 6_000,
+                    preservesSource: false
+                )
+            ],
+            fallbackVersion: nil
+        )
+
+        XCTAssertEqual(options.last?.id, "1080p-medium")
+        XCTAssertEqual(options.last?.label, "1080p Medium")
+        XCTAssertEqual(options.last?.subtitle, "Maximum bitrate: 6 Mbps")
     }
 
     func testEmptyServerQualityCatalogOnlyOffersAuto() {
@@ -1275,12 +1321,14 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         let qualities = [
             PlaybackV3AvailableQuality(
                 label: "1080p",
+                displayName: nil,
                 height: 1_080,
                 bitrateKbps: 8_000,
                 preservesSource: false
             ),
             PlaybackV3AvailableQuality(
                 label: "audio_high",
+                displayName: nil,
                 height: nil,
                 bitrateKbps: 320,
                 preservesSource: false
@@ -1544,6 +1592,7 @@ final class PlaybackProtocolV3Tests: XCTestCase {
             availableQualities: [
                 PlaybackV3AvailableQuality(
                     label: "original",
+                    displayName: nil,
                     height: height,
                     bitrateKbps: bitrateKbps,
                     preservesSource: true

--- a/iosApp/Tests/PlaybackProtocolV3Tests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3Tests.swift
@@ -613,6 +613,8 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         let plan = makePlan(
             delivery: PlaybackProtocolV3.PlanDelivery.transcodeHLS,
             streamProtocol: "hls",
+            sourceDynamicRange: "hdr10",
+            dynamicRange: "sdr",
             transformations: [
                 PlaybackV3Transformation(
                     name: "hdr_to_sdr_tonemap",
@@ -623,6 +625,8 @@ final class PlaybackProtocolV3Tests: XCTestCase {
             ]
         )
 
+        XCTAssertEqual(plan.source.dynamicRange, "hdr10")
+        XCTAssertEqual(plan.effectiveRecipe.dynamicRange, "sdr")
         XCTAssertNoThrow(try ApplePlaybackV3PlanAdapter.validate(plan))
     }
 
@@ -1488,6 +1492,7 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         width: Int = 1_920,
         height: Int = 1_080,
         bitrateKbps: Int = 8_000,
+        sourceDynamicRange: String? = nil,
         dynamicRange: String = "sdr",
         selectedAudioIndex: Int = 0,
         selectedSubtitleIndex: Int? = nil,
@@ -1500,7 +1505,8 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         timelineOffset: Double = 0,
         sourceDurationSeconds: Double? = 5_400
     ) -> PlaybackV3Plan {
-        PlaybackV3Plan(
+        let sourceDynamicRange = sourceDynamicRange ?? dynamicRange
+        return PlaybackV3Plan(
             protocolVersion: 3,
             planId: planId,
             sessionId: "session-v3",
@@ -1590,15 +1596,15 @@ final class PlaybackProtocolV3Tests: XCTestCase {
                 videoCodec: videoCodec,
                 videoProfile: "high",
                 videoLevel: 41,
-                bitDepth: dynamicRange == "sdr" ? 8 : 10,
+                bitDepth: sourceDynamicRange == "sdr" ? 8 : 10,
                 colorRange: "tv",
                 width: width,
                 height: height,
                 frameRate: 23.976,
                 bitrateKbps: bitrateKbps,
-                dynamicRange: dynamicRange,
+                dynamicRange: sourceDynamicRange,
                 hdr10Plus: false,
-                dolbyVisionProfile: dynamicRange == "dolby_vision" ? 7 : nil,
+                dolbyVisionProfile: sourceDynamicRange == "dolby_vision" ? 7 : nil,
                 dvBlCompatId: nil,
                 dvEnhancementLayer: "none",
                 audioCodec: audioCodec,

--- a/iosApp/iosApp/Screens/Player/AetherPlaybackStatsProjection.swift
+++ b/iosApp/iosApp/Screens/Player/AetherPlaybackStatsProjection.swift
@@ -8,19 +8,28 @@ struct AetherPlaybackStatsSourceMetadata: Equatable {
     let container: String?
     let playbackRate: Double?
     let secondarySubtitleLabel: String?
+    let plannedSourceDynamicRange: String?
+    let plannedOutputDynamicRange: String?
+    let plannedSourceDolbyVisionProfile: Int?
 
     init(
         sourceURL: URL?,
         delivery: String?,
         container: String?,
         playbackRate: Double?,
-        secondarySubtitleLabel: String? = nil
+        secondarySubtitleLabel: String? = nil,
+        plannedSourceDynamicRange: String? = nil,
+        plannedOutputDynamicRange: String? = nil,
+        plannedSourceDolbyVisionProfile: Int? = nil
     ) {
         source = Self.sourceLabel(for: sourceURL)
         self.delivery = Self.deliveryLabel(delivery)
         self.container = Self.containerLabel(container)
         self.playbackRate = playbackRate
         self.secondarySubtitleLabel = secondarySubtitleLabel
+        self.plannedSourceDynamicRange = plannedSourceDynamicRange
+        self.plannedOutputDynamicRange = plannedOutputDynamicRange
+        self.plannedSourceDolbyVisionProfile = plannedSourceDolbyVisionProfile
     }
 
     private static func sourceLabel(for url: URL?) -> String? {
@@ -171,7 +180,7 @@ enum AetherPlaybackStatsProjection {
             container: source.container,
             video: videoStream(snapshot),
             audio: audioStream(track: activeAudio, decoder: snapshot.activeAudioDecoder),
-            dynamicRange: dynamicRangeLabel(snapshot),
+            dynamicRange: dynamicRangeLabel(snapshot, source: source),
             subtitles: subtitleLabel(
                 route: snapshot.route,
                 active: snapshot.isSubtitleActive,
@@ -289,13 +298,49 @@ enum AetherPlaybackStatsProjection {
         return "\(coded) (\(displayWidth)×\(height) display)"
     }
 
-    private static func dynamicRangeLabel(_ snapshot: AetherPlaybackStatsSnapshot) -> String? {
+    private static func dynamicRangeLabel(
+        _ snapshot: AetherPlaybackStatsSnapshot,
+        source metadata: AetherPlaybackStatsSourceMetadata
+    ) -> String? {
         guard snapshot.sourceVideoWidth > 0, snapshot.sourceVideoHeight > 0 else { return nil }
+        if let planned = plannedDynamicRangeLabel(metadata) { return planned }
         let source = videoFormatLabel(snapshot.sourceVideoFormat, dvProfile: snapshot.sourceDVProfile)
         let output = videoFormatLabel(snapshot.outputVideoFormat, dvProfile: nil)
         return snapshot.sourceVideoFormat == snapshot.outputVideoFormat
             ? source
             : "\(source) → \(output)"
+    }
+
+    /// A server-transformed stream reaches Aether after conversion, so both of
+    /// Aether's format fields describe the delivered SDR/HDR bytes. Preserve
+    /// the original-to-effective transition from the negotiated V3 plan when
+    /// those ranges differ; equal ranges leave live panel adaptation to Aether.
+    private static func plannedDynamicRangeLabel(
+        _ source: AetherPlaybackStatsSourceMetadata
+    ) -> String? {
+        guard let input = normalized(source.plannedSourceDynamicRange)?.lowercased(),
+              let output = normalized(source.plannedOutputDynamicRange)?.lowercased(),
+              input != output,
+              let inputLabel = plannedVideoFormatLabel(
+                input,
+                dvProfile: source.plannedSourceDolbyVisionProfile
+              ),
+              let outputLabel = plannedVideoFormatLabel(output, dvProfile: nil) else {
+            return nil
+        }
+        return "\(inputLabel) → \(outputLabel)"
+    }
+
+    private static func plannedVideoFormatLabel(_ value: String, dvProfile: Int?) -> String? {
+        switch value {
+        case "sdr": return "SDR"
+        case "hdr10": return "HDR10"
+        case "hdr10_plus", "hdr10+": return "HDR10+"
+        case "hlg": return "HLG"
+        case "dolby_vision":
+            return dvProfile.map { "Dolby Vision Profile \($0)" } ?? "Dolby Vision"
+        default: return nil
+        }
     }
 
     private static func videoFormatLabel(_ format: VideoFormat, dvProfile: Int?) -> String {

--- a/iosApp/iosApp/Screens/Player/ApplePlaybackQuality.swift
+++ b/iosApp/iosApp/Screens/Player/ApplePlaybackQuality.swift
@@ -130,7 +130,12 @@ enum ApplePlaybackQuality {
             let height = quality.height ?? 0
             return ApplePlaybackQualityOption(
                 id: id,
-                label: playbackLabel(id: id, height: height, isOriginal: isOriginal),
+                label: playbackLabel(
+                    serverDisplayName: quality.displayName,
+                    id: id,
+                    height: height,
+                    isOriginal: isOriginal
+                ),
                 resolution: isOriginal || height <= 0 ? "" : "\(height)p",
                 bitrateKbps: max(0, quality.bitrateKbps),
                 isOriginal: isOriginal,
@@ -158,8 +163,17 @@ enum ApplePlaybackQuality {
         }
     }
 
-    private static func playbackLabel(id: String, height: Int, isOriginal: Bool) -> String {
+    private static func playbackLabel(
+        serverDisplayName: String?,
+        id: String,
+        height: Int,
+        isOriginal: Bool
+    ) -> String {
         if isOriginal { return "Original" }
+        if let serverDisplayName {
+            let normalized = serverDisplayName.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !normalized.isEmpty { return normalized }
+        }
         switch height {
         case 2_160: return "Up to 4K"
         case 1_080: return "Up to 1080p HD"

--- a/iosApp/iosApp/Screens/Player/ApplePlaybackQuality.swift
+++ b/iosApp/iosApp/Screens/Player/ApplePlaybackQuality.swift
@@ -29,6 +29,13 @@ struct ApplePlaybackQualityOption: Identifiable, Hashable {
     }
 }
 
+struct ApplePlaybackV3QualitySelection: Equatable {
+    let clientQualityId: String
+    let serverPreference: String
+    let bandwidthCapKbps: Int?
+    let isServerOwned: Bool
+}
+
 enum ApplePlaybackQuality {
     static let autoId = "auto"
     static let originalId = "original"
@@ -161,6 +168,51 @@ enum ApplePlaybackQuality {
         default:
             return value
         }
+    }
+
+    /// Resolve an in-player V3 choice without confusing a server-owned rung
+    /// with a same-named Settings preset. Compound rung labels are exact plan
+    /// identities, and their bitrate comes from that plan rather than Apple's
+    /// independently maintained Settings ladder.
+    static func protocolV3Selection(
+        requestedQualityId: String,
+        availableQualities: [PlaybackV3AvailableQuality]
+    ) -> ApplePlaybackV3QualitySelection {
+        let clientQualityId = protocolV3QualityId(requestedQualityId)
+        if clientQualityId == autoId {
+            return ApplePlaybackV3QualitySelection(
+                clientQualityId: autoId,
+                serverPreference: autoId,
+                bandwidthCapKbps: nil,
+                isServerOwned: true
+            )
+        }
+        if let offered = availableQualities.first(where: {
+            protocolV3QualityId($0.label) == clientQualityId
+        }) {
+            let preservesSource = offered.preservesSource || clientQualityId == originalId
+            return ApplePlaybackV3QualitySelection(
+                clientQualityId: clientQualityId,
+                serverPreference: clientQualityId,
+                bandwidthCapKbps: preservesSource ? nil : positiveBitrate(offered.bitrateKbps),
+                isServerOwned: true
+            )
+        }
+
+        let axes = AppleQualityAxes.split(clientQualityId)
+        let serverPreference = settingsOptions.contains(where: { $0.id == clientQualityId })
+            ? axes.resolution
+            : clientQualityId
+        return ApplePlaybackV3QualitySelection(
+            clientQualityId: clientQualityId,
+            serverPreference: serverPreference,
+            bandwidthCapKbps: axes.bitrateKbps,
+            isServerOwned: false
+        )
+    }
+
+    private static func positiveBitrate(_ bitrateKbps: Int) -> Int? {
+        bitrateKbps > 0 ? bitrateKbps : nil
     }
 
     private static func playbackLabel(

--- a/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
@@ -386,6 +386,10 @@ actor PlaybackSessionBridge {
         var attemptedPlanKeys: [String]
         var attemptCount: Int
         var clientQualityId: String
+        /// True after the user selects an exact quality identifier advertised
+        /// by the active plan. Recovery replans must keep that identifier
+        /// instead of translating it through the local Settings ladder.
+        var usesServerQualityPreference: Bool
         /// The independent bandwidth ceiling captured for this attempt. Every
         /// replan must repeat it or recovery silently widens the connection.
         var bandwidthCapKbps: Int?
@@ -1089,6 +1093,7 @@ actor PlaybackSessionBridge {
             attemptedPlanKeys: [planAttemptKey],
             attemptCount: 1,
             clientQualityId: staged.clientQualityId,
+            usesServerQualityPreference: false,
             bandwidthCapKbps: staged.bandwidthCapKbps,
             snapshot: staged.snapshot,
             serverFeatures: staged.serverFeatures,
@@ -1330,13 +1335,26 @@ actor PlaybackSessionBridge {
         }()
         let selectedTracks = PlaybackV3SelectedTracks(audio: selectedAudio, subtitle: selectedSubtitle)
         let normalizedPosition = position.isFinite ? max(0, position) : 0
-        let requestedClientQualityId = qualityPreference.map {
-            ApplePlaybackQuality.protocolV3QualityId($0)
-        } ?? active.clientQualityId
-        let requestedBandwidthCapKbps = AppleQualityAxes.resolvedBitrateCap(
-            qualityOverride: qualityPreference,
-            fallbackBitrateKbps: active.bandwidthCapKbps
-        )
+        let qualitySelection = qualityPreference.map {
+            ApplePlaybackQuality.protocolV3Selection(
+                requestedQualityId: $0,
+                availableQualities: active.plan.availableQualities
+            )
+        }
+        let requestedClientQualityId = qualitySelection?.clientQualityId
+            ?? active.clientQualityId
+        let requestedUsesServerQualityPreference = qualitySelection?.isServerOwned
+            ?? active.usesServerQualityPreference
+        let requestedQualityPreference = qualitySelection?.serverPreference
+            ?? (requestedUsesServerQualityPreference
+                ? requestedClientQualityId
+                : protocolV3QualityPreference(requestedClientQualityId))
+        let requestedBandwidthCapKbps: Int?
+        if let qualitySelection {
+            requestedBandwidthCapKbps = qualitySelection.bandwidthCapKbps
+        } else {
+            requestedBandwidthCapKbps = active.bandwidthCapKbps
+        }
         let eventName = isSeekReanchor
             ? "seek_reanchor_requested"
             : (invalidatesIntent ? "plan_invalidated" : "plan_failed")
@@ -1394,7 +1412,7 @@ actor PlaybackSessionBridge {
             planAttemptKey: active.planAttemptKey,
             attemptedPlanKeys: attemptedKeys,
             attemptCount: invalidatesIntent ? 1 : active.attemptCount,
-            qualityPreference: protocolV3QualityPreference(requestedClientQualityId),
+            qualityPreference: requestedQualityPreference,
             positionSeconds: normalizedPosition,
             metered: false,
             bandwidthEstimateKbps: nil,
@@ -1568,6 +1586,7 @@ actor PlaybackSessionBridge {
             active.serverFeatures = response.serverFeatures
             active.plan = nextPlan
             active.clientQualityId = requestedClientQualityId
+            active.usesServerQualityPreference = requestedUsesServerQualityPreference
             active.bandwidthCapKbps = requestedBandwidthCapKbps
             stageProtocolV3Transition(
                 candidateSessionId: nextSessionId,

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -1180,12 +1180,16 @@ class PlayerViewModel {
         let secondaryLabel = selectedSecondarySubtitleId.flatMap { selectedID in
             subtitleTracks.first { $0.trackId == selectedID }?.primaryLabel
         }
+        let playbackPlan = activePreparedProtocolV3?.plan
         let source = AetherPlaybackStatsSourceMetadata(
             sourceURL: spec.sourceURL,
             delivery: spec.delivery,
             container: currentSelectedVersion?.container,
             playbackRate: isHoldFastForwarding ? 2 : settings.playbackSpeed,
-            secondarySubtitleLabel: secondaryLabel
+            secondarySubtitleLabel: secondaryLabel,
+            plannedSourceDynamicRange: playbackPlan?.source.dynamicRange,
+            plannedOutputDynamicRange: playbackPlan?.effectiveRecipe.dynamicRange,
+            plannedSourceDolbyVisionProfile: playbackPlan?.source.dolbyVisionProfile
         )
         let snapshot = AetherPlaybackStatsSnapshot(
             engine: aetherPlaybackController.engine

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/PlaybackProtocolV3Models.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/PlaybackProtocolV3Models.swift
@@ -468,6 +468,8 @@ struct PlaybackV3DegradationWarning: Codable, Equatable {
 
 struct PlaybackV3AvailableQuality: Codable, Equatable {
     let label: String
+    /// Optional server-owned presentation label for compound quality rungs.
+    let displayName: String?
     /// Audio-only quality rungs have no meaningful video height.
     let height: Int?
     let bitrateKbps: Int


### PR DESCRIPTION
## Summary

- sync the Playback V3 conformance fixtures with the server HDR-to-SDR tone-mapping contract
- decode and use server-owned display names for compound quality rungs
- preserve the negotiated source-to-output dynamic-range transition in Stats for Nerds

## Context

Server tone mapping is delivered as ordinary packaged HLS, so Apple playback was already compatible. This keeps the client contract, quality UI, and playback diagnostics aligned with the new server behavior.

Related server PR: https://github.com/Silo-Server/silo-server/pull/634

## Testing

- Focused iOS XCTest run: 45 tests passed, 0 failures
- SiloTV tvOS Simulator build succeeded
- SiloMac macOS build succeeded
- Vendored Playback V3 fixtures match server commit 745b767f73088309953972de9ea23f33d854496e byte-for-byte

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Playback statistics now show planned dynamic-range conversions, including HDR10-to-SDR, HDR10+, HLG, and Dolby Vision scenarios.
  - Quality selections can display clearer server-provided names for compound resolutions while retaining fallback labels.
  - Improved playback support and reporting for HDR, Dolby Vision, audio conversion, subtitles, and server-managed HLS plans.
  - Playback quality changes now better preserve selected server-provided options and bandwidth preferences.

- **Bug Fixes**
  - Corrected playback statistics so they reflect planned output formats when server-side tone mapping changes the dynamic range.

- **Tests**
  - Expanded conformance coverage across additional HDR, Dolby Vision, quality, and transformation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->