### PR TITLE
feat(ios): center remote controls and map hardware volume

### DIFF
--- a/iosApp/Tests/SiloControlTests.swift
+++ b/iosApp/Tests/SiloControlTests.swift
@@ -1,9 +1,6 @@
 import XCTest
 @testable import Silo
 
-/// NOTE: This project has no unit-test target wired into project.yml yet, so
-/// these tests are not currently compiled or executed. They document the
-/// intended behavior and will run once a SiloTests target is added.
 final class SiloControlTests: XCTestCase {
     private func roundTrip(_ message: SiloControlMessage) throws -> SiloControlMessage {
         let data = try JSONEncoder().encode(message)
@@ -150,6 +147,44 @@ extension SiloControlTests {
         clock.ingest(.fixture(isPlaying: false, currentTime: 1200, duration: 3000),
                      asOf: t0.addingTimeInterval(1.0))
         XCTAssertEqual(clock.displayTime(asOf: t0.addingTimeInterval(1.0)), 1200, accuracy: 0.01)
+    }
+}
+
+extension SiloControlTests {
+    func testHeldVolumeSurvivesAStaleReplyMidBurst() {
+        var reconciler = RemoteVolumeReconciler()
+        let t0 = Date(timeIntervalSince1970: 1000)
+        // Two hardware steps before the TV answers either one.
+        reconciler.requested(0.5625, at: t0)
+        reconciler.requested(0.625, at: t0.addingTimeInterval(0.1))
+        // The reply to the first step must not rewind the level, or the next
+        // step would recompute 0.625 and the second press would be lost.
+        XCTAssertEqual(reconciler.reconcile(inbound: 0.5625, at: t0.addingTimeInterval(0.2)),
+                       0.625, accuracy: 0.0001)
+        // Once the TV catches up, its value is authoritative again.
+        XCTAssertEqual(reconciler.reconcile(inbound: 0.625, at: t0.addingTimeInterval(0.3)),
+                       0.625, accuracy: 0.0001)
+        XCTAssertEqual(reconciler.reconcile(inbound: 0.2, at: t0.addingTimeInterval(0.4)),
+                       0.2, accuracy: 0.0001)
+    }
+
+    func testHeldVolumeIsReleasedWhenTheWindowLapses() {
+        var reconciler = RemoteVolumeReconciler()
+        let t0 = Date(timeIntervalSince1970: 1000)
+        reconciler.requested(0.9, at: t0)
+        // A dropped command, or a change made on the TV itself, must not leave
+        // the remote showing a level the TV does not have.
+        let lapsed = t0.addingTimeInterval(RemoteVolumeReconciler.window + 0.1)
+        XCTAssertEqual(reconciler.reconcile(inbound: 0.3, at: lapsed), 0.3, accuracy: 0.0001)
+    }
+
+    func testMuteClearsTheHeldVolume() {
+        var reconciler = RemoteVolumeReconciler()
+        let t0 = Date(timeIntervalSince1970: 1000)
+        reconciler.requested(0.9, at: t0)
+        reconciler.clear()
+        XCTAssertEqual(reconciler.reconcile(inbound: 0.3, at: t0.addingTimeInterval(0.1)),
+                       0.3, accuracy: 0.0001)
     }
 }
 

--- a/iosApp/Tests/SiloControlTests.swift
+++ b/iosApp/Tests/SiloControlTests.swift
@@ -74,6 +74,39 @@ final class SiloControlTests: XCTestCase {
         XCTAssertNil(offer.serverName)
         XCTAssertNil(offer.profileName)
     }
+
+    func testServerIdentityMatchesURLCapitalizationAcrossDevices() {
+        let phone = ServerRegistry.serverId(for: "https://Media.Example.test")
+        let tv = ServerRegistry.serverId(for: "HTTPS://media.example.test/")
+
+        XCTAssertNotEqual(phone, tv, "persisted registry keys remain unchanged")
+        XCTAssertTrue(ServerRegistry.serverIdsMatch(phone, tv))
+    }
+
+    func testServerIdentityMatchesDefaultPortsButNotDifferentOrigins() {
+        let canonical = ServerRegistry.serverId(for: "https://media.example.test/library")
+        let explicitDefault = ServerRegistry.serverId(for: "https://MEDIA.example.test:443/library/")
+        let otherPort = ServerRegistry.serverId(for: "https://media.example.test:8443/library")
+        let otherScheme = ServerRegistry.serverId(for: "http://media.example.test/library")
+        let pathCase = ServerRegistry.serverId(for: "https://media.example.test/Library")
+
+        XCTAssertTrue(ServerRegistry.serverIdsMatch(canonical, explicitDefault))
+        XCTAssertFalse(ServerRegistry.serverIdsMatch(canonical, otherPort))
+        XCTAssertFalse(ServerRegistry.serverIdsMatch(canonical, otherScheme))
+        XCTAssertFalse(ServerRegistry.serverIdsMatch(canonical, pathCase))
+    }
+
+    func testServerIdentityDecoderRequiresAValidRoundTrippingHTTPURL() {
+        let original = "https://Média.example.test:443/silo?mode=A#top"
+        let serverId = ServerRegistry.serverId(for: original)
+
+        XCTAssertEqual(ServerRegistry.url(forServerId: serverId), original)
+        XCTAssertNil(ServerRegistry.url(forServerId: "not-a-registry-id"))
+        XCTAssertNil(ServerRegistry.url(forServerId: ServerRegistry.serverId(for: "file:///tmp/silo")))
+        XCTAssertFalse(ServerRegistry.serverIdsMatch(nil, serverId))
+        XCTAssertTrue(ServerRegistry.serverIdsMatch("future-format", "future-format"))
+        XCTAssertFalse(ServerRegistry.serverIdsMatch("future-format-a", "future-format-b"))
+    }
 }
 
 extension SiloControlTests {

--- a/iosApp/iosApp/Control/SiloControlProtocol.swift
+++ b/iosApp/iosApp/Control/SiloControlProtocol.swift
@@ -122,8 +122,10 @@ struct SiloControlPlaybackState: Codable, Equatable, Sendable {
     var subtitlePosition: String? = nil
     var supportsSubtitleDelay: Bool? = nil
     var supportsSubtitlePosition: Bool? = nil
-    let volume: Double
-    let isMuted: Bool
+    // `var` so the iOS remote can apply optimistic volume/mute updates between
+    // TV state acknowledgements.
+    var volume: Double
+    var isMuted: Bool
     let hasNextEpisode: Bool
     let nextEpisodeTitle: String?
     let error: String?

--- a/iosApp/iosApp/Control/iOS/RemoteHardwareVolumeInterceptor.swift
+++ b/iosApp/iosApp/Control/iOS/RemoteHardwareVolumeInterceptor.swift
@@ -1,0 +1,100 @@
+#if os(iOS)
+import AVFoundation
+import MediaPlayer
+import SwiftUI
+
+/// Converts hardware volume changes into remote volume steps while its hidden
+/// `MPVolumeView` suppresses the system HUD. Extreme values are nudged to the
+/// midpoint so every subsequent hardware-button press still produces a delta.
+@MainActor
+final class RemoteHardwareVolumeInterceptor {
+    var onVolumeStep: ((Int) -> Void)?
+
+    let volumeView = MPVolumeView(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
+
+    private(set) var isActive = false
+    private var originalSystemVolume: Float?
+    private var suppressUntil: Date = .distantPast
+    private var claim: AetherAudioSessionOwnership.Claim?
+    private var observation: NSKeyValueObservation?
+
+    func start() {
+        guard !isActive else { return }
+        isActive = true
+
+        let session = AVAudioSession.sharedInstance()
+        originalSystemVolume = session.outputVolume
+        if session.category != .playback {
+            try? session.setCategory(.playback, mode: .default, options: [.mixWithOthers])
+        }
+        try? session.setActive(true)
+
+        claim = AetherAudioSessionOwnership.Claim(isHoldingAudio: { [weak self] in
+            self?.isActive ?? false
+        })
+
+        observation = session.observe(\.outputVolume, options: [.old, .new]) { [weak self] _, change in
+            Task { @MainActor [weak self] in
+                guard let self, Date() >= suppressUntil,
+                      let old = change.oldValue, let new = change.newValue else { return }
+                if new > old {
+                    onVolumeStep?(1)
+                } else if new < old {
+                    onVolumeStep?(-1)
+                }
+                if new <= 0.0625 || new >= 0.9375 {
+                    nudgeSystemVolume(to: 0.5)
+                }
+            }
+        }
+
+        if session.outputVolume <= 0.0625 || session.outputVolume >= 0.9375 {
+            nudgeSystemVolume(to: 0.5)
+        }
+    }
+
+    private func nudgeSystemVolume(to value: Float) {
+        suppressUntil = Date().addingTimeInterval(0.5)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            guard let self else { return }
+            volumeView.subviews.compactMap { $0 as? UISlider }.first?.value = value
+        }
+    }
+
+    func stop() {
+        guard isActive else { return }
+        isActive = false
+        observation?.invalidate()
+        observation = nil
+
+        if let originalSystemVolume {
+            nudgeSystemVolume(to: originalSystemVolume)
+            self.originalSystemVolume = nil
+        }
+
+        let claim = claim
+        let canReleaseSession = claim.map {
+            AetherAudioSessionOwnership.canReleaseSharedSession(excluding: $0)
+        } ?? false
+        self.claim = nil
+        if canReleaseSession {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                try? AVAudioSession.sharedInstance().setActive(
+                    false,
+                    options: .notifyOthersOnDeactivation
+                )
+            }
+        }
+    }
+}
+
+struct HiddenVolumeHost: UIViewRepresentable {
+    let interceptor: RemoteHardwareVolumeInterceptor
+
+    func makeUIView(context: Context) -> MPVolumeView {
+        interceptor.volumeView
+    }
+
+    func updateUIView(_ uiView: MPVolumeView, context: Context) {}
+}
+#endif

--- a/iosApp/iosApp/Control/iOS/RemoteHardwareVolumeInterceptor.swift
+++ b/iosApp/iosApp/Control/iOS/RemoteHardwareVolumeInterceptor.swift
@@ -4,8 +4,10 @@ import MediaPlayer
 import SwiftUI
 
 /// Converts hardware volume changes into remote volume steps while its hidden
-/// `MPVolumeView` suppresses the system HUD. Extreme values are nudged to the
-/// midpoint so every subsequent hardware-button press still produces a delta.
+/// `MPVolumeView` suppresses the system HUD. The system volume is held at a
+/// baseline: every user press is detected as a delta from the baseline and then
+/// snapped back, so the buttons act only as remote controls (local audio volume
+/// is left alone) and every subsequent press still produces a delta.
 @MainActor
 final class RemoteHardwareVolumeInterceptor {
     var onVolumeStep: ((Int) -> Void)?
@@ -14,13 +16,15 @@ final class RemoteHardwareVolumeInterceptor {
 
     private(set) var isActive = false
     private var originalSystemVolume: Float?
-    private var suppressUntil: Date = .distantPast
+    private var baselineVolume: Float = 0.5
+    private var pendingProgrammaticVolume: Float?
     private var claim: AetherAudioSessionOwnership.Claim?
     private var observation: NSKeyValueObservation?
 
     func start() {
         guard !isActive else { return }
         isActive = true
+        pendingProgrammaticVolume = nil
 
         let session = AVAudioSession.sharedInstance()
         originalSystemVolume = session.outputVolume
@@ -33,30 +37,38 @@ final class RemoteHardwareVolumeInterceptor {
             self?.isActive ?? false
         })
 
+        // Hold near the current volume, clamped one hardware step away from the
+        // rails so presses in both directions keep producing deltas.
+        baselineVolume = min(max(session.outputVolume, 0.0625), 0.9375)
+
         observation = session.observe(\.outputVolume, options: [.old, .new]) { [weak self] _, change in
             Task { @MainActor [weak self] in
-                guard let self, Date() >= suppressUntil,
+                guard let self, isActive,
                       let old = change.oldValue, let new = change.newValue else { return }
+                if let pending = pendingProgrammaticVolume, abs(new - pending) < 0.001 {
+                    pendingProgrammaticVolume = nil
+                    return
+                }
                 if new > old {
                     onVolumeStep?(1)
                 } else if new < old {
                     onVolumeStep?(-1)
                 }
-                if new <= 0.0625 || new >= 0.9375 {
-                    nudgeSystemVolume(to: 0.5)
-                }
+                setSystemVolume(to: baselineVolume)
             }
         }
 
-        if session.outputVolume <= 0.0625 || session.outputVolume >= 0.9375 {
-            nudgeSystemVolume(to: 0.5)
+        if session.outputVolume != baselineVolume {
+            setSystemVolume(to: baselineVolume)
         }
     }
 
-    private func nudgeSystemVolume(to value: Float) {
-        suppressUntil = Date().addingTimeInterval(0.5)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-            guard let self else { return }
+    private func setSystemVolume(to value: Float) {
+        pendingProgrammaticVolume = value
+        // Strong capture: restoration on stop() must run even after SwiftUI has
+        // released this interceptor along with the dismissed sheet.
+        let volumeView = volumeView
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             volumeView.subviews.compactMap { $0 as? UISlider }.first?.value = value
         }
     }
@@ -68,21 +80,25 @@ final class RemoteHardwareVolumeInterceptor {
         observation = nil
 
         if let originalSystemVolume {
-            nudgeSystemVolume(to: originalSystemVolume)
+            setSystemVolume(to: originalSystemVolume)
             self.originalSystemVolume = nil
         }
 
-        let claim = claim
-        let canReleaseSession = claim.map {
-            AetherAudioSessionOwnership.canReleaseSharedSession(excluding: $0)
-        } ?? false
-        self.claim = nil
-        if canReleaseSession {
+        if let claim {
+            self.claim = nil
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                try? AVAudioSession.sharedInstance().setActive(
-                    false,
-                    options: .notifyOthersOnDeactivation
-                )
+                Task { @MainActor in
+                    // Ownership can change during the delay (playback starting,
+                    // this remote reopening), so decide at execution time. The
+                    // captured claim stays registered until this runs, but its
+                    // probe reports inactive, so it blocks no one else.
+                    guard AetherAudioSessionOwnership.canReleaseSharedSession(excluding: claim)
+                    else { return }
+                    try? AVAudioSession.sharedInstance().setActive(
+                        false,
+                        options: .notifyOthersOnDeactivation
+                    )
+                }
             }
         }
     }

--- a/iosApp/iosApp/Control/iOS/RemoteHardwareVolumeInterceptor.swift
+++ b/iosApp/iosApp/Control/iOS/RemoteHardwareVolumeInterceptor.swift
@@ -28,8 +28,19 @@ final class RemoteHardwareVolumeInterceptor {
 
         let session = AVAudioSession.sharedInstance()
         originalSystemVolume = session.outputVolume
+        // Opening the remote must not interrupt another app's audio. The session
+        // can already be `.playback` *without* `.mixWithOthers` — a stopped
+        // Aether engine leaves it that way — and category alone is not enough to
+        // tell: activating a non-mixing session is what does the interrupting.
         if session.category != .playback {
             try? session.setCategory(.playback, mode: .default, options: [.mixWithOthers])
+        } else if !session.categoryOptions.contains(.mixWithOthers) {
+            // Keep the mode and options local playback established; add mixing.
+            try? session.setCategory(
+                .playback,
+                mode: session.mode,
+                options: session.categoryOptions.union(.mixWithOthers)
+            )
         }
         try? session.setActive(true)
 
@@ -64,12 +75,25 @@ final class RemoteHardwareVolumeInterceptor {
     }
 
     private func setSystemVolume(to value: Float) {
-        pendingProgrammaticVolume = value
-        // Strong capture: restoration on stop() must run even after SwiftUI has
-        // released this interceptor along with the dismissed sheet.
+        // Strong capture of the view (not self): restoration on stop() must run
+        // even after SwiftUI has released this interceptor with the dismissed
+        // sheet.
         let volumeView = volumeView
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            volumeView.subviews.compactMap { $0 as? UISlider }.first?.value = value
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            MainActor.assumeIsolated {
+                guard let slider = volumeView.subviews.compactMap({ $0 as? UISlider }).first
+                else { return }
+                // Claim the value as ours only here, immediately before a write
+                // that will actually move the volume. Claiming it at schedule
+                // time would swallow a real press that lands on the same value
+                // first — an up press followed by a down press inside the delay
+                // returns to the baseline — and claiming a no-op write would
+                // swallow the next genuine press at that value.
+                if abs(AVAudioSession.sharedInstance().outputVolume - value) >= 0.001 {
+                    self?.pendingProgrammaticVolume = value
+                }
+                slider.value = value
+            }
         }
     }
 

--- a/iosApp/iosApp/Control/iOS/RemoteVolumeReconciler.swift
+++ b/iosApp/iosApp/Control/iOS/RemoteVolumeReconciler.swift
@@ -1,0 +1,49 @@
+#if os(iOS)
+import Foundation
+
+/// Holds a locally-requested volume in place until the TV echoes it back.
+///
+/// Volume commands are absolute, and the TV answers each one with a full state
+/// frame. During a burst of hardware-button steps the reply to the *first* step
+/// arrives while later steps are still in flight; taking that frame at face
+/// value rewinds the level, and the next step is then computed from the stale
+/// value — resending a volume already requested and dropping the press.
+///
+/// So the requested level wins over inbound state until the TV confirms it, or
+/// until ``window`` lapses. The window matters: a command can be dropped, and
+/// the level can change on the TV itself, and neither should leave the remote
+/// permanently showing a volume the TV does not have.
+struct RemoteVolumeReconciler {
+    static let window: TimeInterval = 4
+    static let tolerance = 0.001
+
+    private var pending: Double?
+    private var requestedAt = Date(timeIntervalSince1970: 0)
+
+    /// Records a volume this client just asked the TV for.
+    mutating func requested(_ volume: Double, at now: Date = Date()) {
+        pending = volume
+        requestedAt = now
+    }
+
+    /// Drops any held level, for changes that supersede it — an explicit mute,
+    /// or a session that no longer has state.
+    mutating func clear() {
+        pending = nil
+    }
+
+    /// The volume to show for an inbound state frame.
+    mutating func reconcile(inbound: Double, at now: Date = Date()) -> Double {
+        guard let pending else { return inbound }
+        if abs(inbound - pending) < Self.tolerance {
+            self.pending = nil    // confirmed
+            return inbound
+        }
+        if now.timeIntervalSince(requestedAt) >= Self.window {
+            self.pending = nil    // lost, or changed on the TV — trust the TV
+            return inbound
+        }
+        return pending
+    }
+}
+#endif

--- a/iosApp/iosApp/Control/iOS/SiloControlClient.swift
+++ b/iosApp/iosApp/Control/iOS/SiloControlClient.swift
@@ -115,7 +115,8 @@ final class SiloControlClient {
             errorMessage = "Choose a server before controlling a TV."
             return false
         }
-        guard target.serverId == activeServerId || (allowCrossServer && target.protocolVersion >= 2) else {
+        let targetsActiveServer = ServerRegistry.serverIdsMatch(target.serverId, activeServerId)
+        guard targetsActiveServer || (allowCrossServer && target.protocolVersion >= 2) else {
             errorMessage = "That TV is connected to a different server."
             return false
         }
@@ -170,7 +171,7 @@ final class SiloControlClient {
         }
         isConnecting = false
         let connected = self.connectionId == connectionId && self.session != nil
-        if connected, target.serverId == activeServerId {
+        if connected, targetsActiveServer {
             persistLastTarget(target)
         }
         return connected
@@ -216,7 +217,8 @@ final class SiloControlClient {
                 profileName: profileName,
                 session: session
             )
-            guard ready.serverId == activeServer.id, ready.profileId == profileId else {
+            guard ServerRegistry.serverIdsMatch(ready.serverId, activeServer.id),
+                  ready.profileId == profileId else {
                 throw SiloControlHandoffError.invalidResponse
             }
             adoptEffectiveTarget(server: activeServer)
@@ -456,7 +458,10 @@ final class SiloControlClient {
               !isReconnecting,
               autoResumeTask == nil,
               let persisted = Self.loadPersistedTarget(),
-              persisted.serverId == ServerRegistry.shared.activeServerId
+              ServerRegistry.serverIdsMatch(
+                  persisted.serverId,
+                  ServerRegistry.shared.activeServerId
+              )
         else { return }
 
         autoResumeGeneration += 1

--- a/iosApp/iosApp/Control/iOS/SiloControlClient.swift
+++ b/iosApp/iosApp/Control/iOS/SiloControlClient.swift
@@ -373,11 +373,16 @@ final class SiloControlClient {
     /// Applies one hardware-button volume step. Updates `state` optimistically
     /// so rapid presses accumulate instead of re-sending the same absolute
     /// value while the TV's state acknowledgement is still in flight.
+    ///
+    /// Steps always start from the retained `volume`, never from the zero the UI
+    /// shows while muted: the TV keeps its level independently of mute, so
+    /// sending `0` would overwrite it and leave a later unmute silent. A step
+    /// down while muted is therefore a no-op — the TV is already silent, and the
+    /// only thing a command could do there is destroy the stored level.
     func stepVolumeOptimistic(_ step: Int) {
-        guard var s = state else { return }
-        let current = s.isMuted ? 0 : s.volume
-        let next = min(1, max(0, current + Double(step) / 16))
-        if step > 0, s.isMuted {
+        guard var s = state, !(s.isMuted && step < 0) else { return }
+        let next = min(1, max(0, s.volume + Double(step) / 16))
+        if s.isMuted {
             s.isMuted = false
             send(.setMuted(false))
         }

--- a/iosApp/iosApp/Control/iOS/SiloControlClient.swift
+++ b/iosApp/iosApp/Control/iOS/SiloControlClient.swift
@@ -48,12 +48,16 @@ private enum SiloControlHandoffError: LocalizedError {
 @Observable
 final class SiloControlClient {
     private(set) var activeTarget: SiloControlTarget?
-    private(set) var state: SiloControlPlaybackState?
+    private(set) var state: SiloControlPlaybackState? {
+        didSet { if state == nil { volumeReconciler.clear() } }
+    }
     private(set) var isConnecting = false
     var errorMessage: String?
     var isShowingRemoteControl = false
 
     let clock = RemotePlaybackClock()
+
+    private var volumeReconciler = RemoteVolumeReconciler()
 
     private let nowPlaying = NowPlayingController()
     private var nowPlayingArtworkTask: Task<Void, Never>?
@@ -367,12 +371,31 @@ final class SiloControlClient {
     }
 
     func playNext() { send(.playNext) }
-    func setVolume(_ v: Double) { send(.setVolume(min(max(v, 0), 1))) }
-    func setMuted(_ m: Bool) { send(.setMuted(m)) }
 
-    /// Applies one hardware-button volume step. Updates `state` optimistically
-    /// so rapid presses accumulate instead of re-sending the same absolute
-    /// value while the TV's state acknowledgement is still in flight.
+    /// Shows the requested level immediately and holds it until the TV reports
+    /// it — see ``RemoteVolumeReconciler`` for why absolute volume commands need
+    /// that hold.
+    func setVolume(_ v: Double) {
+        let clamped = min(max(v, 0), 1)
+        volumeReconciler.requested(clamped)
+        if var s = state {
+            s.volume = clamped
+            state = s
+        }
+        send(.setVolume(clamped))
+    }
+
+    func setMuted(_ m: Bool) {
+        // A held level describes an unmuted volume; an explicit mute supersedes it.
+        volumeReconciler.clear()
+        if var s = state {
+            s.isMuted = m
+            state = s
+        }
+        send(.setMuted(m))
+    }
+
+    /// Applies one hardware-button volume step.
     ///
     /// Steps always start from the retained `volume`, never from the zero the UI
     /// shows while muted: the TV keeps its level independently of mute, so
@@ -380,15 +403,17 @@ final class SiloControlClient {
     /// down while muted is therefore a no-op — the TV is already silent, and the
     /// only thing a command could do there is destroy the stored level.
     func stepVolumeOptimistic(_ step: Int) {
-        guard var s = state, !(s.isMuted && step < 0) else { return }
-        let next = min(1, max(0, s.volume + Double(step) / 16))
-        if s.isMuted {
-            s.isMuted = false
-            send(.setMuted(false))
-        }
-        s.volume = next
-        state = s
-        send(.setVolume(next))
+        guard let s = state, !(s.isMuted && step < 0) else { return }
+        if s.isMuted { setMuted(false) }
+        setVolume(s.volume + Double(step) / 16)
+    }
+
+    private func reconcileOptimisticVolume(
+        _ next: SiloControlPlaybackState
+    ) -> SiloControlPlaybackState {
+        var reconciled = next
+        reconciled.volume = volumeReconciler.reconcile(inbound: next.volume)
+        return reconciled
     }
 
     func hideRemoteControl() {
@@ -570,7 +595,8 @@ final class SiloControlClient {
         case .handoffCancel(let cancel):
             guard cancel.requestId == pendingHandoffRequestId else { return }
             handoffCancellation = cancel
-        case .state(let state):
+        case .state(let inbound):
+            let state = reconcileOptimisticVolume(inbound)
             self.state = state
             clock.ingest(state)
             updateNowPlaying(for: state)

--- a/iosApp/iosApp/Control/iOS/SiloControlClient.swift
+++ b/iosApp/iosApp/Control/iOS/SiloControlClient.swift
@@ -370,6 +370,22 @@ final class SiloControlClient {
     func setVolume(_ v: Double) { send(.setVolume(min(max(v, 0), 1))) }
     func setMuted(_ m: Bool) { send(.setMuted(m)) }
 
+    /// Applies one hardware-button volume step. Updates `state` optimistically
+    /// so rapid presses accumulate instead of re-sending the same absolute
+    /// value while the TV's state acknowledgement is still in flight.
+    func stepVolumeOptimistic(_ step: Int) {
+        guard var s = state else { return }
+        let current = s.isMuted ? 0 : s.volume
+        let next = min(1, max(0, current + Double(step) / 16))
+        if step > 0, s.isMuted {
+            s.isMuted = false
+            send(.setMuted(false))
+        }
+        s.volume = next
+        state = s
+        send(.setVolume(next))
+    }
+
     func hideRemoteControl() {
         isShowingRemoteControl = false
     }

--- a/iosApp/iosApp/Control/iOS/SiloControlRemoteView.swift
+++ b/iosApp/iosApp/Control/iOS/SiloControlRemoteView.swift
@@ -10,10 +10,16 @@ struct SiloControlRemoteView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var artwork = SiloControlArtworkResolver()
     @State private var isShowingPicker = false
+    @State private var volumeButtons = RemoteHardwareVolumeInterceptor()
 
     var body: some View {
         NavigationStack {
             ZStack {
+                HiddenVolumeHost(interceptor: volumeButtons)
+                    .frame(width: 1, height: 1)
+                    .opacity(0.0001)
+                    .allowsHitTesting(false)
+                    .accessibilityHidden(true)
                 SiloControlArtworkBackground(urlString: artwork.backdropURL ?? artwork.posterURL)
                 content
             }
@@ -42,6 +48,17 @@ struct SiloControlRemoteView: View {
                         } label: {
                             Label("Stop Playback", systemImage: "stop.fill")
                         }
+                        if controller.state?.supportsVideoGravity == true {
+                            Menu {
+                                ForEach(VideoGravity.allCases, id: \.rawValue) { gravity in
+                                    Button { controller.send(.setVideoGravity(gravity.rawValue)) } label: {
+                                        Label(gravity.label, systemImage: controller.state?.videoGravity == gravity.rawValue ? "checkmark" : "rectangle.inset.filled")
+                                    }
+                                }
+                            } label: {
+                                Label("Aspect Ratio", systemImage: "rectangle.inset.filled")
+                            }
+                        }
                         Divider()
                         Button(role: .destructive) {
                             controller.disconnect()
@@ -61,6 +78,17 @@ struct SiloControlRemoteView: View {
             }
         }
         .preferredColorScheme(.dark)
+        .onAppear {
+            volumeButtons.onVolumeStep = { step in
+                guard let state = controller.state else { return }
+                let current = state.isMuted ? 0 : state.volume
+                let next = min(1, max(0, current + Double(step) / 16))
+                if step > 0, state.isMuted { controller.setMuted(false) }
+                controller.setVolume(next)
+            }
+            volumeButtons.start()
+        }
+        .onDisappear { volumeButtons.stop() }
         .task(id: controller.state?.contentId) {
             await artwork.resolve(contentId: controller.state?.contentId)
         }
@@ -166,20 +194,18 @@ private struct RemoteNowPlayingContent: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            Spacer(minLength: 8)
             artwork
-            Spacer(minLength: 16)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding(.vertical, 12)
             titleBlock
             playingOnPill.padding(.top, 10)
-            scrubber.padding(.top, 22)
-            transport.padding(.top, 18)
-            volumeRow.padding(.top, 18)
-            Spacer(minLength: 16)
-            secondaryControls
+            scrubber.padding(.top, 24)
+            transport.padding(.top, 20)
+            volumeRow.padding(.top, 20)
+            secondaryControls.padding(.top, 20)
             if let error = state.error, !error.isEmpty {
                 errorBanner(error).padding(.top, 12)
             }
-            Spacer(minLength: 8)
         }
         .padding(.horizontal, 24)
         .padding(.bottom, 12)
@@ -274,6 +300,12 @@ private struct RemoteNowPlayingContent: View {
 
     private var transport: some View {
         HStack(spacing: 28) {
+            if state.hasNextEpisode {
+                Image(systemName: "forward.end.fill")
+                    .font(.system(size: 24, weight: .regular))
+                    .hidden()
+            }
+
             Button {
                 onSeek(max(0, clock.displayTime() - 10))
             } label: {
@@ -337,21 +369,23 @@ private struct RemoteNowPlayingContent: View {
             .tint(Color.continuumOnSurface)
             .accessibilityLabel("Volume")
             .accessibilityValue("\(Int((state.isMuted ? 0 : state.volume) * 100)) percent")
+
+            Image(systemName: "speaker.wave.3.fill")
+                .font(.system(size: 18, weight: .medium))
+                .frame(width: 28)
+                .foregroundStyle(Color.continuumOnSurface.opacity(0.55))
         }
+        .frame(maxWidth: 280)
         .foregroundStyle(Color.continuumOnSurface)
         .buttonStyle(.plain)
     }
 
     private var secondaryControls: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(alignment: .top, spacing: 8) {
-                if !state.audioTracks.isEmpty { audioMenu.frame(minWidth: 76) }
-                if hasSubtitleControls { subtitleMenu.frame(minWidth: 76) }
-                if !state.qualityOptions.isEmpty { qualityMenu.frame(minWidth: 76) }
-                speedMenu.frame(minWidth: 76)
-                if state.supportsVideoGravity { displayMenu.frame(minWidth: 76) }
-            }
-            .padding(.horizontal, 2)
+        HStack(alignment: .top, spacing: 8) {
+            if !state.qualityOptions.isEmpty { qualityMenu }
+            if !state.audioTracks.isEmpty { audioMenu }
+            if hasSubtitleControls { subtitleMenu }
+            speedMenu
         }
     }
 
@@ -462,19 +496,6 @@ private struct RemoteNowPlayingContent: View {
             }
         } label: { RemoteChipLabel(systemImage: "speedometer", caption: "Speed") }
         .accessibilityValue(speedLabel(state.playbackSpeed))
-    }
-
-    private var displayMenu: some View {
-        Menu {
-            if state.supportsVideoGravity {
-                ForEach(VideoGravity.allCases, id: \.rawValue) { gravity in
-                    Button { onCommand(.setVideoGravity(gravity.rawValue)) } label: {
-                        Label(gravity.label, systemImage: state.videoGravity == gravity.rawValue ? "checkmark" : "rectangle.inset.filled")
-                    }
-                }
-            }
-        } label: { RemoteChipLabel(systemImage: "rectangle.inset.filled", caption: "Aspect") }
-        .accessibilityValue(VideoGravity(rawValue: state.videoGravity)?.label ?? state.videoGravity)
     }
 
     private func speedLabel(_ speed: Double) -> String {

--- a/iosApp/iosApp/Control/iOS/SiloControlRemoteView.swift
+++ b/iosApp/iosApp/Control/iOS/SiloControlRemoteView.swift
@@ -87,17 +87,24 @@ struct SiloControlRemoteView: View {
         }
         .onDisappear { volumeButtons.stop() }
         .onChange(of: scenePhase) { updateVolumeInterception() }
-        .onChange(of: controller.state == nil) { updateVolumeInterception() }
+        .onChange(of: hasActivePlayback) { updateVolumeInterception() }
         .task(id: controller.state?.contentId) {
             await artwork.resolve(contentId: controller.state?.contentId)
         }
     }
 
+    /// A connected-but-idle TV still publishes state, with no content id. It has
+    /// no player to route volume at, so commands come back `player_not_ready`;
+    /// interception there would only cost the phone its own volume buttons.
+    private var hasActivePlayback: Bool {
+        !(controller.state?.contentId ?? "").isEmpty
+    }
+
     /// Hardware-volume interception is live only while the scene is active and
-    /// a usable remote state exists: an inactive scene must return the buttons
-    /// to the phone, and without state a press could not reach the TV anyway.
+    /// the TV is actually playing something: an inactive scene must return the
+    /// buttons to the phone, and without playback a press reaches nothing.
     private func updateVolumeInterception() {
-        if scenePhase == .active, controller.state != nil {
+        if scenePhase == .active, hasActivePlayback {
             volumeButtons.start()
         } else {
             volumeButtons.stop()

--- a/iosApp/iosApp/Control/iOS/SiloControlRemoteView.swift
+++ b/iosApp/iosApp/Control/iOS/SiloControlRemoteView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 struct SiloControlRemoteView: View {
     @Bindable var controller: SiloControlClient
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.scenePhase) private var scenePhase
     @State private var artwork = SiloControlArtworkResolver()
     @State private var isShowingPicker = false
     @State private var volumeButtons = RemoteHardwareVolumeInterceptor()
@@ -80,17 +81,26 @@ struct SiloControlRemoteView: View {
         .preferredColorScheme(.dark)
         .onAppear {
             volumeButtons.onVolumeStep = { step in
-                guard let state = controller.state else { return }
-                let current = state.isMuted ? 0 : state.volume
-                let next = min(1, max(0, current + Double(step) / 16))
-                if step > 0, state.isMuted { controller.setMuted(false) }
-                controller.setVolume(next)
+                controller.stepVolumeOptimistic(step)
             }
-            volumeButtons.start()
+            updateVolumeInterception()
         }
         .onDisappear { volumeButtons.stop() }
+        .onChange(of: scenePhase) { updateVolumeInterception() }
+        .onChange(of: controller.state == nil) { updateVolumeInterception() }
         .task(id: controller.state?.contentId) {
             await artwork.resolve(contentId: controller.state?.contentId)
+        }
+    }
+
+    /// Hardware-volume interception is live only while the scene is active and
+    /// a usable remote state exists: an inactive scene must return the buttons
+    /// to the phone, and without state a press could not reach the TV anyway.
+    private func updateVolumeInterception() {
+        if scenePhase == .active, controller.state != nil {
+            volumeButtons.start()
+        } else {
+            volumeButtons.stop()
         }
     }
 

--- a/iosApp/iosApp/Control/iOS/SiloControlTargetPickerView.swift
+++ b/iosApp/iosApp/Control/iOS/SiloControlTargetPickerView.swift
@@ -89,7 +89,10 @@ struct SiloControlTargetPickerView: View {
                                 .font(.subheadline)
                                 .foregroundStyle(Color.continuumPrimary)
                         } else if let serverName = target.serverName {
-                            Text(target.serverId == ServerRegistry.shared.activeServerId
+                            Text(ServerRegistry.serverIdsMatch(
+                                target.serverId,
+                                ServerRegistry.shared.activeServerId
+                            )
                                  ? serverName
                                  : "Will temporarily use your server")
                                 .font(.subheadline)
@@ -115,7 +118,9 @@ struct SiloControlTargetPickerView: View {
     private var displayedTargets: [SiloControlTarget] {
         guard request == nil else { return browser.found }
         guard let activeServerId = ServerRegistry.shared.activeServerId else { return [] }
-        return browser.found.filter { $0.serverId == activeServerId }
+        return browser.found.filter {
+            ServerRegistry.serverIdsMatch($0.serverId, activeServerId)
+        }
     }
 }
 

--- a/iosApp/iosApp/Control/tvOS/RemotePlaybackIdentityManager.swift
+++ b/iosApp/iosApp/Control/tvOS/RemotePlaybackIdentityManager.swift
@@ -86,7 +86,7 @@ final class RemotePlaybackIdentityManager {
 
     func matches(_ offer: SiloControlHandoffOffer, controllerDeviceId: String) -> Bool {
         guard let activeIdentity else { return false }
-        return activeIdentity.serverId == offer.serverId
+        return ServerRegistry.serverIdsMatch(activeIdentity.serverId, offer.serverId)
             && activeIdentity.profileId == offer.profileId
             && activeIdentity.controllerDeviceId == controllerDeviceId
     }
@@ -270,7 +270,10 @@ final class RemotePlaybackIdentityManager {
         }
         activationGenerationPending = generationID
         let previousIdentity = activeIdentity
-        let usesDifferentServer = scope.serverId != ServerRegistry.shared.activeServerId
+        let usesDifferentServer = !ServerRegistry.serverIdsMatch(
+            scope.serverId,
+            ServerRegistry.shared.activeServerId
+        )
         await HTTPClient.shared.cancelInFlightRequests()
         guard activationGenerationPending == generationID,
               !Task.isCancelled else {

--- a/iosApp/iosApp/Control/tvOS/TVControlReceiver.swift
+++ b/iosApp/iosApp/Control/tvOS/TVControlReceiver.swift
@@ -318,7 +318,10 @@ final class TVControlReceiver {
             remoteControllerName = hello.deviceName
             remoteControllerDeviceId = hello.deviceId
             remoteControllerServerId = serverId
-            if serverId == RemotePlaybackIdentityManager.shared.effectiveServerId {
+            if ServerRegistry.serverIdsMatch(
+                serverId,
+                RemotePlaybackIdentityManager.shared.effectiveServerId
+            ) {
                 isAuthorized = true
                 refreshStandbyState()
                 sendState()
@@ -472,7 +475,10 @@ final class TVControlReceiver {
     }
 
     private func handleLaunch(_ launch: SiloControlLaunchRequest) {
-        guard launch.serverId == RemotePlaybackIdentityManager.shared.effectiveServerId else {
+        guard ServerRegistry.serverIdsMatch(
+            launch.serverId,
+            RemotePlaybackIdentityManager.shared.effectiveServerId
+        ) else {
             sendError(code: "server_mismatch", message: "This Apple TV is connected to a different Silo server.")
             return
         }
@@ -600,7 +606,10 @@ final class TVControlReceiver {
 
     private func reconcileAuthorizationAfterRestore() {
         remoteLaunchReady = false
-        isAuthorized = remoteControllerServerId == RemotePlaybackIdentityManager.shared.effectiveServerId
+        isAuthorized = ServerRegistry.serverIdsMatch(
+            remoteControllerServerId,
+            RemotePlaybackIdentityManager.shared.effectiveServerId
+        )
         if isAuthorized {
             sendState()
         } else {

--- a/iosApp/iosApp/Networking/ServerRegistry.swift
+++ b/iosApp/iosApp/Networking/ServerRegistry.swift
@@ -763,10 +763,10 @@ final class ServerRegistry {
 
     // MARK: - ID derivation
 
-    /// Canonical registry ID for a URL. Two URLs that normalize to the
-    /// same string share an ID; otherwise they are treated as distinct
-    /// servers (which may produce duplicate entries for the same instance
-    /// reached at e.g. LAN vs Tailscale — an accepted limitation).
+    /// Registry key for a URL. The exact normalized spelling is deliberately
+    /// preserved because this value already scopes credentials and local data.
+    /// User-facing server comparisons must use ``serverIdsMatch(_:_:)`` so
+    /// harmless URL spelling differences do not split one server in two.
     static func serverId(for url: String) -> String {
         let normalized = normalize(url: url)
         let data = Data(normalized.utf8)
@@ -780,6 +780,64 @@ final class ServerRegistry {
         var s = url.trimmingCharacters(in: .whitespacesAndNewlines)
         while s.hasSuffix("/") { s.removeLast() }
         return s
+    }
+
+    /// Reverses the legacy URL-derived registry key. This is intentionally
+    /// narrow: the decoded value must be a plausible HTTP(S) server URL and
+    /// must round-trip to the exact supplied ID. Unknown future ID formats are
+    /// therefore never mistaken for a URL.
+    static func url(forServerId serverId: String) -> String? {
+        guard !serverId.isEmpty else { return nil }
+        var base64 = serverId
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let padding = base64.count % 4
+        if padding != 0 {
+            base64.append(String(repeating: "=", count: 4 - padding))
+        }
+        guard let data = Data(base64Encoded: base64),
+              let decoded = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        let normalized = normalize(url: decoded)
+        guard canonicalComparisonURL(for: normalized) != nil,
+              self.serverId(for: normalized) == serverId else {
+            return nil
+        }
+        return normalized
+    }
+
+    /// Compares local registry IDs as server origins without changing either
+    /// device's persisted key. URL schemes and hosts are case-insensitive and
+    /// default ports are equivalent; credentials, paths, queries, and
+    /// fragments retain their ordinary case-sensitive semantics.
+    static func serverIdsMatch(_ lhs: String?, _ rhs: String?) -> Bool {
+        guard let lhs, let rhs, !lhs.isEmpty, !rhs.isEmpty else { return false }
+        if lhs == rhs { return true }
+        guard let lhsURL = url(forServerId: lhs),
+              let rhsURL = url(forServerId: rhs),
+              let lhsCanonical = canonicalComparisonURL(for: lhsURL),
+              let rhsCanonical = canonicalComparisonURL(for: rhsURL) else {
+            return false
+        }
+        return lhsCanonical == rhsCanonical
+    }
+
+    private static func canonicalComparisonURL(for url: String) -> String? {
+        guard var components = URLComponents(string: normalize(url: url)),
+              let scheme = components.scheme?.lowercased(),
+              ["http", "https"].contains(scheme),
+              let host = components.host?.lowercased(),
+              !host.isEmpty else {
+            return nil
+        }
+        components.scheme = scheme
+        components.host = host
+        if (scheme == "http" && components.port == 80)
+            || (scheme == "https" && components.port == 443) {
+            components.port = nil
+        }
+        return components.string
     }
 
     // MARK: - Persistence


### PR DESCRIPTION
## Summary

- Center the iOS remote playback controls and improve layout spacing.
- Map hardware volume buttons to remote volume adjustments while suppressing the system HUD.
- Add aspect-ratio controls and rebalance secondary playback actions.

## Testing

- Not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Hardware volume buttons now control remote playback while the app is active, with automatic mute and volume safeguards.
  - Added conditional aspect-ratio controls and refined playback controls, artwork sizing, speaker indicators, and secondary actions.
- **Bug Fixes**
  - Improved server recognition across capitalization, default ports, and equivalent URL formats.
  - Strengthened validation for saved and restored server connections.
- **Tests**
  - Added coverage for server identity matching, URL validation, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->