### PR TITLE
fix(playback): keep remote audio tracks in picker

### DIFF
--- a/iosApp/Tests/PlaybackProtocolV3Tests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3Tests.swift
@@ -1262,6 +1262,63 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         XCTAssertTrue(off.allSatisfy { !$0.isSelected })
     }
 
+    func testV3AudioPickerFallsBackToCatalogInventoryWhenAetherPublishesNone() {
+        let version = makeVersion(
+            container: "mkv",
+            videoCodec: "h264",
+            audioCodec: "eac3",
+            audioTracks: [
+                makeAudio(index: 2, codec: "eac3", isDefault: true),
+                makeAudio(index: 5, codec: "aac", isDefault: false),
+            ]
+        )
+
+        let tracks = ApplePlaybackV3PlanAdapter.audioPickerTracks(
+            aetherTracks: [],
+            plan: makePlan(selectedAudioIndex: 1),
+            version: version
+        )
+
+        XCTAssertEqual(tracks.map(\.trackId), [0, 1])
+        XCTAssertEqual(tracks.map(\.ffIndex), [2, 5])
+        XCTAssertEqual(tracks.map(\.srcId), [0, 1])
+        XCTAssertEqual(tracks.filter(\.isSelected).map(\.trackId), [1])
+    }
+
+    func testV3AudioPickerKeepsAetherInventoryWhenAvailable() {
+        let aetherTrack = PlayerTrack(
+            trackId: 7,
+            kind: .audio,
+            title: "Engine track",
+            lang: "en",
+            codec: "flac",
+            audioChannelCount: 2,
+            bitrate: nil,
+            isDefault: true,
+            isForced: false,
+            isHearingImpaired: false,
+            isExternal: false,
+            isSelected: true,
+            ffIndex: 7,
+            srcId: 0
+        )
+        let version = makeVersion(
+            container: "mkv",
+            videoCodec: "h264",
+            audioCodec: "eac3",
+            audioTracks: [makeAudio(index: 2, codec: "eac3", isDefault: true)]
+        )
+
+        XCTAssertEqual(
+            ApplePlaybackV3PlanAdapter.audioPickerTracks(
+                aetherTracks: [aetherTrack],
+                plan: makePlan(selectedAudioIndex: 0),
+                version: version
+            ),
+            [aetherTrack]
+        )
+    }
+
     /// `convert` mounts an artifact exactly like `render` does, so every gate
     /// that arms the local selection must accept it. Treating it as "not
     /// locally rendered" arms explicit Off over a mounted artifact.

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -2797,7 +2797,7 @@ class PlayerViewModel {
         let existingLiveTracks = subtitleTracks.filter {
             SubtitleTrackIdSpace.isAILive($0.trackId)
         }
-        audioTracks = engine.audioTracks.enumerated().map { ordinal, track in
+        let aetherAudioTracks = engine.audioTracks.enumerated().map { ordinal, track in
             PlayerTrack(
                 trackId: Int64(track.id),
                 kind: .audio,
@@ -2815,6 +2815,11 @@ class PlayerViewModel {
                 srcId: ordinal
             )
         }
+        audioTracks = ApplePlaybackV3PlanAdapter.audioPickerTracks(
+            aetherTracks: aetherAudioTracks,
+            plan: activePreparedProtocolV3?.plan,
+            version: currentSelectedVersion
+        )
         let aetherSubtitleTracks = engine.subtitleTracks.map { track in
             let appTrackID = aetherPlaybackController.appSubtitleID(forAetherID: track.id)
             return PlayerTrack(
@@ -2866,7 +2871,8 @@ class PlayerViewModel {
         }
         chapters = mediaChapters.isEmpty ? serverProvidedChapters : mediaChapters
 
-        selectedAudioId = engine.activeAudioTrackIndex.map(Int64.init)
+        selectedAudioId = audioTracks.first(where: \.isSelected)?.trackId
+            ?? engine.activeAudioTrackIndex.map(Int64.init)
         // A locally-registered sidecar is selected client-side, so the plan —
         // which predates the track — must not republish over it. Once the
         // server publishes that ordinal the plan is authoritative again.
@@ -2891,8 +2897,12 @@ class PlayerViewModel {
         // load is established; `loadAether` re-enters this method at that point.
         let loadIsEstablished = isAetherLoadEstablished
 
+        // Catalog fallback rows are picker state for server-owned replans; only
+        // a track Aether actually published may drive its local selection API.
         if let wantedIndex = pendingAudioFfIndex,
-           let match = audioTracks.first(where: { audioSelectionIndex(for: $0) == wantedIndex }) {
+           let match = aetherAudioTracks.first(where: {
+               audioSelectionIndex(for: $0) == wantedIndex
+           }) {
             switch DeferredTrackSelectionGate.outcome(
                 isLoadEstablished: loadIsEstablished,
                 engineAlreadyMatches: engine.activeAudioTrackIndex.map(Int64.init) == match.trackId

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3PlanAdapter.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3PlanAdapter.swift
@@ -227,6 +227,42 @@ enum ApplePlaybackV3PlanAdapter {
         }
     }
 
+    /// Keeps Aether authoritative when it publishes audio tracks, but fills
+    /// the picker from the selected catalog version when a remote V3 route
+    /// exposes only its packaged rendition. Audio changes on that route are
+    /// already server-owned replans, so each fallback row carries the catalog
+    /// ordinal in `srcId` and the plan's selected ordinal drives the checkmark.
+    static func audioPickerTracks(
+        aetherTracks: [PlayerTrack],
+        plan: PlaybackV3Plan?,
+        version: FileVersion?
+    ) -> [PlayerTrack] {
+        guard aetherTracks.isEmpty,
+              let plan,
+              let version else {
+            return aetherTracks
+        }
+        let selectedOrdinal = plan.selectedTracks.audio?.index
+        return (version.audioTracks ?? []).enumerated().map { ordinal, track in
+            PlayerTrack(
+                trackId: Int64(ordinal),
+                kind: .audio,
+                title: track.title,
+                lang: track.language,
+                codec: track.codec,
+                audioChannelCount: track.channels,
+                bitrate: track.bitrate.map(Int64.init),
+                isDefault: track.isDefault ?? false,
+                isForced: false,
+                isHearingImpaired: false,
+                isExternal: false,
+                isSelected: ordinal == selectedOrdinal,
+                ffIndex: track.index,
+                srcId: ordinal
+            )
+        }
+    }
+
     /// V3 subtitle identities are external-first combined ordinals. Apple’s
     /// embedded picker carries FFmpeg stream indices instead, and watch detail
     /// lists embedded tracks before external tracks, so the wire identity must


### PR DESCRIPTION
## Problem

Protocol V3 remote playback can publish no selectable audio inventory through Aether even though the selected catalog file has multiple audio tracks. The Apple player replaced its picker state with that empty engine inventory, so the in-player **Audio & Subtitles** sheet omitted the Audio section.

Closes #214.

## Solution

- Preserve Aether as the authoritative inventory when it publishes audio tracks.
- When Aether publishes none during a Protocol V3 session, project the selected catalog version's audio tracks into picker state.
- Mark the active row from `selected_tracks.audio.index` and retain the server ordinal used by the existing `audio_track_changed` replan flow.
- Keep catalog fallback rows picker-only so deferred local selection never sends a server ordinal to Aether as an engine track ID.

The server already accepts and preserves audio selection ordinals, so no server change is required.

## Validation

- `PlaybackProtocolV3Tests`: 43 passed, 0 failed, 0 skipped.
- Studio-local iOS Simulator: build, install, and launch passed.
- Studio-local tvOS Simulator: build, install, and launch passed.
- Staged privacy leak check passed.
- Required ponytail review: `Lean already. Ship.`

## Risk

The fallback is deliberately narrow: it applies only when Aether publishes no audio tracks and both a Protocol V3 plan and selected catalog version are available. Original/offline and fully probed routes retain their existing engine inventory and local-selection behavior.

## Visual evidence

Not attached because the preserved simulator contains private media metadata that should not be uploaded as public PR evidence. The focused regression tests cover the missing-inventory case, selected ordinal, stream-index mapping, server ordinal mapping, and engine-inventory precedence.

## AI disclosure

OpenAI GPT-5 implemented and reviewed this change using the Codex desktop app. No additional AI model or agent harness was used. Local build and test validation used the repository's Mac builder workflow and Xcode.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fallback audio track selection from the catalog when no tracks are provided by Aether.
  * Preserved catalog audio metadata and ordering for playback selection.

* **Bug Fixes**
  * Improved audio selection handling when Aether-provided inventory is available.
  * Ensured pending audio selections resolve consistently against the available track list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->