### PR TITLE
feat(apple): add episode details to media card captions

### DIFF
--- a/iosApp/iosApp/Components/EpisodeCardCaption.swift
+++ b/iosApp/iosApp/Components/EpisodeCardCaption.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Episode context for card captions. Episode cards are captioned with the
+/// series name, so the season/episode code and episode title live on the
+/// secondary line ("S01E02 · Pilot") in place of the year. The line is always
+/// rendered single-line and tail-truncated so card heights stay uniform
+/// across a row.
+enum EpisodeCardCaption {
+    /// "S01E02" — zero-padded so codes line up across a row.
+    static func code(season: Int, episode: Int) -> String {
+        String(format: "S%02dE%02d", season, episode)
+    }
+
+    static func isEpisode(_ item: SectionItem) -> Bool {
+        item.type.lowercased() == "episode"
+    }
+
+    static func code(for item: SectionItem) -> String? {
+        guard isEpisode(item),
+              let season = item.seasonNumber,
+              let episode = item.episodeNumber else { return nil }
+        return code(season: season, episode: episode)
+    }
+
+    /// The episode's own title, or `nil` when it is empty or merely repeats
+    /// the series name (some scanners fill unknown titles that way).
+    static func episodeTitle(for item: SectionItem) -> String? {
+        guard isEpisode(item) else { return nil }
+        let title = item.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !title.isEmpty else { return nil }
+        if let series = item.seriesTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+           series.caseInsensitiveCompare(title) == .orderedSame {
+            return nil
+        }
+        return title
+    }
+
+    /// Secondary caption line: "S01E02 · Pilot". Falls back to whichever part
+    /// is available; `nil` for non-episodes.
+    static func line(for item: SectionItem) -> String? {
+        let parts = [code(for: item), episodeTitle(for: item)].compactMap { $0 }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    /// Spoken form for accessibility: "Season 1, Episode 2, Pilot".
+    static func accessibilityLabel(for item: SectionItem) -> String? {
+        guard isEpisode(item) else { return nil }
+        var parts: [String] = []
+        if let season = item.seasonNumber, let episode = item.episodeNumber {
+            let seasonLabel = season == 0 ? "Specials" : "Season \(season)"
+            parts.append("\(seasonLabel), Episode \(episode)")
+        }
+        if let title = episodeTitle(for: item) {
+            parts.append(title)
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: ", ")
+    }
+}

--- a/iosApp/iosApp/Components/EpisodeThumbCard.swift
+++ b/iosApp/iosApp/Components/EpisodeThumbCard.swift
@@ -267,8 +267,11 @@ struct EpisodeThumbCard: View {
         item.seriesTitle ?? item.title
     }
 
-    /// Secondary line — episode title for episodes, otherwise year.
+    /// Secondary line — "S01E02 · Pilot" for episodes, otherwise year.
     private var subtitleLine: String? {
+        if let episodeLine = EpisodeCardCaption.line(for: item) {
+            return episodeLine
+        }
         if item.seriesTitle != nil {
             return item.title
         }
@@ -282,8 +285,7 @@ struct EpisodeThumbCard: View {
         var components = [displayTitle]
         if let episodeAccessibilityLabel {
             components.append(episodeAccessibilityLabel)
-        }
-        if let subtitleLine {
+        } else if let subtitleLine {
             components.append(subtitleLine)
         }
         if isPlayed {
@@ -293,10 +295,7 @@ struct EpisodeThumbCard: View {
     }
 
     private var episodeAccessibilityLabel: String? {
-        if let season = item.seasonNumber, let episode = item.episodeNumber {
-            return "S\(season) · E\(episode)"
-        }
-        return nil
+        EpisodeCardCaption.accessibilityLabel(for: item)
     }
 
     private var progressValue: Double? {

--- a/iosApp/iosApp/Components/MediaCard.swift
+++ b/iosApp/iosApp/Components/MediaCard.swift
@@ -60,6 +60,10 @@ struct MediaCard: View {
     let posterUrl: String
     var thumbhash: String? = nil
     var year: Int? = nil
+    /// Secondary caption line drawn in place of the year — episode cards pass
+    /// "S01E02 · Pilot" so the code and episode title sit under the series
+    /// name. Always one line; see `EpisodeCardCaption`.
+    var subtitle: String? = nil
     var progress: Double? = nil
     var userState: MediaItemUserState? = nil
     /// Data for the optional overlay badges (resolution, ratings, …).
@@ -138,6 +142,7 @@ struct MediaCard: View {
         FocusableMediaCard(
             title: title,
             year: year,
+            subtitle: subtitle,
             episodeAccessibilityLabel: episodeAccessibilityLabel,
             captionStyle: uiCustomization.cardPresentation.caption,
             cardWidth: cardWidth,
@@ -411,10 +416,15 @@ struct MediaCard: View {
 
     @ViewBuilder
     private var yearText: some View {
-        if let year {
-            Text(String(year))
+        if let secondLine = subtitle ?? year.map(String.init) {
+            Text(secondLine)
                 .font(.continuumCaption)
                 .foregroundColor(.continuumSecondaryText)
+                // One line, tail-truncated: an episode title must never wrap
+                // and push the row below it.
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(width: cardWidth, alignment: .leading)
         }
     }
 
@@ -472,6 +482,8 @@ extension View {
 private struct FocusableMediaCard<Content: View>: View {
     let title: String
     let year: Int?
+    /// Replaces the year on the metadata line when present.
+    let subtitle: String?
     let episodeAccessibilityLabel: String?
     let captionStyle: CardCaptionStyle
     let cardWidth: CGFloat
@@ -522,12 +534,15 @@ private struct FocusableMediaCard<Content: View>: View {
                         .clipped()
                         .animation(.easeOut(duration: 0.15), value: isFocused)
 
-                    if captionStyle.showsMetadata, let year {
-                        Text(String(year))
+                    if captionStyle.showsMetadata,
+                       let secondLine = subtitle ?? year.map(String.init) {
+                        Text(secondLine)
                             .font(.continuumPosterMetadata)
                             .foregroundStyle(Color.continuumSecondaryText)
                             .lineLimit(1)
+                            .truncationMode(.tail)
                             .frame(width: cardWidth, alignment: .leading)
+                            .clipped()
                     }
                 }
                 .frame(width: cardWidth, alignment: .leading)

--- a/iosApp/iosApp/Components/MediaRow.swift
+++ b/iosApp/iosApp/Components/MediaRow.swift
@@ -397,6 +397,7 @@ struct MediaRow: View {
                 posterUrl: item.posterUrl ?? "",
                 thumbhash: item.posterThumbhash,
                 year: item.year,
+                subtitle: EpisodeCardCaption.line(for: item),
                 progress: progressValue(for: item),
                 userState: item.userState,
                 overlayData: OverlayData.from(item),
@@ -564,12 +565,9 @@ struct MediaRow: View {
     }
 
     /// Episode context for accessibility when a poster is captioned with its
-    /// series title. Episode numbers are not drawn over card artwork.
+    /// series title.
     private func episodeAccessibilityLabel(for item: SectionItem) -> String? {
-        guard item.type.lowercased() == "episode",
-              let season = item.seasonNumber,
-              let episode = item.episodeNumber else { return nil }
-        return "S\(season) · E\(episode)"
+        EpisodeCardCaption.accessibilityLabel(for: item)
     }
 
     // MARK: - Metrics

--- a/iosApp/iosApp/Screens/Home/Feed/HomeFeedKit.swift
+++ b/iosApp/iosApp/Screens/Home/Feed/HomeFeedKit.swift
@@ -90,9 +90,11 @@ enum HomeFeedMeta {
         return parts.joined(separator: "  ·  ")
     }
 
-    static func episodeCode(for item: SectionItem) -> String? {
-        guard let season = item.seasonNumber, let episode = item.episodeNumber else { return nil }
-        return "S\(season) E\(episode)"
+    /// Secondary caption line under a card title: "S01E02 · Pilot" for
+    /// episodes, otherwise the year. One line, so every card in a row keeps
+    /// the same height.
+    static func cardSecondLine(for item: SectionItem) -> String? {
+        EpisodeCardCaption.line(for: item) ?? item.year.map(String.init)
     }
 
     /// Caption under a resume still — "23m left".
@@ -397,11 +399,13 @@ struct HomePosterCard: View {
                 .lineLimit(1)
                 .truncationMode(.tail)
 
-            if showsMetadata, let year = item.year {
-                Text(String(year))
+            if showsMetadata, let secondLine = HomeFeedMeta.cardSecondLine(for: item) {
+                Text(secondLine)
                     .font(.system(size: 11, weight: .regular))
                     .foregroundStyle(Color.continuumOnSurface.opacity(0.5))
                     .monospacedDigit()
+                    .lineLimit(1)
+                    .truncationMode(.tail)
             }
         }
         .frame(width: width, alignment: .leading)
@@ -409,9 +413,11 @@ struct HomePosterCard: View {
 
     private var accessibilityDescription: String {
         var components = [HomeFeedMeta.cardTitle(for: item)]
-        components.append(
-            contentsOf: [episodeAccessibilityLabel, item.year.map(String.init)].compactMap { $0 }
-        )
+        if let episodeAccessibilityLabel {
+            components.append(episodeAccessibilityLabel)
+        } else if let year = item.year {
+            components.append(String(year))
+        }
         if isPlayed {
             components.append("Watched")
         }
@@ -552,6 +558,18 @@ struct HomeStillCard: View {
                 .foregroundStyle(Color.continuumOnSurface)
                 .lineLimit(1)
 
+            if showsMetadata {
+                // Episode code + title (or the year for movies). Space is
+                // reserved even when empty so a row mixing episodes and
+                // movies keeps one caption height.
+                Text(HomeFeedMeta.cardSecondLine(for: item) ?? "")
+                    .font(.system(size: 11, weight: .regular))
+                    .foregroundStyle(Color.continuumOnSurface.opacity(0.7))
+                    .monospacedDigit()
+                    .lineLimit(1, reservesSpace: true)
+                    .truncationMode(.tail)
+            }
+
             if showsMetadata, let subtitle = HomeFeedMeta.resumeCaption(for: item) {
                 Text(subtitle)
                     .font(.system(size: 11, weight: .regular))
@@ -564,8 +582,10 @@ struct HomeStillCard: View {
 
     private var accessibilityDescription: String {
         var components = [HomeFeedMeta.cardTitle(for: item)]
-        if let episodeCode = HomeFeedMeta.episodeCode(for: item) {
-            components.append(episodeCode)
+        if let episodeLabel = EpisodeCardCaption.accessibilityLabel(for: item) {
+            components.append(episodeLabel)
+        } else if let year = item.year {
+            components.append(String(year))
         }
         if let resumeCaption = HomeFeedMeta.resumeCaption(for: item) {
             components.append(resumeCaption)

--- a/iosApp/iosApp/Screens/Home/Feed/HomeFeedRow.swift
+++ b/iosApp/iosApp/Screens/Home/Feed/HomeFeedRow.swift
@@ -139,10 +139,7 @@ struct HomeFeedRow: View {
     /// Episode context for accessibility when episode-discovery cards are
     /// visually captioned with their series name.
     private func episodeAccessibilityLabel(for item: SectionItem) -> String? {
-        guard item.type.lowercased() == "episode",
-              let season = item.seasonNumber,
-              let episode = item.episodeNumber else { return nil }
-        return "S\(season) · E\(episode)"
+        EpisodeCardCaption.accessibilityLabel(for: item)
     }
 
     /// Removal is only offered where it means something — a resume row.


### PR DESCRIPTION
## Summary

- Add shared episode caption formatting for zero-padded season and episode codes with episode titles.
- Display episode details on media, thumbnail, home poster, and home still cards in place of the year.
- Preserve single-line truncation and consistent card heights across mixed-content rows.
- Improve accessibility labels with spoken season, episode, and title details.

## Testing

- Not run; no build or test results were provided.

AI disclosure: Generated with GPT-5 using the Codex agent harness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized episode captions across home feed and media cards.
  * Episode cards now show clearer secondary metadata, including season and episode details when available.
  * Improved accessibility labels for episode cards.
  * Metadata captions are limited to one line with truncated overflow.
  * Resume-time information remains visible alongside episode or movie context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->