### PR TITLE
docs: standardize contribution guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,14 +44,9 @@ fastlane/Preview.html
 fastlane/screenshots/
 fastlane/test_output/
 
-# Local tooling state
-# `.agents/skills` is a symlink to `.claude/skills` so non-Claude agents find the
-# same files; everything else under .agents/ is per-developer scratch.
-/.agents/*
-!/.agents/skills
-# Ignore everything in .claude/ except the committed, shared skills.
-/.claude/*
-!/.claude/skills/
+# Local agent/tooling state
+/.agents/
+/.claude/
 .codex/
 .cursor/
 .sweetpad/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,11 +32,6 @@ Those commands assume a local Xcode. When developing from a Linux host, every Ap
 operation runs on the remote `mac-builder` Mac instead — read the `mac-builder` skill first, and
 `docs/mac-builder.md` for setup and background.
 
-## Skills
-
-Task-specific guides live in `.claude/skills/`, also reachable as `.agents/skills/` for agents
-that look there. Read the one that matches the task instead of working from this file alone.
-
 ## Coding Style & Naming Conventions
 
 Use Swift 5 and SwiftUI naming conventions. Types use `PascalCase`; functions and properties use `camelCase`. Keep platform-specific code under the existing `iOS`, `tvOS`, or `macOS` folders and update `project.yml` instead of hand-editing generated `.xcodeproj` files. Preserve existing Apple bundle IDs and keychain groups during this migration for TestFlight continuity.
@@ -49,6 +44,42 @@ manual directional focus mutation.
 ## Testing Guidelines
 
 Apple tests use XCTest under `iosApp/Tests/`. Do not add tests for small changes or UI changes unless requested. For shared logic changes, add focused tests only for critical or high-risk behavior.
+
+## Writing
+
+Run a final readability pass on every human-facing issue, pull request,
+document, or status update.
+
+- Lead with the outcome.
+- Use concrete, plain language and active voice.
+- Cut filler, stock framing, repetition, and promotional claims.
+- Preserve meaning, evidence, citations, uncertainty, and established
+  terminology.
+- Never rewrite exact quotations, commands, logs, identifiers, API names, or
+  contractual language.
+- Match the tone to the audience and use only formatting that improves
+  readability.
+
+## Pull requests
+
+Never create a pull request unless the developer explicitly asks for one.
+
+Use a Conventional Commit title in plain language. Start the body with the
+problem, explain the solution next, and end with the required AI disclosure,
+including the exact model identifier, agent harness, and any other AI tooling.
+Include repository-required issue links, validation evidence, risks, and
+follow-up work.
+
+- Keep one concern per pull request. If an honest description needs the word
+  "also," split the work.
+- Include before-and-after images for UI changes. Include a short video when
+  motion or timing matters.
+- Upload pull request evidence to GitHub. Never commit PR-only assets such as
+  `.github/pr-assets/`.
+- When babysitting a pull request, poll checks and review comments created
+  after the last push. Verify bot findings against the source, fix real issues,
+  and dismiss false positives with a written reason. Remain quiet when nothing
+  new has appeared. Stop when the latest commit is green.
 
 ## Security & Configuration Tips
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,61 @@
-# Contributing
+# Contributing to Silo Apple
 
-Thanks for contributing to Silo Apple.
+The [Silo contribution guide](https://github.com/Silo-Server/.github/blob/main/CONTRIBUTING.md)
+covers project-wide coordination, focused changes, evidence, AI disclosure, and
+pull request expectations. Those requirements apply here; this guide adds the
+Apple-specific workflow.
+
+## Before you start
+
+Open an [issue](https://github.com/Silo-Server/silo-apple/issues) before
+implementing a feature, navigation or behavior change, large refactor, or work
+that changes the shared server contract. Documentation, narrow fixes, and
+well-scoped parity corrections can go straight to a pull request.
+
+This repository owns the iOS, tvOS, and macOS clients. Server/API work belongs
+in [`silo-server`](https://github.com/Silo-Server/silo-server), and shared client
+behavior should be checked against
+[`silo-android`](https://github.com/Silo-Server/silo-android).
+
+## Development setup
+
+Read [README.md](README.md) for prerequisites, signing setup, and build commands,
+then read [AGENTS.md](AGENTS.md) for module ownership and platform guidance.
+Regenerate `iosApp/Silo.xcodeproj` from `iosApp/project.yml`; never hand-edit the
+generated project.
+
+## Validate your change
+
+Build every affected platform and run the focused XCTest targets. A typical
+unsigned iOS gate is:
+
+```sh
+cd iosApp
+xcodegen generate
+xcodebuild build \
+  -project Silo.xcodeproj \
+  -scheme Silo \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  CODE_SIGNING_ALLOWED=NO
+xcodebuild test \
+  -project Silo.xcodeproj \
+  -scheme Silo \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+The `SiloTests` bundle belongs to the `Silo` scheme; there are currently no
+separate tvOS or macOS test bundles. Use `SiloTV` with a tvOS simulator for tvOS
+builds and `SiloMac` with `platform=macOS` for macOS builds. Exercise visible
+changes in the affected app and include screenshots or a short recording in the
+pull request.
+
+## Open the pull request
+
+Use a Conventional Commit title, explain which platforms are affected, paste
+the actual validation results, and call out any server or Android coordination.
+Read the [AI-assisted contribution policy](https://github.com/Silo-Server/silo-server/blob/main/docs/ai-contributions.md)
+and include its disclosure block.
 
 ## Licensing of contributions
 
@@ -20,7 +75,14 @@ You retain copyright in your contribution; no assignment is requested.
 ## Practical notes
 
 - Repository layout, build commands, and coding conventions are in
-  [CLAUDE.md](CLAUDE.md) and the docs under `docs/`.
+  [AGENTS.md](AGENTS.md) and the docs under `docs/`.
 - Third-party components and their licenses are inventoried in
   [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md); update it when a
   dependency changes.
+
+## Instructions for coding agents
+
+Coding agents must read [AGENTS.md](AGENTS.md) before changing the repository
+(`CLAUDE.md` points to the same guidance). The organization-wide contribution
+guide and AI-assisted contribution policy apply to agent and human authors
+equally.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Try the latest beta builds of the iOS and tvOS apps:
 
 ## Prerequisites
 
-- Xcode 16+
+- Xcode 26+
 - `xcodegen`
 - Ruby 3.2 with Bundler for release automation
 - A running Silo server for local auth, browsing, and playback validation
@@ -127,6 +127,12 @@ Personal Apple Developer teams cannot join the production App Group, so Top Shel
 ## Release Flow
 
 Fastlane lanes are defined in `fastlane/Fastfile`. All Apple IDs, team IDs, signing repo URLs, and App Store Connect credentials must come from CI environment variables.
+
+## Contributing
+
+Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. Features,
+navigation or behavior changes, large refactors, and shared contract changes
+should start as an issue.
 
 ## License & Trademarks
 


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow fix

Apple’s contribution guide needed the shared organization workflow and complete platform validation commands, while its README listed an outdated Xcode requirement.

## Approach

Expand the existing guide without changing its contribution-license terms, document the actual iOS XCTest command and tvOS/macOS test-bundle limits, update the Xcode prerequisite, embed shared writing/PR rules in `AGENTS.md`, simplify stale local-skill ignore rules, and retain `CLAUDE.md -> AGENTS.md`.

## Validation

- Xcode schemes, test bundle membership, project generation, and documented commands were checked against `project.yml` and repository guidance.
- All changed relative documentation links — passed.
- `git diff --check` — passed.
- Existing `CLAUDE.md -> AGENTS.md` target and resolved contents — verified.
- Xcode builds and simulator tests — not run; this PR changes documentation and agent guidance only.

## Risks

Documentation and contributor-workflow changes only. No Swift, SwiftUI, Xcode project generation, signing, bundle identifiers, or application behavior changed.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: Codex desktop with Codex subagents
- Tool(s): Codex
- Model(s): GPT-5; the exact backend identifier was not exposed by the harness
- Involvement: AI-assisted
- Adversarial review: An independent subagent compared the guide with the XcodeGen project, schemes, tests, platform targets, licensing terms, and current prerequisites. Fresh ponytail-reviews of the staged diff and exact commit both found no unnecessary complexity: “Lean already. Ship.”

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded contribution guidance with setup, validation, pull request, issue, and AI disclosure requirements.
  - Added standards for human-facing content and clarified coding-agent expectations.
  - Updated README prerequisites to Xcode 26+ and linked contributors to the contribution workflow.
  - Removed outdated skills-related guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->