### PR TITLE
Polish iOS browsing, detail glass, and offline downloads

### DIFF
--- a/iosApp/Tests/UICustomizationPreferencesTests.swift
+++ b/iosApp/Tests/UICustomizationPreferencesTests.swift
@@ -96,7 +96,7 @@ final class UICustomizationPreferencesTests: XCTestCase {
         XCTAssertEqual(
             mediaCardAccessibilityLabel(
                 title: "The Episode",
-                episodeBadge: "S2 · E10",
+                episodeLabel: "S2 · E10",
                 year: 2026,
                 isWatched: true
             ),

--- a/iosApp/iosApp/Components/AdaptiveLayout.swift
+++ b/iosApp/iosApp/Components/AdaptiveLayout.swift
@@ -46,6 +46,20 @@ enum AdaptiveColumns {
             return max(minimumCount, standardCount - 1)
         }
     }
+
+    /// Fits a fixed-density grid card inside its actual container while
+    /// preserving the standard poster width whenever enough room is available.
+    static func fittedPosterWidth(
+        containerWidth: CGFloat,
+        columnCount: Int,
+        spacing: CGFloat,
+        maximumWidth: CGFloat = ContinuumTheme.posterCardWidth
+    ) -> CGFloat {
+        guard containerWidth > 0, columnCount > 0 else { return maximumWidth }
+        let totalSpacing = CGFloat(max(0, columnCount - 1)) * spacing
+        let availableWidth = max(1, containerWidth - totalSpacing)
+        return min(maximumWidth, availableWidth / CGFloat(columnCount))
+    }
 }
 
 extension View {

--- a/iosApp/iosApp/Components/EpisodeThumbCard.swift
+++ b/iosApp/iosApp/Components/EpisodeThumbCard.swift
@@ -4,8 +4,8 @@ import SwiftUI
 /// "Next Up", "Continue Watching", etc.
 ///
 /// Shows the episode still / backdrop, series title, and episode metadata.
-/// tvOS keeps the artwork clear except for server-configured card overlays;
-/// compact S/E artwork badges remain available to the touch layouts.
+/// Episode numbering stays in accessibility and detail metadata rather than
+/// being drawn over the artwork.
 /// On tvOS the image sits inside a `.card` button for focus lift/parallax and
 /// a FocusState binding drives the title highlight.
 struct EpisodeThumbCard: View {
@@ -177,7 +177,7 @@ struct EpisodeThumbCard: View {
             .clipShape(RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius))
 
             #if !os(tvOS)
-            // Scrim gradient so the compact episode badge reads over bright stills.
+            // Scrim keeps bottom overlays and progress legible over bright stills.
             LinearGradient(
                 colors: [.clear, .black.opacity(0.75)],
                 startPoint: .center,
@@ -188,8 +188,7 @@ struct EpisodeThumbCard: View {
             #endif
 
             // Server / user-customized overlay badges. `wide` variant
-            // gives the bottom corners enough headroom that they don't
-            // collide with the S/E text + progress bar.
+            // gives the bottom corners enough headroom for the progress bar.
             if overlayStore.enabled {
                 CardOverlays(
                     data: resolvedOverlayData,
@@ -199,24 +198,6 @@ struct EpisodeThumbCard: View {
                 .frame(width: cardWidth, height: cardHeight)
                 .clipShape(RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius))
             }
-
-            #if !os(tvOS)
-            // Compact touch-layout episode badge. Apple TV landing cards keep
-            // this corner clear; server-configured quality/audio overlays above
-            // remain unchanged.
-            if let badge = episodeBadge {
-                Text(badge)
-                    .font(.continuumCaption)
-                    .fontWeight(.semibold)
-                    .foregroundColor(.white)
-                    .padding(.horizontal, badgeHPadding)
-                    .padding(.vertical, badgeVPadding)
-                    .background(
-                        Capsule().fill(Color.black.opacity(0.65))
-                    )
-                    .padding(badgeInset)
-            }
-            #endif
 
             // Progress bar (resume)
             if showProgress, let p = progressValue, p > 0 {
@@ -299,8 +280,8 @@ struct EpisodeThumbCard: View {
 
     private var accessibilityDescription: String {
         var components = [displayTitle]
-        if let episodeBadge {
-            components.append(episodeBadge)
+        if let episodeAccessibilityLabel {
+            components.append(episodeAccessibilityLabel)
         }
         if let subtitleLine {
             components.append(subtitleLine)
@@ -311,8 +292,7 @@ struct EpisodeThumbCard: View {
         return components.joined(separator: ", ")
     }
 
-    /// "S1 · E4" badge if we have season+episode numbers.
-    private var episodeBadge: String? {
+    private var episodeAccessibilityLabel: String? {
         if let season = item.seasonNumber, let episode = item.episodeNumber {
             return "S\(season) · E\(episode)"
         }
@@ -330,22 +310,6 @@ struct EpisodeThumbCard: View {
     }
 
     // MARK: - Metrics
-
-    private var badgeHPadding: CGFloat {
-        #if os(tvOS)
-        return 14
-        #else
-        return 8
-        #endif
-    }
-
-    private var badgeVPadding: CGFloat {
-        #if os(tvOS)
-        return 7
-        #else
-        return 4
-        #endif
-    }
 
     private var badgeInset: CGFloat {
         #if os(tvOS)

--- a/iosApp/iosApp/Components/ErrorView.swift
+++ b/iosApp/iosApp/Components/ErrorView.swift
@@ -47,7 +47,6 @@ struct ErrorView: View {
             .padding(.top, ContinuumTheme.smallPadding)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .continuumBackground()
     }
 
     private var headline: String {

--- a/iosApp/iosApp/Components/LoadingView.swift
+++ b/iosApp/iosApp/Components/LoadingView.swift
@@ -3,10 +3,15 @@ import SwiftUI
 /// Full-screen loading indicator.
 struct LoadingView: View {
     var message: String? = nil
+    var usesPageBackground = false
 
     var body: some View {
         ZStack {
-            Color.continuumBackground.ignoresSafeArea()
+            if usesPageBackground {
+                ContinuumPageBackdrop()
+            } else {
+                Color.continuumBackground.ignoresSafeArea()
+            }
 
             VStack(spacing: 20) {
                 SiloWordmarkView(width: 132)

--- a/iosApp/iosApp/Components/MediaCard.swift
+++ b/iosApp/iosApp/Components/MediaCard.swift
@@ -10,13 +10,13 @@ enum MediaCardAspect {
 
 func mediaCardAccessibilityLabel(
     title: String,
-    episodeBadge: String?,
+    episodeLabel: String?,
     year: Int?,
     isWatched: Bool
 ) -> String {
     var components = [title]
-    if let episodeBadge, !episodeBadge.isEmpty {
-        components.append(episodeBadge)
+    if let episodeLabel, !episodeLabel.isEmpty {
+        components.append(episodeLabel)
     }
     if let year {
         components.append(String(year))
@@ -88,10 +88,9 @@ struct MediaCard: View {
     /// rows (§5.6) pass 208 so two rows + the marquee fit above the fold;
     /// the poster keeps its 2:3 ratio.
     var cardWidthOverride: CGFloat? = nil
-    /// "S2 · E10" badge drawn over the bottom-leading corner of the poster
-    /// for episodes rendered in a poster row (e.g. "Recently Released
-    /// Episodes"). `nil` for movies / series / audiobooks.
-    var episodeBadge: String? = nil
+    /// Episode context retained for the card's accessibility label. Episode
+    /// numbers are intentionally not drawn over poster artwork.
+    var episodeAccessibilityLabel: String? = nil
     /// Fires after a favorite/watchlist toggle from the card's context
     /// menu commits server-side, with the item's new state. Favorites /
     /// Watchlist grids use it to drop the card from the list in place.
@@ -139,7 +138,7 @@ struct MediaCard: View {
         FocusableMediaCard(
             title: title,
             year: year,
-            episodeBadge: episodeBadge,
+            episodeAccessibilityLabel: episodeAccessibilityLabel,
             captionStyle: uiCustomization.cardPresentation.caption,
             cardWidth: cardWidth,
             action: action,
@@ -352,20 +351,6 @@ struct MediaCard: View {
                     .clipShape(RoundedRectangle(cornerRadius: ContinuumTheme.cornerRadius))
             }
 
-            // Episode badge (e.g. "S2 · E10") for episodes shown as posters,
-            // so new episodes of the same series stay distinguishable.
-            if let episodeBadge {
-                Text(episodeBadge)
-                    .font(.continuumCaption)
-                    .fontWeight(.semibold)
-                    .foregroundColor(.white)
-                    .padding(.horizontal, episodeBadgeHPadding)
-                    .padding(.vertical, episodeBadgeVPadding)
-                    .background(Capsule().fill(Color.black.opacity(0.65)))
-                    .padding(episodeBadgeInset)
-                    .frame(width: cardWidth, height: cardHeight, alignment: .bottomLeading)
-            }
-
             // Progress bar at bottom of poster (inside rounded corners)
             if let progress, progress > 0 {
                 VStack {
@@ -408,7 +393,7 @@ struct MediaCard: View {
     private var accessibilityDescription: String {
         mediaCardAccessibilityLabel(
             title: title,
-            episodeBadge: episodeBadge,
+            episodeLabel: episodeAccessibilityLabel,
             year: year,
             isWatched: isPlayed
         )
@@ -459,29 +444,6 @@ struct MediaCard: View {
         #endif
     }
 
-    private var episodeBadgeHPadding: CGFloat {
-        #if os(tvOS)
-        return 14
-        #else
-        return 8
-        #endif
-    }
-
-    private var episodeBadgeVPadding: CGFloat {
-        #if os(tvOS)
-        return 7
-        #else
-        return 4
-        #endif
-    }
-
-    private var episodeBadgeInset: CGFloat {
-        #if os(tvOS)
-        return 14
-        #else
-        return 6
-        #endif
-    }
 }
 
 // MARK: - Zoom transition source helper
@@ -510,7 +472,7 @@ extension View {
 private struct FocusableMediaCard<Content: View>: View {
     let title: String
     let year: Int?
-    let episodeBadge: String?
+    let episodeAccessibilityLabel: String?
     let captionStyle: CardCaptionStyle
     let cardWidth: CGFloat
     let action: () -> Void
@@ -614,7 +576,7 @@ private struct FocusableMediaCard<Content: View>: View {
     private var accessibilityDescription: String {
         mediaCardAccessibilityLabel(
             title: title,
-            episodeBadge: episodeBadge,
+            episodeLabel: episodeAccessibilityLabel,
             year: year,
             isWatched: isWatched
         )

--- a/iosApp/iosApp/Components/MediaRow.swift
+++ b/iosApp/iosApp/Components/MediaRow.swift
@@ -411,7 +411,7 @@ struct MediaRow: View {
                 onSetWatched: watchedToggleAction(for: item),
                 aspect: layout == .square ? .square : .poster,
                 cardWidthOverride: cardWidth,
-                episodeBadge: episodeBadge(for: item)
+                episodeAccessibilityLabel: episodeAccessibilityLabel(for: item)
             )
         case .thumbnail:
             EpisodeThumbCard(
@@ -563,19 +563,13 @@ struct MediaRow: View {
         item.type.lowercased() == "episode" ? (item.seriesTitle ?? item.title) : item.title
     }
 
-    /// "S2 · E10" badge for an episode rendered as a poster, so new episodes
-    /// of the same series stay distinguishable. `nil` for non-episodes.
-    private func episodeBadge(for item: SectionItem) -> String? {
-        #if os(tvOS)
-        // Landing-page episode cards on Apple TV intentionally reserve their
-        // artwork overlays for the server-controlled CardOverlays system.
-        return nil
-        #else
+    /// Episode context for accessibility when a poster is captioned with its
+    /// series title. Episode numbers are not drawn over card artwork.
+    private func episodeAccessibilityLabel(for item: SectionItem) -> String? {
         guard item.type.lowercased() == "episode",
               let season = item.seasonNumber,
               let episode = item.episodeNumber else { return nil }
         return "S\(season) · E\(episode)"
-        #endif
     }
 
     // MARK: - Metrics

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -955,7 +955,7 @@ struct ContentView: View {
         case .onboardingTour:
             #if os(tvOS)
             EmptyStateView(icon: "sparkles", title: "Take the tour on your phone or the web", subtitle: nil)
-                .continuumBackground()
+                .continuumPageBackground()
             #else
             OnboardingTourView(router: router)
             #endif
@@ -974,7 +974,7 @@ struct ContentView: View {
                 title: "Coming Soon",
                 subtitle: "This screen is under construction."
             )
-            .continuumBackground()
+            .continuumPageBackground()
         }
     }
 
@@ -1009,7 +1009,7 @@ struct ContentView: View {
             #endif
         default:
             EmptyStateView(icon: "questionmark.circle", title: "Unknown", subtitle: nil)
-                .continuumBackground()
+                .continuumPageBackground()
         }
     }
 }
@@ -2397,7 +2397,7 @@ struct MainTabView: View {
         case .downloads:
             #if os(tvOS)
             EmptyStateView(icon: "questionmark.circle", title: "Unknown", subtitle: nil)
-                .continuumBackground()
+                .continuumPageBackground()
             #else
             DownloadsView()
             #endif
@@ -2417,20 +2417,20 @@ struct MainTabView: View {
         case .offlineSeriesBrowse(let seriesId):
             #if os(tvOS)
             EmptyStateView(icon: "questionmark.circle", title: "Unknown", subtitle: nil)
-                .continuumBackground()
+                .continuumPageBackground()
             #else
             OfflineSeriesBrowseView(seriesId: seriesId)
             #endif
         case .offlineDownloadDetail(let downloadId):
             #if os(tvOS)
             EmptyStateView(icon: "questionmark.circle", title: "Unknown", subtitle: nil)
-                .continuumBackground()
+                .continuumPageBackground()
             #else
             OfflineDownloadDetailView(downloadId: downloadId)
             #endif
         default:
             EmptyStateView(icon: "questionmark.circle", title: "Unknown", subtitle: nil)
-                .continuumBackground()
+                .continuumPageBackground()
         }
     }
 
@@ -2559,8 +2559,11 @@ private struct ItemDetailSheet: View {
         router.presentedItemDetail?.contentId ?? presentation.contentId
     }
 
+    /// iPhone detail cards are intentionally fixed to the title that was
+    /// opened. iPad keeps its existing wider, source-aware page deck.
     private var browseSource: ItemDetailBrowseSource? {
-        router.presentedItemDetail?.browseSource ?? presentation.browseSource
+        guard UIDevice.current.userInterfaceIdiom != .phone else { return nil }
+        return router.presentedItemDetail?.browseSource ?? presentation.browseSource
     }
 
     private var pageContentIDs: [String] {

--- a/iosApp/iosApp/Control/iOS/SiloControlTargetPickerView.swift
+++ b/iosApp/iosApp/Control/iOS/SiloControlTargetPickerView.swift
@@ -20,7 +20,7 @@ struct SiloControlTargetPickerView: View {
                     searchingState
                 }
             }
-            .background(Color.continuumBackground.ignoresSafeArea())
+            .continuumPageBackground()
             .navigationTitle("Remote Control")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/iosApp/iosApp/Downloads/DownloadActionButton.swift
+++ b/iosApp/iosApp/Downloads/DownloadActionButton.swift
@@ -56,6 +56,7 @@ struct DownloadActionButton: View {
 
     private var manager: DownloadManager { DownloadManager.shared }
     private var record: DownloadRecord? { manager.record(forContentId: contentId) }
+    private var isRegistrationPending: Bool { manager.isRegistering(contentId: contentId) }
     @State private var confirmingCancel = false
     /// Guard text for the pre-download confirmation; non-nil presents it.
     @State private var largeDownloadWarning: String?
@@ -137,115 +138,127 @@ struct DownloadActionButton: View {
                 Button("Discard Download", role: .destructive, action: cancel)
                 Button("Keep Download", role: .cancel) {}
             }
-            .confirmationDialog(
-                "\(largeDownloadWarning ?? "") Download anyway?",
+            // Keep the large-file gate separate from the cancel menu. Two
+            // confirmation dialogs on one control compete for the same SwiftUI
+            // presentation host and can consume the tap without showing either.
+            .alert(
+                "Large Download",
                 isPresented: Binding(
                     get: { largeDownloadWarning != nil },
                     set: { if !$0 { largeDownloadWarning = nil } }
-                ),
-                titleVisibility: .visible
+                )
             ) {
                 Button("Download Anyway", action: startWithDefaults)
                 if style != .compact {
                     Button("Choose Options…") { showOptions = true }
                 }
                 Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("\(largeDownloadWarning ?? "This download is large.") Download anyway?")
             }
     }
 
     @ViewBuilder
     private var content: some View {
-        switch record?.localStatus {
-        case .none:
-            let button = Button(action: handleDownloadTap) {
-                circleLabel(icon: "arrow.down.to.line", active: false)
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Download")
-            if style != .compact {
-                button.contextMenu {
-                    Button { showOptions = true } label: {
-                        Label("Download Options…", systemImage: "slider.horizontal.3")
-                    }
+        if isRegistrationPending, record == nil {
+            circleLabel(icon: "arrow.down.circle", active: true, showSpinner: true)
+                .accessibilityLabel("Registering download")
+                .allowsHitTesting(false)
+        } else {
+            switch record?.localStatus {
+            case .none:
+                let button = Button(action: handleDownloadTap) {
+                    circleLabel(icon: "arrow.down.to.line", active: false)
                 }
-            } else {
-                button
-            }
-
-        case .downloading:
-            Menu {
-                Button(action: pause) {
-                    Label("Pause", systemImage: "pause")
-                }
-                Button(role: .destructive) { confirmingCancel = true } label: {
-                    Label("Cancel Download", systemImage: "xmark.circle")
-                }
-            } label: {
-                progressLabel(fraction: record?.progressFraction ?? 0, paused: false)
-            }
-            .accessibilityLabel("Downloading")
-
-        case .paused:
-            Menu {
-                Button(action: resume) {
-                    Label("Resume", systemImage: "play")
-                }
-                Button(role: .destructive) { confirmingCancel = true } label: {
-                    Label("Cancel Download", systemImage: "xmark.circle")
-                }
-            } label: {
-                progressLabel(fraction: record?.progressFraction ?? 0, paused: true)
-            }
-            .accessibilityLabel("Download paused")
-
-        case .registering, .preparing, .queued, .fetchingAssets:
-            Menu {
-                Button(role: .destructive) { confirmingCancel = true } label: {
-                    Label("Cancel Download", systemImage: "xmark.circle")
-                }
-            } label: {
-                circleLabel(icon: "arrow.down.circle", active: true, showSpinner: true)
-            }
-            .accessibilityLabel("Preparing download")
-
-        case .completed:
-            Menu {
-                Button(role: .destructive, action: delete) {
-                    Label("Delete Download", systemImage: "trash")
-                }
-            } label: {
-                circleLabel(icon: "checkmark.circle.fill", active: true, tint: .green)
-            }
-            .accessibilityLabel("Downloaded")
-
-        case .revoked:
-            Menu {
-                Button(role: .destructive, action: delete) {
-                    Label("Delete Download", systemImage: "trash")
-                }
-            } label: {
-                circleLabel(icon: "checkmark.circle", active: true, tint: .yellow)
-            }
-            .accessibilityLabel("Downloaded (re-download no longer allowed)")
-
-        case .failed:
-            Menu {
+                .buttonStyle(.plain)
+                .accessibilityLabel("Download")
                 if style != .compact {
-                    Button { showOptions = true } label: {
-                        Label("Retry With Options", systemImage: "arrow.clockwise")
+                    button.contextMenu {
+                        Button { showOptions = true } label: {
+                            Label("Download Options…", systemImage: "slider.horizontal.3")
+                        }
                     }
                 } else {
-                    Button(action: retry) {
-                        Label("Try Again", systemImage: "arrow.clockwise")
+                    button
+                }
+
+            case .downloading:
+                Menu {
+                    Button(action: pause) {
+                        Label("Pause", systemImage: "pause")
                     }
+                    Button(role: .destructive) { confirmingCancel = true } label: {
+                        Label("Cancel Download", systemImage: "xmark.circle")
+                    }
+                } label: {
+                    progressLabel(fraction: record?.progressFraction ?? 0, paused: false)
                 }
-                Button(role: .destructive, action: delete) {
-                    Label("Remove", systemImage: "trash")
+                .accessibilityLabel("Downloading")
+                .accessibilityValue(progressAccessibilityValue)
+
+            case .paused:
+                Menu {
+                    Button(action: resume) {
+                        Label("Resume", systemImage: "play")
+                    }
+                    Button(role: .destructive) { confirmingCancel = true } label: {
+                        Label("Cancel Download", systemImage: "xmark.circle")
+                    }
+                } label: {
+                    progressLabel(fraction: record?.progressFraction ?? 0, paused: true)
                 }
-            } label: {
-                circleLabel(icon: "exclamationmark.triangle", active: true, tint: .orange)
+                .accessibilityLabel("Download paused")
+                .accessibilityValue(progressAccessibilityValue)
+
+            case .registering, .preparing, .queued, .fetchingAssets:
+                Menu {
+                    Button(role: .destructive) { confirmingCancel = true } label: {
+                        Label("Cancel Download", systemImage: "xmark.circle")
+                    }
+                } label: {
+                    circleLabel(icon: "arrow.down.circle", active: true, showSpinner: true)
+                }
+                .accessibilityLabel("Preparing download")
+
+            case .completed:
+                Menu {
+                    Button(role: .destructive, action: delete) {
+                        Label("Delete Download", systemImage: "trash")
+                    }
+                } label: {
+                    circleLabel(icon: "checkmark.circle.fill", active: true, tint: .green)
+                }
+                .accessibilityLabel("Downloaded")
+
+            case .revoked:
+                Menu {
+                    Button(role: .destructive, action: delete) {
+                        Label("Delete Download", systemImage: "trash")
+                    }
+                } label: {
+                    circleLabel(icon: "checkmark.circle", active: true, tint: .yellow)
+                }
+                .accessibilityLabel("Downloaded (re-download no longer allowed)")
+
+            case .failed:
+                Menu {
+                    if style != .compact {
+                        Button { showOptions = true } label: {
+                            Label("Retry With Options", systemImage: "arrow.clockwise")
+                        }
+                    } else {
+                        Button(action: retry) {
+                            Label("Try Again", systemImage: "arrow.clockwise")
+                        }
+                    }
+                    Button(role: .destructive, action: delete) {
+                        Label("Remove", systemImage: "trash")
+                    }
+                } label: {
+                    circleLabel(icon: "exclamationmark.triangle", active: true, tint: .orange)
+                }
+                .accessibilityLabel("Download failed")
             }
-            .accessibilityLabel("Download failed")
         }
     }
 
@@ -255,6 +268,7 @@ struct DownloadActionButton: View {
     /// would land on disk (max of the Auto range, or the exact size of the
     /// selected version) warrants confirming first.
     private func handleDownloadTap() {
+        guard !isRegistrationPending, record == nil else { return }
         let estimate = versions.isEmpty
             ? DownloadSizeEstimate.estimate(fileSizes: candidateFileSizes)
             : DownloadSizeEstimate.estimate(versions: versions, fileId: selectedVersionFileId)
@@ -422,6 +436,7 @@ struct DownloadActionButton: View {
     /// A static "Download" caption under a green tick would misreport the
     /// state, so the caption tracks the record like the glyph does.
     private var captionText: String {
+        if isRegistrationPending, record == nil { return "Preparing" }
         switch record?.localStatus {
         case .none: return "Download"
         case .downloading: return "Downloading"
@@ -524,9 +539,7 @@ struct DownloadActionButton: View {
                             style: StrokeStyle(lineWidth: 2, lineCap: .round)
                         )
                         .rotationEffect(.degrees(-90))
-                    Image(systemName: paused ? "play.fill" : "pause.fill")
-                        .font(.system(size: 8, weight: .bold))
-                        .foregroundColor(.white)
+                    progressCenter(fraction: fraction, paused: paused)
                 }
                 .frame(width: 21, height: 21)
             }
@@ -548,11 +561,31 @@ struct DownloadActionButton: View {
                 )
                 .rotationEffect(.degrees(-90))
                 .padding(style == .regular ? 4 : 3)
-            Image(systemName: paused ? "play.fill" : "pause.fill")
-                .font(.system(size: style == .regular ? 10 : 8, weight: .bold))
-                .foregroundColor(.white)
+            progressCenter(fraction: fraction, paused: paused)
         }
         .frame(width: diameter, height: diameter)
+    }
+
+    @ViewBuilder
+    private func progressCenter(fraction: Double, paused: Bool) -> some View {
+        if paused {
+            Image(systemName: "play.fill")
+                .font(.system(size: style == .regular ? 10 : 8, weight: .bold))
+                .foregroundColor(.white)
+        } else {
+            Text("\(progressPercent(fraction))")
+                .font(.system(size: style == .compact ? 7 : 8, weight: .bold, design: .rounded))
+                .monospacedDigit()
+                .foregroundColor(.white)
+        }
+    }
+
+    private var progressAccessibilityValue: String {
+        "\(progressPercent(record?.progressFraction ?? 0)) percent"
+    }
+
+    private func progressPercent(_ fraction: Double) -> Int {
+        Int((min(max(fraction, 0), 1) * 100).rounded())
     }
 }
 #endif

--- a/iosApp/iosApp/Downloads/DownloadActionButton.swift
+++ b/iosApp/iosApp/Downloads/DownloadActionButton.swift
@@ -346,6 +346,9 @@ struct DownloadActionButton: View {
                 // premature "started" over a failed create would be the
                 // last the user ever hears of this download.
                 announceStart()
+            } catch DownloadError.registrationAlreadyInFlight {
+                // The original request owns the manager-level Preparing state.
+                // Do not announce a second success or replace it with an error.
             } catch {
                 announceStartFailure()
             }

--- a/iosApp/iosApp/Downloads/DownloadManager.swift
+++ b/iosApp/iosApp/Downloads/DownloadManager.swift
@@ -6,12 +6,14 @@ enum DownloadError: LocalizedError {
     case unavailable
     case fileURLUnavailable
     case emptyRegistrationResponse
+    case registrationAlreadyInFlight
 
     var errorDescription: String? {
         switch self {
         case .unavailable: return "Downloads aren't available for this profile."
         case .fileURLUnavailable: return "Could not resolve the download URL."
         case .emptyRegistrationResponse: return "The server didn't create a download."
+        case .registrationAlreadyInFlight: return "This download is already being prepared."
         }
     }
 }
@@ -575,7 +577,9 @@ final class DownloadManager {
         guard downloadsEnabled else { throw DownloadError.unavailable }
 
         let registrationContentId = episodeId ?? contentId
-        guard pendingRegistrationContentIds.insert(registrationContentId).inserted else { return }
+        guard pendingRegistrationContentIds.insert(registrationContentId).inserted else {
+            throw DownloadError.registrationAlreadyInFlight
+        }
         defer { pendingRegistrationContentIds.remove(registrationContentId) }
 
         // Series/season batches are original-quality only per the server

--- a/iosApp/iosApp/Downloads/DownloadManager.swift
+++ b/iosApp/iosApp/Downloads/DownloadManager.swift
@@ -7,6 +7,7 @@ enum DownloadError: LocalizedError {
     case fileURLUnavailable
     case emptyRegistrationResponse
     case registrationAlreadyInFlight
+    case scopeChangedDuringRegistration
 
     var errorDescription: String? {
         switch self {
@@ -14,6 +15,7 @@ enum DownloadError: LocalizedError {
         case .fileURLUnavailable: return "Could not resolve the download URL."
         case .emptyRegistrationResponse: return "The server didn't create a download."
         case .registrationAlreadyInFlight: return "This download is already being prepared."
+        case .scopeChangedDuringRegistration: return "The active profile changed before the download could start."
         }
     }
 }
@@ -126,6 +128,14 @@ final class DownloadManager {
     /// to the manager (rather than one button) so a detail rebuild cannot make
     /// the preparing indicator disappear during registration.
     private(set) var pendingRegistrationContentIds: Set<String> = []
+    /// Each pending id owns a unique token. An older request may finish after
+    /// sign-out and reactivation, but its defer must never clear a newer
+    /// request for the same content id.
+    private var pendingRegistrationTokens: [String: UUID] = [:]
+    /// Incremented whenever the active server/profile identity is invalidated
+    /// or replaced. Network responses captured under an older generation are
+    /// discarded before they can mutate the newly active scope.
+    private var registrationScopeGeneration: UInt64 = 0
     var canDownloadSeason: Bool { downloadsEnabled && capability?.seasonDownload == true }
     var canMonitorSeries: Bool { downloadsEnabled && capability?.seriesMonitoring == true }
 
@@ -393,8 +403,11 @@ final class DownloadManager {
             releaseHeldSessionEvents()
             return true
         }
-        scopeServerId = serverId
-        scopeProfileId = profileId
+        if serverId != scopeServerId || profileId != scopeProfileId {
+            invalidatePendingRegistrations()
+            scopeServerId = serverId
+            scopeProfileId = profileId
+        }
 
         let loadTask: Task<DownloadStoreFile, Never>
         let loadToken: UUID
@@ -466,7 +479,7 @@ final class DownloadManager {
         retryTasks.removeAll()
         pendingPauseIds.removeAll()
         pendingResumeIds.removeAll()
-        pendingRegistrationContentIds.removeAll()
+        invalidatePendingRegistrations()
         scopeLoadTask?.cancel()
         scopeLoadTask = nil
         scopeLoadToken = nil
@@ -577,10 +590,21 @@ final class DownloadManager {
         guard downloadsEnabled else { throw DownloadError.unavailable }
 
         let registrationContentId = episodeId ?? contentId
-        guard pendingRegistrationContentIds.insert(registrationContentId).inserted else {
+        guard pendingRegistrationTokens[registrationContentId] == nil else {
             throw DownloadError.registrationAlreadyInFlight
         }
-        defer { pendingRegistrationContentIds.remove(registrationContentId) }
+        let registrationToken = UUID()
+        let capturedScopeGeneration = registrationScopeGeneration
+        let capturedServerId = scopeServerId
+        let capturedProfileId = scopeProfileId
+        pendingRegistrationTokens[registrationContentId] = registrationToken
+        pendingRegistrationContentIds.insert(registrationContentId)
+        defer {
+            finishPendingRegistration(
+                contentId: registrationContentId,
+                token: registrationToken
+            )
+        }
 
         // Series/season batches are original-quality only per the server
         // contract; single items may use any advertised public quality preset.
@@ -599,6 +623,11 @@ final class DownloadManager {
             caps: DownloadCaps.current()
         )
         let rows = try await ContinuumAPI.shared.createDownload(request)
+        guard capturedScopeGeneration == registrationScopeGeneration,
+              capturedServerId == scopeServerId,
+              capturedProfileId == scopeProfileId else {
+            throw DownloadError.scopeChangedDuringRegistration
+        }
         guard !rows.isEmpty else { throw DownloadError.emptyRegistrationResponse }
         for row in rows {
             upsertRow(
@@ -613,6 +642,18 @@ final class DownloadManager {
         persist()
         processQueue()
         ensurePolling()
+    }
+
+    private func invalidatePendingRegistrations() {
+        registrationScopeGeneration &+= 1
+        pendingRegistrationTokens.removeAll()
+        pendingRegistrationContentIds.removeAll()
+    }
+
+    private func finishPendingRegistration(contentId: String, token: UUID) {
+        guard pendingRegistrationTokens[contentId] == token else { return }
+        pendingRegistrationTokens.removeValue(forKey: contentId)
+        pendingRegistrationContentIds.remove(contentId)
     }
 
     private func resolvedDownloadQuality(_ requestedQuality: String?) -> String {

--- a/iosApp/iosApp/Downloads/DownloadManager.swift
+++ b/iosApp/iosApp/Downloads/DownloadManager.swift
@@ -5,11 +5,13 @@ import OSLog
 enum DownloadError: LocalizedError {
     case unavailable
     case fileURLUnavailable
+    case emptyRegistrationResponse
 
     var errorDescription: String? {
         switch self {
         case .unavailable: return "Downloads aren't available for this profile."
         case .fileURLUnavailable: return "Could not resolve the download URL."
+        case .emptyRegistrationResponse: return "The server didn't create a download."
         }
     }
 }
@@ -50,6 +52,14 @@ final class DownloadManager {
 
     private(set) var scopeServerId: String = ""
     private(set) var scopeProfileId: String = ""
+
+    /// Coalesces the several legitimate app-lifecycle callers that can all ask
+    /// for the same scope at launch. Without this, a late disk read can replace
+    /// a newly registered in-memory download with its older empty snapshot.
+    private var scopeLoadTask: Task<DownloadStoreFile, Never>?
+    private var scopeLoadToken: UUID?
+    private var scopeLoadServerId = ""
+    private var scopeLoadProfileId = ""
 
     private let sessionDelegate = DownloadSessionDelegate()
     private var intentionalCancels: Set<Int> = []
@@ -110,6 +120,10 @@ final class DownloadManager {
     /// whole `file` blob — reassigned on every transfer progress tick — as
     /// their observed state.
     private(set) var downloadsEnabled: Bool = false
+    /// Leaf ids currently waiting for POST /downloads to return. This belongs
+    /// to the manager (rather than one button) so a detail rebuild cannot make
+    /// the preparing indicator disappear during registration.
+    private(set) var pendingRegistrationContentIds: Set<String> = []
     var canDownloadSeason: Bool { downloadsEnabled && capability?.seasonDownload == true }
     var canMonitorSeries: Bool { downloadsEnabled && capability?.seriesMonitoring == true }
 
@@ -167,6 +181,10 @@ final class DownloadManager {
     /// The download record for a leaf content id (movie or episode), if any.
     func record(forContentId contentId: String) -> DownloadRecord? {
         file.records.values.first { $0.contentId == contentId || $0.episodeId == contentId }
+    }
+
+    func isRegistering(contentId: String) -> Bool {
+        pendingRegistrationContentIds.contains(contentId)
     }
 
     func record(id: String) -> DownloadRecord? { file.records[id] }
@@ -375,7 +393,40 @@ final class DownloadManager {
         }
         scopeServerId = serverId
         scopeProfileId = profileId
-        file = await DownloadStore.shared.load(serverId: serverId, profileId: profileId)
+
+        let loadTask: Task<DownloadStoreFile, Never>
+        let loadToken: UUID
+        if let existing = scopeLoadTask,
+           scopeLoadServerId == serverId,
+           scopeLoadProfileId == profileId,
+           let existingToken = scopeLoadToken {
+            loadTask = existing
+            loadToken = existingToken
+        } else {
+            scopeLoadTask?.cancel()
+            let token = UUID()
+            let task = Task {
+                await DownloadStore.shared.load(serverId: serverId, profileId: profileId)
+            }
+            scopeLoadTask = task
+            scopeLoadToken = token
+            scopeLoadServerId = serverId
+            scopeLoadProfileId = profileId
+            loadTask = task
+            loadToken = token
+        }
+
+        let loadedFile = await loadTask.value
+        guard scopeServerId == serverId, scopeProfileId == profileId else { return false }
+        if scopeLoadToken == loadToken {
+            // Exactly one waiter installs this snapshot. Later waiters observe
+            // the already-hydrated `file` instead of assigning it a second time.
+            file = loadedFile
+            scopeLoadTask = nil
+            scopeLoadToken = nil
+            scopeLoadServerId = ""
+            scopeLoadProfileId = ""
+        }
         releaseHeldSessionEvents()
         refreshStorageUsage()
         await backfillEpisodeMetadataIfNeeded()
@@ -413,6 +464,12 @@ final class DownloadManager {
         retryTasks.removeAll()
         pendingPauseIds.removeAll()
         pendingResumeIds.removeAll()
+        pendingRegistrationContentIds.removeAll()
+        scopeLoadTask?.cancel()
+        scopeLoadTask = nil
+        scopeLoadToken = nil
+        scopeLoadServerId = ""
+        scopeLoadProfileId = ""
         scopeServerId = ""
         scopeProfileId = ""
         file = .empty
@@ -517,6 +574,10 @@ final class DownloadManager {
     ) async throws {
         guard downloadsEnabled else { throw DownloadError.unavailable }
 
+        let registrationContentId = episodeId ?? contentId
+        guard pendingRegistrationContentIds.insert(registrationContentId).inserted else { return }
+        defer { pendingRegistrationContentIds.remove(registrationContentId) }
+
         // Series/season batches are original-quality only per the server
         // contract; single items may use any advertised public quality preset.
         let isBatch = series || seasonNumber != nil
@@ -534,6 +595,7 @@ final class DownloadManager {
             caps: DownloadCaps.current()
         )
         let rows = try await ContinuumAPI.shared.createDownload(request)
+        guard !rows.isEmpty else { throw DownloadError.emptyRegistrationResponse }
         for row in rows {
             upsertRow(
                 row,

--- a/iosApp/iosApp/Downloads/DownloadOptionsSheet.swift
+++ b/iosApp/iosApp/Downloads/DownloadOptionsSheet.swift
@@ -93,7 +93,7 @@ struct DownloadOptionsSheet: View {
             .navigationBarTitleDisplayMode(.inline)
             #endif
             .continuumScrollContentBackgroundHidden()
-            .background(Color.continuumBackground)
+            .continuumPageBackground()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }

--- a/iosApp/iosApp/Downloads/DownloadsView.swift
+++ b/iosApp/iosApp/Downloads/DownloadsView.swift
@@ -38,6 +38,7 @@ struct DownloadsView: View {
                 content
             }
         }
+        .continuumPageBackground()
         .navigationTitle(isSelecting ? "\(selection.count) Selected" : "Downloads")
         #if os(iOS)
         .navigationBarTitleDisplayMode(.large)
@@ -166,7 +167,6 @@ struct DownloadsView: View {
             .padding(.bottom, 8)
             .animation(.easeInOut(duration: 0.2), value: isSelecting)
         }
-        .background(Color.continuumBackground)
     }
 
     @ViewBuilder

--- a/iosApp/iosApp/Downloads/SeriesDownloadControls.swift
+++ b/iosApp/iosApp/Downloads/SeriesDownloadControls.swift
@@ -9,6 +9,8 @@ struct SeriesDownloadMenuButton: View {
     let detail: ItemDetail
     let seasons: [Season]
     let selectedSeason: Season?
+    let episodes: [EpisodeListItem]
+    let episodesBySeason: [Int: [EpisodeListItem]]
 
     private var manager: DownloadManager { DownloadManager.shared }
     @State private var activeSheet: SeriesDownloadSheet?
@@ -25,6 +27,15 @@ struct SeriesDownloadMenuButton: View {
 
     private var seriesId: String { detail.seriesId ?? detail.contentId }
     private var isMonitored: Bool { manager.subscription(forSeriesId: seriesId) != nil }
+    private var cachedEpisodesBySeason: [Int: [EpisodeListItem]] {
+        var cached = episodesBySeason
+        if let seasonNumber = selectedSeason?.seasonNumber,
+           cached[seasonNumber]?.isEmpty != false,
+           !episodes.isEmpty {
+            cached[seasonNumber] = episodes
+        }
+        return cached
+    }
 
     private var circleLabel: some View {
         Image(systemName: isMonitored ? "arrow.down.circle.fill" : "arrow.down.circle")
@@ -85,7 +96,10 @@ struct SeriesDownloadMenuButton: View {
                 SeriesDownloadOptionsSheet(
                     seriesId: seriesId,
                     seriesTitle: detail.title,
+                    seasons: seasons,
                     selectedSeason: selectedSeason,
+                    cachedEpisodesBySeason: cachedEpisodesBySeason,
+                    posterThumbhash: detail.posterThumbhash,
                     canDownloadSeason: manager.canDownloadSeason,
                     canMonitorSeries: manager.canMonitorSeries,
                     isMonitored: isMonitored,
@@ -113,7 +127,10 @@ private enum SeriesDownloadSheet: Identifiable {
 private struct SeriesDownloadOptionsSheet: View {
     let seriesId: String
     let seriesTitle: String
+    let seasons: [Season]
     let selectedSeason: Season?
+    let cachedEpisodesBySeason: [Int: [EpisodeListItem]]
+    let posterThumbhash: String?
     let canDownloadSeason: Bool
     let canMonitorSeries: Bool
     let isMonitored: Bool
@@ -128,6 +145,24 @@ private struct SeriesDownloadOptionsSheet: View {
         NavigationStack {
             Form {
                 Section {
+                    if !availableSeasons.isEmpty {
+                        NavigationLink {
+                            SeriesSeasonDownloadPicker(
+                                seriesId: seriesId,
+                                seriesTitle: seriesTitle,
+                                seasons: availableSeasons,
+                                cachedEpisodesBySeason: cachedEpisodesBySeason,
+                                posterThumbhash: posterThumbhash
+                            )
+                        } label: {
+                            optionLabel(
+                                title: "Choose Episodes",
+                                detail: "Open a season and select episodes",
+                                icon: "checklist"
+                            )
+                        }
+                    }
+
                     if canDownloadSeason, let selectedSeason {
                         optionButton(
                             title: "Download Season \(selectedSeason.seasonNumber)",
@@ -183,7 +218,7 @@ private struct SeriesDownloadOptionsSheet: View {
             .navigationBarTitleDisplayMode(.inline)
             #endif
             .continuumScrollContentBackgroundHidden()
-            .background(Color.continuumBackground)
+            .continuumPageBackground()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
@@ -205,6 +240,12 @@ private struct SeriesDownloadOptionsSheet: View {
         } message: {
             Text(errorMessage ?? "")
         }
+    }
+
+    private var availableSeasons: [Season] {
+        let sorted = seasons.sortedForDisplay()
+        if sorted.isEmpty, let selectedSeason { return [selectedSeason] }
+        return sorted
     }
 
     /// Run a download request, dismissing only on success — a silent
@@ -230,27 +271,408 @@ private struct SeriesDownloadOptionsSheet: View {
         action: @escaping () -> Void
     ) -> some View {
         Button(action: action) {
-            HStack(spacing: 12) {
-                Image(systemName: icon)
-                    .font(.system(size: 17, weight: .semibold))
+            optionLabel(title: title, detail: detail, icon: icon)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func optionLabel(title: String, detail: String, icon: String) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundColor(.continuumOnSurface)
+                .frame(width: 28)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.system(size: 16, weight: .semibold))
                     .foregroundColor(.continuumOnSurface)
-                    .frame(width: 28)
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(title)
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundColor(.continuumOnSurface)
-                    Text(detail)
+                Text(detail)
+                    .font(.continuumCaption)
+                    .foregroundColor(.continuumSecondaryText)
+            }
+            Spacer(minLength: 8)
+            Image(systemName: "chevron.right")
+                .font(.system(size: 12, weight: .bold))
+                .foregroundColor(.continuumSecondaryText)
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+/// First level of the single-episode flow. Keeping seasons as navigation
+/// destinations makes the download sheet scale to long-running series without
+/// turning the first screen into one enormous checklist.
+private struct SeriesSeasonDownloadPicker: View {
+    let seriesId: String
+    let seriesTitle: String
+    let seasons: [Season]
+    let cachedEpisodesBySeason: [Int: [EpisodeListItem]]
+    let posterThumbhash: String?
+
+    var body: some View {
+        List {
+            Section {
+                ForEach(seasons.sortedForDisplay()) { season in
+                    NavigationLink {
+                        SeriesEpisodeDownloadPicker(
+                            seriesId: seriesId,
+                            seriesTitle: seriesTitle,
+                            season: season,
+                            initialEpisodes: cachedEpisodesBySeason[season.seasonNumber] ?? [],
+                            posterThumbhash: season.posterThumbhash ?? posterThumbhash
+                        )
+                    } label: {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(seasonName(season))
+                                .font(.system(size: 16, weight: .semibold))
+                                .foregroundColor(.continuumOnSurface)
+                            Text("\(season.episodeCount) episode\(season.episodeCount == 1 ? "" : "s")")
+                                .font(.continuumCaption)
+                                .foregroundColor(.continuumSecondaryText)
+                        }
+                        .padding(.vertical, 4)
+                    }
+                }
+            } header: {
+                Text("Select a season")
+            }
+        }
+        .navigationTitle("Choose Episodes")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .continuumScrollContentBackgroundHidden()
+        .continuumPageBackground()
+    }
+
+    private func seasonName(_ season: Season) -> String {
+        if season.isSpecials == true || season.seasonNumber == 0 {
+            return season.title ?? "Specials"
+        }
+        return "Season \(season.seasonNumber)"
+    }
+}
+
+/// Native multi-selection for one season. A season's episode list is reused
+/// from the detail model when available and fetched on demand otherwise.
+private struct SeriesEpisodeDownloadPicker: View {
+    let seriesId: String
+    let seriesTitle: String
+    let season: Season
+    let posterThumbhash: String?
+
+    @Environment(\.dismiss) private var dismiss
+    private var manager: DownloadManager { DownloadManager.shared }
+
+    @State private var episodes: [EpisodeListItem]
+    @State private var selectedEpisodeIds: Set<String> = []
+    @State private var isLoading = false
+    @State private var isWorking = false
+    @State private var errorMessage: String?
+
+    init(
+        seriesId: String,
+        seriesTitle: String,
+        season: Season,
+        initialEpisodes: [EpisodeListItem],
+        posterThumbhash: String?
+    ) {
+        self.seriesId = seriesId
+        self.seriesTitle = seriesTitle
+        self.season = season
+        self.posterThumbhash = posterThumbhash
+        _episodes = State(initialValue: Self.sorted(initialEpisodes))
+    }
+
+    private var selectableEpisodeIds: Set<String> {
+        Set(episodes.compactMap { episode in
+            isSelectable(episode) ? episode.contentId : nil
+        })
+    }
+
+    private var selectedEpisodes: [EpisodeListItem] {
+        episodes.filter {
+            selectedEpisodeIds.contains($0.contentId) && isSelectable($0)
+        }
+    }
+
+    private var allSelectableAreSelected: Bool {
+        !selectableEpisodeIds.isEmpty
+            && selectableEpisodeIds.isSubset(of: selectedEpisodeIds)
+    }
+
+    var body: some View {
+        Group {
+            if isLoading, episodes.isEmpty {
+                VStack(spacing: 12) {
+                    ProgressView()
+                    Text("Loading episodes…")
                         .font(.continuumCaption)
                         .foregroundColor(.continuumSecondaryText)
                 }
-                Spacer(minLength: 8)
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 12, weight: .bold))
-                    .foregroundColor(.continuumSecondaryText)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if episodes.isEmpty {
+                EmptyStateView(
+                    icon: "film.stack",
+                    title: "No Episodes",
+                    subtitle: "No downloadable episodes were found for this season."
+                )
+            } else {
+                List {
+                    Section {
+                        ForEach(episodes) { episode in
+                            episodeRow(episode)
+                        }
+                    } header: {
+                        HStack {
+                            Text("Episodes")
+                            Spacer()
+                            if !selectableEpisodeIds.isEmpty {
+                                Button(allSelectableAreSelected ? "Clear" : "Select All") {
+                                    toggleSelectAll()
+                                }
+                                .textCase(nil)
+                            }
+                        }
+                    }
+                }
+                .continuumScrollContentBackgroundHidden()
             }
-            .padding(.vertical, 4)
+        }
+        .continuumPageBackground()
+        .navigationTitle(seasonName)
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .safeAreaInset(edge: .bottom) {
+            if !episodes.isEmpty {
+                downloadBar
+            }
+        }
+        .task { await loadEpisodesIfNeeded() }
+        .alert(
+            "Couldn't Continue",
+            isPresented: Binding(
+                get: { errorMessage != nil },
+                set: { if !$0 { errorMessage = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(errorMessage ?? "")
+        }
+    }
+
+    private var seasonName: String {
+        if season.isSpecials == true || season.seasonNumber == 0 {
+            return season.title ?? "Specials"
+        }
+        return "Season \(season.seasonNumber)"
+    }
+
+    private var downloadBar: some View {
+        Button(action: startSelectedDownloads) {
+            HStack(spacing: 9) {
+                if isWorking {
+                    ProgressView()
+                        .controlSize(.small)
+                        .tint(.black)
+                } else {
+                    Image(systemName: "arrow.down.to.line")
+                }
+                Text(downloadButtonTitle)
+                    .fontWeight(.bold)
+            }
+            .font(.system(size: 15))
+            .frame(maxWidth: .infinity)
+            .frame(height: 50)
+            .background(selectedEpisodes.isEmpty ? Color.continuumDisabled : Color.continuumOnSurface)
+            .foregroundColor(.black)
+            .clipShape(RoundedRectangle(cornerRadius: 15, style: .continuous))
         }
         .buttonStyle(.plain)
+        .disabled(selectedEpisodes.isEmpty || isWorking)
+        .padding(.horizontal, 16)
+        .padding(.top, 10)
+        .padding(.bottom, 8)
+        .background(.ultraThinMaterial)
+    }
+
+    private var downloadButtonTitle: String {
+        let count = selectedEpisodes.count
+        if count == 0 { return "Select Episodes" }
+        return "Download \(count) Episode\(count == 1 ? "" : "s")"
+    }
+
+    private func episodeRow(_ episode: EpisodeListItem) -> some View {
+        let selectable = isSelectable(episode)
+        return Button {
+            guard selectable, !isWorking else { return }
+            toggle(episode.contentId)
+        } label: {
+            HStack(spacing: 12) {
+                selectionIndicator(for: episode)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(episode.title ?? "Episode \(episode.episodeNumber)")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundColor(.continuumOnSurface)
+                        .lineLimit(1)
+                    Text(episodeDetailText(episode))
+                        .font(.continuumCaption)
+                        .foregroundColor(.continuumSecondaryText)
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 8)
+
+                if let status = statusText(for: episode) {
+                    Text(status)
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(statusTint(for: episode))
+                }
+            }
+            .padding(.vertical, 4)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!selectable || isWorking)
+    }
+
+    @ViewBuilder
+    private func selectionIndicator(for episode: EpisodeListItem) -> some View {
+        if manager.isRegistering(contentId: episode.contentId) {
+            ProgressView()
+                .controlSize(.small)
+                .frame(width: 24, height: 24)
+        } else if let record = manager.record(forContentId: episode.contentId) {
+            Image(systemName: statusIcon(for: record.localStatus))
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundColor(statusTint(for: episode))
+                .frame(width: 24, height: 24)
+        } else {
+            DownloadSelectionCircle(selected: selectedEpisodeIds.contains(episode.contentId))
+        }
+    }
+
+    private func episodeDetailText(_ episode: EpisodeListItem) -> String {
+        var parts = ["Episode \(episode.episodeNumber)"]
+        if let runtime = episode.runtime, runtime > 0 {
+            parts.append("\(runtime) min")
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    private func statusText(for episode: EpisodeListItem) -> String? {
+        if manager.isRegistering(contentId: episode.contentId) { return "Preparing" }
+        guard let record = manager.record(forContentId: episode.contentId) else { return nil }
+        switch record.localStatus {
+        case .registering, .preparing, .queued, .fetchingAssets: return "Preparing"
+        case .downloading: return "\(Int((record.progressFraction * 100).rounded()))%"
+        case .paused: return "Paused"
+        case .completed, .revoked: return "Downloaded"
+        case .failed: return "Failed"
+        }
+    }
+
+    private func statusIcon(for status: LocalDownloadStatus) -> String {
+        switch status {
+        case .registering, .preparing, .queued, .fetchingAssets: return "arrow.down.circle"
+        case .downloading: return "arrow.down.circle.fill"
+        case .paused: return "pause.circle.fill"
+        case .completed, .revoked: return "checkmark.circle.fill"
+        case .failed: return "exclamationmark.triangle.fill"
+        }
+    }
+
+    private func statusTint(for episode: EpisodeListItem) -> Color {
+        guard let status = manager.record(forContentId: episode.contentId)?.localStatus else {
+            return .continuumSecondaryText
+        }
+        switch status {
+        case .completed, .revoked: return .green
+        case .failed: return .orange
+        default: return .continuumOnSurface.opacity(0.78)
+        }
+    }
+
+    private func isSelectable(_ episode: EpisodeListItem) -> Bool {
+        manager.record(forContentId: episode.contentId) == nil
+            && !manager.isRegistering(contentId: episode.contentId)
+    }
+
+    private func toggle(_ contentId: String) {
+        if selectedEpisodeIds.contains(contentId) {
+            selectedEpisodeIds.remove(contentId)
+        } else {
+            selectedEpisodeIds.insert(contentId)
+        }
+    }
+
+    private func toggleSelectAll() {
+        if allSelectableAreSelected {
+            selectedEpisodeIds.subtract(selectableEpisodeIds)
+        } else {
+            selectedEpisodeIds.formUnion(selectableEpisodeIds)
+        }
+    }
+
+    private func loadEpisodesIfNeeded() async {
+        guard episodes.isEmpty, !isLoading else { return }
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            let response = try await ContinuumAPI.shared.episodes(
+                seriesId: seriesId,
+                seasonNumber: season.seasonNumber
+            )
+            guard !Task.isCancelled else { return }
+            episodes = Self.sorted(response.episodes)
+        } catch is CancellationError {
+            return
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func startSelectedDownloads() {
+        let targets = selectedEpisodes
+        guard !targets.isEmpty, !isWorking else { return }
+        isWorking = true
+        Task {
+            do {
+                for episode in targets {
+                    guard isSelectable(episode) else {
+                        selectedEpisodeIds.remove(episode.contentId)
+                        continue
+                    }
+                    try await manager.downloadEpisode(
+                        seriesId: seriesId,
+                        episodeId: episode.contentId,
+                        displayTitle: episode.title ?? "Episode \(episode.episodeNumber)",
+                        displaySubtitle: "S\(episode.seasonNumber) · E\(episode.episodeNumber)",
+                        posterThumbhash: posterThumbhash,
+                        quality: DownloadSettings.shared.resolvedFormat(
+                            allowedFormats: manager.capability?.qualityPresets ?? []
+                        )
+                    )
+                    selectedEpisodeIds.remove(episode.contentId)
+                }
+                dismiss()
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+            isWorking = false
+        }
+    }
+
+    private static func sorted(_ episodes: [EpisodeListItem]) -> [EpisodeListItem] {
+        episodes.sorted { lhs, rhs in
+            if lhs.episodeNumber != rhs.episodeNumber {
+                return lhs.episodeNumber < rhs.episodeNumber
+            }
+            return lhs.contentId < rhs.contentId
+        }
     }
 }
 

--- a/iosApp/iosApp/Downloads/SeriesDownloadControls.swift
+++ b/iosApp/iosApp/Downloads/SeriesDownloadControls.swift
@@ -323,7 +323,7 @@ private struct SeriesSeasonDownloadPicker: View {
                         )
                     } label: {
                         VStack(alignment: .leading, spacing: 4) {
-                            Text(seasonName(season))
+                            Text(season.downloadDisplayName)
                                 .font(.system(size: 16, weight: .semibold))
                                 .foregroundColor(.continuumOnSurface)
                             Text("\(season.episodeCount) episode\(season.episodeCount == 1 ? "" : "s")")
@@ -343,13 +343,6 @@ private struct SeriesSeasonDownloadPicker: View {
         #endif
         .continuumScrollContentBackgroundHidden()
         .continuumPageBackground()
-    }
-
-    private func seasonName(_ season: Season) -> String {
-        if season.isSpecials == true || season.seasonNumber == 0 {
-            return season.title ?? "Specials"
-        }
-        return "Season \(season.seasonNumber)"
     }
 }
 
@@ -440,7 +433,7 @@ private struct SeriesEpisodeDownloadPicker: View {
             }
         }
         .continuumPageBackground()
-        .navigationTitle(seasonName)
+        .navigationTitle(season.downloadDisplayName)
         #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
         #endif
@@ -461,13 +454,6 @@ private struct SeriesEpisodeDownloadPicker: View {
         } message: {
             Text(errorMessage ?? "")
         }
-    }
-
-    private var seasonName: String {
-        if season.isSpecials == true || season.seasonNumber == 0 {
-            return season.title ?? "Specials"
-        }
-        return "Season \(season.seasonNumber)"
     }
 
     private var downloadBar: some View {
@@ -537,6 +523,15 @@ private struct SeriesEpisodeDownloadPicker: View {
         }
         .buttonStyle(.plain)
         .disabled(!selectable || isWorking)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(episodeAccessibilityLabel(episode))
+        .accessibilityValue(episodeAccessibilityValue(episode))
+        .accessibilityAddTraits(
+            selectedEpisodeIds.contains(episode.contentId) ? .isSelected : []
+        )
+        .accessibilityHint(
+            selectable ? "Double tap to toggle this episode for download." : ""
+        )
     }
 
     @ViewBuilder
@@ -561,6 +556,20 @@ private struct SeriesEpisodeDownloadPicker: View {
             parts.append("\(runtime) min")
         }
         return parts.joined(separator: " · ")
+    }
+
+    private func episodeAccessibilityLabel(_ episode: EpisodeListItem) -> String {
+        let details = episodeDetailText(episode)
+        guard let title = episode.title?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !title.isEmpty else {
+            return details
+        }
+        return "\(title), \(details)"
+    }
+
+    private func episodeAccessibilityValue(_ episode: EpisodeListItem) -> String {
+        if let status = statusText(for: episode) { return status }
+        return selectedEpisodeIds.contains(episode.contentId) ? "Selected" : "Not selected"
     }
 
     private func statusText(for episode: EpisodeListItem) -> String? {

--- a/iosApp/iosApp/Downloads/Views/DownloadReclaimSheet.swift
+++ b/iosApp/iosApp/Downloads/Views/DownloadReclaimSheet.swift
@@ -25,11 +25,11 @@ struct DownloadReclaimSheet: View {
                         title: "All Caught Up",
                         subtitle: "There are no watched downloads to clear right now."
                     )
-                    .background(Color.continuumBackground)
                 } else {
                     list
                 }
             }
+            .continuumPageBackground()
             .navigationTitle("Free Up Space")
             #if os(iOS)
             .navigationBarTitleDisplayMode(.inline)
@@ -60,7 +60,6 @@ struct DownloadReclaimSheet: View {
                 Color.clear.frame(height: 24)
             }
         }
-        .background(Color.continuumBackground)
     }
 
     private var header: some View {

--- a/iosApp/iosApp/Downloads/Views/OfflineBrowse.swift
+++ b/iosApp/iosApp/Downloads/Views/OfflineBrowse.swift
@@ -29,9 +29,9 @@ struct OfflineSeriesBrowseView: View {
                     title: "No Downloads",
                     subtitle: "This series has no downloaded episodes."
                 )
-                .background(Color.continuumBackground)
             }
         }
+        .continuumPageBackground()
         .navigationTitle(group?.title ?? "Series")
         #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
@@ -92,7 +92,6 @@ struct OfflineSeriesBrowseView: View {
                 Color.clear.frame(height: 30)
             }
         }
-        .background(Color.continuumBackground)
     }
 
     private func seasonChips(_ group: DownloadSeriesGroup) -> some View {
@@ -207,9 +206,9 @@ struct OfflineDownloadDetailView: View {
                 content(record)
             } else {
                 EmptyStateView(icon: "arrow.down.circle", title: "Download Removed", subtitle: nil)
-                    .background(Color.continuumBackground)
             }
         }
+        .continuumPageBackground()
         .navigationTitle("")
         #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
@@ -267,7 +266,6 @@ struct OfflineDownloadDetailView: View {
                 Color.clear.frame(height: 30)
             }
         }
-        .background(Color.continuumBackground)
     }
 
     private func still(_ record: DownloadRecord) -> some View {

--- a/iosApp/iosApp/Extensions/ViewExtensions.swift
+++ b/iosApp/iosApp/Extensions/ViewExtensions.swift
@@ -9,7 +9,7 @@ struct ContinuumPageBackdrop: View {
     var body: some View {
         #if os(iOS)
         ZStack {
-            Color(hex: "#1D1F1D")
+            Color(hex: "#171917")
 
             RadialGradient(
                 stops: [

--- a/iosApp/iosApp/Extensions/ViewExtensions.swift
+++ b/iosApp/iosApp/Extensions/ViewExtensions.swift
@@ -2,6 +2,48 @@ import SwiftUI
 
 // MARK: - Common View Modifiers
 
+/// The shared signed-in page canvas. On iOS it is a fixed, fully opaque
+/// charcoal wash with static tonal depth; it never samples page artwork.
+/// Other platforms retain their existing pure-black canvas.
+struct ContinuumPageBackdrop: View {
+    var body: some View {
+        #if os(iOS)
+        ZStack {
+            Color(hex: "#1D1F1D")
+
+            RadialGradient(
+                stops: [
+                    .init(color: .white.opacity(0.035), location: 0),
+                    .init(color: .white.opacity(0.018), location: 0.36),
+                    .init(color: .clear, location: 1),
+                ],
+                center: UnitPoint(x: 0.46, y: 0.42),
+                startRadius: 0,
+                endRadius: 520
+            )
+
+            LinearGradient(
+                stops: [
+                    .init(color: .white.opacity(0.012), location: 0),
+                    .init(color: .clear, location: 0.45),
+                    .init(color: .black.opacity(0.045), location: 1),
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        }
+        .ignoresSafeArea()
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+        #else
+        Color.continuumBackground
+            .ignoresSafeArea()
+            .allowsHitTesting(false)
+            .accessibilityHidden(true)
+        #endif
+    }
+}
+
 enum ContinuumNavigationTitleDisplayMode {
     case automatic
     case inline
@@ -9,9 +51,17 @@ enum ContinuumNavigationTitleDisplayMode {
 }
 
 extension View {
-    /// Apply the standard Continuum dark background.
+    /// Apply the original pure-black Continuum canvas.
     func continuumBackground() -> some View {
         self.background(Color.continuumBackground.ignoresSafeArea())
+    }
+
+    /// Apply the fixed charcoal page canvas without changing semantic black
+    /// ink used by controls, artwork masks, Settings, or media surfaces.
+    func continuumPageBackground() -> some View {
+        self.background {
+            ContinuumPageBackdrop()
+        }
     }
 
     /// Card-style surface with rounded corners — zero elevation (Plezy style).

--- a/iosApp/iosApp/Extensions/ViewExtensions.swift
+++ b/iosApp/iosApp/Extensions/ViewExtensions.swift
@@ -9,7 +9,7 @@ struct ContinuumPageBackdrop: View {
     var body: some View {
         #if os(iOS)
         ZStack {
-            Color(hex: "#171917")
+            Color(hex: "#111111")
 
             RadialGradient(
                 stops: [

--- a/iosApp/iosApp/Networking/Models.swift
+++ b/iosApp/iosApp/Networking/Models.swift
@@ -700,6 +700,14 @@ struct Season: Codable, Identifiable, Hashable {
     let userData: SeasonUserData?
     var id: String { contentId }
 
+    /// Consistent label for season pickers and episode-section headings.
+    var downloadDisplayName: String {
+        if isSpecials == true || seasonNumber == 0 {
+            return title ?? "Specials"
+        }
+        return "Season \(seasonNumber)"
+    }
+
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         contentId = try c.decode(String.self, forKey: .contentId)

--- a/iosApp/iosApp/Screens/Browse/BrowseView.swift
+++ b/iosApp/iosApp/Screens/Browse/BrowseView.swift
@@ -34,7 +34,7 @@ struct BrowseView: View {
                 emptyContent
             }
         }
-        .continuumBackground()
+        .continuumPageBackground()
         .overlay(alignment: .top) {
             // Grid is painted from cache but the server can't be reached —
             // flag the staleness instead of letting refresh fail silently.
@@ -102,6 +102,7 @@ struct BrowseView: View {
                     items: viewModel.items,
                     isLoading: viewModel.isLoading,
                     hasMore: viewModel.hasMore,
+                    forcesThreeColumnsOnPhone: libraryId != nil,
                     onItemTap: { router.navigate(to: .itemDetail(browseItem: $0)) },
                     onLoadMore: {
                         Task { await viewModel.loadItems() }
@@ -339,7 +340,7 @@ struct LibraryDetailView: View {
             tabContent
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .continuumBackground()
+        .continuumPageBackground()
         .task {
             await loadLibraryMetadataIfNeeded()
         }
@@ -454,7 +455,7 @@ struct LibraryRecommendedView: View {
         }
         .animation(.easeInOut(duration: 0.18), value: isRefreshing)
         .animation(.easeInOut(duration: 0.18), value: ConnectionMonitor.shared.isOffline)
-        .continuumBackground()
+        .continuumPageBackground()
         .task(id: libraryId) {
             await viewModel.loadSections(libraryId: libraryId)
         }

--- a/iosApp/iosApp/Screens/Browse/CatalogGrid.swift
+++ b/iosApp/iosApp/Screens/Browse/CatalogGrid.swift
@@ -7,6 +7,9 @@ struct CatalogGrid: View {
     let items: [BrowseItem]
     let isLoading: Bool
     let hasMore: Bool
+    /// Library grids stay three-up on iPhone even when the shared card
+    /// preference is Large. Other CatalogGrid call sites remain adaptive.
+    var forcesThreeColumnsOnPhone = false
     let onItemTap: (BrowseItem) -> Void
     let onLoadMore: () -> Void
     @Environment(AppRouter.self) private var router
@@ -30,7 +33,13 @@ struct CatalogGrid: View {
     #else
     @Environment(\.horizontalSizeClass) private var hSize
     private var columns: [GridItem] {
-        AdaptiveColumns.posters(
+        if usesThreeColumnPhoneLayout {
+            return Array(
+                repeating: GridItem(.flexible(), spacing: 8),
+                count: 3
+            )
+        }
+        return AdaptiveColumns.posters(
             for: hSize,
             posterSize: uiCustomization.cardPresentation.posterSize,
             spacing: 8
@@ -52,7 +61,8 @@ struct CatalogGrid: View {
                     action: { onItemTap(item) },
                     playAction: playAction(for: item),
                     contentId: item.contentId,
-                    aspect: item.isAudiobook ? .square : .poster
+                    aspect: item.isAudiobook ? .square : .poster,
+                    cardWidthOverride: phoneCardWidthOverride
                 )
                 .frame(maxWidth: .infinity)
                 .onAppear {
@@ -97,5 +107,21 @@ struct CatalogGrid: View {
         #else
         return nil
         #endif
+    }
+
+    private var usesThreeColumnPhoneLayout: Bool {
+        #if os(iOS)
+        forcesThreeColumnsOnPhone && UIDevice.current.userInterfaceIdiom == .phone
+        #else
+        false
+        #endif
+    }
+
+    /// MediaCard applies the global poster-size scale after its override. Undo
+    /// that scale here so these phone columns use the standard 120pt card width.
+    private var phoneCardWidthOverride: CGFloat? {
+        guard usesThreeColumnPhoneLayout else { return nil }
+        return ContinuumTheme.posterCardWidth
+            / uiCustomization.cardPresentation.posterSize.scale
     }
 }

--- a/iosApp/iosApp/Screens/Browse/CatalogGrid.swift
+++ b/iosApp/iosApp/Screens/Browse/CatalogGrid.swift
@@ -14,6 +14,7 @@ struct CatalogGrid: View {
     let onLoadMore: () -> Void
     @Environment(AppRouter.self) private var router
     @State private var uiCustomization = UICustomizationPreferences.shared
+    @State private var gridWidth: CGFloat = 0
     #if !os(tvOS)
     @State private var detailBrowseOriginID = UUID().uuidString
     @State private var detailBrowseSource: ItemDetailBrowseSource?
@@ -72,6 +73,14 @@ struct CatalogGrid: View {
                 }
             }
         }
+        #if os(iOS)
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.width
+        } action: { width in
+            guard abs(width - gridWidth) >= 0.5 else { return }
+            gridWidth = width
+        }
+        #endif
         #if !os(tvOS)
         .scrollTargetLayout()
         .environment(\.itemDetailBrowseSource, detailBrowseSource)
@@ -118,10 +127,14 @@ struct CatalogGrid: View {
     }
 
     /// MediaCard applies the global poster-size scale after its override. Undo
-    /// that scale here so these phone columns use the standard 120pt card width.
+    /// that scale here, then cap the standard width to the measured grid cell.
     private var phoneCardWidthOverride: CGFloat? {
         guard usesThreeColumnPhoneLayout else { return nil }
-        return ContinuumTheme.posterCardWidth
-            / uiCustomization.cardPresentation.posterSize.scale
+        let fittedWidth = AdaptiveColumns.fittedPosterWidth(
+            containerWidth: gridWidth,
+            columnCount: 3,
+            spacing: 8
+        )
+        return fittedWidth / uiCustomization.cardPresentation.posterSize.scale
     }
 }

--- a/iosApp/iosApp/Screens/Browse/FilterView.swift
+++ b/iosApp/iosApp/Screens/Browse/FilterView.swift
@@ -31,7 +31,7 @@ struct FilterView: View {
             .listStyle(.plain)
             .filterScrollContentBackgroundHidden()
             .environment(\.defaultMinListRowHeight, 50)
-            .continuumBackground()
+            .continuumPageBackground()
             .navigationTitle("Filter")
             .continuumNavigationTitleDisplayMode(.inline)
             .toolbar {
@@ -282,7 +282,7 @@ private struct FacetValuePicker: View {
         .listStyle(.plain)
         .filterScrollContentBackgroundHidden()
         .environment(\.defaultMinListRowHeight, 50)
-        .continuumBackground()
+        .continuumPageBackground()
         .navigationTitle(facet.title)
         .continuumNavigationTitleDisplayMode(.inline)
         .continuumNavigationBarSurfaceBackground()

--- a/iosApp/iosApp/Screens/Browse/LibrariesTabView.swift
+++ b/iosApp/iosApp/Screens/Browse/LibrariesTabView.swift
@@ -267,7 +267,7 @@ struct LibrariesTabView: View {
                 )
             }
         }
-        .continuumBackground()
+        .continuumPageBackground()
         #if !os(macOS)
         .toolbar(.hidden, for: .navigationBar)
         #endif
@@ -628,7 +628,7 @@ private struct LibraryPickerSheet: View {
             .padding(.horizontal, ContinuumTheme.padding)
             .padding(.vertical, ContinuumTheme.padding)
         }
-        .continuumBackground()
+        .continuumPageBackground()
         .navigationTitle("Libraries")
     }
 }

--- a/iosApp/iosApp/Screens/Calendar/CalendarView.swift
+++ b/iosApp/iosApp/Screens/Calendar/CalendarView.swift
@@ -58,7 +58,7 @@ struct CalendarView: View {
         // No standalone title bar: the search / profile actions live inside
         // the floating calendar card so the agenda reclaims that height.
         phoneContent
-            .continuumBackground()
+            .continuumPageBackground()
         #if os(iOS)
             .toolbar(.hidden, for: .navigationBar)
         #endif

--- a/iosApp/iosApp/Screens/Collections/CollectionDetailView.swift
+++ b/iosApp/iosApp/Screens/Collections/CollectionDetailView.swift
@@ -8,6 +8,7 @@ struct CollectionDetailView: View {
     @State private var isLoading = false
     @State private var error: ErrorState?
     @State private var uiCustomization = UICustomizationPreferences.shared
+    @State private var gridWidth: CGFloat = 0
     @Environment(AppRouter.self) private var router
     @Environment(\.horizontalSizeClass) private var hSize
 
@@ -72,6 +73,14 @@ struct CollectionDetailView: View {
                     .frame(maxWidth: .infinity)
                 }
             }
+            #if os(iOS)
+            .onGeometryChange(for: CGFloat.self) { proxy in
+                proxy.size.width
+            } action: { width in
+                guard abs(width - gridWidth) >= 0.5 else { return }
+                gridWidth = width
+            }
+            #endif
             .padding(ContinuumTheme.padding)
         }
     }
@@ -101,8 +110,12 @@ struct CollectionDetailView: View {
 
     private var phoneCardWidthOverride: CGFloat? {
         guard usesThreeColumnPhoneLayout else { return nil }
-        return ContinuumTheme.posterCardWidth
-            / uiCustomization.cardPresentation.posterSize.scale
+        let fittedWidth = AdaptiveColumns.fittedPosterWidth(
+            containerWidth: gridWidth,
+            columnCount: 3,
+            spacing: 12
+        )
+        return fittedWidth / uiCustomization.cardPresentation.posterSize.scale
     }
 
     private func loadItems() async {

--- a/iosApp/iosApp/Screens/Collections/CollectionDetailView.swift
+++ b/iosApp/iosApp/Screens/Collections/CollectionDetailView.swift
@@ -12,7 +12,13 @@ struct CollectionDetailView: View {
     @Environment(\.horizontalSizeClass) private var hSize
 
     private var columns: [GridItem] {
-        AdaptiveColumns.posters(
+        if usesThreeColumnPhoneLayout {
+            return Array(
+                repeating: GridItem(.flexible(), spacing: 12),
+                count: 3
+            )
+        }
+        return AdaptiveColumns.posters(
             for: hSize,
             posterSize: uiCustomization.cardPresentation.posterSize
         )
@@ -34,7 +40,7 @@ struct CollectionDetailView: View {
                 )
             }
         }
-        .continuumBackground()
+        .continuumPageBackground()
         .navigationTitle("Collection")
         .continuumNavigationTitleDisplayMode(.large)
         .task {
@@ -60,7 +66,8 @@ struct CollectionDetailView: View {
                             router.navigate(to: .itemDetail(browseItem: item))
                         },
                         playAction: playAction(for: item),
-                        contentId: item.contentId
+                        contentId: item.contentId,
+                        cardWidthOverride: phoneCardWidthOverride
                     )
                     .frame(maxWidth: .infinity)
                 }
@@ -82,6 +89,20 @@ struct CollectionDetailView: View {
         #else
         return nil
         #endif
+    }
+
+    private var usesThreeColumnPhoneLayout: Bool {
+        #if os(iOS)
+        UIDevice.current.userInterfaceIdiom == .phone
+        #else
+        false
+        #endif
+    }
+
+    private var phoneCardWidthOverride: CGFloat? {
+        guard usesThreeColumnPhoneLayout else { return nil }
+        return ContinuumTheme.posterCardWidth
+            / uiCustomization.cardPresentation.posterSize.scale
     }
 
     private func loadItems() async {

--- a/iosApp/iosApp/Screens/Collections/CollectionsView.swift
+++ b/iosApp/iosApp/Screens/Collections/CollectionsView.swift
@@ -34,7 +34,7 @@ struct CollectionsView: View {
                 )
             }
         }
-        .continuumBackground()
+        .continuumPageBackground()
         .navigationTitle("Collections")
         .continuumNavigationTitleDisplayMode(.large)
         .toolbar {
@@ -211,7 +211,7 @@ struct CollectionsView: View {
                 Spacer()
             }
             .padding(ContinuumTheme.padding)
-            .continuumBackground()
+            .continuumPageBackground()
             .navigationTitle("New Collection")
             .continuumNavigationTitleDisplayMode(.inline)
             .toolbar {
@@ -240,7 +240,7 @@ private struct GroupActionSheet: View {
     var body: some View {
         NavigationStack {
             content
-                .continuumBackground()
+                .continuumPageBackground()
                 .continuumNavigationTitleDisplayMode(.inline)
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
@@ -441,7 +441,13 @@ struct LibraryCollectionsView: View {
     @Environment(\.horizontalSizeClass) private var hSize
 
     private var columns: [GridItem] {
-        AdaptiveColumns.posters(
+        if usesThreeColumnPhoneLayout {
+            return Array(
+                repeating: GridItem(.flexible(), spacing: 12),
+                count: 3
+            )
+        }
+        return AdaptiveColumns.posters(
             for: hSize,
             posterSize: uiCustomization.cardPresentation.posterSize
         )
@@ -471,7 +477,7 @@ struct LibraryCollectionsView: View {
                 )
             }
         }
-        .continuumBackground()
+        .continuumPageBackground()
         .task(id: libraryId) {
             await viewModel.loadCollections(libraryId: libraryId)
         }
@@ -498,7 +504,10 @@ struct LibraryCollectionsView: View {
                             kind: collection.kind
                         )
                     ) {
-                        LibraryCollectionCard(collection: collection)
+                        LibraryCollectionCard(
+                            collection: collection,
+                            usesStandardPhoneWidth: usesThreeColumnPhoneLayout
+                        )
                     }
                     .buttonStyle(.plain)
                     .frame(maxWidth: .infinity)
@@ -508,14 +517,25 @@ struct LibraryCollectionsView: View {
             }
         }
     }
+
+    private var usesThreeColumnPhoneLayout: Bool {
+        #if os(iOS)
+        UIDevice.current.userInterfaceIdiom == .phone
+        #else
+        false
+        #endif
+    }
 }
 
 private struct LibraryCollectionCard: View {
     let collection: LibraryCollection
+    let usesStandardPhoneWidth: Bool
     @State private var uiCustomization = UICustomizationPreferences.shared
 
     private var cardWidth: CGFloat {
-        ContinuumTheme.posterCardWidth * uiCustomization.cardPresentation.posterSize.scale
+        ContinuumTheme.posterCardWidth * (usesStandardPhoneWidth
+            ? 1
+            : uiCustomization.cardPresentation.posterSize.scale)
     }
     private var cardHeight: CGFloat {
         cardWidth * (ContinuumTheme.posterCardHeight / ContinuumTheme.posterCardWidth)
@@ -626,7 +646,7 @@ struct LibraryCollectionDetailView: View {
                 )
             }
         }
-        .continuumBackground()
+        .continuumPageBackground()
         .navigationTitle(title ?? "Collection")
         .continuumNavigationTitleDisplayMode(.large)
         .task(id: "\(libraryId)-\(collectionId)") {
@@ -648,6 +668,7 @@ struct LibraryCollectionDetailView: View {
                     items: items,
                     isLoading: isLoading,
                     hasMore: hasMore,
+                    forcesThreeColumnsOnPhone: true,
                     onItemTap: { item in
                         router.navigate(to: .itemDetail(browseItem: item))
                     },

--- a/iosApp/iosApp/Screens/Collections/CollectionsView.swift
+++ b/iosApp/iosApp/Screens/Collections/CollectionsView.swift
@@ -438,6 +438,7 @@ struct LibraryCollectionsView: View {
 
     @State private var viewModel = LibraryCollectionsViewModel()
     @State private var uiCustomization = UICustomizationPreferences.shared
+    @State private var gridWidth: CGFloat = 0
     @Environment(\.horizontalSizeClass) private var hSize
 
     private var columns: [GridItem] {
@@ -506,7 +507,7 @@ struct LibraryCollectionsView: View {
                     ) {
                         LibraryCollectionCard(
                             collection: collection,
-                            usesStandardPhoneWidth: usesThreeColumnPhoneLayout
+                            cardWidthOverride: libraryCollectionCardWidthOverride
                         )
                     }
                     .buttonStyle(.plain)
@@ -515,6 +516,14 @@ struct LibraryCollectionsView: View {
                     .accessibilityLabel(libraryCollectionAccessibilityLabel(collection))
                 }
             }
+            #if os(iOS)
+            .onGeometryChange(for: CGFloat.self) { proxy in
+                proxy.size.width
+            } action: { width in
+                guard abs(width - gridWidth) >= 0.5 else { return }
+                gridWidth = width
+            }
+            #endif
         }
     }
 
@@ -525,17 +534,25 @@ struct LibraryCollectionsView: View {
         false
         #endif
     }
+
+    private var libraryCollectionCardWidthOverride: CGFloat? {
+        guard usesThreeColumnPhoneLayout else { return nil }
+        return AdaptiveColumns.fittedPosterWidth(
+            containerWidth: gridWidth,
+            columnCount: 3,
+            spacing: 12
+        )
+    }
 }
 
 private struct LibraryCollectionCard: View {
     let collection: LibraryCollection
-    let usesStandardPhoneWidth: Bool
+    let cardWidthOverride: CGFloat?
     @State private var uiCustomization = UICustomizationPreferences.shared
 
     private var cardWidth: CGFloat {
-        ContinuumTheme.posterCardWidth * (usesStandardPhoneWidth
-            ? 1
-            : uiCustomization.cardPresentation.posterSize.scale)
+        cardWidthOverride
+            ?? (ContinuumTheme.posterCardWidth * uiCustomization.cardPresentation.posterSize.scale)
     }
     private var cardHeight: CGFloat {
         cardWidth * (ContinuumTheme.posterCardHeight / ContinuumTheme.posterCardWidth)

--- a/iosApp/iosApp/Screens/Detail/AudiobookDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/AudiobookDetailContent.swift
@@ -123,7 +123,7 @@ struct AudiobookDetailContent: View {
             }
             .ignoresSafeArea(edges: .top)
         }
-        .continuumBackground()
+        .continuumPageBackground()
     }
 
     private var phoneSections: some View {

--- a/iosApp/iosApp/Screens/Detail/ItemDetailView.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailView.swift
@@ -28,6 +28,177 @@ private struct ControlRequestBox: Identifiable {
     var id: String { request.contentId }
     init(_ request: SiloControlPlaybackRequest) { self.request = request }
 }
+
+/// Static top-control layout. Scroll progress is read only by the tiny opacity
+/// leaves below, so changing chrome never rebuilds buttons or their actions.
+private struct PhoneDetailTopChrome: View {
+    let title: String
+    let isScrollGlassEnabled: Bool
+    let scrollState: PhoneDetailScrollState
+    let leadingSystemName: String?
+    let leadingAccessibilityLabel: String?
+    let onLeadingTap: () -> Void
+    let trailingSystemName: String
+    let onTrailingTap: () -> Void
+
+    var body: some View {
+        ZStack(alignment: .top) {
+            PhoneDetailTopGlass(
+                isEnabled: isScrollGlassEnabled,
+                scrollState: scrollState
+            )
+
+            PhoneDetailScrollTitle(
+                title: title,
+                isEnabled: isScrollGlassEnabled,
+                scrollState: scrollState
+            )
+
+            HStack {
+                if let leadingSystemName {
+                    Button(action: onLeadingTap) {
+                        controlIcon(
+                            systemName: leadingSystemName,
+                            size: leadingSystemName == "chevron.left" ? 17 : 16
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(leadingAccessibilityLabel ?? "Back")
+                }
+
+                Spacer(minLength: 20)
+
+                Button(action: onTrailingTap) {
+                    controlIcon(systemName: trailingSystemName, size: 16)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Remote Control")
+            }
+            .padding(.horizontal, 18)
+            .padding(.top, 9)
+        }
+        .zIndex(20)
+    }
+
+    private func controlIcon(systemName: String, size: CGFloat) -> some View {
+        ZStack {
+            PhoneDetailControlGlass(
+                isScrollGlassEnabled: isScrollGlassEnabled,
+                scrollState: scrollState
+            )
+
+            Image(systemName: systemName)
+                .font(.system(size: size, weight: .semibold))
+                .foregroundStyle(.white)
+        }
+        .frame(
+            width: ContinuumTheme.topBarIconHitSize,
+            height: ContinuumTheme.topBarIconHitSize
+        )
+        .contentShape(Circle())
+    }
+}
+
+/// Dynamic opacity around a stable glass subtree. The expensive native glass
+/// node is equatable and retained while only its compositor alpha changes.
+private struct PhoneDetailTopGlass: View {
+    let isEnabled: Bool
+    let scrollState: PhoneDetailScrollState
+
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+
+    @ViewBuilder
+    var body: some View {
+        if isEnabled {
+            PhoneDetailStaticGlassStrip(reduceTransparency: reduceTransparency)
+                .equatable()
+                .opacity(phoneDetailSmoothProgress(scrollState.offset, from: 200, to: 360))
+                .allowsHitTesting(false)
+                .accessibilityHidden(true)
+        }
+    }
+}
+
+private struct PhoneDetailStaticGlassStrip: View, Equatable {
+    let reduceTransparency: Bool
+
+    var body: some View {
+        Group {
+            if reduceTransparency {
+                Color(white: 0.16).opacity(0.98)
+            } else {
+                Color.clear
+                    .siloGlass(in: Rectangle(), tint: Color.black.opacity(0.10))
+                    .overlay(Color.white.opacity(0.025))
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: ContinuumTheme.topBarIconHitSize + 18)
+    }
+}
+
+private struct PhoneDetailScrollTitle: View {
+    let title: String
+    let isEnabled: Bool
+    let scrollState: PhoneDetailScrollState
+
+    @ViewBuilder
+    var body: some View {
+        if isEnabled {
+            let progress = phoneDetailSmoothProgress(scrollState.offset, from: 400, to: 480)
+            Text(title)
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(.white)
+                .lineLimit(1)
+                .minimumScaleFactor(0.82)
+                .padding(.horizontal, 96)
+                .frame(
+                    maxWidth: .infinity,
+                    minHeight: ContinuumTheme.topBarIconHitSize,
+                    alignment: .center
+                )
+                .padding(.top, 9)
+                .opacity(progress)
+                .allowsHitTesting(false)
+                .accessibilityHidden(progress < 0.5)
+        }
+    }
+}
+
+private struct PhoneDetailControlGlass: View {
+    let isScrollGlassEnabled: Bool
+    let scrollState: PhoneDetailScrollState
+
+    var body: some View {
+        PhoneDetailStaticControlGlass()
+            .equatable()
+            .opacity(
+                isScrollGlassEnabled
+                    ? 1 - phoneDetailSmoothProgress(scrollState.offset, from: 150, to: 260)
+                    : 1
+            )
+    }
+}
+
+private struct PhoneDetailStaticControlGlass: View, Equatable {
+    var body: some View {
+        Color.clear
+            .frame(
+                width: ContinuumTheme.topBarIconHitSize,
+                height: ContinuumTheme.topBarIconHitSize
+            )
+            .siloGlass(in: Circle(), interactive: true)
+    }
+}
+
+private func phoneDetailSmoothProgress(
+    _ value: CGFloat,
+    from lowerBound: CGFloat,
+    to upperBound: CGFloat
+) -> CGFloat {
+    let progress = min(max((value - lowerBound) / (upperBound - lowerBound), 0), 1)
+    return progress * progress * (3 - (2 * progress))
+}
 #endif
 
 #if !os(tvOS)
@@ -87,8 +258,10 @@ private struct ItemDetailPhoneContent: View {
     @State private var refreshOnPlayerDismiss = false
     @State private var offlinePlayChoice: OfflinePlayChoice?
     @State private var unreachablePlayRequest: UnreachablePlayRequest?
+    @State private var detailScrollState = PhoneDetailScrollState()
     #if os(iOS)
     @Environment(SiloControlClient.self) private var siloControl
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var controlRequestBox: ControlRequestBox?
     @State private var isShowingControlPicker = false
     @State private var isShowingRemoteControl = false
@@ -125,6 +298,7 @@ private struct ItemDetailPhoneContent: View {
             isLoadingNextUpWatchDetail = false
             selectedSeriesEpisodeId = nil
             refreshOnPlayerDismiss = false
+            detailScrollState.reset()
             await viewModel.loadDetail(contentId: contentId)
             seedSubtitleOverrideIfNeeded()
         }
@@ -238,60 +412,37 @@ private struct ItemDetailPhoneContent: View {
 
     #if os(iOS)
     private var detailTopControls: some View {
-        HStack {
-            if let onClose {
-                Button(action: onClose) {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundStyle(.white)
-                        .frame(
-                            width: ContinuumTheme.topBarIconHitSize,
-                            height: ContinuumTheme.topBarIconHitSize
-                        )
-                        .siloGlass(in: Circle(), interactive: true)
-                        .contentShape(Circle())
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Close details")
-            } else if !router.itemDetailPath.isEmpty {
-                Button {
+        let showsClose = onClose != nil
+        let showsBack = !showsClose && !router.itemDetailPath.isEmpty
+
+        return PhoneDetailTopChrome(
+            title: viewModel.detail?.title ?? "",
+            isScrollGlassEnabled: supportsScrollGlassChrome,
+            scrollState: detailScrollState,
+            leadingSystemName: showsClose ? "xmark" : (showsBack ? "chevron.left" : nil),
+            leadingAccessibilityLabel: showsClose ? "Close details" : (showsBack ? "Back" : nil),
+            onLeadingTap: {
+                if let onClose {
+                    onClose()
+                } else if !router.itemDetailPath.isEmpty {
                     router.itemDetailPath.removeLast()
-                } label: {
-                    Image(systemName: "chevron.left")
-                        .font(.system(size: 17, weight: .semibold))
-                        .foregroundStyle(.white)
-                        .frame(
-                            width: ContinuumTheme.topBarIconHitSize,
-                            height: ContinuumTheme.topBarIconHitSize
-                        )
-                        .siloGlass(in: Circle(), interactive: true)
-                        .contentShape(Circle())
                 }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Back")
-            }
+            },
+            trailingSystemName: siloControl.hasActiveSession
+                ? "appletvremote.gen4.fill"
+                : "appletvremote.gen4",
+            onTrailingTap: handleRemoteControlTap
+        )
+    }
 
-            Spacer(minLength: 20)
-
-            Button(action: handleRemoteControlTap) {
-                Image(systemName: siloControl.hasActiveSession
-                    ? "appletvremote.gen4.fill"
-                    : "appletvremote.gen4")
-                    .font(.system(size: 16, weight: .semibold))
-                    .foregroundStyle(.white)
-                    .frame(
-                        width: ContinuumTheme.topBarIconHitSize,
-                        height: ContinuumTheme.topBarIconHitSize
-                    )
-                    .siloGlass(in: Circle(), interactive: true)
-                    .contentShape(Circle())
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Remote Control")
+    private var supportsScrollGlassChrome: Bool {
+        guard UIDevice.current.userInterfaceIdiom == .phone,
+              horizontalSizeClass != .regular,
+              let detail = viewModel.detail else {
+            return false
         }
-        .padding(.horizontal, 28)
-        .padding(.top, 18)
-        .zIndex(20)
+        return SiloMediaType.isMovieLibrary(detail.type)
+            || SiloMediaType.isSeries(detail.type)
     }
 
     /// Movies and episodes retain the existing cast-and-play behavior. Series
@@ -589,6 +740,7 @@ private struct ItemDetailPhoneContent: View {
                 trailerStatusMessage: viewModel.trailerFetch.statusMessage,
                 isFindingTrailers: viewModel.trailerFetch.isFetching,
                 onTrailerStatusShown: { viewModel.trailerFetch.acknowledge() },
+                scrollState: detailScrollState,
                 belowOverview: {
                     DescriptionTranslationView(viewModel: viewModel, contentId: detail.contentId)
                         .id(detail.contentId)
@@ -696,6 +848,7 @@ private struct ItemDetailPhoneContent: View {
                 trailerStatusMessage: viewModel.trailerFetch.statusMessage,
                 isFindingTrailers: viewModel.trailerFetch.isFetching,
                 onTrailerStatusShown: { viewModel.trailerFetch.acknowledge() },
+                scrollState: detailScrollState,
                 belowOverview: {
                     DescriptionTranslationView(viewModel: viewModel, contentId: detail.contentId)
                         .id(detail.contentId)

--- a/iosApp/iosApp/Screens/Detail/MovieDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/MovieDetailContent.swift
@@ -49,6 +49,9 @@ struct MovieDetailContent<BelowOverview: View>: View {
     let isFindingTrailers: Bool
     /// Called once a terminal status message has been on screen long enough.
     let onTrailerStatusShown: () -> Void
+    /// Reference-backed scroll state observed only by the small parallax and
+    /// pinned-chrome views, keeping the native ScrollView's body stable.
+    let scrollState: PhoneDetailScrollState
     /// On-view description-translation affordance, built at the detail call
     /// site (which owns the view model) and rendered under the overview.
     @ViewBuilder let belowOverview: () -> BelowOverview
@@ -60,7 +63,11 @@ struct MovieDetailContent<BelowOverview: View>: View {
     @State private var showDownloadOptions = false
 
     var body: some View {
-        PhoneDetailPageSurface(backdropURL: detail.backdropUrl) {
+        PhoneDetailPageSurface(
+            backdropURL: detail.backdropUrl,
+            backdropThumbhash: detail.backdropThumbhash,
+            enablesArtworkGlass: SiloMediaType.isMovieLibrary(detail.type)
+        ) {
             ScrollView(.vertical, showsIndicators: false) {
                 VStack(alignment: .leading, spacing: heroToContentSpacing) {
                     hero
@@ -69,6 +76,13 @@ struct MovieDetailContent<BelowOverview: View>: View {
                 .padding(.bottom, 40)
             }
             .ignoresSafeArea(edges: .top)
+            .coordinateSpace(name: PhoneDetailScrollCoordinateSpace.name)
+            .onScrollGeometryChange(for: CGFloat.self) { geometry in
+                let offset = max(0, geometry.contentOffset.y + geometry.contentInsets.top)
+                return offset <= 150 ? 0 : min(offset, 480)
+            } action: { _, offset in
+                scrollState.update(offset)
+            }
         }
         .continuumResumePlaybackAlert(
             isPresented: $showResumeDialog,
@@ -105,6 +119,7 @@ struct MovieDetailContent<BelowOverview: View>: View {
             factsLine: PhoneHeroMetadata.movieFactsLine(from: detail, version: effectiveVersion),
             creditText: PhoneHeroMetadata.creditText(from: detail),
             overlayData: OverlayData.from(detail),
+            enablesArtworkParallax: SiloMediaType.isMovieLibrary(detail.type),
             actions: { actionStack },
             belowOverview: {
                 VStack(spacing: 14) {

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneDetailHero.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneDetailHero.swift
@@ -1,19 +1,77 @@
 #if !os(tvOS)
 import SwiftUI
 
-/// Fully opaque, artwork-matched surface shared by every mobile video-detail
-/// page. The sampled tint is composited over black, so scrolling never exposes
-/// a live material or blur after the artwork itself has left the screen.
+/// Shared reference state for the pinned chrome. Artwork parallax is driven by
+/// a render-time `visualEffect`, so the native scroll view never has to publish
+/// its high-frequency movement through SwiftUI state just to move the image.
+@Observable
+@MainActor
+final class PhoneDetailScrollState {
+    private(set) var offset: CGFloat = 0
+
+    func update(_ rawOffset: CGFloat) {
+        // Nothing in the chrome changes below 150 points or above 480. Folding
+        // those plateaus onto their endpoints avoids invalidating even the
+        // small chrome views while their rendered output is completely static.
+        let clamped = min(max(0, rawOffset), 480)
+        let normalized = clamped <= 150 ? 0 : clamped
+        guard abs(normalized - offset) >= 0.5 else { return }
+        offset = normalized
+    }
+
+    func reset() {
+        offset = 0
+    }
+}
+
+/// The named native scroll coordinate space used by render-time parallax.
+/// A name resolves to the nearest ancestor, so separately presented detail
+/// cards cannot interfere with one another.
+enum PhoneDetailScrollCoordinateSpace {
+    static let name = "phone-detail-scroll"
+}
+
+/// Artwork-matched surface shared by mobile video-detail pages. Compact iPhone
+/// movie/series cards keep a saturated, heavily softened copy of the hero fixed
+/// behind the ScrollView. It supplies the colour field that remains visible as
+/// the sharp artwork drifts away more slowly than the foreground content.
 struct PhoneDetailPageSurface<Content: View>: View {
     let backdropURL: String?
+    let backdropThumbhash: String?
+    let enablesArtworkGlass: Bool
     @ViewBuilder let content: () -> Content
 
     @State private var sampledTint = Color(red: 0.04, green: 0.12, blue: 0.14)
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
 
     var body: some View {
         ZStack {
             Color.black
-            sampledTint.opacity(0.42)
+
+            if usesArtworkGlass, let backdropURL, !backdropURL.isEmpty {
+                GeometryReader { geometry in
+                    AsyncImageView(
+                        url: backdropURL,
+                        thumbhash: backdropThumbhash,
+                        contentMode: .fill
+                    )
+                    .frame(width: geometry.size.width, height: geometry.size.height)
+                    .scaleEffect(1.18)
+                    .saturation(1.28)
+                    .brightness(-0.10)
+                    .blur(radius: 46, opaque: true)
+                    .clipped()
+                }
+                .allowsHitTesting(false)
+
+                Color.black.opacity(0.28)
+                sampledTint.opacity(0.10)
+                PhoneDetailGrainOverlay()
+            } else {
+                sampledTint.opacity(0.42)
+            }
+
             content()
         }
         .ignoresSafeArea()
@@ -32,6 +90,145 @@ struct PhoneDetailPageSurface<Content: View>: View {
                 sampledTint = tint
             }
         }
+    }
+
+    private var usesArtworkGlass: Bool {
+        guard enablesArtworkGlass, !reduceTransparency else { return false }
+        #if os(iOS)
+        return UIDevice.current.userInterfaceIdiom == .phone
+            && horizontalSizeClass != .regular
+        #else
+        return false
+        #endif
+    }
+}
+
+/// A fixed one-device-pixel monochrome dither. At 1.4% opacity it is not meant
+/// to read as a texture; it only breaks up 8-bit colour steps in large, slowly
+/// changing gradients. The tiny tile is generated once and never animates.
+private struct PhoneDetailGrainOverlay: View {
+    var body: some View {
+        if let texture = PhoneDetailGrainTexture.image {
+            Image(decorative: texture, scale: 3)
+                .resizable(resizingMode: .tile)
+                .interpolation(.none)
+                .blendMode(.overlay)
+                .opacity(0.012)
+                .allowsHitTesting(false)
+                .accessibilityHidden(true)
+        }
+    }
+}
+
+private enum PhoneDetailGrainTexture {
+    static let image: CGImage? = {
+        let width = 96
+        let height = 96
+        var seed: UInt64 = 0x9E37_79B9_7F4A_7C15
+        var pixels = [UInt8](repeating: 0, count: width * height)
+
+        for index in pixels.indices {
+            seed ^= seed << 13
+            seed ^= seed >> 7
+            seed ^= seed << 17
+            pixels[index] = UInt8(truncatingIfNeeded: seed >> 24)
+        }
+
+        guard let provider = CGDataProvider(data: Data(pixels) as CFData) else {
+            return nil
+        }
+
+        return CGImage(
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bitsPerPixel: 8,
+            bytesPerRow: width,
+            space: CGColorSpaceCreateDeviceGray(),
+            bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.none.rawValue),
+            provider: provider,
+            decode: nil,
+            shouldInterpolate: false,
+            intent: .defaultIntent
+        )
+    }()
+}
+
+/// Artwork moves at roughly half foreground speed. Its translation and
+/// scroll-linked dimming are render-time effects derived directly from the
+/// native scroll geometry, avoiding an observable-state update and image-view
+/// rebuild on every frame.
+private struct PhoneDetailParallaxArtwork: View {
+    let url: String?
+    let thumbhash: String?
+    let height: CGFloat
+    let isEnabled: Bool
+
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        let parallaxEnabled = usesParallax
+        ZStack {
+            artwork
+                .frame(height: height)
+                .frame(maxWidth: .infinity)
+                .clipped()
+                .visualEffect { content, proxy in
+                    let minY = proxy.frame(in: .named(PhoneDetailScrollCoordinateSpace.name)).minY
+                    let offset = min(max(0, -minY), 540)
+                    return content.offset(
+                        y: parallaxEnabled ? offset * 0.52 : 0
+                    )
+                }
+
+            Color.black
+                .visualEffect { content, proxy in
+                    let minY = proxy.frame(in: .named(PhoneDetailScrollCoordinateSpace.name)).minY
+                    let offset = min(max(0, -minY), 540)
+                    return content.opacity(
+                        parallaxEnabled
+                            ? 0.30 * min(max(offset / 360, 0), 1)
+                            : 0
+                    )
+                }
+                .allowsHitTesting(false)
+        }
+        .frame(height: height)
+        .clipped()
+        .mask(artworkMask)
+    }
+
+    @ViewBuilder
+    private var artwork: some View {
+        if let url, !url.isEmpty {
+            AsyncImageView(url: url, thumbhash: thumbhash, contentMode: .fill)
+        } else {
+            Color.continuumSurface
+        }
+    }
+
+    private var usesParallax: Bool {
+        guard isEnabled, !reduceMotion else { return false }
+        #if os(iOS)
+        return UIDevice.current.userInterfaceIdiom == .phone
+            && horizontalSizeClass != .regular
+        #else
+        return false
+        #endif
+    }
+
+    private var artworkMask: some View {
+        LinearGradient(
+            stops: [
+                .init(color: .black, location: 0),
+                .init(color: .black, location: 0.72),
+                .init(color: .black.opacity(0.76), location: 0.84),
+                .init(color: .clear, location: 1),
+            ],
+            startPoint: .top,
+            endPoint: .bottom
+        )
     }
 }
 
@@ -57,6 +254,7 @@ struct PhoneDetailHero<Actions: View, BelowOverview: View>: View {
     /// Retained at the call boundary for source compatibility. Detail artwork
     /// intentionally renders no card-overlay badges in this redesigned surface.
     var overlayData: OverlayData? = nil
+    var enablesArtworkParallax = false
     @ViewBuilder let actions: () -> Actions
     @ViewBuilder let belowOverview: () -> BelowOverview
 
@@ -117,11 +315,12 @@ struct PhoneDetailHero<Actions: View, BelowOverview: View>: View {
 
     private var compactArtwork: some View {
         ZStack(alignment: .bottom) {
-            artwork
-                .frame(height: compactArtworkHeight)
-                .frame(maxWidth: .infinity)
-                .clipped()
-                .mask(compactArtworkMask)
+            PhoneDetailParallaxArtwork(
+                url: resolvedArtworkURL,
+                thumbhash: resolvedArtworkThumbhash,
+                height: compactArtworkHeight,
+                isEnabled: enablesArtworkParallax
+            )
 
             LinearGradient(
                 colors: [Color.black.opacity(0.34), .clear],
@@ -135,6 +334,7 @@ struct PhoneDetailHero<Actions: View, BelowOverview: View>: View {
                 .padding(.bottom, 6)
         }
         .frame(height: compactArtworkHeight)
+        .clipped()
         .accessibilityElement(children: .contain)
     }
 
@@ -145,19 +345,6 @@ struct PhoneDetailHero<Actions: View, BelowOverview: View>: View {
 
     private var compactLogoHeight: CGFloat {
         min(max(compactArtworkHeight * 0.24, 104), 138)
-    }
-
-    private var compactArtworkMask: some View {
-        LinearGradient(
-            stops: [
-                .init(color: .black, location: 0),
-                .init(color: .black, location: 0.72),
-                .init(color: .black.opacity(0.76), location: 0.84),
-                .init(color: .clear, location: 1),
-            ],
-            startPoint: .top,
-            endPoint: .bottom
-        )
     }
 
     // MARK: - Expanded iPad layout

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeFormatting.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeFormatting.swift
@@ -9,14 +9,6 @@ enum PhoneEpisodeFormatting {
         episode.title ?? "Episode \(episode.episodeNumber)"
     }
 
-    static func cardNumberLabel(for episode: EpisodeListItem) -> String {
-        "EPISODE \(episode.episodeNumber)"
-    }
-
-    static func compactNumberLabel(for episode: EpisodeListItem) -> String {
-        String(format: "S%02dE%02d", episode.seasonNumber, episode.episodeNumber)
-    }
-
     static func metadataLine(for episode: EpisodeListItem) -> String? {
         var parts: [String] = []
         if let airDate = DetailDateFormatting.abbreviatedDate(episode.airDate) {

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeListRow.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeListRow.swift
@@ -104,17 +104,11 @@ struct PhoneEpisodeListRow: View {
 
     private var metadata: some View {
         VStack(alignment: .leading, spacing: 4) {
-            HStack(spacing: 8) {
-                Text(PhoneEpisodeFormatting.compactNumberLabel(for: episode))
-                    .font(.caption.bold())
-                    .foregroundStyle(.secondary)
-
-                if let metadataLine = PhoneEpisodeFormatting.metadataLine(for: episode) {
-                    Text(metadataLine)
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
-                        .lineLimit(1)
-                }
+            if let metadataLine = PhoneEpisodeFormatting.metadataLine(for: episode) {
+                Text(metadataLine)
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
             }
 
             Text(PhoneEpisodeFormatting.title(for: episode))

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeRail.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeRail.swift
@@ -127,14 +127,8 @@ private struct PhoneEpisodeCard: View {
             still
             if captionStyle.showsTitle {
                 VStack(alignment: .leading, spacing: 4) {
-                    HStack(spacing: 6) {
-                        Text(PhoneEpisodeFormatting.cardNumberLabel(for: episode))
-                            .font(.system(size: 10, weight: .bold))
-                            .tracking(1.0)
-                            .foregroundStyle(Color.continuumOnSurface.opacity(0.55))
-                        if isCurrent {
-                            nowViewingTag
-                        }
+                    if isCurrent {
+                        nowViewingTag
                     }
 
                     Text(PhoneEpisodeFormatting.title(for: episode))

--- a/iosApp/iosApp/Screens/Detail/SeasonDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/SeasonDetailContent.swift
@@ -279,10 +279,7 @@ struct SeasonDetailContent<BelowOverview: View>: View {
             $0.seasonNumber == detail.seasonNumber
         })
         guard let season else { return "Episodes" }
-        let label = season.seasonNumber == 0
-            ? (season.title ?? "Specials")
-            : "Season \(season.seasonNumber)"
-        return "\(label) Episodes"
+        return "\(season.downloadDisplayName) Episodes"
     }
 
     @ViewBuilder

--- a/iosApp/iosApp/Screens/Detail/SeasonDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/SeasonDetailContent.swift
@@ -174,6 +174,8 @@ struct SeasonDetailContent<BelowOverview: View>: View {
                     detail: detail,
                     seasons: seasons,
                     selectedSeason: selectedSeason ?? seasons.first(where: { $0.seasonNumber == detail.seasonNumber }),
+                    episodes: episodes,
+                    episodesBySeason: episodesBySeason,
                     style: .labeled
                 )
             }

--- a/iosApp/iosApp/Screens/Detail/SeriesDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/SeriesDetailContent.swift
@@ -48,6 +48,9 @@ struct SeriesDetailContent<BelowOverview: View>: View {
     let isFindingTrailers: Bool
     /// Called once a terminal status message has been on screen long enough.
     let onTrailerStatusShown: () -> Void
+    /// Reference-backed scroll state observed only by the small parallax and
+    /// pinned-chrome views, keeping the native ScrollView's body stable.
+    let scrollState: PhoneDetailScrollState
     /// On-view description-translation affordance, built at the detail call
     /// site (which owns the view model) and rendered under the overview.
     @ViewBuilder let belowOverview: () -> BelowOverview
@@ -63,7 +66,11 @@ struct SeriesDetailContent<BelowOverview: View>: View {
     @State private var pendingEpisodePlayRequest: PendingEpisodePlayRequest?
 
     var body: some View {
-        PhoneDetailPageSurface(backdropURL: detail.backdropUrl) {
+        PhoneDetailPageSurface(
+            backdropURL: detail.backdropUrl,
+            backdropThumbhash: detail.backdropThumbhash,
+            enablesArtworkGlass: true
+        ) {
             ScrollView(.vertical, showsIndicators: false) {
                 VStack(alignment: .leading, spacing: heroToContentSpacing) {
                     hero
@@ -72,6 +79,13 @@ struct SeriesDetailContent<BelowOverview: View>: View {
                 .padding(.bottom, 40)
             }
             .ignoresSafeArea(edges: .top)
+            .coordinateSpace(name: PhoneDetailScrollCoordinateSpace.name)
+            .onScrollGeometryChange(for: CGFloat.self) { geometry in
+                let offset = max(0, geometry.contentOffset.y + geometry.contentInsets.top)
+                return offset <= 150 ? 0 : min(offset, 480)
+            } action: { _, offset in
+                scrollState.update(offset)
+            }
         }
         .continuumResumePlaybackAlert(
             isPresented: Binding(
@@ -125,6 +139,7 @@ struct SeriesDetailContent<BelowOverview: View>: View {
             factsLine: PhoneHeroMetadata.seriesFactsLine(from: detail),
             creditText: PhoneHeroMetadata.creditText(from: detail),
             overlayData: OverlayData.from(detail),
+            enablesArtworkParallax: true,
             actions: { actionStack },
             // Match MovieDetailContent exactly through the playback controls:
             // Play/actions, show overview and credits, translation affordance,
@@ -184,6 +199,8 @@ struct SeriesDetailContent<BelowOverview: View>: View {
                         detail: detail,
                         seasons: seasons,
                         selectedSeason: selectedSeason,
+                        episodes: episodes,
+                        episodesBySeason: episodesBySeason,
                         style: .labeled
                     )
                 }

--- a/iosApp/iosApp/Screens/Detail/SeriesDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/SeriesDetailContent.swift
@@ -455,10 +455,7 @@ struct SeriesDetailContent<BelowOverview: View>: View {
 
     private var episodeSectionTitle: String {
         guard let selectedSeason else { return "Episodes" }
-        let seasonLabel = selectedSeason.seasonNumber == 0
-            ? (selectedSeason.title ?? "Specials")
-            : "Season \(selectedSeason.seasonNumber)"
-        return "\(seasonLabel) Episodes"
+        return "\(selectedSeason.downloadDisplayName) Episodes"
     }
 
     private var episodeCountSubtitle: String? {

--- a/iosApp/iosApp/Screens/Home/Feed/HomeFeedKit.swift
+++ b/iosApp/iosApp/Screens/Home/Feed/HomeFeedKit.swift
@@ -95,7 +95,7 @@ enum HomeFeedMeta {
         return "S\(season) E\(episode)"
     }
 
-    /// Caption under a resume still — "S2 E4  ·  23m left".
+    /// Caption under a resume still — "23m left".
     ///
     /// Some items carry a resume position but no duration, which left their
     /// card showing a progress bar and no caption while the card beside it had
@@ -112,8 +112,7 @@ enum HomeFeedMeta {
             progressText = nil
         }
 
-        let pieces = [episodeCode(for: item), progressText].compactMap { $0 }
-        return pieces.isEmpty ? nil : pieces.joined(separator: "  ·  ")
+        return progressText
     }
 
     /// The title a card should be captioned with. Episodes caption with the
@@ -292,10 +291,9 @@ struct HomePosterCard: View {
     /// Audiobook covers are square; stretching one into a 2:3 poster crops
     /// its edges off.
     var aspect: MediaCardAspect = .poster
-    /// "S2 · E10" for an episode rendered as a poster. Without it, several
-    /// episodes of one series are captioned identically (they caption with
-    /// the series name) and become indistinguishable cards.
-    var episodeBadge: String? = nil
+    /// Episode context retained for accessibility. Episode numbers are
+    /// intentionally not drawn over poster artwork.
+    var episodeAccessibilityLabel: String? = nil
     /// Long-press actions, matching what `MediaCard` offers elsewhere.
     var onRemoveFromContinueWatching: (() -> Void)? = nil
     var onSetWatched: ((Bool) async -> Bool)? = nil
@@ -352,8 +350,8 @@ struct HomePosterCard: View {
         .overlay {
             // Home uses the same renderer and resolved profile preferences as
             // Browse, For You, Watchlist, and Favorites. Keep this below the
-            // episode/progress/watched affordances so those controls retain
-            // their established corner priority.
+            // progress and watched affordances so those controls retain their
+            // established corner priority.
             if overlayStore.enabled {
                 CardOverlays(
                     data: OverlayData.from(item),
@@ -367,17 +365,6 @@ struct HomePosterCard: View {
                         style: .continuous
                     )
                 )
-            }
-        }
-        .overlay(alignment: .bottomLeading) {
-            if let episodeBadge {
-                Text(episodeBadge)
-                    .font(.system(size: 10, weight: .semibold))
-                    .foregroundStyle(.white)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 3)
-                    .background(Capsule().fill(.black.opacity(0.65)))
-                    .padding(6)
             }
         }
         .overlay(alignment: .topTrailing) {
@@ -422,7 +409,9 @@ struct HomePosterCard: View {
 
     private var accessibilityDescription: String {
         var components = [HomeFeedMeta.cardTitle(for: item)]
-        components.append(contentsOf: [episodeBadge, item.year.map(String.init)].compactMap { $0 })
+        components.append(
+            contentsOf: [episodeAccessibilityLabel, item.year.map(String.init)].compactMap { $0 }
+        )
         if isPlayed {
             components.append("Watched")
         }
@@ -575,6 +564,9 @@ struct HomeStillCard: View {
 
     private var accessibilityDescription: String {
         var components = [HomeFeedMeta.cardTitle(for: item)]
+        if let episodeCode = HomeFeedMeta.episodeCode(for: item) {
+            components.append(episodeCode)
+        }
         if let resumeCaption = HomeFeedMeta.resumeCaption(for: item) {
             components.append(resumeCaption)
         }

--- a/iosApp/iosApp/Screens/Home/Feed/HomeFeedRow.swift
+++ b/iosApp/iosApp/Screens/Home/Feed/HomeFeedRow.swift
@@ -13,10 +13,6 @@ struct HomeFeedRow: View {
     /// Long-press actions, forwarded to every card in the row.
     var onRemoveFromContinueWatching: ((SectionItem) -> Void)? = nil
     var onSetWatched: ((SectionItem, Bool) async -> Bool)? = nil
-    /// Continue Watching reports only the card that has finished settling in
-    /// the center. Home uses it to change a fixed backdrop wash; no feed layout
-    /// state depends on this callback.
-    var onCenteredResumeItemChange: ((SectionItem?) -> Void)? = nil
     @State private var uiCustomization = UICustomizationPreferences.shared
     @State private var visibleItemId: String?
     @Environment(AppRouter.self) private var router
@@ -66,18 +62,12 @@ struct HomeFeedRow: View {
                     preferred: visibleItemId ?? section.items.first?.contentId
                 )
                 visibleItemId = initialId
-                publishResumeSelection(initialId)
             }
             .onChange(of: section.items.map(\.contentId)) { _, newIds in
                 let preferred = newIds.contains(visibleItemId ?? "")
                     ? visibleItemId
                     : newIds.first
                 visibleItemId = preferred
-                publishResumeSelection(preferred)
-            }
-            .onScrollPhaseChange { _, newPhase in
-                guard newPhase == .idle else { return }
-                publishResumeSelection(visibleItemId)
             }
             #if os(iOS)
             .onChange(of: router.presentedItemDetail) { _, presentation in
@@ -144,14 +134,6 @@ struct HomeFeedRow: View {
             return section.items.first?.contentId
         }
         return preferred
-    }
-
-    private func publishResumeSelection(_ id: String?) {
-        guard isResume, let onCenteredResumeItemChange else { return }
-        let selected = id.flatMap { id in
-            section.items.first(where: { $0.contentId == id })
-        }
-        onCenteredResumeItemChange(selected)
     }
 
     /// "S2 · E10" for an episode drawn as a poster. Episode-discovery rows

--- a/iosApp/iosApp/Screens/Home/Feed/HomeFeedRow.swift
+++ b/iosApp/iosApp/Screens/Home/Feed/HomeFeedRow.swift
@@ -106,7 +106,7 @@ struct HomeFeedRow: View {
                                 showsMetadata: uiCustomization.cardPresentation.caption.showsMetadata,
                                 showsProgress: isResume,
                                 aspect: isAudiobookRow ? .square : .poster,
-                                episodeBadge: episodeBadge(for: item),
+                                episodeAccessibilityLabel: episodeAccessibilityLabel(for: item),
                                 onRemoveFromContinueWatching: removalAction(for: item),
                                 onSetWatched: watchedAction(for: item)
                             )
@@ -136,10 +136,9 @@ struct HomeFeedRow: View {
         return preferred
     }
 
-    /// "S2 · E10" for an episode drawn as a poster. Episode-discovery rows
-    /// caption with the series name, so without this several episodes of one
-    /// series render as identical cards.
-    private func episodeBadge(for item: SectionItem) -> String? {
+    /// Episode context for accessibility when episode-discovery cards are
+    /// visually captioned with their series name.
+    private func episodeAccessibilityLabel(for item: SectionItem) -> String? {
         guard item.type.lowercased() == "episode",
               let season = item.seasonNumber,
               let episode = item.episodeNumber else { return nil }

--- a/iosApp/iosApp/Screens/Home/HomeView.swift
+++ b/iosApp/iosApp/Screens/Home/HomeView.swift
@@ -28,11 +28,6 @@ struct HomeView: View {
     @State private var isRefreshing = false
     @State private var refreshStartedAt: Date?
     @State private var refreshHideTask: Task<Void, Never>?
-    /// The settled Continue Watching card drives an opaque, fixed page wash.
-    /// It never enters the vertical layout, so changing cards cannot move rows.
-    @State private var focusedContinueWatchingItem: SectionItem?
-    @State private var homeArtworkTint = Color(red: 0.04, green: 0.12, blue: 0.14)
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     #if os(iOS)
     @State private var isShowingControlPicker = false
     @Environment(SiloControlClient.self) private var siloControl
@@ -204,9 +199,6 @@ struct HomeView: View {
             await viewModel.loadSections()
             await loadCurrentProfile()
         }
-        .task(id: focusedContinueWatchingArtworkURL) {
-            await loadHomeArtworkTint()
-        }
         .refreshable {
             await refreshHome()
         }
@@ -249,12 +241,7 @@ struct HomeView: View {
                         HomeFeedRow(
                             section: section,
                             onRemoveFromContinueWatching: dismissContinueWatching,
-                            onSetWatched: setWatched,
-                            onCenteredResumeItemChange: { item in
-                                guard HomeFeed.isResume(section),
-                                      item?.contentId != focusedContinueWatchingItem?.contentId else { return }
-                                focusedContinueWatchingItem = item
-                            }
+                            onSetWatched: setWatched
                         )
                         .id(HomeFocusTarget.row(section.id))
                     }
@@ -287,67 +274,9 @@ struct HomeView: View {
     }
 
     #if !os(tvOS)
-    /// Fully opaque and blur-free: Home paints only the sampled artwork colour,
-    /// never the artwork itself. A soft tonal bloom sits around the Continue
-    /// Watching zone so the colour feels feathered like the detail surface
-    /// without introducing a live material, image or black underlay.
-    @ViewBuilder
+    /// Home uses the same fixed canvas as the rest of the signed-in app.
     private var homeFeedBackground: some View {
-        #if os(iOS)
-        ZStack {
-            // The sampled tint is the opaque page itself. No image or black
-            // backing is painted behind Home.
-            homeArtworkTint
-                .brightness(-0.055)
-
-            RadialGradient(
-                stops: [
-                    .init(color: .white.opacity(0.10), location: 0),
-                    .init(color: .white.opacity(0.055), location: 0.26),
-                    .init(color: .white.opacity(0.018), location: 0.58),
-                    .init(color: .clear, location: 1),
-                ],
-                center: UnitPoint(x: 0.46, y: 0.48),
-                startRadius: 0,
-                endRadius: 470
-            )
-
-            LinearGradient(
-                stops: [
-                    .init(color: .white.opacity(0.025), location: 0),
-                    .init(color: .clear, location: 0.24),
-                    .init(color: .white.opacity(0.025), location: 0.48),
-                    .init(color: .clear, location: 0.82),
-                    .init(color: .white.opacity(0.012), location: 1),
-                ],
-                startPoint: .top,
-                endPoint: .bottom
-            )
-        }
-        #else
-        Color.continuumBackground
-        #endif
-    }
-
-    private var focusedContinueWatchingArtworkURL: String? {
-        let backdrop = visibleFocusedContinueWatchingItem?.backdropUrl?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        if let backdrop, !backdrop.isEmpty { return backdrop }
-
-        let poster = visibleFocusedContinueWatchingItem?.posterUrl?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        return poster?.isEmpty == false ? poster : nil
-    }
-
-    private var visibleFocusedContinueWatchingItem: SectionItem? {
-        guard let focusedContinueWatchingItem else { return nil }
-        let remainsVisible = displayedSections.contains { section in
-            HomeFeed.isResume(section)
-                && section.items.contains(where: {
-                    $0.contentId == focusedContinueWatchingItem.contentId
-                })
-        }
-        return remainsVisible ? focusedContinueWatchingItem : nil
+        ContinuumPageBackdrop()
     }
 
     #if os(iOS)
@@ -382,34 +311,6 @@ struct HomeView: View {
         .animation(.easeOut(duration: 0.12), value: router.presentedItemDetail == nil)
     }
     #endif
-
-    private func loadHomeArtworkTint() async {
-        let fallback = Color(red: 0.04, green: 0.12, blue: 0.14)
-        guard let rawURL = focusedContinueWatchingArtworkURL,
-              let url = URL(string: rawURL) else {
-            setHomeArtworkTint(fallback)
-            return
-        }
-
-        if let cached = HeroBackdropPalette.cachedTint(for: url) {
-            setHomeArtworkTint(cached)
-        }
-
-        guard let sampled = await HeroBackdropPalette.tintColor(for: url),
-              !Task.isCancelled,
-              focusedContinueWatchingArtworkURL == rawURL else { return }
-        setHomeArtworkTint(sampled)
-    }
-
-    private func setHomeArtworkTint(_ tint: Color) {
-        if reduceMotion {
-            homeArtworkTint = tint
-        } else {
-            withAnimation(.easeInOut(duration: 0.24)) {
-                homeArtworkTint = tint
-            }
-        }
-    }
 
     private func refreshHome() async {
         await MainActor.run {

--- a/iosApp/iosApp/Screens/Home/HomeView.swift
+++ b/iosApp/iosApp/Screens/Home/HomeView.swift
@@ -285,20 +285,14 @@ struct HomeView: View {
     /// away. The fixed utility cluster remains independently overlaid above it.
     private var homeScrollIdentityHeader: some View {
         HStack {
-            Text("SILO")
-                // Match the locked tvOS wordmark exactly. The Skyline metrics
-                // are tvOS-scoped, so repeat their approved values here.
-                .font(.system(size: 26, weight: .heavy))
-                .tracking(26 * 0.34)
-                .foregroundStyle(.white)
-                .accessibilityLabel("Silo")
+            SiloWordmarkView(width: 72)
 
             Spacer(minLength: 8)
         }
         .padding(.horizontal, ContinuumTheme.padding)
         // The ScrollView now begins inside the device safe area, exactly like
-        // the fixed utility overlay. Matching their top inset puts the SILO
-        // baseline on the same row instead of underneath the status clock.
+        // the fixed utility overlay. Matching their top inset keeps the logo
+        // on the same row instead of underneath the status clock.
         .padding(.top, headerTopInset)
         .frame(
             height: topRunwaySpacing(topSafeAreaInset: 0),

--- a/iosApp/iosApp/Screens/People/PersonDetailView.swift
+++ b/iosApp/iosApp/Screens/People/PersonDetailView.swift
@@ -319,7 +319,7 @@ struct PersonDetailView: View {
             Color.clear
         } else {
             EmptyStateView(icon: "person", title: "Person not found")
-                .continuumBackground()
+                .continuumPageBackground()
         }
     }
 
@@ -388,7 +388,7 @@ private struct TVPersonDetailContent: View {
             }
             .padding(.bottom, 72)
         }
-        .continuumBackground()
+        .continuumPageBackground()
     }
 
     private var header: some View {
@@ -515,7 +515,7 @@ private struct PhonePersonDetailContent: View {
             }
             .padding(.bottom, ContinuumTheme.largePadding)
         }
-        .continuumBackground()
+        .continuumPageBackground()
     }
 
     private var header: some View {

--- a/iosApp/iosApp/Screens/Personal/FavoritesView.swift
+++ b/iosApp/iosApp/Screens/Personal/FavoritesView.swift
@@ -37,18 +37,64 @@ struct IOSPersonalMediaSectionPicker: View {
     }
 }
 
-/// Saved titles use compact, Home-like rails rather than stretching two cards
-/// across an iPhone. Six titles is the maximum membership of one rail; larger
-/// lists continue in as many vertically stacked rails as needed.
-struct IOSPersonalMediaCarouselRows: View {
+/// Saved titles use a fixed three-column poster grid on iPhone. iPad retains
+/// the wider Home-like rails that make better use of its additional width.
+struct IOSPersonalMediaPosterLayout: View {
     let items: [BrowseItem]
     let onUserStateChanged: (BrowseItem, MediaItemUserState) -> Void
 
     @Environment(AppRouter.self) private var router
+    @State private var uiCustomization = UICustomizationPreferences.shared
     @State private var originID = UUID().uuidString
     @State private var rowScrollPositions: [Int: String] = [:]
 
+    @ViewBuilder
     var body: some View {
+        if UIDevice.current.userInterfaceIdiom == .phone {
+            phoneGrid
+        } else {
+            tabletCarouselRows
+        }
+    }
+
+    private var phoneGrid: some View {
+        LazyVGrid(
+            columns: Array(
+                repeating: GridItem(.flexible(), spacing: 8, alignment: .top),
+                count: 3
+            ),
+            spacing: 12
+        ) {
+            ForEach(items) { item in
+                MediaCard(
+                    title: item.title,
+                    posterUrl: item.posterUrl ?? "",
+                    thumbhash: item.posterThumbhash,
+                    year: item.year,
+                    userState: item.userState,
+                    overlayData: OverlayData.from(item),
+                    action: {
+                        router.navigate(to: .itemDetail(contentId: item.contentId))
+                    },
+                    contentId: item.contentId,
+                    cardWidthOverride: phoneCardWidthOverride,
+                    onUserStateChanged: { state in
+                        onUserStateChanged(item, state)
+                    }
+                )
+                .frame(maxWidth: .infinity)
+            }
+        }
+        .environment(
+            \.itemDetailBrowseSource,
+            ItemDetailBrowseSource(
+                originID: originID,
+                contentIDs: items.map(\.contentId)
+            )
+        )
+    }
+
+    private var tabletCarouselRows: some View {
         LazyVStack(alignment: .leading, spacing: 24) {
             ForEach(Array(rows.enumerated()), id: \.offset) { rowIndex, rowItems in
                 ScrollView(.horizontal, showsIndicators: false) {
@@ -100,6 +146,13 @@ struct IOSPersonalMediaCarouselRows: View {
                 rowScrollPositions[rowIndex] = contentID
             }
         }
+    }
+
+    /// MediaCard scales overrides by the selected global preference. Cancel
+    /// that scale so all three phone columns keep the standard poster width.
+    private var phoneCardWidthOverride: CGFloat {
+        ContinuumTheme.posterCardWidth
+            / uiCustomization.cardPresentation.posterSize.scale
     }
 
     private var rows: [[BrowseItem]] {
@@ -182,7 +235,7 @@ struct FavoritesView: View {
                 if filteredIOSItems.isEmpty {
                     iosSelectedSectionEmptyState
                 } else {
-                    IOSPersonalMediaCarouselRows(items: filteredIOSItems) { item, state in
+                    IOSPersonalMediaPosterLayout(items: filteredIOSItems) { item, state in
                         guard !state.isFavorite else { return }
                         withAnimation {
                             items.removeAll { $0.contentId == item.contentId }
@@ -234,7 +287,7 @@ struct FavoritesView: View {
                 )
             }
         }
-        .continuumBackground()
+        .continuumPageBackground()
         .modifier(PersonalListNavigationChrome(title: showsNavigationTitle ? "Favorites" : nil))
         .task {
             await loadFavorites()

--- a/iosApp/iosApp/Screens/Personal/FavoritesView.swift
+++ b/iosApp/iosApp/Screens/Personal/FavoritesView.swift
@@ -45,6 +45,7 @@ struct IOSPersonalMediaPosterLayout: View {
 
     @Environment(AppRouter.self) private var router
     @State private var uiCustomization = UICustomizationPreferences.shared
+    @State private var gridWidth: CGFloat = 0
     @State private var originID = UUID().uuidString
     @State private var rowScrollPositions: [Int: String] = [:]
 
@@ -84,6 +85,12 @@ struct IOSPersonalMediaPosterLayout: View {
                 )
                 .frame(maxWidth: .infinity)
             }
+        }
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.width
+        } action: { width in
+            guard abs(width - gridWidth) >= 0.5 else { return }
+            gridWidth = width
         }
         .environment(
             \.itemDetailBrowseSource,
@@ -149,10 +156,13 @@ struct IOSPersonalMediaPosterLayout: View {
     }
 
     /// MediaCard scales overrides by the selected global preference. Cancel
-    /// that scale so all three phone columns keep the standard poster width.
+    /// that scale, then cap the standard width to the measured grid cell.
     private var phoneCardWidthOverride: CGFloat {
-        ContinuumTheme.posterCardWidth
-            / uiCustomization.cardPresentation.posterSize.scale
+        AdaptiveColumns.fittedPosterWidth(
+            containerWidth: gridWidth,
+            columnCount: 3,
+            spacing: 8
+        ) / uiCustomization.cardPresentation.posterSize.scale
     }
 
     private var rows: [[BrowseItem]] {

--- a/iosApp/iosApp/Screens/Personal/HistoryView.swift
+++ b/iosApp/iosApp/Screens/Personal/HistoryView.swift
@@ -27,7 +27,7 @@ struct HistoryView: View {
                 )
             }
         }
-        .continuumBackground()
+        .continuumPageBackground()
         .navigationTitle("History")
         .continuumNavigationTitleDisplayMode(.large)
         .task {

--- a/iosApp/iosApp/Screens/Personal/WatchlistView.swift
+++ b/iosApp/iosApp/Screens/Personal/WatchlistView.swift
@@ -73,7 +73,7 @@ struct WatchlistView: View {
                 )
             }
         }
-        .continuumBackground()
+        .continuumPageBackground()
         .modifier(PersonalListNavigationChrome(title: showsNavigationTitle ? "Watchlist" : nil))
         .task {
             await loadWatchlist()
@@ -100,7 +100,7 @@ struct WatchlistView: View {
                 if filteredIOSItems.isEmpty {
                     iosSelectedSectionEmptyState
                 } else {
-                    IOSPersonalMediaCarouselRows(items: filteredIOSItems) { item, state in
+                    IOSPersonalMediaPosterLayout(items: filteredIOSItems) { item, state in
                         guard !state.inWatchlist else { return }
                         withAnimation {
                             items.removeAll { $0.contentId == item.contentId }

--- a/iosApp/iosApp/Screens/Profiles/CreateProfileView.swift
+++ b/iosApp/iosApp/Screens/Profiles/CreateProfileView.swift
@@ -288,7 +288,7 @@ struct CreateProfileView: View {
     private var iOSLayout: some View {
         NavigationStack {
             ZStack {
-                Color.continuumBackground.ignoresSafeArea()
+                ContinuumPageBackdrop()
 
                 ScrollView {
                     VStack(spacing: ContinuumTheme.largePadding) {

--- a/iosApp/iosApp/Screens/Profiles/EditProfileView.swift
+++ b/iosApp/iosApp/Screens/Profiles/EditProfileView.swift
@@ -19,7 +19,7 @@ struct EditProfileView: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                Color.continuumBackground.ignoresSafeArea()
+                ContinuumPageBackdrop()
 
                 ScrollView {
                     VStack(spacing: ContinuumTheme.largePadding) {

--- a/iosApp/iosApp/Screens/Profiles/PINEntryView.swift
+++ b/iosApp/iosApp/Screens/Profiles/PINEntryView.swift
@@ -37,7 +37,7 @@ struct PINEntryView: View {
 
     private var phoneBody: some View {
         ZStack {
-            Color.continuumBackground.ignoresSafeArea()
+            ContinuumPageBackdrop()
 
             VStack(spacing: 32) {
                 header(avatarSize: 64)

--- a/iosApp/iosApp/Screens/Recommendations/RecommendationsView.swift
+++ b/iosApp/iosApp/Screens/Recommendations/RecommendationsView.swift
@@ -85,7 +85,7 @@ struct RecommendationsView: View {
 
             pageContent
         }
-        .continuumBackground()
+        .continuumPageBackground()
         #if os(iOS)
         .toolbar(.hidden, for: .navigationBar)
         #endif

--- a/iosApp/iosApp/Screens/Requests/Detail/RequestDetailView.swift
+++ b/iosApp/iosApp/Screens/Requests/Detail/RequestDetailView.swift
@@ -23,11 +23,11 @@ struct RequestDetailView: View {
                 loadedContent(detail)
             } else if let error = viewModel.error {
                 ErrorView(state: error, onRetry: { Task { await viewModel.load() } })
-                    .continuumBackground()
+                    .continuumPageBackground()
             } else {
-                LoadingView()
+                LoadingView(usesPageBackground: true)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .continuumBackground()
+                    .continuumPageBackground()
             }
         }
         .task(id: viewModel.tmdbId) {
@@ -56,7 +56,7 @@ struct RequestDetailView: View {
             phoneContent(detail)
             #endif
         }
-        .continuumBackground()
+        .continuumPageBackground()
         #if os(tvOS)
         .background(alignment: .top) {
             tvBackdrop(detail)

--- a/iosApp/iosApp/Screens/Requests/Hub/RequestsHubView.swift
+++ b/iosApp/iosApp/Screens/Requests/Hub/RequestsHubView.swift
@@ -19,7 +19,7 @@ struct RequestsHubView: View {
             .padding(.top, ContinuumTheme.smallPadding)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .continuumBackground()
+        .continuumPageBackground()
         #if os(tvOS)
         .safeAreaPadding(.horizontal, 40)
         #endif
@@ -55,7 +55,7 @@ struct RequestsHubView: View {
         } else if let error = viewModel.error {
             ErrorView(state: error, onRetry: { Task { await viewModel.load() } })
         } else if viewModel.isLoading {
-            LoadingView()
+            LoadingView(usesPageBackground: true)
                 .frame(maxWidth: .infinity)
                 .padding(.top, 80)
         } else if viewModel.myRequests.isEmpty && viewModel.carousels.isEmpty {
@@ -83,7 +83,7 @@ struct RequestsHubView: View {
     @ViewBuilder
     private var searchResults: some View {
         if viewModel.isSearching && viewModel.searchResults.isEmpty {
-            LoadingView()
+            LoadingView(usesPageBackground: true)
                 .frame(maxWidth: .infinity)
                 .padding(.top, 80)
         } else if viewModel.hasSearched && viewModel.searchResults.isEmpty {

--- a/iosApp/iosApp/Screens/Requests/MyRequests/MyRequestsView.swift
+++ b/iosApp/iosApp/Screens/Requests/MyRequests/MyRequestsView.swift
@@ -13,7 +13,7 @@ struct MyRequestsView: View {
             if let error = viewModel.error, viewModel.buckets.isEmpty {
                 ErrorView(state: error, onRetry: { Task { await viewModel.load() } })
             } else if viewModel.isLoading && viewModel.buckets.isEmpty {
-                LoadingView()
+                LoadingView(usesPageBackground: true)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if viewModel.isEmpty {
                 EmptyStateView(
@@ -25,7 +25,7 @@ struct MyRequestsView: View {
                 bucketList
             }
         }
-        .continuumBackground()
+        .continuumPageBackground()
         .navigationTitle("My Requests")
         .continuumNavigationTitleDisplayMode(.inline)
         .continuumToolbarColorSchemeDark()

--- a/iosApp/iosApp/Screens/Search/SearchView.swift
+++ b/iosApp/iosApp/Screens/Search/SearchView.swift
@@ -51,7 +51,7 @@ struct SearchView: View {
             .continuumFormWidth(tvSearchContentWidth)
 #endif
         }
-        .continuumBackground()
+        .continuumPageBackground()
         #if os(tvOS)
         .safeAreaPadding(.horizontal, tvSearchSafeHorizontalPadding)
         #endif

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
@@ -707,41 +707,20 @@ private struct EpisodeCardLabel: View {
             still
             if captionStyle.showsTitle {
                 VStack(alignment: .leading, spacing: 7) {
-                    HStack(alignment: .firstTextBaseline, spacing: 10) {
-                        Text(episodeNumberLabel)
-                            .font(.system(size: 16, weight: .bold))
-                            .tracking(1.6)
-                            .foregroundStyle(Color.continuumOnSurface.opacity(0.62))
-                            .fixedSize(horizontal: true, vertical: false)
-                        if hidesEpisodeTitle, let compactEpisodeTitle {
-                            Text("·")
-                                .font(.system(size: 16, weight: .bold))
-                                .foregroundStyle(Color.continuumOnSurface.opacity(0.48))
-                                .fixedSize(horizontal: true, vertical: false)
-                            Text(compactEpisodeTitle)
-                                .font(.system(size: 20, weight: .semibold))
-                                .foregroundStyle(titleColor)
-                                .lineLimit(1)
-                                .truncationMode(.tail)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-                        if !hidesEpisodeTitle {
-                            Spacer(minLength: 8)
-                        }
-                    }
-                    // Season tabs keep their label inside the moving control
-                    // and never animate its layout independently. Apply that
-                    // same rule only to the compact Series episode caption.
-                    .frame(
-                        width: hidesEpisodeTitle ? cardWidth : nil,
-                        height: hidesEpisodeTitle ? 28 : nil,
-                        alignment: .topLeading
-                    )
-                    .clipped()
-                    .transaction { transaction in
-                        guard hidesEpisodeTitle else { return }
-                        transaction.animation = nil
-                        transaction.disablesAnimations = true
+                    if hidesEpisodeTitle, let compactEpisodeTitle {
+                        // Keep the compact Series caption inside the moving
+                        // control without animating its layout independently.
+                        Text(compactEpisodeTitle)
+                            .font(.system(size: 20, weight: .semibold))
+                            .foregroundStyle(titleColor)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                            .frame(width: cardWidth, height: 28, alignment: .topLeading)
+                            .clipped()
+                            .transaction { transaction in
+                                transaction.animation = nil
+                                transaction.disablesAnimations = true
+                            }
                     }
 
                     if !hidesEpisodeTitle {
@@ -771,10 +750,6 @@ private struct EpisodeCardLabel: View {
     private var titleColor: Color {
         if isCurrent { return .continuumOnSurface }
         return isFocused ? .continuumOnSurface : Color.continuumOnSurface.opacity(0.92)
-    }
-
-    private var episodeNumberLabel: String {
-        "EPISODE \(episode.episodeNumber)"
     }
 
     private var compactEpisodeTitle: String? {


### PR DESCRIPTION
## What this PR is

I've been working through a fairly broad iOS polish and reliability pass. The main goals were to make the app feel more consistent, improve the movie and series detail experience, remove the lag from vertical scrolling, and fix the download flow properly rather than just changing how the button looked.

This PR changes 39 existing Swift files (`+1,309 / -359`). It is intentionally **iOS only**. There are no server migrations, no download API contract changes, and no tvOS-specific files have been changed.

## What I wanted to improve

- Stop the Home background changing as I move through Continue Watching.
- Give the signed-in iOS pages one consistent, slightly darker charcoal/grey background, while leaving Settings alone.
- Keep movie and series detail pages artwork-led, but give them that glass/parallax feeling where the content and logo move faster than the background.
- Fit three posters on each row in compact iPhone libraries, collections, Watchlist, and Favorites.
- Remove the left/right swipe between movie or series detail cards on iPhone, without affecting normal vertical scrolling.
- Fix downloads so the preparing state, live percentage, and Downloads-tab item all behave reliably.
- Add a proper season and episode picker for series downloads instead of putting download buttons on every episode card.

## Home and the shared iOS background

I added a fixed, fully opaque `#1D1F1D` charcoal canvas with a small amount of static radial and vertical tonal depth. It is slightly darker than the first version and does not depend on any artwork.

Home no longer tracks the centred Continue Watching card, samples its artwork colour, or animates between sampled tints. That means moving through Continue Watching can no longer recolour the page or make the background feel like it is shifting underneath the content.

I applied the same canvas to the other signed-in iOS surfaces that were still using pure black, including:

- Home
- Libraries and all of their tabs
- Browse and filters
- Collections and collection details
- Watchlist, Favorites, and History
- Downloads, offline browse/details, and download sheets
- Search and Calendar
- Recommendations and Requests
- People pages
- Profile create/edit/PIN screens
- Remote target selection
- Relevant loading, error, and empty states

Settings has deliberately been left alone. The shared helper also returns the existing pure-black canvas on tvOS and macOS, so this is not a visual redesign for those platforms.

## Three posters per row on iPhone

Library catalog grids now use three flexible poster columns on compact iPhone. I made the same change for collections, collection contents, Watchlist, and Favorites.

The global poster-size preference is neutralised only for these forced three-column phone grids. This prevents the Large preference from pushing them back to two columns, while leaving the rest of the app's adaptive card behaviour alone.

iPad keeps its current wider/adaptive layouts. Watchlist and Favorites also keep their existing rail layout on iPad.

## Movie and series detail pages

For compact iPhone movie and series details, there is now a saturated, darkened, heavily softened copy of the backdrop fixed behind the native vertical `ScrollView`. The sharp hero artwork moves at `0.52x` the foreground scroll distance, so the logo and card content move up faster than the background.

This is the effect I was aiming for: the layout feels like glass moving over a colour-matched background rather than one flat image moving as a single block.

I also changed the surrounding detail treatment:

- The hero now blends into the continuing artwork-derived colour field underneath it, removing the hard cut line below the logo and metadata.
- A deterministic 96×96 monochrome dither texture is tiled at only 1.2% opacity. It is there to break up colour banding, not to look visibly grainy.
- The pinned glass strip is smaller.
- Close/back and remote buttons sit 18 points from the sides and are vertically centred in that strip.
- The strip, circular button glass, and centred title fade with smoothstep curves instead of snapping between states.
- Reduce Motion disables the parallax.
- Reduce Transparency falls back to an opaque strip and a non-artwork surface.

I removed source-aware horizontal detail paging on compact iPhone, so swiping left or right no longer changes to the next movie or series. The existing iPad detail deck is preserved.

## Making vertical scrolling smooth

I wanted to keep the final design exactly as approved, so the performance changes are under the hood rather than another visual redesign.

The parallax translation and artwork dimming now use SwiftUI's render-time `visualEffect` geometry in the native named scroll coordinate space. The artwork no longer publishes every small movement through observable SwiftUI state, which avoids repeatedly rebuilding the `AsyncImageView`, mask, and hero tree while a finger is moving.

The small amount of state still needed for pinned chrome is limited to its actual visual range (`150...480pt`) and ignores changes smaller than 0.5pt. Scroll observation is isolated to small opacity-only leaves, while the button actions and native glass subtrees remain stable and equatable.

None of the approved spacing, colour, blur, artwork, or control-placement values were changed to get this performance improvement.

## Download fixes

This is more than a download-button UI change. I fixed the state and lifecycle problems behind the behaviour:

- Pending registration is now owned by `DownloadManager`, so the preparing spinner does not disappear if the detail view rebuilds while `POST /downloads` is still running.
- A second tap cannot register the same movie or episode twice while the first request is pending.
- Simultaneous scope hydration requests are now coalesced and tokenised. A late, stale empty disk snapshot can no longer replace a download that has just been registered in memory. This was the reason a download could start but then fail to appear in the Downloads tab.
- An empty server registration response is now treated as a real error and shown to the user instead of making the button silently return to idle.
- Active download rings show the current integer percentage in the centre. VoiceOver receives the same percentage as an accessibility value.
- Paused downloads keep the resume icon in the centre of the ring.
- The large-file warning is now a dedicated alert. Previously it competed with the cancel `confirmationDialog` attached to the same view, which could cause the warning not to appear.

## Selecting individual series episodes

The main series download popup now includes **Choose Episodes**.

The flow is deliberately kept simple and scalable:

1. Open the download popup.
2. Choose a season.
3. Select one, several, or all available episodes.
4. Start the selected downloads.

It reuses episode data already loaded by the detail page and fetches a season on demand when the data is not cached. Episodes are kept in a stable order and show the episode number, runtime, and live Preparing / percentage / Paused / Downloaded / Failed state.

Already downloaded or currently registering episodes cannot be selected twice. Selected episodes are registered sequentially so failures can be surfaced clearly. Whole-season downloads, whole-series downloads, and series monitoring are all still available in the same popup.

There are no individual download buttons cluttering the episode cards; all per-episode selection now lives in this one download flow.

## Bugs fixed and why they happened

| What was happening | Why | What I changed |
|---|---|---|
| Home changed colour as Continue Watching moved | The centred carousel item drove artwork palette sampling and page tint state | Removed the selection publishing/sampling path and use one fixed opaque canvas |
| The download spinner disappeared before progress started | The button had no durable state until the server returned a download record | Track pending content IDs in `DownloadManager` and render Preparing from manager state |
| A started download sometimes did not appear in Downloads | Concurrent lifecycle scope loads could install an older empty disk snapshot after registration | Coalesce scope loads and allow only the active token to install its result |
| A download tap could appear to do nothing | An empty registration response was accepted as success | Throw and display `emptyRegistrationResponse` |
| The large-download warning could fail to appear | Two `confirmationDialog`s were competing on one SwiftUI view | Use a separate alert for the large-file gate |
| Individual series episodes could not be selected from the main download flow | Series controls only exposed season/all-series batch actions | Added season navigation and native multi-selection |
| A left/right swipe changed the movie or series card | Compact iPhone inherited the source-aware detail paging deck | Remove the browse source on iPhone only |
| Detail scrolling felt laggy | The first parallax version republished every scroll step through state and rebuilt expensive artwork/chrome trees | Move artwork motion to render-time geometry and limit observable state to the chrome's active range |
| A hard seam and some banding were visible below the hero | The sharp hero faded into a flatter sampled-colour surface | Continue the blurred artwork field behind the mask and add very light static dithering |

## Performance results

I have kept these numbers honest. This is a deterministic update-path comparison against the first state-driven parallax implementation, not an FPS figure that was never measured.

| Scroll update budget over a 0...540pt hero movement at 0.5pt sampling | First implementation | Final implementation | Result |
|---|---:|---:|---:|
| Observable publications used to move/dim the hero artwork | up to 1,080 | 0 | 100% removed |
| Observable publications used by pinned chrome | up to 1,080 | up to 660 | 38.9% fewer |

The final chrome number comes directly from its active interval: `(480 - 150) / 0.5 = 660`. Below 150pt and above 480pt, it stays on a stable plateau. The hero continues moving smoothly at render time without publishing observable state.

I manually reviewed the final version in the iPhone Simulator after this optimisation and approved the scrolling and visual behaviour. I am not claiming a device FPS result because I kept control of the simulator for the final interactive review rather than running an automated UI trace.

## Validation

- `git diff --check origin/main...HEAD` passes.
- The final Debug iOS Simulator build passes:

  ```sh
  xcodebuild build -project Silo.xcodeproj -scheme Silo -configuration Debug -destination 'platform=iOS Simulator,id=BA5D2813-AB04-4BD8-81C8-7F8D5333273A' -derivedDataPath ../DerivedData
  ```

- The final incremental build took **15.2 seconds** on the local simulator toolchain. I am listing this as build validation only, not as a runtime performance benchmark.
- I manually covered the fixed Home canvas, shared page backgrounds, three-column grids, movie/series vertical scrolling and chrome transitions, removal of horizontal detail paging, movie download registration/progress/Downloads insertion, and single/multi-episode series selection.
- Existing unrelated warnings in `CompanionPairingCoordinator.swift` and `PlayerViewModel.swift` remain. I did not observe a new warning from this change set.
- The repository currently has tag/release and manual-dispatch workflows, but no pull-request-triggered build workflow, so opening this PR does not automatically start an upstream CI build.

## Scope

- **iOS only.** No tvOS-specific source file or tvOS interaction has been changed.
- Settings is intentionally unchanged.
- Movie and series details intentionally remain artwork-driven instead of using the fixed app canvas.
- iPad keeps adaptive poster layouts and its source-aware detail deck.
- Existing download API models, whole-season/whole-series actions, pause/resume/cancel/delete behaviour, offline playback, and monitoring contracts are preserved.

## AI disclosure

I designed and directed this work. I used **OpenAI Codex with the Sol model at ultra reasoning** as an implementation assistant for coding, debugging, performance optimisation, review, and validation. The product decisions, visual references, iteration priorities, and final approval are mine.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added episode selection and sequential downloads by season.
  * Added download registration progress, duplicate-tap prevention, percentage indicators, and clearer download states.
  * Added parallax artwork, scroll-linked glass controls, and grain effects to phone detail pages.
  * Added three-column poster grids on iPhone for selected screens.
* **Improvements**
  * Updated page backgrounds throughout the app for a more consistent appearance.
  * iPhone detail views now remain fixed to the opened title.
  * Season and special labels are clearer.
  * Episode numbers are now presented through accessibility and detail metadata rather than artwork badges.
* **Bug Fixes**
  * Prevented stale download registrations from affecting a newly changed account or server scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->