### PR TITLE
Show Home before profile settings refresh

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -887,8 +887,8 @@ struct ContentView: View {
                 requiresPIN: profile.hasPin
             )
             StartupContentPrefetcher.prefetchAuthenticatedContent()
-            await PlayerSettings.shared.refreshFromServer()
             router.resetToHome()
+            await PlayerSettings.shared.refreshFromServer()
             print("[DebugAutoLogin] signed in and selected profile")
         } catch {
             print("[DebugAutoLogin] failed: \(error)")

--- a/iosApp/iosApp/Screens/Profiles/ProfileSelectionViewModel.swift
+++ b/iosApp/iosApp/Screens/Profiles/ProfileSelectionViewModel.swift
@@ -59,8 +59,11 @@ class ProfileSelectionViewModel {
                 requiresPIN: profile.hasPin
             )
             StartupContentPrefetcher.prefetchAuthenticatedContent()
-            await PlayerSettings.shared.refreshFromServer()
+            // Change screens before the settings request suspends. The refresh
+            // applies this profile's cached playback quality synchronously,
+            // then updates it from the server while Home is already visible.
             router.resetToHome()
+            await PlayerSettings.shared.refreshFromServer()
         } catch {
             self.error = ErrorState(error)
         }
@@ -77,8 +80,8 @@ class ProfileSelectionViewModel {
             requiresPIN: profile.hasPin
         )
         StartupContentPrefetcher.prefetchAuthenticatedContent()
-        await PlayerSettings.shared.refreshFromServer()
         router.resetToHome()
+        await PlayerSettings.shared.refreshFromServer()
     }
 
     /// The picker itself has no active profile, but the server requires the


### PR DESCRIPTION
## What I changed

I fixed the delay after selecting an iOS profile. A successful profile selection previously waited for the server-backed player-settings refresh before changing screens, which could make the app look stuck even though the profile had already been accepted.

The router now shows Home immediately after profile verification and content prefetch setup. The existing settings refresh still runs immediately afterward: it applies the selected profile's cached playback settings before its first network wait, then refreshes the canonical values from the server. This keeps an immediate Play action aligned with the user's selected playback quality without holding the profile transition behind the network.

The same ordering is used for profiles with and without a PIN, as well as the debug auto-login path.

## Testing

- 45 focused profile and playback-quality tests passed with 0 failures.
- A signed iPhone 17 Pro simulator build passed on Xcode 26.6 / iOS 26.5.
- I verified the corrected handoff in the signed simulator build without clearing the saved login.

## AI disclosure

I identified the profile handoff problem and specified the expected behavior. I used AI assistance to help implement and validate the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile selection navigation by returning to the Home screen before refreshing player settings.
  * Ensured cached playback quality is applied promptly while updated settings load in the background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->