### PR TITLE
fix(navigation): keep Downloads visible from launch

### DIFF
--- a/iosApp/Tests/UICustomizationPreferencesTests.swift
+++ b/iosApp/Tests/UICustomizationPreferencesTests.swift
@@ -1110,6 +1110,21 @@ final class UICustomizationPreferencesTests: XCTestCase {
         )
     }
 
+    func testDownloadsDestinationIsStableBeforeCapabilityHydration() {
+        let initial = appendingStableDownloadsDestination(to: [
+            .app(.home),
+            .app(.recommendations),
+            .app(.calendar),
+        ])
+
+        XCTAssertEqual(initial.last?.id, .app(.downloads))
+        XCTAssertEqual(
+            appendingStableDownloadsDestination(to: initial),
+            initial,
+            "capability updates must not insert a duplicate or reflow the tab bar"
+        )
+    }
+
     func testLegacyCollectionOutboxIdentityMigratesToStructuredIdentity() async throws {
         let suiteName = "ui-customization-legacy-collection-id-suite-\(UUID().uuidString)"
         let standardName = "ui-customization-legacy-collection-id-standard-\(UUID().uuidString)"

--- a/iosApp/Tests/UICustomizationPreferencesTests.swift
+++ b/iosApp/Tests/UICustomizationPreferencesTests.swift
@@ -1119,6 +1119,15 @@ final class UICustomizationPreferencesTests: XCTestCase {
 
         XCTAssertEqual(initial.last?.id, .app(.downloads))
         XCTAssertEqual(
+            initial.map(\.id),
+            [
+                .app(.home),
+                .app(.recommendations),
+                .app(.calendar),
+                .app(.downloads),
+            ]
+        )
+        XCTAssertEqual(
             appendingStableDownloadsDestination(to: initial),
             initial,
             "capability updates must not insert a duplicate or reflow the tab bar"

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -1540,6 +1540,20 @@ struct MainTabDestination: Identifiable, Equatable {
     }
 }
 
+#if !os(tvOS)
+/// Keeps Downloads in the mobile/desktop shell from the first rendered frame.
+/// Capability hydration controls the destination's content and actions, not
+/// whether the tab exists, so the tab bar never inserts an item after launch.
+func appendingStableDownloadsDestination(
+    to destinations: [MainTabDestination]
+) -> [MainTabDestination] {
+    guard !destinations.contains(where: { $0.id == .app(.downloads) }) else {
+        return destinations
+    }
+    return destinations + [.app(.downloads)]
+}
+#endif
+
 private struct MainTabSidebarDestination: Identifiable {
     let destination: MainTabDestination
     let isNestedLibrary: Bool
@@ -1884,12 +1898,11 @@ struct MainTabView: View {
         #endif
     }
 
-    /// Visible tabs, plus a Downloads tab when the server advertises the
-    /// downloads capability for this profile. Reading
-    /// `DownloadManager.shared.downloadsEnabled` here registers the tab bar
-    /// as an observer, so the tab appears as soon as capability loads.
+    /// Visible tabs always include Downloads on supported platforms. The
+    /// destination owns its empty/unavailable state, keeping the tab bar from
+    /// reflowing when capability hydration completes after first render.
     private var visibleDestinations: [MainTabDestination] {
-        var destinations = projectedMainTabDestinations(
+        let destinations = projectedMainTabDestinations(
             primaryMenu: uiCustomization.primaryMenu,
             availableLibraries: librarySnapshot.availableLibraries(
                 for: currentLibraryAuthority
@@ -1897,12 +1910,10 @@ struct MainTabView: View {
             showAudiobooks: navPrefs.showAudiobooks
         )
         #if !os(tvOS)
-        if DownloadManager.shared.downloadsEnabled,
-           !destinations.contains(where: { $0.id == .app(.downloads) }) {
-            destinations.append(.app(.downloads))
-        }
-        #endif
+        return appendingStableDownloadsDestination(to: destinations)
+        #else
         return destinations
+        #endif
     }
 
     private var currentLibraryAuthority: MainTabLibraryAuthority? {

--- a/iosApp/iosApp/Downloads/DownloadsView.swift
+++ b/iosApp/iosApp/Downloads/DownloadsView.swift
@@ -295,14 +295,14 @@ struct DownloadsView: View {
         }
         #endif
 
-        if isSelecting {
+        if manager.downloadsEnabled && isSelecting {
             ToolbarItem(placement: .navigation) {
                 Button(allSelected ? "Clear" : "Select All") { toggleSelectAll() }
             }
             ToolbarItem(placement: .primaryAction) {
                 Button("Done") { exitSelectMode() }
             }
-        } else if !listItems.isEmpty {
+        } else if manager.downloadsEnabled && !listItems.isEmpty {
             ToolbarItem(placement: .primaryAction) {
                 Button("Select") { isSelecting = true }
             }
@@ -311,7 +311,7 @@ struct DownloadsView: View {
 
     @ViewBuilder
     private var bottomBar: some View {
-        if isSelecting && !selection.isEmpty {
+        if manager.downloadsEnabled && isSelecting && !selection.isEmpty {
             Button {
                 pendingDeletion = PendingDeletion(ids: selectedDownloadIds, endsSelection: true)
             } label: {

--- a/iosApp/iosApp/Navigation/TabRouter.swift
+++ b/iosApp/iosApp/Navigation/TabRouter.swift
@@ -35,9 +35,8 @@ enum AppTab: String, CaseIterable, Identifiable {
         #if os(tvOS)
         return [.home, .libraries, .search, .recommendations, .settings, .switchProfile, .switchServer]
         #else
-        // Downloads is appended dynamically by `MainTabView` only when the
-        // server advertises the capability, so it stays hidden when the
-        // feature is off rather than showing an empty tab.
+        // MainTabView appends Downloads as a stable shell destination after
+        // projecting the customizable content destinations.
         return [.home, .libraries, .recommendations, .calendar]
         #endif
     }


### PR DESCRIPTION
## What I changed

I noticed the Downloads tab was missing when the iOS app first opened, then suddenly appeared after the server download capability finished loading. That made the whole bottom tab bar reflow after launch.

I changed Downloads into a stable shell destination from the first rendered frame. Capability hydration still controls the Downloads screen content and actions, but it no longer adds or removes the tab itself. The helper is also idempotent so later state updates cannot insert a duplicate destination.

This keeps the existing customizable content destinations while making Downloads predictable and always reachable.

## Testing

I designed and tested this behavior to make sure the bottom bar stays stable from launch.

- iOS app target builds successfully
- Added and passed a focused regression test for pre-capability tab visibility
- Verified repeated state updates do not duplicate or reflow Downloads

## AI disclosure

I designed the navigation behavior and tested the result. I used AI assistance to help implement the change and add regression coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The Downloads tab now appears immediately in the main tab bar on supported platforms, without waiting for server capability information.
  - Downloads remains in a stable position when tab settings are applied repeatedly.

- **Bug Fixes**
  - Prevented duplicate Downloads tabs and unexpected tab reordering during navigation setup.

- **Documentation**
  - Updated tab behavior documentation to reflect the stable Downloads placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->