### PR TITLE
fix(tvos): increase metadata and wordmark sizes

### DIFF
--- a/iosApp/iosApp/Theme/ContinuumTheme.swift
+++ b/iosApp/iosApp/Theme/ContinuumTheme.swift
@@ -149,9 +149,9 @@ struct ContinuumTheme {
         static let barIconSize: CGFloat = 58
         /// Gap between the search button and the avatar.
         static let barTrailingSpacing: CGFloat = 22
-        static let wordmarkSize: CGFloat = 26
-        /// Wordmark letter tracking — +0.34 em.
-        static let wordmarkTracking: CGFloat = 26 * 0.34
+        /// Width of the logo asset in the top bar. The asset is ~1.9:1, so
+        /// this renders about 50pt tall inside the 64pt bar row.
+        static let wordmarkWidth: CGFloat = 96
         /// Bar opacity while focus is down in the content zone (§5.1).
         static let barDimmedOpacity: Double = 0.7
 

--- a/iosApp/iosApp/Theme/Typography.swift
+++ b/iosApp/iosApp/Theme/Typography.swift
@@ -21,10 +21,10 @@ extension Font {
     /// Movie/series names directly beneath artwork. Kept quieter than general
     /// subheadlines so dense eight-across rows remain readable rather than
     /// visually shouting over the posters.
-    static let continuumPosterTitle = Font.system(size: 20, weight: .medium)
+    static let continuumPosterTitle = Font.system(size: 24, weight: .medium)
 
     /// Year, episode title, and other secondary poster-card metadata.
-    static let continuumPosterMetadata = Font.system(size: 17, weight: .regular)
+    static let continuumPosterMetadata = Font.system(size: 20, weight: .regular)
 
     /// Body text — descriptions, synopses (26pt regular)
     static let continuumBody = Font.system(size: 26)

--- a/iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift
@@ -343,12 +343,11 @@ struct TVTopMenuBar: View {
 
     // MARK: - Clusters
 
+    /// Brand logo (mark + wordmark asset), sized to the bar row so it sits
+    /// on the same centre line as the tab capsules and trailing icons.
     private var wordmark: some View {
-        Text("SILO")
-            .font(.system(size: ContinuumTheme.Skyline.wordmarkSize, weight: .heavy))
-            .tracking(ContinuumTheme.Skyline.wordmarkTracking)
-            .foregroundStyle(.white)
-            .accessibilityLabel("Silo")
+        SiloWordmarkView(width: ContinuumTheme.Skyline.wordmarkWidth)
+            .frame(height: ContinuumTheme.Skyline.barHeight)
             .accessibilityHidden(true)
     }
 


### PR DESCRIPTION
## Summary

- Increase tvOS poster title and metadata font sizes for improved readability.
- Replace the text-based top-bar `SILO` label with the Silo wordmark asset.
- Size the wordmark to align with the top navigation bar and trailing controls.

## Testing

- Not run; visual-only tvOS changes.
- Xcode build and simulator validation should be run before merge.

AI disclosure: Generated with GPT-5 using the Codex agent harness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Visual Updates**
  * Updated the tvOS top-menu wordmark to use the official Silo logo asset for improved branding consistency.
  * Adjusted the wordmark width and sizing for the tvOS menu layout.
  * Increased poster title and metadata text sizes for improved readability.
* **Accessibility**
  * Updated the top-menu wordmark’s accessibility behavior to prevent redundant announcements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->