### PR TITLE
fix(playback): V3 subtitle inventory as picker state with one mounted artifact

### DIFF
--- a/iosApp/Tests/AetherPlaybackBoundaryTests.swift
+++ b/iosApp/Tests/AetherPlaybackBoundaryTests.swift
@@ -447,8 +447,7 @@ final class AetherPlaybackBoundaryTests: XCTestCase {
             ],
             resolveURL: { URL(string: $0, relativeTo: URL(string: "https://dev.example.test")) },
             audioSourceStreamIndex: 7,
-            preferredAudioLanguages: ["eng"],
-            preferredSubtitleLanguages: ["eng"]
+            preferredAudioLanguages: ["eng"]
         )
 
         XCTAssertEqual(spec.sourceURL, resolvedSource)
@@ -458,7 +457,12 @@ final class AetherPlaybackBoundaryTests: XCTestCase {
             "Authorization": "Bearer current-token",
         ])
         XCTAssertEqual(spec.options.preferredAudioLanguages, ["eng"])
-        XCTAssertEqual(spec.options.preferredSubtitleLanguages, ["eng"])
+        XCTAssertEqual(
+            spec.options.preferredSubtitleLanguages,
+            [],
+            "the V3 plan's exact subtitle artifact must not be overridden by engine language policy"
+        )
+        XCTAssertEqual(spec.options.nativeSubtitlePreferredLanguages, [])
         XCTAssertEqual(spec.audioSourceStreamIndex, 7)
         XCTAssertFalse(spec.options.audioOnly)
         XCTAssertFalse(spec.options.autoplay)
@@ -790,52 +794,28 @@ final class AetherPlaybackBoundaryTests: XCTestCase {
         XCTAssertTrue(spec.externalSubtitleAppTrackIDs.isEmpty)
     }
 
-    /// End-to-end translation over the reported inventory (ar, da, en, es at
-    /// combined indices 0...3, sidecars registered after the load because
-    /// playback started with subtitles off): the English app id must resolve to
-    /// the Aether id English was registered under, and every id must round-trip.
-    func testPostLoadSidecarRegistrationKeepsAppAndAetherSubtitleIDsPaired() throws {
+    /// The full V3 inventory remains available to the picker without becoming
+    /// a set of mounted Aether resources. Only a later plan artifact may claim
+    /// a declared Aether alias.
+    func testV3InventoryIsPickerStateRatherThanMountedAetherTracks() throws {
         let plan = try sidecarInventoryPlan(
             mode: "off",
             selectedTrackId: "file:42:subtitle:2",
             includeArtifact: true
         )
         let spec = try Self.loadSpec(for: plan.plan, sessionID: plan.sessionID)
+        let tracks = ApplePlaybackV3PlanAdapter.subtitlePickerTracks(plan: plan.plan)
         let controller = try AetherPlaybackController()
         defer { controller.stop() }
         controller.beginLoad(spec)
 
-        // Registration order is the plan's inventory order, exactly as the
-        // post-load path in `PlayerViewModel.loadPendingExternalSubtitles`
-        // walks it.
-        var appTrackIDsByLanguage: [String: Int64] = [:]
-        for item in plan.plan.subtitle.inventory where item.delivery == "sidecar" {
-            let appTrackID = SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: item.combinedIndex)
-            appTrackIDsByLanguage[item.language ?? ""] = appTrackID
-            controller.addExternalSubtitleTrack(
-                ExternalSubtitleTrack(
-                    url: URL(fileURLWithPath: "/tmp/movie.\(item.language ?? "und").srt"),
-                    name: item.label,
-                    language: item.language
-                ),
-                appTrackID: appTrackID
-            )
-        }
-
-        let englishAppID = try XCTUnwrap(appTrackIDsByLanguage["eng"])
-        let englishAetherID = try XCTUnwrap(
-            controller.engine.subtitleTracks.first(where: { $0.language == "eng" })?.id
-        )
-        XCTAssertEqual(controller.aetherSubtitleID(forAppID: englishAppID), englishAetherID)
-        XCTAssertEqual(controller.appSubtitleID(forAetherID: englishAetherID), englishAppID)
-        // The Arabic sidecar owns `base + 0`; nothing else may translate to it.
-        XCTAssertEqual(
-            controller.aetherSubtitleID(forAppID: try XCTUnwrap(appTrackIDsByLanguage["ara"])),
-            AetherEngine.externalSubtitleTrackIDBase
-        )
-        for (_, appTrackID) in appTrackIDsByLanguage {
-            let aetherID = try XCTUnwrap(controller.aetherSubtitleID(forAppID: appTrackID))
-            XCTAssertEqual(controller.appSubtitleID(forAetherID: aetherID), appTrackID)
+        XCTAssertEqual(tracks.count, plan.plan.subtitle.inventory.count)
+        XCTAssertEqual(tracks.map(\.srcId), plan.plan.subtitle.inventory.map { $0.combinedIndex })
+        XCTAssertTrue(tracks.allSatisfy { !$0.isSelected })
+        XCTAssertTrue(spec.options.externalSubtitles.isEmpty)
+        for track in tracks {
+            XCTAssertFalse(controller.containsSubtitle(appTrackID: track.trackId))
+            XCTAssertNil(controller.aetherSubtitleID(forAppID: track.trackId))
         }
     }
 
@@ -875,13 +855,32 @@ final class AetherPlaybackBoundaryTests: XCTestCase {
         }
     }
 
