### PR TITLE
fix(playback): resolve non-default audio before original-file load

### DIFF
--- a/iosApp/Tests/AetherPlaybackBoundaryTests.swift
+++ b/iosApp/Tests/AetherPlaybackBoundaryTests.swift
@@ -73,6 +73,22 @@ final class AetherPlaybackBoundaryTests: XCTestCase {
         XCTAssertEqual(languages, ["en"])
     }
 
+    func testNonDefaultSameLanguageAudioRequiresAnExactFirstOpenProbe() {
+        let tracks = [
+            makeAudioTrack(language: "eng", isDefault: true),
+            makeAudioTrack(language: "eng", isDefault: false),
+        ]
+
+        XCTAssertFalse(AetherInitialAudioPreference.requiresExactStreamProbe(
+            selectedOrdinal: 0,
+            tracks: tracks
+        ))
+        XCTAssertTrue(AetherInitialAudioPreference.requiresExactStreamProbe(
+            selectedOrdinal: 1,
+            tracks: tracks
+        ))
+    }
+
     private func makeAudioTrack(language: String?, isDefault: Bool) -> AudioTrack {
         AudioTrack(
             index: nil,
@@ -430,6 +446,7 @@ final class AetherPlaybackBoundaryTests: XCTestCase {
                 "Authorization": "Bearer current-token",
             ],
             resolveURL: { URL(string: $0, relativeTo: URL(string: "https://dev.example.test")) },
+            audioSourceStreamIndex: 7,
             preferredAudioLanguages: ["eng"],
             preferredSubtitleLanguages: ["eng"]
         )
@@ -442,7 +459,7 @@ final class AetherPlaybackBoundaryTests: XCTestCase {
         ])
         XCTAssertEqual(spec.options.preferredAudioLanguages, ["eng"])
         XCTAssertEqual(spec.options.preferredSubtitleLanguages, ["eng"])
-        XCTAssertNil(spec.audioSourceStreamIndex)
+        XCTAssertEqual(spec.audioSourceStreamIndex, 7)
         XCTAssertFalse(spec.options.audioOnly)
         XCTAssertFalse(spec.options.autoplay)
         XCTAssertFalse(spec.options.nativeRemoteHLS)

