### PR TITLE
Polish tvOS discovery, detail performance, and episode navigation

### DIFF
--- a/iosApp/Tests/TVHeroArtworkResolverTests.swift
+++ b/iosApp/Tests/TVHeroArtworkResolverTests.swift
@@ -89,4 +89,29 @@ final class TVHeroArtworkResolverTests: XCTestCase {
 
         XCTAssertEqual(artwork, poster)
     }
+
+    func testSkylineUpMovesToPreviousRow() {
+        XCTAssertEqual(
+            tvSkylineRowMoveTarget(currentIndex: 2, rowCount: 4, direction: .up),
+            .row(1)
+        )
+    }
+
+    func testSkylineUpFromFirstRowHandsFocusToTopMenu() {
+        XCTAssertEqual(
+            tvSkylineRowMoveTarget(currentIndex: 0, rowCount: 4, direction: .up),
+            .topMenu
+        )
+    }
+
+    func testSkylineDownMovesToNextRowAndStopsAtEnd() {
+        XCTAssertEqual(
+            tvSkylineRowMoveTarget(currentIndex: 1, rowCount: 3, direction: .down),
+            .row(2)
+        )
+        XCTAssertEqual(
+            tvSkylineRowMoveTarget(currentIndex: 2, rowCount: 3, direction: .down),
+            .none
+        )
+    }
 }

--- a/iosApp/iosApp/Components/EpisodeThumbCard.swift
+++ b/iosApp/iosApp/Components/EpisodeThumbCard.swift
@@ -176,7 +176,8 @@ struct EpisodeThumbCard: View {
             .clipped()
             .clipShape(RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius))
 
-            // Scrim gradient so the episode badge reads over bright stills
+            #if !os(tvOS)
+            // Scrim gradient so the compact episode badge reads over bright stills.
             LinearGradient(
                 colors: [.clear, .black.opacity(0.75)],
                 startPoint: .center,
@@ -184,6 +185,7 @@ struct EpisodeThumbCard: View {
             )
             .frame(width: cardWidth, height: cardHeight)
             .clipShape(RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius))
+            #endif
 
             // Server / user-customized overlay badges. `wide` variant
             // gives the bottom corners enough headroom that they don't

--- a/iosApp/iosApp/Components/EpisodeThumbCard.swift
+++ b/iosApp/iosApp/Components/EpisodeThumbCard.swift
@@ -3,8 +3,9 @@ import SwiftUI
 /// Horizontal (16:9) media card for episode and resume content — used in
 /// "Next Up", "Continue Watching", etc.
 ///
