### PR TITLE
fix(playback): recover after Aether authorization expires

### DIFF
--- a/iosApp/Tests/AetherPlaybackBoundaryTests.swift
+++ b/iosApp/Tests/AetherPlaybackBoundaryTests.swift
@@ -125,6 +125,62 @@ final class AetherPlaybackBoundaryTests: XCTestCase {
         XCTAssertEqual(request.headers["X-Transport"], "preserved")
     }
 
+    func testExpiredBearerRecoveryRecognizesTypedSourceAndAVPlayer401Failures() {
+        XCTAssertTrue(AetherAuthenticationRecoveryPolicy.isExpiredBearerFailure(
+            PlaybackErrorInfo(
+                kind: .sourceRefused,
+                message: "origin refused source",
+                underlyingCode: 401
+            )
+        ))
+        XCTAssertTrue(AetherAuthenticationRecoveryPolicy.isExpiredBearerFailure(
+            PlaybackErrorInfo(
+                kind: .nativeItemFailed,
+                message: "localized AVPlayer failure",
+                underlyingDomain: NSURLErrorDomain,
+                underlyingCode: NSURLErrorUserAuthenticationRequired
+            )
+        ))
+    }
+
+    func testExpiredBearerRecoveryRejectsNonAuthenticationFailures() {
+        for failure in [
+            PlaybackErrorInfo(
+                kind: .sourceRefused,
+                message: "forbidden",
+                underlyingCode: 403
+            ),
+            PlaybackErrorInfo(
+                kind: .nativeItemFailed,
+                message: "timed out",
+                underlyingDomain: NSURLErrorDomain,
+                underlyingCode: NSURLErrorTimedOut
+            ),
+            PlaybackErrorInfo(
+                kind: .vodSourceFailed,
+                message: "read failed",
+                underlyingCode: 401
+            ),
+        ] {
+            XCTAssertFalse(AetherAuthenticationRecoveryPolicy.isExpiredBearerFailure(failure))
+        }
+    }
+
+    func testExpiredBearerRecoveryRequiresAChangedAuthorizationHeader() {
+        XCTAssertTrue(AetherAuthenticationRecoveryPolicy.shouldReload(
+            failedHeaders: ["authorization": "Bearer old-token"],
+            refreshedHeaders: ["Authorization": "Bearer new-token"]
+        ))
+        XCTAssertFalse(AetherAuthenticationRecoveryPolicy.shouldReload(
+            failedHeaders: ["Authorization": "Bearer current-token"],
+            refreshedHeaders: ["authorization": "Bearer current-token"]
+        ))
+        XCTAssertFalse(AetherAuthenticationRecoveryPolicy.shouldReload(
+            failedHeaders: ["Authorization": "Bearer old-token"],
+            refreshedHeaders: [:]
+        ))
+    }
+
     func testHeaderAuthenticatedStreamRejectsAbsoluteAndNonMediaRoutes() {
         for raw in [
             "https://dev.example.test/api/v1/stream/session-1",
@@ -499,6 +555,44 @@ final class AetherPlaybackBoundaryTests: XCTestCase {
 
         XCTAssertTrue(spec.options.nativeRemoteHLS)
         XCTAssertEqual(spec.options.httpHeaders["Authorization"], "Bearer test")
+    }
+
+    func testV3CredentialReloadTranslatesCurrentSourcePositionOntoPlanTimeline() throws {
+        let fixtureURL = try PlaybackV3FixtureTestSupport.fixtureURL(
+            named: "decision_response",
+            bundleClass: Self.self
+        )
+        var object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: fixtureURL)) as? [String: Any]
+        )
+        var planObject = try XCTUnwrap(object["playback_plan"] as? [String: Any])
+        var timeline = try XCTUnwrap(planObject["timeline"] as? [String: Any])
+        timeline["source_start_seconds"] = 42.5
+        timeline["stream_origin_seconds"] = 30.0
+        timeline["player_start_seconds"] = 12.5
+        timeline["timeline_offset_seconds"] = 30.0
+        planObject["timeline"] = timeline
+        object["playback_plan"] = planObject
+
+        let response = try PlaybackV3FixtureTestSupport.decoder.decode(
+            PlaybackV3DecisionResponse.self,
+            from: JSONSerialization.data(withJSONObject: object)
+        )
+        guard case .playable(let plan, let sessionID) = response.validatedForApple() else {
+            return XCTFail("Expected a playable fixture")
+        }
+        let spec = try AetherLoadSpec(
+            validating: plan,
+            sessionID: sessionID,
+            matchContentEnabled: false,
+            sourceURLOverride: URL(string: "https://dev.example.test/api/v1/stream/session"),
+            requestHeaders: ["Authorization": "Bearer refreshed-token"],
+            resumeSourcePosition: 92.0,
+            panelIsInHDRMode: false
+        )
+
+        XCTAssertEqual(spec.timeline.aetherStartPosition, 12.5)
+        XCTAssertEqual(spec.aetherStartPosition, 62.0)
     }
 
     func testV3SubtitleArtifactUsesMergedCurrentRequestHeaders() throws {

--- a/iosApp/Tests/AetherPlaybackBoundaryTests.swift
+++ b/iosApp/Tests/AetherPlaybackBoundaryTests.swift
@@ -1228,6 +1228,28 @@ final class AetherPlaybackBoundaryTests: XCTestCase {
         )
     }
 