--- a/iosApp/Tests/AppleDecodeCapabilitiesTests.swift
+++ b/iosApp/Tests/AppleDecodeCapabilitiesTests.swift
@@ -158,7 +158,7 @@ final class AppleDecodeCapabilitiesTests: XCTestCase {
             originalHTTP.validatedClaims.contains(
                 PlaybackProtocolV3.clientSelectedAudioTrackClaim
             ),
-            "The Aether original-file executor maps the plan's selected audio ordinal after probing."
+            "The Aether original-file executor maps the plan's selected audio ordinal to an exact stream before opening non-default audio."
         )
 
         let progressive = try XCTUnwrap(

--- a/iosApp/iosApp/Screens/Player/AetherLoadSpec.swift
+++ b/iosApp/iosApp/Screens/Player/AetherLoadSpec.swift
@@ -7,9 +7,9 @@ import Foundation
 /// user's broader profile preference to Aether in that case can start a
 /// different track, publish first frame, and then force a full pipeline reload
 /// when the exact ordinal is applied after inventory arrives. Prefer the
-/// selected track's language for the first open; the existing post-probe
-/// ordinal reconciliation remains the exact fallback for unlabeled or
-/// same-language tracks.
+/// selected track's language for the first open. Non-default original-file
+/// tracks are resolved to an exact stream id before loading; the existing
+/// post-open reconciliation remains a fallback for partial metadata.
 enum AetherInitialAudioPreference {
     static func languages(
         selectedOrdinal: Int?,
@@ -25,6 +25,21 @@ enum AetherInitialAudioPreference {
 
         let fallback = fallbackLanguage.trimmingCharacters(in: .whitespacesAndNewlines)
         return fallback.isEmpty ? [] : [fallback]
+    }
+
+    /// Whether an original-file load must resolve the plan's dense ordinal to
+    /// an AVStream id before opening Aether. The container default needs no
+    /// override; every other selection does. Language is deliberately ignored:
+    /// TrueHD and its compatibility track commonly share the same tag, so even
+    /// a non-empty language cannot prove which stream Aether will choose.
+    static func requiresExactStreamProbe(
+        selectedOrdinal: Int?,
+        tracks: [AudioTrack]
+    ) -> Bool {
+        guard let selectedOrdinal else { return false }
+        guard !tracks.isEmpty else { return true }
+        let defaultOrdinal = tracks.firstIndex { $0.isDefault == true } ?? 0
+        return selectedOrdinal != defaultOrdinal
     }
 }
 
@@ -220,6 +235,7 @@ struct AetherLoadSpec {
         requestHeaders: [String: String]? = nil,
         resolveURL: ((String) -> URL?)? = nil,
         apiOriginURL: URL? = nil,
+        audioSourceStreamIndex: Int32? = nil,
         preferredAudioLanguages: [String] = [],
         preferredSubtitleLanguages: [String] = [],
         forwardBufferSegments: Int? = nil,
@@ -249,11 +265,10 @@ struct AetherLoadSpec {
         let effectiveHeaders = requestHeaders ?? plan.stream.headers
 
         // Protocol V3's selected audio index is an ordinal in the server's
-        // audio-track list, not an FFmpeg AVStream index. Keep it out of
-        // LoadOptions: after Aether publishes its probed inventory,
-        // PlayerViewModel maps that ordinal to Aether's stream id and applies
-        // the plan-authoritative selection. This lets original HTTP remain a
-        // byte-for-byte source while still honoring a non-default track.
+        // audio-track list, not an FFmpeg AVStream index. The caller resolves
+        // a non-default original-file ordinal through Aether's authenticated
+        // probe and passes the resulting stream id separately. The post-open
+        // reconciliation remains a fallback for older/partial metadata.
         if let selectedIndex = plan.selectedTracks.audio?.index {
             guard selectedIndex >= 0 else {
                 throw ValidationError.invalidAudioTrackIndex(selectedIndex)
@@ -318,7 +333,7 @@ struct AetherLoadSpec {
         self.delivery = plan.delivery
         self.sourceURL = sourceURL
         self.timeline = timeline
-        self.audioSourceStreamIndex = nil
+        self.audioSourceStreamIndex = audioSourceStreamIndex
         self.externalSubtitleAppTrackIDs = externalSubtitleAppTrackIDs
         let isServerHLS = [
             PlaybackProtocolV3.PlanDelivery.remuxHLS,

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -2319,6 +2319,39 @@ class PlayerViewModel {
             : .field
         let spec: AetherLoadSpec
         if let v3 = prepared.protocolV3 {
+            let audioSourceStreamIndex: Int32?
+            let selectedAudioOrdinal = v3.plan.selectedTracks.audio?.index
+            let catalogAudioTracks = prepared.selectedVersion.audioTracks ?? []
+            if v3.plan.delivery == PlaybackProtocolV3.PlanDelivery.originalHTTP,
+               AetherInitialAudioPreference.requiresExactStreamProbe(
+                   selectedOrdinal: selectedAudioOrdinal,
+                   tracks: catalogAudioTracks
+               ),
+               let selectedAudioOrdinal {
+                // A V3 audio identity is a dense ordinal, but Aether's exact
+                // first-open override is an FFmpeg AVStream id. Resolve it
+                // with the same authenticated source and headers the real
+                // load will use. This extra open is limited to non-default
+                // original-file audio; without it, a same-language
+                // TrueHD/compatibility pair starts on the container default
+                // and depends on a fragile post-load pipeline rebuild.
+                let sourceURL = streamRequest.url
+                let sourceHeaders = streamRequest.headers
+                let probe = try await Task.detached(priority: .userInitiated) {
+                    try AetherEngine.probe(
+                        url: sourceURL,
+                        options: LoadOptions(httpHeaders: sourceHeaders)
+                    )
+                }.value
+                try requireCurrentStreamLoad(expectedStreamLoadGeneration)
+                guard probe.audioTracks.indices.contains(selectedAudioOrdinal),
+                      let exactStreamIndex = Int32(exactly: probe.audioTracks[selectedAudioOrdinal].id) else {
+                    throw AetherLoadSpec.ValidationError.invalidAudioTrackIndex(selectedAudioOrdinal)
+                }
+                audioSourceStreamIndex = exactStreamIndex
+            } else {
+                audioSourceStreamIndex = nil
+            }
             spec = try AetherLoadSpec(
                 validating: v3.plan,
                 sessionID: prepared.session.sessionId,
@@ -2338,6 +2371,7 @@ class PlayerViewModel {
                     )?.url
                 },
                 apiOriginURL: URL(string: streamRequest.serverUrl),
+                audioSourceStreamIndex: audioSourceStreamIndex,
                 preferredAudioLanguages: preferredAudio,
                 preferredSubtitleLanguages: preferredSubtitles,
                 forwardBufferSegments: forwardBufferSegments,

--- a/iosApp/iosApp/tvOS/Navigation/TVFocusWatchdog.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVFocusWatchdog.swift
@@ -110,10 +110,10 @@ struct TVFocusWatchdogModifier: ViewModifier {
             level: .warning,
             category: .focus,
             tag: "FocusRepair",
-            message: "no focused item; repairing",
+            message: "no focused item after \(consecutiveMisses) checks; repair attempt \(repairsThisOutage)",
             attrs: [
-                "misses": .int(consecutiveMisses),
-                "attempt": .int(repairsThisOutage),
+                "target": .string("focusSystem"),
+                "action": .string("repair"),
             ]
         )
         onRepair()
@@ -128,10 +128,12 @@ struct TVFocusWatchdogModifier: ViewModifier {
         DiagnosticsCoordinator.recordBreadcrumb(
             category: .focus,
             tag: "FocusRepair",
-            message: repairPending ? "focus restored after repair" : "focus recovered unaided",
+            message: repairPending
+                ? "focus restored after \(consecutiveMisses) checks"
+                : "focus recovered unaided after \(consecutiveMisses) checks",
             attrs: [
-                "misses": .int(consecutiveMisses),
-                "focused": .string(focused),
+                "target": .string(focused),
+                "action": .string(repairPending ? "restoredAfterRepair" : "recoveredUnaided"),
             ]
         )
     }


### PR DESCRIPTION
## Summary

- Probe original-file media to resolve non-default audio ordinals to exact Aether stream IDs before loading.
- Preserve resolved stream metadata in `AetherLoadSpec` with fallback reconciliation for partial metadata.
- Improve tvOS focus-repair diagnostics with outage counts and repair actions.
- Update playback boundary and capability tests.

## Testing

- Updated `AetherPlaybackBoundaryTests` for exact stream probing and stream-index propagation.
- Updated `AppleDecodeCapabilitiesTests` assertions for non-default audio handling.
- Full Apple test suite not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved audio track selection for original-file playback, including exact stream resolution when multiple tracks share a language.
  * Added more reliable handling of selected audio streams for Protocol V3 HTTP playback.
  * Enhanced TV focus recovery details with clearer status and action information.
* **Bug Fixes**
  * Corrected audio source stream selection during playback initialization.
  * Expanded automated coverage for non-default audio track playback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->