### PR TITLE
feat(ios): unify root page header chrome

### DIFF
--- a/iosApp/iosApp/Components/TabTopBarActions.swift
+++ b/iosApp/iosApp/Components/TabTopBarActions.swift
@@ -1,17 +1,19 @@
 import SwiftUI
 
 /// The shared right-hand action cluster used at the top of tab-root screens:
-/// Search and a profile-avatar menu with Settings / Switch Profile / Sign Out.
+/// Search, the iOS TV remote control, and a profile-avatar menu with
+/// Settings / Switch Profile / Sign Out. Every root page renders the same
+/// three controls so the header reads identically across Home, Libraries,
+/// For You, and Calendar.
 ///
 /// Each tab renders its own leading content (e.g. library selector on the
-/// Libraries tab, a static title on Home) and places this view on the
+/// Libraries tab, the wordmark on Home) and places this view on the
 /// trailing side of a single `HStack` row.
 struct TabTopBarActions: View {
-    let profile: UserProfile?
-    /// Home opts into circular native Liquid Glass so these utilities match
-    /// the close/remote detail controls. Other roots keep their established
-    /// chrome until they explicitly adopt the same treatment.
-    var usesGlass = false
+    /// Circular native Liquid Glass matching the close/remote detail
+    /// controls. On by default because every root header now floats over
+    /// the shared `PageChromeGlass` strip.
+    var usesGlass = true
     let onSearch: () -> Void
     let onOpenSettings: () -> Void
     /// Opens the media-requests hub. The menu row only renders when the
@@ -21,10 +23,17 @@ struct TabTopBarActions: View {
     let onSwitchServer: () -> Void
     let onSignOut: () -> Void
 
+    /// Shared session cache so switching pages never refetches or flashes
+    /// the avatar fallback.
+    private let profileStore = CurrentProfileStore.shared
+    #if os(iOS)
+    @Environment(SiloControlClient.self) private var siloControl
+    @State private var isShowingControlPicker = false
+    #endif
+
     var body: some View {
-        // Plain icon glyphs (no glass chip) spaced evenly, matching the
-        // clean top-right cluster used by Plex. The profile avatar is the
-        // only filled shape, so it reads as the account control.
+        // Icons spaced evenly, matching the clean top-right cluster used by
+        // Plex. Order is fixed: Search, Remote (iOS), Profile.
         HStack(spacing: ContinuumTheme.topBarIconSpacing) {
             TopBarIconButton(
                 systemImage: "magnifyingglass",
@@ -32,8 +41,13 @@ struct TabTopBarActions: View {
                 usesGlass: usesGlass,
                 action: onSearch
             )
+            #if os(iOS)
+            SiloControlModeButton(controller: siloControl, usesGlass: usesGlass) {
+                isShowingControlPicker = true
+            }
+            #endif
             ProfileAvatarMenu(
-                profile: profile,
+                profile: profileStore.profile,
                 usesGlass: usesGlass,
                 onOpenSettings: onOpenSettings,
                 onOpenRequests: onOpenRequests,
@@ -42,6 +56,14 @@ struct TabTopBarActions: View {
                 onSignOut: onSignOut
             )
         }
+        #if os(iOS)
+        .sheet(isPresented: $isShowingControlPicker) {
+            SiloControlTargetPickerView(request: nil, controller: siloControl)
+        }
+        #endif
+        // No-op once cached; covers a page shown before the session-level
+        // load finished.
+        .task { await profileStore.refresh() }
     }
 }
 
@@ -140,7 +162,7 @@ private struct ProfileAvatarMenu: View {
     }
 }
 
-/// Keeps all three Home utilities on the exact same 44pt native-glass circle.
+/// Keeps all top-bar utilities on the exact same 44pt native-glass circle.
 /// A modifier avoids duplicating branches inside Button and Menu labels.
 private struct TopBarCircularGlass: ViewModifier {
     let enabled: Bool

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -232,6 +232,7 @@ struct ContentView: View {
                 await ImageSizeCapability.shared.refresh()
                 await RequestsFeatureStore.shared.refresh()
                 await SubtitleProvidersStore.shared.refresh()
+                await CurrentProfileStore.shared.refresh()
                 await uiCustomization.refresh()
                 #if os(iOS)
                 await ApplePushRegistrationCoordinator.shared.prepareForAuthenticatedProfile()

--- a/iosApp/iosApp/DesignSystem/PageChromeGlass.swift
+++ b/iosApp/iosApp/DesignSystem/PageChromeGlass.swift
@@ -1,0 +1,120 @@
+import SwiftUI
+
+/// Scroll offset published by a page's vertical `ScrollView` so its pinned
+/// top chrome can fade in a glass strip once content passes underneath.
+/// Reference-backed like `PhoneDetailScrollState`, so only the small strip
+/// re-evaluates while the scroll view's body stays stable.
+@Observable
+@MainActor
+final class PageChromeScrollState {
+    private(set) var offset: CGFloat = 0
+
+    func update(_ rawOffset: CGFloat) {
+        // The strip is fully opaque past `fadeEnd`; folding larger offsets
+        // onto that endpoint avoids invalidating the chrome while scrolling
+        // deep into the page.
+        let clamped = min(max(0, rawOffset), PageChromeGlass.fadeEnd)
+        guard abs(clamped - offset) >= 0.5 else { return }
+        offset = clamped
+    }
+
+    func reset() {
+        offset = 0
+    }
+}
+
+/// Full-width Liquid Glass strip that fades in behind pinned page chrome as
+/// the page scrolls. Mirrors the Detail page's `PhoneDetailTopGlass`: the
+/// native glass node is equatable and retained while only its alpha changes.
+/// Place it as the chrome's `background` and let it ignore the top safe area
+/// so it also covers the status-bar region.
+struct PageChromeGlass: View {
+    /// Offset at which the strip starts to appear.
+    static let fadeStart: CGFloat = 8
+    /// Offset at which the strip is fully opaque.
+    static let fadeEnd: CGFloat = 56
+
+    let scrollState: PageChromeScrollState
+
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+
+    var body: some View {
+        #if os(tvOS)
+        EmptyView()
+        #else
+        PageChromeStaticGlass(reduceTransparency: reduceTransparency)
+            .equatable()
+            .opacity(
+                pageChromeSmoothProgress(
+                    scrollState.offset,
+                    from: Self.fadeStart,
+                    to: Self.fadeEnd
+                )
+            )
+            .ignoresSafeArea(edges: .top)
+            .allowsHitTesting(false)
+            .accessibilityHidden(true)
+        #endif
+    }
+}
+
+private struct PageChromeStaticGlass: View, Equatable {
+    let reduceTransparency: Bool
+
+    var body: some View {
+        if reduceTransparency {
+            Color(white: 0.16).opacity(0.98)
+        } else {
+            Color.clear
+                .siloGlass(in: Rectangle(), tint: Color.black.opacity(0.10))
+                .overlay(Color.white.opacity(0.025))
+        }
+    }
+}
+
+private func pageChromeSmoothProgress(
+    _ value: CGFloat,
+    from lowerBound: CGFloat,
+    to upperBound: CGFloat
+) -> CGFloat {
+    let progress = min(max((value - lowerBound) / (upperBound - lowerBound), 0), 1)
+    return progress * progress * (3 - (2 * progress))
+}
+
+extension View {
+    /// Publish this vertical `ScrollView`'s offset to `state`. No-op on tvOS,
+    /// which has no floating page chrome.
+    @ViewBuilder
+    func reportsPageChromeScroll(to state: PageChromeScrollState) -> some View {
+        #if os(tvOS)
+        self
+        #else
+        self.onScrollGeometryChange(for: CGFloat.self) { geometry in
+            let offset = max(0, geometry.contentOffset.y + geometry.contentInsets.top)
+            return min(offset, PageChromeGlass.fadeEnd)
+        } action: { _, offset in
+            state.update(offset)
+        }
+        #endif
+    }
+
+    /// Publish this vertical `ScrollView`'s offset to the
+    /// `PageChromeScrollState` in the environment, if a parent installed one.
+    /// Lets shared tab content (Browse, Recommended, Collections) feed the
+    /// Library tab's chrome without knowing about it.
+    func reportsPageChromeScroll() -> some View {
+        modifier(EnvironmentPageChromeScrollReporter())
+    }
+}
+
+private struct EnvironmentPageChromeScrollReporter: ViewModifier {
+    @Environment(PageChromeScrollState.self) private var scrollState: PageChromeScrollState?
+
+    func body(content: Content) -> some View {
+        if let scrollState {
+            content.reportsPageChromeScroll(to: scrollState)
+        } else {
+            content
+        }
+    }
+}

--- a/iosApp/iosApp/Networking/CurrentProfileStore.swift
+++ b/iosApp/iosApp/Networking/CurrentProfileStore.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Session-scoped holder for the active profile so top-bar avatars render
+/// from one cached value instead of every root page refetching the profile
+/// list on appearance and briefly flashing the fallback initial.
+///
+/// Follows the `RequestsFeatureStore` precedent: a `@MainActor` `@Observable`
+/// singleton, loaded once per session and reset on profile/server switch.
+/// Reset + refresh hooks live in `AuthService`/`ServerRegistry`/`ContentView`
+/// next to the existing capability-store calls.
+@MainActor
+@Observable
+final class CurrentProfileStore {
+    static let shared = CurrentProfileStore()
+
+    /// Nil until the first successful load; the avatar renders a fallback.
+    private(set) var profile: UserProfile?
+
+    /// Bumped on every `reset()` so a load that finishes after a sign-out
+    /// or profile switch discards its result instead of repopulating the
+    /// next account's avatar.
+    private var generation = 0
+    private var inFlight: Task<Void, Never>?
+
+    /// Load the active profile if it isn't cached yet. Concurrent callers
+    /// share one request. Pass `force` to refetch after a known change.
+    func refresh(force: Bool = false) async {
+        if !force, profile != nil { return }
+        if let inFlight {
+            await inFlight.value
+            return
+        }
+        let gen = generation
+        let task = Task { @MainActor in
+            defer { inFlight = nil }
+            guard let profileId = AuthService.shared.profileId else { return }
+            guard let profiles = try? await AuthService.shared.getProfiles(),
+                  gen == generation else { return }
+            profile = profiles.first(where: { $0.id == profileId })
+        }
+        inFlight = task
+        await task.value
+    }
+
+    func reset() {
+        generation &+= 1
+        inFlight?.cancel()
+        inFlight = nil
+        profile = nil
+    }
+}

--- a/iosApp/iosApp/Networking/ServerRegistry.swift
+++ b/iosApp/iosApp/Networking/ServerRegistry.swift
@@ -464,6 +464,7 @@ final class ServerRegistry {
             AICapabilities.shared.reset()
             ImageSizeCapability.shared.reset()
             RequestsFeatureStore.shared.reset()
+            CurrentProfileStore.shared.reset()
             SubtitleProvidersStore.shared.reset()
             RequestsEventBus.shared.reset()
             // Re-probe against the just-activated server: a switch between
@@ -472,6 +473,7 @@ final class ServerRegistry {
             // until the next foreground. Fire-and-forget — the probe
             // degrades to disabled on any failure.
             Task { await RequestsFeatureStore.shared.refresh() }
+            Task { await CurrentProfileStore.shared.refresh() }
             // Same shape: without a re-probe the destination server's
             // image-size support would stay unknown, and TV requests would
             // silently fall back to the server's default image variants.
@@ -748,12 +750,14 @@ final class ServerRegistry {
                 AICapabilities.shared.reset()
                 ImageSizeCapability.shared.reset()
                 RequestsFeatureStore.shared.reset()
+                CurrentProfileStore.shared.reset()
                 SubtitleProvidersStore.shared.reset()
                 RequestsEventBus.shared.reset()
                 // Same rationale as `switchTo`: the fallback server may
                 // already be signed in, with no auth-state change to
                 // trigger the usual probe.
                 Task { await RequestsFeatureStore.shared.refresh() }
+                Task { await CurrentProfileStore.shared.refresh() }
                 Task { await ImageSizeCapability.shared.refresh() }
                 Task { await SubtitleProvidersStore.shared.refresh() }
             }

--- a/iosApp/iosApp/Screens/Auth/AuthService.swift
+++ b/iosApp/iosApp/Screens/Auth/AuthService.swift
@@ -211,6 +211,7 @@ final class AuthService: @unchecked Sendable {
             await AICapabilities.shared.refresh()
             await ImageSizeCapability.shared.refresh()
             await RequestsFeatureStore.shared.refresh()
+            await CurrentProfileStore.shared.refresh(force: true)
             // Unlike the two above, this one gates *enablement* of an entry
             // point that stays visible either way, and it defaults to
             // available — so a slow or failing probe never hides anything.
@@ -528,6 +529,7 @@ final class AuthService: @unchecked Sendable {
         AICapabilities.shared.reset()
         ImageSizeCapability.shared.reset()
         RequestsFeatureStore.shared.reset()
+        CurrentProfileStore.shared.reset()
         SubtitleProvidersStore.shared.reset()
         RequestsEventBus.shared.reset()
         #if os(tvOS)
@@ -697,6 +699,7 @@ final class AuthService: @unchecked Sendable {
         AICapabilities.shared.reset()
         ImageSizeCapability.shared.reset()
         RequestsFeatureStore.shared.reset()
+        CurrentProfileStore.shared.reset()
         SubtitleProvidersStore.shared.reset()
         RequestsEventBus.shared.reset()
         #if os(tvOS)

--- a/iosApp/iosApp/Screens/Browse/BrowseView.swift
+++ b/iosApp/iosApp/Screens/Browse/BrowseView.swift
@@ -83,6 +83,7 @@ struct BrowseView: View {
             }
             .frame(maxWidth: .infinity)
         }
+        .reportsPageChromeScroll()
     }
 
     private var scrollContent: some View {
@@ -111,6 +112,7 @@ struct BrowseView: View {
                 .padding(.horizontal, ContinuumTheme.padding)
             }
         }
+        .reportsPageChromeScroll()
     }
 
     // MARK: - Search Bar
@@ -484,6 +486,7 @@ struct LibraryRecommendedView: View {
             .padding(.bottom, ContinuumTheme.largePadding)
         }
         .continuumScrollEdgeEffect()
+        .reportsPageChromeScroll()
     }
 
     private var refreshStatusTopPadding: CGFloat {

--- a/iosApp/iosApp/Screens/Browse/LibrariesTabView.swift
+++ b/iosApp/iosApp/Screens/Browse/LibrariesTabView.swift
@@ -216,8 +216,10 @@ struct LibrariesTabView: View {
     @State private var isLoading = true
     @State private var error: ErrorState?
     @State private var showPicker = false
-    @State private var currentProfile: UserProfile?
     @State private var navPrefs = AppNavPreferences.shared
+    /// Feeds the glass strip behind the hoisted top chrome. Tab content reads
+    /// it from the environment so each tab's ScrollView can report its offset.
+    @State private var chromeScrollState = PageChromeScrollState()
 
     /// Persist the last-selected library per authored root so visiting Series
     /// cannot replace the Movies or aggregate selection. Fixed-library roots
@@ -284,7 +286,6 @@ struct LibrariesTabView: View {
             // under the new destination.
             applyLibrarySelection()
             await loadLibraries()
-            await loadCurrentProfile()
         }
         .onChange(of: navPrefs.showAudiobooks) {
             applyLibrarySelection()
@@ -318,8 +319,14 @@ struct LibrariesTabView: View {
             // Forces the whole tab subtree to reset when switching
             // libraries, so stale content never flashes on screen.
             .id(activeLibrary.id)
+            .environment(chromeScrollState)
             .safeAreaInset(edge: .top, spacing: 0) {
                 topChrome(activeLibrary: activeLibrary)
+                    // Same scroll-driven glass as the Detail page chrome so
+                    // the selector and actions stay legible over posters.
+                    .background {
+                        PageChromeGlass(scrollState: chromeScrollState)
+                    }
             }
     }
 
@@ -344,7 +351,6 @@ struct LibrariesTabView: View {
                     fixedLibraryId: fixedLibraryId,
                     visibleLibraryCount: visibleLibraries.count
                 ),
-                profile: currentProfile,
                 onLibraryTap: { showPicker = true },
                 onSearch: { router.navigate(to: .search) },
                 onOpenSettings: { router.navigate(to: .settings) },
@@ -479,17 +485,6 @@ struct LibrariesTabView: View {
         }
     }
 
-    /// Load the currently-selected profile so we can render its avatar in
-    /// the top bar. Non-fatal on failure — we fall back to a generic icon.
-    private func loadCurrentProfile() async {
-        guard let profileId = AuthService.shared.profileId else { return }
-        do {
-            let profiles = try await AuthService.shared.getProfiles()
-            currentProfile = profiles.first(where: { $0.id == profileId })
-        } catch {
-            // Leave currentProfile nil; the top bar renders a fallback.
-        }
-    }
 }
 
 // MARK: - Top Bar
@@ -499,7 +494,6 @@ struct LibrariesTabView: View {
 private struct LibrariesTopBar: View {
     let activeLibrary: Library
     let canSwitch: Bool
-    let profile: UserProfile?
     let onLibraryTap: () -> Void
     let onSearch: () -> Void
     let onOpenSettings: () -> Void
@@ -521,7 +515,6 @@ private struct LibrariesTopBar: View {
             Spacer(minLength: 8)
 
             TabTopBarActions(
-                profile: profile,
                 onSearch: onSearch,
                 onOpenSettings: onOpenSettings,
                 onOpenRequests: onOpenRequests,

--- a/iosApp/iosApp/Screens/Calendar/CalendarView.swift
+++ b/iosApp/iosApp/Screens/Calendar/CalendarView.swift
@@ -11,7 +11,6 @@ struct CalendarView: View {
     var onTopMenuFocusRequest: (() -> Void)? = nil
 
     @State private var viewModel = CalendarViewModel()
-    @State private var currentProfile: UserProfile?
     @Environment(AppRouter.self) private var router
     #if os(tvOS)
     /// Focus hand-off for day selection: picking a day in the week strip
@@ -30,7 +29,6 @@ struct CalendarView: View {
         rootLayout
             .task {
                 await viewModel.load()
-                await loadCurrentProfile()
             }
         #if !os(tvOS)
             .refreshable {
@@ -125,7 +123,6 @@ struct CalendarView: View {
                 Spacer(minLength: 8)
 
                 TabTopBarActions(
-                    profile: currentProfile,
                     onSearch: { router.navigate(to: .search) },
                     onOpenSettings: { router.navigate(to: .settings) },
                     onOpenRequests: { router.navigate(to: .requestsHub) },
@@ -407,17 +404,4 @@ struct CalendarView: View {
     }
     #endif
 
-    /// Load the active profile so the iOS top bar can render its avatar.
-    /// Non-fatal on failure — the bar falls back to a generic icon.
-    private func loadCurrentProfile() async {
-        #if !os(tvOS)
-        guard let profileId = AuthService.shared.profileId else { return }
-        do {
-            let profiles = try await AuthService.shared.getProfiles()
-            currentProfile = profiles.first(where: { $0.id == profileId })
-        } catch {
-            // Leave currentProfile nil; the top bar renders a fallback.
-        }
-        #endif
-    }
 }

--- a/iosApp/iosApp/Screens/Collections/CollectionsView.swift
+++ b/iosApp/iosApp/Screens/Collections/CollectionsView.swift
@@ -466,6 +466,7 @@ struct LibraryCollectionsView: View {
                     .padding(ContinuumTheme.padding)
                     .padding(.bottom, ContinuumTheme.largePadding)
                 }
+                .reportsPageChromeScroll()
             } else if let error = viewModel.error {
                 ErrorView(state: error, onRetry: { Task { await viewModel.loadCollections(libraryId: libraryId) } })
             } else if viewModel.isLoading {

--- a/iosApp/iosApp/Screens/Home/HomeView.swift
+++ b/iosApp/iosApp/Screens/Home/HomeView.swift
@@ -24,19 +24,18 @@ struct HomeView: View {
     #endif
     #if !os(tvOS)
     @State private var homeSectionPreferences = HomeSectionPreferences.shared
-    @State private var currentProfile: UserProfile?
     @State private var isRefreshing = false
     @State private var refreshStartedAt: Date?
     @State private var refreshHideTask: Task<Void, Never>?
+    /// Feeds the glass strip behind the floating header as rows scroll under it.
+    @State private var chromeScrollState = PageChromeScrollState()
     #if os(iOS)
-    @State private var isShowingControlPicker = false
-    @Environment(SiloControlClient.self) private var siloControl
-    /// Breathing room between the status-bar safe area and the floating header,
-    /// so the logo + action icons sit comfortably below the Dynamic Island
-    /// rather than crowding it (matching Plex's tight-but-relaxed top spacing).
-    private let headerTopInset: CGFloat = 4
+    /// Breathing room between the status-bar safe area and the floating
+    /// header. Uses the same value as the Libraries and For You top chrome so
+    /// the shared action cluster sits at one height on every root page.
+    private let headerTopInset: CGFloat = ContinuumTheme.smallPadding
     /// The LazyVStack already contributes its normal section spacing after the
-    /// scroll-owned wordmark. Adding a second large header gap pushed the first
+    /// header runway. Adding a second large header gap pushed the first
     /// visible row far down the screen whenever an earlier Home row was hidden.
     private let headerToContentGap: CGFloat = 0
     #endif
@@ -133,46 +132,41 @@ struct HomeView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
 
-            HStack(spacing: 12) {
-                #if os(iOS)
-                // The wordmark lives inside the vertical ScrollView and leaves
-                // with the page. Only the three glass utilities stay pinned.
-                Spacer(minLength: 8)
-                #else
+            HStack(alignment: .center, spacing: 12) {
+                #if !os(iOS)
                 SidebarToggleButton()
-                SiloWordmarkView(width: 72)
-                Spacer(minLength: 8)
                 #endif
+                // The wordmark is pinned with the utilities so it stays put
+                // over the glass strip instead of scrolling away with the feed.
+                // It occupies the same 44pt row as the icon buttons so its
+                // centre lines up with theirs.
+                SiloWordmarkView(width: 72)
+                    .frame(height: ContinuumTheme.topBarIconHitSize)
+                Spacer(minLength: 8)
 
-                // Trailing action cluster: cast / search / profile, evenly
-                // spaced as one group so the gaps between glyphs are uniform
-                // (matching Plex's top-right icon row).
-                HStack(spacing: ContinuumTheme.topBarIconSpacing) {
-                    #if os(iOS)
-                    SiloControlModeButton(controller: siloControl, usesGlass: true) {
-                        isShowingControlPicker = true
-                    }
-                    #endif
-
-                    TabTopBarActions(
-                        profile: currentProfile,
-                        usesGlass: true,
-                        onSearch: { router.navigate(to: .search) },
-                        onOpenSettings: { router.navigate(to: .settings) },
-                        onOpenRequests: { router.navigate(to: .requestsHub) },
-                        onSwitchProfile: {
-                            router.switchProfile()
-                        },
-                        onSwitchServer: { router.navigate(to: .serverList) },
-                        onSignOut: { router.signOutAndReset() }
-                    )
-                }
+                // Trailing action cluster shared by every root page.
+                TabTopBarActions(
+                    onSearch: { router.navigate(to: .search) },
+                    onOpenSettings: { router.navigate(to: .settings) },
+                    onOpenRequests: { router.navigate(to: .requestsHub) },
+                    onSwitchProfile: {
+                        router.switchProfile()
+                    },
+                    onSwitchServer: { router.navigate(to: .serverList) },
+                    onSignOut: { router.signOutAndReset() }
+                )
             }
             .padding(.horizontal, ContinuumTheme.padding)
             #if os(iOS)
             .padding(.top, headerTopInset)
             #endif
             .padding(.bottom, ContinuumTheme.smallPadding)
+            // Same scroll-driven glass as the Detail page chrome so the
+            // utilities stay legible over bright artwork once rows scroll
+            // underneath.
+            .background {
+                PageChromeGlass(scrollState: chromeScrollState)
+            }
 
             if isRefreshing {
                 RefreshStatusPill()
@@ -197,16 +191,10 @@ struct HomeView: View {
         .task {
             homeSectionPreferences.refresh()
             await viewModel.loadSections()
-            await loadCurrentProfile()
         }
         .refreshable {
             await refreshHome()
         }
-        #if os(iOS)
-        .sheet(isPresented: $isShowingControlPicker) {
-            SiloControlTargetPickerView(request: nil, controller: siloControl)
-        }
-        #endif
         #endif
         }
         .alert(
@@ -226,16 +214,11 @@ struct HomeView: View {
         GeometryReader { geometry in
             ScrollView(.vertical, showsIndicators: false) {
                 LazyVStack(alignment: .leading, spacing: HomeFeedMetrics.sectionSpacing) {
-                    #if os(iOS)
-                    homeScrollIdentityHeader
-                        .id(HomeFocusTarget.topSpacer)
-                    #else
-                    // Preserve the existing non-iOS runway while the iOS
-                    // wordmark becomes part of the scrolling feed.
+                    // Clear runway under the pinned header so the first row
+                    // starts below the wordmark and utilities.
                     Color.clear
-                        .frame(height: topRunwaySpacing(topSafeAreaInset: geometry.safeAreaInsets.top))
+                        .frame(height: topRunwaySpacing(topSafeAreaInset: runwaySafeAreaInset(geometry)))
                         .id(HomeFocusTarget.topSpacer)
-                    #endif
 
                     ForEach(displayedSections) { section in
                         HomeFeedRow(
@@ -248,6 +231,7 @@ struct HomeView: View {
                 }
                 .padding(.bottom, HomeFeedMetrics.bottomRunway)
             }
+            .reportsPageChromeScroll(to: chromeScrollState)
             #if os(macOS)
             .continuumScrollEdgeEffect()
             #endif
@@ -279,32 +263,6 @@ struct HomeView: View {
         ContinuumPageBackdrop()
     }
 
-    #if os(iOS)
-    /// Scroll-owned Home identity. Its frame exactly replaces the former clear
-    /// runway, so first-row spacing is unchanged while the logo can now scroll
-    /// away. The fixed utility cluster remains independently overlaid above it.
-    private var homeScrollIdentityHeader: some View {
-        HStack {
-            SiloWordmarkView(width: 72)
-
-            Spacer(minLength: 8)
-        }
-        .padding(.horizontal, ContinuumTheme.padding)
-        // The ScrollView now begins inside the device safe area, exactly like
-        // the fixed utility overlay. Matching their top inset keeps the logo
-        // on the same row instead of underneath the status clock.
-        .padding(.top, headerTopInset)
-        .frame(
-            height: topRunwaySpacing(topSafeAreaInset: 0),
-            alignment: .top
-        )
-        // A large sheet leaves the status-bar region visible by design. Hide
-        // the scroll-owned wordmark while details are presented so it never
-        // ghosts above the card's rounded top edge.
-        .opacity(router.presentedItemDetail == nil ? 1 : 0)
-        .animation(.easeOut(duration: 0.12), value: router.presentedItemDetail == nil)
-    }
-    #endif
 
     private func refreshHome() async {
         await MainActor.run {
@@ -343,17 +301,6 @@ struct HomeView: View {
         }
     }
 
-    /// Load the currently-selected profile so we can render its avatar in
-    /// the top bar. Non-fatal on failure — we fall back to a generic icon.
-    private func loadCurrentProfile() async {
-        guard let profileId = AuthService.shared.profileId else { return }
-        do {
-            let profiles = try await AuthService.shared.getProfiles()
-            currentProfile = profiles.first(where: { $0.id == profileId })
-        } catch {
-            // Leave currentProfile nil; the top bar renders a fallback.
-        }
-    }
     #endif
 
     // MARK: - Navigation
@@ -380,6 +327,16 @@ struct HomeView: View {
     #if !os(tvOS)
     private var sectionSpacing: CGFloat {
         ContinuumTheme.largePadding
+    }
+
+    /// On iOS the ScrollView already starts inside the safe area, so the
+    /// runway must not count the status-bar inset a second time.
+    private func runwaySafeAreaInset(_ geometry: GeometryProxy) -> CGFloat {
+        #if os(iOS)
+        return 0
+        #else
+        return geometry.safeAreaInsets.top
+        #endif
     }
 
     private func topRunwaySpacing(topSafeAreaInset: CGFloat) -> CGFloat {

--- a/iosApp/iosApp/Screens/Personal/FavoritesView.swift
+++ b/iosApp/iosApp/Screens/Personal/FavoritesView.swift
@@ -255,6 +255,7 @@ struct FavoritesView: View {
             }
             .padding(ContinuumTheme.padding)
         }
+        .reportsPageChromeScroll()
     }
 
     private var filteredIOSItems: [BrowseItem] {
@@ -344,6 +345,7 @@ struct FavoritesView: View {
             }
             .padding(ContinuumTheme.padding)
         }
+        .reportsPageChromeScroll()
         #endif
     }
 

--- a/iosApp/iosApp/Screens/Personal/WatchlistView.swift
+++ b/iosApp/iosApp/Screens/Personal/WatchlistView.swift
@@ -110,6 +110,7 @@ struct WatchlistView: View {
             }
             .padding(ContinuumTheme.padding)
         }
+        .reportsPageChromeScroll()
         #else
         ScrollView {
             LazyVGrid(columns: columns, spacing: 16) {
@@ -138,6 +139,7 @@ struct WatchlistView: View {
             }
             .padding(ContinuumTheme.padding)
         }
+        .reportsPageChromeScroll()
         #endif
     }
 

--- a/iosApp/iosApp/Screens/Recommendations/RecommendationsView.swift
+++ b/iosApp/iosApp/Screens/Recommendations/RecommendationsView.swift
@@ -14,8 +14,12 @@ struct RecommendationsView: View {
     var onTopMenuFocusRequest: (() -> Void)? = nil
 
     @State private var viewModel: RecommendationsViewModel
-    @State private var currentProfile: UserProfile?
     @State private var savedListSelection: SavedShortcut = .watchlist
+    #if !os(tvOS)
+    /// Feeds the shared glass strip behind the pinned header as rows scroll
+    /// under it, matching Home and the Library tab.
+    @State private var chromeScrollState = PageChromeScrollState()
+    #endif
     @Environment(AppRouter.self) private var router
 
     init(
@@ -33,14 +37,7 @@ struct RecommendationsView: View {
     var body: some View {
         rootLayout
             .task {
-                #if os(iOS)
-                async let recommendations: Void = viewModel.loadRecommendations()
-                async let profile: Void = loadCurrentProfile()
-                _ = await (recommendations, profile)
-                #else
                 await viewModel.loadRecommendations()
-                await loadCurrentProfile()
-                #endif
             }
         #if !os(tvOS)
             .refreshable {
@@ -57,40 +54,51 @@ struct RecommendationsView: View {
         tvOSPageContent
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         #else
-        VStack(spacing: 0) {
-            HStack(spacing: 12) {
-                SidebarToggleButton()
-
-                Text("Recommendations")
-                    .font(.continuumTitle)
-                    .foregroundColor(.continuumOnSurface)
-
-                Spacer(minLength: 8)
-
-                TabTopBarActions(
-                    profile: currentProfile,
-                    onSearch: { router.navigate(to: .search) },
-                    onOpenSettings: { router.navigate(to: .settings) },
-                    onOpenRequests: { router.navigate(to: .requestsHub) },
-                    onSwitchProfile: {
-                        router.switchProfile()
-                    },
-                    onSwitchServer: { router.navigate(to: .serverList) },
-                    onSignOut: { router.signOutAndReset() }
-                )
+        // Content scrolls under the pinned header, which sits in a top
+        // safe-area inset with the shared glass strip behind it (same
+        // structure as `LibrariesTabView`).
+        pageContent
+            .environment(chromeScrollState)
+            .safeAreaInset(edge: .top, spacing: 0) {
+                topChrome
+                    .background {
+                        PageChromeGlass(scrollState: chromeScrollState)
+                    }
             }
-            .padding(.horizontal, ContinuumTheme.padding)
-            .padding(.top, ContinuumTheme.smallPadding)
-            .padding(.bottom, ContinuumTheme.smallPadding)
-
-            pageContent
-        }
         .continuumPageBackground()
         #if os(iOS)
         .toolbar(.hidden, for: .navigationBar)
         #endif
         #endif
     }
+
+    #if !os(tvOS)
+    private var topChrome: some View {
+        HStack(spacing: 12) {
+            SidebarToggleButton()
+
+            Text("Recommendations")
+                .font(.continuumTitle)
+                .foregroundColor(.continuumOnSurface)
+
+            Spacer(minLength: 8)
+
+            TabTopBarActions(
+                onSearch: { router.navigate(to: .search) },
+                onOpenSettings: { router.navigate(to: .settings) },
+                onOpenRequests: { router.navigate(to: .requestsHub) },
+                onSwitchProfile: {
+                    router.switchProfile()
+                },
+                onSwitchServer: { router.navigate(to: .serverList) },
+                onSignOut: { router.signOutAndReset() }
+            )
+        }
+        .padding(.horizontal, ContinuumTheme.padding)
+        .padding(.top, ContinuumTheme.smallPadding)
+        .padding(.bottom, ContinuumTheme.smallPadding)
+    }
+    #endif
 
     #if os(tvOS)
     /// For You uses the exact Skyline page shell as Home. Recommendation
@@ -265,6 +273,7 @@ struct RecommendationsView: View {
             #endif
             .padding(.bottom, ContinuumTheme.largePadding)
         }
+        .reportsPageChromeScroll()
     }
 
     /// Shown when the server has no recommendation sections: rather than an
@@ -290,17 +299,6 @@ struct RecommendationsView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    /// Load the currently-selected profile so we can render its avatar in
-    /// the top bar. Non-fatal on failure — we fall back to a generic icon.
-    private func loadCurrentProfile() async {
-        guard let profileId = AuthService.shared.profileId else { return }
-        do {
-            let profiles = try await AuthService.shared.getProfiles()
-            currentProfile = profiles.first(where: { $0.id == profileId })
-        } catch {
-            // Leave currentProfile nil; the top bar renders a fallback.
-        }
-    }
 
     private var sectionSpacing: CGFloat {
         #if os(tvOS)


### PR DESCRIPTION
## Problem

The iOS root pages (Home, Libraries, For You, Calendar) each drew their own top bar. The insets differed, so the header icons sat at different heights between Home and the other pages. Once bright artwork scrolled under the header, the buttons and text became hard to read because nothing backed them. Home's wordmark scrolled away with the feed. Each page also refetched the profile list on appearance, so the avatar flashed its fallback initial on every tab switch.

## Solution

Share one header treatment across the root pages.

- `PageChromeGlass` fades in the same Liquid Glass strip the Detail page uses, behind the pinned chrome, as the page scrolls. It is driven by a reference-backed scroll state so the ScrollView body stays stable. Tab content on Libraries and For You reports its offset through the environment, so Browse, Collections, Watchlist, and Favorites feed the chrome without knowing about it.
- The Home wordmark is pinned in the header row instead of scrolling with the feed.
- `TabTopBarActions` owns Search, Remote (iOS), and Profile in a fixed order with glass on by default, and hosts the remote target picker sheet. Home, Libraries, For You, and Calendar all render the same cluster.
- Home uses the same top inset as the other pages, and the wordmark is centred on the 44pt icon row.
- `CurrentProfileStore` caches the active profile for the session. It resets on profile switch, sign out, and server switch, and refreshes after profile selection, on cold restore, and on server switch, alongside the existing capability stores.

## Validation

- Signed iOS build installed and launched on a physical iPhone. Header icons sit at one height across Home, Movies, and For You, the wordmark is centred with them, and the glass strip fades in under the status bar on scroll (checked on the iPhone 17 Pro simulator).
- tvOS and macOS schemes build clean. The glass strip compiles to a no-op on tvOS.
- Not covered: Calendar keeps its own glass card layout and was not changed beyond picking up the shared action cluster.

## Risks

- The fade thresholds (8 to 56 points) were chosen for a short header and may want tuning.
- The profile store is a new session cache. If a profile's avatar is edited on another client mid-session, the header will not pick it up until the next reset or refresh point.

## AI disclosure

Implemented with Claude Code using Claude Fable 5.1 (`claude-fable-5-1`). Product direction, review, and final approval are the maintainer's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared pinned top bar with scroll-responsive glass styling across primary screens.
  * Added an iOS server-control button with a target-selection sheet.
  * Added consistent glass page chrome for Browse, Libraries, Collections, Favorites, Watchlist, Home, and Recommendations.
  * Improved active-profile availability and refresh behavior during sign-in, startup, profile changes, and server switching.
* **Bug Fixes**
  * Improved profile consistency after cache resets and server changes.
  * Added reduced-transparency support for page chrome.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->