+    func testTransportIntentCanChangeDuringAnUncommittedLoad() throws {
+        let controller = try AetherPlaybackController()
+        defer { controller.stop() }
+        let spec = try AetherLoadSpec(
+            directURL: URL(string: "https://dev.example.test/media.mp4")!,
+            headers: [:],
+            startPosition: 0,
+            audioOnly: false
+        )
+
+        controller.beginLoad(spec, shouldPlayWhenReady: false)
+        XCTAssertFalse(controller.shouldPlayWhenReady)
+
+        // Play is deliberately ignored by the engine until finishLoad, but
+        // the user's intent must still be retained for the commit boundary.
+        controller.play()
+        XCTAssertTrue(controller.shouldPlayWhenReady)
+
+        controller.pause()
+        XCTAssertFalse(controller.shouldPlayWhenReady)
+    }
+
     func testPlayAfterCommitRestoresATornDownSession() {
         XCTAssertEqual(
             AetherPlayIntent.action(

--- a/iosApp/iosApp/Screens/Player/AetherLoadSpec.swift
+++ b/iosApp/iosApp/Screens/Player/AetherLoadSpec.swift
@@ -43,6 +43,40 @@ enum AetherInitialAudioPreference {
     }
 }
 
+/// Decides whether a committed Aether load failed because the bearer frozen
+/// into its media request expired, and whether rebuilding it would actually
+/// install a different credential.
+///
+/// Keep this typed and token-agnostic: AVFoundation localizes its messages,
+/// while the error domain/code and Aether's source-refusal status are stable.
+/// Comparing the complete header value bounds recovery to one reload per
+/// credential generation; a revoked current token falls through to the normal
+/// Protocol V3 route ladder instead of looping on the same URL forever.
+enum AetherAuthenticationRecoveryPolicy {
+    static func isExpiredBearerFailure(_ failure: PlaybackErrorInfo) -> Bool {
+        if failure.kind == .sourceRefused {
+            return failure.underlyingDomain == nil && failure.underlyingCode == 401
+        }
+        return failure.kind == .nativeItemFailed
+            && failure.underlyingDomain == NSURLErrorDomain
+            && failure.underlyingCode == NSURLErrorUserAuthenticationRequired
+    }
+
+    static func shouldReload(
+        failedHeaders: [String: String],
+        refreshedHeaders: [String: String]
+    ) -> Bool {
+        guard let refreshed = authorizationHeader(in: refreshedHeaders) else { return false }
+        return authorizationHeader(in: failedHeaders) != refreshed
+    }
+
+    private static func authorizationHeader(in headers: [String: String]) -> String? {
+        headers.first { key, _ in
+            key.caseInsensitiveCompare("Authorization") == .orderedSame
+        }?.value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
 /// Immutable inputs for one Aether load generation.
 ///
 /// The initialisers are main-actor isolated because they sample the display
@@ -64,6 +98,10 @@ struct AetherLoadSpec {
     let delivery: String
     let sourceURL: URL
     let timeline: PlaybackTimelineMapper
+    /// Player-axis position handed to `AetherEngine.load`. Usually the plan's
+    /// declared start, but a same-plan credential reload resumes at the current
+    /// source position translated through the still-active timeline.
+    let aetherStartPosition: Double
     let options: LoadOptions
     let audioSourceStreamIndex: Int32?
     /// App-facing ids for `options.externalSubtitles`, positionally parallel to
@@ -138,6 +176,7 @@ struct AetherLoadSpec {
         delivery = PlaybackProtocolV3.PlanDelivery.originalHTTP
         sourceURL = offlineURL
         timeline = PlaybackTimelineMapper(directStartSeconds: startPosition)
+        aetherStartPosition = timeline.aetherStartPosition
         self.audioSourceStreamIndex = audioSourceStreamIndex
         externalSubtitleAppTrackIDs = sidecars.map { sidecar -> Int64? in
             SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: sidecar.index)
@@ -203,6 +242,7 @@ struct AetherLoadSpec {
         delivery = PlaybackProtocolV3.PlanDelivery.originalHTTP
         sourceURL = directURL
         timeline = PlaybackTimelineMapper(directStartSeconds: startPosition)
+        aetherStartPosition = timeline.aetherStartPosition
         audioSourceStreamIndex = nil
         externalSubtitleAppTrackIDs = sidecars.map { sidecar -> Int64? in
             SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: sidecar.index)
@@ -242,6 +282,7 @@ struct AetherLoadSpec {
         audioBridgeMode: AudioBridgeMode = Self.defaultAudioBridgeMode,
         deinterlaceMode: DeinterlaceMode = Self.defaultDeinterlaceMode,
         deinterlaceFieldRate: DeinterlaceFieldRate = Self.defaultDeinterlaceFieldRate,
+        resumeSourcePosition: Double? = nil,
         panelIsInHDRMode: Bool? = nil
     ) throws {
         guard PlaybackProtocolV3.PlanDelivery.supported.contains(plan.delivery) else {
@@ -333,6 +374,13 @@ struct AetherLoadSpec {
         self.delivery = plan.delivery
         self.sourceURL = sourceURL
         self.timeline = timeline
+        if let resumeSourcePosition, resumeSourcePosition.isFinite {
+            aetherStartPosition = timeline.playerPosition(
+                forSourceTime: max(0, resumeSourcePosition)
+            )
+        } else {
+            aetherStartPosition = timeline.aetherStartPosition
+        }
         self.audioSourceStreamIndex = audioSourceStreamIndex
         self.externalSubtitleAppTrackIDs = externalSubtitleAppTrackIDs
         let isServerHLS = [

--- a/iosApp/iosApp/Screens/Player/AetherPlaybackController.swift
+++ b/iosApp/iosApp/Screens/Player/AetherPlaybackController.swift
@@ -93,6 +93,10 @@ final class AetherPlaybackController {
     private var didPublishEnd = false
     private var transportIntentGeneration: UInt64 = 0
     private var transportRestoreTask: Task<Void, Never>?
+    /// The user's latest transport intent, independent of transient engine
+    /// states such as loading, buffering, and error. A replacement load reads
+    /// this after it commits so Play/Pause commands issued while loading win.
+    private(set) var shouldPlayWhenReady = false
     private var desiredVolume: Float = 1
     private var muted = false
     private var aetherSubtitleIDByAppID: [Int64: Int] = [:]
@@ -128,11 +132,15 @@ final class AetherPlaybackController {
     /// Establishes load identity synchronously, before `AetherEngine.load` can
     /// synchronously publish any state for the replacement media.
     @discardableResult
-    func beginLoad(_ spec: AetherLoadSpec) -> LoadEpoch {
+    func beginLoad(
+        _ spec: AetherLoadSpec,
+        shouldPlayWhenReady: Bool = true
+    ) -> LoadEpoch {
         generation &+= 1
         transportIntentGeneration &+= 1
         transportRestoreTask?.cancel()
         transportRestoreTask = nil
+        self.shouldPlayWhenReady = shouldPlayWhenReady
         let epoch = LoadEpoch(rawValue: generation)
         applyBackgroundPlaybackPreference()
         activeLoadEpoch = epoch
@@ -195,6 +203,7 @@ final class AetherPlaybackController {
     }
 
     func play() {
+        shouldPlayWhenReady = true
         // `beginLoad` installs spec/epoch before `engine.load` returns, and
         // that window looks identical to a background teardown: route `.none`,
         // session not ready. Reloading here would start a second `engine.load`
@@ -257,6 +266,7 @@ final class AetherPlaybackController {
     }
 
     func pause() {
+        shouldPlayWhenReady = false
         transportIntentGeneration &+= 1
         transportRestoreTask?.cancel()
         transportRestoreTask = nil
@@ -373,6 +383,7 @@ final class AetherPlaybackController {
         transportIntentGeneration &+= 1
         transportRestoreTask?.cancel()
         transportRestoreTask = nil
+        shouldPlayWhenReady = false
         activeLoadEpoch = nil
         hasCommittedActiveLoad = false
         activeSpec = nil

--- a/iosApp/iosApp/Screens/Player/AetherPlaybackController.swift
+++ b/iosApp/iosApp/Screens/Player/AetherPlaybackController.swift
@@ -156,7 +156,7 @@ final class AetherPlaybackController {
         do {
             try await engine.load(
                 url: spec.sourceURL,
-                startPosition: spec.timeline.aetherStartPosition,
+                startPosition: spec.aetherStartPosition,
                 options: spec.options,
                 audioSourceStreamIndex: spec.audioSourceStreamIndex
             )

--- a/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
@@ -578,6 +578,23 @@ actor PlaybackSessionBridge {
         return true
     }
 
+    /// Returns the committed wire session only when it still belongs to the
+    /// exact plan the player is recovering. This lets the player rebuild the
+    /// same immutable plan with refreshed request headers without asking the
+    /// server to advance the route ladder.
+    func committedProtocolV3Session(
+        planId expectedPlanId: String,
+        sessionId expectedSessionId: String
+    ) -> PlaybackSessionResponse? {
+        guard pendingProtocolV3Transition == nil,
+              sessionId == expectedSessionId,
+              currentSession?.sessionId == expectedSessionId,
+              activeProtocolV3?.plan.planId == expectedPlanId else {
+            return nil
+        }
+        return currentSession
+    }
+
     /// Promotes a candidate that Aether could not open solely so the client
     /// can report that exact failed attempt and request the next server route.
     /// This is not an execution commit: it emits no success event, binds no

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -624,6 +624,9 @@ class PlayerViewModel {
     /// would otherwise have no idea why it was abandoned.
     @ObservationIgnored
     private var lastAetherAudioTrackSwitchFailure: PlaybackErrorInfo?
+    /// Serializes every Protocol V3 source replacement, including a same-plan
+    /// reload whose only change is a refreshed bearer. Reusing this gate keeps
+    /// credential recovery from racing route replans, seeks, or track changes.
     private var protocolV3ReplanTask: Task<Void, Never>?
     private var nextUpLookupTask: Task<Void, Never>?
     private var nextUpOnDeckTask: Task<Void, Never>?
@@ -1252,6 +1255,9 @@ class PlayerViewModel {
             // replans.
             return
         }
+        if attemptProtocolV3AuthenticationReload(after: failure) {
+            return
+        }
         let serverCanAdapt: Set<PlaybackErrorKind> = [
             .sourceRefused,
             .vodSourceFailed,
@@ -1396,6 +1402,162 @@ class PlayerViewModel {
             classification: protocolV3FailureClassification(message),
             message: message
         )
+    }
+
+    /// Rebuilds the committed plan with the account bearer currently held by
+    /// `ContinuumAPI`. Protocol V3 media URLs are stable across access-token
+    /// refreshes, but Aether/AVPlayer freezes request headers at asset load.
+    /// A normal authenticated progress request first gives the shared HTTP
+    /// client a chance to refresh an expired token; the reload proceeds only
+    /// when that produced a different Authorization value.
+    @discardableResult
+    private func attemptProtocolV3AuthenticationReload(
+        after failure: PlaybackErrorInfo
+    ) -> Bool {
+        guard AetherAuthenticationRecoveryPolicy.isExpiredBearerFailure(failure),
+              protocolV3ReplanTask == nil,
+              let protocolV3 = activePreparedProtocolV3,
+              protocolV3.serverFeatures.contains(
+                  PlaybackProtocolV3.headerAuthenticatedMediaFeature
+              ),
+              let sessionId = activePlaybackSessionId,
+              let watchDetail = currentWatchDetail,
+              let selectedVersion = currentSelectedVersion,
+              let failedSpec = aetherPlaybackController.activeSpec,
+              failedSpec.planID == protocolV3.plan.planId,
+              failedSpec.sessionID == sessionId,
+              committedProtocolV3LoadEpoch != nil else {
+            return false
+        }
+
+        let planId = protocolV3.plan.planId
+        let resumePosition = currentTime.isFinite ? max(0, currentTime) : 0
+        let failedHeaders = failedSpec.options.httpHeaders
+        let fallbackClassification = failure.kind.rawValue
+        let fallbackMessage = failure.message
+
+        progressTask?.cancel()
+        progressTask = nil
+        isLoading = true
+        isBuffering = false
+        bufferingProgress = nil
+        streamLoadGeneration &+= 1
+        let recoveryGeneration = streamLoadGeneration
+
+        Self.logger.warning(
+            "Protocol V3 media credential expired; refreshing and reloading plan \(planId, privacy: .public) at source position \(resumePosition, privacy: .public)"
+        )
+
+        protocolV3ReplanTask = Task { @MainActor [weak self] in
+            guard let self, !self.isDisposed else { return }
+            var shouldFallbackToReplan = true
+            defer {
+                self.protocolV3ReplanTask = nil
+                if !self.isDisposed,
+                   recoveryGeneration == self.streamLoadGeneration {
+                    if shouldFallbackToReplan {
+                        if !self.attemptProtocolV3Replan(
+                            position: resumePosition,
+                            classification: fallbackClassification,
+                            message: fallbackMessage
+                        ) {
+                            self.finalizeTerminalPlaybackError(fallbackMessage)
+                        }
+                    } else if let queuedTrackChange = self.pendingProtocolV3TrackChange {
+                        self.pendingProtocolV3TrackChange = nil
+                        self.attemptProtocolV3Replan(
+                            position: self.currentTime,
+                            classification: queuedTrackChange.classification,
+                            message: queuedTrackChange.message,
+                            requeueWhenBusy: true,
+                            trackTarget: queuedTrackChange.target
+                        )
+                    } else if let queuedTarget = self.pendingProtocolV3SeekReanchorPosition {
+                        self.pendingProtocolV3SeekReanchorPosition = nil
+                        self.commitSeek(to: queuedTarget, source: "queuedAuthReloadReanchor")
+                    }
+                }
+            }
+
+            do {
+                // This request uses the normal API transport, whose 401 path
+                // refreshes TokenStore before retrying. Its result is otherwise
+                // best-effort; the header comparison below is authoritative.
+                _ = await self.sessionBridge.reportProgress(
+                    position: resumePosition,
+                    isPaused: !self.isPlaying
+                )
+                try self.requireCurrentStreamLoad(recoveryGeneration)
+                guard self.activePlaybackSessionId == sessionId,
+                      self.activePreparedProtocolV3?.plan.planId == planId,
+                      let session = await self.sessionBridge.committedProtocolV3Session(
+                          planId: planId,
+                          sessionId: sessionId
+                      ) else {
+                    throw CancellationError()
+                }
+                try self.requireCurrentStreamLoad(recoveryGeneration)
+
+                let prepared = PreparedPlayback(
+                    watchDetail: watchDetail,
+                    selectedVersion: selectedVersion,
+                    session: session,
+                    activeQualityId: self.activeQualityId,
+                    protocolV3: protocolV3
+                )
+                guard let streamRequest = await self.makeStreamRequest(
+                    session: session,
+                    additionalHeaders: protocolV3.plan.stream.headers,
+                    requiresHeaderAuthenticatedMedia: true,
+                    allowsAuthorizedMediaOrigins:
+                        protocolV3.negotiatedAuthorizedMediaOrigins
+                ) else {
+                    throw AetherLoadSpec.ValidationError.invalidStreamURL(session.streamUrl)
+                }
+                try self.requireCurrentStreamLoad(recoveryGeneration)
+                guard AetherAuthenticationRecoveryPolicy.shouldReload(
+                    failedHeaders: failedHeaders,
+                    refreshedHeaders: streamRequest.headers
+                ) else {
+                    Self.logger.warning(
+                        "Protocol V3 media credential did not change; using bounded route recovery"
+                    )
+                    return
+                }
+
+                // A local in-window seek can finish while the refresh request
+                // is suspended. Sample the source-axis position again at the
+                // last synchronous point before beginLoad replaces the epoch,
+                // so credential recovery never jumps back over that seek.
+                let reloadPosition = self.currentTime.isFinite
+                    ? max(0, self.currentTime)
+                    : resumePosition
+                self.resolvedServerUrl = streamRequest.serverUrl
+                try await self.loadAether(
+                    prepared: prepared,
+                    streamRequest: streamRequest,
+                    expectedStreamLoadGeneration: recoveryGeneration,
+                    resumeSourcePosition: reloadPosition
+                )
+                try self.requireCurrentStreamLoad(recoveryGeneration)
+                guard self.activePlaybackSessionId == sessionId,
+                      self.activePreparedProtocolV3?.plan.planId == planId else {
+                    throw CancellationError()
+                }
+                self.markProtocolV3AetherLoadCommitted()
+                shouldFallbackToReplan = false
+                Self.logger.info(
+                    "Protocol V3 media credential reload succeeded for plan \(planId, privacy: .public)"
+                )
+            } catch is CancellationError {
+                shouldFallbackToReplan = false
+            } catch {
+                Self.logger.error(
+                    "Protocol V3 media credential reload failed; using bounded route recovery: \(MediaLogRedactor.sanitize(error), privacy: .public)"
+                )
+            }
+        }
+        return true
     }
 
     /// The track a queued change is actually asking for. `.subtitle(nil)` is
@@ -2293,7 +2455,8 @@ class PlayerViewModel {
     private func loadAether(
         prepared: PreparedPlayback,
         streamRequest: StreamRequest,
-        expectedStreamLoadGeneration: UInt64
+        expectedStreamLoadGeneration: UInt64,
+        resumeSourcePosition: Double? = nil
     ) async throws {
         try requireCurrentStreamLoad(expectedStreamLoadGeneration)
         let preferredSubtitles = subtitleOrderingLanguage.map { [$0] } ?? []
@@ -2377,7 +2540,8 @@ class PlayerViewModel {
                 forwardBufferSegments: forwardBufferSegments,
                 audioBridgeMode: audioBridgeMode,
                 deinterlaceMode: deinterlaceMode,
-                deinterlaceFieldRate: deinterlaceFieldRate
+                deinterlaceFieldRate: deinterlaceFieldRate,
+                resumeSourcePosition: resumeSourcePosition
             )
         } else if streamRequest.url.isFileURL {
             let audioStreamIndex: Int32?

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -1485,7 +1485,7 @@ class PlayerViewModel {
                 // best-effort; the header comparison below is authoritative.
                 _ = await self.sessionBridge.reportProgress(
                     position: resumePosition,
-                    isPaused: !self.isPlaying
+                    isPaused: !self.aetherPlaybackController.shouldPlayWhenReady
                 )
                 try self.requireCurrentStreamLoad(recoveryGeneration)
                 guard self.activePlaybackSessionId == sessionId,
@@ -1532,12 +1532,14 @@ class PlayerViewModel {
                 let reloadPosition = self.currentTime.isFinite
                     ? max(0, self.currentTime)
                     : resumePosition
+                let shouldPlayWhenReady = self.aetherPlaybackController.shouldPlayWhenReady
                 self.resolvedServerUrl = streamRequest.serverUrl
                 try await self.loadAether(
                     prepared: prepared,
                     streamRequest: streamRequest,
                     expectedStreamLoadGeneration: recoveryGeneration,
-                    resumeSourcePosition: reloadPosition
+                    resumeSourcePosition: reloadPosition,
+                    shouldPlayWhenReady: shouldPlayWhenReady
                 )
                 try self.requireCurrentStreamLoad(recoveryGeneration)
                 guard self.activePlaybackSessionId == sessionId,
@@ -2456,7 +2458,8 @@ class PlayerViewModel {
         prepared: PreparedPlayback,
         streamRequest: StreamRequest,
         expectedStreamLoadGeneration: UInt64,
-        resumeSourcePosition: Double? = nil
+        resumeSourcePosition: Double? = nil,
+        shouldPlayWhenReady: Bool = true
     ) async throws {
         try requireCurrentStreamLoad(expectedStreamLoadGeneration)
         let preferredSubtitles = subtitleOrderingLanguage.map { [$0] } ?? []
@@ -2592,7 +2595,10 @@ class PlayerViewModel {
         isBuffering = false
         bufferingProgress = nil
         scrubPreviewProvider.endSession()
-        let loadEpoch = aetherPlaybackController.beginLoad(spec)
+        let loadEpoch = aetherPlaybackController.beginLoad(
+            spec,
+            shouldPlayWhenReady: shouldPlayWhenReady
+        )
         activeAetherLoadEpoch = loadEpoch
         establishedAetherLoadEpoch = nil
         lastAetherAudioTrackSwitchFailure = nil
@@ -2640,7 +2646,11 @@ class PlayerViewModel {
         adoptAetherInventory()
         reapplyAetherGain()
 
-        aetherPlaybackController.play()
+        if aetherPlaybackController.shouldPlayWhenReady {
+            aetherPlaybackController.play()
+        } else {
+            aetherPlaybackController.pause()
+        }
     }
 
     /// Whether the engine may be driven off a deferred (not user-initiated)


### PR DESCRIPTION
## Summary

- recognize typed HTTP 401 and AVPlayer authentication failures on committed header-authenticated Protocol V3 loads
- refresh the account bearer through the existing API transport, then rebuild the same committed plan at the latest source position
- require a changed Authorization header before reloading and otherwise fall back to the existing bounded Protocol V3 route ladder
- preserve timeline mapping, queued track changes, seek reanchors, and local seeks made while refresh is in flight

## Why

Aether and AVPlayer freeze request headers when an asset is loaded. During long playback, the normal API transport can rotate an expired account token while the active media asset continues using the old bearer. The media request then fails with 401 even though the playback URL and committed plan are still valid.

An earlier pre-Aether fix in #172 addressed signed `?st=` media URLs, but that PR closed unmerged and #180 replaced that player path with the current tokenless-media/header-authenticated contract. This implements the equivalent recovery at the current Aether boundary.

## Validation

- `xcodegen generate`
- `xcodebuild test -project Silo.xcodeproj -scheme Silo -destination 'platform=iOS Simulator,...' -only-testing:SiloTests/AetherPlaybackBoundaryTests CODE_SIGNING_ALLOWED=NO` — 43 passed, 1 fixture-dependent skip, 0 failures
- `xcodebuild build -project Silo.xcodeproj -scheme SiloTV -destination 'platform=tvOS Simulator,...' CODE_SIGNING_ALLOWED=NO` — succeeded

A full-suite attempt executed 1,140 tests but reported 14 failures in unrelated suites and then hung while Xcode finalized the result bundle. The scoped player suite completed cleanly before and after the final concurrency adjustment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery for expired playback authorization.
  * Preserves the current playback position when reloading authenticated media.
  * Maintains pending track changes and seek adjustments during recovery.
  * Supports improved position mapping for Protocol V3 playback sessions.

* **Bug Fixes**
  * Prevents unnecessary reloads when refreshed authorization is unchanged.
  * Falls back to bounded route recovery when authentication recovery is unavailable.
  * Ensures playback reloads use the correct starting position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->