### PR TITLE
fix(tvos): keep the playback HUD's focus owner stable across replans

### DIFF
--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -103,7 +103,12 @@ struct PlayerView: View {
                     //     the signed ladder, Tap Select = commit + exit,
                     //     Menu = cancel + exit (handled in onExitCommand).
                     //     Taps against Up/Down are ignored; holds are no-ops.
-                    if !viewModel.isLoading && (!viewModel.showIntroSkip || viewModel.isHoldSeeking) &&
+                    // Never while the HUD is presented: the sink and the HUD's
+                    // focus graph would be two owners for the same presses
+                    // (docs/tvos-focus.md), and the sink's Down handler
+                    // force-switches the HUD tab underneath the user.
+                    if !viewModel.isLoading && !viewModel.isHUDPresented &&
+                        (!viewModel.showIntroSkip || viewModel.isHoldSeeking) &&
                         (!viewModel.showControls || viewModel.isHoldSeeking) {
                         TVPressCaptureView(
                             onArrowTap: { direction in
@@ -160,7 +165,14 @@ struct PlayerView: View {
                         .ignoresSafeArea()
                     }
 
-                    if !viewModel.isLoading && !viewModel.isHoldSeeking {
+                    // `isLoading` also covers Protocol V3 replans (track or
+                    // quality changes made *from inside the HUD*). Unmounting
+                    // here for those would destroy the HUD's @State/@FocusState
+                    // mid-press and reseed focus on a reset tab, so the HUD
+                    // keeps its host mounted through a replan. A replacement
+                    // load closes the HUD in `resetPublishedLoadState`, so
+                    // cold starts and item changes still unmount as before.
+                    if (!viewModel.isLoading || viewModel.isHUDPresented) && !viewModel.isHoldSeeking {
                         TVPlayerControls(
                             viewModel: viewModel,
                             showsTimelinePreview: isTimelinePreviewVisible,
@@ -259,10 +271,15 @@ struct PlayerView: View {
                 }
             } else if viewModel.isHoldSeeking {
                 viewModel.cancelHoldSeek()
+            } else if viewModel.isHUDPresented {
+                // Before the `isLoading` escape: a replan issued from the HUD
+                // keeps the HUD mounted while `isLoading` is true, and Menu
+                // during that window must close the HUD, not exit the player.
+                // A genuinely stalled load is still escapable — the first
+                // Menu closes the HUD, the next one lands below.
+                viewModel.closeHUD()
             } else if viewModel.isLoading {
                 dismissPlayer()
-            } else if viewModel.isHUDPresented {
-                viewModel.closeHUD()
             } else if !viewModel.isPlaying {
                 // While paused, Menu exits the player instead of hiding the
                 // controls over a frozen frame.

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -3378,6 +3378,11 @@ class PlayerViewModel {
         seekOriginTime = nil
         seekTargetTime = nil
         showControls = false
+        // The HUD belongs to the outgoing item. Replans deliberately bypass
+        // this reset so the HUD survives them; a replacement load must close
+        // it, both because its content is stale and because the tvOS controls
+        // host stays mounted through `isLoading` whenever this flag is up.
+        isHUDPresented = false
         showNextUpScreen = false
         nextUpEpisode = nil
         nextUpOnDeckItems = []
@@ -6932,6 +6937,17 @@ class PlayerViewModel {
     private static let autoHideSeconds: UInt64 = 5
 
     private func scheduleHideControls() {
+        // The HUD pins its host visible (`pinControlsVisible` in `openHUD`).
+        // Actions taken from inside it — track selection, remote play/pause —
+        // funnel through here and must not re-arm the auto-hide out from
+        // under the open HUD: on tvOS the hide swaps the press-capture sink
+        // in beneath it, splitting remote presses across two owners.
+        // `closeHUD()` calls back in after clearing the flag, which restores
+        // the normal auto-hide lifecycle.
+        if isHUDPresented {
+            pinControlsVisible()
+            return
+        }
         hideControlsTask?.cancel()
         showControls = true
         hideControlsTask = Task { @MainActor [weak self] in


### PR DESCRIPTION
## Problem

Selecting a subtitle (or audio) track from the tvOS playback HUD misbehaved: the HUD would blank and come back on the Info tab, and in some timings the remote stopped moving through the menu entirely — Left/Right skipped the video behind it, and Down snapped the HUD to the Video tab.

The HUD's own focus graph (`TVPlayerInfoHUD`) is fine and follows `docs/tvos-focus.md`. All three causes are in the host layer, and all three surfaced when Protocol V3 made a track change into a server replan.

## Causes and fixes

**1. A replan unmounted the open HUD.** Under V3, `selectSubtitle` / `selectAudio` go through `attemptProtocolV3Replan`, which sets `isLoading`. `TVPlayerControls` was mounted on `!isLoading`, so the selecting press tore down the HUD mid-press, destroying its `@State`/`@FocusState` — including the remembered `activeHUDTab` — and reseeded focus from scratch on remount.

The controls host now stays mounted through a replan while the HUD is presented. Replacement loads still unmount as before, and now close the HUD explicitly in `resetPublishedLoadState` since its content belongs to the outgoing item.

**2. Track selection re-armed the auto-hide the HUD had cancelled.** Both selection paths end in `scheduleHideControls()`, undoing the `pinControlsVisible()` that `openHUD()` set. Five seconds later the hide fired and pulled the HUD's host out from under it.

`scheduleHideControls` now re-pins instead of scheduling while `isHUDPresented`; `closeHUD()` calls back in after clearing the flag, restoring the normal lifecycle.

**3. The press sink could mount beneath the open HUD.** `TVPressCaptureView` was gated on `!showControls` without regard for the HUD, so once (2) fired, the fullscreen sink and the HUD's focus graph were two owners for the same presses — the hybrid `docs/tvos-focus.md` warns against. Its Down handler calls `openSettingsHUD()`, which is what forced the tab to Video. Now also gated on `!isHUDPresented`.

Menu handling is reordered to match: `isHUDPresented` is checked before the `isLoading` escape, so Menu during a HUD-initiated replan closes the HUD rather than exiting the player. A stalled load stays escapable — the first Menu closes the HUD, the next falls through.

## Validation

- `SiloTV` compiles clean (`generic/platform=tvOS`).
- Signed device build succeeds; installed and launched on an Apple TV 4K (3rd gen), tvOS device build.
- `PlaybackProtocolV3Tests` + `AetherPlaybackBoundaryTests` pass.
- **Not yet done:** the full `SiloTests` suite, and hands-on confirmation of the corrected focus behavior on the device. Worth a manual pass on hardware before merge.

No behavior change on iOS or macOS — the mount gates and press sink are tvOS-only, and `openHUD` has no non-tvOS callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the tvOS player HUD behavior during loading and content changes.
  * The transport controls now remain available while in-HUD loading or replanning is underway.
  * Presses are routed consistently while the HUD is open, preventing accidental dismissal.
  * Menu now closes the HUD before dismissing a loading player.
  * Replacing the current item automatically closes the options HUD.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->