-/// Shows the episode still / backdrop, the series title + episode code
-/// (e.g. "S2 · E3") as an overlay, and the episode title plus runtime beneath.
+/// Shows the episode still / backdrop, series title, and episode metadata.
+/// tvOS keeps the artwork clear except for server-configured card overlays;
+/// compact S/E artwork badges remain available to the touch layouts.
 /// On tvOS the image sits inside a `.card` button for focus lift/parallax and
 /// a FocusState binding drives the title highlight.
 struct EpisodeThumbCard: View {
@@ -72,21 +73,27 @@ struct EpisodeThumbCard: View {
             if uiCustomization.cardPresentation.caption.showsTitle {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(displayTitle)
-                        .font(.continuumSubheadline)
+                        .font(.continuumPosterTitle)
                         .foregroundStyle(
                             isFocused
                                 ? Color.continuumOnSurface
                                 : Color.continuumOnSurface.opacity(0.85)
                         )
                         .lineLimit(1)
+                        .truncationMode(.tail)
+                        .frame(width: cardWidth, alignment: .leading)
+                        .clipped()
                         .animation(.easeOut(duration: 0.15), value: isFocused)
 
                     if uiCustomization.cardPresentation.caption.showsMetadata,
                        let subtitle = subtitleLine {
                         Text(subtitle)
-                            .font(.continuumCaption)
+                            .font(.continuumPosterMetadata)
                             .foregroundStyle(Color.continuumSecondaryText)
                             .lineLimit(1)
+                            .truncationMode(.tail)
+                            .frame(width: cardWidth, alignment: .leading)
+                            .clipped()
                     }
                 }
                 .frame(width: cardWidth, alignment: .leading)
@@ -191,7 +198,10 @@ struct EpisodeThumbCard: View {
                 .clipShape(RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius))
             }
 
-            // Episode badge overlay (e.g. "S2 · E3")
+            #if !os(tvOS)
+            // Compact touch-layout episode badge. Apple TV landing cards keep
+            // this corner clear; server-configured quality/audio overlays above
+            // remain unchanged.
             if let badge = episodeBadge {
                 Text(badge)
                     .font(.continuumCaption)
@@ -204,6 +214,7 @@ struct EpisodeThumbCard: View {
                     )
                     .padding(badgeInset)
             }
+            #endif
 
             // Progress bar (resume)
             if showProgress, let p = progressValue, p > 0 {

--- a/iosApp/iosApp/Components/MediaCard.swift
+++ b/iosApp/iosApp/Components/MediaCard.swift
@@ -546,22 +546,26 @@ private struct FocusableMediaCard<Content: View>: View {
             if captionStyle.showsTitle {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(title)
-                        .font(.continuumSubheadline)
+                        .font(.continuumPosterTitle)
                         .foregroundStyle(
                             isFocused
                                 ? Color.continuumOnSurface
                                 : Color.continuumOnSurface.opacity(0.85)
                         )
-                        // Single line, truncated — keeps poster cards a uniform
-                        // height and the row short under the bottom-anchored marquee.
+                        // A fixed one-line box guarantees even pathological
+                        // titles cannot wrap or paint into the next poster.
                         .lineLimit(1)
                         .truncationMode(.tail)
+                        .frame(width: cardWidth, alignment: .leading)
+                        .clipped()
                         .animation(.easeOut(duration: 0.15), value: isFocused)
 
                     if captionStyle.showsMetadata, let year {
                         Text(String(year))
-                            .font(.continuumCaption)
+                            .font(.continuumPosterMetadata)
                             .foregroundStyle(Color.continuumSecondaryText)
+                            .lineLimit(1)
+                            .frame(width: cardWidth, alignment: .leading)
                     }
                 }
                 .frame(width: cardWidth, alignment: .leading)

--- a/iosApp/iosApp/Components/MediaRow.swift
+++ b/iosApp/iosApp/Components/MediaRow.swift
@@ -25,9 +25,6 @@ struct MediaRow: View {
     var onItemPlay: ((SectionItem) -> Void)? = nil
     var onSeeAll: (() -> Void)? = nil
     var showProgress: Bool = false
-    /// Keeps the card as the sole focus target while showing that its detail
-    /// metadata is being prepared before navigation.
-    var loadingItemId: String? = nil
     var icon: String? = nil
     var layout: MediaRowLayout = .poster
     /// Preserve a caller's immediate thumbnail action instead of presenting
@@ -74,9 +71,6 @@ struct MediaRow: View {
     /// focus leaving the row (nil) is deliberately not reported so the
     /// marquee retains the last previewed item while focus is in chrome.
     var onItemFocus: ((SectionItem) -> Void)? = nil
-    /// Raw focus ownership changes for work that must stop when the source
-    /// card is abandoned. Unlike `onItemFocus`, this also reports `nil`.
-    var onFocusedItemIdChange: ((String?) -> Void)? = nil
     /// Optional width for poster/square cards — Skyline's dense landing
     /// rows (§5.6) pass a compact width. Episode thumbs are unaffected.
     var cardWidth: CGFloat? = nil
@@ -122,7 +116,6 @@ struct MediaRow: View {
         .focusSection()
         .modifier(TVRowMoveHandler(onMoveUp: onMoveUp, onMoveDown: onMoveDown))
         .onChange(of: focusedItemId) { _, newValue in
-            onFocusedItemIdChange?(newValue)
             guard let newValue,
                   let item = items.first(where: { $0.contentId == newValue }) else { return }
             lastFocusedItemId = newValue
@@ -343,11 +336,6 @@ struct MediaRow: View {
             LazyHStack(spacing: cardSpacing) {
                 ForEach(items) { item in
                     mediaCard(for: item)
-                        .overlay {
-                            if loadingItemId == item.contentId {
-                                pendingNavigationIndicator
-                            }
-                        }
                 }
             }
             #if !os(tvOS)
@@ -426,24 +414,6 @@ struct MediaRow: View {
                 onSetWatched: watchedToggleAction(for: item)
             )
         }
-    }
-
-    private var pendingNavigationIndicator: some View {
-        ZStack {
-            Circle()
-                .fill(Color.black.opacity(0.76))
-                .overlay {
-                    Circle().stroke(Color.white.opacity(0.18), lineWidth: 1)
-                }
-
-            ProgressView()
-                .controlSize(.large)
-                .tint(.white)
-        }
-        .frame(width: 76, height: 76)
-        .shadow(color: .black.opacity(0.45), radius: 14, y: 5)
-        .allowsHitTesting(false)
-        .accessibilityHidden(true)
     }
 
     /// tvOS: bind every card to the row's @FocusState so the row can

--- a/iosApp/iosApp/Components/MediaRow.swift
+++ b/iosApp/iosApp/Components/MediaRow.swift
@@ -51,6 +51,10 @@ struct MediaRow: View {
     /// where `.userInitiated` defaultFocus alone doesn't fire because the
     /// focus engine isn't doing the moving.
     var focusRequest: Int = 0
+    /// Optional item to claim for a programmatic row handoff. When absent the
+    /// request retains its existing first-item behavior. Skyline uses this to
+    /// restore the exact card last focused in the preceding row.
+    var focusRequestItemId: String? = nil
     /// Monotonic token emitted when a card-pushed detail route pops. The row
     /// that still owns restoration reclaims its exact last-focused card.
     var detailReturnFocusRequest: Int = 0
@@ -138,19 +142,22 @@ struct MediaRow: View {
     #if os(tvOS)
     private func applyFocusRequest(_ request: Int, proxy: ScrollViewProxy) {
         guard request > 0, request != lastAppliedFocusRequest,
-              let firstItem = items.first else { return }
+              let targetItem = focusRequestItemId.flatMap({ requestedId in
+                  items.first(where: { $0.contentId == requestedId })
+              }) ?? items.first,
+              focusRestorationOwner?.wrappedValue != false else { return }
         lastAppliedFocusRequest = request
-        // Scroll home first, claim a turn later: a row parked deep in its
-        // strip keeps the first card unmounted (LazyHStack) or clipped, and
+        // Scroll to the requested card first, claim a turn later: a row parked
+        // deep in its strip can keep that card unmounted (LazyHStack) or clipped, and
         // the focus engine silently drops @FocusState writes to views it
         // can't focus. The instant scroll mounts/unclips the card; the
         // deferred write then lands on a focusable target.
         withAnimation(reduceMotion ? nil : .easeInOut(duration: ContinuumTheme.slowDuration)) {
-            proxy.scrollTo(firstItem.id, anchor: .leading)
+            proxy.scrollTo(targetItem.id, anchor: .center)
         }
         DispatchQueue.main.async {
             Self.focusLogger.debug("mediaRow.applyFocus request=\(request, privacy: .public)")
-            claimFirstItemFocus(firstItem)
+            claimRequestedItemFocus(targetItem)
         }
     }
 
@@ -161,17 +168,19 @@ struct MediaRow: View {
     /// rows (and their cards) under whatever it had focused. @FocusState
     /// reflects *actual* focus, so a rejected/overridden write reads back as
     /// a different value — retry until the scroll settles and ours is last.
-    private func claimFirstItemFocus(_ firstItem: SectionItem, attempt: Int = 0) {
-        focusedItemId = firstItem.contentId
-        lastFocusedItemId = firstItem.contentId
-        onItemFocus?(firstItem)
+    private func claimRequestedItemFocus(_ targetItem: SectionItem, attempt: Int = 0) {
+        guard focusRestorationOwner?.wrappedValue != false else { return }
+        focusedItemId = targetItem.contentId
+        lastFocusedItemId = targetItem.contentId
+        onItemFocus?(targetItem)
         // Window must outlast the ~300ms animated ride home plus the engine's
         // settling repairs, or the last mid-flight repair wins after all.
         guard attempt < 8 else { return }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
-            guard focusedItemId != firstItem.contentId else { return }
+            guard focusRestorationOwner?.wrappedValue != false,
+                  focusedItemId != targetItem.contentId else { return }
             Self.focusLogger.debug("mediaRow.reclaimFocus attempt=\(attempt + 1, privacy: .public)")
-            claimFirstItemFocus(firstItem, attempt: attempt + 1)
+            claimRequestedItemFocus(targetItem, attempt: attempt + 1)
         }
     }
 
@@ -573,10 +582,16 @@ struct MediaRow: View {
     /// "S2 · E10" badge for an episode rendered as a poster, so new episodes
     /// of the same series stay distinguishable. `nil` for non-episodes.
     private func episodeBadge(for item: SectionItem) -> String? {
+        #if os(tvOS)
+        // Landing-page episode cards on Apple TV intentionally reserve their
+        // artwork overlays for the server-controlled CardOverlays system.
+        return nil
+        #else
         guard item.type.lowercased() == "episode",
               let season = item.seasonNumber,
               let episode = item.episodeNumber else { return nil }
         return "S\(season) · E\(episode)"
+        #endif
     }
 
     // MARK: - Metrics

--- a/iosApp/iosApp/Components/MediaRow.swift
+++ b/iosApp/iosApp/Components/MediaRow.swift
@@ -140,6 +140,8 @@ struct MediaRow: View {
               }) ?? items.first,
               focusRestorationOwner?.wrappedValue != false else { return }
         lastAppliedFocusRequest = request
+        focusRestorationGeneration += 1
+        let generation = focusRestorationGeneration
         // Scroll to the requested card first, claim a turn later: a row parked
         // deep in its strip can keep that card unmounted (LazyHStack) or clipped, and
         // the focus engine silently drops @FocusState writes to views it
@@ -150,7 +152,7 @@ struct MediaRow: View {
         }
         DispatchQueue.main.async {
             Self.focusLogger.debug("mediaRow.applyFocus request=\(request, privacy: .public)")
-            claimRequestedItemFocus(targetItem)
+            claimRequestedItemFocus(targetItem, generation: generation)
         }
     }
 
@@ -161,8 +163,14 @@ struct MediaRow: View {
     /// rows (and their cards) under whatever it had focused. @FocusState
     /// reflects *actual* focus, so a rejected/overridden write reads back as
     /// a different value — retry until the scroll settles and ours is last.
-    private func claimRequestedItemFocus(_ targetItem: SectionItem, attempt: Int = 0) {
-        guard focusRestorationOwner?.wrappedValue != false else { return }
+    private func claimRequestedItemFocus(
+        _ targetItem: SectionItem,
+        generation: Int,
+        attempt: Int = 0
+    ) {
+        guard generation == focusRestorationGeneration,
+              focusRestorationOwner?.wrappedValue != false,
+              items.contains(where: { $0.contentId == targetItem.contentId }) else { return }
         focusedItemId = targetItem.contentId
         lastFocusedItemId = targetItem.contentId
         onItemFocus?(targetItem)
@@ -170,10 +178,16 @@ struct MediaRow: View {
         // settling repairs, or the last mid-flight repair wins after all.
         guard attempt < 8 else { return }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
-            guard focusRestorationOwner?.wrappedValue != false,
+            guard generation == focusRestorationGeneration,
+                  focusRestorationOwner?.wrappedValue != false,
+                  items.contains(where: { $0.contentId == targetItem.contentId }),
                   focusedItemId != targetItem.contentId else { return }
             Self.focusLogger.debug("mediaRow.reclaimFocus attempt=\(attempt + 1, privacy: .public)")
-            claimRequestedItemFocus(targetItem, attempt: attempt + 1)
+            claimRequestedItemFocus(
+                targetItem,
+                generation: generation,
+                attempt: attempt + 1
+            )
         }
     }
 

--- a/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
@@ -273,6 +273,13 @@ class ItemDetailViewModel {
     ) async -> ItemDetail? {
         guard generation == detailGeneration else { return nil }
 
+        #if os(tvOS)
+        // Non-blocking: the movie cast portraits join the already-installed
+        // shared image pipeline as soon as the existing catalog payload lands.
+        // No metadata request or navigation gate is added here.
+        PosterImageCache.prefetchVisibleMovieCast(for: item)
+        #endif
+
         let initial: ItemDetail
         if supportsPlaybackMetadata(item),
            let cachedWatchDetail: WatchDetail = ResponseCache.shared.get(
@@ -460,6 +467,11 @@ class ItemDetailViewModel {
     func hydrateFromCache(contentId: String) {
         if detail == nil,
            let cached: ItemDetail = ResponseCache.shared.get(CacheKey.itemDetail(contentId)) {
+            #if os(tvOS)
+            // Start a disk/memory-cache promotion before the cached detail is
+            // published into the first body evaluation.
+            PosterImageCache.prefetchVisibleMovieCast(for: cached)
+            #endif
             detail = cached
             isWatched = cached.userData?.played ?? false
 

--- a/iosApp/iosApp/Screens/Home/SectionRow.swift
+++ b/iosApp/iosApp/Screens/Home/SectionRow.swift
@@ -50,11 +50,8 @@ struct SectionRow: View {
     @State private var detailBrowseOriginID = UUID().uuidString
     #endif
 
-    @State private var pendingDetailNavigationItemId: String?
     #if os(tvOS)
     @Environment(AppRouter.self) private var router
-    @State private var detailNavigationTask: Task<Void, Never>?
-    @State private var detailNavigationGeneration = 0
     #endif
 
     private var isContinueWatching: Bool {
@@ -112,7 +109,6 @@ struct SectionRow: View {
             onItemPlay: playItem,
             onSeeAll: onSeeAll,
             showProgress: showProgress,
-            loadingItemId: pendingDetailNavigationItemId,
             icon: isContinueWatching ? "play.circle.fill" : nil,
             layout: layout,
             prefersDefaultFocusOnFirstItem: prefersDefaultFocusOnFirstItem,
@@ -128,15 +124,11 @@ struct SectionRow: View {
             },
             onMoveUp: onMoveUp,
             onItemFocus: onItemFocus,
-            onFocusedItemIdChange: { focusedItemId in
-                cancelPendingDetailNavigation(unlessFocusedOn: focusedItemId)
-            },
             cardWidth: cardWidth,
             cardVerticalPadding: cardVerticalPadding,
             onMoveDown: onMoveDown,
             focusRestorationOwner: focusRestorationOwner
         )
-        .onDisappear { cancelPendingDetailNavigation() }
         #if !os(tvOS)
         .environment(
             \.itemDetailBrowseSource,
@@ -177,7 +169,7 @@ struct SectionRow: View {
                let seriesId = item.seriesId?.trimmingCharacters(in: .whitespacesAndNewlines),
                !seriesId.isEmpty,
                let seasonNumber = item.seasonNumber {
-                prepareSeriesDetailAndNavigate(
+                navigateToSeriesDetail(
                     to: seriesId,
                     from: item,
                     seasonNumber: seasonNumber,
@@ -190,7 +182,7 @@ struct SectionRow: View {
         }
 
         if SiloMediaType.isSeries(item.type) {
-            prepareSeriesDetailAndNavigate(to: item.contentId, from: item)
+            navigateToSeriesDetail(to: item.contentId, from: item)
             return
         }
         #endif
@@ -198,64 +190,21 @@ struct SectionRow: View {
     }
 
     #if os(tvOS)
-    /// A cold Series payload cannot be reconstructed safely from an episode
-    /// card. Keep the fully-rendered source rail on screen while joining the
-    /// existing metadata flight, then push only after the destination cache
-    /// can paint a real header on its first frame.
-    private func prepareSeriesDetailAndNavigate(
+    /// Match Movie navigation: push the branded route seed immediately while
+    /// the existing marquee warm-up and destination request pool finish the
+    /// authoritative Series payload and hierarchy in parallel.
+    private func navigateToSeriesDetail(
         to seriesContentId: String,
         from item: SectionItem,
         seasonNumber: Int? = nil,
         episodeContentId: String? = nil
     ) {
-        guard pendingDetailNavigationItemId == nil else { return }
-
-        let cacheKey = CacheKey.itemDetail(seriesContentId)
-        if let _: ItemDetail = ResponseCache.shared.get(cacheKey) {
-            finishSeriesDetailNavigation(
-                to: seriesContentId,
-                from: item,
-                seasonNumber: seasonNumber,
-                episodeContentId: episodeContentId
-            )
-            return
-        }
-
-        pendingDetailNavigationItemId = item.contentId
-        detailNavigationGeneration &+= 1
-        let generation = detailNavigationGeneration
-        detailNavigationTask = Task { @MainActor in
-            defer {
-                if detailNavigationGeneration == generation {
-                    pendingDetailNavigationItemId = nil
-                    detailNavigationTask = nil
-                }
-            }
-
-            do {
-                let detail = try await MetadataRequestPool.shared.itemDetail(
-                    contentId: seriesContentId
-                )
-                try Task.checkCancellation()
-                ResponseCache.shared.set(detail, for: cacheKey)
-            } catch is CancellationError {
-                return
-            } catch {
-                // Preserve the existing retry/error destination when the
-                // preload itself fails; the important cold path still waits
-                // on the populated cache instead of pushing a blank shell.
-            }
-
-            guard !Task.isCancelled,
-                  detailNavigationGeneration == generation,
-                  pendingDetailNavigationItemId == item.contentId else { return }
-            finishSeriesDetailNavigation(
-                to: seriesContentId,
-                from: item,
-                seasonNumber: seasonNumber,
-                episodeContentId: episodeContentId
-            )
-        }
+        finishSeriesDetailNavigation(
+            to: seriesContentId,
+            from: item,
+            seasonNumber: seasonNumber,
+            episodeContentId: episodeContentId
+        )
     }
 
     private func finishSeriesDetailNavigation(
@@ -274,24 +223,6 @@ struct SectionRow: View {
         onItemTap(seriesContentId, item)
     }
 
-    private func cancelPendingDetailNavigation(unlessFocusedOn focusedItemId: String?) {
-        guard let pendingDetailNavigationItemId,
-              focusedItemId != pendingDetailNavigationItemId else { return }
-        detailNavigationGeneration &+= 1
-        detailNavigationTask?.cancel()
-        detailNavigationTask = nil
-        self.pendingDetailNavigationItemId = nil
-    }
-
-    private func cancelPendingDetailNavigation() {
-        detailNavigationGeneration &+= 1
-        detailNavigationTask?.cancel()
-        detailNavigationTask = nil
-        pendingDetailNavigationItemId = nil
-    }
-    #else
-    private func cancelPendingDetailNavigation(unlessFocusedOn focusedItemId: String?) {}
-    private func cancelPendingDetailNavigation() {}
     #endif
 
     /// Home injects a model-owned mutation so its membership-driven rows and

--- a/iosApp/iosApp/Screens/Home/SectionRow.swift
+++ b/iosApp/iosApp/Screens/Home/SectionRow.swift
@@ -27,6 +27,8 @@ struct SectionRow: View {
     /// when an unrelated view (e.g. the tvOS top menu) hands focus down into
     /// this row rather than the user d-padding into it.
     var focusRequest: Int = 0
+    /// Optional exact item target for the programmatic focus kick.
+    var focusRequestItemId: String? = nil
     /// tvOS detail-pop token forwarded to `MediaRow`; the row's ownership gate
     /// ensures only the launch row restores its exact previously focused card.
     var detailReturnFocusRequest: Int = 0
@@ -116,6 +118,7 @@ struct SectionRow: View {
             prefersDefaultFocusOnFirstItem: prefersDefaultFocusOnFirstItem,
             defaultFocusPriority: defaultFocusPriority,
             focusRequest: focusRequest,
+            focusRequestItemId: focusRequestItemId,
             detailReturnFocusRequest: detailReturnFocusRequest,
             onRemoveFromContinueWatching: isContinueWatching ? onRemoveFromContinueWatching : nil,
             onOpenContextDetail: nil,

--- a/iosApp/iosApp/Screens/Personal/FavoritesView.swift
+++ b/iosApp/iosApp/Screens/Personal/FavoritesView.swift
@@ -125,6 +125,10 @@ struct IOSPersonalMediaCarouselRows: View {
 /// Grid of the user's favorited items.
 struct FavoritesView: View {
     let showsNavigationTitle: Bool
+    let usesTVTopMenu: Bool
+    var focusRequest: Int
+    var isTopMenuFocused: Bool
+    var onTopMenuFocusRequest: (() -> Void)?
 
     @State private var items: [BrowseItem] = []
     @State private var isLoading = false
@@ -132,6 +136,8 @@ struct FavoritesView: View {
     @State private var uiCustomization = UICustomizationPreferences.shared
     #if os(tvOS)
     @State private var selectedSection: FavoriteMediaSection = .movies
+    @FocusState private var focusedSection: FavoriteMediaSection?
+    @State private var lastAppliedFocusRequest = 0
     #endif
     @Environment(AppRouter.self) private var router
     @Environment(\.horizontalSizeClass) private var hSize
@@ -141,13 +147,9 @@ struct FavoritesView: View {
 
     private var columns: [GridItem] {
         #if os(tvOS)
-        let count = AdaptiveColumns.tvPosterCount(
-            standardCount: 6,
-            posterSize: uiCustomization.cardPresentation.posterSize
-        )
         return Array(
-            repeating: GridItem(.flexible(), spacing: 48, alignment: .top),
-            count: count
+            repeating: GridItem(.flexible(), spacing: 40, alignment: .top),
+            count: 8
         )
         #else
         AdaptiveColumns.posters(
@@ -157,8 +159,18 @@ struct FavoritesView: View {
         #endif
     }
 
-    init(showsNavigationTitle: Bool = true) {
+    init(
+        showsNavigationTitle: Bool = true,
+        usesTVTopMenu: Bool = false,
+        focusRequest: Int = 0,
+        isTopMenuFocused: Bool = false,
+        onTopMenuFocusRequest: (() -> Void)? = nil
+    ) {
         self.showsNavigationTitle = showsNavigationTitle
+        self.usesTVTopMenu = usesTVTopMenu
+        self.focusRequest = focusRequest
+        self.isTopMenuFocused = isTopMenuFocused
+        self.onTopMenuFocusRequest = onTopMenuFocusRequest
     }
 
     #if os(iOS)
@@ -230,6 +242,11 @@ struct FavoritesView: View {
         .refreshable {
             await loadFavorites()
         }
+        #if os(tvOS)
+        .onAppear { applyFocusRequest(focusRequest) }
+        .onChange(of: focusRequest) { _, request in applyFocusRequest(request) }
+        .onChange(of: items.map(\.contentId)) { _, _ in applyFocusRequest(focusRequest) }
+        #endif
     }
 
     @ViewBuilder
@@ -275,6 +292,12 @@ struct FavoritesView: View {
     private var tvGridContent: some View {
         ScrollView(.vertical, showsIndicators: false) {
             VStack(alignment: .leading, spacing: 40) {
+                if usesTVTopMenu {
+                    Text("Favorites")
+                        .font(.system(size: 64, weight: .bold))
+                        .foregroundStyle(Color.continuumOnSurface)
+                }
+
                 sectionSelector
 
                 if filteredItems.isEmpty {
@@ -294,7 +317,7 @@ struct FavoritesView: View {
                 }
             }
             .padding(.horizontal, ContinuumTheme.safePadding)
-            .padding(.top, 20)
+            .padding(.top, usesTVTopMenu ? TVTopMenuLayout.contentTopInset : 20)
             .padding(.bottom, ContinuumTheme.safePadding)
         }
     }
@@ -313,11 +336,17 @@ struct FavoritesView: View {
                 }
                 .buttonStyle(FavoriteSectionPillStyle(isSelected: selectedSection == section))
                 .accessibilityAddTraits(selectedSection == section ? .isSelected : [])
+                .focused($focusedSection, equals: section)
             }
 
             Spacer(minLength: 0)
         }
         .focusSection()
+        .onMoveCommand { direction in
+            if direction == .up {
+                onTopMenuFocusRequest?()
+            }
+        }
     }
 
     private var selectedSectionEmptyState: some View {
@@ -350,7 +379,7 @@ struct FavoritesView: View {
             },
             playAction: playAction(for: item),
             contentId: item.contentId,
-            cardWidthOverride: 252,
+            cardWidthOverride: tvCardWidthOverride,
             onUserStateChanged: { state in
                 guard !state.isFavorite else { return }
                 withAnimation(.easeInOut(duration: ContinuumTheme.normalDuration)) {
@@ -358,6 +387,23 @@ struct FavoritesView: View {
                 }
             }
         )
+    }
+
+    /// `MediaCard` applies the global size preference after this override;
+    /// divide it out so the final eight-across grid stays at 176 points.
+    private var tvCardWidthOverride: CGFloat {
+        ContinuumTheme.Skyline.densePosterCardWidth
+            / uiCustomization.cardPresentation.posterSize.scale
+    }
+
+    private func applyFocusRequest(_ request: Int) {
+        guard usesTVTopMenu,
+              request > 0,
+              request != lastAppliedFocusRequest,
+              !isTopMenuFocused,
+              !items.isEmpty else { return }
+        lastAppliedFocusRequest = request
+        focusedSection = selectedSection
     }
     #endif
 

--- a/iosApp/iosApp/Screens/Personal/WatchlistView.swift
+++ b/iosApp/iosApp/Screens/Personal/WatchlistView.swift
@@ -3,6 +3,10 @@ import SwiftUI
 /// Grid of items in the user's watchlist.
 struct WatchlistView: View {
     let showsNavigationTitle: Bool
+    let usesTVTopMenu: Bool
+    var focusRequest: Int
+    var isTopMenuFocused: Bool
+    var onTopMenuFocusRequest: (() -> Void)?
 
     @State private var items: [BrowseItem] = []
     @State private var isLoading = false
@@ -14,15 +18,37 @@ struct WatchlistView: View {
     @Environment(AppRouter.self) private var router
     @Environment(\.horizontalSizeClass) private var hSize
 
+    #if os(tvOS)
+    @FocusState private var focusedContentId: String?
+    @State private var lastAppliedFocusRequest = 0
+    #endif
+
     private var columns: [GridItem] {
+        #if os(tvOS)
+        return Array(
+            repeating: GridItem(.flexible(), spacing: 40, alignment: .top),
+            count: 8
+        )
+        #else
         AdaptiveColumns.posters(
             for: hSize,
             posterSize: uiCustomization.cardPresentation.posterSize
         )
+        #endif
     }
 
-    init(showsNavigationTitle: Bool = true) {
+    init(
+        showsNavigationTitle: Bool = true,
+        usesTVTopMenu: Bool = false,
+        focusRequest: Int = 0,
+        isTopMenuFocused: Bool = false,
+        onTopMenuFocusRequest: (() -> Void)? = nil
+    ) {
         self.showsNavigationTitle = showsNavigationTitle
+        self.usesTVTopMenu = usesTVTopMenu
+        self.focusRequest = focusRequest
+        self.isTopMenuFocused = isTopMenuFocused
+        self.onTopMenuFocusRequest = onTopMenuFocusRequest
     }
 
     var body: some View {
@@ -55,11 +81,18 @@ struct WatchlistView: View {
         .refreshable {
             await loadWatchlist()
         }
+        #if os(tvOS)
+        .onAppear { applyFocusRequest(focusRequest) }
+        .onChange(of: focusRequest) { _, request in applyFocusRequest(request) }
+        .onChange(of: items.map(\.contentId)) { _, _ in applyFocusRequest(focusRequest) }
+        #endif
     }
 
     @ViewBuilder
     private var gridContent: some View {
-        #if os(iOS)
+        #if os(tvOS)
+        tvGridContent
+        #elseif os(iOS)
         ScrollView {
             VStack(spacing: 16) {
                 IOSPersonalMediaSectionPicker(selection: $selectedSection)
@@ -108,7 +141,73 @@ struct WatchlistView: View {
         #endif
     }
 
-    #if os(iOS)
+    #if os(tvOS)
+    private var tvGridContent: some View {
+        ScrollView(.vertical, showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 40) {
+                if usesTVTopMenu {
+                    Text("Watchlist")
+                        .font(.system(size: 64, weight: .bold))
+                        .foregroundStyle(Color.continuumOnSurface)
+                }
+
+                LazyVGrid(columns: columns, alignment: .leading, spacing: 60) {
+                    ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+                        MediaCard(
+                            title: item.title,
+                            posterUrl: item.posterUrl ?? "",
+                            thumbhash: item.posterThumbhash,
+                            year: item.year,
+                            userState: item.userState,
+                            overlayData: OverlayData.from(item),
+                            action: {
+                                router.navigate(to: .itemDetail(contentId: item.contentId))
+                            },
+                            playAction: playAction(for: item),
+                            focusedItemId: $focusedContentId,
+                            contentId: item.contentId,
+                            cardWidthOverride: tvCardWidthOverride,
+                            onUserStateChanged: { state in
+                                guard !state.inWatchlist else { return }
+                                withAnimation(.easeInOut(duration: ContinuumTheme.normalDuration)) {
+                                    items.removeAll { $0.contentId == item.contentId }
+                                }
+                            }
+                        )
+                        .frame(maxWidth: .infinity)
+                        .onMoveCommand { direction in
+                            if direction == .up, index < columns.count {
+                                onTopMenuFocusRequest?()
+                            }
+                        }
+                    }
+                }
+                .focusSection()
+            }
+            .padding(.horizontal, ContinuumTheme.safePadding)
+            .padding(.top, usesTVTopMenu ? TVTopMenuLayout.contentTopInset : ContinuumTheme.smallPadding)
+            .padding(.bottom, ContinuumTheme.safePadding)
+        }
+    }
+
+    /// Keep the final poster width stable even when the global poster-size
+    /// preference is changed—`MediaCard` applies that scale after overrides.
+    /// Eight 176-point posters plus 40-point gaps fit the tvOS safe width.
+    private var tvCardWidthOverride: CGFloat {
+        ContinuumTheme.Skyline.densePosterCardWidth
+            / uiCustomization.cardPresentation.posterSize.scale
+    }
+
+    private func applyFocusRequest(_ request: Int) {
+        guard usesTVTopMenu,
+              request > 0,
+              request != lastAppliedFocusRequest,
+              !isTopMenuFocused,
+              let firstId = items.first?.contentId else { return }
+        lastAppliedFocusRequest = request
+        focusedContentId = firstId
+    }
+    #elseif os(iOS)
     private var filteredIOSItems: [BrowseItem] {
         items.filter(selectedSection.includes)
     }

--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -417,13 +417,13 @@ struct PlayerView: View {
                     object: nil
                 )
 
-                await ItemDetailCache.shared.refreshAfterPlayback(
+                let refreshedContentIds = await ItemDetailCache.shared.refreshAfterPlayback(
                     contentIds: touchedContentIds
                 )
                 NotificationCenter.default.post(
                     name: .tvPlaybackStateDidRefresh,
                     object: TVPlaybackStateRefreshEvent(
-                        refreshedContentIds: touchedContentIds,
+                        refreshedContentIds: refreshedContentIds,
                         completedContentIds: completedContentIds
                     )
                 )

--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -1,6 +1,19 @@
 import AetherEngine
 import SwiftUI
 
+#if os(tvOS)
+/// Published only after final playback progress is committed and every
+/// resident detail model affected by that playback has refreshed.
+struct TVPlaybackStateRefreshEvent {
+    let refreshedContentIds: Set<String>
+    let completedContentIds: Set<String>
+}
+
+extension Notification.Name {
+    static let tvPlaybackStateDidRefresh = Notification.Name("tvPlaybackStateDidRefresh")
+}
+#endif
+
 /// Full-screen video player. Thin shell around `PlayerViewModel` that picks
 /// the platform-appropriate controls overlay. iOS gets touch-driven controls
 /// with bottom sheets; tvOS gets a focus-driven transport bar plus the
@@ -383,17 +396,37 @@ struct PlayerView: View {
             orientationCoordinator.deactivatePlayer()
             #endif
             #if os(tvOS)
-            // Progress/watched state for this item (and its parent
-            // season/series) was mutated server-side during playback.
-            // Flag the detail cache so the next visit to any of those
-            // pages shows corrected userData instead of pre-play values.
-            let touchedContentIds = viewModel.contentIdsNeedingDetailRefresh
-            if touchedContentIds.isEmpty {
-                ItemDetailCache.shared.markStaleFamily(contentId: contentId)
-            } else {
-                for id in touchedContentIds {
-                    ItemDetailCache.shared.markStaleFamily(contentId: id)
-                }
+            // A detail/Home read launched synchronously from this disappear
+            // can beat cleanup's final progress POST and cache the old watched
+            // state. Capture the mutation set now, then invalidate and reload
+            // only after the session bridge has finished its final write.
+            let touchedContentIds = viewModel.contentIdsNeedingDetailRefresh.isEmpty
+                ? Set([contentId])
+                : viewModel.contentIdsNeedingDetailRefresh
+            let completedContentIds = viewModel.completedContentIdsNeedingDetailAdvance
+            Task { @MainActor in
+                await viewModel.waitForCleanupCompletion()
+
+                // A Home request may have started as the cover disappeared.
+                // Retire that generation before asking for the authoritative
+                // Continue Watching row produced by the completed write.
+                StartupContentPrefetcher.invalidateHomeSectionsInFlight()
+                ResponseCache.shared.remove(CacheKey.homeSections)
+                NotificationCenter.default.post(
+                    name: .homeSectionsShouldRefresh,
+                    object: nil
+                )
+
+                await ItemDetailCache.shared.refreshAfterPlayback(
+                    contentIds: touchedContentIds
+                )
+                NotificationCenter.default.post(
+                    name: .tvPlaybackStateDidRefresh,
+                    object: TVPlaybackStateRefreshEvent(
+                        refreshedContentIds: touchedContentIds,
+                        completedContentIds: completedContentIds
+                    )
+                )
             }
             #endif
         }

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -595,6 +595,10 @@ class PlayerViewModel {
     private var realtimeUnavailabilityObserverToken: UUID?
     private var realtimeConnectivityObserverToken: UUID?
     private var cleanupCompletionTask: Task<Void, Never>?
+    /// Natural EOF should not wait for the ten-second periodic reporter. Keep
+    /// the immediate write so teardown/autoplay can await it before claiming
+    /// and stopping the same server session.
+    private var naturalEndProgressTask: Task<Void, Never>?
 
     /// Build the live-subtitle coordinator with adapters bound to this VM. The
     /// adapters touch the VM's playback + live-track + notice surface, so they
@@ -900,6 +904,11 @@ class PlayerViewModel {
     /// apply to the end-of-playback screen.
     private var nextUpPromptDismissed = false
     private(set) var contentIdsNeedingDetailRefresh: Set<String> = []
+    /// Items that crossed the same completion boundary used by the final
+    /// server progress report. The tvOS detail page consumes this only after
+    /// that report has finished so it can move its editorial selection to the
+    /// next unwatched episode without racing stale catalog data.
+    private(set) var completedContentIdsNeedingDetailAdvance: Set<String> = []
     var nextUpCarouselItems: [PlayerOnDeckItem] {
         let hiddenIds = Set([lastLoadRequest?.contentId, nextUpEpisode?.contentId].compactMap { $0 })
         return nextUpOnDeckItems.filter { !hiddenIds.contains($0.contentId) }
@@ -2562,6 +2571,29 @@ class PlayerViewModel {
         )
     }
 
+    /// Snapshot every detail surface affected by the current playback item
+    /// before a replacement load or teardown clears `currentWatchDetail`.
+    /// Series and synthetic season ids are included because tvOS keeps the
+    /// combined Series page resident while its episode player is pushed.
+    private func recordCurrentPlaybackMutation(markedCompleted: Bool) {
+        let currentContentId = currentWatchDetail?.contentId ?? lastLoadRequest?.contentId
+        if let currentContentId, !currentContentId.isEmpty {
+            contentIdsNeedingDetailRefresh.insert(currentContentId)
+            if markedCompleted {
+                completedContentIdsNeedingDetailAdvance.insert(currentContentId)
+            }
+        }
+
+        guard let detail = currentWatchDetail,
+              let rawSeriesId = detail.seriesId else { return }
+        let seriesId = rawSeriesId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !seriesId.isEmpty else { return }
+        contentIdsNeedingDetailRefresh.insert(seriesId)
+        if let seasonNumber = detail.seasonNumber {
+            contentIdsNeedingDetailRefresh.insert("\(seriesId)-S\(seasonNumber)")
+        }
+    }
+
     private func loadAether(
         prepared: PreparedPlayback,
         streamRequest: StreamRequest,
@@ -3323,6 +3355,29 @@ class PlayerViewModel {
             playbackRate: settings.playbackSpeed
         )
 
+        if !isPremature {
+            recordCurrentPlaybackMutation(markedCompleted: true)
+
+            // Aether has already delivered the native terminal event, so
+            // publish the terminal position now rather than waiting for the
+            // periodic reporter's next ten-second tick. Teardown still sends
+            // its authoritative final report; it awaits this task first so
+            // the two writes cannot race the same session lifecycle.
+            if offlinePlaybackContext == nil,
+               currentTime.isFinite,
+               currentTime >= 0 {
+                let priorNaturalEndProgressTask = naturalEndProgressTask
+                let endPosition = currentTime
+                naturalEndProgressTask = Task { [sessionBridge] in
+                    await priorNaturalEndProgressTask?.value
+                    _ = await sessionBridge.reportProgress(
+                        position: endPosition,
+                        isPaused: true
+                    )
+                }
+            }
+        }
+
         // Natural end of an offline download: latch the local watched state
         // immediately (not just at close) so retention/reclaim see it even
         // if the process dies before `cleanup()` runs. DownloadManager is
@@ -3603,6 +3658,16 @@ class PlayerViewModel {
         #if os(tvOS)
         PosterImageCache.trimDecodedMemory()
         #endif
+        let currentItemCompleted = PlayerNextUpCompletionPolicy.shouldFinalizeAsCompleted(
+            isNextUpPresented: showNextUpScreen,
+            hasReachedEndOfFile: hasReachedEndOfFile,
+            currentTime: currentTime,
+            duration: duration,
+            promptSeconds: settings.nextUpPromptSeconds
+        )
+        recordCurrentPlaybackMutation(markedCompleted: currentItemCompleted)
+        let pendingNaturalEndProgressTask = naturalEndProgressTask
+        naturalEndProgressTask = nil
         lastLoadRequest = request
         offlinePlaybackContext = nil
         contentIdsNeedingDetailRefresh.insert(request.contentId)
@@ -3661,6 +3726,7 @@ class PlayerViewModel {
                 }
             }
 
+            await pendingNaturalEndProgressTask?.value
             if let snapshotPosition, snapshotPosition.isFinite, snapshotPosition >= 0 {
                 if shouldFinalizeCurrentSession {
                     await self.sessionBridge.stopSession(position: snapshotPosition, isPaused: true)
@@ -5842,6 +5908,16 @@ class PlayerViewModel {
     func cleanup() {
         guard !isDisposed else { return }
         Self.logger.info("PlayerViewModel.cleanup()")
+        let currentItemCompleted = PlayerNextUpCompletionPolicy.shouldFinalizeAsCompleted(
+            isNextUpPresented: showNextUpScreen,
+            hasReachedEndOfFile: hasReachedEndOfFile,
+            currentTime: currentTime,
+            duration: duration,
+            promptSeconds: settings.nextUpPromptSeconds
+        )
+        recordCurrentPlaybackMutation(markedCompleted: currentItemCompleted)
+        let pendingNaturalEndProgressTask = naturalEndProgressTask
+        naturalEndProgressTask = nil
         isDisposed = true
         #if os(iOS)
         // A restore waiting on a cover that will now never mount has to be
@@ -5979,6 +6055,7 @@ class PlayerViewModel {
                 await realtimeClient.removeUnavailabilityObserver(unavailabilityToken)
             }
             await realtimeClient.unbind()
+            await pendingNaturalEndProgressTask?.value
             if stopServerSessionOnTeardown {
                 await sessionBridge.stopSession(position: finalPosition, isPaused: true)
             }

--- a/iosApp/iosApp/Screens/Recommendations/RecommendationsView.swift
+++ b/iosApp/iosApp/Screens/Recommendations/RecommendationsView.swift
@@ -104,7 +104,14 @@ struct RecommendationsView: View {
                 focusRequest: focusRequest,
                 isTopMenuFocused: isTopMenuFocused,
                 onTopMenuFocusRequest: onTopMenuFocusRequest,
-                onItemTap: { router.navigate(to: .itemDetail(contentId: $0)) }
+                onItemTap: { destinationContentId, item in
+                    router.navigate(
+                        to: .itemDetail(
+                            destinationContentId: destinationContentId,
+                            sectionItem: item
+                        )
+                    )
+                }
             )
             .task(id: initialMarqueePrewarmKey) {
                 await prewarmInitialMarqueeDetails()

--- a/iosApp/iosApp/Screens/Recommendations/RecommendationsView.swift
+++ b/iosApp/iosApp/Screens/Recommendations/RecommendationsView.swift
@@ -54,17 +54,7 @@ struct RecommendationsView: View {
     @ViewBuilder
     private var rootLayout: some View {
         #if os(tvOS)
-        ZStack(alignment: .top) {
-            TVRootHeroBackdrop(
-                tintColor: .continuumBackground,
-                artworkURL: nil,
-                artworkThumbhash: nil,
-                isVisible: false
-            )
-
-            pageContent
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-        }
+        tvOSPageContent
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         #else
         VStack(spacing: 0) {
@@ -101,6 +91,92 @@ struct RecommendationsView: View {
         #endif
         #endif
     }
+
+    #if os(tvOS)
+    /// For You uses the exact Skyline page shell as Home. Recommendation
+    /// sections supply only the content; the shared feed owns the backdrop,
+    /// marquee, rail geometry, focus hand-off, and vertical scrolling.
+    @ViewBuilder
+    private var tvOSPageContent: some View {
+        if !viewModel.sections.isEmpty {
+            TVSkylineSectionFeed(
+                sections: viewModel.sections,
+                focusRequest: focusRequest,
+                isTopMenuFocused: isTopMenuFocused,
+                onTopMenuFocusRequest: onTopMenuFocusRequest,
+                onItemTap: { router.navigate(to: .itemDetail(contentId: $0)) }
+            )
+            .task(id: initialMarqueePrewarmKey) {
+                await prewarmInitialMarqueeDetails()
+            }
+        } else if let error = viewModel.error {
+            ErrorView(
+                state: error,
+                onRetry: { Task { await viewModel.loadRecommendations() } }
+            )
+        } else if viewModel.isLoading {
+            Color.clear
+        } else {
+            EmptyStateView(
+                icon: "sparkles.tv",
+                title: "No recommendations yet",
+                subtitle: "Watch or rate a few titles to build your personalised recommendations."
+            )
+        }
+    }
+
+    /// Two rows × eight visible cards, matching the For You viewport. Only
+    /// items missing their lightweight content-rating field need detail
+    /// prewarming, and requests run three at a time to avoid a server burst.
+    private var initialMarqueePrewarmKey: String {
+        initialMarqueeItems.map(\.contentId).joined(separator: "|")
+    }
+
+    private var initialMarqueeItems: [SectionItem] {
+        viewModel.sections.prefix(2).flatMap { section in
+            Array(section.items.prefix(8))
+        }
+    }
+
+    private func prewarmInitialMarqueeDetails() async {
+        let contentIds = initialMarqueeItems.compactMap { item -> String? in
+            let rating = item.contentRating?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard rating?.isEmpty != false else { return nil }
+            let key = CacheKey.itemDetail(item.contentId)
+            let cached: ItemDetail? = ResponseCache.shared.get(key)
+            return cached == nil ? item.contentId : nil
+        }
+
+        let maxConcurrent = 3
+        for batchStart in stride(from: 0, to: contentIds.count, by: maxConcurrent) {
+            guard !Task.isCancelled else { return }
+            let batchEnd = min(batchStart + maxConcurrent, contentIds.count)
+            let batch = Array(contentIds[batchStart..<batchEnd])
+            let details = await withTaskGroup(of: (String, ItemDetail?).self) { group in
+                for contentId in batch {
+                    group.addTask {
+                        let detail = try? await ContinuumAPI.shared.itemDetail(
+                            contentId: contentId
+                        )
+                        return (contentId, detail)
+                    }
+                }
+
+                var results: [(String, ItemDetail)] = []
+                for await (contentId, detail) in group {
+                    if let detail { results.append((contentId, detail)) }
+                }
+                return results
+            }
+
+            guard !Task.isCancelled else { return }
+            for (contentId, detail) in details {
+                ResponseCache.shared.set(detail, for: CacheKey.itemDetail(contentId))
+            }
+        }
+    }
+    #endif
 
     /// The Watchlist/Favorites shortcut row renders in every state — the
     /// user's saved lists are reachable from here even when there are no

--- a/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
+++ b/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
@@ -37,6 +37,14 @@ enum StartupContentPrefetcher {
     private static var userLibrariesTask: Task<LibrariesResponse, Error>?
     private static var librarySectionsTasks: [Int: Task<SectionsResponse, Error>] = [:]
     private static var browseFirstPageTasks: [String: Task<CatalogResponse, Error>] = [:]
+    #if os(tvOS)
+    /// One bounded cold-start warmup for the Series library the top-level tab
+    /// will actually open. This is separate from `librarySectionsTasks`: the
+    /// latter makes the landing page available, while this task also primes
+    /// the first Series hero payload so Select never has to paint a loading
+    /// action pill before the real detail screen.
+    private static var tvSeriesLandingTasks: [Int: Task<Void, Never>] = [:]
+    #endif
     private static var profileScopedGeneration = 0
     private static var homeSectionsGeneration = 0
     private static var profilesGeneration = 0
@@ -49,12 +57,18 @@ enum StartupContentPrefetcher {
         userLibrariesTask?.cancel()
         librarySectionsTasks.values.forEach { $0.cancel() }
         browseFirstPageTasks.values.forEach { $0.cancel() }
+        #if os(tvOS)
+        tvSeriesLandingTasks.values.forEach { $0.cancel() }
+        #endif
 
         homeSectionsTask = nil
         recommendationsTask = nil
         userLibrariesTask = nil
         librarySectionsTasks.removeAll()
         browseFirstPageTasks.removeAll()
+        #if os(tvOS)
+        tvSeriesLandingTasks.removeAll()
+        #endif
     }
 
     static func resetAllPrefetches() {
@@ -442,6 +456,52 @@ enum StartupContentPrefetcher {
         }
     }
 
+    #if os(tvOS)
+    /// Warm the exact cold path used by a Series root tab: its section payload
+    /// plus one initial Series detail. The work is deliberately limited to a
+    /// single card and does not fetch cast portraits; Series cast sits below
+    /// the first viewport and keeps its existing lazy path.
+    static func prefetchTVSeriesLanding(libraryId: Int) {
+        guard tvSeriesLandingTasks[libraryId] == nil else { return }
+        let generation = profileScopedGeneration
+
+        tvSeriesLandingTasks[libraryId] = Task(priority: .userInitiated) {
+            defer {
+                // A task from the prior profile must never clear a replacement
+                // registered for the same numeric library id.
+                if profileScopedGeneration == generation {
+                    tvSeriesLandingTasks[libraryId] = nil
+                }
+            }
+
+            guard let response = try? await fetchLibrarySections(libraryId: libraryId),
+                  !Task.isCancelled,
+                  profileScopedGeneration == generation,
+                  let item = firstSeriesItem(in: response) else { return }
+
+            let key = CacheKey.itemDetail(item.contentId)
+            if let _: ItemDetail = ResponseCache.shared.get(key) { return }
+
+            guard let detail = try? await MetadataRequestPool.shared.itemDetail(
+                contentId: item.contentId
+            ),
+            !Task.isCancelled,
+            profileScopedGeneration == generation else { return }
+
+            ResponseCache.shared.set(detail, for: key)
+        }
+    }
+
+    private static func firstSeriesItem(in response: SectionsResponse) -> SectionItem? {
+        for section in response.sections where !section.isFeatured && !section.items.isEmpty {
+            if let item = section.items.first(where: { SiloMediaType.isSeries($0.type) }) {
+                return item
+            }
+        }
+        return nil
+    }
+    #endif
+
     static func fetchLibrarySections(libraryId: Int) async throws -> SectionsResponse {
         let generation = profileScopedGeneration
         // Verbose: these two run once per library on the landing prefetch and
@@ -597,11 +657,29 @@ enum StartupContentPrefetcher {
 
     private static func prefetchActiveLibraryLanding() {
         Task {
-            guard let response = try? await fetchUserLibraries(),
-                  let library = preferredLibrary(from: response.libraries) else {
-                return
+            guard let response = try? await fetchUserLibraries() else { return }
+
+            // Preserve the existing selected-library landing prefetch on every
+            // platform. tvOS additionally has a dedicated Series root tab;
+            // warm its persisted scope during the same launch window instead
+            // of waiting for the user to enter that tab.
+            if let library = preferredLibrary(from: response.libraries) {
+                prefetchLibraryLanding(libraryId: library.id)
             }
-            prefetchLibraryLanding(libraryId: library.id)
+
+            #if os(tvOS)
+            let seriesLibraries = response.libraries
+                .filter { TVLibraryTabType.series.matches($0) }
+                .sorted {
+                    ($0.sortOrder ?? Int.max, $0.id) < ($1.sortOrder ?? Int.max, $1.id)
+                }
+            if let library = TVLibraryScopeStore.shared.resolvedLibrary(
+                for: .series,
+                in: seriesLibraries
+            ) {
+                prefetchTVSeriesLanding(libraryId: library.id)
+            }
+            #endif
         }
     }
 

--- a/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
+++ b/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
@@ -15,6 +15,12 @@ enum StartupContentPrefetcher {
     private static let maxHomeArtworkURLs = 12
     #endif
     private static let maxSectionArtworkURLs = 12
+    /// For You shows two eight-card rows in its initial viewport. Logos are
+    /// tiny compared with backdrops, so warm exactly those visible candidates
+    /// rather than waiting for each focus rest to begin its own request.
+    #if os(tvOS)
+    private static let maxRecommendationLogoURLs = 16
+    #endif
     private static let maxBrowseArtworkURLs = 12
     private static let maxProfileArtworkURLs = 8
     private static let browsePageSize = 60
@@ -363,6 +369,9 @@ enum StartupContentPrefetcher {
             #endif
             ResponseCache.shared.set(response, for: CacheKey.recommendations)
             prefetchSectionArtwork(for: response, maxCount: maxSectionArtworkURLs)
+            #if os(tvOS)
+            prefetchRecommendationLogos(for: response)
+            #endif
             return response
         } catch {
             if profileScopedGeneration == generation {
@@ -705,6 +714,31 @@ enum StartupContentPrefetcher {
         guard !urls.isEmpty else { return }
         PosterImageCache.prefetcher.startPrefetching(with: urls)
     }
+
+    #if os(tvOS)
+    /// Match `RecommendationsViewModel` ordering so the first two rows the
+    /// user can actually focus are the ones whose logo art is ready first.
+    private static func prefetchRecommendationLogos(for response: SectionsResponse) {
+        let nonEmpty = response.sections.filter { !$0.items.isEmpty }
+        let forYou = nonEmpty.filter { $0.title.lowercased() == "for you" }
+        let others = nonEmpty.filter { $0.title.lowercased() != "for you" }
+        let initialRows = (forYou + others).prefix(2)
+
+        var urls: [URL] = []
+        var seen = Set<String>()
+        for section in initialRows {
+            for item in section.items.prefix(8) {
+                guard urls.count < maxRecommendationLogoURLs,
+                      let url = normalizedURL(from: item.logoUrl),
+                      seen.insert(url.absoluteString).inserted else { continue }
+                urls.append(url)
+            }
+        }
+
+        guard !urls.isEmpty else { return }
+        PosterImageCache.prefetcher.startPrefetching(with: urls)
+    }
+    #endif
 
     private static func prefetchBrowseArtwork(for response: CatalogResponse) {
         var urls: [URL] = []

--- a/iosApp/iosApp/Theme/ContinuumTheme.swift
+++ b/iosApp/iosApp/Theme/ContinuumTheme.swift
@@ -254,6 +254,10 @@ struct ContinuumTheme {
         static let marqueeTitleSizeLibrary: CGFloat = 66
         static let marqueeMetaSizeHome: CGFloat = 20
         static let marqueeMetaSizeLibrary: CGFloat = 19
+        /// Fixed leading slot for the age/content-rating pill. For You often
+        /// backfills this value from item detail; reserving the slot prevents
+        /// the remaining metadata from sliding sideways when it arrives.
+        static let marqueeRatingSlotWidth: CGFloat = 104
         static let marqueeSynopsisSize: CGFloat = 22
         /// Synopsis column cap (§4.1) — narrower than the content block.
         static let marqueeSynopsisMaxWidth: CGFloat = 780

--- a/iosApp/iosApp/Theme/Typography.swift
+++ b/iosApp/iosApp/Theme/Typography.swift
@@ -18,6 +18,14 @@ extension Font {
     /// Card titles and subheadlines (28pt semibold)
     static let continuumSubheadline = Font.system(size: 28, weight: .semibold)
 
+    /// Movie/series names directly beneath artwork. Kept quieter than general
+    /// subheadlines so dense eight-across rows remain readable rather than
+    /// visually shouting over the posters.
+    static let continuumPosterTitle = Font.system(size: 20, weight: .medium)
+
+    /// Year, episode title, and other secondary poster-card metadata.
+    static let continuumPosterMetadata = Font.system(size: 17, weight: .regular)
+
     /// Body text — descriptions, synopses (26pt regular)
     static let continuumBody = Font.system(size: 26)
 

--- a/iosApp/iosApp/tvOS/Caching/ItemDetailCache.swift
+++ b/iosApp/iosApp/tvOS/Caching/ItemDetailCache.swift
@@ -85,6 +85,37 @@ final class ItemDetailCache {
         refresh(contentId)
     }
 
+    /// Refresh resident detail models only after the player's final progress
+    /// write has completed. Unlike `markStaleFamily`, this is awaited by the
+    /// player teardown path so a catalog read can never overtake the watched
+    /// mutation and permanently repaint the pre-play state.
+    func refreshAfterPlayback(contentIds: Set<String>) async {
+        var targets = contentIds
+        for contentId in contentIds {
+            guard let detail = entries[contentId]?.detail,
+                  let rawSeriesId = detail.seriesId else { continue }
+            let seriesId = rawSeriesId.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !seriesId.isEmpty else { continue }
+            targets.insert(seriesId)
+            if let seasonNumber = detail.seasonNumber {
+                targets.insert("\(seriesId)-S\(seasonNumber)")
+            }
+        }
+
+        // Most-recently visited first: in the normal Series -> player return,
+        // the visible combined Series page updates before any older cached
+        // episode/season page. Each model keeps painting its cached payload
+        // while this non-coalesced authoritative refresh runs.
+        let residentTargets = order.reversed().filter { targets.contains($0) }
+        for contentId in residentTargets {
+            guard let viewModel = entries[contentId] else { continue }
+            await viewModel.loadDetail(
+                contentId: contentId,
+                coalescesMetadataRequests: false
+            )
+        }
+    }
+
     /// Drop every cached entry. Called from `AuthService.signOut` and
     /// profile-switch to keep per-profile userData from leaking across
     /// accounts.

--- a/iosApp/iosApp/tvOS/Caching/ItemDetailCache.swift
+++ b/iosApp/iosApp/tvOS/Caching/ItemDetailCache.swift
@@ -89,7 +89,8 @@ final class ItemDetailCache {
     /// write has completed. Unlike `markStaleFamily`, this is awaited by the
     /// player teardown path so a catalog read can never overtake the watched
     /// mutation and permanently repaint the pre-play state.
-    func refreshAfterPlayback(contentIds: Set<String>) async {
+    @discardableResult
+    func refreshAfterPlayback(contentIds: Set<String>) async -> Set<String> {
         var targets = contentIds
         for contentId in contentIds {
             guard let detail = entries[contentId]?.detail,
@@ -114,6 +115,7 @@ final class ItemDetailCache {
                 coalescesMetadataRequests: false
             )
         }
+        return Set(residentTargets)
     }
 
     /// Drop every cached entry. Called from `AuthService.signOut` and

--- a/iosApp/iosApp/tvOS/Caching/PosterImageCache.swift
+++ b/iosApp/iosApp/tvOS/Caching/PosterImageCache.swift
@@ -19,6 +19,15 @@ import UIKit
 /// The pipeline is installed as the `ImagePipeline.shared` at first access so
 /// every `LazyImage` / `ImagePipeline.shared` caller picks it up automatically.
 enum PosterImageCache {
+    #if os(tvOS)
+    /// A movie's cast rail is part of the first detail viewport, but its
+    /// portraits used to begin loading only after SwiftUI mounted each card.
+    /// Warm just the first screenful through the same shared Nuke pipeline as
+    /// the hero artwork. `ImagePrefetcher` queues these requests and returns
+    /// immediately, so detail navigation and first paint never wait on them.
+    private static let visibleMovieCastPortraitLimit = 8
+    #endif
+
     private static var memoryWarningObserver: NSObjectProtocol?
 
     /// Call once at app launch before any SwiftUI view renders.
@@ -93,4 +102,26 @@ enum PosterImageCache {
         p.priority = .normal
         return p
     }()
+
+    #if os(tvOS)
+    /// Prefetch only movie portraits. Series cast lives farther down its page
+    /// and deliberately keeps the normal lazy-loading path.
+    static func prefetchVisibleMovieCast(for detail: ItemDetail) {
+        guard detail.type == "movie", let cast = detail.cast else { return }
+
+        var urls: [URL] = []
+        var seen = Set<String>()
+        for member in cast {
+            guard urls.count < visibleMovieCastPortraitLimit else { break }
+            guard let value = member.photoUrl?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !value.isEmpty,
+                  let url = URL(string: value),
+                  seen.insert(url.absoluteString).inserted else { continue }
+            urls.append(url)
+        }
+
+        guard !urls.isEmpty else { return }
+        prefetcher.startPrefetching(with: urls)
+    }
+    #endif
 }

--- a/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
+++ b/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
@@ -693,6 +693,11 @@ final class TVFocusMarqueeModel {
             return
         }
         if let cached = enrichmentCache[contentId] {
+            if let cachedDetail: ItemDetail = ResponseCache.shared.get(
+                CacheKey.itemDetail(contentId)
+            ) {
+                PosterImageCache.prefetchVisibleMovieCast(for: cachedDetail)
+            }
             enrichment = cached
             enrichmentState = .completed
             sampleTintIfNeeded(for: backdropURL)
@@ -720,6 +725,7 @@ final class TVFocusMarqueeModel {
            let cachedDetail: ItemDetail = ResponseCache.shared.get(
                CacheKey.itemDetail(contentId)
            ) {
+            PosterImageCache.prefetchVisibleMovieCast(for: cachedDetail)
             let cached = TVMarqueeEnrichment(detail: cachedDetail)
             enrichmentCache[contentId] = cached
             enrichment = cached
@@ -754,6 +760,7 @@ final class TVFocusMarqueeModel {
 
             if let detail = fetchedDetail {
                 guard !Task.isCancelled, let self else { return }
+                PosterImageCache.prefetchVisibleMovieCast(for: detail)
                 // The marquee already paid for the same catalog request the
                 // detail route needs. Keep the complete payload—not only the
                 // tiny marquee projection—so pressing Select after resting on

--- a/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
+++ b/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
@@ -76,11 +76,17 @@ struct TVMarqueeContent: Equatable {
     /// Optional server logo art that may replace the text title once
     /// cached — the title always renders as text first.
     let logoUrl: String?
-    /// Codec/HDR + content-rating chips (`4K · DOLBY VISION · ATMOS · TV-MA`).
+    /// Technical capability chips (`4K · DOLBY VISION · ATMOS`).
     let badges: [String]
-    /// Dot-joined meta tokens after the badges: year · genre · runtime,
-    /// or `S2 E7 · episode title · 45 min · 23 min left` for episodes.
+    /// Dot-joined identity tokens: year · genre · runtime, or
+    /// `S2 E7 · episode title · 45 min · 23 min left` for episodes.
     let metaParts: [String]
+    /// Where runtime belongs in `metaParts`. Detail enrichment inserts its
+    /// fallback here when a lightweight section payload omitted runtime.
+    let runtimeMetaIndex: Int
+    /// Runtime already supplied by the section payload, if present. Kept
+    /// separately so a detail fallback can be added without duplicating it.
+    let runtimeText: String?
     let synopsis: String?
     /// A genuine landscape backdrop from the section payload. This must stay
     /// separate from the poster fallback so the hero can wait for detail
@@ -127,24 +133,33 @@ extension TVMarqueeContent {
                 meta.append(token)
             }
             meta.append(item.title)
-            if let length = Self.lengthText(runtimeMinutes: item.runtime, durationSeconds: item.durationSeconds) {
-                meta.append(length)
-            }
-            if let timeLeft = Self.timeLeftText(position: item.positionSeconds, duration: item.durationSeconds) {
-                meta.append(timeLeft)
-            }
         } else {
             if let year = item.year, year > 0 { meta.append(String(year)) }
             if let genre = item.genres?.first(where: { !$0.isEmpty }) { meta.append(genre) }
-            if let length = Self.lengthText(runtimeMinutes: item.runtime, durationSeconds: item.durationSeconds) {
-                meta.append(length)
-            }
-            if let rating = item.ratingImdb { meta.append(String(format: "%.1f", rating)) }
         }
 
-        var badges = Self.badges(from: item.overlaySummary)
+        let runtimeMetaIndex = meta.count
+        let runtimeText = Self.lengthText(
+            runtimeMinutes: item.runtime,
+            durationSeconds: item.durationSeconds
+        )
+        if let runtimeText { meta.append(runtimeText) }
+        if !isEpisode, let rating = item.ratingImdb {
+            meta.append(String(format: "%.1f", rating))
+        }
+        // A runtime is useful everywhere; remaining time is resume-state
+        // information and belongs exclusively to a genuinely started item in
+        // Continue Watching. Unstarted next-up items therefore show no value.
+        if isContinueWatching,
+           let timeLeft = Self.timeLeftText(
+               position: item.positionSeconds,
+               duration: item.durationSeconds
+           ) {
+            meta.append(timeLeft)
+        }
+
+        let badges = Self.badges(from: item.overlaySummary)
         let contentRatingBadge = Self.nonEmpty(item.contentRating)?.uppercased()
-        if let contentRatingBadge { badges.append(contentRatingBadge) }
 
         self.init(
             id: "\(rowTitle)#\(item.contentId)",
@@ -156,6 +171,8 @@ extension TVMarqueeContent {
             logoUrl: item.logoUrl,
             badges: badges,
             metaParts: meta,
+            runtimeMetaIndex: runtimeMetaIndex,
+            runtimeText: runtimeText,
             synopsis: item.overview,
             backdropUrl: Self.nonEmpty(item.backdropUrl),
             backdropThumbhash: item.backdropThumbhash,
@@ -193,6 +210,8 @@ extension TVMarqueeContent {
             logoUrl: nil,
             badges: [],
             metaParts: meta,
+            runtimeMetaIndex: meta.count,
+            runtimeText: nil,
             synopsis: nil,
             backdropUrl: nil,
             backdropThumbhash: nil,
@@ -252,7 +271,8 @@ extension TVMarqueeContent {
     /// progress rules MediaRow uses for its bars.
     private static func timeLeftText(position: Double?, duration: Double?) -> String? {
         guard let position, let duration,
-              duration > 0, position > 60, position / duration < 0.95 else {
+              duration > 0, position > 0, position < duration,
+              position / duration < 0.95 else {
             return nil
         }
         let remaining = max(Int(((duration - position) / 60).rounded(.up)), 1)
@@ -513,6 +533,13 @@ final class TVContinueWatchingPlaybackMetadataStore {
 struct TVMarqueeEnrichment: Equatable {
     /// `Aired Mar 12, 2026 · Pedro Pascal, Bella Ramsey, Anna Torv`
     let detailLine: String?
+    /// Recommendation payloads may omit the age/content rating even though
+    /// item detail carries it. Keep that fallback with the other marquee
+    /// enrichment so For You renders the same leading rating pill as Home.
+    let contentRatingBadge: String?
+    /// Item-detail runtime fills section payloads that omit it (notably some
+    /// recommendation and library rows).
+    let runtimeText: String?
     /// The detail-level backdrop. For episodes this is the series backdrop —
     /// far higher-res than the episode still the section payload carries — so
     /// the root hero swaps to it once enrichment arrives.
@@ -522,6 +549,12 @@ struct TVMarqueeEnrichment: Equatable {
     init(detail: ItemDetail) {
         backdropUrl = detail.backdropUrl
         backdropThumbhash = detail.backdropThumbhash
+        let trimmedRating = detail.contentRating?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        contentRatingBadge = trimmedRating?.isEmpty == false
+            ? trimmedRating?.uppercased()
+            : nil
+        runtimeText = Self.runtimeText(minutes: detail.runtime)
         var parts: [String] = []
         if let airDate = Self.airDateText(detail.airDate) {
             parts.append("Aired \(airDate)")
@@ -545,6 +578,16 @@ struct TVMarqueeEnrichment: Equatable {
             ?? (try? Date(raw, strategy: .iso8601.year().month().day()))
         guard let date else { return nil }
         return date.formatted(date: .abbreviated, time: .omitted)
+    }
+
+    private static func runtimeText(minutes: Int?) -> String? {
+        guard let minutes, minutes > 0 else { return nil }
+        if minutes >= 60 {
+            let hours = minutes / 60
+            let remainder = minutes % 60
+            return remainder == 0 ? "\(hours)h" : "\(hours)h \(remainder)m"
+        }
+        return "\(minutes) min"
     }
 }
 
@@ -666,6 +709,24 @@ final class TVFocusMarqueeModel {
                     )
                 }
                 await seriesContextWarmup
+            }
+            return
+        }
+
+        // For You prewarms the two visible rows. Consume that shared detail
+        // cache synchronously so rating/runtime/logo-adjacent metadata paints
+        // on the first focused frame instead of repeating the same request.
+        if !candidate.prefersLastUsedPlaybackMetadata,
+           let cachedDetail: ItemDetail = ResponseCache.shared.get(
+               CacheKey.itemDetail(contentId)
+           ) {
+            let cached = TVMarqueeEnrichment(detail: cachedDetail)
+            enrichmentCache[contentId] = cached
+            enrichment = cached
+            enrichmentState = .completed
+            sampleTintIfNeeded(for: backdropURL)
+            enrichTask = Task {
+                await Self.warmSeriesContext(for: candidate)
             }
             return
         }
@@ -956,8 +1017,13 @@ struct TVFocusMarquee: View {
 
     private var accessibilityDescription: String {
         guard let content else { return "" }
-        let parts = [content.eyebrow, content.title]
+        let rating = content.contentRatingBadge ?? enrichment?.contentRatingBadge ?? ""
+        let fallbackRuntime = content.runtimeText == nil
+            ? (enrichment?.runtimeText ?? "")
+            : ""
+        let parts = [content.eyebrow, content.title, rating]
             + content.metaParts
+            + [fallbackRuntime]
             + [content.synopsis ?? "", enrichment?.detailLine ?? ""]
         return parts
             .filter { !$0.isEmpty }
@@ -972,7 +1038,7 @@ struct TVFocusMarquee: View {
             return nil
         }
         guard !presentation.badges.isEmpty else { return nil }
-        return presentation.badges + [content.contentRatingBadge].compactMap { $0 }
+        return presentation.badges
     }
 
     /// Polite live region: queue a low-priority announcement that never
@@ -1125,16 +1191,33 @@ private struct TVMarqueeBlock: View {
 
     @ViewBuilder
     private var metaLine: some View {
-        if !displayedMetaParts.isEmpty {
+        if content.contentId != nil || !displayedMetaParts.isEmpty {
             HStack(spacing: 10) {
-                if let episodeRatingBadge {
-                    badgeChip(episodeRatingBadge)
+                if content.contentId != nil {
+                    ZStack(alignment: .leading) {
+                        Color.clear
+                        if let contentRatingBadge = displayedContentRatingBadge {
+                            badgeChip(contentRatingBadge)
+                        }
+                    }
+                    .frame(
+                        width: ContinuumTheme.Skyline.marqueeRatingSlotWidth,
+                        height: 27,
+                        alignment: .leading
+                    )
+                    // The detail line retains its gentle fade, but a rating
+                    // pill must simply appear inside its already-reserved slot.
+                    .transaction { transaction in
+                        transaction.animation = nil
+                    }
                 }
 
-                Text(displayedMetaParts.joined(separator: " · "))
-                    .font(.system(size: scale.metaSize, weight: .medium))
-                    .foregroundStyle(Color.continuumSecondaryText)
-                    .lineLimit(1)
+                if !displayedMetaParts.isEmpty {
+                    Text(displayedMetaParts.joined(separator: " · "))
+                        .font(.system(size: scale.metaSize, weight: .medium))
+                        .foregroundStyle(Color.continuumSecondaryText)
+                        .lineLimit(1)
+                }
             }
             .frame(
                 maxWidth: ContinuumTheme.Skyline.marqueeSynopsisMaxWidth,
@@ -1143,34 +1226,34 @@ private struct TVMarqueeBlock: View {
         }
     }
 
-    /// Continue Watching episodes lead with only their location and title.
-    /// Runtime and remaining-time data stay available to VoiceOver, but no
-    /// longer compete with the episode name in the visible identity row.
     private var displayedMetaParts: [String] {
-        content.isEpisode ? Array(content.metaParts.prefix(2)) : content.metaParts
-    }
-
-    /// Episode ratings belong with episode identity, immediately before the
-    /// season/episode token. Movie ratings remain in the technical row.
-    private var episodeRatingBadge: String? {
-        content.isEpisode ? content.contentRatingBadge : nil
-    }
-
-    private var displayedTechnicalBadges: [String] {
-        guard let episodeRatingBadge else { return displayedBadges }
-        return displayedBadges.filter {
-            $0.localizedCaseInsensitiveCompare(episodeRatingBadge) != .orderedSame
+        var parts = content.metaParts
+        if content.runtimeText == nil,
+           let fallbackRuntime = enrichment?.runtimeText {
+            parts.insert(
+                fallbackRuntime,
+                at: min(content.runtimeMetaIndex, parts.count)
+            )
         }
+        return parts
     }
 
-    /// Technical capabilities and rating sit below the async aired/cast line.
+    /// Use the section value immediately when available, then fill omissions
+    /// from the same cached item-detail request that supplies cast/backdrop.
+    private var displayedContentRatingBadge: String? {
+        content.contentRatingBadge ?? enrichment?.contentRatingBadge
+    }
+
+    /// Technical capabilities sit below the async aired/cast line. Content
+    /// ratings consistently lead the identity line above, matching Continue
+    /// Watching across Home, Movies, and Series.
     /// Every media item reserves the same slot, so saved-file enrichment can
     /// update the labels without moving the Home marquee or its first row.
     @ViewBuilder
     private var badgeLine: some View {
         if content.contentId != nil {
             HStack(spacing: 10) {
-                ForEach(displayedTechnicalBadges, id: \.self) { badge in
+                ForEach(displayedBadges, id: \.self) { badge in
                     badgeChip(badge)
                 }
             }
@@ -1201,15 +1284,17 @@ private struct TVMarqueeBlock: View {
 
     // MARK: Logo swap-in
 
-    /// Show cached logo art instantly; otherwise fetch at low priority
-    /// and swap in whenever it lands. The text title is never delayed.
+    /// Show cached logo art instantly; otherwise fetch at normal priority and
+    /// swap in whenever it lands. This is the currently focused title, so it
+    /// should not sit behind speculative poster/backdrop work in the pipeline.
+    /// The text title is never delayed.
     private func loadLogoIfCached() {
         guard let logoUrl = content.logoUrl, !logoUrl.isEmpty,
               let url = URL(string: logoUrl) else {
             return
         }
 
-        let request = ImageRequest(url: url, priority: .low)
+        let request = ImageRequest(url: url, priority: .normal)
         if let cached = ImagePipeline.shared.cache[request] {
             logoImage = cached.image
             return

--- a/iosApp/iosApp/tvOS/Components/TVRootHeroBackdrop.swift
+++ b/iosApp/iosApp/tvOS/Components/TVRootHeroBackdrop.swift
@@ -36,8 +36,13 @@ struct TVBackdropArtworkFadeMask: View {
             LinearGradient(
                 stops: [
                     .init(color: .black, location: 0.0),
-                    .init(color: .black, location: 0.42),
-                    .init(color: .clear, location: 1.0),
+                    .init(color: .black, location: 0.38),
+                    .init(color: .black.opacity(0.88), location: 0.52),
+                    .init(color: .black.opacity(0.58), location: 0.68),
+                    .init(color: .black.opacity(0.24), location: 0.81),
+                    // Reach zero before the detail hero's lower boundary so
+                    // its clip can never reveal a straight artwork edge.
+                    .init(color: .clear, location: 0.90),
                 ],
                 startPoint: .top,
                 endPoint: .bottom

--- a/iosApp/iosApp/tvOS/Components/TVRootHeroBackdrop.swift
+++ b/iosApp/iosApp/tvOS/Components/TVRootHeroBackdrop.swift
@@ -1,6 +1,51 @@
 #if os(tvOS)
 import SwiftUI
 
+/// One backdrop footprint shared by Skyline landings and item details.
+/// tvOS content is rendered in a 16:9 logical viewport, so deriving the
+/// height from the available width keeps the artwork request, crop, and mask
+/// identical even when the detail hero itself is shorter than the viewport.
+enum TVBackdropArtworkLayout {
+    static let widthFraction: CGFloat = 0.64
+    static let heightFraction: CGFloat = 0.70
+
+    static func artworkSize(forViewportWidth viewportWidth: CGFloat) -> CGSize {
+        let viewportHeight = viewportWidth * 9 / 16
+        return CGSize(
+            width: viewportWidth * widthFraction,
+            height: viewportHeight * heightFraction
+        )
+    }
+}
+
+/// Shared corner falloff for the root marquee and movie/series details.
+/// Keeping one mask prevents the artwork edge from visibly changing while
+/// the already-focused card opens its seeded detail route.
+struct TVBackdropArtworkFadeMask: View {
+    var body: some View {
+        LinearGradient(
+            stops: [
+                .init(color: .black, location: 0.0),
+                .init(color: .black, location: 0.32),
+                .init(color: .clear, location: 1.0),
+            ],
+            startPoint: .trailing,
+            endPoint: .leading
+        )
+        .mask {
+            LinearGradient(
+                stops: [
+                    .init(color: .black, location: 0.0),
+                    .init(color: .black, location: 0.42),
+                    .init(color: .clear, location: 1.0),
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        }
+    }
+}
+
 /// Page-level ambient hero backdrop for root tvOS screens.
 ///
 /// Keeping this behind the whole page instead of inside the hero/marquee
@@ -29,10 +74,6 @@ struct TVRootHeroBackdrop: View {
     /// one — only artwork→artwork swaps get the ambient crossfade.
     @State private var hasDisplayedArtwork = false
 
-    /// Crisp art occupies the upper-right corner; the corner mask fades it
-    /// out toward the leading edge and the bottom into the sampled wash.
-    private let artWidthFraction: CGFloat = 0.64
-    private let artHeightFraction: CGFloat = 0.70
     /// Near-crisp by request (§ user direction). Bump a little only if the
     /// server's backdrop is low-res enough to show compression artifacts.
     private let artBlur: CGFloat = 0
@@ -93,21 +134,22 @@ struct TVRootHeroBackdrop: View {
     @ViewBuilder
     private var backdropImage: some View {
         GeometryReader { geometry in
-            let artWidth = geometry.size.width * artWidthFraction
-            let artHeight = geometry.size.height * artHeightFraction
+            let artworkSize = TVBackdropArtworkLayout.artworkSize(
+                forViewportWidth: geometry.size.width
+            )
 
             if let artworkURL, !artworkURL.isEmpty {
                 AsyncImageView(
                     url: artworkURL,
                     thumbhash: artworkThumbhash,
-                    targetSize: CGSize(width: artWidth, height: artHeight),
+                    targetSize: artworkSize,
                     contentMode: .fill
                 )
                 .id(artworkURL)
-                .frame(width: artWidth, height: artHeight)
+                .frame(width: artworkSize.width, height: artworkSize.height)
                 .clipped()
                 .blur(radius: artBlur)
-                .mask { cornerFadeMask }
+                .mask { TVBackdropArtworkFadeMask() }
                 // Anchor the art block to the screen's top-right corner; the
                 // mask keeps only that corner opaque, so the corner reads as
                 // fully painted with no gap and the art dissolves inward.
@@ -124,33 +166,6 @@ struct TVRootHeroBackdrop: View {
             }
         }
         .ignoresSafeArea()
-    }
-
-    /// Corner falloff: opaque only at the top-right, fading to clear toward
-    /// the leading edge (horizontal ramp) and the bottom (vertical ramp).
-    /// Nesting the two ramps as masks multiplies their alpha, so the art
-    /// dissolves into the sampled wash on its left and below.
-    private var cornerFadeMask: some View {
-        LinearGradient(
-            stops: [
-                .init(color: .black, location: 0.0),
-                .init(color: .black, location: 0.32),
-                .init(color: .clear, location: 1.0),
-            ],
-            startPoint: .trailing,
-            endPoint: .leading
-        )
-        .mask {
-            LinearGradient(
-                stops: [
-                    .init(color: .black, location: 0.0),
-                    .init(color: .black, location: 0.42),
-                    .init(color: .clear, location: 1.0),
-                ],
-                startPoint: .top,
-                endPoint: .bottom
-            )
-        }
     }
 
     /// Full-width black ramp pinned to the top so the wordmark, tabs, and

--- a/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
+++ b/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
@@ -1,3 +1,33 @@
+enum TVSkylineVerticalMove {
+    case up
+    case down
+}
+
+enum TVSkylineRowMoveTarget: Equatable {
+    case topMenu
+    case row(Int)
+    case none
+}
+
+/// Pure row-boundary routing used by every Skyline landing. Explicit routing
+/// avoids asking the focus engine to discover a row that is still clipped by
+/// the lower-half viewport while the vertical stack is scrolling.
+func tvSkylineRowMoveTarget(
+    currentIndex: Int,
+    rowCount: Int,
+    direction: TVSkylineVerticalMove
+) -> TVSkylineRowMoveTarget {
+    guard rowCount > 0, currentIndex >= 0, currentIndex < rowCount else {
+        return .none
+    }
+    switch direction {
+    case .up:
+        return currentIndex == 0 ? .topMenu : .row(currentIndex - 1)
+    case .down:
+        return currentIndex + 1 < rowCount ? .row(currentIndex + 1) : .none
+    }
+}
+
 #if os(tvOS)
 import SwiftUI
 
@@ -7,9 +37,10 @@ import SwiftUI
 /// so the two stay pixel-identical — the only difference is the sections each
 /// feeds in.
 ///
-/// Row movement is owned by tvOS focus + the vertical scroll view. Each row
-/// remains a native focus section, so row-to-row movement preserves tvOS'
-/// geometric focus behavior instead of forcing the first item.
+/// Rows remain native focus sections. Downward movement stays entirely native
+/// so one remote gesture advances one row with the platform's normal pacing.
+/// Upward movement only intervenes when the clipped band needs help revealing
+/// the preceding row.
 struct TVSkylineSectionFeed: View {
     /// Section rows to page through, in order (already filtered to
     /// non-empty, non-featured by the caller).
@@ -36,8 +67,20 @@ struct TVSkylineSectionFeed: View {
 
     /// Debounced focused-card state driving the marquee + backdrop.
     @State private var marqueeModel = TVFocusMarqueeModel()
-    /// Token handed to row 1 so its first card claims focus on shell entry.
-    @State private var contentFocusToken = 0
+    /// Per-row focus handoff tokens. A single monotonic generation prevents a
+    /// request from colliding with a token that row applied earlier.
+    @State private var rowFocusRequestGeneration = 0
+    @State private var rowFocusRequests: [String: Int] = [:]
+    @State private var rowFocusRequestItemIds: [String: String] = [:]
+    @State private var lastFocusedItemIds: [String: String] = [:]
+    /// Invalidates a queued scroll-then-focus claim when another touchpad
+    /// gesture arrives first. Without this generation, the older async claim
+    /// can run after the newer one and bounce focus back a row.
+    @State private var rowNavigationGeneration = 0
+    /// A touchpad swipe can emit several Up commands while the destination is
+    /// still being revealed. Treat that burst as one gesture so it cannot page
+    /// through several rows before focus has visually settled.
+    @State private var isUpwardRowMoveInFlight = false
     /// Snaps the row band back to the first section before a focus claim.
     /// The band clips rows outside the viewport, and tvOS refuses to focus a
     /// clipped view — so when entry focus fires while the user is parked on a
@@ -88,6 +131,8 @@ struct TVSkylineSectionFeed: View {
         .onChange(of: focusRequest) { _, request in requestEntryFocus(request) }
         .onChange(of: isTopMenuFocused) { _, isFocused in
             if isFocused {
+                rowNavigationGeneration &+= 1
+                isUpwardRowMoveInFlight = false
                 focusRestorationOwnerSectionId = nil
             }
         }
@@ -117,7 +162,11 @@ struct TVSkylineSectionFeed: View {
                 ScrollView(.vertical, showsIndicators: false) {
                     LazyVStack(alignment: .leading, spacing: ContinuumTheme.Skyline.rowBandPreviewSpacing) {
                         ForEach(Array(sections.enumerated()), id: \.element.id) { index, section in
-                            featuredRow(section, isFirstRow: index == 0)
+                            featuredRow(
+                                section,
+                                at: index,
+                                scrollProxy: scrollProxy
+                            )
                                 .fixedSize(horizontal: false, vertical: true)
                                 .id(section.id)
                         }
@@ -146,7 +195,11 @@ struct TVSkylineSectionFeed: View {
     }
 
     @ViewBuilder
-    private func featuredRow(_ section: ResolvedSection, isFirstRow: Bool) -> some View {
+    private func featuredRow(
+        _ section: ResolvedSection,
+        at index: Int,
+        scrollProxy: ScrollViewProxy
+    ) -> some View {
         SectionRow(
             section: section,
             onItemTap: onItemTap,
@@ -158,17 +211,27 @@ struct TVSkylineSectionFeed: View {
             // movement between rows geometric — only system-initiated
             // resolutions use the preference. The imperative entry token
             // below is unchanged and covers every other entry path.
-            prefersDefaultFocusOnFirstItem: isFirstRow,
+            prefersDefaultFocusOnFirstItem: index == 0,
             defaultFocusPriority: .automatic,
-            focusRequest: isFirstRow ? contentFocusToken : 0,
+            focusRequest: rowFocusRequests[section.id] ?? 0,
+            focusRequestItemId: rowFocusRequestItemIds[section.id],
             detailReturnFocusRequest: detailReturnFocusRequest,
-            onMoveUp: isFirstRow ? onTopMenuFocusRequest : nil,
+            onMoveUp: {
+                moveFocusUp(
+                    from: index,
+                    scrollProxy: scrollProxy
+                )
+            },
             onItemFocus: { item in
                 focusRestorationOwnerSectionId = section.id
+                lastFocusedItemIds[section.id] = item.contentId
                 previewFocusedItem(item, in: section)
             },
             cardWidth: ContinuumTheme.Skyline.densePosterCardWidth,
             cardVerticalPadding: ContinuumTheme.Skyline.rowBandCardVerticalPadding,
+            // Preserve the original smooth tvOS focus/scroll behavior when
+            // moving down. Programmatic Down paging made one touchpad swipe
+            // produce several rapid row jumps.
             onMoveDown: nil,
             focusRestorationOwner: Binding(
                 get: { focusRestorationOwnerSectionId == section.id },
@@ -185,6 +248,64 @@ struct TVSkylineSectionFeed: View {
     }
 
     // MARK: - Focus
+
+    private func moveFocusUp(
+        from index: Int,
+        scrollProxy: ScrollViewProxy
+    ) {
+        guard !isUpwardRowMoveInFlight else { return }
+        switch tvSkylineRowMoveTarget(
+            currentIndex: index,
+            rowCount: sections.count,
+            direction: .up
+        ) {
+        case .topMenu:
+            rowNavigationGeneration &+= 1
+            isUpwardRowMoveInFlight = false
+            focusRestorationOwnerSectionId = nil
+            onTopMenuFocusRequest?()
+        case .row(let targetIndex):
+            let targetSection = sections[targetIndex]
+            let targetItemId = lastFocusedItemIds[targetSection.id]
+                ?? targetSection.items.first?.contentId
+            rowNavigationGeneration &+= 1
+            let navigationGeneration = rowNavigationGeneration
+            isUpwardRowMoveInFlight = true
+            // Ownership changes before the animation so any retry still queued
+            // by the previous row immediately yields instead of stealing focus
+            // back during a rapid touchpad gesture.
+            focusRestorationOwnerSectionId = targetSection.id
+            withAnimation(
+                reduceMotion
+                    ? nil
+                    : .easeInOut(duration: ContinuumTheme.slowDuration)
+            ) {
+                scrollProxy.scrollTo(targetSection.id, anchor: .top)
+            }
+            // Let the preceding row become focusable before claiming it. A
+            // later release ends the gesture burst without accelerating into
+            // another row; a new deliberate press/swipe then moves once more.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.12) {
+                guard navigationGeneration == rowNavigationGeneration else { return }
+                requestRowFocus(targetSection.id, itemId: targetItemId)
+            }
+            DispatchQueue.main.asyncAfter(
+                deadline: .now() + ContinuumTheme.slowDuration + 0.12
+            ) {
+                guard navigationGeneration == rowNavigationGeneration else { return }
+                isUpwardRowMoveInFlight = false
+            }
+        case .none:
+            break
+        }
+    }
+
+    private func requestRowFocus(_ sectionId: String, itemId: String? = nil) {
+        focusRestorationOwnerSectionId = sectionId
+        rowFocusRequestItemIds[sectionId] = itemId
+        rowFocusRequestGeneration += 1
+        rowFocusRequests[sectionId] = rowFocusRequestGeneration
+    }
 
     /// Entry focus → the first row's first card. Tokens that arrive before
     /// the rows mount wait as a pending claim. A claim is dropped while the
@@ -204,12 +325,20 @@ struct TVSkylineSectionFeed: View {
         if isTopMenuFocused { return }
         guard request != lastAppliedRequest else { return }
         lastAppliedRequest = request
+        guard let firstSectionId = sections.first?.id else { return }
+        rowNavigationGeneration &+= 1
+        let navigationGeneration = rowNavigationGeneration
+        isUpwardRowMoveInFlight = false
+        focusRestorationOwnerSectionId = firstSectionId
         // Scroll the band home first, then claim on the next turn: the claim
         // is a @FocusState write on the first row's first card, which the
         // engine drops while that card is still clipped out of the viewport.
         entryScrollToken += 1
         DispatchQueue.main.async {
-            contentFocusToken += 1
+            guard navigationGeneration == rowNavigationGeneration,
+                  !isTopMenuFocused,
+                  sections.contains(where: { $0.id == firstSectionId }) else { return }
+            requestRowFocus(firstSectionId, itemId: sections.first?.items.first?.contentId)
         }
     }
 

--- a/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
+++ b/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
@@ -37,10 +37,9 @@ import SwiftUI
 /// so the two stay pixel-identical — the only difference is the sections each
 /// feeds in.
 ///
-/// Rows remain native focus sections. Downward movement stays entirely native
-/// so one remote gesture advances one row with the platform's normal pacing.
-/// Upward movement only intervenes when the clipped band needs help revealing
-/// the preceding row.
+/// Row-to-row movement belongs to the tvOS focus engine and the vertical
+/// scroll view. Programmatic focus is reserved for entering the page and
+/// returning from detail; ordinary Up/Down movement stays geometric.
 struct TVSkylineSectionFeed: View {
     /// Section rows to page through, in order (already filtered to
     /// non-empty, non-featured by the caller).
@@ -67,20 +66,9 @@ struct TVSkylineSectionFeed: View {
 
     /// Debounced focused-card state driving the marquee + backdrop.
     @State private var marqueeModel = TVFocusMarqueeModel()
-    /// Per-row focus handoff tokens. A single monotonic generation prevents a
-    /// request from colliding with a token that row applied earlier.
-    @State private var rowFocusRequestGeneration = 0
-    @State private var rowFocusRequests: [String: Int] = [:]
-    @State private var rowFocusRequestItemIds: [String: String] = [:]
-    @State private var lastFocusedItemIds: [String: String] = [:]
-    /// Invalidates a queued scroll-then-focus claim when another touchpad
-    /// gesture arrives first. Without this generation, the older async claim
-    /// can run after the newer one and bounce focus back a row.
-    @State private var rowNavigationGeneration = 0
-    /// A touchpad swipe can emit several Up commands while the destination is
-    /// still being revealed. Treat that burst as one gesture so it cannot page
-    /// through several rows before focus has visually settled.
-    @State private var isUpwardRowMoveInFlight = false
+    /// Token handed only to row 1 when the shell explicitly enters content.
+    /// It is never changed during ordinary row-to-row navigation.
+    @State private var contentFocusToken = 0
     /// Snaps the row band back to the first section before a focus claim.
     /// The band clips rows outside the viewport, and tvOS refuses to focus a
     /// clipped view — so when entry focus fires while the user is parked on a
@@ -131,8 +119,6 @@ struct TVSkylineSectionFeed: View {
         .onChange(of: focusRequest) { _, request in requestEntryFocus(request) }
         .onChange(of: isTopMenuFocused) { _, isFocused in
             if isFocused {
-                rowNavigationGeneration &+= 1
-                isUpwardRowMoveInFlight = false
                 focusRestorationOwnerSectionId = nil
             }
         }
@@ -160,13 +146,13 @@ struct TVSkylineSectionFeed: View {
 
             ScrollViewReader { scrollProxy in
                 ScrollView(.vertical, showsIndicators: false) {
-                    LazyVStack(alignment: .leading, spacing: ContinuumTheme.Skyline.rowBandPreviewSpacing) {
+                    // Keep every row's focus section mounted. A LazyVStack can
+                    // remove the clipped row immediately above/below, leaving
+                    // the Focus Engine no geometric destination and tempting
+                    // callers to force focus manually.
+                    VStack(alignment: .leading, spacing: ContinuumTheme.Skyline.rowBandPreviewSpacing) {
                         ForEach(Array(sections.enumerated()), id: \.element.id) { index, section in
-                            featuredRow(
-                                section,
-                                at: index,
-                                scrollProxy: scrollProxy
-                            )
+                            featuredRow(section, isFirstRow: index == 0)
                                 .fixedSize(horizontal: false, vertical: true)
                                 .id(section.id)
                         }
@@ -195,11 +181,7 @@ struct TVSkylineSectionFeed: View {
     }
 
     @ViewBuilder
-    private func featuredRow(
-        _ section: ResolvedSection,
-        at index: Int,
-        scrollProxy: ScrollViewProxy
-    ) -> some View {
+    private func featuredRow(_ section: ResolvedSection, isFirstRow: Bool) -> some View {
         SectionRow(
             section: section,
             onItemTap: onItemTap,
@@ -211,27 +193,20 @@ struct TVSkylineSectionFeed: View {
             // movement between rows geometric — only system-initiated
             // resolutions use the preference. The imperative entry token
             // below is unchanged and covers every other entry path.
-            prefersDefaultFocusOnFirstItem: index == 0,
+            prefersDefaultFocusOnFirstItem: isFirstRow,
             defaultFocusPriority: .automatic,
-            focusRequest: rowFocusRequests[section.id] ?? 0,
-            focusRequestItemId: rowFocusRequestItemIds[section.id],
+            focusRequest: isFirstRow ? contentFocusToken : 0,
             detailReturnFocusRequest: detailReturnFocusRequest,
-            onMoveUp: {
-                moveFocusUp(
-                    from: index,
-                    scrollProxy: scrollProxy
-                )
-            },
+            // This is the sole directional interception: Up from the first
+            // content row crosses the intentional page-to-tab-bar boundary.
+            // Every other vertical move remains native.
+            onMoveUp: isFirstRow ? onTopMenuFocusRequest : nil,
             onItemFocus: { item in
                 focusRestorationOwnerSectionId = section.id
-                lastFocusedItemIds[section.id] = item.contentId
                 previewFocusedItem(item, in: section)
             },
             cardWidth: ContinuumTheme.Skyline.densePosterCardWidth,
             cardVerticalPadding: ContinuumTheme.Skyline.rowBandCardVerticalPadding,
-            // Preserve the original smooth tvOS focus/scroll behavior when
-            // moving down. Programmatic Down paging made one touchpad swipe
-            // produce several rapid row jumps.
             onMoveDown: nil,
             focusRestorationOwner: Binding(
                 get: { focusRestorationOwnerSectionId == section.id },
@@ -248,70 +223,6 @@ struct TVSkylineSectionFeed: View {
     }
 
     // MARK: - Focus
-
-    private func moveFocusUp(
-        from index: Int,
-        scrollProxy: ScrollViewProxy
-    ) {
-        guard !isUpwardRowMoveInFlight else { return }
-        switch tvSkylineRowMoveTarget(
-            currentIndex: index,
-            rowCount: sections.count,
-            direction: .up
-        ) {
-        case .topMenu:
-            rowNavigationGeneration &+= 1
-            isUpwardRowMoveInFlight = false
-            focusRestorationOwnerSectionId = nil
-            onTopMenuFocusRequest?()
-        case .row(let targetIndex):
-            let targetSection = sections[targetIndex]
-            let targetItemId = lastFocusedItemIds[targetSection.id]
-                ?? targetSection.items.first?.contentId
-            rowNavigationGeneration &+= 1
-            let navigationGeneration = rowNavigationGeneration
-            isUpwardRowMoveInFlight = true
-            // Ownership changes before the animation so any retry still queued
-            // by the previous row immediately yields instead of stealing focus
-            // back during a rapid touchpad gesture.
-            focusRestorationOwnerSectionId = targetSection.id
-            withAnimation(
-                reduceMotion
-                    ? nil
-                    : .easeInOut(duration: ContinuumTheme.slowDuration)
-            ) {
-                scrollProxy.scrollTo(targetSection.id, anchor: .top)
-            }
-            // Let the preceding row become focusable before claiming it. A
-            // later release ends the gesture burst without accelerating into
-            // another row; a new deliberate press/swipe then moves once more.
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.12) {
-                guard navigationGeneration == rowNavigationGeneration,
-                      let currentSection = sections.first(where: { $0.id == targetSection.id }),
-                      let currentItemId = targetItemId.flatMap({ candidateId in
-                          currentSection.items.contains(where: { $0.contentId == candidateId })
-                              ? candidateId
-                              : nil
-                      }) ?? currentSection.items.first?.contentId else { return }
-                requestRowFocus(currentSection.id, itemId: currentItemId)
-            }
-            DispatchQueue.main.asyncAfter(
-                deadline: .now() + ContinuumTheme.slowDuration + 0.12
-            ) {
-                guard navigationGeneration == rowNavigationGeneration else { return }
-                isUpwardRowMoveInFlight = false
-            }
-        case .none:
-            break
-        }
-    }
-
-    private func requestRowFocus(_ sectionId: String, itemId: String? = nil) {
-        focusRestorationOwnerSectionId = sectionId
-        rowFocusRequestItemIds[sectionId] = itemId
-        rowFocusRequestGeneration += 1
-        rowFocusRequests[sectionId] = rowFocusRequestGeneration
-    }
 
     /// Entry focus → the first row's first card. Tokens that arrive before
     /// the rows mount wait as a pending claim. A claim is dropped while the
@@ -332,20 +243,15 @@ struct TVSkylineSectionFeed: View {
         guard request != lastAppliedRequest else { return }
         lastAppliedRequest = request
         guard let firstSectionId = sections.first?.id else { return }
-        rowNavigationGeneration &+= 1
-        let navigationGeneration = rowNavigationGeneration
-        isUpwardRowMoveInFlight = false
         focusRestorationOwnerSectionId = firstSectionId
         // Scroll the band home first, then claim on the next turn: the claim
         // is a @FocusState write on the first row's first card, which the
         // engine drops while that card is still clipped out of the viewport.
         entryScrollToken += 1
         DispatchQueue.main.async {
-            guard navigationGeneration == rowNavigationGeneration,
-                  !isTopMenuFocused,
-                  let firstSection = sections.first(where: { $0.id == firstSectionId }),
-                  let firstItemId = firstSection.items.first?.contentId else { return }
-            requestRowFocus(firstSection.id, itemId: firstItemId)
+            guard !isTopMenuFocused,
+                  sections.first?.id == firstSectionId else { return }
+            contentFocusToken += 1
         }
     }
 

--- a/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
+++ b/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
@@ -286,8 +286,14 @@ struct TVSkylineSectionFeed: View {
             // later release ends the gesture burst without accelerating into
             // another row; a new deliberate press/swipe then moves once more.
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.12) {
-                guard navigationGeneration == rowNavigationGeneration else { return }
-                requestRowFocus(targetSection.id, itemId: targetItemId)
+                guard navigationGeneration == rowNavigationGeneration,
+                      let currentSection = sections.first(where: { $0.id == targetSection.id }),
+                      let currentItemId = targetItemId.flatMap({ candidateId in
+                          currentSection.items.contains(where: { $0.contentId == candidateId })
+                              ? candidateId
+                              : nil
+                      }) ?? currentSection.items.first?.contentId else { return }
+                requestRowFocus(currentSection.id, itemId: currentItemId)
             }
             DispatchQueue.main.asyncAfter(
                 deadline: .now() + ContinuumTheme.slowDuration + 0.12
@@ -337,8 +343,9 @@ struct TVSkylineSectionFeed: View {
         DispatchQueue.main.async {
             guard navigationGeneration == rowNavigationGeneration,
                   !isTopMenuFocused,
-                  sections.contains(where: { $0.id == firstSectionId }) else { return }
-            requestRowFocus(firstSectionId, itemId: sections.first?.items.first?.contentId)
+                  let firstSection = sections.first(where: { $0.id == firstSectionId }),
+                  let firstItemId = firstSection.items.first?.contentId else { return }
+            requestRowFocus(firstSection.id, itemId: firstItemId)
         }
     }
 

--- a/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
@@ -887,6 +887,13 @@ struct TVMainTabView: View {
     }
 
     private func prefetchLibrarySectionsIfNeeded(_ library: Library) {
+        if TVLibraryTabType.series.matches(library) {
+            // This joins the same single-flight section request as the panel
+            // preview, then primes one Series hero. Repeated focus visits are
+            // cache-only and never fan out across the whole rail.
+            StartupContentPrefetcher.prefetchTVSeriesLanding(libraryId: library.id)
+            return
+        }
         let cached: SectionsResponse? = ResponseCache.shared.get(
             CacheKey.librarySections(library.id)
         )
@@ -1052,6 +1059,7 @@ struct TVMainTabView: View {
            let cached: LibrariesResponse = ResponseCache.shared.get(CacheKey.userLibraries) {
             libraries = cached.libraries
             ensureSelectedRootIsVisible()
+            prefetchActiveSeriesLanding()
         }
 
         do {
@@ -1063,11 +1071,20 @@ struct TVMainTabView: View {
                 response.libraries.contains { $0.id == libraryId }
             }
             ensureSelectedRootIsVisible()
+            prefetchActiveSeriesLanding()
         } catch {
             // Keep whatever tabs we already have (cached or none) — Home
             // and Calendar always stay reachable, so a transient failure
             // never strands the user.
         }
+    }
+
+    /// Backstop the launch prefetch with the shell's authoritative in-session
+    /// scope. This covers a changed Series-library selection without making
+    /// any other tab wait for the warmup.
+    private func prefetchActiveSeriesLanding() {
+        guard let library = activeLibrary(for: .series) else { return }
+        StartupContentPrefetcher.prefetchTVSeriesLanding(libraryId: library.id)
     }
 
     /// The selected root can stop being visible — a library refresh removes

--- a/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
@@ -17,6 +17,11 @@ func tvVisibleRootsFocusRearm(
 #if os(tvOS)
 import SwiftUI
 
+private enum TVPersonalRootDestination: Hashable {
+    case watchlist
+    case favorites
+}
+
 /// Root tvOS shell. Owns a custom Skyline top bar instead of relying on
 /// `TabView(.sidebarAdaptable)`, so content can use horizontal remote
 /// navigation without the system sidebar claiming leftward focus.
@@ -27,6 +32,11 @@ import SwiftUI
 struct TVMainTabView: View {
     @Bindable var router: AppRouter
     @State private var selectedRoot: TVRootDestination = .home
+    /// Watchlist and Favorites are root-shell pages rather than pushed
+    /// destinations, so the Skyline bar and profile controls remain present.
+    /// The previously selected content root stays underneath and is restored
+    /// when the user backs out of the personal page.
+    @State private var personalRoot: TVPersonalRootDestination?
     /// Seeded from the startup prefetch so the bar's first frame already
     /// shows the active profile's avatar instead of filling it in late.
     @State private var currentProfile: UserProfile? = {
@@ -123,9 +133,6 @@ struct TVMainTabView: View {
                 rootContent
                     .navigationDestination(for: Route.self) { route in
                         routeContent(for: route)
-                            .environment(\.tvDetailTopMenuReturn) {
-                                returnFromPushedRouteToTopMenu()
-                            }
                     }
             }
 
@@ -148,7 +155,9 @@ struct TVMainTabView: View {
                     onEnterPanel: enterPanelFor,
                     onProfilePressed: openProfilePanelImmediately,
                     onContentFocusHandoff: suppressTopMenuFocusForContentHandoff,
-                    onExit: selectedRoot == .home ? nil : returnToHomeInMenu
+                    onExit: personalRoot != nil
+                        ? returnFromPersonalRootInMenu
+                        : (selectedRoot == .home ? nil : returnToHomeInMenu)
                 )
             }
 
@@ -336,14 +345,21 @@ struct TVMainTabView: View {
             Color.continuumBackground
                 .ignoresSafeArea()
 
-            selectedRootContent
+            Group {
+                if let personalRoot {
+                    personalRootContent(personalRoot)
+                        .id(personalRoot)
+                } else {
+                    selectedRootContent
+                        .id(selectedRoot)
+                }
+            }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 // §4.2 tab content switch: an explicit 200 ms opacity
                 // crossfade keyed on the selected root, so the incoming page
                 // fades in and the outgoing one fades out in place (it never
                 // slides). The crossfade animation is supplied by `selectRoot`;
                 // Reduce Motion snaps via the `.identity` transition.
-                .id(selectedRoot)
                 .transition(reduceMotion ? .identity : .opacity)
                 .focusScope(tabContentNamespace)
                 // Keep the page from taking remote/pointer events while a
@@ -423,6 +439,28 @@ struct TVMainTabView: View {
         case .calendar:
             CalendarView(
                 focusRequest: contentFocusRequest,
+                onTopMenuFocusRequest: { focusTopMenuIfVisible() }
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func personalRootContent(_ destination: TVPersonalRootDestination) -> some View {
+        switch destination {
+        case .watchlist:
+            WatchlistView(
+                showsNavigationTitle: false,
+                usesTVTopMenu: true,
+                focusRequest: contentFocusRequest,
+                isTopMenuFocused: isTopMenuFocused,
+                onTopMenuFocusRequest: { focusTopMenuIfVisible() }
+            )
+        case .favorites:
+            FavoritesView(
+                showsNavigationTitle: false,
+                usesTVTopMenu: true,
+                focusRequest: contentFocusRequest,
+                isTopMenuFocused: isTopMenuFocused,
                 onTopMenuFocusRequest: { focusTopMenuIfVisible() }
             )
         }
@@ -1093,6 +1131,7 @@ struct TVMainTabView: View {
         // Reduce Motion snaps (the `.identity` transition + nil animation).
         withAnimation(reduceMotion ? nil : .easeInOut(duration: ContinuumTheme.normalDuration)) {
             selectedRoot = root
+            personalRoot = nil
             openPanel = nil
         }
         panelEntersFocus = false
@@ -1148,18 +1187,6 @@ struct TVMainTabView: View {
         }
     }
 
-    /// Up from the topmost detail controls deliberately leaves the pushed
-    /// route and hands focus to the root menu. Back/Menu remains distinct: it
-    /// performs one ordinary pop and restores the Continue Watching card.
-    private func returnFromPushedRouteToTopMenu() {
-        guard !router.path.isEmpty else {
-            focusTopMenuIfVisible()
-            return
-        }
-        barOwnsFocusOnPopToRoot = true
-        router.popToRoot()
-    }
-
     private func returnToHomeInMenu() {
         selectedRoot = .home
         panelReturnFocus = nil
@@ -1169,6 +1196,12 @@ struct TVMainTabView: View {
             // Home button unfocused after the exit-to-home gesture.
             isTopMenuFocusSuppressed = false
             topMenuFocusRequest += 1
+        }
+    }
+
+    private func returnFromPersonalRootInMenu() {
+        withAnimation(reduceMotion ? nil : .easeInOut(duration: ContinuumTheme.normalDuration)) {
+            personalRoot = nil
         }
     }
 
@@ -1182,8 +1215,34 @@ struct TVMainTabView: View {
     /// focus to the bar instead of letting the engine free-resolve into
     /// the row band.
     private func navigateFromBar(_ route: Route) {
+        switch route {
+        case .watchlist:
+            showPersonalRoot(.watchlist)
+            return
+        case .favorites:
+            showPersonalRoot(.favorites)
+            return
+        default:
+            break
+        }
+
         barOwnsFocusOnPopToRoot = true
         router.navigate(to: route)
+    }
+
+    private func showPersonalRoot(_ destination: TVPersonalRootDestination) {
+        router.popToRoot()
+        barOwnsFocusOnPopToRoot = false
+        suppressTopMenuFocusForContentHandoff()
+        withAnimation(reduceMotion ? nil : .easeInOut(duration: ContinuumTheme.normalDuration)) {
+            personalRoot = destination
+            openPanel = nil
+        }
+        panelEntersFocus = false
+        panelHasFocus = false
+        DispatchQueue.main.async {
+            contentFocusRequest += 1
+        }
     }
 
     private func switchProfile() {

--- a/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
@@ -1307,6 +1307,7 @@ struct TVMainTabView: View {
             ) else { return }
             await MainActor.run {
                 selectedRoot = .home
+                personalRoot = nil
                 currentProfile = nil
                 libraries = []
                 loadedLibraryAuthority = nil

--- a/iosApp/iosApp/tvOS/Screens/Components/TVCollectionPosterCard.swift
+++ b/iosApp/iosApp/tvOS/Screens/Components/TVCollectionPosterCard.swift
@@ -102,15 +102,17 @@ struct TVCollectionPosterCard: View {
     private var caption: some View {
         VStack(spacing: 4) {
             Text(collection.name)
-                .font(.system(size: 22, weight: .semibold))
+                .font(.continuumPosterTitle)
                 .foregroundColor(isFocused ? .continuumOnSurface : .continuumOnSurface.opacity(0.92))
                 .lineLimit(1)
                 .truncationMode(.tail)
+                .frame(width: resolvedCardWidth, alignment: .center)
+                .clipped()
                 .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: isFocused)
 
             if uiCustomization.cardPresentation.caption.showsMetadata, let countText {
                 Text(countText)
-                    .font(.system(size: 18, weight: .regular))
+                    .font(.continuumPosterMetadata)
                     .foregroundColor(.continuumSecondaryText)
                     .lineLimit(1)
             }

--- a/iosApp/iosApp/tvOS/Screens/Components/TVMediaCard.swift
+++ b/iosApp/iosApp/tvOS/Screens/Components/TVMediaCard.swift
@@ -203,17 +203,23 @@ struct TVMediaCard: View {
     private var caption: some View {
         VStack(spacing: 4) {
             Text(title)
-                .font(.system(size: 22, weight: .semibold))
+                .font(.continuumPosterTitle)
                 .foregroundColor(isFocused ? .continuumOnSurface : .continuumOnSurface.opacity(0.92))
                 .lineLimit(1)
                 .truncationMode(.tail)
+                .frame(width: resolvedCardWidth, alignment: .center)
+                .clipped()
                 .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: isFocused)
 
             if uiCustomization.cardPresentation.caption.showsMetadata,
                let secondLine = subtitle ?? year.map(String.init) {
                 Text(secondLine)
-                    .font(.system(size: 18, weight: .regular))
+                    .font(.continuumPosterMetadata)
                     .foregroundColor(.continuumSecondaryText)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .frame(width: resolvedCardWidth, alignment: .center)
+                    .clipped()
             }
         }
         .multilineTextAlignment(.center)

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVDetailActions.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVDetailActions.swift
@@ -1,20 +1,6 @@
 #if os(tvOS)
 import SwiftUI
 
-/// The root shell supplies this only for pushed tvOS detail routes. Up from
-/// the hero action row is an intentional focus boundary: it returns to the
-/// root and gives ownership to the persistent top menu.
-private struct TVDetailTopMenuReturnKey: EnvironmentKey {
-    static let defaultValue: (() -> Void)? = nil
-}
-
-extension EnvironmentValues {
-    var tvDetailTopMenuReturn: (() -> Void)? {
-        get { self[TVDetailTopMenuReturnKey.self] }
-        set { self[TVDetailTopMenuReturnKey.self] = newValue }
-    }
-}
-
 // MARK: - Primary pill
 
 /// VidHub-style primary play button. Solid white, large, dominant —
@@ -332,7 +318,6 @@ struct TVDetailActionRow<PlaybackSelectors: View, MoreMenu: View>: View {
     @ViewBuilder let moreMenu: () -> MoreMenu
 
     @Environment(\.resetFocus) private var resetFocus
-    @Environment(\.tvDetailTopMenuReturn) private var returnToTopMenu
     @State private var didResetInitialPlayFocus = false
     @State private var initialFocusSeasonKey: String?
     @State private var initialPlayFocusTask: Task<Void, Never>?
@@ -408,10 +393,11 @@ struct TVDetailActionRow<PlaybackSelectors: View, MoreMenu: View>: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .focusSection()
         .onMoveCommand { direction in
-            // This row is the top boundary of the detail focus graph. Keep
-            // left/right native within the row; only Up changes ownership.
+            // This is a hard top boundary for a pushed detail page. Consuming
+            // Up here keeps focus on the action row; it must never behave like
+            // Back/Menu or pop the movie/series page to the root.
             if direction == .up {
-                returnToTopMenu?()
+                return
             }
         }
         .onChange(of: playbackSelectorsFocused) { _, isFocused in

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVDetailFocusScroll.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVDetailFocusScroll.swift
@@ -82,7 +82,7 @@ private struct DetailFocusScrollModifier: ViewModifier {
     /// 0.2s `normalDuration` read as an abrupt snap next to them.
     private static let scrollAnimation = Animation.easeInOut(duration: 0.45)
     private static let browseScrollAnimation = Animation.smooth(
-        duration: 1.0,
+        duration: 0.55,
         extraBounce: 0
     )
 
@@ -90,10 +90,10 @@ private struct DetailFocusScrollModifier: ViewModifier {
     /// write is clobbered, then sparse late ones to outlast the engine's
     /// input-deferred reveal after rapid d-pad sequences.
     private static let assertDelays: [Double] = [0.02, 0.15, 0.45, 0.8, 1.1]
-    /// Series row-to-row moves share one fixed viewport. One immediate smooth
-    /// write starts the motion, then a single late write outlasts tvOS's native
-    /// reveal without repeatedly restarting the curve.
-    private static let browseAssertDelays: [Double] = [0, 1.08]
+    /// Series row-to-row moves share one fixed viewport. A single write owns
+    /// entry into that viewport; a delayed duplicate can fire after a later
+    /// focus move and is visible as a page bounce.
+    private static let browseAssertDelays: [Double] = [0]
 
     func body(content: Content) -> some View {
         // Mirror focus into the shared state on every render so in-flight
@@ -116,7 +116,11 @@ private struct DetailFocusScrollModifier: ViewModifier {
                 // Series browsing is a fixed first-viewport experience: the
                 // logo and artwork remain the visual anchor while cards move
                 // horizontally beneath the focused carousel slot.
-                assertScroll(to: heroId, anchor: .top, while: .browse)
+                if browseRestoreRequest > 0 {
+                    restoreBrowseScroll(to: heroId, anchor: .top)
+                } else {
+                    assertScroll(to: heroId, anchor: .top, while: .browse)
+                }
             }
             .onChange(of: browseHoldRequest) { _, request in
                 guard request > 0, browseFocusKey != nil else { return }
@@ -125,13 +129,6 @@ private struct DetailFocusScrollModifier: ViewModifier {
                 // reveal window instead of letting it pan down and correcting
                 // back afterward.
                 holdScroll(to: heroId, anchor: .top, while: .browse)
-            }
-            .onChange(of: browseRestoreRequest) { _, request in
-                guard request > 0, browseFocusKey != nil else { return }
-                // Version -> Episodes intentionally returns to the complete
-                // main framing. Use the slower browse curve rather than the
-                // focus engine's abrupt reveal.
-                assertScroll(to: heroId, anchor: .top, while: .browse)
             }
             .onChange(of: similarRailFocused) { _, focused in
                 guard focused, let similarSectionId else { return }
@@ -186,10 +183,11 @@ private struct DetailFocusScrollModifier: ViewModifier {
         state.generation &+= 1
         let generation = state.generation
 
-        // Eighteen frames at 40 Hz cover the native single-swipe reveal while
-        // remaining short enough that the next deliberate move is unaffected.
-        for frame in 0...18 {
-            let delay = Double(frame) / 40
+        // Ten frames at 60 Hz cover the native row-to-row reveal. The Series
+        // page explicitly releases this lock before focusing Cast, so these
+        // corrections never compete with its first deliberate page scroll.
+        for frame in 0...9 {
+            let delay = Double(frame) / 60
             DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [state] in
                 guard state.generation == generation,
                       state.focusedRegion == region else { return }
@@ -198,6 +196,22 @@ private struct DetailFocusScrollModifier: ViewModifier {
                 withTransaction(transaction) {
                     proxy.scrollTo(id, anchor: anchor)
                 }
+            }
+        }
+    }
+
+    /// Returning from a lower supporting rail is the only animated entry into
+    /// the fixed Series viewport. Final position ownership is handled by the
+    /// outer scroll view's idle phase rather than delayed correction timers.
+    private func restoreBrowseScroll(to id: String, anchor: UnitPoint) {
+        state.generation &+= 1
+        let generation = state.generation
+
+        DispatchQueue.main.async { [state] in
+            guard state.generation == generation,
+                  state.focusedRegion == .browse else { return }
+            withAnimation(Self.browseScrollAnimation) {
+                proxy.scrollTo(id, anchor: anchor)
             }
         }
     }

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVDetailHero.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVDetailHero.swift
@@ -149,66 +149,26 @@ struct TVDetailHero<Actions: View, BelowSynopsis: View>: View {
     private var backdrop: some View {
         GeometryReader { geometry in
             let resolvedBackdropHeight = backdropHeight ?? heroHeight
-            let artworkWidth = geometry.size.width * 0.64
-            let artworkHeight = min(
-                resolvedBackdropHeight * 0.94,
-                artworkWidth * 9 / 16
+            let artworkSize = TVBackdropArtworkLayout.artworkSize(
+                forViewportWidth: geometry.size.width
             )
-            // The standard Movie mask is shared verbatim. A compact Series
-            // header only changes whether that completed fade may draw beyond
-            // the editorial layout boundary.
-            let bottomFadeEnd: CGFloat = 1
-            let bottomFadeStart = max(0, bottomFadeEnd - 0.30)
 
             if let url = backdropUrl, !url.isEmpty {
                 CachedAsyncImage(
                     url: url,
-                    targetSize: CGSize(width: artworkWidth, height: artworkHeight),
+                    targetSize: artworkSize,
                     thumbhash: backdropThumbhash,
                     contentMode: .fill
                 )
-                .frame(width: artworkWidth, height: artworkHeight)
+                .frame(width: artworkSize.width, height: artworkSize.height)
                 .clipped()
-                .mask {
-                    artworkFadeMask(
-                        bottomFadeStart: bottomFadeStart,
-                        bottomFadeEnd: bottomFadeEnd
-                    )
-                }
+                .mask { TVBackdropArtworkFadeMask() }
                 .frame(
                     width: geometry.size.width,
                     height: resolvedBackdropHeight,
                     alignment: .topTrailing
                 )
             }
-        }
-    }
-
-    /// The image is crisp in the top-right and dissolves into the solid page
-    /// tint on its leading and lower edges. No blur or translucent material.
-    private func artworkFadeMask(
-        bottomFadeStart: CGFloat,
-        bottomFadeEnd: CGFloat
-    ) -> some View {
-        LinearGradient(
-            stops: [
-                .init(color: .black, location: 0.0),
-                .init(color: .black, location: 0.46),
-                .init(color: .clear, location: 1.0),
-            ],
-            startPoint: .trailing,
-            endPoint: .leading
-        )
-        .mask {
-            LinearGradient(
-                stops: [
-                    .init(color: .black, location: 0.0),
-                    .init(color: .black, location: bottomFadeStart),
-                    .init(color: .clear, location: max(0.72, bottomFadeEnd)),
-                ],
-                startPoint: .top,
-                endPoint: .bottom
-            )
         }
     }
 

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
@@ -123,14 +123,7 @@ struct TVEpisodeRail: View {
     /// the competing native focus-scroll animation that caused the bump.
     private var anchoredRail: some View {
         GeometryReader { geometry in
-            // Keep the existing leading position, but end the hard crop after
-            // the final card that fits completely. A fractional next card is
-            // therefore hidden rather than sliced at the page's right edge.
-            anchoredButton(
-                viewportWidth: anchoredWholeCardViewportWidth(
-                    availableWidth: geometry.size.width
-                )
-            )
+            anchoredButton(viewportWidth: geometry.size.width)
         }
         .frame(height: anchoredRailHeight)
         .focusSection()
@@ -250,25 +243,6 @@ struct TVEpisodeRail: View {
 
     private var episodeIdentityKey: String {
         episodes.map(\.contentId).joined(separator: "|")
-    }
-
-    /// Width of the largest whole-card group that fits at the current user
-    /// card scale. The left clearance is unchanged; matching trailing room
-    /// lets the final card's Home-style lift remain fully visible too.
-    private func anchoredWholeCardViewportWidth(availableWidth: CGFloat) -> CGFloat {
-        guard availableWidth > 0 else { return 0 }
-
-        let focusClearance = EpisodeHomeHoverMetrics.leadingInset(
-            for: anchoredCardWidth
-        )
-        let step = anchoredCardWidth + cardSpacing
-        let usableWidth = max(anchoredCardWidth, availableWidth - (focusClearance * 2))
-        let fittingCount = max(1, Int(floor((usableWidth + cardSpacing) / step)))
-        let visibleCount = min(max(episodes.count, 1), fittingCount)
-        let cardsWidth = CGFloat(visibleCount) * anchoredCardWidth
-            + CGFloat(max(visibleCount - 1, 0)) * cardSpacing
-
-        return min(availableWidth, focusClearance + cardsWidth + focusClearance)
     }
 
     private func anchoredContentOffset(viewportWidth: CGFloat) -> CGFloat {
@@ -690,23 +664,32 @@ private struct EpisodeCardLabel: View {
                             Text("·")
                                 .font(.system(size: 16, weight: .bold))
                                 .foregroundStyle(Color.continuumOnSurface.opacity(0.48))
+                                .fixedSize(horizontal: true, vertical: false)
                             Text(compactEpisodeTitle)
                                 .font(.system(size: 20, weight: .semibold))
                                 .foregroundStyle(titleColor)
                                 .lineLimit(1)
                                 .truncationMode(.tail)
-                                .layoutPriority(1)
+                                .frame(maxWidth: .infinity, alignment: .leading)
                         }
-                        Spacer(minLength: 8)
+                        if !hidesEpisodeTitle {
+                            Spacer(minLength: 8)
+                        }
                     }
-                    // The compact Series caption is always the same 28-point
-                    // line beneath its still. Different title glyphs can no
-                    // longer alter the card's measured height while the rail
-                    // animates from one episode to the next.
+                    // Season tabs keep their label inside the moving control
+                    // and never animate its layout independently. Apply that
+                    // same rule only to the compact Series episode caption.
                     .frame(
+                        width: hidesEpisodeTitle ? cardWidth : nil,
                         height: hidesEpisodeTitle ? 28 : nil,
                         alignment: .topLeading
                     )
+                    .clipped()
+                    .transaction { transaction in
+                        guard hidesEpisodeTitle else { return }
+                        transaction.animation = nil
+                        transaction.disablesAnimations = true
+                    }
 
                     if !hidesEpisodeTitle {
                         HStack(alignment: .firstTextBaseline, spacing: 16) {

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
@@ -123,7 +123,14 @@ struct TVEpisodeRail: View {
     /// the competing native focus-scroll animation that caused the bump.
     private var anchoredRail: some View {
         GeometryReader { geometry in
-            anchoredButton(viewportWidth: geometry.size.width)
+            // Keep the existing leading position, but end the hard crop after
+            // the final card that fits completely. A fractional next card is
+            // therefore hidden rather than sliced at the page's right edge.
+            anchoredButton(
+                viewportWidth: anchoredWholeCardViewportWidth(
+                    availableWidth: geometry.size.width
+                )
+            )
         }
         .frame(height: anchoredRailHeight)
         .focusSection()
@@ -243,6 +250,25 @@ struct TVEpisodeRail: View {
 
     private var episodeIdentityKey: String {
         episodes.map(\.contentId).joined(separator: "|")
+    }
+
+    /// Width of the largest whole-card group that fits at the current user
+    /// card scale. The left clearance is unchanged; matching trailing room
+    /// lets the final card's Home-style lift remain fully visible too.
+    private func anchoredWholeCardViewportWidth(availableWidth: CGFloat) -> CGFloat {
+        guard availableWidth > 0 else { return 0 }
+
+        let focusClearance = EpisodeHomeHoverMetrics.leadingInset(
+            for: anchoredCardWidth
+        )
+        let step = anchoredCardWidth + cardSpacing
+        let usableWidth = max(anchoredCardWidth, availableWidth - (focusClearance * 2))
+        let fittingCount = max(1, Int(floor((usableWidth + cardSpacing) / step)))
+        let visibleCount = min(max(episodes.count, 1), fittingCount)
+        let cardsWidth = CGFloat(visibleCount) * anchoredCardWidth
+            + CGFloat(max(visibleCount - 1, 0)) * cardSpacing
+
+        return min(availableWidth, focusClearance + cardsWidth + focusClearance)
     }
 
     private func anchoredContentOffset(viewportWidth: CGFloat) -> CGFloat {
@@ -654,7 +680,7 @@ private struct EpisodeCardLabel: View {
             still
             if captionStyle.showsTitle {
                 VStack(alignment: .leading, spacing: 7) {
-                    HStack(spacing: 10) {
+                    HStack(alignment: .firstTextBaseline, spacing: 10) {
                         Text(episodeNumberLabel)
                             .font(.system(size: 16, weight: .bold))
                             .tracking(1.6)
@@ -673,6 +699,14 @@ private struct EpisodeCardLabel: View {
                         }
                         Spacer(minLength: 8)
                     }
+                    // The compact Series caption is always the same 28-point
+                    // line beneath its still. Different title glyphs can no
+                    // longer alter the card's measured height while the rail
+                    // animates from one episode to the next.
+                    .frame(
+                        height: hidesEpisodeTitle ? 28 : nil,
+                        alignment: .topLeading
+                    )
 
                     if !hidesEpisodeTitle {
                         HStack(alignment: .firstTextBaseline, spacing: 16) {

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
@@ -52,6 +52,7 @@ struct TVEpisodeRail: View {
     @FocusState private var focusedCardId: String?
     @FocusState private var anchoredRailFocused: Bool
     @State private var anchoredIndex = 0
+    @State private var anchoredScrollPosition = ScrollPosition(x: 0)
     @State private var anchoredPlayedOverrides: [String: Bool] = [:]
     @State private var anchoredFavoriteOverrides: [String: Bool] = [:]
     @State private var uiCustomization = UICustomizationPreferences.shared
@@ -119,33 +120,35 @@ struct TVEpisodeRail: View {
     }
 
     /// Series uses one focus owner for the entire rail. Cards are passive
-    /// labels and the active index drives a single render offset, eliminating
-    /// the competing native focus-scroll animation that caused the bump.
+    /// labels and the active index drives one native ScrollView position,
+    /// eliminating competing focus owners while leaving scrolling to SwiftUI.
     private var anchoredRail: some View {
         GeometryReader { geometry in
             anchoredButton(viewportWidth: geometry.size.width)
+                .onAppear {
+                    seedAnchoredIndex(viewportWidth: geometry.size.width)
+                }
+                .onChange(of: episodeIdentityKey) { _, _ in
+                    seedAnchoredIndex(viewportWidth: geometry.size.width)
+                }
+                .onChange(of: currentContentId) { _, _ in
+                    guard !anchoredRailFocused else { return }
+                    seedAnchoredIndex(viewportWidth: geometry.size.width)
+                }
+                .onChange(of: focusRequest) { _, request in
+                    guard request > 0 else { return }
+                    seedAnchoredIndex(viewportWidth: geometry.size.width)
+                    anchoredRailFocused = true
+                }
         }
         .frame(height: anchoredRailHeight)
         .focusSection()
-        .onAppear(perform: seedAnchoredIndex)
-        .onChange(of: episodeIdentityKey) { _, _ in
-            seedAnchoredIndex()
-        }
-        .onChange(of: currentContentId) { _, _ in
-            guard !anchoredRailFocused else { return }
-            seedAnchoredIndex()
-        }
         .onChange(of: anchoredRailFocused) { _, isFocused in
             onFocusedEpisodeChange?(isFocused ? anchoredEpisode?.contentId : nil)
         }
         .onChange(of: anchoredIndex) { _, _ in
             guard anchoredRailFocused else { return }
             onFocusedEpisodeChange?(anchoredEpisode?.contentId)
-        }
-        .onChange(of: focusRequest) { _, request in
-            guard request > 0 else { return }
-            seedAnchoredIndex()
-            anchoredRailFocused = true
         }
         .onDisappear {
             onFocusedEpisodeChange?(nil)
@@ -159,8 +162,8 @@ struct TVEpisodeRail: View {
                 onSelect(contentId)
             }
         } label: {
-            ZStack(alignment: .topLeading) {
-                HStack(alignment: .top, spacing: cardSpacing) {
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHStack(alignment: .top, spacing: cardSpacing) {
                     ForEach(Array(episodes.enumerated()), id: \.element.contentId) { index, episode in
                         let isHovered = anchoredRailFocused && index == anchoredIndex
                         EpisodeCardLabel(
@@ -187,9 +190,14 @@ struct TVEpisodeRail: View {
                     .leading,
                     EpisodeHomeHoverMetrics.leadingInset(for: anchoredCardWidth)
                 )
+                .padding(
+                    .trailing,
+                    anchoredTrailingInset(viewportWidth: viewportWidth)
+                )
                 .padding(.vertical, 12)
-                .offset(x: -anchoredContentOffset(viewportWidth: viewportWidth))
             }
+            .scrollPosition($anchoredScrollPosition)
+            .scrollDisabled(true)
             .frame(
                 width: viewportWidth,
                 height: anchoredRailHeight,
@@ -200,16 +208,18 @@ struct TVEpisodeRail: View {
         }
         .buttonStyle(TVAnchoredEpisodeButtonStyle())
         .focused($anchoredRailFocused)
-        .onMoveCommand(perform: handleAnchoredMove)
+        .onMoveCommand { direction in
+            handleAnchoredMove(direction, viewportWidth: viewportWidth)
+        }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(anchoredAccessibilityLabel)
         .accessibilityValue("Episode \(anchoredIndex + 1) of \(max(episodes.count, 1))")
         .accessibilityAdjustableAction { direction in
             switch direction {
             case .increment:
-                moveAnchoredSelection(by: 1)
+                moveAnchoredSelection(by: 1, viewportWidth: viewportWidth)
             case .decrement:
-                moveAnchoredSelection(by: -1)
+                moveAnchoredSelection(by: -1, viewportWidth: viewportWidth)
             @unknown default:
                 break
             }
@@ -245,7 +255,10 @@ struct TVEpisodeRail: View {
         episodes.map(\.contentId).joined(separator: "|")
     }
 
-    private func anchoredContentOffset(viewportWidth: CGFloat) -> CGFloat {
+    private func anchoredContentOffset(
+        for index: Int,
+        viewportWidth: CGFloat
+    ) -> CGFloat {
         guard !episodes.isEmpty else { return 0 }
         let step = anchoredCardWidth + cardSpacing
         let contentWidth = CGFloat(episodes.count) * anchoredCardWidth
@@ -256,10 +269,29 @@ struct TVEpisodeRail: View {
         // both edges while the last episode remains entirely visible; any
         // remainder becomes harmless trailing breathing room.
         let maximumOffset = ceil(minimumTrailingOffset / step) * step
-        return min(CGFloat(anchoredIndex) * step, maximumOffset)
+        return min(CGFloat(index) * step, maximumOffset)
     }
 
-    private func seedAnchoredIndex() {
+    /// Adds only the extra scrollable width needed to preserve the rail's
+    /// existing stepped trailing boundary. SwiftUI can then clamp concrete
+    /// scroll positions natively without changing the final card grouping.
+    private func anchoredTrailingInset(viewportWidth: CGFloat) -> CGFloat {
+        guard !episodes.isEmpty else { return 0 }
+        let leadingInset = EpisodeHomeHoverMetrics.leadingInset(for: anchoredCardWidth)
+        let contentWidth = CGFloat(episodes.count) * anchoredCardWidth
+            + CGFloat(max(episodes.count - 1, 0)) * cardSpacing
+        let naturalMaximumOffset = max(
+            0,
+            leadingInset + contentWidth - viewportWidth
+        )
+        let desiredMaximumOffset = anchoredContentOffset(
+            for: episodes.count - 1,
+            viewportWidth: viewportWidth
+        )
+        return max(0, desiredMaximumOffset - naturalMaximumOffset)
+    }
+
+    private func seedAnchoredIndex(viewportWidth: CGFloat) {
         let seededIndex: Int
         if let currentContentId,
            let index = episodes.firstIndex(where: { $0.contentId == currentContentId }) {
@@ -277,15 +309,24 @@ struct TVEpisodeRail: View {
         transaction.disablesAnimations = true
         withTransaction(transaction) {
             anchoredIndex = seededIndex
+            anchoredScrollPosition.scrollTo(
+                x: anchoredContentOffset(
+                    for: seededIndex,
+                    viewportWidth: viewportWidth
+                )
+            )
         }
     }
 
-    private func handleAnchoredMove(_ direction: MoveCommandDirection) {
+    private func handleAnchoredMove(
+        _ direction: MoveCommandDirection,
+        viewportWidth: CGFloat
+    ) {
         switch direction {
         case .left:
-            moveAnchoredSelection(by: -1)
+            moveAnchoredSelection(by: -1, viewportWidth: viewportWidth)
         case .right:
-            moveAnchoredSelection(by: 1)
+            moveAnchoredSelection(by: 1, viewportWidth: viewportWidth)
         case .up:
             onMoveUp?()
         case .down:
@@ -295,15 +336,27 @@ struct TVEpisodeRail: View {
         }
     }
 
-    private func moveAnchoredSelection(by delta: Int) {
+    private func moveAnchoredSelection(
+        by delta: Int,
+        viewportWidth: CGFloat
+    ) {
         let nextIndex = anchoredIndex + delta
         guard episodes.indices.contains(nextIndex) else { return }
-        withAnimation(
-            reduceMotion
-                ? nil
-                : .smooth(duration: 0.30, extraBounce: 0)
-        ) {
-            anchoredIndex = nextIndex
+
+        // Keep focus/selection state out of the scroll animation transaction.
+        // That prevents hero metadata and every card from inheriting the
+        // carousel's animation while the native ScrollView moves its content.
+        anchoredIndex = nextIndex
+        let targetOffset = anchoredContentOffset(
+            for: nextIndex,
+            viewportWidth: viewportWidth
+        )
+        if reduceMotion {
+            anchoredScrollPosition.scrollTo(x: targetOffset)
+        } else {
+            withAnimation(.smooth(duration: 0.30, extraBounce: 0)) {
+                anchoredScrollPosition.scrollTo(x: targetOffset)
+            }
         }
     }
 

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailLoadingView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailLoadingView.swift
@@ -42,10 +42,8 @@ struct TVItemDetailLoadingView: View {
 
     private var cinematicArtwork: some View {
         GeometryReader { geometry in
-            let artworkWidth = geometry.size.width * 0.64
-            let artworkHeight = min(
-                TVDetailLayout.heroHeight * 0.94,
-                artworkWidth * 9 / 16
+            let artworkSize = TVBackdropArtworkLayout.artworkSize(
+                forViewportWidth: geometry.size.width
             )
 
             Group {
@@ -53,7 +51,7 @@ struct TVItemDetailLoadingView: View {
                     AsyncImageView(
                         url: url,
                         thumbhash: seed?.backdropThumbhash,
-                        targetSize: CGSize(width: artworkWidth, height: artworkHeight),
+                        targetSize: artworkSize,
                         contentMode: .fill
                     )
                 } else {
@@ -61,36 +59,13 @@ struct TVItemDetailLoadingView: View {
                         .fill(Color.white.opacity(0.035))
                 }
             }
-            .frame(width: artworkWidth, height: artworkHeight)
+            .frame(width: artworkSize.width, height: artworkSize.height)
             .clipped()
-            .mask { cinematicArtworkMask }
+            .mask { TVBackdropArtworkFadeMask() }
             .frame(
                 width: geometry.size.width,
                 height: TVDetailLayout.heroHeight,
                 alignment: .topTrailing
-            )
-        }
-    }
-
-    private var cinematicArtworkMask: some View {
-        LinearGradient(
-            stops: [
-                .init(color: .black, location: 0),
-                .init(color: .black, location: 0.46),
-                .init(color: .clear, location: 1),
-            ],
-            startPoint: .trailing,
-            endPoint: .leading
-        )
-        .mask {
-            LinearGradient(
-                stops: [
-                    .init(color: .black, location: 0),
-                    .init(color: .black, location: 0.70),
-                    .init(color: .clear, location: 1),
-                ],
-                startPoint: .top,
-                endPoint: .bottom
             )
         }
     }

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
@@ -31,6 +31,11 @@ struct TVItemDetailView: View {
     @State private var failedSeriesRedirectEpisodeContentId: String?
     @State private var isLoadingNextUpPlaybackDetail = false
     @State private var didLoadNextUpPlaybackDetail = false
+    /// Serializes rapid season-tab intent before it reaches the async view
+    /// model. A superseded task must never begin after its replacement and
+    /// make an older season the selected one.
+    @State private var seriesSeasonSelectionTask: Task<Void, Never>?
+    @State private var seriesSeasonSelectionGeneration = 0
     /// Whether remote YouTube trailers should be presented, probed once per
     /// page appearance. Real Apple TVs require the YouTube app because tvOS
     /// has no browser fallback. The simulator deliberately presents the
@@ -81,6 +86,8 @@ struct TVItemDetailView: View {
             viewModel.resumeTrailerFetchIfNeeded()
         }
         .onDisappear {
+            seriesSeasonSelectionTask?.cancel()
+            seriesSeasonSelectionTask = nil
             Self.focusLogger.debug("itemDetail.disappear contentId=\(contentId, privacy: .public) pathDepth=\(router.path.count, privacy: .public)")
             viewModel.cancelDeferredEpisodeFavoriteStateRefresh()
             // The coordinator's poll is not owned by `.task`, so it would
@@ -108,6 +115,9 @@ struct TVItemDetailView: View {
             }
         }
         .task(id: contentId) {
+            seriesSeasonSelectionTask?.cancel()
+            seriesSeasonSelectionTask = nil
+            seriesSeasonSelectionGeneration &+= 1
             let navigationContext = TVSeriesDetailNavigationContextStore.take(
                 for: contentId
             )
@@ -124,6 +134,10 @@ struct TVItemDetailView: View {
                 await applySeriesNavigationContext(navigationContext)
             }
             seedSubtitleOverrideIfNeeded()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .tvPlaybackStateDidRefresh)) { note in
+            guard let event = note.object as? TVPlaybackStateRefreshEvent else { return }
+            applyCompletedPlaybackRefresh(event)
         }
     }
 
@@ -151,6 +165,49 @@ struct TVItemDetailView: View {
         }
         guard !Task.isCancelled else { return }
         activeSeriesEpisodeContentId = context.episodeContentId
+    }
+
+    /// The cache has already reloaded authoritative watched/progress data when
+    /// this arrives. Advance only the editorial episode selection; the native
+    /// episode rail keeps ownership of focus and scrolling exactly as before.
+    private func applyCompletedPlaybackRefresh(_ event: TVPlaybackStateRefreshEvent) {
+        guard event.refreshedContentIds.contains(contentId),
+              viewModel.detail?.type == "series",
+              !event.completedContentIds.isEmpty else { return }
+
+        let activeWasCompleted = activeSeriesEpisodeContentId.map {
+            event.completedContentIds.contains($0)
+        } ?? false
+        let completedEpisodeIsVisible = viewModel.episodes.contains {
+            event.completedContentIds.contains($0.contentId)
+        }
+        guard activeSeriesEpisodeContentId == nil
+                || activeWasCompleted
+                || completedEpisodeIsVisible else { return }
+
+        if let inProgress = viewModel.episodes.first(where: {
+            $0.userData?.isInProgress == true && !($0.userData?.played ?? false)
+        }) {
+            activeSeriesEpisodeContentId = inProgress.contentId
+            return
+        }
+
+        if let activeSeriesEpisodeContentId,
+           let completedIndex = viewModel.episodes.firstIndex(where: {
+               $0.contentId == activeSeriesEpisodeContentId
+           }),
+           let next = viewModel.episodes.dropFirst(completedIndex + 1).first(where: {
+               !($0.userData?.played ?? false)
+           }) {
+            self.activeSeriesEpisodeContentId = next.contentId
+            return
+        }
+
+        if let nextUnwatched = viewModel.episodes.first(where: {
+            !($0.userData?.played ?? false)
+        }) {
+            activeSeriesEpisodeContentId = nextUnwatched.contentId
+        }
     }
 
     private var preferredAudioTrackIndex: Int? {
@@ -363,6 +420,7 @@ struct TVItemDetailView: View {
                 seasons: viewModel.seasons,
                 selectedSeason: viewModel.selectedSeason,
                 episodes: viewModel.episodes,
+                episodesBySeason: viewModel.episodesBySeason,
                 activeEpisodeContentId: activeSeriesEpisodeContentId,
                 episodeFavoriteStates: viewModel.episodeFavoriteStates,
                 isLoadingEpisodes: viewModel.isLoadingEpisodes,
@@ -388,7 +446,17 @@ struct TVItemDetailView: View {
                 onTrailerStatusShown: { viewModel.trailerFetch.acknowledge() },
                 onSelectSeason: { season in
                     activeSeriesEpisodeContentId = nil
-                    Task { await viewModel.selectSeason(season) }
+                    seriesSeasonSelectionTask?.cancel()
+                    seriesSeasonSelectionGeneration &+= 1
+                    let generation = seriesSeasonSelectionGeneration
+                    seriesSeasonSelectionTask = Task { @MainActor in
+                        guard !Task.isCancelled,
+                              generation == seriesSeasonSelectionGeneration else { return }
+                        await viewModel.selectSeason(season)
+                        guard !Task.isCancelled,
+                              generation == seriesSeasonSelectionGeneration else { return }
+                        seriesSeasonSelectionTask = nil
+                    }
                 },
                 onActivateEpisode: { id in
                     activeSeriesEpisodeContentId = id
@@ -495,11 +563,6 @@ struct TVItemDetailView: View {
                 id: viewModel.selectedSeason?.contentId,
                 priority: .background
             ) {
-                do {
-                    try await Task.sleep(for: .milliseconds(1_500))
-                } catch {
-                    return
-                }
                 await prefetchAdjacentSeriesSeasons(for: detail)
             }
         } else {
@@ -1149,6 +1212,16 @@ struct TVItemDetailView: View {
             }
             if !stillURLs.isEmpty {
                 PosterImageCache.prefetcher.startPrefetching(with: stillURLs)
+            }
+
+            let sorted = response.episodes.sorted {
+                $0.episodeNumber < $1.episodeNumber
+            }
+            if viewModel.episodesBySeason[season.seasonNumber] == nil {
+                // Feed the route-scoped page cache as well as ResponseCache.
+                // The full season rail can then mount this neighbour before
+                // the first tab movement instead of warming only after it.
+                viewModel.episodesBySeason[season.seasonNumber] = sorted
             }
         }
     }

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -478,19 +478,24 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
             // Allow the newly selected season rail to mount at its settled
             // internal episode offset before the full-width page starts moving.
             await Task.yield()
+            if !reduceMotion {
+                // Give the incoming episode render surface one display frame
+                // to paint before moving it, avoiding a small first-frame hitch.
+                try? await Task.sleep(for: .milliseconds(17))
+            }
             guard !Task.isCancelled,
                   generation == seasonTransitionGeneration else { return }
 
             withAnimation(
                 reduceMotion
                     ? nil
-                    : .smooth(duration: 0.42, extraBounce: 0)
+                    : .timingCurve(0.4, 0, 0.2, 1, duration: 0.46)
             ) {
                 seasonPanProgress = 1
             }
 
             if !reduceMotion {
-                try? await Task.sleep(for: .milliseconds(450))
+                try? await Task.sleep(for: .milliseconds(480))
             } else {
                 await Task.yield()
             }
@@ -541,11 +546,15 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     }
 
     /// Holds the episode area to one measured Home-card footprint while each
-    /// season behaves as a full-width carousel page. Only this clipped viewport
-    /// moves; the season tabs, controls, and every lower section remain fixed.
+    /// season behaves as a full-width carousel page. Only this viewport moves;
+    /// the season tabs, controls, and every lower section remain fixed. The
+    /// episode rail owns its own crop, so this wrapper must not cut off the
+    /// trailing page inset the rail deliberately borrows.
     private var smoothlyChangingEpisodeBody: some View {
         GeometryReader { geometry in
             let width = geometry.size.width
+            let viewportWidth = width + TVDetailLayout.horizontalInset
+            let leftClipCanvasWidth = viewportWidth * 2
             let direction: CGFloat = seasonTransitionMovesForward ? 1 : -1
 
             ZStack(alignment: .topLeading) {
@@ -557,7 +566,19 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                             height: episodeRailReservedHeight,
                             alignment: .topLeading
                         )
-                        .offset(x: -direction * seasonPanProgress * width)
+                        // Preserve the rail's existing layout width, then
+                        // widen only the temporary raster surface so its
+                        // borrowed trailing inset is never cropped.
+                        .frame(
+                            width: viewportWidth,
+                            height: episodeRailReservedHeight,
+                            alignment: .topLeading
+                        )
+                        // The outgoing tab page is immutable. Rasterize it
+                        // once before the existing page offset so episode art
+                        // and its number/title cannot render on separate paths.
+                        .drawingGroup(opaque: false, colorMode: .nonLinear)
+                        .offset(x: -direction * seasonPanProgress * viewportWidth)
                         .allowsHitTesting(false)
                         .accessibilityHidden(true)
                 }
@@ -568,26 +589,47 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                         height: episodeRailReservedHeight,
                         alignment: .topLeading
                     )
+                    .frame(
+                        width: viewportWidth,
+                        height: episodeRailReservedHeight,
+                        alignment: .topLeading
+                    )
+                    .lockEpisodeCaptionsForSeasonTabSwitch(
+                        outgoingSeasonPage != nil
+                    )
                     .offset(
                         x: outgoingSeasonPage == nil
                             ? 0
-                            : direction * (1 - seasonPanProgress) * width
+                            : direction * (1 - seasonPanProgress) * viewportWidth
                     )
             }
+            // Retain the settled rail's leading crop, but put the matching
+            // right crop a full page beyond the visible display. Cards can
+            // then cross the screen's trailing edge without a transient cut.
+            .frame(
+                width: leftClipCanvasWidth,
+                height: episodeRailReservedHeight,
+                alignment: .topLeading
+            )
+            .clipped()
         }
         .frame(height: episodeRailReservedHeight, alignment: .topLeading)
-        .clipped()
     }
 
     private var liveEpisodePage: some View {
         ZStack(alignment: .topLeading) {
             episodeBody
                 .id(isLoadingEpisodes ? "loading" : "ready")
-                .transition(.opacity)
+                // The season-page slide already supplies the transition.
+                // Avoid fading its episode paint at the same time, which
+                // briefly dimmed the cards and added competing composition.
+                .transition(outgoingSeasonPage == nil ? .opacity : .identity)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .animation(
-            reduceMotion ? nil : .easeInOut(duration: 0.18),
+            reduceMotion || outgoingSeasonPage != nil
+                ? nil
+                : .easeInOut(duration: 0.18),
             value: isLoadingEpisodes
         )
     }
@@ -866,6 +908,20 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         VStack(alignment: .leading, spacing: TVDetailLayout.sectionHeaderSpacing) {
             TVSectionHeader(title: "Details")
             TVDetailFactsSection(detail: detail)
+        }
+    }
+}
+
+private extension View {
+    /// During a Series season-tab page switch only, flatten the incoming page
+    /// before its existing offset animates. Outside that short transition the
+    /// live episode carousel is returned unchanged.
+    @ViewBuilder
+    func lockEpisodeCaptionsForSeasonTabSwitch(_ isSwitching: Bool) -> some View {
+        if isSwitching {
+            drawingGroup(opaque: false, colorMode: .nonLinear)
+        } else {
+            self
         }
     }
 }

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -77,6 +77,8 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     @State private var episodeRailFocusRequest = 0
     @State private var supportingRailFocusRequest = 0
     @State private var modeActivationTask: Task<Void, Never>?
+    @State private var modeFocusAppearanceTask: Task<Void, Never>?
+    @State private var presentedFocusedModeId: String?
     @State private var seasonTransitionMovesForward = true
     @State private var seasonTransitionInFlight = false
     @State private var seasonTransitionTargetId: String?
@@ -165,6 +167,9 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         .onDisappear {
             modeActivationTask?.cancel()
             modeActivationTask = nil
+            modeFocusAppearanceTask?.cancel()
+            modeFocusAppearanceTask = nil
+            presentedFocusedModeId = nil
             seasonTransitionTask?.cancel()
             seasonTransitionTask = nil
             var transaction = Transaction(animation: nil)
@@ -365,6 +370,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                     TVSeriesModeTab(
                         title: "Show",
                         isSelected: isShowingSeriesOverview,
+                        rendersFocusedAppearance: presentedFocusedModeId == showModeId,
                         action: showSeriesOverview
                     )
                     .id(showModeId)
@@ -374,6 +380,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                         TVSeriesModeTab(
                             title: seasonLabel(season),
                             isSelected: !isShowingSeriesOverview && selectedSeason?.id == season.id,
+                            rendersFocusedAppearance: presentedFocusedModeId == season.id,
                             action: { activateSeason(season) }
                         )
                         .id(season.id)
@@ -391,11 +398,20 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                 priority: .userInitiated
             )
             .onChange(of: selectedModeId) { _, newId in
+                // A click activates immediately, before the focus-paint dwell
+                // finishes. Promote that one focused tab without allowing an
+                // independently cached highlight to survive on the old tab.
+                if focusedModeId == newId {
+                    modeFocusAppearanceTask?.cancel()
+                    modeFocusAppearanceTask = nil
+                    presentedFocusedModeId = newId
+                }
                 withAnimation(.easeOut(duration: ContinuumTheme.fastDuration)) {
                     proxy.scrollTo(newId, anchor: .center)
                 }
             }
             .onChange(of: focusedModeId) { _, focusedId in
+                updateModeFocusAppearance(for: focusedId)
                 guard let focusedId else {
                     modeActivationTask?.cancel()
                     modeActivationTask = nil
@@ -404,6 +420,28 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                 primaryFocusRegion = .mode
                 scheduleModeActivation(for: focusedId)
             }
+        }
+    }
+
+    /// Own the row's focus paint in one place so rapid lateral input can show
+    /// at most one white pill. The short dwell still filters the sub-frame
+    /// focus offer produced by a downward gesture into the episode rail.
+    private func updateModeFocusAppearance(for modeId: String?) {
+        modeFocusAppearanceTask?.cancel()
+        modeFocusAppearanceTask = nil
+        presentedFocusedModeId = nil
+
+        guard let modeId else { return }
+        if modeId == selectedModeId {
+            presentedFocusedModeId = modeId
+            return
+        }
+
+        modeFocusAppearanceTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(150))
+            guard !Task.isCancelled, focusedModeId == modeId else { return }
+            presentedFocusedModeId = modeId
+            modeFocusAppearanceTask = nil
         }
     }
 
@@ -931,6 +969,7 @@ private extension View {
 private struct TVSeriesModeTab: View {
     let title: String
     let isSelected: Bool
+    let rendersFocusedAppearance: Bool
     let action: () -> Void
 
     var body: some View {
@@ -940,18 +979,25 @@ private struct TVSeriesModeTab: View {
                 .padding(.horizontal, 24)
                 .frame(height: 52)
         }
-        .buttonStyle(TVSeriesModeTabStyle(isSelected: isSelected))
+        .buttonStyle(
+            TVSeriesModeTabStyle(
+                isSelected: isSelected,
+                rendersFocusedAppearance: rendersFocusedAppearance
+            )
+        )
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 }
 
 private struct TVSeriesModeTabStyle: ButtonStyle {
     let isSelected: Bool
+    let rendersFocusedAppearance: Bool
 
     func makeBody(configuration: Configuration) -> some View {
         TVSeriesModeTabBody(
             configuration: configuration,
-            isSelected: isSelected
+            isSelected: isSelected,
+            rendersFocusedAppearance: rendersFocusedAppearance
         )
     }
 }
@@ -959,8 +1005,7 @@ private struct TVSeriesModeTabStyle: ButtonStyle {
 private struct TVSeriesModeTabBody: View {
     let configuration: ButtonStyleConfiguration
     let isSelected: Bool
-    @Environment(\.isFocused) private var isFocused
-    @State private var rendersFocusedAppearance = false
+    let rendersFocusedAppearance: Bool
 
     var body: some View {
         configuration.label
@@ -984,28 +1029,6 @@ private struct TVSeriesModeTabBody: View {
                 value: rendersFocusedAppearance
             )
             .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: isSelected)
-            .task(id: isFocused) {
-                guard isFocused else {
-                    rendersFocusedAppearance = false
-                    return
-                }
-                if isSelected {
-                    rendersFocusedAppearance = true
-                    return
-                }
-                // A downward Siri Remote gesture can briefly offer focus to a
-                // neighboring pill before entering the episode composite.
-                // Ignore that sub-frame transient without delaying the current
-                // selected season or changing normal lateral navigation.
-                try? await Task.sleep(for: .milliseconds(150))
-                guard !Task.isCancelled, isFocused else { return }
-                rendersFocusedAppearance = true
-            }
-            .onChange(of: isSelected) { _, selected in
-                if selected && isFocused {
-                    rendersFocusedAppearance = true
-                }
-            }
     }
 }
 #endif

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -1,5 +1,6 @@
 #if os(tvOS)
 import SwiftUI
+import UIKit
 
 /// Single-page Series experience for tvOS. `Show` and every season are
 /// in-place modes: the series backdrop never changes, episode focus updates
@@ -12,14 +13,123 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         case episodes
     }
 
-    /// A frozen copy of the visible season rail. Keeping the outgoing page
-    /// separate from the live incoming rail lets one signed progress value move
-    /// both pages, so reversing direction can never reuse a stale transition.
+    /// Stable data for one page in the full linear season rail. Page geometry
+    /// is owned by the season list; only loaded season content is retained.
     private struct SeasonPageSnapshot {
         let seasonId: String
         let episodes: [EpisodeListItem]
         let currentContentId: String?
         let isLoading: Bool
+    }
+
+    /// Mutable observation storage that deliberately does not invalidate the
+    /// large detail view every display frame. It records the native scroll
+    /// view's presentation offset so a rapid reversal can stop the old motion
+    /// exactly where it is before issuing the newest destination.
+    private final class SeasonScrollTracker {
+        var liveOffset: CGFloat = 0
+    }
+
+    /// Owns only the outer vertical UIScrollView. Locking this concrete scroll
+    /// view leaves every nested horizontal season/episode rail fully native.
+    /// Its return animator can be stopped at the presentation position when a
+    /// rapid Down reverses direction, so an old trip to the hero cannot win.
+    private final class PageScrollCoordinator {
+        weak var scrollView: UIScrollView?
+        private var returnAnimator: UIViewPropertyAnimator?
+        private var animationGeneration = 0
+        private(set) var primaryOwnsViewport = false
+
+        func attach(_ scrollView: UIScrollView) {
+            guard self.scrollView !== scrollView else { return }
+            stopReturnAnimation()
+            self.scrollView = scrollView
+            if primaryOwnsViewport {
+                pinTopAndLock()
+            }
+        }
+
+        func enterPrimary(animated: Bool, reduceMotion: Bool) {
+            primaryOwnsViewport = true
+            stopReturnAnimation()
+            guard let scrollView else { return }
+
+            scrollView.isScrollEnabled = true
+            let target = topOffset(in: scrollView)
+            guard animated,
+                  !reduceMotion,
+                  abs(scrollView.contentOffset.y - target.y) > 0.5 else {
+                scrollView.setContentOffset(target, animated: false)
+                scrollView.isScrollEnabled = false
+                return
+            }
+
+            animationGeneration &+= 1
+            let generation = animationGeneration
+            let timing = UICubicTimingParameters(
+                controlPoint1: CGPoint(x: 0.4, y: 0),
+                controlPoint2: CGPoint(x: 0.2, y: 1)
+            )
+            let animator = UIViewPropertyAnimator(
+                duration: 0.55,
+                timingParameters: timing
+            )
+            returnAnimator = animator
+            animator.addAnimations { [weak scrollView] in
+                scrollView?.setContentOffset(target, animated: false)
+            }
+            animator.addCompletion { [weak self, weak scrollView] _ in
+                guard let self,
+                      self.animationGeneration == generation,
+                      self.primaryOwnsViewport,
+                      let scrollView else { return }
+                self.returnAnimator = nil
+                scrollView.setContentOffset(
+                    self.topOffset(in: scrollView),
+                    animated: false
+                )
+                scrollView.isScrollEnabled = false
+            }
+            animator.startAnimation()
+        }
+
+        func releasePrimary() {
+            primaryOwnsViewport = false
+            stopReturnAnimation()
+            scrollView?.isScrollEnabled = true
+        }
+
+        func detach() {
+            primaryOwnsViewport = false
+            stopReturnAnimation()
+            scrollView?.isScrollEnabled = true
+            scrollView = nil
+        }
+
+        private func pinTopAndLock() {
+            guard let scrollView else { return }
+            scrollView.setContentOffset(topOffset(in: scrollView), animated: false)
+            scrollView.isScrollEnabled = false
+        }
+
+        private func stopReturnAnimation() {
+            animationGeneration &+= 1
+            guard let returnAnimator else { return }
+            self.returnAnimator = nil
+            if returnAnimator.state == .active {
+                returnAnimator.stopAnimation(false)
+                returnAnimator.finishAnimation(at: .current)
+            } else {
+                returnAnimator.stopAnimation(true)
+            }
+        }
+
+        private func topOffset(in scrollView: UIScrollView) -> CGPoint {
+            CGPoint(
+                x: scrollView.contentOffset.x,
+                y: -scrollView.adjustedContentInset.top
+            )
+        }
     }
 
     let detail: ItemDetail
@@ -29,6 +139,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     let seasons: [Season]
     let selectedSeason: Season?
     let episodes: [EpisodeListItem]
+    let episodesBySeason: [Int: [EpisodeListItem]]
     let activeEpisodeContentId: String?
     let episodeFavoriteStates: [String: Bool]
     let isLoadingEpisodes: Bool
@@ -66,33 +177,33 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     @Namespace private var modeFocusNamespace
     @FocusState private var playFocused: Bool
     @FocusState private var showActionRowFocused: Bool
-    @FocusState private var similarRailFocused: Bool
     @FocusState private var focusedModeId: String?
     @State private var isShowingSeriesOverview = true
     @State private var focusedEpisodeContentId: String?
-    @State private var primaryViewportActive = false
     @State private var primaryFocusRegion: PrimaryFocusRegion = .outside
-    @State private var browseHoldRequest = 0
-    @State private var browseRestoreRequest = 0
     @State private var episodeRailFocusRequest = 0
     @State private var supportingRailFocusRequest = 0
+    @State private var supportingRailFocusGeneration = 0
     @State private var modeActivationTask: Task<Void, Never>?
     @State private var modeFocusAppearanceTask: Task<Void, Never>?
     @State private var presentedFocusedModeId: String?
-    @State private var seasonTransitionMovesForward = true
     @State private var seasonTransitionInFlight = false
     @State private var seasonTransitionTargetId: String?
-    @State private var pendingSeasonActivationId: String?
     @State private var seasonTransitionGeneration = 0
     @State private var seasonTransitionTask: Task<Void, Never>?
-    @State private var outgoingSeasonPage: SeasonPageSnapshot?
-    @State private var seasonPanProgress: CGFloat = 1
+    @State private var visibleSeasonId: String?
+    @State private var seasonPageSnapshots: [String: SeasonPageSnapshot] = [:]
+    @State private var seasonPageScrollPosition = ScrollPosition(x: 0)
+    @State private var seasonPageViewportWidth: CGFloat = 0
+    @State private var seasonScrollTracker = SeasonScrollTracker()
+    @State private var pageScrollCoordinator = PageScrollCoordinator()
     @State private var uiCustomization = UICustomizationPreferences.shared
     @ObservedObject private var profilePrefsStore = ProfilePrefsStore.shared
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private let showModeId = "series-show-overview"
     private let episodeSectionScrollId = "series-episode-section"
+    private let castSectionScrollId = "series-cast-section"
     private let heroScrollId = "series-hero"
     private let similarSectionScrollId = "series-similar-section"
 
@@ -109,15 +220,30 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                                 .id(episodeSectionScrollId)
                             if let cast = detail.cast, !cast.isEmpty {
                                 castSection(cast: cast)
+                                    .id(castSectionScrollId)
                             }
                             trailersSection
                             similarSection
-                                .focused($similarRailFocused)
                                 .id(similarSectionScrollId)
                             detailsSection
                         }
                         .padding(.horizontal, TVDetailLayout.horizontalInset)
                         .padding(.bottom, TVDetailLayout.pageBottomPadding)
+                    }
+                    .background {
+                        TVSeriesPageScrollResolver { scrollView in
+                            pageScrollCoordinator.attach(scrollView)
+                        }
+                    }
+                }
+                .onChange(of: supportingRailFocusRequest) { _, request in
+                    guard request > 0, hasCast else { return }
+                    if reduceMotion {
+                        scrollProxy.scrollTo(castSectionScrollId, anchor: .center)
+                    } else {
+                        withAnimation(.smooth(duration: 0.55, extraBounce: 0)) {
+                            scrollProxy.scrollTo(castSectionScrollId, anchor: .center)
+                        }
                     }
                 }
                 .ignoresSafeArea()
@@ -128,41 +254,27 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                     seasonRowFocused: false,
                     actionRowFocused: showActionRowFocused,
                     episodeSectionId: episodeSectionScrollId,
-                    heroId: heroScrollId,
-                    browseFocusKey: browseFocusKey,
-                    browseHoldRequest: browseHoldRequest,
-                    browseRestoreRequest: browseRestoreRequest,
-                    similarRailFocused: similarRailFocused,
-                    similarSectionId: similarSectionScrollId
+                    heroId: heroScrollId
                 )
-                .task(id: hasPrimaryFocus) {
-                    let focused = hasPrimaryFocus
-                    if focused {
-                        primaryViewportActive = true
-                    } else {
-                        // Keep the first viewport active across the short gap
-                        // between one programmatic focus owner releasing and
-                        // the next one accepting the same remote gesture.
-                        try? await Task.sleep(for: .milliseconds(180))
-                        guard !Task.isCancelled else { return }
-                        primaryViewportActive = false
-                        primaryFocusRegion = .outside
-                    }
-                }
             }
         }
         .onAppear {
             if activeEpisodeContentId != nil {
                 isShowingSeriesOverview = false
             }
+            synchronizeCurrentSeasonPage()
         }
         .onChange(of: activeEpisodeContentId) { _, contentId in
             if contentId != nil {
                 isShowingSeriesOverview = false
             }
         }
-        .onChange(of: selectedSeason?.id) { _, seasonId in
-            startSeasonPanIfReady(for: seasonId)
+        .onChange(of: seasonPageReadinessKey) { _, _ in
+            if seasonTransitionInFlight {
+                startSeasonScrollIfReady()
+            } else {
+                synchronizeCurrentSeasonPage()
+            }
         }
         .onDisappear {
             modeActivationTask?.cancel()
@@ -175,12 +287,14 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
             var transaction = Transaction(animation: nil)
             transaction.disablesAnimations = true
             withTransaction(transaction) {
-                outgoingSeasonPage = nil
-                seasonPanProgress = 1
+                seasonPageSnapshots.removeAll(keepingCapacity: false)
+                visibleSeasonId = nil
+                seasonPageScrollPosition = ScrollPosition(x: 0)
+                seasonScrollTracker.liveOffset = 0
             }
+            pageScrollCoordinator.detach()
             seasonTransitionInFlight = false
             seasonTransitionTargetId = nil
-            pendingSeasonActivationId = nil
         }
     }
 
@@ -379,7 +493,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                     ForEach(seasons) { season in
                         TVSeriesModeTab(
                             title: seasonLabel(season),
-                            isSelected: !isShowingSeriesOverview && selectedSeason?.id == season.id,
+                            isSelected: selectedModeId == season.id,
                             rendersFocusedAppearance: presentedFocusedModeId == season.id,
                             action: { activateSeason(season) }
                         )
@@ -417,7 +531,19 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                     modeActivationTask = nil
                     return
                 }
+                let previousRegion = primaryFocusRegion
                 primaryFocusRegion = .mode
+                if previousRegion == .outside {
+                    pageScrollCoordinator.enterPrimary(
+                        animated: true,
+                        reduceMotion: reduceMotion
+                    )
+                } else if previousRegion != .mode {
+                    pageScrollCoordinator.enterPrimary(
+                        animated: false,
+                        reduceMotion: reduceMotion
+                    )
+                }
                 scheduleModeActivation(for: focusedId)
             }
         }
@@ -438,7 +564,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         }
 
         modeFocusAppearanceTask = Task { @MainActor in
-            try? await Task.sleep(for: .milliseconds(150))
+            try? await Task.sleep(for: .milliseconds(70))
             guard !Task.isCancelled, focusedModeId == modeId else { return }
             presentedFocusedModeId = modeId
             modeFocusAppearanceTask = nil
@@ -446,13 +572,16 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     }
 
     private var selectedModeId: String {
-        isShowingSeriesOverview ? showModeId : (selectedSeason?.id ?? showModeId)
+        guard !isShowingSeriesOverview else { return showModeId }
+        return seasonTransitionTargetId
+            ?? visibleSeasonId
+            ?? selectedSeason?.id
+            ?? showModeId
     }
 
     private func showSeriesOverview() {
         modeActivationTask?.cancel()
         modeActivationTask = nil
-        pendingSeasonActivationId = nil
         isShowingSeriesOverview = true
         onActivateEpisode(nil)
     }
@@ -462,63 +591,121 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         modeActivationTask = nil
         isShowingSeriesOverview = false
         if seasonTransitionInFlight {
-            // A reversal must not mutate the direction of the page that is
-            // already moving. Retain only the viewer's latest destination and
-            // begin it after the current page settles.
-            pendingSeasonActivationId = season.id == seasonTransitionTargetId
-                ? nil
-                : season.id
+            guard season.id != seasonTransitionTargetId else { return }
+            retargetSeasonTransition(to: season)
             return
         }
-        guard selectedSeason?.id != season.id else {
-            pendingSeasonActivationId = nil
+        guard visibleSeasonId != season.id else {
             return
         }
         beginSeasonTransition(to: season)
     }
 
     private func beginSeasonTransition(to season: Season) {
-        pendingSeasonActivationId = nil
-        if let targetIndex = seasons.firstIndex(where: { $0.id == season.id }),
-           let currentId = selectedSeason?.id,
-           let currentIndex = seasons.firstIndex(where: { $0.id == currentId }) {
-            seasonTransitionMovesForward = targetIndex > currentIndex
-        }
-
-        outgoingSeasonPage = SeasonPageSnapshot(
-            seasonId: selectedSeason?.id ?? "series-season-none",
-            episodes: episodes,
-            currentContentId: displayedEpisode?.contentId,
-            isLoading: isLoadingEpisodes
-        )
+        let currentPage = currentSeasonPageSnapshot
         var transaction = Transaction(animation: nil)
         transaction.disablesAnimations = true
         withTransaction(transaction) {
-            seasonPanProgress = 0
+            seasonPageSnapshots[currentPage.seasonId] = currentPage
+            visibleSeasonId = currentPage.seasonId
         }
 
         seasonTransitionTask?.cancel()
+        seasonTransitionTask = nil
         seasonTransitionGeneration &+= 1
         seasonTransitionInFlight = true
         seasonTransitionTargetId = season.id
         onActivateEpisode(nil)
         onSelectSeason(season)
+        startMountedSeasonScrollIfAvailable(to: season.id)
     }
 
-    private func startSeasonPanIfReady(for seasonId: String?) {
-        guard seasonTransitionInFlight,
-              seasonId == seasonTransitionTargetId,
-              outgoingSeasonPage != nil else { return }
-
+    private func retargetSeasonTransition(to season: Season) {
+        // Stop the current native animation at its presentation offset before
+        // giving it a new destination. Without this freeze, several opposing
+        // setContentOffset animations can finish out of order under rapid taps.
         seasonTransitionTask?.cancel()
+        seasonTransitionTask = nil
+        freezeSeasonScrollAtLiveOffset()
+        seasonTransitionGeneration &+= 1
+        seasonTransitionTargetId = season.id
+        onActivateEpisode(nil)
+        onSelectSeason(season)
+        startMountedSeasonScrollIfAvailable(to: season.id)
+    }
+
+    private func startSeasonScrollIfReady() {
+        guard seasonTransitionInFlight,
+              seasonTransitionTask == nil,
+              let targetId = seasonTransitionTargetId,
+              selectedSeason?.id == targetId,
+              let targetSeason = seasons.first(where: { $0.id == targetId }),
+              !isLoadingEpisodes,
+              seasonPageViewportWidth > 0 else { return }
+
+        // The selected season publishes before its episode request completes.
+        // Do not move the old page toward a loading placeholder or stale rows;
+        // the complete incoming rail must be mounted before native scrolling.
+        guard episodes.isEmpty || episodes.allSatisfy({
+            $0.seasonNumber == targetSeason.seasonNumber
+        }) else { return }
+
+        let incomingPage = currentSeasonPageSnapshot
+        guard incomingPage.seasonId == targetId,
+              let destinationOffset = seasonPageOffset(
+                for: targetId,
+                pageWidth: seasonPageViewportWidth
+              ) else { return }
+
+        var mountTransaction = Transaction(animation: nil)
+        mountTransaction.disablesAnimations = true
+        withTransaction(mountTransaction) {
+            // Populate the target's permanent slot before the rail moves. The
+            // old and new seasons now coexist as literal neighbours in one
+            // HStack, rather than swapping through a temporary side page.
+            seasonPageSnapshots[targetId] = incomingPage
+        }
+        startSeasonScroll(
+            to: targetId,
+            destinationOffset: destinationOffset,
+            waitsForPageMount: true
+        )
+    }
+
+    private func startMountedSeasonScrollIfAvailable(to targetId: String) {
+        guard let targetSeason = seasons.first(where: { $0.id == targetId }),
+              let mountedPage = availableSeasonPage(for: targetSeason),
+              let destinationOffset = seasonPageOffset(
+                for: targetId,
+                pageWidth: seasonPageViewportWidth
+              ) else { return }
+        if seasonPageSnapshots[targetId] == nil {
+            var transaction = Transaction(animation: nil)
+            transaction.disablesAnimations = true
+            withTransaction(transaction) {
+                seasonPageSnapshots[targetId] = mountedPage
+            }
+        }
+        startSeasonScroll(
+            to: targetId,
+            destinationOffset: destinationOffset,
+            waitsForPageMount: false
+        )
+    }
+
+    private func startSeasonScroll(
+        to targetId: String,
+        destinationOffset: CGFloat,
+        waitsForPageMount: Bool
+    ) {
+        guard seasonTransitionInFlight,
+              seasonTransitionTargetId == targetId,
+              seasonTransitionTask == nil else { return }
+
         let generation = seasonTransitionGeneration
         seasonTransitionTask = Task { @MainActor in
-            // Allow the newly selected season rail to mount at its settled
-            // internal episode offset before the full-width page starts moving.
             await Task.yield()
-            if !reduceMotion {
-                // Give the incoming episode render surface one display frame
-                // to paint before moving it, avoiding a small first-frame hitch.
+            if waitsForPageMount && !reduceMotion {
                 try? await Task.sleep(for: .milliseconds(17))
             }
             guard !Task.isCancelled,
@@ -529,7 +716,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                     ? nil
                     : .timingCurve(0.4, 0, 0.2, 1, duration: 0.46)
             ) {
-                seasonPanProgress = 1
+                seasonPageScrollPosition = ScrollPosition(x: destinationOffset)
             }
 
             if !reduceMotion {
@@ -544,21 +731,32 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     }
 
     private func finishSeasonTransition() {
+        guard let completedSeasonId = seasonTransitionTargetId else {
+            seasonTransitionInFlight = false
+            seasonTransitionTask = nil
+            return
+        }
         var transaction = Transaction(animation: nil)
         transaction.disablesAnimations = true
         withTransaction(transaction) {
-            outgoingSeasonPage = nil
-            seasonPanProgress = 1
+            // Stay on the real destination page. There is deliberately no
+            // recenter, page deletion, or content replacement after scrolling.
+            visibleSeasonId = completedSeasonId
+            if let offset = seasonPageOffset(
+                for: completedSeasonId,
+                pageWidth: seasonPageViewportWidth
+            ) {
+                // Programmatic native scrolling can still be completing an
+                // older animation when direction reverses. Pin the final
+                // content offset to the latest requested season so the rail
+                // and selected tab can never settle on different pages.
+                seasonPageScrollPosition = ScrollPosition(x: offset)
+                seasonScrollTracker.liveOffset = offset
+            }
         }
         seasonTransitionInFlight = false
         seasonTransitionTargetId = nil
         seasonTransitionTask = nil
-
-        guard let pendingId = pendingSeasonActivationId else { return }
-        pendingSeasonActivationId = nil
-        guard pendingId != selectedSeason?.id,
-              let pendingSeason = seasons.first(where: { $0.id == pendingId }) else { return }
-        beginSeasonTransition(to: pendingSeason)
     }
 
     /// Season pills behave like tvOS tabs: resting focus activates one without
@@ -570,7 +768,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         guard modeId != selectedModeId else { return }
 
         modeActivationTask = Task { @MainActor in
-            try? await Task.sleep(for: .milliseconds(160))
+            try? await Task.sleep(for: .milliseconds(70))
             guard !Task.isCancelled,
                   focusedModeId == modeId,
                   modeId != selectedModeId else { return }
@@ -583,97 +781,199 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         }
     }
 
-    /// Holds the episode area to one measured Home-card footprint while each
-    /// season behaves as a full-width carousel page. Only this viewport moves;
-    /// the season tabs, controls, and every lower section remain fixed. The
-    /// episode rail owns its own crop, so this wrapper must not cut off the
-    /// trailing page inset the rail deliberately borrows.
+    private var seasonPageReadinessKey: String {
+        let seasonId = selectedSeason?.id ?? "series-season-none"
+        let loadingState = isLoadingEpisodes ? "loading" : "ready"
+        let episodeIds = episodes.map(\.contentId).joined(separator: "|")
+        return "\(seasonId):\(loadingState):\(episodeIds)"
+    }
+
+    private var currentSeasonPageSnapshot: SeasonPageSnapshot {
+        SeasonPageSnapshot(
+            seasonId: selectedSeason?.id ?? "series-season-none",
+            episodes: episodes,
+            currentContentId: displayedEpisode?.contentId,
+            isLoading: isLoadingEpisodes
+        )
+    }
+
+    private func synchronizeCurrentSeasonPage() {
+        guard !seasonTransitionInFlight else { return }
+        let page = currentSeasonPageSnapshot
+        var transaction = Transaction(animation: nil)
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            seasonPageSnapshots[page.seasonId] = page
+            visibleSeasonId = page.seasonId
+            if let offset = seasonPageOffset(
+                for: page.seasonId,
+                pageWidth: seasonPageViewportWidth
+            ) {
+                seasonPageScrollPosition = ScrollPosition(x: offset)
+                seasonScrollTracker.liveOffset = offset
+            }
+        }
+    }
+
+    /// The fixed season tabs select between full-width episode pages. The
+    /// inner episode carousel remains unchanged; this native outer ScrollView
+    /// moves the complete old and new season rails together as one page.
     private var smoothlyChangingEpisodeBody: some View {
         GeometryReader { geometry in
             let width = geometry.size.width
             let viewportWidth = width + TVDetailLayout.horizontalInset
-            let leftClipCanvasWidth = viewportWidth * 2
-            let direction: CGFloat = seasonTransitionMovesForward ? 1 : -1
 
-            ZStack(alignment: .topLeading) {
-                if let outgoingSeasonPage {
-                    snapshotEpisodeBody(outgoingSeasonPage)
-                        .id(outgoingSeasonPage.seasonId)
-                        .frame(
-                            width: width,
-                            height: episodeRailReservedHeight,
-                            alignment: .topLeading
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(alignment: .top, spacing: 0) {
+                    ForEach(seasons) { season in
+                        seasonRailPage(
+                            for: season,
+                            contentWidth: width,
+                            pageWidth: viewportWidth
                         )
-                        // Preserve the rail's existing layout width, then
-                        // widen only the temporary raster surface so its
-                        // borrowed trailing inset is never cropped.
-                        .frame(
-                            width: viewportWidth,
-                            height: episodeRailReservedHeight,
-                            alignment: .topLeading
+                        .id(season.id)
+                        // Only the page currently inside the viewport may
+                        // participate in tvOS focus. Cached rails elsewhere on
+                        // the giant strip remain visual neighbours, not rival
+                        // focus destinations.
+                        .disabled(
+                            season.id != (visibleSeasonId ?? selectedSeason?.id)
                         )
-                        // The outgoing tab page is immutable. Rasterize it
-                        // once before the existing page offset so episode art
-                        // and its number/title cannot render on separate paths.
-                        .drawingGroup(opaque: false, colorMode: .nonLinear)
-                        .offset(x: -direction * seasonPanProgress * viewportWidth)
-                        .allowsHitTesting(false)
-                        .accessibilityHidden(true)
+                    }
                 }
-
-                liveEpisodePage
-                    .frame(
-                        width: width,
-                        height: episodeRailReservedHeight,
-                        alignment: .topLeading
-                    )
-                    .frame(
-                        width: viewportWidth,
-                        height: episodeRailReservedHeight,
-                        alignment: .topLeading
-                    )
-                    .lockEpisodeCaptionsForSeasonTabSwitch(
-                        outgoingSeasonPage != nil
-                    )
-                    .offset(
-                        x: outgoingSeasonPage == nil
-                            ? 0
-                            : direction * (1 - seasonPanProgress) * viewportWidth
-                    )
+                .scrollTargetLayout()
             }
-            // Retain the settled rail's leading crop, but put the matching
-            // right crop a full page beyond the visible display. Cards can
-            // then cross the screen's trailing edge without a transient cut.
+            .scrollPosition($seasonPageScrollPosition)
+            .scrollTargetBehavior(.paging)
+            .scrollDisabled(true)
             .frame(
-                width: leftClipCanvasWidth,
+                width: viewportWidth,
                 height: episodeRailReservedHeight,
                 alignment: .topLeading
             )
             .clipped()
+            .onScrollGeometryChange(for: CGFloat.self) { geometry in
+                geometry.contentOffset.x
+            } action: { _, liveOffset in
+                seasonScrollTracker.liveOffset = liveOffset
+            }
+            .onAppear {
+                updateSeasonPageViewportWidth(viewportWidth)
+            }
+            .onChange(of: viewportWidth) { _, newWidth in
+                updateSeasonPageViewportWidth(newWidth)
+            }
         }
         .frame(height: episodeRailReservedHeight, alignment: .topLeading)
     }
 
-    private var liveEpisodePage: some View {
-        ZStack(alignment: .topLeading) {
-            episodeBody
-                .id(isLoadingEpisodes ? "loading" : "ready")
-                // The season-page slide already supplies the transition.
-                // Avoid fading its episode paint at the same time, which
-                // briefly dimmed the cards and added competing composition.
-                .transition(outgoingSeasonPage == nil ? .opacity : .identity)
+    /// Every real season owns one permanent, page-width position in a single
+    /// linear rail. Unloaded positions stay lightweight, while the current and
+    /// target episode carousels remain attached to their actual season slots.
+    @ViewBuilder
+    private func seasonRailPage(
+        for season: Season,
+        contentWidth: CGFloat,
+        pageWidth: CGFloat
+    ) -> some View {
+        if let page = availableSeasonPage(for: season) {
+            seasonEpisodeBody(page)
+                .frame(
+                    width: contentWidth,
+                    height: episodeRailReservedHeight,
+                    alignment: .topLeading
+                )
+                .frame(
+                    width: pageWidth,
+                    height: episodeRailReservedHeight,
+                    alignment: .topLeading
+                )
+        } else if !seasonTransitionInFlight, selectedSeason?.id == season.id {
+            seasonEpisodeBody(currentSeasonPageSnapshot)
+                .frame(
+                    width: contentWidth,
+                    height: episodeRailReservedHeight,
+                    alignment: .topLeading
+                )
+                .frame(
+                    width: pageWidth,
+                    height: episodeRailReservedHeight,
+                    alignment: .topLeading
+                )
+        } else {
+            Color.clear
+                .frame(
+                    width: pageWidth,
+                    height: episodeRailReservedHeight,
+                    alignment: .topLeading
+                )
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .animation(
-            reduceMotion || outgoingSeasonPage != nil
-                ? nil
-                : .easeInOut(duration: 0.18),
-            value: isLoadingEpisodes
+    }
+
+    private func availableSeasonPage(for season: Season) -> SeasonPageSnapshot? {
+        if let snapshot = seasonPageSnapshots[season.id] {
+            return snapshot
+        }
+        guard let cachedEpisodes = episodesBySeason[season.seasonNumber] else {
+            return nil
+        }
+        let suggestedContentId = cachedEpisodes.first(where: {
+            $0.userData?.isInProgress == true
+        })?.contentId ?? cachedEpisodes.first(where: {
+            !($0.userData?.played ?? false)
+        })?.contentId ?? cachedEpisodes.first?.contentId
+        return SeasonPageSnapshot(
+            seasonId: season.id,
+            episodes: cachedEpisodes,
+            currentContentId: suggestedContentId,
+            isLoading: false
         )
     }
 
+    private func updateSeasonPageViewportWidth(_ width: CGFloat) {
+        guard width > 0, width != seasonPageViewportWidth else { return }
+        var transaction = Transaction(animation: nil)
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            seasonPageViewportWidth = width
+            let seasonId = visibleSeasonId ?? selectedSeason?.id
+            let offset = seasonId.flatMap {
+                seasonPageOffset(for: $0, pageWidth: width)
+            } ?? 0
+            seasonPageScrollPosition = ScrollPosition(x: offset)
+            seasonScrollTracker.liveOffset = offset
+        }
+        startSeasonScrollIfReady()
+    }
+
+    private func freezeSeasonScrollAtLiveOffset() {
+        guard seasonPageViewportWidth > 0 else { return }
+        let lastOffset = CGFloat(max(seasons.count - 1, 0))
+            * seasonPageViewportWidth
+        let liveOffset = min(
+            max(seasonScrollTracker.liveOffset, 0),
+            lastOffset
+        )
+        var transaction = Transaction(animation: nil)
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            seasonPageScrollPosition = ScrollPosition(x: liveOffset)
+        }
+    }
+
+    private func seasonPageOffset(
+        for seasonId: String,
+        pageWidth: CGFloat
+    ) -> CGFloat? {
+        guard pageWidth > 0,
+              let index = seasons.firstIndex(where: { $0.id == seasonId }) else {
+            return nil
+        }
+        return CGFloat(index) * pageWidth
+    }
+
     @ViewBuilder
-    private func snapshotEpisodeBody(_ snapshot: SeasonPageSnapshot) -> some View {
+    private func seasonEpisodeBody(_ snapshot: SeasonPageSnapshot) -> some View {
         if snapshot.isLoading {
             TVEpisodeRailPlaceholder(
                 cardWidth: ContinuumTheme.thumbnailCardWidth
@@ -691,13 +991,24 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         } else {
             TVEpisodeRail(
                 episodes: snapshot.episodes,
-                onSelect: { _ in },
+                onSelect: quickPlayEpisode,
+                onPlay: quickPlayEpisode,
+                onFocusedEpisodeChange: focusEpisode,
+                onSetWatched: onSetEpisodeWatched,
+                onSetFavorite: onSetEpisodeFavorite,
                 currentContentId: snapshot.currentContentId,
+                currentContentIsFavorite: snapshot.currentContentId.map {
+                    episodeFavoriteStates[$0] ?? false
+                } ?? false,
+                favoriteStates: episodeFavoriteStates,
                 baseCardWidth: ContinuumTheme.thumbnailCardWidth,
                 cardHeightRatio: ContinuumTheme.thumbnailCardHeight
                     / ContinuumTheme.thumbnailCardWidth,
                 cardSpacing: 40,
-                anchorsFocusedCard: true
+                anchorsFocusedCard: true,
+                onMoveUp: focusSelectedMode,
+                onMoveDown: focusPlaybackSelector,
+                focusRequest: episodeRailFocusRequest
             )
             .padding(.trailing, -TVDetailLayout.horizontalInset)
         }
@@ -713,78 +1024,50 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
             + 24
     }
 
-    @ViewBuilder
-    private var episodeBody: some View {
-        if selectedSeason == nil && seasons.isEmpty {
-            EmptyView()
-        } else if isLoadingEpisodes {
-            TVEpisodeRailPlaceholder(
-                cardWidth: ContinuumTheme.thumbnailCardWidth
-                    * uiCustomization.cardPresentation.posterSize.scale,
-                cardHeightRatio: ContinuumTheme.thumbnailCardHeight
-                    / ContinuumTheme.thumbnailCardWidth,
-                cardSpacing: 40,
-                hidesEpisodeTitle: true
-            )
-        } else if episodes.isEmpty {
-            Text("No episodes available")
-                .font(.system(size: 22, weight: .regular))
-                .foregroundColor(.continuumSecondaryText)
-                .frame(maxWidth: .infinity, alignment: .topLeading)
-        } else {
-            TVEpisodeRail(
-                episodes: episodes,
-                onSelect: quickPlayEpisode,
-                onPlay: quickPlayEpisode,
-                onFocusedEpisodeChange: focusEpisode,
-                onSetWatched: onSetEpisodeWatched,
-                onSetFavorite: onSetEpisodeFavorite,
-                currentContentId: displayedEpisode?.contentId,
-                currentContentIsFavorite: displayedEpisode.map {
-                    episodeFavoriteStates[$0.contentId] ?? false
-                } ?? false,
-                favoriteStates: episodeFavoriteStates,
-                baseCardWidth: ContinuumTheme.thumbnailCardWidth,
-                cardHeightRatio: ContinuumTheme.thumbnailCardHeight
-                    / ContinuumTheme.thumbnailCardWidth,
-                cardSpacing: 40,
-                anchorsFocusedCard: true,
-                onMoveUp: focusSelectedMode,
-                onMoveDown: focusPlaybackSelector,
-                focusRequest: episodeRailFocusRequest
-            )
-            // The body already owns a 100-point page inset. Let only this
-            // Series carousel borrow the trailing inset so its third visible
-            // large card and focus ring remain complete at every step.
-            .padding(.trailing, -TVDetailLayout.horizontalInset)
-        }
-    }
-
     private func focusSelectedMode() {
         focusedModeId = selectedModeId
     }
 
     private func focusPlaybackSelector() {
-        // Selectors now live in the persistent hero action row. Preserve the
-        // carousel's existing Down exit by handing off to the next supporting
-        // rail instead of leaving a dead lower focus target.
-        supportingRailFocusRequest &+= 1
+        focusSupportingRail()
     }
 
     private func focusSupportingRail() {
-        supportingRailFocusRequest &+= 1
+        // The focus engine snapshots scroll eligibility before delivering the
+        // episode rail's move command. Unlock now, then request Cast on the
+        // next main-loop turn so its first focus update receives native reveal.
+        pageScrollCoordinator.releasePrimary()
+        primaryFocusRegion = .outside
+        supportingRailFocusGeneration &+= 1
+        let generation = supportingRailFocusGeneration
+        DispatchQueue.main.async {
+            guard supportingRailFocusGeneration == generation,
+                  primaryFocusRegion == .outside else { return }
+            supportingRailFocusRequest &+= 1
+        }
     }
 
     private func focusEpisode(_ contentId: String?) {
         focusedEpisodeContentId = contentId
         guard let contentId else { return }
 
+        // Cancel a queued Episodes -> Cast handoff if focus has already moved
+        // back into the fixed top viewport before the next focus update.
+        supportingRailFocusGeneration &+= 1
         let previousRegion = primaryFocusRegion
         primaryFocusRegion = .episodes
         switch previousRegion {
         case .mode:
-            browseHoldRequest &+= 1
-        case .outside, .episodes:
+            pageScrollCoordinator.enterPrimary(
+                animated: false,
+                reduceMotion: reduceMotion
+            )
+        case .outside:
+            pageScrollCoordinator.enterPrimary(
+                animated: true,
+                reduceMotion: reduceMotion
+            )
+        case .episodes:
             break
         }
 
@@ -802,15 +1085,6 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
             episode.flatMap { selectedFileId(for: $0) },
             false
         )
-    }
-
-    private var browseFocusKey: String? {
-        primaryViewportActive ? "series-primary" : nil
-    }
-
-    private var hasPrimaryFocus: Bool {
-        focusedEpisodeContentId != nil
-            || focusedModeId != nil
     }
 
     private var moreMenu: some View {
@@ -936,6 +1210,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                 focusRequest: supportingRailFocusRequest
             )
         }
+        .padding(.top, 20)
     }
 
     private var hasCast: Bool {
@@ -950,16 +1225,60 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     }
 }
 
-private extension View {
-    /// During a Series season-tab page switch only, flatten the incoming page
-    /// before its existing offset animates. Outside that short transition the
-    /// live episode carousel is returned unchanged.
-    @ViewBuilder
-    func lockEpisodeCaptionsForSeasonTabSwitch(_ isSwitching: Bool) -> some View {
-        if isSwitching {
-            drawingGroup(opaque: false, colorMode: .nonLinear)
-        } else {
-            self
+/// Resolves the UIKit scroll view that directly owns the Series page. The
+/// marker sits behind the root vertical content, so its nearest scroll-view
+/// ancestor is never one of the nested horizontal rails.
+private struct TVSeriesPageScrollResolver: UIViewRepresentable {
+    let onResolve: (UIScrollView) -> Void
+
+    func makeUIView(context: Context) -> ResolverView {
+        let view = ResolverView()
+        view.isUserInteractionEnabled = false
+        view.backgroundColor = .clear
+        view.onResolve = onResolve
+        return view
+    }
+
+    func updateUIView(_ uiView: ResolverView, context: Context) {
+        uiView.onResolve = onResolve
+        uiView.resolveIfNeeded()
+    }
+
+    final class ResolverView: UIView {
+        var onResolve: ((UIScrollView) -> Void)?
+        private weak var resolvedScrollView: UIScrollView?
+        private var resolutionScheduled = false
+
+        override func didMoveToSuperview() {
+            super.didMoveToSuperview()
+            resolveIfNeeded()
+        }
+
+        override func didMoveToWindow() {
+            super.didMoveToWindow()
+            resolveIfNeeded()
+        }
+
+        func resolveIfNeeded() {
+            if let resolvedScrollView {
+                onResolve?(resolvedScrollView)
+                return
+            }
+            guard !resolutionScheduled else { return }
+            resolutionScheduled = true
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                self.resolutionScheduled = false
+                var ancestor = self.superview
+                while let view = ancestor {
+                    if let scrollView = view as? UIScrollView {
+                        self.resolvedScrollView = scrollView
+                        self.onResolve?(scrollView)
+                        return
+                    }
+                    ancestor = view.superview
+                }
+            }
         }
     }
 }

--- a/iosApp/iosApp/tvOS/Screens/Libraries/TVLibraryCollectionsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Libraries/TVLibraryCollectionsView.swift
@@ -12,7 +12,7 @@ struct TVLibraryCollectionsView: View {
     /// Whether the top menu currently holds focus; deferred entry claims
     /// are dropped while the user is up in the menu.
     var isTopMenuFocused: Bool = false
-    /// Boundary hand-up toward the pill row for the first card.
+    /// Boundary hand-up toward the pill row for the first visual grid row.
     let onMoveUp: (() -> Void)?
 
     @State private var collectionSections: [LibraryCollectionSection] = []
@@ -66,6 +66,9 @@ struct TVLibraryCollectionsView: View {
                 .first(where: { !$0.collections.isEmpty })
             let firstSectionId = focusTarget?.id
             let firstCardId = focusTarget?.collections.first?.id
+            let firstVisualRowIds = Set(
+                focusTarget?.collections.prefix(resolvedColumnCount).map(\.id) ?? []
+            )
 
             VStack(alignment: .leading, spacing: 44) {
                 ForEach(collectionSections) { section in
@@ -98,12 +101,15 @@ struct TVLibraryCollectionsView: View {
                             ForEach(section.collections) { collection in
                                 let isFirstOverall =
                                     section.id == firstSectionId && collection.id == firstCardId
+                                let isInFirstVisualRow =
+                                    section.id == firstSectionId
+                                    && firstVisualRowIds.contains(collection.id)
                                 TVCollectionCard(
                                     collection: collection,
                                     prefersDefaultFocus: isFirstOverall,
                                     defaultFocusNamespace: collectionsFocusNamespace,
                                     focusRequest: isFirstOverall ? contentFocusToken : 0,
-                                    onMoveUp: isFirstOverall ? onMoveUp : nil,
+                                    onMoveUp: isInFirstVisualRow ? onMoveUp : nil,
                                     action: {
                                         router.navigate(to: .libraryCollection(
                                             libraryId: library.id,
@@ -202,9 +208,8 @@ struct TVLibraryCollectionsView: View {
 
 // MARK: - Collection card
 
-/// Attaches an Up-move handler only when one is supplied, so that cards which
-/// should NOT hand focus up (every card except the first) don't intercept and
-/// consume the Up command the focus engine needs to move between grid rows.
+/// Attaches an Up-move handler only when one is supplied, so lower grid rows
+/// do not intercept the command the focus engine needs to move upward.
 private struct TVCollectionCardMoveUpHandler: ViewModifier {
     let onMoveUp: (() -> Void)?
 
@@ -224,7 +229,7 @@ private struct TVCollectionCardMoveUpHandler: ViewModifier {
 
 /// Grid wrapper around `TVCollectionPosterCard` (§6.3) that carries the
 /// Collections pill's focus machinery: the programmatic entry kick, the
-/// first-card hand-up to the pill row, and the recycle guard. The visual
+/// first-row hand-up to the pill row, and the recycle guard. The visual
 /// is the shared poster card; this struct owns only focus plumbing.
 private struct TVCollectionCard: View {
     let collection: LibraryCollection
@@ -235,10 +240,9 @@ private struct TVCollectionCard: View {
     /// `prefersDefaultFocus` alone doesn't fire when the scope isn't being
     /// entered by the engine.
     var focusRequest: Int = 0
-    /// Supplied only to the first collection card: Up returns focus to the
-    /// pill row — the Collections analogue of the Browse layout's first-row
-    /// hand-up. Attached to this card alone so Up from lower grid rows still
-    /// moves to the row above instead of jumping to the chrome.
+    /// Supplied to every card in the first visual grid row: Up returns focus
+    /// to the pill row. Lower rows omit it so native grid movement still walks
+    /// through every intervening collection row.
     var onMoveUp: (() -> Void)? = nil
     let action: () -> Void
 


### PR DESCRIPTION
## What this changes

I designed and directed a full tvOS usability and performance pass through iterative Apple TV simulator testing. The goal was to make every main surface feel like one app, keep remote navigation predictable, and remove visible loading from the paths people use most.

This is the complete simulator-tested pass, including the later fixes that came out of repeatedly trying to break the first versions with fast remote input. It covers the shared landing pages, the final Series season rail, the episode carousel, the vertical Series focus path, and the playback-completion handoff back into Home and Series detail.

### One visual system across every root page

- Movies, Series, and For You now use the same hero height, vertical positioning, row rhythm, and top navigation geometry as Home.
- For You is rebuilt on the shared Skyline presentation instead of feeling like a separate page. Its old Watchlist and Favorites sub-tabs are removed.
- Watchlist and Favorites retain the Silo logo, top tab bar, profile, and settings shell, and use a stable eight-poster grid on tvOS.
- Poster and Continue Watching labels use the same smaller readable type treatment, with single-line truncation for long titles so text never spills into another card.
- Runtime is included with the main hero metadata across Home and the root tabs. Continue Watching adds time remaining only when a real started watch state exists.
- Ratings and other For You metadata are prefetched and given stable layout space so they do not arrive late and push the title around.
- Episode season/episode pills are removed from normal cards while server-controlled technical overlays such as 4K, Dolby Vision, and EAC3 remain intact.

### Remote and focus behavior

- Home, Movies, Series, and For You now leave normal Up/Down movement to the native tvOS focus engine and vertical `ScrollView` geometry.
- Every landing-page row stays mounted in a regular `VStack`, so the Focus Engine always has a real row above and below to discover. The prior lazy stack could remove the clipped neighbour at exactly the moment focus needed it.
- Programmatic focus is now limited to entering content, restoring the exact launch card after returning from detail, and the intentional first-row-to-top-menu boundary. Normal row movement no longer uses delayed focus claims or animation timers.
- Moving horizontally several posters into a row and then pressing Up or Down no longer resets that row to its first poster.
- Moving down from a horizontally scrolled Continue Watching row no longer drags the destination row sideways to an unrelated poster; the move is vertical and native.
- Rapid Up/Down input no longer leaves focus between rows or allows an older delayed request to pull focus back after the user has already moved again.
- Focus can always return from lower rows to the first row and from the first row to the persistent top menu.
- Watchlist and Favorites hand focus cleanly between their first row and the persistent top shell.
- Card clicks continue to use the optimized shared detail route, including For You.
- The root-page change is intentionally isolated to Home, Movies, Series, and For You. It does not replace or split the Movies/Series library dropdown, which remains one composite two-column control by design.

### Detail-page continuity

- Movie and Series detail backdrops use the same artwork sizing and positioning as the landing hero, making selection feel like a continuous open rather than a visual jump.
- The shared backdrop mask now fades smoothly into the page instead of ending at a hard horizontal line.
- Series detail keeps its hero, season tabs, and episodes as one locked first viewport. Moving horizontally through episodes does not count as scrolling down the page.
- The first Down from Episodes now deliberately unlocks the outer vertical scroll view before asking tvOS to focus Cast & Crew on the next run-loop turn. This fixes the case where the actor card received focus but the page stayed at the top until a second Down press.
- Cast & Crew is moved down by 20 points for cleaner separation from the episode rail.
- Cast & Crew, Trailers, Similar, and the bottom information panel remain ordinary sequential focus transitions in both directions.
- Returning from a lower rail to Episodes uses one cancellable 0.55-second smooth return. Old delayed correction writes were removed so rapid reversals cannot bounce the page or strand a stale focus point.
- The outer Series scroll coordinator stops an in-flight return animation at its presentation position before accepting the next direction, then locks the top viewport only after the return settles.

### Final Series season rail

- The season pills stay anchored exactly where they are. They act as the selection points; the episode pages move beneath them.
- Every real season has one permanent full-width position in a single native horizontal rail. Season 1 is the start, the last season is the end, and a 20-season show uses the same model without a fake three-page recentering trick.
- Switching seasons moves the complete outgoing and incoming episode pages together as one connected wheel. The old page does not disappear and leave a blank space while the next page reloads.
- Loaded pages stay attached to their real season positions. Unloaded positions remain lightweight empty slots, so the giant rail has stable geometry without eagerly rendering every episode card for every season.
- Adjacent season data is warmed immediately instead of waiting 1.5 seconds. A cached neighbour can therefore begin moving as soon as it is selected.
- When a page is not already cached, the incoming episode page is mounted in its permanent slot first, given at most one display frame (17 ms) to paint, and then moved with the native `ScrollPosition` API.
- The season movement uses a 0.46-second cubic timing curve. There is no fade, no temporary overlay page, no post-animation recenter, and no deletion/replacement of the page that just arrived.
- Rapid S1 → S2 → S1 or repeated opposite-direction input cancels the older generation, freezes the native scroll view at its live presentation offset, and retargets from that exact position. The newest season request is the only one allowed to finish.
- The final offset is pinned to the newest selected season after the animation, preventing the tab and episode content from settling on different seasons.
- Off-screen cached season pages are disabled for focus, so attached neighbours cannot compete with the visible episode carousel.
- Episode captions remain fixed to their cards, so episode numbers and titles do not bounce or render on a separate animation path during a season move.

The earlier short-prepaint/cubic-slide work removed the right-edge flash, dim frame, and jagged step from the original temporary-page transition. The final implementation keeps those corrections but replaces the temporary two-page swap with the full native linear rail described above.

### Final episode carousel

- The Series episode rail keeps one focus owner for the entire row, which is the behavior that stopped focus falling out of later episodes and into Cast & Crew.
- The cards now live inside a native horizontal SwiftUI `ScrollView` controlled by `ScrollPosition`; the previous manually rendered offset is gone.
- Left/Right changes the active episode immediately, then moves only the scroll position with a 0.30-second smooth animation. Hero text and every card no longer inherit the carousel animation transaction.
- Seeding and return-focus updates set the selected episode and scroll position without animation, preventing a stale animated move from winning after navigation.
- The intentional leading peek is preserved, and the calculated trailing inset keeps the final group and focus ring fully visible without right-edge clipping.
- Watched and favorite overrides, Select/Play behavior, context menus, accessibility adjustment, and the established episode focus model remain intact.

### Playback completion and Continue Watching

- AetherEngine is still the player engine, pinned here at commit `0ae80496ab6f3fda135f43ef195ff10961c0e625`.
- I traced the exact boundary before changing anything. Aether already observes Apple’s native `AVPlayerItem.didPlayToEndTimeNotification`, publishes its ended state, and Silo receives it as `.ended` in `PlayerViewModel`. There is no missing engine event and no AetherEngine fork change in this PR.
- The real bug happened after that native event. Silo moved the player to its end state but normally waited for the next periodic progress report, which runs every 10 seconds. That explains the roughly five-second average delay seen on Home: completion depended on where EOF landed inside that interval.
- Natural EOF now starts an immediate terminal progress report at the exact duration. The existing stop-session report remains the authoritative final write and is still sent during teardown.
- Autoplay, manual Next Up selection, and teardown await any in-flight terminal report before claiming/stopping the same server session, so two lifecycle paths cannot race each other.
- The current episode, parent Series, and synthetic season detail IDs are captured before player state is cleared. This includes every episode crossed during autoplay, not only the item that originally opened the player.
- Player dismissal no longer launches a detail refresh at the same time as the final progress POST. It waits for cleanup to finish first, then performs a non-coalesced authoritative refresh of only the resident affected detail models.
- Any Home request that began during cover dismissal is invalidated by generation, the stale Home response cache is removed, and Continue Watching is fetched again only after final progress has committed.
- The Series page keeps painting its cached content during the refresh, so there is no spinner or blank reload.
- Once authoritative episode state is back, a completed Series episode advances the editorial selection to the current in-progress episode (for autoplay) or the next unwatched episode. This changes no episode focus or scrolling code.
- The completion event publishes the exact expanded set of resident episode, Series, and Season detail models that finished refreshing, so the visible Series route cannot be skipped by the next-episode handler.
- Premature end-of-stream detection remains protected: a connection loss with more than eight seconds remaining while playback is still below 98.5% is not recorded as a clean completion and does not auto-advance the Series page.

This completion fix belongs in Silo now rather than a separate AetherEngine PR. The engine already supplies the correct Apple-native terminal signal; the stale state was caused by Silo’s reporting/cache ordering after that signal.

### Cold-path performance

- Series no longer holds the source card behind a loading spinner before navigation.
- On tvOS, startup warms the selected Series landing sections and exactly one initial Series detail payload. It joins the existing metadata single-flight/cache path, runs without blocking another tab, and is cancelled at profile boundaries.
- That warmup is intentionally bounded: it does not fan out across a rail and it does not preload Series cast portraits, which remain below the initial viewport.
- Movie details keep their fast path while the first visible cast portraits enter the shared Nuke image pipeline as soon as the catalog detail arrives. Navigation and first paint do not wait on portrait downloads.
- For You uses the same seeded detail navigation path as Home and the library tabs, preserving backdrop continuity and cache reuse.

### Coded timing and work bounds

These are implementation bounds, not invented synthetic benchmark numbers:

| Path | Bound in this PR | Why it is bounded |
|---|---:|---|
| Season-pill focus dwell | 70 ms | Prevents a fast sweep across several tabs from fetching every intermediate season; Select remains immediate. |
| Uncached season prepaint | Up to 17 ms | Gives the incoming permanent page one display frame before native movement starts. |
| Full season-page movement | 0.46 s | One cubic native scroll; stale generations are cancelled and cannot finish later. |
| Episode carousel movement | 0.30 s | Only `ScrollPosition` animates; focus/selection state commits outside the animation. |
| Lower rail → Episodes return | 0.55 s | One cancellable outer-scroll animation with no delayed duplicate assertion. |
| Top viewport stabilization | 10 frames at 60 Hz (~167 ms) | Covers tvOS’s immediate reveal only; the old 1.08-second late write that could bounce a later focus move is gone. |
| Playback progress cadence before this fix | 10 s | EOF no longer waits for this periodic loop; it reports immediately. |
| Startup Series warmup | Exactly 1 detail payload | No rail-wide metadata or cast-portrait fanout. |

### Bugs fixed in the final simulator iterations

- Season content disappearing before the incoming season appeared.
- Season movement looking like two disconnected pages instead of one giant wheel.
- A blank rail after some season transitions.
- Rapid back-and-forth season input settling on the wrong season.
- A stale highlighted season tab disagreeing with the episode content.
- Initial season movement feeling cold until pages had been manually “warmed up.”
- Episode Left/Right losing focus around later episodes and dropping into actor cards.
- Episode captions and hero metadata inheriting the rail animation and visibly bumping.
- Episodes → Cast & Crew moving focus without moving the page until a second Down.
- Cast & Crew → Episodes snapping too fast or allowing an older pan to finish afterward.
- Rapid Episodes ↔ Cast ↔ Trailers ↔ bottom-info reversals leaving stale focus/scroll positions.
- Returning quickly from lower rails with the supposedly locked first Series page offset broken.
- Landing-page Up/Down feeling robotic because delayed programmatic focus fought native tvOS movement.
- Moving between landing rows resetting the horizontal selection to the first poster.
- Moving down from a horizontally scrolled row shifting the destination row sideways.
- Rapid landing-page row movement getting stuck before returning to the first row or top tab bar.
- Continue Watching waiting for the periodic reporter after an episode ended.
- Series detail returning with the completed episode still unchecked.
- Series detail continuing to target the completed episode instead of the next playable episode.

### Validation

- Regenerated the local project from `iosApp/project.yml` with XcodeGen during the PR validation cycle.
- Built the complete `SiloTV` Debug scheme successfully for the tvOS 26.5 simulator after the final eight-file patch. The build used normal local signing (`Sign to Run Locally`), compiled the full 11-target dependency graph, and resolved the pinned AetherEngine commit above.
- Installed the resulting app over the existing simulator installation rather than uninstalling it, preserving login/application data, and launched the updated bundle successfully.
- `git diff --check` and the staged-diff whitespace check both passed before commit.
- Manually iterated through Home, Movies, Series, For You, Watchlist, Favorites, cold Series entry, detail opening, season tabs, episode rails, D-pad input, touchpad swipes, and click behavior.
- Repeated S1 → S2 → S1 and opposite-direction season changes rapidly until the final rail consistently landed on the newest requested season with connected outgoing/incoming pages and no blank result.
- Moved across later episode cards, then repeatedly moved Down and Up to confirm episode focus stayed in the episode carousel and returned to the same selected episode.
- Repeated Episodes → Cast & Crew → Trailers → lower information and the full reverse path with fast input, confirming one focus transition per row, the intended top lock, and no late page bounce.
- Moved several posters across before changing rows on Home, Movies, Series, and For You, confirming vertical movement did not reset the source row or horizontally reposition the destination row.
- Repeated return to the first landing row and Up into the top tab bar so the native row change did not regress the intentional menu boundary.
- Traced the completion path end to end from Aether’s Apple-native notification through Silo’s `.ended` handler, final progress POST, session stop, cache invalidation, Home fetch, resident detail refresh, and next-episode selection.
- The completion code was compiled and installed without issuing an artificial production-server progress mutation or altering the database for a test.
- I personally tested the episode-completion refresh in the installed build and confirmed it works perfectly: the finished episode updates as completed on return and Series detail advances to the next episode.
- CodeRabbit’s single follow-up finding was traced against the real runtime path before it was accepted. The resident refresh-target contract was corrected in `398fd7b`, and the signed incremental `SiloTV` build passed afterward without changing season, episode-carousel, or focus code.
- The latest build has one unrelated pre-existing Swift 6 isolation warning around `liveSubtitleCueLimit`; no warning was introduced by these changes.
- No server, database, deployment, dependency, or environment configuration changes are included.

### Review size and boundaries

- Current PR: 11 commits, 30 files, 1,881 additions, and 649 deletions.
- Final simulator-driven patch: 8 files, 914 additions, and 408 deletions.
- CodeRabbit follow-up correction: 2 files, 5 insertions, and 3 deletions.
- No new carousel dependency was added. The final implementation uses SwiftUI `ScrollView`, `ScrollPosition`, tvOS Focus Engine geometry, and a narrowly scoped UIKit bridge only for ownership of the outer Series page scroll view.
- AetherEngine source is unchanged.
- Search, Calendar, Settings controls, the Movies/Series composite library dropdown, movie-detail focus behavior, server configuration, `.env`, Docker, deployment, and database schema/data are outside the final simulator patch.
- The playback-completion change does not modify the season wheel, episode focus model, or any landing-page focus transition.

### Design and implementation

I made the product, layout, interaction, focus, timing, and performance decisions and directed every simulator iteration and regression test. OpenAI Codex using GPT-5.6 Sol with Ultra reasoning assisted with implementation, integration, and code tracing under my direction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved tvOS navigation between content rows, including clearer movement to the top menu.
  - Watchlist and Favorites are now accessible as dedicated root pages with improved focus restoration.
  - Recommendation and Series content is preloaded with additional artwork and details for faster browsing.
  - Movie cast images are preloaded when visible.

- **Improvements**
  - Updated poster typography, spacing, truncation, and artwork sizing across tvOS.
  - Improved marquee metadata, ratings, runtime display, and accessibility descriptions.
  - Refined season-switching animations and episode rail layout.
  - Kept tvOS artwork clear of episode badges and gradient overlays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
