### PR TITLE
fix(tvos): keep video visible across episode autoplay

### DIFF
--- a/iosApp/Resources/OpenSourceLicenses/README.txt
+++ b/iosApp/Resources/OpenSourceLicenses/README.txt
@@ -6,9 +6,9 @@ texts are bundled beside this file and are available from Settings > About >
 Open Source Licenses.
 
 AetherEngine
-  Revision: 0ae80496ab6f3fda135f43ef195ff10961c0e625 (release 6.34.0)
+  Revision: e238d1d2da52b58bffd7f8135bb2b04e32915cee (release 6.34.0 + native item handoff fix)
   License: GNU LGPL version 3 with the upstream Apple Store / DRM exception
-  Source: https://github.com/superuser404notfound/AetherEngine/tree/0ae80496ab6f3fda135f43ef195ff10961c0e625
+  Source: https://github.com/blurbery/AetherEngine/tree/e238d1d2da52b58bffd7f8135bb2b04e32915cee
   Rebuild: the Package.swift and source tree at that revision
 
 FFmpegBuild and embedded media frameworks

--- a/iosApp/Silo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iosApp/Silo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -3,9 +3,9 @@
     {
       "identity" : "aetherengine",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/superuser404notfound/AetherEngine",
+      "location" : "https://github.com/blurbery/AetherEngine",
       "state" : {
-        "revision" : "0ae80496ab6f3fda135f43ef195ff10961c0e625"
+        "revision" : "e238d1d2da52b58bffd7f8135bb2b04e32915cee"
       }
     },
     {

--- a/iosApp/iosApp/Screens/Player/AetherPlaybackController.swift
+++ b/iosApp/iosApp/Screens/Player/AetherPlaybackController.swift
@@ -308,6 +308,12 @@ final class AetherPlaybackController {
     func prepareForReplacement() {
         invalidateActiveLoad(preservingExternalPlaybackPolicy: true)
         engine.deactivatesAudioSessionOnStop = false
+        // Aether otherwise unloads the outgoing AVPlayerItem at the start of
+        // `load`, leaving the shared player layer itemless during the Next Up
+        // mini-player -> full-screen transition. On tvOS that gap can strand
+        // the layer black even though the successor's audio and clock advance.
+        // Arm Aether's one-shot atomic item swap before pausing the old item.
+        engine.prepareForItemReplacement()
         engine.pause()
         refreshExternalPlaybackState()
         publishSystemMediaChanged()

--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -56,8 +56,8 @@ packages:
   # The only media engine in the replacement player. Keep this at an exact
   # reviewed revision; Package.resolved also freezes its binary dependencies.
   AetherEngine:
-    url: https://github.com/superuser404notfound/AetherEngine
-    revision: 0ae80496ab6f3fda135f43ef195ff10961c0e625
+    url: https://github.com/blurbery/AetherEngine
+    revision: e238d1d2da52b58bffd7f8135bb2b04e32915cee
   Nuke:
     url: https://github.com/kean/Nuke
     from: "12.8.0"


### PR DESCRIPTION
## Problem

I reproduced the Apple TV autoplay failure again during a real episode handoff: the next episode started, audio played and the playback clock advanced, but the screen stayed black. Backing out and reopening the same episode restored the picture.

The server-side trace rules out a failed stream handoff:

- The successor session started about 1.1 seconds after the outgoing session ended.
- It stayed on the expected direct-play route.
- Media range requests continued returning successfully.
- The app reported its first-frame signal about 3.7 seconds after the successor started, even though the television still showed black.
- Playback progress continued for at least 59.7 seconds with audio.
- There were no authorization, remux, transcode, route-selection, or media-delivery errors around the transition.

I have intentionally left the server address, session identifiers, account details, and viewing history out of this PR.

## Root cause

The replacement work already merged in #202 keeps Silo's Aether controller, native host, display criteria, audio-session policy, and playback intent alive across the episode boundary. That part is working as intended, but it exposed one remaining engine-level gap.

On a normal foreground replacement, AetherEngine 6.34.0 still allowed the retained native host to run its ordinary teardown. That path calls `replaceCurrentItem(with: nil)` before the next item exists. The reused host then performs its normal unload once more before finally attaching the successor.

The Next Up mini-player is relevant because Silo changes presentation at the same time as that nil-item interval. The minimised view is not independently detaching the Aether surface, but the combined mini-player-to-full-screen transition makes the itemless player layer vulnerable to staying black. The countdown, Play Now button, Siri Remote play command, and remote-control next command all converge on `playNextEpisodeNow()`, so they all hit the same replacement path and showed the same symptom.

## Solution

I added a supported one-shot handoff to AetherEngine and arm it from Silo's existing replacement boundary immediately before the outgoing episode is paused:

1. `AetherPlaybackController.prepareForReplacement()` invalidates the outgoing Silo load as before.
2. It calls `prepareForItemReplacement()` on Aether.
3. The next engine `load()` consumes that request exactly once.
4. For a native-to-native transition, Aether keeps the outgoing `AVPlayerItem` attached while it prepares the successor.
5. The successor replaces the outgoing item atomically on the same `AVPlayer` and player layer.

The dependency is pinned to an exact reviewed revision based directly on Silo's existing AetherEngine 6.34.0 commit. I did not upgrade through the intervening engine releases, because that would mix a broad dependency migration into an isolated playback fix. The public API, package lock, project specification, and LGPL source reference all point to the same exact commit.

I also ported and validated the engine change against current AetherEngine `main`, without forcing that larger dependency upgrade into this fix. That portable commit is ready for a separate upstream submission: https://github.com/blurbery/AetherEngine/commit/1386a80

## Regression coverage

| Case | Expected behavior | Coverage |
| --- | --- | --- |
| Foreground native → native episode replacement | Keep outgoing item until one atomic successor swap | Policy and one-shot lifecycle tests |
| Countdown autoplay | Uses `playNextEpisodeNow()` and the same prepared replacement | Existing shared call path |
| Play Now / Siri Remote / remote next command | Uses the same replacement path as countdown | Existing shared call path |
| First load or outgoing non-native session | Consume the request without retaining an incompatible host | New non-native consumption test |
| A later unrelated load | Does not inherit an earlier replacement request | New consume-exactly-once test |
| Final stop / backing out | Cancels a pending request and performs normal teardown | New stop-cancellation test |
| Active Picture in Picture | Existing mandatory handoff remains active with or without a foreground request | Expanded PiP policy and lifecycle tests |
| Silo load identity and playback intent | Outgoing epoch invalidated, successor epoch distinct, autoplay intent retained | Existing `AetherPlaybackBoundaryTests` coverage from #202 |

## Proof and measurements

### Replacement seam

This is a deterministic operation count through the exact native replacement path, not a wall-clock performance claim:

| Native-to-native episode handoff | Before | After |
| --- | ---: | ---: |
| Explicit `replaceCurrentItem(with: nil)` calls | 2 | 0 |
| Total AVPlayer item mutations | 3 | 1 |
| Deliberate nil-item interval | Present | Removed |

That removes both explicit nil assignments and reduces item mutations at the seam by 66.7%. More importantly, there is no longer a period where the shared player layer has no item while Silo changes from the Next Up presentation back to full-screen playback.

### Automated validation

The exact AetherEngine revision pinned by this PR passed the complete public CI matrix:

- iOS Simulator build: passed
- tvOS Simulator build: passed
- visionOS Simulator build: passed
- macOS build and tests: passed
- 1,958 tests in 282 suites: passed in 69.343 seconds
- Transport probe build: passed

Run: https://github.com/blurbery/AetherEngine/actions/runs/33621069137

The equivalent change against current AetherEngine `main` also passed its complete platform matrix: https://github.com/blurbery/AetherEngine/actions/runs/33621760009

The Silo branch is one commit ahead of current upstream `main`, zero commits behind, and changes only the replacement call plus the exact dependency and license pins. It does not bring the production fork's unrelated commits into this PR.

## Scope and release check

This does not change the server playback plan, force a transcode, alter the Next Up timing/UI, or change final teardown. It only selects Aether's existing atomic native item-swap mechanism for an explicitly prepared foreground replacement.

The engine behavior, API contract, package resolution, and platform builds are covered here. A final real-device episode transition on the affected Apple TV is still the release acceptance check; I have not described simulator builds as physical-device proof.

## AI Disclosure

I orchestrated this change and provided the reproduction, constraints, and acceptance criteria. I used the OpenAI Codex desktop agent harness with `gpt-5.6-sol` at ultra reasoning for the code investigation, implementation, regression analysis, and validation. No other AI tooling was used.