+    func testDeclaredArtifactAliasFollowsTheSelectedCombinedIndex() throws {
+        let plan = try sidecarInventoryPlan(
+            mode: "render",
+            selectedTrackId: "file:42:subtitle:3",
+            includeArtifact: true,
+            decisionTrackId: "opaque-selected-track"
+        )
+        let spec = try Self.loadSpec(for: plan.plan, sessionID: plan.sessionID)
+
+        XCTAssertEqual(
+            spec.externalSubtitleAppTrackIDs,
+            [SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: 3)]
+        )
+    }
+
     /// The four-sidecar inventory from the reported file: ar, da, en, es at
     /// combined indices 0...3 plus an embedded PGS track at 4.
     private func sidecarInventoryPlan(
         mode: String,
         selectedTrackId: String,
-        includeArtifact: Bool
+        includeArtifact: Bool,
+        decisionTrackId: String? = nil
     ) throws -> (plan: PlaybackV3Plan, sessionID: String) {
+        let selectedCombinedIndex = try XCTUnwrap(
+            Int(selectedTrackId.split(separator: ":").last ?? "")
+        )
         let fixtureURL = try PlaybackV3FixtureTestSupport.fixtureURL(
             named: "decision_response",
             bundleClass: Self.self
@@ -921,12 +920,12 @@ final class AetherPlaybackBoundaryTests: XCTestCase {
         ])
         var subtitle: [String: Any] = [
             "mode": mode,
-            "track_id": selectedTrackId,
+            "track_id": decisionTrackId ?? selectedTrackId,
             "inventory": inventory,
         ]
         if includeArtifact {
             subtitle["artifact"] = [
-                "url": "/stream/session/subtitles/2.srt?file_id=42",
+                "url": "/stream/session/subtitles/\(selectedCombinedIndex).srt?file_id=42",
                 "mime_type": "application/x-subrip",
                 "format": "srt",
                 "timing_origin_seconds": 0,
@@ -934,7 +933,10 @@ final class AetherPlaybackBoundaryTests: XCTestCase {
         }
         planObject["subtitle"] = subtitle
         var selectedTracks = try XCTUnwrap(planObject["selected_tracks"] as? [String: Any])
-        selectedTracks["subtitle"] = ["id": selectedTrackId, "index": 2]
+        selectedTracks["subtitle"] = [
+            "id": selectedTrackId,
+            "index": selectedCombinedIndex,
+        ]
         planObject["selected_tracks"] = selectedTracks
         object["playback_plan"] = planObject
 

--- a/iosApp/Tests/PlaybackProtocolV3Tests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3Tests.swift
@@ -671,6 +671,19 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         XCTAssertEqual(
             ApplePlaybackV3PlanAdapter.serverCombinedSubtitleIndex(
                 for: makePlayerSubtitle(
+                    trackId: SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: 1),
+                    isExternal: false,
+                    ffIndex: nil,
+                    srcId: 1
+                ),
+                in: version
+            ),
+            1,
+            "a server inventory row keeps its combined ordinal even when its source is embedded"
+        )
+        XCTAssertEqual(
+            ApplePlaybackV3PlanAdapter.serverCombinedSubtitleIndex(
+                for: makePlayerSubtitle(
                     trackId: 12,
                     isExternal: false,
                     ffIndex: 5,
@@ -1165,6 +1178,199 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         ))
     }
 
+    /// The one resolver every V3 subtitle consumer shares. Order matches the
+    /// Android `resolvedSelectedSubtitleIndex`, with the Apple-only
+    /// `subtitle.track_id` fallback strictly last.
+    func testSelectedSubtitleInventoryItemResolutionOrder() {
+        let inventory = [
+            makeInventoryItem(combinedIndex: 0, source: "external"),
+            makeInventoryItem(combinedIndex: 1, source: "embedded"),
+            makeInventoryItem(combinedIndex: 2, source: "embedded"),
+        ]
+
+        // The ordinal wins even when the identity names another row.
+        let byIndex = makePlan(
+            selectedSubtitleIdentity: PlaybackV3TrackIdentity(
+                id: "file:42:subtitle:0",
+                index: 2
+            ),
+            subtitleMode: "render",
+            subtitleInventory: inventory
+        )
+        XCTAssertEqual(byIndex.selectedSubtitleInventoryItem?.combinedIndex, 2)
+        XCTAssertEqual(byIndex.selectedSubtitleCombinedIndex, 2)
+
+        // No ordinal: the stable server identity resolves the row.
+        let byIdentity = makePlan(
+            selectedSubtitleIdentity: PlaybackV3TrackIdentity(
+                id: "file:42:subtitle:1",
+                index: nil
+            ),
+            subtitleMode: "render",
+            subtitleInventory: inventory
+        )
+        XCTAssertEqual(byIdentity.selectedSubtitleInventoryItem?.combinedIndex, 1)
+        XCTAssertEqual(byIdentity.selectedSubtitleCombinedIndex, 1)
+
+        // Transitional plan: only the decision's own track id is available.
+        let byDecisionTrackId = makePlan(
+            decisionSubtitleTrackId: "file:42:subtitle:2",
+            subtitleMode: "render",
+            subtitleInventory: inventory
+        )
+        XCTAssertEqual(byDecisionTrackId.selectedSubtitleInventoryItem?.combinedIndex, 2)
+
+        // Nothing names a published row.
+        let unresolved = makePlan(
+            selectedSubtitleIdentity: PlaybackV3TrackIdentity(
+                id: "file:42:subtitle:9",
+                index: nil
+            ),
+            subtitleMode: "render",
+            subtitleInventory: inventory
+        )
+        XCTAssertNil(unresolved.selectedSubtitleInventoryItem)
+        XCTAssertNil(unresolved.selectedSubtitleCombinedIndex)
+    }
+
+    /// A plan that names its subtitle by identity alone still marks that row
+    /// selected — otherwise the picker reads "Off" over visible captions and
+    /// the next replan drops them for real. `off` still selects nothing.
+    func testSubtitlePickerSelectsResolvedRowWithoutASelectedOrdinal() {
+        let inventory = [
+            makeInventoryItem(combinedIndex: 0, source: "external"),
+            makeInventoryItem(combinedIndex: 1, source: "embedded"),
+        ]
+        let identity = PlaybackV3TrackIdentity(id: "file:42:subtitle:1", index: nil)
+
+        let rendered = ApplePlaybackV3PlanAdapter.subtitlePickerTracks(
+            plan: makePlan(
+                selectedSubtitleIdentity: identity,
+                subtitleMode: "render",
+                subtitleInventory: inventory
+            )
+        )
+        XCTAssertEqual(rendered.filter(\.isSelected).map(\.srcId), [1])
+
+        let off = ApplePlaybackV3PlanAdapter.subtitlePickerTracks(
+            plan: makePlan(
+                selectedSubtitleIdentity: identity,
+                subtitleMode: "off",
+                subtitleInventory: inventory
+            )
+        )
+        XCTAssertTrue(off.allSatisfy { !$0.isSelected })
+    }
+
+    /// `convert` mounts an artifact exactly like `render` does, so every gate
+    /// that arms the local selection must accept it. Treating it as "not
+    /// locally rendered" arms explicit Off over a mounted artifact.
+    func testConvertModeArmsTheLocallyMountedSubtitle() {
+        let version = makeVersion(
+            container: "mkv",
+            videoCodec: "h264",
+            audioCodec: "aac",
+            subtitleTracks: [
+                makeSubtitle(index: 5, codec: "ass", external: false, path: nil)
+            ]
+        )
+        let plan = makePlan(
+            selectedAudioIndex: 0,
+            selectedSubtitleIndex: 0,
+            subtitleMode: "convert",
+            subtitleInventory: [
+                makeInventoryItem(combinedIndex: 0, source: "embedded")
+            ]
+        )
+        let original = PlayerViewModel.LoadRequest(
+            contentId: "movie-1",
+            preferredFileId: 42,
+            preferredAudioTrackIndex: 0,
+            preferredSubtitleTrackIndex: nil,
+            preferredSidecarSubtitleTrackId: nil,
+            startFromBeginning: true
+        )
+        let adopted = original.adoptingProtocolV3Intent(
+            plan: plan,
+            selectedVersion: version,
+            activeQualityId: "original"
+        )
+        let intent = PlayerViewModel.protocolV3PendingTrackIntent(
+            plan: plan,
+            request: adopted
+        )
+
+        XCTAssertEqual(
+            adopted.preferredSidecarSubtitleTrackId,
+            SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: 0)
+        )
+        XCTAssertEqual(intent.sidecarSubtitleTrackId, adopted.preferredSidecarSubtitleTrackId)
+        XCTAssertNotEqual(
+            intent.embeddedSubtitleIndex,
+            -1,
+            "a converted artifact is mounted, so the intent must not arm explicit Off"
+        )
+
+        let sidecarId = SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: 0)
+        XCTAssertEqual(
+            PlayerViewModel.protocolV3SidecarRestoreIntent(
+                snapshot: sidecarId,
+                selectedSubtitleIndex: 0,
+                subtitleMode: "convert"
+            ),
+            .renderLocally(sidecarId)
+        )
+    }
+
+    /// An embedded picker row has to carry its real FFmpeg stream index or the
+    /// persisted pick falls through to the explicit-Off sentinel.
+    func testEmbeddedPickerRowsCarryTheirFFmpegStreamIndex() {
+        let version = makeVersion(
+            container: "mkv",
+            videoCodec: "h264",
+            audioCodec: "aac",
+            subtitleTracks: [
+                makeSubtitle(index: nil, codec: "srt", external: true, path: "/movie.en.srt"),
+                makeSubtitle(index: 2, codec: "subrip", external: false, path: nil),
+                makeSubtitle(index: 5, codec: "pgs", external: false, path: nil),
+            ]
+        )
+        let plan = makePlan(
+            selectedSubtitleIndex: 1,
+            subtitleMode: "render",
+            subtitleInventory: [
+                makeInventoryItem(combinedIndex: 0, source: "external"),
+                makeInventoryItem(combinedIndex: 1, source: "embedded"),
+                makeInventoryItem(combinedIndex: 2, source: "embedded", delivery: "burn_in_only"),
+            ]
+        )
+
+        let tracks = ApplePlaybackV3PlanAdapter.subtitlePickerTracks(
+            plan: plan,
+            version: version
+        )
+        XCTAssertEqual(tracks.map(\.ffIndex), [nil, 2, 5])
+        XCTAssertEqual(tracks.map(\.isExternal), [true, false, false])
+        // The published id space is unchanged: rows stay sidecar-space and
+        // still resolve back to their combined ordinal.
+        XCTAssertEqual(
+            tracks.map {
+                ApplePlaybackV3PlanAdapter.serverCombinedSubtitleIndex(
+                    for: $0,
+                    in: version,
+                    inventory: plan.subtitle.inventory
+                )
+            },
+            [0, 1, 2]
+        )
+
+        // Without a version there is nothing to translate against.
+        XCTAssertTrue(
+            ApplePlaybackV3PlanAdapter.subtitlePickerTracks(plan: plan)
+                .allSatisfy { $0.ffIndex == nil }
+        )
+    }
+
     func testV3AudioIntentOverridesBackendDefaultAfterReplan() {
         let version = makeVersion(
             container: "mkv",
@@ -1496,6 +1702,11 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         dynamicRange: String = "sdr",
         selectedAudioIndex: Int = 0,
         selectedSubtitleIndex: Int? = nil,
+        /// Replaces the identity derived from `selectedSubtitleIndex`, so a
+        /// test can publish a stable id with no ordinal.
+        selectedSubtitleIdentity: PlaybackV3TrackIdentity? = nil,
+        /// Replaces `subtitle.track_id`, the transitional Apple-only fallback.
+        decisionSubtitleTrackId: String? = nil,
         subtitleMode: String = "off",
         subtitleInventory: [PlaybackV3SubtitleInventoryItem] = [],
         transformations: [PlaybackV3Transformation] = [],
@@ -1539,7 +1750,7 @@ final class PlaybackProtocolV3Tests: XCTestCase {
                     id: "file:42:audio:\(selectedAudioIndex)",
                     index: selectedAudioIndex
                 ),
-                subtitle: selectedSubtitleIndex.map {
+                subtitle: selectedSubtitleIdentity ?? selectedSubtitleIndex.map {
                     PlaybackV3TrackIdentity(id: "file:42:subtitle:\($0)", index: $0)
                 }
             ),
@@ -1578,7 +1789,8 @@ final class PlaybackProtocolV3Tests: XCTestCase {
             ),
             subtitle: PlaybackV3SubtitleDecision(
                 mode: subtitleMode,
-                trackId: selectedSubtitleIndex.map { "file:42:subtitle:\($0)" },
+                trackId: decisionSubtitleTrackId
+                    ?? selectedSubtitleIndex.map { "file:42:subtitle:\($0)" },
                 artifact: nil,
                 inventory: subtitleInventory
             ),

--- a/iosApp/iosApp/Screens/Player/AetherLoadSpec.swift
+++ b/iosApp/iosApp/Screens/Player/AetherLoadSpec.swift
@@ -237,7 +237,6 @@ struct AetherLoadSpec {
         apiOriginURL: URL? = nil,
         audioSourceStreamIndex: Int32? = nil,
         preferredAudioLanguages: [String] = [],
-        preferredSubtitleLanguages: [String] = [],
         forwardBufferSegments: Int? = nil,
         audioBridgeMode: AudioBridgeMode = Self.defaultAudioBridgeMode,
         deinterlaceMode: DeinterlaceMode = Self.defaultDeinterlaceMode,
@@ -281,7 +280,7 @@ struct AetherLoadSpec {
         var externalSubtitles: [ExternalSubtitleTrack] = []
         var externalSubtitleAppTrackIDs: [Int64?] = []
         if let artifact = plan.subtitle.artifact,
-           ["render", "convert"].contains(plan.subtitle.mode) {
+           PlaybackProtocolV3.SubtitleMode.locallyRendered.contains(plan.subtitle.mode) {
             guard abs(artifact.timingOriginSeconds - plan.timeline.timelineOffsetSeconds) < 0.001 else {
                 throw ValidationError.unsupportedSubtitleTimingOrigin(
                     origin: artifact.timingOriginSeconds,
@@ -298,9 +297,9 @@ struct AetherLoadSpec {
                   ["http", "https", "file"].contains(artifactURL.scheme?.lowercased() ?? "") else {
                 throw ValidationError.invalidSubtitleArtifactURL(artifact.url)
             }
-            let inventoryItem = plan.subtitle.inventory.first { item in
-                item.trackId == plan.subtitle.trackId
-            }
+            // One shared resolution order for the selected row; see
+            // `PlaybackV3Plan.selectedSubtitleInventoryItem`.
+            let inventoryItem = plan.selectedSubtitleInventoryItem
             externalSubtitles.append(ExternalSubtitleTrack(
                 url: artifactURL,
                 name: inventoryItem?.label,
@@ -349,9 +348,12 @@ struct AetherLoadSpec {
             preserveASSMarkup: false,
             prepareNativeSubtitles: true,
             eagerNativeSubtitleReaders: true,
-            nativeSubtitlePreferredLanguages: preferredSubtitleLanguages,
+            // V3 already selected one exact artifact. Language preference is
+            // planning input, not permission for the engine to select a
+            // different embedded or inventory track after the plan arrives.
+            nativeSubtitlePreferredLanguages: [],
             preferredAudioLanguages: preferredAudioLanguages,
-            preferredSubtitleLanguages: preferredSubtitleLanguages,
+            preferredSubtitleLanguages: [],
             externalSubtitles: externalSubtitles,
             forwardBufferSegments: forwardBufferSegments,
             autoplay: false,

--- a/iosApp/iosApp/Screens/Player/AetherPlaybackController.swift
+++ b/iosApp/iosApp/Screens/Player/AetherPlaybackController.swift
@@ -431,7 +431,14 @@ final class AetherPlaybackController {
     /// The inverse of `appSubtitleID(forAetherID:)`. Internal so the boundary
     /// tests can assert the translation round-trips.
     func aetherSubtitleID(forAppID id: Int64) -> Int? {
-        aetherSubtitleIDByAppID[id] ?? Int(exactly: id)
+        if let translated = aetherSubtitleIDByAppID[id] {
+            return translated
+        }
+        // A Silo sidecar id is not an Aether id. Passing an unaliased value
+        // through reaches Aether as an unknown external id and is silently
+        // ignored, leaving the previously selected subtitle on screen.
+        guard !SubtitleTrackIdSpace.isSidecar(id) else { return nil }
+        return Int(exactly: id)
     }
 
     private func observeEngine() {

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -455,7 +455,7 @@ class PlayerViewModel {
     var availableSecondarySubtitleTracks: [PlayerTrack] {
         guard backendCapabilities.supportsSecondarySubtitles else { return [] }
         return orderedSubtitles(subtitleTracks.filter {
-            !SubtitleCodecClassifier.isBitmap($0.codec)
+            !SubtitleCodecClassifier.isBitmap($0.codec) && canRenderAsSecondarySubtitle($0)
         })
     }
     private func orderedSubtitles(_ tracks: [PlayerTrack]) -> [PlayerTrack] {
@@ -690,6 +690,15 @@ class PlayerViewModel {
     /// `pendingExternalSubtitles`, this survives the first successful
     /// registration so route recovery can re-register sidecars later.
     private var knownExternalSubtitles: [SubtitleUrl] = []
+    /// Picker rows for sidecars this session registered with Aether itself —
+    /// a finished AI translation/transcription or a downloaded subtitle.
+    ///
+    /// Under Protocol V3 the published picker is rebuilt from the plan's
+    /// inventory, and the plan that is active when a job completes predates
+    /// the new track, so without this the finished subtitle would vanish from
+    /// the menu until the next replan. Rows are unioned in, de-duped against
+    /// the plan, and dropped once the server publishes the same ordinal.
+    private var locallyRegisteredSidecarSubtitleTracks: [PlayerTrack] = []
     /// Server-supplied preferred track indices (ffmpeg stream indices). Kept
     /// until we've observed a matching track in the core's track-list and
     /// applied it, or until the user makes a manual selection.
@@ -797,10 +806,14 @@ class PlayerViewModel {
             selectedVersion: FileVersion,
             activeQualityId: String
         ) -> LoadRequest {
-            let selectedSubtitleIndex = plan.selectedTracks.subtitle?.index
-            let selectedSubtitle = selectedSubtitleIndex.flatMap { selectedIndex in
-                plan.subtitle.inventory.first(where: { $0.combinedIndex == selectedIndex })
-            }
+            // Shared resolution order; see
+            // `PlaybackV3Plan.selectedSubtitleInventoryItem`. An `off` plan
+            // selects nothing even if it still carries a stale identity.
+            let isSubtitleOff = plan.subtitle.mode == PlaybackProtocolV3.SubtitleMode.off
+            let selectedSubtitleIndex = isSubtitleOff
+                ? nil
+                : plan.selectedSubtitleCombinedIndex
+            let selectedSubtitle = isSubtitleOff ? nil : plan.selectedSubtitleInventoryItem
             let embeddedFFmpegIndex: Int? = selectedSubtitle.flatMap { item in
                 // A sidecar is the server-selected artifact even when it was
                 // extracted from an embedded stream. Arming both identities
@@ -1514,6 +1527,33 @@ class PlayerViewModel {
         trackTarget: QueuedProtocolV3TrackTarget? = nil,
         outputRouteSnapshot: ApplePlaybackV3CapabilitySnapshot? = nil
     ) -> Bool {
+        // One classification of the user's target. A track change must have a
+        // stable server ordinal before it is queued or issued: falling back to
+        // the currently published engine selection would turn an unmappable tap
+        // into a successful replan for the track that was already playing.
+        //
+        // The dimension the user did not touch stays `nil` here and is read
+        // back from the player below, after any queued pick is re-published.
+        let explicitAudioTrackIndex: Int?
+        let explicitSubtitleTrackIndex: Int?
+        let targetsSubtitle: Bool
+        switch trackTarget {
+        case .audio(_, nil), .subtitle(.some, nil):
+            return false
+        case .audio(_, let selectionIndex):
+            explicitAudioTrackIndex = selectionIndex
+            explicitSubtitleTrackIndex = nil
+            targetsSubtitle = false
+        case .subtitle(let trackId, let combinedIndex):
+            explicitAudioTrackIndex = nil
+            // Nil subtitle with a nil track id is explicit Off.
+            explicitSubtitleTrackIndex = trackId == nil ? nil : combinedIndex
+            targetsSubtitle = true
+        case nil:
+            explicitAudioTrackIndex = nil
+            explicitSubtitleTrackIndex = nil
+            targetsSubtitle = false
+        }
         if protocolV3ReplanTask != nil {
             if operation == PlaybackProtocolV3.ReplanOperation.seekReanchor {
                 // Rapid windowed seeks are latest-wins. Re-issue the newest
@@ -1550,6 +1590,23 @@ class PlayerViewModel {
             restoreQueuedProtocolV3TrackSelection(trackTarget)
         }
         let selectedSubtitleSnapshot = selectedSubtitleId
+        // The user-facing selection can be republished from Aether while the
+        // async replan task is waiting to start (inventory/store discovery is
+        // still active after a replacement load). A user track change already
+        // carries the stable server identity captured at tap time; freeze the
+        // request indices here instead of re-reading mutable player state from
+        // inside the task.
+        let requestedAudioTrackIndex = explicitAudioTrackIndex
+            ?? resolvedAudioTrackIndexForResume()
+        let requestedSubtitleTrackIndex = targetsSubtitle
+            ? explicitSubtitleTrackIndex
+            : resolvedProtocolV3SubtitleIndexForResume()
+        if targetsSubtitle {
+            cmpLog(
+                "[CMP-SUB] phase=replan_request requested_index="
+                    + (requestedSubtitleTrackIndex.map(String.init) ?? "off")
+            )
+        }
         progressTask?.cancel()
         isLoading = true
         isBuffering = false
@@ -1617,12 +1674,20 @@ class PlayerViewModel {
                     message: message,
                     operation: operation,
                     qualityPreference: qualityPreference,
-                    audioTrackIndex: self.resolvedAudioTrackIndexForResume(),
-                    subtitleTrackIndex: self.resolvedProtocolV3SubtitleIndexForResume(),
+                    audioTrackIndex: requestedAudioTrackIndex,
+                    subtitleTrackIndex: requestedSubtitleTrackIndex,
                     outputRouteSnapshot: outputRouteSnapshot
                 ) else {
                     self.finalizeTerminalPlaybackError(message)
                     return
+                }
+                if targetsSubtitle {
+                    cmpLog(
+                        "[CMP-SUB] phase=replan_response selected_index="
+                            + (prepared.protocolV3?.plan.selectedTracks.subtitle?.index.map(String.init) ?? "off")
+                            + " mode="
+                            + (prepared.protocolV3?.plan.subtitle.mode ?? "unknown")
+                    )
                 }
                 uncommittedPrepared = prepared
                 guard !Task.isCancelled,
@@ -2373,7 +2438,6 @@ class PlayerViewModel {
                 apiOriginURL: URL(string: streamRequest.serverUrl),
                 audioSourceStreamIndex: audioSourceStreamIndex,
                 preferredAudioLanguages: preferredAudio,
-                preferredSubtitleLanguages: preferredSubtitles,
                 forwardBufferSegments: forwardBufferSegments,
                 audioBridgeMode: audioBridgeMode,
                 deinterlaceMode: deinterlaceMode,
@@ -2576,8 +2640,26 @@ class PlayerViewModel {
                     : nil
             )
         }
-        subtitleTracks = aetherSubtitleTracks + existingLiveTracks.filter { liveTrack in
-            !aetherSubtitleTracks.contains { $0.trackId == liveTrack.trackId }
+        // V3 inventory is an authoritative menu, not a preload list. Aether
+        // receives only the current plan's artifact; presenting its probed
+        // embedded tracks alongside every server sidecar would create two
+        // identities (and two selectors) for the same subtitle rows.
+        let planSubtitleTracks = activePreparedProtocolV3.map { prepared in
+            ApplePlaybackV3PlanAdapter.subtitlePickerTracks(
+                plan: prepared.plan,
+                version: currentSelectedVersion
+            )
+        }
+        // …but a sidecar this session registered itself (a finished AI job or
+        // a downloaded subtitle) is real and selectable before any plan names
+        // it, so it is unioned in until the server publishes its ordinal.
+        let publishedSubtitleTracks = planSubtitleTracks.map { planTracks in
+            planTracks + locallyRegisteredSidecarSubtitleTracks.filter { local in
+                !planTracks.contains { $0.trackId == local.trackId }
+            }
+        } ?? aetherSubtitleTracks
+        subtitleTracks = publishedSubtitleTracks + existingLiveTracks.filter { liveTrack in
+            !publishedSubtitleTracks.contains { $0.trackId == liveTrack.trackId }
         }
         let mediaChapters = engine.mediaChapters.map { chapter in
             PlayerChapterInfo(
@@ -2589,9 +2671,22 @@ class PlayerViewModel {
         chapters = mediaChapters.isEmpty ? serverProvidedChapters : mediaChapters
 
         selectedAudioId = engine.activeAudioTrackIndex.map(Int64.init)
-        if selectedSubtitleId.map(SubtitleTrackIdSpace.isAILive) != true {
-            selectedSubtitleId = engine.activeSubtitleTrackIndex.map {
-                aetherPlaybackController.appSubtitleID(forAetherID: $0)
+        // A locally-registered sidecar is selected client-side, so the plan —
+        // which predates the track — must not republish over it. Once the
+        // server publishes that ordinal the plan is authoritative again.
+        let holdsLocalSidecarSelection = selectedSubtitleId.map { id in
+            locallyRegisteredSidecarSubtitleTracks.contains { $0.trackId == id }
+                && planSubtitleTracks?.contains { $0.trackId == id } != true
+        } ?? false
+        if selectedSubtitleId.map(SubtitleTrackIdSpace.isAILive) != true,
+           !holdsLocalSidecarSelection {
+            if activePreparedProtocolV3 != nil {
+                selectedSubtitleId = publishedSubtitleTracks
+                    .first(where: \.isSelected)?.trackId
+            } else {
+                selectedSubtitleId = engine.activeSubtitleTrackIndex.map {
+                    aetherPlaybackController.appSubtitleID(forAetherID: $0)
+                }
             }
         }
 
@@ -2635,6 +2730,14 @@ class PlayerViewModel {
                     applySubtitleTrackSelection(nil, reason: "pending_subtitle_off")
                 }
             } else if let match = aetherSubtitleTracks.first(where: { $0.ffIndex == wantedIndex }) {
+                // The engine still selects an embedded stream by its raw id,
+                // but under V3 the *published* row for that stream lives in
+                // the plan's sidecar id space. Publishing the engine id would
+                // leave the picker showing nothing selected and resolve to no
+                // combined ordinal on the next replan.
+                let publishedTrackID = publishedSubtitleTracks
+                    .first { $0.ffIndex == wantedIndex }?
+                    .trackId ?? match.trackId
                 switch DeferredTrackSelectionGate.outcome(
                     isLoadEstablished: loadIsEstablished,
                     engineAlreadyMatches: engine.activeSubtitleTrackIndex == wantedIndex
@@ -2643,16 +2746,20 @@ class PlayerViewModel {
                     break
                 case .adoptWithoutEngineCall:
                     pendingSubtitleFfIndex = nil
-                    selectedSubtitleId = match.trackId
+                    selectedSubtitleId = publishedTrackID
                 case .applyToEngine:
                     pendingSubtitleFfIndex = nil
-                    selectedSubtitleId = match.trackId
+                    selectedSubtitleId = publishedTrackID
                     applySubtitleTrackSelection(match.trackId, reason: "pending_subtitle_index")
                 }
             }
         }
 
+        // Reassert even when Aether publishes the same synthetic id: V3 changed
+        // the resource behind that reused id, and the current plan's artifact
+        // URL — not id equality — is authoritative.
         if let pendingTrackID = pendingSidecarSubtitleTrackId,
+           loadIsEstablished,
            subtitleTracks.contains(where: { $0.trackId == pendingTrackID }) {
             pendingSidecarSubtitleTrackId = nil
             selectedSubtitleId = pendingTrackID
@@ -3135,6 +3242,7 @@ class PlayerViewModel {
         bufferedAheadSeconds = 0
         playbackStats = .empty
         knownExternalSubtitles = []
+        locallyRegisteredSidecarSubtitleTracks = []
         pendingServerRenderedSubtitleTrackId = nil
         // Subtitle `-1` is the explicit "Off" sentinel; Aether inventory
         // adoption disables subtitles when it sees a negative value.
@@ -3159,16 +3267,20 @@ class PlayerViewModel {
     }
 
     private func resolvedSubtitleTrackIndexForResume() -> Int? {
-        if let selectedSubtitleId,
-           let selected = subtitleTracks.first(where: { $0.trackId == selectedSubtitleId }),
-           let ffIndex = selected.ffIndex {
-            return ffIndex
-        }
+        // The id space decides, not the row's metadata: a V3 picker row is
+        // published in the sidecar space and carries its FFmpeg index only so
+        // an embedded pick can be persisted. Restoring it as an embedded index
+        // would arm both identities for the same subtitle.
         if let selectedSubtitleId, SubtitleTrackIdSpace.isSidecar(selectedSubtitleId) {
             // Sidecars are re-applied client-side after the playback
             // session returns `subtitle_urls`; keep embedded subtitles off
             // until that explicit sidecar selection is restored.
             return -1
+        }
+        if let selectedSubtitleId,
+           let selected = subtitleTracks.first(where: { $0.trackId == selectedSubtitleId }),
+           let ffIndex = selected.ffIndex {
+            return ffIndex
         }
         if !subtitleTracks.isEmpty || lastLoadRequest?.preferredSubtitleTrackIndex == -1 {
             return -1
@@ -4629,6 +4741,15 @@ class PlayerViewModel {
         )
         if activePreparedProtocolV3 != nil,
            !SubtitleTrackIdSpace.isAILive(track.trackId) {
+            let trackTarget = queuedTrackTarget(forSubtitle: track)
+            if case .subtitle(_, let combinedIndex) = trackTarget {
+                cmpLog(
+                    "[CMP-SUB] phase=user_tap source="
+                        + (track.isExternal ? "external" : "embedded")
+                        + " combined_index="
+                        + (combinedIndex.map(String.init) ?? "unmapped")
+                )
+            }
             // The replan is what actually switches the track, so nothing is
             // persisted or recorded until one is under way.
             guard attemptProtocolV3Replan(
@@ -4636,7 +4757,7 @@ class PlayerViewModel {
                 classification: "subtitle_track_changed",
                 message: "User selected subtitle track \(track.title ?? String(track.trackId)).",
                 requeueWhenBusy: true,
-                trackTarget: queuedTrackTarget(forSubtitle: track)
+                trackTarget: trackTarget
             ) else {
                 selectedSubtitleId = priorSubtitleId
                 pendingSubtitleFfIndex = priorPendingSubtitleFfIndex
@@ -4785,6 +4906,7 @@ class PlayerViewModel {
         // Secondary sub cannot equal the primary sid; guard at the UI layer
         // so the user gets an immediate no-op rather than seeing stale state.
         guard track.trackId != selectedSubtitleId else { return }
+        guard canRenderAsSecondarySubtitle(track) else { return }
         selectedSecondarySubtitleId = track.trackId
         applySecondarySubtitleTrackSelection(track.trackId)
         scheduleHideControls()
@@ -4999,9 +5121,9 @@ class PlayerViewModel {
             return nil
         }
         switch subtitleMode {
-        case "render":
+        case let mode? where PlaybackProtocolV3.SubtitleMode.locallyRendered.contains(mode):
             return .renderLocally(snapshot)
-        case "burn_in":
+        case PlaybackProtocolV3.SubtitleMode.burnIn:
             return .serverRendered(snapshot)
         default:
             return nil
@@ -5038,7 +5160,8 @@ class PlayerViewModel {
         plan: PlaybackV3Plan,
         request: LoadRequest
     ) -> ProtocolV3PendingTrackIntent {
-        let rendersSubtitleLocally = plan.subtitle.mode == "render"
+        let rendersSubtitleLocally = PlaybackProtocolV3.SubtitleMode.locallyRendered
+            .contains(plan.subtitle.mode)
         return ProtocolV3PendingTrackIntent(
             audioIndex: request.preferredAudioTrackIndex,
             embeddedSubtitleIndex: rendersSubtitleLocally
@@ -5112,6 +5235,27 @@ class PlayerViewModel {
             ),
             appTrackID: trackId
         )
+        // The active V3 plan predates this track, so the plan-derived picker
+        // cannot name it. Keep the row session-side until a later plan's
+        // inventory publishes the same ordinal.
+        if !locallyRegisteredSidecarSubtitleTracks.contains(where: { $0.trackId == trackId }) {
+            locallyRegisteredSidecarSubtitleTracks.append(PlayerTrack(
+                trackId: trackId,
+                kind: .sub,
+                title: descriptor.label,
+                lang: descriptor.language,
+                codec: descriptor.codec,
+                audioChannelCount: nil,
+                bitrate: nil,
+                isDefault: descriptor.isDefault ?? false,
+                isForced: descriptor.forced ?? false,
+                isHearingImpaired: descriptor.isHearingImpaired ?? false,
+                isExternal: true,
+                isSelected: false,
+                ffIndex: nil,
+                srcId: descriptor.index
+            ))
+        }
         adoptAetherInventory()
     }
 
@@ -5419,6 +5563,7 @@ class PlayerViewModel {
         autoSkippedCreditsKey = nil
         autoSkipIntroCancelledKey = nil
         knownExternalSubtitles = []
+        locallyRegisteredSidecarSubtitleTracks = []
         subtitleAI.reset()
         deferredLiveSubtitleCloseTask?.cancel()
         deferredLiveSubtitleCloseTask = nil
@@ -5848,6 +5993,15 @@ class PlayerViewModel {
     }
 
     private func loadPendingExternalSubtitles() {
+        if activePreparedProtocolV3 != nil {
+            // `subtitle.inventory` feeds the V3 picker. Loading all of its URLs
+            // into Aether gives the engine an uncommitted set of alternatives
+            // and lets language/default policy override `subtitle.artifact`.
+            // The exact selected artifact was already declared in AetherLoadSpec.
+            pendingExternalSubtitles = []
+            Self.logger.info("[CMP-SUB] keeping V3 subtitle inventory picker-only")
+            return
+        }
         let restoredFromKnownCache = pendingExternalSubtitles.isEmpty
         let allPending = restoredFromKnownCache
             ? knownExternalSubtitles
@@ -6060,7 +6214,74 @@ class PlayerViewModel {
             aetherPlaybackController.selectSecondarySubtitleTrack(id: nil)
             return
         }
+        registerSecondarySubtitleWithAetherIfNeeded(track)
+        // Only a track Aether actually holds can be rendered as the secondary
+        // one. Under V3 the plan mounts a single artifact, so an inventory row
+        // that could not be registered above has no engine id at all — showing
+        // it checked while nothing renders is worse than refusing the pick.
+        guard aetherPlaybackController.containsSubtitle(appTrackID: trackId)
+                || !SubtitleTrackIdSpace.isSidecar(trackId) else {
+            Self.logger.warning(
+                "[CMP-SUB] secondary subtitle \(trackId, privacy: .public) has no Aether track; clearing"
+            )
+            selectedSecondarySubtitleId = nil
+            aetherPlaybackController.selectSecondarySubtitleTrack(id: nil)
+            return
+        }
         aetherPlaybackController.selectSecondarySubtitleTrack(id: trackId)
+    }
+
+    /// Mounts a V3 inventory sidecar on demand so it can be used as the
+    /// secondary subtitle.
+    ///
+    /// The plan declares exactly one artifact, which is the primary. Every
+    /// other picker row is server metadata the engine has never seen, so a
+    /// dual-subtitle pick has to register its URL before it can be selected.
+    private func registerSecondarySubtitleWithAetherIfNeeded(_ track: PlayerTrack) {
+        guard !aetherPlaybackController.containsSubtitle(appTrackID: track.trackId),
+              let url = protocolV3InventorySidecarURL(for: track) else {
+            return
+        }
+        aetherPlaybackController.addExternalSubtitleTrack(
+            ExternalSubtitleTrack(
+                url: url,
+                name: track.title,
+                language: track.lang,
+                isForced: track.isForced,
+                isHearingImpaired: track.isHearingImpaired,
+                isDefault: track.isDefault,
+                httpHeaders: aetherSubtitleRequestHeaders(for: url),
+                formatHint: track.codec
+            ),
+            appTrackID: track.trackId
+        )
+    }
+
+    /// Resolved sidecar URL the active plan publishes for this picker row, or
+    /// nil when the row is not a downloadable sidecar (`burn_in_only` rows
+    /// carry no URL) or no V3 plan is active.
+    private func protocolV3InventorySidecarURL(for track: PlayerTrack) -> URL? {
+        guard let plan = activePreparedProtocolV3?.plan,
+              let combinedIndex = track.srcId,
+              let item = plan.subtitle.inventory.first(where: {
+                  $0.combinedIndex == combinedIndex
+              }),
+              item.delivery == "sidecar",
+              let raw = item.url?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !raw.isEmpty else {
+            return nil
+        }
+        return resolveServerUrl(raw, serverUrl: resolvedServerUrl)
+    }
+
+    /// Whether a picker row can actually be rendered as the secondary
+    /// subtitle: it is either already mounted in Aether or can be mounted from
+    /// the plan inventory on demand.
+    private func canRenderAsSecondarySubtitle(_ track: PlayerTrack) -> Bool {
+        guard activePreparedProtocolV3 != nil else { return true }
+        if SubtitleTrackIdSpace.isAILive(track.trackId) { return false }
+        return aetherPlaybackController.containsSubtitle(appTrackID: track.trackId)
+            || protocolV3InventorySidecarURL(for: track) != nil
     }
 
     // MARK: - Live AI subtitle track seam

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -5992,6 +5992,51 @@ class PlayerViewModel {
         track.srcId ?? track.ffIndex
     }
 
+    /// Re-registers session-created sidecars (finished AI jobs, downloaded
+    /// subtitles) with a freshly loaded engine under V3.
+    ///
+    /// Their `knownExternalSubtitles` entries were recorded for exactly this
+    /// moment, but the V3 picker-only gate skips the generic re-registration
+    /// path, so without this a quality/route replan leaves the row selected
+    /// in the menu with no Aether resource behind it.
+    private func reregisterLocallyCreatedSidecarsWithAether() {
+        guard backendCapabilities.supportsExternalPrimarySubtitles else { return }
+        var reregistered = false
+        for local in locallyRegisteredSidecarSubtitleTracks {
+            guard !aetherPlaybackController.containsSubtitle(appTrackID: local.trackId),
+                  let known = knownExternalSubtitles.first(where: {
+                      SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: $0.index) == local.trackId
+                  }),
+                  let url = resolveServerUrl(known.url, serverUrl: resolvedServerUrl) else {
+                continue
+            }
+            aetherPlaybackController.addExternalSubtitleTrack(
+                ExternalSubtitleTrack(
+                    url: url,
+                    name: known.label,
+                    language: known.language,
+                    isForced: known.forced ?? false,
+                    isHearingImpaired: known.hearingImpaired ?? false,
+                    isDefault: known.default ?? false,
+                    httpHeaders: aetherSubtitleRequestHeaders(for: url),
+                    formatHint: known.codec
+                ),
+                appTrackID: local.trackId
+            )
+            reregistered = true
+        }
+        guard reregistered else { return }
+        // If the local row was the active selection, the new engine load lost
+        // it; arm the existing pending path so inventory adoption reasserts
+        // the engine-side selection once the load is established. The plan
+        // cannot contest this id — it does not know the track.
+        if let selectedSubtitleId,
+           locallyRegisteredSidecarSubtitleTracks.contains(where: { $0.trackId == selectedSubtitleId }) {
+            pendingSidecarSubtitleTrackId = selectedSubtitleId
+        }
+        adoptAetherInventory()
+    }
+
     private func loadPendingExternalSubtitles() {
         if activePreparedProtocolV3 != nil {
             // `subtitle.inventory` feeds the V3 picker. Loading all of its URLs
@@ -5999,6 +6044,11 @@ class PlayerViewModel {
             // and lets language/default policy override `subtitle.artifact`.
             // The exact selected artifact was already declared in AetherLoadSpec.
             pendingExternalSubtitles = []
+            // A sidecar this session created itself (finished AI job or
+            // downloaded subtitle) is not in the plan, so a reload rebuilds
+            // the alias table without it while the picker still shows its
+            // row; only those tracks are re-registered here.
+            reregisterLocallyCreatedSidecarsWithAether()
             Self.logger.info("[CMP-SUB] keeping V3 subtitle inventory picker-only")
             return
         }

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3PlanAdapter.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3PlanAdapter.swift
@@ -119,14 +119,14 @@ enum ApplePlaybackV3PlanAdapter {
         // plan does not lose its active subtitle if a transitional server
         // omitted that one inventory URL.
         if let artifact = plan.subtitle.artifact,
-           let selectedIndex = plan.selectedTracks.subtitle?.index,
+           let selectedIndex = plan.selectedSubtitleCombinedIndex,
            !subtitleUrls.contains(where: { $0.index == selectedIndex }) {
             // §8: the inventory is authoritative. Describe the track from its
             // own entry when the server published one — a `burn_in_only` entry
             // has no URL but still carries the correct identity. Only fall back
             // to the counted catalog lookup when the inventory names no entry
             // for this ordinal at all.
-            let published = plan.subtitle.inventory.first { $0.combinedIndex == selectedIndex }
+            let published = plan.selectedSubtitleInventoryItem
             let selected = published == nil
                 ? subtitleTrack(atServerCombinedIndex: selectedIndex, in: selectedVersion)
                 : nil
@@ -175,6 +175,56 @@ enum ApplePlaybackV3PlanAdapter {
                 audioCodec: plan.effectiveRecipe.audioCodec
             )
         )
+    }
+
+    /// Protocol V3's subtitle inventory is picker state, not a preload list.
+    /// Project every authoritative server row into the app's menu without
+    /// registering its URL with Aether. The active plan's single artifact is
+    /// mounted separately by `AetherLoadSpec`.
+    ///
+    /// `version` is only needed to give embedded rows their FFmpeg stream
+    /// index. Without it those rows persist as the explicit-Off sentinel,
+    /// because `TrackSelectionPersistence` identifies an embedded pick by that
+    /// index; the combined ordinal alone cannot stand in for it.
+    static func subtitlePickerTracks(
+        plan: PlaybackV3Plan,
+        version: FileVersion? = nil
+    ) -> [PlayerTrack] {
+        // A selected row and a rendered row are different questions: `off`
+        // means nothing is selected no matter what the plan still names.
+        let selectedIndex = plan.subtitle.mode == PlaybackProtocolV3.SubtitleMode.off
+            ? nil
+            : plan.selectedSubtitleCombinedIndex
+        return plan.subtitle.inventory.compactMap { item in
+            guard item.combinedIndex >= 0 else { return nil }
+            let ffIndex: Int? = item.source == "embedded"
+                ? version.flatMap {
+                    ffmpegSubtitleStreamIndex(
+                        serverCombinedIndex: item.combinedIndex,
+                        in: $0,
+                        inventory: plan.subtitle.inventory
+                    )
+                }
+                : nil
+            return PlayerTrack(
+                trackId: SubtitleTrackIdSpace.makeSidecarTrackId(
+                    urlIndex: item.combinedIndex
+                ),
+                kind: .sub,
+                title: item.label,
+                lang: item.language,
+                codec: item.codec,
+                audioChannelCount: nil,
+                bitrate: nil,
+                isDefault: item.default,
+                isForced: item.forced,
+                isHearingImpaired: item.hearingImpaired,
+                isExternal: item.source != "embedded",
+                isSelected: item.combinedIndex == selectedIndex,
+                ffIndex: ffIndex,
+                srcId: item.combinedIndex
+            )
+        }
     }
 
     /// V3 subtitle identities are external-first combined ordinals. Apple’s
@@ -241,7 +291,7 @@ enum ApplePlaybackV3PlanAdapter {
         in version: FileVersion,
         inventory: [PlaybackV3SubtitleInventoryItem]
     ) -> Int? {
-        if playerTrack.isExternal {
+        if SubtitleTrackIdSpace.isSidecar(playerTrack.trackId) || playerTrack.isExternal {
             // A sidecar player track is minted from a published `SubtitleUrl`,
             // whose `index` *is* the server's combined ordinal — so this is an
             // echo, not a derivation, and must not be re-mapped through the

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/PlaybackProtocolV3Models.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/PlaybackProtocolV3Models.swift
@@ -63,6 +63,22 @@ enum PlaybackProtocolV3 {
         ]
     }
 
+    /// What the plan asks the client to do with the selected subtitle.
+    enum SubtitleMode {
+        static let off = "off"
+        static let render = "render"
+        /// Server-transcoded cues the client still renders itself. Only the
+        /// artifact's format differs from `render`.
+        static let convert = "convert"
+        static let burnIn = "burn_in"
+
+        /// Modes whose artifact the client mounts and renders locally. Every
+        /// gate that arms a local subtitle selection must accept all of them:
+        /// a gate that only knows `render` turns a mounted artifact into an
+        /// explicit Off while the picker still shows the row selected.
+        static let locallyRendered: Set<String> = [render, convert]
+    }
+
     /// How much the client actually knows about its own decoders. The server
     /// gates direct/copy routes on this: `exact` and `platformAttested` are
     /// matched against `video_decode` entries, `declared` only against the flat
@@ -502,6 +518,44 @@ struct PlaybackV3Plan: Codable, Equatable {
     let subtitleFidelityPolicy: String
     /// Quality rungs the server will honour for a `quality_change` replan.
     let availableQualities: [PlaybackV3AvailableQuality]
+}
+
+extension PlaybackV3Plan {
+    /// The one inventory row this plan's subtitle decision names.
+    ///
+    /// Every consumer that needs "which row is selected" resolves it here so
+    /// the picker, the load spec, the renewal intent and the session
+    /// projection cannot disagree with each other. The order matches the
+    /// shared Android resolver (`resolvedSelectedSubtitleIndex`):
+    /// `selected_tracks.subtitle.index` is authoritative, then its stable
+    /// `id`. The trailing `subtitle.track_id` match is Apple-only and last:
+    /// it is the transitional shape this client already accepted and must
+    /// keep accepting, but it never outranks the neutral identity.
+    ///
+    /// `subtitle.mode` is deliberately not consulted. A caller that must
+    /// distinguish "off" from "selected but not locally rendered" — the
+    /// picker — applies that gate itself.
+    var selectedSubtitleInventoryItem: PlaybackV3SubtitleInventoryItem? {
+        if let index = selectedTracks.subtitle?.index,
+           let byIndex = subtitle.inventory.first(where: { $0.combinedIndex == index }) {
+            return byIndex
+        }
+        if let id = selectedTracks.subtitle?.id,
+           let byIdentity = subtitle.inventory.first(where: { $0.trackId == id }) {
+            return byIdentity
+        }
+        if let trackId = subtitle.trackId {
+            return subtitle.inventory.first { $0.trackId == trackId }
+        }
+        return nil
+    }
+
+    /// The selected combined ordinal, falling back to the wire index when the
+    /// inventory names no row for it (a transitional plan can still be
+    /// executable without publishing the row).
+    var selectedSubtitleCombinedIndex: Int? {
+        selectedSubtitleInventoryItem?.combinedIndex ?? selectedTracks.subtitle?.index
+    }
 }
 
 struct PlaybackV3Terminal: Codable, Equatable {


### PR DESCRIPTION
## What

Under Protocol V3, the subtitle menu is now derived from the plan's authoritative `subtitle.inventory` (sidecar-space ids per combined ordinal) instead of Aether's probed track list, and only the plan-selected artifact is mounted in the engine. Subtitle/audio track changes ride replans with the server ordinal frozen at tap time, so an engine inventory republish cannot clobber an in-flight pick, and an unmappable tap is refused instead of silently replanning to the already-playing track.

## Key changes

- **Shared selection resolver** — `PlaybackV3Plan.selectedSubtitleInventoryItem` (`selected_tracks.subtitle.index` → `selected_tracks.subtitle.id` → decision `subtitle.track_id`, matching Android's `resolvedSelectedSubtitleIndex` where the fields overlap) replaces four divergent copies in AetherLoadSpec, the renewal intent, the session projection, and the picker. A transitional plan with no selected ordinal now resolves by identity instead of publishing "nothing selected" over rendering captions.
- **`SubtitleMode.locallyRendered` (`render` + `convert`)** drives every local-render gate; a `convert` plan arms the mounted artifact instead of an explicit Off.
- **Secondary (dual) subtitles** mount the chosen inventory sidecar with Aether on demand; rows that cannot be mounted (`burn_in_only`, no URL) are hidden from the secondary menu and a failed mount clears the pick instead of showing a checked row that renders nothing.
- **Completed AI/downloaded sidecars** are kept in a session-scoped list and unioned into the picker until a later plan publishes their ordinal, so a finished job no longer vanishes from the menu.
- **Embedded picker rows carry their real FFmpeg stream index**, so persistence takes the version-metadata branch instead of writing the explicit-Off sentinel (`-1`), and remembered embedded picks survive to the next episode.
- **Deferred ffIndex adoption** publishes the plan row's sidecar-space id while still driving the engine with the raw stream id, so the picker and resume resolution stay consistent.
- V3 language preferences are no longer passed to the engine (the plan already selected one exact artifact); the dead initializer parameter is deleted.

## Testing

- `xcodebuild build` (Silo scheme, iPhone 17 Pro Max simulator): **BUILD SUCCEEDED**, no new warnings.
- Targeted: `PlaybackProtocolV3Tests` + `AetherPlaybackBoundaryTests` — 82 tests, 0 failures. New tests cover the resolver order, the no-ordinal identity fallback, convert-mode arming, and embedded ffIndex rows.
- Full suite: 14 failures in 7 tests (profile/settings/UI-customization), verified pre-existing on a clean tree — identical failures with this change stashed; none playback-related.

🤖 Generated with [Claude Code](https://claude.com/claude-code)