### PR TITLE
fix(tvos): stabilize scrub preview thumbnails

### DIFF
--- a/iosApp/iosApp/Screens/Player/AetherScrubPreviewProvider.swift
+++ b/iosApp/iosApp/Screens/Player/AetherScrubPreviewProvider.swift
@@ -83,8 +83,10 @@ final class AetherScrubPreviewProvider {
 
     /// Requests only the latest scrub target. The short trailing debounce,
     /// single pending slot, and prompt extractor shutdown bound work during a
-    /// fast drag. Both session and request generations fence late cache/decode
-    /// results before publication.
+    /// fast drag. A valid local request keeps the last successful still visible
+    /// until a replacement succeeds; cache misses are not lifecycle boundaries.
+    /// Both session and request generations fence late cache/decode results
+    /// before publication.
     ///
     /// Targets the loaded transport cannot express — chiefly a backward scrub
     /// before a re-anchored HLS plan's `timeline_offset_seconds` — are dropped
@@ -108,11 +110,11 @@ final class AetherScrubPreviewProvider {
         }
 
         requestGeneration &+= 1
-        onPreview?(nil)
         guard case let .local(playerTime) = spec.timeline.seekDisposition(
             forSourceTime: sourceTime
         ) else {
             pendingRequest = nil
+            onPreview?(nil)
             return
         }
         pendingRequest = PendingRequest(
@@ -191,9 +193,8 @@ final class AetherScrubPreviewProvider {
                   requestGeneration == request.requestGeneration else {
                 continue
             }
-            onPreview?(image.map {
-                Preview(image: $0, sourceTime: request.sourceTime)
-            })
+            guard let image else { continue }
+            onPreview?(Preview(image: image, sourceTime: request.sourceTime))
         }
     }
 

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPlayerControls.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPlayerControls.swift
@@ -19,6 +19,10 @@ enum TVPlayerTimeDisplayMode: Equatable {
 /// either hides the HUD, dismisses the overlay, or exits the player
 /// depending on what's on screen.
 struct TVPlayerControls: View {
+    private static let transportHorizontalInset: CGFloat = 80
+    private static let scrubPreviewCardWidth: CGFloat = 340
+    private static let scrubPreviewBottomInset: CGFloat = 300
+
     let viewModel: PlayerViewModel
     let showsTimelinePreview: Bool
     let timeDisplayMode: TVPlayerTimeDisplayMode
@@ -249,7 +253,7 @@ struct TVPlayerControls: View {
                 passiveTimelineBar
                 timeRow
             }
-            .padding(.horizontal, 80)
+            .padding(.horizontal, Self.transportHorizontalInset)
             .padding(.bottom, 48)
         }
         .allowsHitTesting(false)
@@ -300,14 +304,23 @@ struct TVPlayerControls: View {
                 .padding(.horizontal, 80)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
             if viewModel.isScrubbing, let image = viewModel.scrubPreviewImage {
-                scrubPreviewCard(image)
-                    .padding(.bottom, 214)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
-                    .transition(.opacity)
-                    .allowsHitTesting(false)
+                GeometryReader { proxy in
+                    scrubPreviewCard(image)
+                        .frame(width: Self.scrubPreviewCardWidth)
+                        .padding(.leading, scrubPreviewLeadingInset(in: proxy.size.width))
+                        .padding(.bottom, Self.scrubPreviewBottomInset)
+                        .frame(
+                            maxWidth: .infinity,
+                            maxHeight: .infinity,
+                            alignment: .bottomLeading
+                        )
+                }
+                .transition(.opacity)
+                .allowsHitTesting(false)
+                .accessibilityHidden(true)
             }
             transportStack
-                .padding(.horizontal, 80)
+                .padding(.horizontal, Self.transportHorizontalInset)
                 .padding(.bottom, 48)
         }
         .onAppear {
@@ -361,6 +374,22 @@ struct TVPlayerControls: View {
             tint: Color.black.opacity(0.28)
         )
         .shadow(color: .black.opacity(0.5), radius: 18, y: 7)
+    }
+
+    /// Aligns the preview with the scrubber puck while keeping the complete
+    /// card inside the same horizontal bounds as the transport timeline.
+    private func scrubPreviewLeadingInset(in containerWidth: CGFloat) -> CGFloat {
+        let trackWidth = max(containerWidth - (Self.transportHorizontalInset * 2), 0)
+        let playheadCenter = Self.transportHorizontalInset
+            + (trackWidth * CGFloat(progressFraction))
+        let minimumLeading = Self.transportHorizontalInset
+        let maximumLeading = containerWidth
+            - Self.transportHorizontalInset
+            - Self.scrubPreviewCardWidth
+        return min(
+            max(playheadCenter - (Self.scrubPreviewCardWidth / 2), minimumLeading),
+            maximumLeading
+        )
     }
 
     /// The sleep-timer chip floats in the top-right when active. Buffering is


### PR DESCRIPTION
## Problem

Related issue: N/A — reported internally, with no public issue or duplicate pull request.

The tvOS scrub preview was cleared before every valid thumbnail request. During held or focused timeline seeking, this made the card disappear and reappear as frames loaded. On the normal progress bar, the card stayed in the center instead of following the current scrub target.

Related implementation context: #180 and #92.

## Approach

A valid local request now retains the last successful still until the next image succeeds. Invalid or unrepresentable targets, playback replans, interaction completion, lifecycle resets, and session changes still clear the preview.

The normal progress bar positions the 340-point card from the same scrub fraction and 80-point inset as the puck, clamps it at both timeline edges, and raises it above the seek-rate chip. The layer remains passive and outside the tvOS focus graph.

## Validation

- `git diff --check`
- Mandatory `@ponytail-review`: `Lean already. Ship.`
- Signed `SiloTV` physical-device build succeeded and its embedded profile validated.
- The build installed and launched on a physical Apple TV; the running process was verified.
- No automated tests were added, following repository guidance for a focused UI change.
- Hands-on visual confirmation remains with the maintainer before merge.
- UI media omitted at maintainer direction.

## Risks

- When extraction misses a frame, the retained still may briefly trail the scrub target while the time label and puck continue to track it. Session, lifecycle, replan, and invalid-target boundaries still clear stale content.
- The preview uses the existing full-screen tvOS timeline geometry: a 340-point card, 80-point track insets, and edge clamping.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: Codex desktop agent harness
- Tool(s): OpenAI Codex with Codex multi-agent reviewers
- Model(s): `gpt-5.6-sol`
- Involvement: AI-assisted; maintainer visual verification pending
- Adversarial review: Independent reviews covered provider lifecycle semantics, tvOS geometry and focus behavior, public duplicate work, and over-engineering. One unnecessary narrow-canvas branch was removed; the final diff passed the mandatory review with `Lean already. Ship.`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scrub previews now remain visible during valid local requests when a new preview is unavailable.
  * Invalid or non-local requests clear previews appropriately.
  * Scrub preview positioning now aligns with the playhead and stays within the timeline bounds.
  * Timeline and idle overlays now maintain consistent horizontal spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->