### PR TITLE
fix(profiles): handle DiceBear SVG avatar references

### DIFF
--- a/iosApp/iosApp/Screens/Profiles/ProfileTile.swift
+++ b/iosApp/iosApp/Screens/Profiles/ProfileTile.swift
@@ -295,12 +295,12 @@ enum ProfileAvatarResolver {
 
         let lowercased = trimmed.lowercased()
 
-        // The Nuke pipeline registers no SVG decoder, so the server's legacy
-        // `/profile-avatars/{id}.svg` preset URLs cannot be rendered here.
-        // Decline them and let the caller's raw-ref fallback chain apply.
-        // Uploads are .webp and DiceBear presets are PNG, so both pass.
+        // The Nuke pipeline registers no SVG decoder. Legacy presets use an
+        // `.svg` extension, while DiceBear uses an `/svg` format path.
+        // Decline both and let the caller's raw-ref fallback build a PNG URL.
+        // Uploaded avatars are WebP and continue through this path.
         let pathOnly = lowercased.split(separator: "?", maxSplits: 1)[0]
-        if pathOnly.hasSuffix(".svg") { return nil }
+        if pathOnly.hasSuffix(".svg") || pathOnly.hasSuffix("/svg") { return nil }
 
         if lowercased.hasPrefix("http://")
             || lowercased.hasPrefix("https://")


### PR DESCRIPTION
## Summary

- Detect DiceBear avatar URLs that use the `/svg` format path.
- Fall back to a PNG avatar URL that the Nuke image pipeline can render.
- Preserve support for uploaded WebP avatars and legacy `.svg` presets.

## Testing

- Not run (source-only URL resolution change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile image handling by falling back to PNG images when an SVG file path or SVG-ending path is provided.
  * Preserved existing behavior for other image URL formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->