### PR TITLE
fix(player): keep next-up video visible through episode transitions

### DIFF
--- a/.github/workflows/player-regression.yml
+++ b/.github/workflows/player-regression.yml
@@ -57,6 +57,7 @@ jobs:
           set -o pipefail
           xcodebuild "$ACTION" -project iosApp/Silo.xcodeproj -scheme "$SCHEME" \
             -destination "$DESTINATION" -derivedDataPath /tmp/silo-derived \
+            -parallel-testing-enabled NO \
             -resultBundlePath /tmp/player-validation.xcresult \
             CODE_SIGNING_ALLOWED=NO | tee /tmp/player-validation.log
       - name: Record synthetic preview expansion and successor playback
@@ -72,6 +73,7 @@ jobs:
           xcodebuild test-without-building -project iosApp/Silo.xcodeproj -scheme Silo \
             -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
             -derivedDataPath /tmp/silo-derived \
+            -parallel-testing-enabled NO \
             -only-testing:SiloTests/PlayerSurfaceLayoutTests/testPlayingPreviewExpandsWithoutReplacingItemOrLosingItsLayer \
             -resultBundlePath /tmp/preview-recording.xcresult CODE_SIGNING_ALLOWED=NO
       - name: Upload validation evidence

--- a/.github/workflows/player-regression.yml
+++ b/.github/workflows/player-regression.yml
@@ -87,3 +87,13 @@ jobs:
             /tmp/preview-transition.mp4
             /tmp/preview-recording.xcresult
           retention-days: 7
+      - name: Package simulator tests for focused visual verification
+        if: matrix.action == 'test' && !cancelled()
+        run: ditto -c -k --keepParent /tmp/silo-derived/Build/Products /tmp/Silo-simulator-tests.zip
+      - name: Upload compiled simulator tests
+        if: matrix.action == 'test' && !cancelled()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Silo-simulator-tests
+          path: /tmp/Silo-simulator-tests.zip
+          retention-days: 3

--- a/.github/workflows/player-regression.yml
+++ b/.github/workflows/player-regression.yml
@@ -11,12 +11,17 @@ on:
   push:
     branches: [fix/next-up-persistent-surface]
   workflow_dispatch:
+    inputs:
+      baseline_ref:
+        description: Optional unchanged upstream commit for a comparative full-suite run
+        type: string
+        required: false
 
 permissions:
   contents: read
 
 concurrency:
-  group: player-regression-${{ github.ref }}
+  group: player-regression-${{ github.ref }}-${{ inputs.baseline_ref || 'head' }}
   cancel-in-progress: true
 
 jobs:
@@ -40,6 +45,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+          ref: ${{ inputs.baseline_ref || github.sha }}
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '26.3'
@@ -48,7 +54,8 @@ jobs:
           curl -fsSL -o /tmp/xcodegen.zip https://github.com/yonaskolb/XcodeGen/releases/download/2.43.0/xcodegen.zip
           unzip -q /tmp/xcodegen.zip -d /tmp/xcodegen-dist
           /tmp/xcodegen-dist/xcodegen/bin/xcodegen generate --spec iosApp/project.yml
-      - name: Validate player
+      - name: Build player
+        id: build
         env:
           SCHEME: ${{ matrix.scheme }}
           DESTINATION: ${{ matrix.destination }}
@@ -60,16 +67,36 @@ jobs:
             # required by Keychain. No certificate or release secret is used.
             xcodebuild build-for-testing -project iosApp/Silo.xcodeproj -scheme "$SCHEME" \
               -destination "$DESTINATION" -derivedDataPath /tmp/silo-derived \
-              CODE_SIGNING_ALLOWED=YES CODE_SIGN_IDENTITY=-
-            ACTION=test-without-building
+              CODE_SIGNING_ALLOWED=YES CODE_SIGN_IDENTITY=- | tee /tmp/player-build.log
+          else
+            xcodebuild build -project iosApp/Silo.xcodeproj -scheme "$SCHEME" \
+              -destination "$DESTINATION" -derivedDataPath /tmp/silo-derived \
+              -resultBundlePath /tmp/player-validation.xcresult \
+              CODE_SIGNING_ALLOWED=NO | tee /tmp/player-validation.log
           fi
-          xcodebuild "$ACTION" -project iosApp/Silo.xcodeproj -scheme "$SCHEME" \
-            -destination "$DESTINATION" -derivedDataPath /tmp/silo-derived \
+      - name: Package simulator tests for focused visual verification
+        if: matrix.action == 'test' && !inputs.baseline_ref
+        run: ditto -c -k --keepParent /tmp/silo-derived/Build/Products /tmp/Silo-simulator-tests.zip
+      - name: Upload compiled simulator tests
+        if: matrix.action == 'test' && !inputs.baseline_ref
+        uses: actions/upload-artifact@v4
+        with:
+          name: Silo-simulator-tests
+          path: /tmp/Silo-simulator-tests.zip
+          retention-days: 3
+      - name: Run complete iOS suite
+        if: matrix.action == 'test'
+        timeout-minutes: 12
+        run: |
+          set -o pipefail
+          xcodebuild test-without-building -project iosApp/Silo.xcodeproj -scheme Silo \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath /tmp/silo-derived \
             -parallel-testing-enabled NO \
+            -test-timeouts-enabled YES -maximum-test-execution-time-allowance 60 \
             -resultBundlePath /tmp/player-validation.xcresult \
-            CODE_SIGNING_ALLOWED=NO | tee /tmp/player-validation.log
+            CODE_SIGNING_ALLOWED=YES CODE_SIGN_IDENTITY=- | tee /tmp/player-validation.log
       - name: Record synthetic preview expansion and successor playback
-        if: matrix.action == 'test' && !cancelled()
+        if: matrix.action == 'test' && !inputs.baseline_ref && steps.build.outcome == 'success' && !cancelled()
         shell: bash
         run: |
           set -euo pipefail
@@ -83,25 +110,16 @@ jobs:
             -derivedDataPath /tmp/silo-derived \
             -parallel-testing-enabled NO \
             -only-testing:SiloTests/PlayerSurfaceLayoutTests/testPlayingPreviewExpandsWithoutReplacingItemOrLosingItsLayer \
-            -resultBundlePath /tmp/preview-recording.xcresult CODE_SIGNING_ALLOWED=NO
+            -resultBundlePath /tmp/preview-recording.xcresult CODE_SIGNING_ALLOWED=YES CODE_SIGN_IDENTITY=-
       - name: Upload validation evidence
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: player-validation-${{ matrix.scheme }}
           path: |
+            /tmp/player-build.log
             /tmp/player-validation.log
             /tmp/player-validation.xcresult
             /tmp/preview-transition.mp4
             /tmp/preview-recording.xcresult
           retention-days: 7
-      - name: Package simulator tests for focused visual verification
-        if: matrix.action == 'test' && !cancelled()
-        run: ditto -c -k --keepParent /tmp/silo-derived/Build/Products /tmp/Silo-simulator-tests.zip
-      - name: Upload compiled simulator tests
-        if: matrix.action == 'test' && !cancelled()
-        uses: actions/upload-artifact@v4
-        with:
-          name: Silo-simulator-tests
-          path: /tmp/Silo-simulator-tests.zip
-          retention-days: 3

--- a/.github/workflows/player-regression.yml
+++ b/.github/workflows/player-regression.yml
@@ -102,15 +102,29 @@ jobs:
           set -euo pipefail
           # Reuse the compiled test bundle. This records only the bounded
           # synthetic-video test, not a second build or the full test suite.
-          xcrun simctl io booted recordVideo /tmp/preview-transition.mp4 &
+          # XCTest can shut down the simulator after the full suite. Boot the
+          # exact recording destination before starting the recorder.
+          simulator_id=$(xcrun simctl list devices available --json | jq -er \
+            '[.devices[][] | select(.name == "iPhone 17 Pro")][0].udid')
+          simulator_state=$(xcrun simctl list devices available --json | jq -r \
+            --arg id "$simulator_id" '.devices[][] | select(.udid == $id) | .state')
+          if [ "$simulator_state" != Booted ]; then
+            xcrun simctl boot "$simulator_id"
+          fi
+          xcrun simctl bootstatus "$simulator_id" -b
+          xcrun simctl io "$simulator_id" recordVideo /tmp/preview-transition.mp4 &
           recorder_pid=$!
           trap 'kill -INT "$recorder_pid" 2>/dev/null || true; wait "$recorder_pid" || true' EXIT
           xcodebuild test-without-building -project iosApp/Silo.xcodeproj -scheme Silo \
-            -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+            -destination "platform=iOS Simulator,id=$simulator_id" \
             -derivedDataPath /tmp/silo-derived \
             -parallel-testing-enabled NO \
             -only-testing:SiloTests/PlayerSurfaceLayoutTests/testPlayingPreviewExpandsWithoutReplacingItemOrLosingItsLayer \
             -resultBundlePath /tmp/preview-recording.xcresult CODE_SIGNING_ALLOWED=YES CODE_SIGN_IDENTITY=-
+          kill -INT "$recorder_pid"
+          wait "$recorder_pid"
+          trap - EXIT
+          test -s /tmp/preview-transition.mp4
       - name: Upload validation evidence
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/player-regression.yml
+++ b/.github/workflows/player-regression.yml
@@ -49,6 +49,35 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '26.3'
+      - name: Prepare iOS simulator
+        if: matrix.action == 'test'
+        timeout-minutes: 10
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Hosted images do not always have a usable pre-created device.
+          # Match the selected Xcode SDK and reuse one explicit destination.
+          runtime_version=$(xcrun --sdk iphonesimulator --show-sdk-version)
+          find_runtime() {
+            xcrun simctl list runtimes --json | jq -r --arg version "$runtime_version" \
+              '[.runtimes[] | select(.isAvailable and .version == $version and
+                (.identifier | startswith("com.apple.CoreSimulator.SimRuntime.iOS-")))][0].identifier // empty'
+          }
+          runtime_id=$(find_runtime)
+          if [ -z "$runtime_id" ]; then
+            xcodebuild -downloadPlatform iOS -buildVersion "$runtime_version"
+            runtime_id=$(find_runtime)
+          fi
+          if [ -z "$runtime_id" ]; then
+            echo "::error::No available iOS $runtime_version simulator runtime"
+            exit 1
+          fi
+          simulator_id=$(xcrun simctl create Silo-Player-Regression \
+            com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro "$runtime_id")
+          echo "SILO_SIMULATOR_ID=$simulator_id" >> "$GITHUB_ENV"
+          echo "SILO_TEST_DESTINATION=platform=iOS Simulator,id=$simulator_id" >> "$GITHUB_ENV"
+          xcrun simctl boot "$simulator_id"
+          xcrun simctl bootstatus "$simulator_id" -b
       - name: Generate Xcode project
         run: |
           curl -fsSL -o /tmp/xcodegen.zip https://github.com/yonaskolb/XcodeGen/releases/download/2.43.0/xcodegen.zip
@@ -66,7 +95,7 @@ jobs:
             # Simulator-only ad-hoc signing supplies the application identifier
             # required by Keychain. No certificate or release secret is used.
             xcodebuild build-for-testing -project iosApp/Silo.xcodeproj -scheme "$SCHEME" \
-              -destination "$DESTINATION" -derivedDataPath /tmp/silo-derived \
+              -destination "$SILO_TEST_DESTINATION" -derivedDataPath /tmp/silo-derived \
               CODE_SIGNING_ALLOWED=YES CODE_SIGN_IDENTITY=- | tee /tmp/player-build.log
           else
             xcodebuild build -project iosApp/Silo.xcodeproj -scheme "$SCHEME" \
@@ -90,13 +119,14 @@ jobs:
         run: |
           set -o pipefail
           xcodebuild test-without-building -project iosApp/Silo.xcodeproj -scheme Silo \
-            -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath /tmp/silo-derived \
+            -destination "$SILO_TEST_DESTINATION" -derivedDataPath /tmp/silo-derived \
             -parallel-testing-enabled NO \
             -test-timeouts-enabled YES -maximum-test-execution-time-allowance 60 \
             -resultBundlePath /tmp/player-validation.xcresult \
             CODE_SIGNING_ALLOWED=YES CODE_SIGN_IDENTITY=- | tee /tmp/player-validation.log
       - name: Record synthetic preview expansion and successor playback
         if: matrix.action == 'test' && !inputs.baseline_ref && steps.build.outcome == 'success' && !cancelled()
+        timeout-minutes: 10
         shell: bash
         run: |
           set -euo pipefail
@@ -104,8 +134,7 @@ jobs:
           # synthetic-video test, not a second build or the full test suite.
           # XCTest can shut down the simulator after the full suite. Boot the
           # exact recording destination before starting the recorder.
-          simulator_id=$(xcrun simctl list devices available --json | jq -er \
-            '[.devices[][] | select(.name == "iPhone 17 Pro")][0].udid')
+          simulator_id="$SILO_SIMULATOR_ID"
           simulator_state=$(xcrun simctl list devices available --json | jq -r \
             --arg id "$simulator_id" '.devices[][] | select(.udid == $id) | .state')
           if [ "$simulator_state" != Booted ]; then

--- a/.github/workflows/player-regression.yml
+++ b/.github/workflows/player-regression.yml
@@ -59,6 +59,21 @@ jobs:
             -destination "$DESTINATION" -derivedDataPath /tmp/silo-derived \
             -resultBundlePath /tmp/player-validation.xcresult \
             CODE_SIGNING_ALLOWED=NO | tee /tmp/player-validation.log
+      - name: Record synthetic preview expansion and successor playback
+        if: matrix.action == 'test'
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Reuse the compiled test bundle. This records only the bounded
+          # synthetic-video test, not a second build or the full test suite.
+          xcrun simctl io booted recordVideo /tmp/preview-transition.mp4 &
+          recorder_pid=$!
+          trap 'kill -INT "$recorder_pid" 2>/dev/null || true; wait "$recorder_pid" || true' EXIT
+          xcodebuild test-without-building -project iosApp/Silo.xcodeproj -scheme Silo \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+            -derivedDataPath /tmp/silo-derived \
+            -only-testing:SiloTests/PlayerSurfaceLayoutTests/testPlayingPreviewExpandsWithoutReplacingItemOrLosingItsLayer \
+            -resultBundlePath /tmp/preview-recording.xcresult CODE_SIGNING_ALLOWED=NO
       - name: Upload validation evidence
         if: always()
         uses: actions/upload-artifact@v4
@@ -67,4 +82,6 @@ jobs:
           path: |
             /tmp/player-validation.log
             /tmp/player-validation.xcresult
+            /tmp/preview-transition.mp4
+            /tmp/preview-recording.xcresult
           retention-days: 7

--- a/.github/workflows/player-regression.yml
+++ b/.github/workflows/player-regression.yml
@@ -1,0 +1,70 @@
+name: Player regression
+
+on:
+  pull_request:
+    paths:
+      - 'iosApp/iosApp/Screens/Player/**'
+      - 'iosApp/Tests/**'
+      - 'iosApp/project.yml'
+      - 'iosApp/**/Package.resolved'
+      - '.github/workflows/player-regression.yml'
+  push:
+    branches: [fix/next-up-persistent-surface]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: player-regression-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: macos-15
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - scheme: Silo
+            destination: 'platform=iOS Simulator,name=iPhone 17 Pro'
+            action: test
+          - scheme: SiloTV
+            destination: 'generic/platform=tvOS Simulator'
+            action: build
+          - scheme: SiloMac
+            destination: 'generic/platform=macOS'
+            action: build
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.3'
+      - name: Generate Xcode project
+        run: |
+          curl -fsSL -o /tmp/xcodegen.zip https://github.com/yonaskolb/XcodeGen/releases/download/2.43.0/xcodegen.zip
+          unzip -q /tmp/xcodegen.zip -d /tmp/xcodegen-dist
+          /tmp/xcodegen-dist/xcodegen/bin/xcodegen generate --spec iosApp/project.yml
+      - name: Validate player
+        env:
+          SCHEME: ${{ matrix.scheme }}
+          DESTINATION: ${{ matrix.destination }}
+          ACTION: ${{ matrix.action }}
+        run: |
+          set -o pipefail
+          xcodebuild "$ACTION" -project iosApp/Silo.xcodeproj -scheme "$SCHEME" \
+            -destination "$DESTINATION" -derivedDataPath /tmp/silo-derived \
+            -resultBundlePath /tmp/player-validation.xcresult \
+            CODE_SIGNING_ALLOWED=NO | tee /tmp/player-validation.log
+      - name: Upload validation evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: player-validation-${{ matrix.scheme }}
+          path: |
+            /tmp/player-validation.log
+            /tmp/player-validation.xcresult
+          retention-days: 7

--- a/.github/workflows/player-regression.yml
+++ b/.github/workflows/player-regression.yml
@@ -55,13 +55,21 @@ jobs:
           ACTION: ${{ matrix.action }}
         run: |
           set -o pipefail
+          if [ "$ACTION" = test ]; then
+            # Simulator-only ad-hoc signing supplies the application identifier
+            # required by Keychain. No certificate or release secret is used.
+            xcodebuild build-for-testing -project iosApp/Silo.xcodeproj -scheme "$SCHEME" \
+              -destination "$DESTINATION" -derivedDataPath /tmp/silo-derived \
+              CODE_SIGNING_ALLOWED=YES CODE_SIGN_IDENTITY=-
+            ACTION=test-without-building
+          fi
           xcodebuild "$ACTION" -project iosApp/Silo.xcodeproj -scheme "$SCHEME" \
             -destination "$DESTINATION" -derivedDataPath /tmp/silo-derived \
             -parallel-testing-enabled NO \
             -resultBundlePath /tmp/player-validation.xcresult \
             CODE_SIGNING_ALLOWED=NO | tee /tmp/player-validation.log
       - name: Record synthetic preview expansion and successor playback
-        if: matrix.action == 'test'
+        if: matrix.action == 'test' && !cancelled()
         shell: bash
         run: |
           set -euo pipefail

--- a/iosApp/Resources/OpenSourceLicenses/README.txt
+++ b/iosApp/Resources/OpenSourceLicenses/README.txt
@@ -6,9 +6,9 @@ texts are bundled beside this file and are available from Settings > About >
 Open Source Licenses.
 
 AetherEngine
-  Revision: e238d1d2da52b58bffd7f8135bb2b04e32915cee (release 6.34.0 + native item handoff fix)
+  Revision: 53ec6c9771a8df326abb23c7d98692b95b18b2c1 (release 6.34.0 + native item handoff and session retirement fixes)
   License: GNU LGPL version 3 with the upstream Apple Store / DRM exception
-  Source: https://github.com/blurbery/AetherEngine/tree/e238d1d2da52b58bffd7f8135bb2b04e32915cee
+  Source: https://github.com/blurbery/AetherEngine/tree/53ec6c9771a8df326abb23c7d98692b95b18b2c1
   Rebuild: the Package.swift and source tree at that revision
 
 FFmpegBuild and embedded media frameworks

--- a/iosApp/Resources/OpenSourceLicenses/README.txt
+++ b/iosApp/Resources/OpenSourceLicenses/README.txt
@@ -6,9 +6,9 @@ texts are bundled beside this file and are available from Settings > About >
 Open Source Licenses.
 
 AetherEngine
-  Revision: 53ec6c9771a8df326abb23c7d98692b95b18b2c1 (release 6.34.0 + native item handoff and session retirement fixes)
+  Revision: 653be639441d3f7d06332a2f995950497ad62e0f (release 6.34.0 + native item handoff and session retirement fixes)
   License: GNU LGPL version 3 with the upstream Apple Store / DRM exception
-  Source: https://github.com/blurbery/AetherEngine/tree/53ec6c9771a8df326abb23c7d98692b95b18b2c1
+  Source: https://github.com/blurbery/AetherEngine/tree/653be639441d3f7d06332a2f995950497ad62e0f
   Rebuild: the Package.swift and source tree at that revision
 
 FFmpegBuild and embedded media frameworks

--- a/iosApp/Silo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iosApp/Silo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,7 +5,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/blurbery/AetherEngine",
       "state" : {
-        "revision" : "53ec6c9771a8df326abb23c7d98692b95b18b2c1"
+        "revision" : "653be639441d3f7d06332a2f995950497ad62e0f"
       }
     },
     {

--- a/iosApp/Silo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iosApp/Silo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,7 +5,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/blurbery/AetherEngine",
       "state" : {
-        "revision" : "e238d1d2da52b58bffd7f8135bb2b04e32915cee"
+        "revision" : "53ec6c9771a8df326abb23c7d98692b95b18b2c1"
       }
     },
     {

--- a/iosApp/Tests/PlayerNextUpCompletionPolicyTests.swift
+++ b/iosApp/Tests/PlayerNextUpCompletionPolicyTests.swift
@@ -2,6 +2,36 @@ import XCTest
 @testable import Silo
 
 final class PlayerNextUpCompletionPolicyTests: XCTestCase {
+    func testAlreadyPlayingOrLoadingCandidateOnlyExpands() {
+        XCTAssertEqual(
+            PlayerNextUpPlaybackAction.resolve(candidateId: "episode-b", currentId: "episode-b"),
+            .expand
+        )
+    }
+
+    func testEarlyNextAndRepeatedCountdownProduceOneLoad() {
+        var currentId = "episode-a"
+        var loads = 0
+        for _ in 0..<100 {
+            switch PlayerNextUpPlaybackAction.resolve(candidateId: "episode-b", currentId: currentId) {
+            case .load(let id):
+                loads += 1
+                // beginFreshLoad sets lastLoadRequest synchronously, before awaits.
+                currentId = id
+            case .expand, .unavailable:
+                break
+            }
+        }
+        XCTAssertEqual(loads, 1)
+    }
+
+    func testMissingCandidateDoesNotReloadCurrentEpisode() {
+        XCTAssertEqual(
+            PlayerNextUpPlaybackAction.resolve(candidateId: nil, currentId: "episode-a"),
+            .unavailable
+        )
+    }
+
     func testEarlyManualPresentationPreservesCurrentPosition() {
         let position = PlayerNextUpCompletionPolicy.progressPosition(
             isNextUpPresented: true,

--- a/iosApp/Tests/PlayerNextUpCompletionPolicyTests.swift
+++ b/iosApp/Tests/PlayerNextUpCompletionPolicyTests.swift
@@ -18,7 +18,7 @@ final class PlayerNextUpCompletionPolicyTests: XCTestCase {
                 loads += 1
                 // beginFreshLoad sets lastLoadRequest synchronously, before awaits.
                 currentId = id
-            case .expand, .unavailable:
+            case .expand, .unavailable, .waitForPicture:
                 break
             }
         }
@@ -29,6 +29,21 @@ final class PlayerNextUpCompletionPolicyTests: XCTestCase {
         XCTAssertEqual(
             PlayerNextUpPlaybackAction.resolve(candidateId: nil, currentId: "episode-a"),
             .unavailable
+        )
+    }
+
+    func testEarlyRepeatedPlayNowWaitsForTheSuccessorsPicture() {
+        for candidate in ["episode-b", "episode-c", nil] {
+            XCTAssertEqual(
+                PlayerNextUpPlaybackAction.resolve(
+                    candidateId: candidate, currentId: "episode-b", awaitingPicture: true
+                ),
+                .waitForPicture
+            )
+        }
+        XCTAssertEqual(
+            PlayerNextUpPlaybackAction.resolve(candidateId: "episode-b", currentId: "episode-b"),
+            .expand
         )
     }
 

--- a/iosApp/Tests/PlayerSurfaceLayoutTests.swift
+++ b/iosApp/Tests/PlayerSurfaceLayoutTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 @MainActor
 final class PlayerSurfaceLayoutTests: XCTestCase {
-    @Observable private final class Presentation {
+    @Observable final class Presentation {
         var preview = false
         var hasPreviewBounds = true
     }

--- a/iosApp/Tests/PlayerSurfaceLayoutTests.swift
+++ b/iosApp/Tests/PlayerSurfaceLayoutTests.swift
@@ -17,6 +17,7 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
         let engine: AetherEngine
         var legacy = false
         var reduceMotion = true
+        var nextUpModel: PlayerViewModel?
 
         var body: some View {
             Group {
@@ -34,7 +35,9 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
                     } content: {
                         ZStack {
                             Color.black.ignoresSafeArea()
-                            if presentation.preview && presentation.hasPreviewBounds {
+                            if presentation.preview, let nextUpModel {
+                                PlayerNextUpScreen(viewModel: nextUpModel, onBack: {})
+                            } else if presentation.preview && presentation.hasPreviewBounds {
                                 Color.clear
                                     .frame(width: 240, height: 135)
                                     .anchorPreference(key: PlayerPreviewBoundsKey.self, value: .bounds) {
@@ -75,7 +78,19 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
         var panel = CGRect.zero
     }
 
+    private func nextUpFixture() throws -> PlayerViewModel {
+        let episode = try JSONDecoder().decode(EpisodeListItem.self, from: Data(
+            #"{"contentId":"synthetic-episode-b","seasonNumber":1,"episodeNumber":2,"title":"The next chapter"}"#.utf8
+        ))
+        let model = PlayerViewModel()
+        model.nextUpEpisode = PlayerNextUpEpisode(episode: episode, seriesId: "synthetic-series", seriesTitle: "Playback regression fixture")
+        model.nextUpCountdownSeconds = 5
+        return model
+    }
+
     func testMobileActionsStayVisibleBesideOrBelowTheSmallerPreview() async throws {
+        let model = try nextUpFixture()
+        defer { model.cleanup() }
         for size in [CGSize(width: 568, height: 320), CGSize(width: 844, height: 390),
                      CGSize(width: 390, height: 844), CGSize(width: 1024, height: 768)] {
             let frames = MobileFrames()
@@ -83,9 +98,9 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
                 Color.black.aspectRatio(16 / 9, contentMode: .fit)
                     .onGeometryChange(for: CGRect.self) { $0.frame(in: .named("mobile-layout")) } action: { frames.preview = $0 }
             } panel: {
-                // Reserve more than the compact metadata + two action rows
-                // need, with a long On Deck shelf competing for space below.
-                Color.blue.frame(height: 240)
+                // Measure the real production metadata/buttons, with a long
+                // On Deck shelf competing for the remaining space below.
+                PlayerNextUpScreen(viewModel: model, onBack: {}).mobileNextUpPanel
                     .onGeometryChange(for: CGRect.self) { $0.frame(in: .named("mobile-layout")) } action: { frames.panel = $0 }
             } extras: {
                 Color.gray.frame(height: 1000)
@@ -95,6 +110,13 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
             defer { window.isHidden = true; window.rootViewController = nil }
             try await settle(window)
             print("Mobile layout \(size): preview=\(frames.preview), actions=\(frames.panel)")
+            let snapshot = UIGraphicsImageRenderer(bounds: window.bounds).image { _ in
+                window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
+            }
+            let attachment = XCTAttachment(image: snapshot)
+            attachment.name = "Next Up controls \(Int(size.width))x\(Int(size.height))"
+            attachment.lifetime = .keepAlways
+            add(attachment)
             XCTAssertGreaterThan(frames.panel.height, 0)
             XCTAssertGreaterThanOrEqual(frames.panel.minY, 0)
             XCTAssertLessThanOrEqual(frames.panel.maxY, size.height)
@@ -165,8 +187,9 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
         let engine = try AetherEngine()
         let presentation = Presentation()
         presentation.preview = true
-        let window = makeWindow(Harness(presentation: presentation, engine: engine, reduceMotion: false))
-        defer { window.isHidden = true; window.rootViewController = nil; engine.stop() }
+        let model = try nextUpFixture()
+        let window = makeWindow(Harness(presentation: presentation, engine: engine, reduceMotion: false, nextUpModel: model))
+        defer { window.isHidden = true; window.rootViewController = nil; engine.stop(); model.cleanup() }
         try await settle(window)
         let surface = try XCTUnwrap(surfaces(in: window).first)
         let url = try XCTUnwrap(Bundle(for: Self.self).url(forResource: "v3_h264_aac", withExtension: "mp4"))

--- a/iosApp/Tests/PlayerSurfaceLayoutTests.swift
+++ b/iosApp/Tests/PlayerSurfaceLayoutTests.swift
@@ -110,9 +110,12 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
             defer { window.isHidden = true; window.rootViewController = nil }
             try await settle(window)
             print("Mobile layout \(size): preview=\(frames.preview), actions=\(frames.panel)")
-            let snapshot = UIGraphicsImageRenderer(bounds: window.bounds).image { _ in
-                window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
-            }
+            // Render the requested viewport, not the host simulator's fixed
+            // window size (which would crop portrait/iPad proof images).
+            let renderer = ImageRenderer(content: layout
+                .frame(width: size.width, height: size.height)
+                .coordinateSpace(name: "mobile-layout").ignoresSafeArea())
+            let snapshot = try XCTUnwrap(renderer.uiImage)
             let attachment = XCTAttachment(image: snapshot)
             attachment.name = "Next Up controls \(Int(size.width))x\(Int(size.height))"
             attachment.lifetime = .keepAlways
@@ -208,6 +211,16 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
             try await Task.sleep(for: .milliseconds(50))
         }
         XCTAssertTrue(layer.isReadyForDisplay, "The synthetic video must actually have a picture before expansion")
+        func attachFrame(_ name: String) {
+            let snapshot = UIGraphicsImageRenderer(bounds: window.bounds).image { _ in
+                window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
+            }
+            let attachment = XCTAttachment(image: snapshot)
+            attachment.name = name
+            attachment.lifetime = .keepAlways
+            add(attachment)
+        }
+        attachFrame("Before expansion - playing synthetic preview")
         let position = player.currentTime().seconds
         var itemChanges = 0
         let observation = player.publisher(for: \.currentItem, options: [.new]).sink { _ in itemChanges += 1 }
@@ -222,6 +235,7 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
         XCTAssertTrue(layer.isReadyForDisplay)
         XCTAssertGreaterThanOrEqual(player.currentTime().seconds, position)
         XCTAssertEqual(itemChanges, 0)
+        attachFrame("After expansion - same synthetic video item")
 
         engine.pause()
         let pausedPosition = player.currentTime().seconds

--- a/iosApp/Tests/PlayerSurfaceLayoutTests.swift
+++ b/iosApp/Tests/PlayerSurfaceLayoutTests.swift
@@ -81,19 +81,20 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
             let frames = MobileFrames()
             let layout = PlayerNextUpMobileLayout {
                 Color.black.aspectRatio(16 / 9, contentMode: .fit)
-                    .onGeometryChange(for: CGRect.self) { $0.frame(in: .global) } action: { frames.preview = $0 }
+                    .onGeometryChange(for: CGRect.self) { $0.frame(in: .named("mobile-layout")) } action: { frames.preview = $0 }
             } panel: {
                 // Reserve more than the compact metadata + two action rows
                 // need, with a long On Deck shelf competing for space below.
                 Color.blue.frame(height: 240)
-                    .onGeometryChange(for: CGRect.self) { $0.frame(in: .global) } action: { frames.panel = $0 }
+                    .onGeometryChange(for: CGRect.self) { $0.frame(in: .named("mobile-layout")) } action: { frames.panel = $0 }
             } extras: {
                 Color.gray.frame(height: 1000)
             }
-            let window = makeWindow(layout, attachToScene: false)
-            window.frame = CGRect(origin: .zero, size: size)
+            let window = makeWindow(layout.frame(width: size.width, height: size.height)
+                .coordinateSpace(name: "mobile-layout").ignoresSafeArea())
             defer { window.isHidden = true; window.rootViewController = nil }
             try await settle(window)
+            print("Mobile layout \(size): preview=\(frames.preview), actions=\(frames.panel)")
             XCTAssertGreaterThan(frames.panel.height, 0)
             XCTAssertGreaterThanOrEqual(frames.panel.minY, 0)
             XCTAssertLessThanOrEqual(frames.panel.maxY, size.height)
@@ -169,7 +170,12 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
         try await settle(window)
         let surface = try XCTUnwrap(surfaces(in: window).first)
         let url = try XCTUnwrap(Bundle(for: Self.self).url(forResource: "v3_h264_aac", withExtension: "mp4"))
-        try await engine.load(url: url)
+        // Hosted CI simulators report no VideoToolbox hardware decoder and
+        // the normal probe chooses software. Use the native URL route to
+        // exercise AVPlayer/layer retention with the same local MP4 fixture.
+        var options = LoadOptions()
+        options.nativeRemoteHLS = true
+        try await engine.load(url: url, options: options)
         engine.play()
         let player = try XCTUnwrap(engine.currentAVPlayer)
         let item = try XCTUnwrap(player.currentItem)
@@ -214,7 +220,7 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
         presentation.hasPreviewBounds = false
         presentation.preview = true
         engine.prepareForItemReplacement()
-        try await engine.load(url: url)
+        try await engine.load(url: url, options: options)
         presentation.hasPreviewBounds = true
         engine.play()
         let successorDeadline = ContinuousClock.now + .seconds(15)

--- a/iosApp/Tests/PlayerSurfaceLayoutTests.swift
+++ b/iosApp/Tests/PlayerSurfaceLayoutTests.swift
@@ -45,7 +45,7 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
                     }
                 }
             }
-            .environment(\.accessibilityReduceMotion, reduceMotion)
+            .transaction { $0.disablesAnimations = reduceMotion }
         }
     }
 

--- a/iosApp/Tests/PlayerSurfaceLayoutTests.swift
+++ b/iosApp/Tests/PlayerSurfaceLayoutTests.swift
@@ -60,12 +60,51 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
         window.layoutIfNeeded()
     }
 
-    private func makeWindow(_ harness: Harness) -> UIWindow {
+    private func makeWindow<Content: View>(_ content: Content, attachToScene: Bool = true) -> UIWindow {
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 844, height: 390))
-        window.windowScene = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first
-        window.rootViewController = UIHostingController(rootView: harness)
+        if attachToScene {
+            window.windowScene = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first
+        }
+        window.rootViewController = UIHostingController(rootView: content)
         window.isHidden = false
         return window
+    }
+
+    private final class MobileFrames {
+        var preview = CGRect.zero
+        var panel = CGRect.zero
+    }
+
+    func testMobileActionsStayVisibleBesideOrBelowTheSmallerPreview() async throws {
+        for size in [CGSize(width: 568, height: 320), CGSize(width: 844, height: 390),
+                     CGSize(width: 390, height: 844), CGSize(width: 1024, height: 768)] {
+            let frames = MobileFrames()
+            let layout = PlayerNextUpMobileLayout {
+                Color.black.aspectRatio(16 / 9, contentMode: .fit)
+                    .onGeometryChange(for: CGRect.self) { $0.frame(in: .global) } action: { frames.preview = $0 }
+            } panel: {
+                // Reserve more than the compact metadata + two action rows
+                // need, with a long On Deck shelf competing for space below.
+                Color.blue.frame(height: 240)
+                    .onGeometryChange(for: CGRect.self) { $0.frame(in: .global) } action: { frames.panel = $0 }
+            } extras: {
+                Color.gray.frame(height: 1000)
+            }
+            let window = makeWindow(layout, attachToScene: false)
+            window.frame = CGRect(origin: .zero, size: size)
+            defer { window.isHidden = true; window.rootViewController = nil }
+            try await settle(window)
+            XCTAssertGreaterThan(frames.panel.height, 0)
+            XCTAssertGreaterThanOrEqual(frames.panel.minY, 0)
+            XCTAssertLessThanOrEqual(frames.panel.maxY, size.height)
+            XCTAssertLessThanOrEqual(frames.panel.maxX, size.width)
+            if size.width > size.height {
+                XCTAssertGreaterThan(frames.panel.minX, frames.preview.maxX)
+            } else {
+                XCTAssertGreaterThan(frames.panel.minY, frames.preview.maxY)
+                XCTAssertLessThanOrEqual(frames.preview.width, 260)
+            }
+        }
     }
 
     func testTwentyPreviewCyclesKeepOneActualAetherView() async throws {

--- a/iosApp/Tests/PlayerSurfaceLayoutTests.swift
+++ b/iosApp/Tests/PlayerSurfaceLayoutTests.swift
@@ -1,0 +1,168 @@
+import AetherEngine
+import AVFoundation
+import Combine
+import SwiftUI
+import XCTest
+@testable import Silo
+
+@MainActor
+final class PlayerSurfaceLayoutTests: XCTestCase {
+    @Observable private final class Presentation {
+        var preview = false
+        var hasPreviewBounds = true
+    }
+
+    private struct Harness: View {
+        let presentation: Presentation
+        let engine: AetherEngine
+        var legacy = false
+        var reduceMotion = true
+
+        var body: some View {
+            Group {
+                if legacy {
+                    // Negative control: the two structural branches used by
+                    // PlayerView before this fix really do recreate the host.
+                    if presentation.preview {
+                        VStack { AetherPlayerSurface(engine: engine).frame(width: 240, height: 135) }
+                    } else {
+                        AetherPlayerSurface(engine: engine)
+                    }
+                } else {
+                    PlayerSurfaceLayout(isPreview: presentation.preview) {
+                        AetherPlayerSurface(engine: engine)
+                    } content: {
+                        ZStack {
+                            Color.black.ignoresSafeArea()
+                            if presentation.preview && presentation.hasPreviewBounds {
+                                Color.clear
+                                    .frame(width: 240, height: 135)
+                                    .anchorPreference(key: PlayerPreviewBoundsKey.self, value: .bounds) {
+                                        .init(bounds: $0)
+                                    }
+                            }
+                        }
+                    }
+                }
+            }
+            .environment(\.accessibilityReduceMotion, reduceMotion)
+        }
+    }
+
+    private func surfaces(in view: UIView) -> [AetherPlayerView] {
+        (view as? AetherPlayerView).map { [$0] } ?? view.subviews.flatMap { surfaces(in: $0) }
+    }
+
+    private func settle(_ window: UIWindow) async throws {
+        window.setNeedsLayout()
+        window.layoutIfNeeded()
+        try await Task.sleep(for: .milliseconds(40))
+        window.layoutIfNeeded()
+    }
+
+    private func makeWindow(_ harness: Harness) -> UIWindow {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 844, height: 390))
+        window.windowScene = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first
+        window.rootViewController = UIHostingController(rootView: harness)
+        window.isHidden = false
+        return window
+    }
+
+    func testTwentyPreviewCyclesKeepOneActualAetherView() async throws {
+        let engine = try AetherEngine()
+        let presentation = Presentation()
+        let window = makeWindow(Harness(presentation: presentation, engine: engine))
+        defer { window.isHidden = true; window.rootViewController = nil; engine.stop() }
+        try await settle(window)
+        let original = try XCTUnwrap(surfaces(in: window).first)
+        for _ in 0..<20 {
+            presentation.preview = true
+            try await settle(window)
+            XCTAssertEqual(surfaces(in: window).count, 1)
+            XCTAssertTrue(surfaces(in: window).first === original)
+            XCTAssertEqual(original.bounds.width, 240, accuracy: 1)
+            XCTAssertEqual(original.bounds.height, 135, accuracy: 1)
+            presentation.preview = false
+            try await settle(window)
+            XCTAssertTrue(surfaces(in: window).first === original)
+            XCTAssertGreaterThan(original.bounds.width, 240)
+        }
+        print("Preview lifecycle: 40 transitions, 1 Aether view, 0 replacements")
+    }
+
+    func testEarlyExpansionAndMissingPreviewGeometryKeepTheSurface() async throws {
+        let engine = try AetherEngine()
+        let presentation = Presentation()
+        let window = makeWindow(Harness(presentation: presentation, engine: engine))
+        defer { window.isHidden = true; window.rootViewController = nil; engine.stop() }
+        try await settle(window)
+        let original = try XCTUnwrap(surfaces(in: window).first)
+        presentation.hasPreviewBounds = false
+        presentation.preview = true
+        try await settle(window)
+        XCTAssertTrue(surfaces(in: window).first === original)
+        presentation.preview = false
+        presentation.preview = true
+        presentation.preview = false
+        try await settle(window)
+        XCTAssertEqual(surfaces(in: window).count, 1)
+        XCTAssertTrue(surfaces(in: window).first === original)
+    }
+
+    func testLegacyNegativeControlRecreatesTheVideoView() async throws {
+        let engine = try AetherEngine()
+        let presentation = Presentation()
+        let window = makeWindow(Harness(presentation: presentation, engine: engine, legacy: true))
+        defer { window.isHidden = true; window.rootViewController = nil; engine.stop() }
+        try await settle(window)
+        let original = try XCTUnwrap(surfaces(in: window).first)
+        presentation.preview = true
+        try await settle(window)
+        XCTAssertFalse(surfaces(in: window).first === original)
+    }
+
+    func testPlayingPreviewExpandsWithoutReplacingItemOrLosingItsLayer() async throws {
+        let engine = try AetherEngine()
+        let presentation = Presentation()
+        presentation.preview = true
+        let window = makeWindow(Harness(presentation: presentation, engine: engine, reduceMotion: false))
+        defer { window.isHidden = true; window.rootViewController = nil; engine.stop() }
+        try await settle(window)
+        let surface = try XCTUnwrap(surfaces(in: window).first)
+        let url = try XCTUnwrap(Bundle(for: Self.self).url(forResource: "v3_h264_aac", withExtension: "mp4"))
+        try await engine.load(url: url)
+        engine.play()
+        let player = try XCTUnwrap(engine.currentAVPlayer)
+        let item = try XCTUnwrap(player.currentItem)
+        let layer = try XCTUnwrap(surface.layer.sublayers?.compactMap { $0 as? AVPlayerLayer }.first)
+        let deadline = ContinuousClock.now + .seconds(15)
+        while !layer.isReadyForDisplay && ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        XCTAssertTrue(layer.isReadyForDisplay, "The synthetic video must actually have a picture before expansion")
+        let position = player.currentTime().seconds
+        var itemChanges = 0
+        let observation = player.publisher(for: \.currentItem, options: [.new]).sink { _ in itemChanges += 1 }
+        defer { observation.cancel() }
+        presentation.preview = false
+        try await settle(window)
+        try await Task.sleep(for: .milliseconds(350))
+        XCTAssertTrue(surfaces(in: window).first === surface)
+        XCTAssertTrue(engine.currentAVPlayer === player)
+        XCTAssertTrue(player.currentItem === item)
+        XCTAssertTrue(layer.superlayer === surface.layer)
+        XCTAssertTrue(layer.isReadyForDisplay)
+        XCTAssertGreaterThanOrEqual(player.currentTime().seconds, position)
+        XCTAssertEqual(itemChanges, 0)
+
+        engine.pause()
+        let pausedPosition = player.currentTime().seconds
+        presentation.preview = true
+        try await settle(window)
+        presentation.preview = false
+        try await settle(window)
+        XCTAssertEqual(player.rate, 0, "Resizing must not resume a paused preview")
+        XCTAssertEqual(player.currentTime().seconds, pausedPosition, accuracy: 0.1)
+        XCTAssertEqual(itemChanges, 0)
+    }
+}

--- a/iosApp/Tests/PlayerSurfaceLayoutTests.swift
+++ b/iosApp/Tests/PlayerSurfaceLayoutTests.swift
@@ -164,5 +164,32 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
         XCTAssertEqual(player.rate, 0, "Resizing must not resume a paused preview")
         XCTAssertEqual(player.currentTime().seconds, pausedPosition, accuracy: 0.1)
         XCTAssertEqual(itemChanges, 0)
+
+        // Next pressed before a preview can lay out: one actual successor
+        // load, using the same player/view/layer, with its own first-frame latch.
+        var nilItems = 0
+        let nilObservation = player.publisher(for: \.currentItem, options: [.new]).sink {
+            if $0 == nil { nilItems += 1 }
+        }
+        defer { nilObservation.cancel() }
+        presentation.hasPreviewBounds = false
+        presentation.preview = true
+        engine.prepareForItemReplacement()
+        presentation.preview = false
+        try await engine.load(url: url)
+        engine.play()
+        let successorDeadline = ContinuousClock.now + .seconds(15)
+        while !engine.hasFirstFrameReadyForDisplay && ContinuousClock.now < successorDeadline {
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        XCTAssertTrue(engine.hasFirstFrameReadyForDisplay)
+        XCTAssertTrue(layer.isReadyForDisplay)
+        XCTAssertTrue(surfaces(in: window).first === surface)
+        XCTAssertTrue(engine.currentAVPlayer === player)
+        XCTAssertTrue(layer.superlayer === surface.layer)
+        XCTAssertFalse(player.currentItem === item)
+        XCTAssertEqual(itemChanges, 1)
+        XCTAssertEqual(nilItems, 0)
+        print("Synthetic next episode: 1 item swap, 0 nil items, same view/player/layer, successor first frame ready")
     }
 }

--- a/iosApp/Tests/PlayerSurfaceLayoutTests.swift
+++ b/iosApp/Tests/PlayerSurfaceLayoutTests.swift
@@ -214,8 +214,8 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
         presentation.hasPreviewBounds = false
         presentation.preview = true
         engine.prepareForItemReplacement()
-        presentation.preview = false
         try await engine.load(url: url)
+        presentation.hasPreviewBounds = true
         engine.play()
         let successorDeadline = ContinuousClock.now + .seconds(15)
         while !engine.hasFirstFrameReadyForDisplay && ContinuousClock.now < successorDeadline {
@@ -223,6 +223,8 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
         }
         XCTAssertTrue(engine.hasFirstFrameReadyForDisplay)
         XCTAssertTrue(layer.isReadyForDisplay)
+        presentation.preview = false
+        try await settle(window)
         XCTAssertTrue(surfaces(in: window).first === surface)
         XCTAssertTrue(engine.currentAVPlayer === player)
         XCTAssertTrue(layer.superlayer === surface.layer)

--- a/iosApp/Tests/UICustomizationPreferencesTests.swift
+++ b/iosApp/Tests/UICustomizationPreferencesTests.swift
@@ -409,8 +409,8 @@ final class UICustomizationPreferencesTests: XCTestCase {
         ])
         XCTAssertEqual(
             projectedMainTabDestinations(primaryMenu: menu).map(\.id),
-            [.app(.home)],
-            "authored categories with no matching profile library must not render dead roots"
+            [.app(.home), .app(.recommendations), .app(.calendar)],
+            "unavailable library categories must fall back to app roots without rendering dead library roots"
         )
 
         let mixed = Library(id: 4, name: "Mixed", type: "mixed", sortOrder: 0, posterUrl: nil)
@@ -512,7 +512,11 @@ final class UICustomizationPreferencesTests: XCTestCase {
             primaryMenu: menu,
             availableLibraries: staleSnapshot.availableLibraries(for: secondProfile)
         )
-        XCTAssertEqual(staleProjection.map(\.id), [.app(.home)])
+        XCTAssertEqual(
+            staleProjection.map(\.id),
+            [.app(.home), .app(.recommendations), .app(.calendar)],
+            "a previous profile's library must stay hidden while the app fallback remains available"
+        )
         XCTAssertEqual(
             resolvedVisibleMainTabDestination(
                 .library(library.id),
@@ -538,7 +542,11 @@ final class UICustomizationPreferencesTests: XCTestCase {
                 libraries: []
             ).availableLibraries(for: secondProfile)
         )
-        XCTAssertEqual(revokedProjection.map(\.id), [.app(.home)])
+        XCTAssertEqual(
+            revokedProjection.map(\.id),
+            [.app(.home), .app(.recommendations), .app(.calendar)],
+            "revoking library access must restore app roots without retaining the library pin"
+        )
         XCTAssertEqual(
             resolvedVisibleMainTabDestination(
                 .library(library.id),

--- a/iosApp/iosApp/Screens/Player/PlayerNextUpCompletionPolicy.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerNextUpCompletionPolicy.swift
@@ -1,5 +1,18 @@
 import Foundation
 
+/// A repeated Play Now/countdown action for the active (or loading) episode
+/// is an expansion, not permission to replace that episode again.
+enum PlayerNextUpPlaybackAction: Equatable {
+    case unavailable
+    case expand
+    case load(String)
+
+    static func resolve(candidateId: String?, currentId: String?) -> Self {
+        guard let candidateId else { return .unavailable }
+        return candidateId == currentId ? .expand : .load(candidateId)
+    }
+}
+
 enum PlayerNextUpCompletionPolicy {
     static func isInPromptWindow(
         currentTime: Double,

--- a/iosApp/iosApp/Screens/Player/PlayerNextUpCompletionPolicy.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerNextUpCompletionPolicy.swift
@@ -4,10 +4,12 @@ import Foundation
 /// is an expansion, not permission to replace that episode again.
 enum PlayerNextUpPlaybackAction: Equatable {
     case unavailable
+    case waitForPicture
     case expand
     case load(String)
 
-    static func resolve(candidateId: String?, currentId: String?) -> Self {
+    static func resolve(candidateId: String?, currentId: String?, awaitingPicture: Bool = false) -> Self {
+        if awaitingPicture { return .waitForPicture }
         guard let candidateId else { return .unavailable }
         return candidateId == currentId ? .expand : .load(candidateId)
     }

--- a/iosApp/iosApp/Screens/Player/PlayerSurfaceLayout.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerSurfaceLayout.swift
@@ -40,7 +40,7 @@ struct PlayerSurfaceLayout<Surface: View, Content: View>: View {
                             RoundedRectangle(cornerRadius: isPreview ? 8 : 0)
                                 .stroke(.white.opacity(isPreview ? 0.16 : 0), lineWidth: 1)
                         }
-                        .shadow(color: .black.opacity(isPreview ? 0.55 : 0), radius: 34, y: 18)
+                        .shadow(color: .black.opacity(isPreview ? 0.55 : 0), radius: isPreview ? 34 : 0, y: isPreview ? 18 : 0)
                         .position(x: frame.midX, y: frame.midY)
                         // Respect the original ScrollView's clipping even though
                         // the video itself is a persistent sibling of that view.

--- a/iosApp/iosApp/Screens/Player/PlayerSurfaceLayout.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerSurfaceLayout.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+/// Next Up supplies geometry, never another video view. Moving a shared
+/// AVPlayerLayer between two representables lets an outgoing view steal or
+/// detach the incoming view's picture during a SwiftUI transition.
+struct PlayerPreviewBoundsKey: PreferenceKey {
+    struct Value {
+        var bounds: Anchor<CGRect>?
+        var viewport: Anchor<CGRect>?
+    }
+
+    static var defaultValue: Value { Value() }
+
+    static func reduce(value: inout Value, nextValue: () -> Value) {
+        let next = nextValue()
+        value.bounds = next.bounds ?? value.bounds
+        value.viewport = next.viewport ?? value.viewport
+    }
+}
+
+struct PlayerSurfaceLayout<Surface: View, Content: View>: View {
+    let isPreview: Bool
+    @ViewBuilder let surface: () -> Surface
+    @ViewBuilder let content: () -> Content
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        content()
+            .overlayPreferenceValue(PlayerPreviewBoundsKey.self) { geometry in
+                GeometryReader { proxy in
+                    let fullFrame = CGRect(origin: .zero, size: proxy.size)
+                    let frame = isPreview ? geometry.bounds.map { proxy[$0] } ?? fullFrame : fullFrame
+                    let viewport = isPreview ? geometry.viewport.map { proxy[$0] } ?? fullFrame : fullFrame
+                    // One structural identity in both modes. Only geometry changes;
+                    // expansion must not load, seek, bind a second host, or resume.
+                    surface()
+                        .frame(width: frame.width, height: frame.height)
+                        .clipShape(RoundedRectangle(cornerRadius: isPreview ? 8 : 0))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: isPreview ? 8 : 0)
+                                .stroke(.white.opacity(isPreview ? 0.16 : 0), lineWidth: 1)
+                        }
+                        .shadow(color: .black.opacity(isPreview ? 0.55 : 0), radius: 34, y: 18)
+                        .position(x: frame.midX, y: frame.midY)
+                        // Respect the original ScrollView's clipping even though
+                        // the video itself is a persistent sibling of that view.
+                        .mask {
+                            Rectangle()
+                                .frame(width: viewport.width, height: viewport.height)
+                                .position(x: viewport.midX, y: viewport.midY)
+                        }
+                        .animation(reduceMotion ? nil : .easeInOut(duration: 0.3), value: isPreview)
+                }
+                .ignoresSafeArea()
+                .allowsHitTesting(false)
+                .accessibilityHidden(true)
+            }
+    }
+}

--- a/iosApp/iosApp/Screens/Player/PlayerSurfaceLayout.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerSurfaceLayout.swift
@@ -57,3 +57,46 @@ struct PlayerSurfaceLayout<Surface: View, Content: View>: View {
             }
     }
 }
+
+/// The preview and primary actions never live inside a scroll view on mobile.
+/// Only the optional On Deck shelf scrolls. Wide screens put actions on the
+/// right; narrow screens cap the preview so it cannot push Play Now below them.
+struct PlayerNextUpMobileLayout<Preview: View, Panel: View, Extras: View>: View {
+    @ViewBuilder let preview: () -> Preview
+    @ViewBuilder let panel: () -> Panel
+    @ViewBuilder let extras: () -> Extras
+
+    var body: some View {
+        GeometryReader { proxy in
+            let horizontalInset = max(20, max(proxy.safeAreaInsets.leading, proxy.safeAreaInsets.trailing) + 12)
+            let topInset = max(16, proxy.safeAreaInsets.top + 12)
+            let bottomInset = max(16, proxy.safeAreaInsets.bottom + 12)
+            let width = max(0, min(1100, proxy.size.width - horizontalInset * 2))
+            let height = max(0, proxy.size.height - topInset - bottomInset)
+            let sideBySide = (width >= 500 && width > height) || width >= 760
+            let previewWidth = sideBySide
+                ? min(480, width * 0.43, height * 0.7 * 16 / 9)
+                : min(260, width, height * 0.22 * 16 / 9)
+            let layout = sideBySide
+                ? AnyLayout(HStackLayout(alignment: .center, spacing: 24))
+                : AnyLayout(VStackLayout(alignment: .center, spacing: 14))
+
+            VStack(spacing: 16) {
+                layout {
+                    preview().frame(width: previewWidth)
+                    panel().frame(maxWidth: sideBySide ? 420 : .infinity)
+                        .layoutPriority(1)
+                }
+                .frame(maxWidth: .infinity)
+                .layoutPriority(1)
+
+                ScrollView(.vertical, showsIndicators: false) {
+                    extras()
+                }
+            }
+            .frame(width: width, height: height, alignment: .top)
+            .frame(maxWidth: .infinity)
+            .padding(.top, topInset)
+        }
+    }
+}

--- a/iosApp/iosApp/Screens/Player/PlayerSurfaceLayout.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerSurfaceLayout.swift
@@ -53,7 +53,7 @@ struct PlayerSurfaceLayout<Surface: View, Content: View>: View {
                 }
                 .ignoresSafeArea()
                 .allowsHitTesting(false)
-                .accessibilityHidden(true)
+                .accessibilityHidden(isPreview)
             }
     }
 }

--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -653,14 +653,21 @@ private struct PlayerNextUpScreen: View {
                     $0.viewport = $1
                 }
                 #else
-                screenContent(maxMainWidth: mainContentWidth(for: proxy))
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-                    .padding(.horizontal, horizontalPadding)
-                    .padding(.vertical, verticalPadding)
+                PlayerNextUpMobileLayout {
+                    miniPlayerPane
+                } panel: {
+                    mobileNextUpPanel
+                } extras: {
+                    if !viewModel.nextUpCarouselItems.isEmpty {
+                        onDeckSection
+                    }
+                }
                 #endif
             }
         }
+        #if os(tvOS)
         .ignoresSafeArea()
+        #endif
         .animation(.easeInOut(duration: 0.2), value: viewModel.nextUpCountdownSeconds)
         .animation(.easeInOut(duration: 0.2), value: viewModel.nextUpEpisode)
         .animation(.easeInOut(duration: 0.2), value: viewModel.nextUpCarouselItems)
@@ -716,20 +723,38 @@ private struct PlayerNextUpScreen: View {
                 .frame(maxWidth: 650, alignment: .leading)
         }
         #else
-        ScrollView(.vertical, showsIndicators: false) {
-            VStack(spacing: sectionSpacing) {
-                miniPlayerPane
-                    .frame(maxWidth: 620)
-                nextUpPanel
-                    .frame(maxWidth: 620)
-            }
-            .frame(maxWidth: .infinity)
-        }
-        .transformAnchorPreference(key: PlayerPreviewBoundsKey.self, value: .bounds) {
-            $0.viewport = $1
-        }
+        EmptyView()
         #endif
     }
+
+    #if !os(tvOS)
+    private var mobileNextUpPanel: some View {
+        VStack(spacing: 10) {
+            eyebrow
+            if let episode = viewModel.nextUpEpisode {
+                metadata(for: episode, compact: true)
+            } else if viewModel.isLoadingNextUpEpisode {
+                Text("Finding the next episode")
+                    .font(.callout)
+                    .foregroundStyle(.white)
+            } else {
+                Text(viewModel.nextUpScreenVideoEnded ? "End of playback" : "Almost finished")
+                    .font(.headline)
+                    .foregroundStyle(.white)
+            }
+            actionRow(hasNextEpisode: viewModel.nextUpEpisode != nil)
+            if viewModel.nextUpEpisode != nil {
+                autoPlayToggle
+            } else if !viewModel.isLoadingNextUpEpisode {
+                Text(finishedMessage)
+                    .font(.caption)
+                    .foregroundStyle(.white.opacity(0.62))
+                    .lineLimit(2)
+            }
+        }
+        .multilineTextAlignment(.center)
+    }
+    #endif
 
     private var miniPlayerPane: some View {
         Color.clear
@@ -796,7 +821,7 @@ private struct PlayerNextUpScreen: View {
         }
     }
 
-    private func metadata(for episode: PlayerNextUpEpisode) -> some View {
+    private func metadata(for episode: PlayerNextUpEpisode, compact: Bool = false) -> some View {
         VStack(alignment: isTV ? .leading : .center, spacing: isTV ? 12 : 7) {
             if let seriesTitle = episode.seriesTitle, !seriesTitle.isEmpty {
                 Text(seriesTitle)
@@ -812,17 +837,17 @@ private struct PlayerNextUpScreen: View {
                     .foregroundStyle(.white)
             }
             .font(.system(size: subtitleSize, weight: .semibold))
-            .lineLimit(2)
+            .lineLimit(compact ? 1 : 2)
             .multilineTextAlignment(isTV ? .leading : .center)
 
             let metadataLine = episodeMetadataLine(for: episode)
-            if !metadataLine.isEmpty {
+            if !compact && !metadataLine.isEmpty {
                 Text(metadataLine)
                     .font(.system(size: captionSize, weight: .medium))
                     .foregroundStyle(.white.opacity(0.46))
             }
 
-            if let overview = episode.overview, !overview.isEmpty {
+            if !compact, let overview = episode.overview, !overview.isEmpty {
                 Text(overview)
                     .font(.system(size: bodySize))
                     .lineLimit(isTV ? 3 : 2)
@@ -903,33 +928,38 @@ private struct PlayerNextUpScreen: View {
         }
         #else
         VStack(spacing: 10) {
-            if hasNextEpisode {
-                Button(action: { viewModel.playNextEpisodeNow() }) {
-                    Label("Play Now", systemImage: "play.fill")
+            HStack(spacing: 12) {
+                if hasNextEpisode {
+                    Button(action: { viewModel.playNextEpisodeNow() }) {
+                        Label("Play Now", systemImage: "play.fill")
+                            .frame(maxWidth: .infinity, minHeight: 44)
+                    }
+                    .siloPrimaryButton()
+                    .accessibilityIdentifier("next-up-play-now")
                 }
-                .siloPrimaryButton()
-                .frame(maxWidth: .infinity)
+                if let seconds = viewModel.nextUpCountdownSeconds {
+                    CountdownRing(seconds: seconds, totalSeconds: viewModel.nextUpCountdownTotalSeconds)
+                }
             }
 
-            if !viewModel.nextUpScreenVideoEnded {
-                Button(action: { viewModel.keepWatchingCurrentEpisode() }) {
-                    Label("Keep Watching", systemImage: "rectangle.inset.filled")
+            HStack(spacing: 10) {
+                if !viewModel.nextUpScreenVideoEnded {
+                    Button(action: { viewModel.keepWatchingCurrentEpisode() }) {
+                        Text("Keep Watching")
+                            .frame(maxWidth: .infinity, minHeight: 44)
+                    }
+                    .siloSecondaryButton()
+                }
+                Button(action: onBack) {
+                    Label("Back", systemImage: "chevron.left")
+                        .frame(minHeight: 44)
                 }
                 .siloSecondaryButton()
-                .frame(maxWidth: .infinity)
-            }
-
-            Button(action: onBack) {
-                Label("Back", systemImage: "chevron.left")
-            }
-            .siloSecondaryButton()
-            .frame(maxWidth: .infinity)
-
-            if let seconds = viewModel.nextUpCountdownSeconds {
-                CountdownRing(seconds: seconds, totalSeconds: viewModel.nextUpCountdownTotalSeconds)
             }
         }
-        .frame(maxWidth: 280)
+        .font(.callout)
+        .lineLimit(1)
+        .frame(maxWidth: 380)
         #endif
     }
 

--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -86,6 +86,7 @@ struct PlayerView: View {
         PlayerSurfaceLayout(isPreview: viewModel.showNextUpScreen) {
             playerSurface()
                 .opacity(viewModel.error == nil ? 1 : 0)
+                .accessibilityHidden(viewModel.error != nil)
         } content: {
             ZStack {
                 Color.black.ignoresSafeArea()

--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -878,6 +878,7 @@ private struct PlayerNextUpScreen: View {
                         .frame(width: 220)
                     }
                     .buttonStyle(TVPillButtonStyle(kind: .primary))
+                    .disabled(viewModel.isNextUpTransitioning)
                     .focused($focusedTarget, equals: .playNow)
                     .prefersDefaultFocus(true, in: defaultFocusNamespace)
                 }
@@ -901,6 +902,7 @@ private struct PlayerNextUpScreen: View {
                         .frame(width: 250)
                     }
                     .buttonStyle(TVPillButtonStyle(kind: .secondary))
+                    .disabled(viewModel.isNextUpTransitioning)
                     .focused($focusedTarget, equals: .keepWatching)
                     .prefersDefaultFocus(!hasNextEpisode, in: defaultFocusNamespace)
                 }
@@ -934,7 +936,7 @@ private struct PlayerNextUpScreen: View {
                         Label("Play Now", systemImage: "play.fill")
                             .frame(maxWidth: .infinity, minHeight: 44)
                     }
-                    .siloPrimaryButton()
+                    .siloPrimaryButton(isLoading: viewModel.isNextUpTransitioning)
                     .accessibilityIdentifier("next-up-play-now")
                 }
                 if let seconds = viewModel.nextUpCountdownSeconds {
@@ -949,6 +951,7 @@ private struct PlayerNextUpScreen: View {
                             .frame(maxWidth: .infinity, minHeight: 44)
                     }
                     .siloSecondaryButton()
+                    .disabled(viewModel.isNextUpTransitioning)
                 }
                 Button(action: onBack) {
                     Label("Back", systemImage: "chevron.left")

--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -83,185 +83,191 @@ struct PlayerView: View {
     }
 
     var body: some View {
-        ZStack(alignment: .top) {
-            Color.black.ignoresSafeArea()
-
-            if let error = viewModel.error {
-                errorView(error)
-            } else {
-                if viewModel.showNextUpScreen {
+        PlayerSurfaceLayout(isPreview: viewModel.showNextUpScreen) {
+            playerSurface()
+                .opacity(viewModel.error == nil ? 1 : 0)
+        } content: {
+            ZStack {
+                Color.black.ignoresSafeArea()
+                if viewModel.showNextUpScreen && viewModel.error == nil {
                     PlayerNextUpScreen(
                         viewModel: viewModel,
                         onBack: {
                             if !viewModel.keepWatchingCurrentEpisode() {
                                 dismissPlayer()
                             }
-                        },
-                        miniPlayer: { playerSurface(ignoresSafeArea: false) }
+                        }
                     )
-                    .transition(.opacity)
+                }
+            }
+        }
+        .overlay(alignment: .top) {
+            ZStack(alignment: .top) {
+                if let error = viewModel.error {
+                    errorView(error)
                 } else {
-                    playerSurface()
+                    if !viewModel.showNextUpScreen {
 
-                    #if os(tvOS)
-                    // Focus sink with UIKit-backed press capture. Mounted
-                    // whenever the transport overlay is hidden OR a seek
-                    // session is active — in both cases it's the sole target
-                    // for the Siri Remote.
-                    //
-                    // Two modes:
-                    //   • Not in seek mode: Tap Left/Right = quick skip,
-                    //     Tap Down = open the player menu, Tap Up = reveal the
-                    //     full transport HUD, Tap Select = pause and
-                    //     enter the focused timeline,
-                    //     Hold Left/Right = enter seek mode.
-                    //   • In seek mode: Tap Left/Right = adjust rate along
-                    //     the signed ladder, Tap Select = commit + exit,
-                    //     Menu = cancel + exit (handled in onExitCommand).
-                    //     Taps against Up/Down are ignored; holds are no-ops.
-                    // Never while the HUD is presented: the sink and the HUD's
-                    // focus graph would be two owners for the same presses
-                    // (docs/tvos-focus.md), and the sink's Down handler
-                    // force-switches the HUD tab underneath the user.
-                    if !viewModel.isLoading && !viewModel.isHUDPresented &&
-                        (!(viewModel.showIntroSkip || viewModel.showCreditsSkip) || viewModel.isHoldSeeking) &&
-                        (!viewModel.showControls || viewModel.isHoldSeeking) {
-                        TVPressCaptureView(
-                            onArrowTap: { direction in
-                                if viewModel.isHoldSeeking {
+                        #if os(tvOS)
+                        // Focus sink with UIKit-backed press capture. Mounted
+                        // whenever the transport overlay is hidden OR a seek
+                        // session is active — in both cases it's the sole target
+                        // for the Siri Remote.
+                        //
+                        // Two modes:
+                        //   • Not in seek mode: Tap Left/Right = quick skip,
+                        //     Tap Down = open the player menu, Tap Up = reveal the
+                        //     full transport HUD, Tap Select = pause and
+                        //     enter the focused timeline,
+                        //     Hold Left/Right = enter seek mode.
+                        //   • In seek mode: Tap Left/Right = adjust rate along
+                        //     the signed ladder, Tap Select = commit + exit,
+                        //     Menu = cancel + exit (handled in onExitCommand).
+                        //     Taps against Up/Down are ignored; holds are no-ops.
+                        // Never while the HUD is presented: the sink and the HUD's
+                        // focus graph would be two owners for the same presses
+                        // (docs/tvos-focus.md), and the sink's Down handler
+                        // force-switches the HUD tab underneath the user.
+                        if !viewModel.isLoading && !viewModel.isHUDPresented &&
+                            (!(viewModel.showIntroSkip || viewModel.showCreditsSkip) || viewModel.isHoldSeeking) &&
+                            (!viewModel.showControls || viewModel.isHoldSeeking) {
+                            TVPressCaptureView(
+                                onArrowTap: { direction in
+                                    if viewModel.isHoldSeeking {
+                                        switch direction {
+                                        case .left:  viewModel.adjustHoldSeekRate(delta: -1)
+                                        case .right: viewModel.adjustHoldSeekRate(delta: +1)
+                                        case .up, .down: break
+                                        }
+                                    } else {
+                                        switch direction {
+                                        case .left:  viewModel.skipBackward()
+                                        case .right: viewModel.skipForward()
+                                        case .down:  viewModel.openSettingsHUD()
+                                        case .up:    viewModel.revealControls()
+                                        }
+                                    }
+                                },
+                                onArrowHoldBegin: { direction in
+                                    // Only Left / Right enter seek mode. Hold on
+                                    // Up / Down is ignored so it can't be
+                                    // accidentally triggered while skipping.
                                     switch direction {
-                                    case .left:  viewModel.adjustHoldSeekRate(delta: -1)
-                                    case .right: viewModel.adjustHoldSeekRate(delta: +1)
+                                    case .left:  viewModel.beginHoldSeek(forward: false)
+                                    case .right: viewModel.beginHoldSeek(forward: true)
                                     case .up, .down: break
                                     }
-                                } else {
-                                    switch direction {
-                                    case .left:  viewModel.skipBackward()
-                                    case .right: viewModel.skipForward()
-                                    case .down:  viewModel.openSettingsHUD()
-                                    case .up:    viewModel.revealControls()
+                                },
+                                onDirectionalPressBegan: {
+                                    timelinePreviewContactCanToggle = false
+                                },
+                                onTouchSurfaceContactBegan: {
+                                    handleTimelinePreviewContactBegan()
+                                },
+                                onTouchSurfaceContactEnded: {
+                                    handleTimelinePreviewContactEnded()
+                                },
+                                onTouchSurfaceContactCancelled: {
+                                    handleTimelinePreviewContactCancelled()
+                                },
+                                onSelect: {
+                                    if viewModel.isHoldSeeking {
+                                        viewModel.commitHoldSeek()
+                                    } else if viewModel.isPlaying {
+                                        timelinePreviewContactCanToggle = false
+                                        hideTimelinePreview(immediately: true)
+                                        viewModel.pauseForTimelineSelection()
+                                        timelineSelectionRequest = UUID()
+                                    } else {
+                                        viewModel.revealControls()
                                     }
                                 }
-                            },
-                            onArrowHoldBegin: { direction in
-                                // Only Left / Right enter seek mode. Hold on
-                                // Up / Down is ignored so it can't be
-                                // accidentally triggered while skipping.
-                                switch direction {
-                                case .left:  viewModel.beginHoldSeek(forward: false)
-                                case .right: viewModel.beginHoldSeek(forward: true)
-                                case .up, .down: break
-                                }
-                            },
-                            onDirectionalPressBegan: {
-                                timelinePreviewContactCanToggle = false
-                            },
-                            onTouchSurfaceContactBegan: {
-                                handleTimelinePreviewContactBegan()
-                            },
-                            onTouchSurfaceContactEnded: {
-                                handleTimelinePreviewContactEnded()
-                            },
-                            onTouchSurfaceContactCancelled: {
-                                handleTimelinePreviewContactCancelled()
-                            },
-                            onSelect: {
-                                if viewModel.isHoldSeeking {
-                                    viewModel.commitHoldSeek()
-                                } else if viewModel.isPlaying {
-                                    timelinePreviewContactCanToggle = false
-                                    hideTimelinePreview(immediately: true)
-                                    viewModel.pauseForTimelineSelection()
-                                    timelineSelectionRequest = UUID()
-                                } else {
-                                    viewModel.revealControls()
-                                }
-                            }
-                        )
-                        .ignoresSafeArea()
-                    }
+                            )
+                            .ignoresSafeArea()
+                        }
 
-                    // `isLoading` also covers Protocol V3 replans (track or
-                    // quality changes made *from inside the HUD*). Unmounting
-                    // here for those would destroy the HUD's @State/@FocusState
-                    // mid-press and reseed focus on a reset tab, so the HUD
-                    // keeps its host mounted through a replan. A replacement
-                    // load closes the HUD in `resetPublishedLoadState`, so
-                    // cold starts and item changes still unmount as before.
-                    if (!viewModel.isLoading || viewModel.isHUDPresented) && !viewModel.isHoldSeeking {
-                        TVPlayerControls(
-                            viewModel: viewModel,
-                            showsTimelinePreview: isTimelinePreviewVisible,
-                            timeDisplayMode: timelineTimeDisplayMode,
-                            timelineSelectionRequest: timelineSelectionRequest,
-                            onToggleTimeDisplayMode: {
-                                withAnimation(.easeOut(duration: ContinuumTheme.fastDuration)) {
-                                    timelineTimeDisplayMode.toggle()
-                                }
-                            },
-                            onDismiss: { dismissPlayer() }
-                        )
-                    }
+                        // `isLoading` also covers Protocol V3 replans (track or
+                        // quality changes made *from inside the HUD*). Unmounting
+                        // here for those would destroy the HUD's @State/@FocusState
+                        // mid-press and reseed focus on a reset tab, so the HUD
+                        // keeps its host mounted through a replan. A replacement
+                        // load closes the HUD in `resetPublishedLoadState`, so
+                        // cold starts and item changes still unmount as before.
+                        if (!viewModel.isLoading || viewModel.isHUDPresented) && !viewModel.isHoldSeeking {
+                            TVPlayerControls(
+                                viewModel: viewModel,
+                                showsTimelinePreview: isTimelinePreviewVisible,
+                                timeDisplayMode: timelineTimeDisplayMode,
+                                timelineSelectionRequest: timelineSelectionRequest,
+                                onToggleTimeDisplayMode: {
+                                    withAnimation(.easeOut(duration: ContinuumTheme.fastDuration)) {
+                                        timelineTimeDisplayMode.toggle()
+                                    }
+                                },
+                                onDismiss: { dismissPlayer() }
+                            )
+                        }
 
-                    // Speed-indicator chip shown only while a seek session is
-                    // active. The overlay/scrubber is suppressed during the
-                    // session (so the capture view keeps focus), so this chip
-                    // is the sole source of visual feedback until Select
-                    // commits or Menu cancels.
-                    if viewModel.isHoldSeeking {
-                        HoldSeekIndicator(
-                            rate: viewModel.holdSeekRate,
-                            previewTime: viewModel.scrubPreviewTime,
-                            duration: viewModel.duration,
-                            previewImage: viewModel.scrubPreviewImage
-                        )
-                        .transition(.opacity)
-                        .allowsHitTesting(false)
-                    }
-                    #else
-                    // The full controls overlay (and its close button) only
-                    // mounts once the decoder opens the file, so a standalone
-                    // close control has to cover the load/buffer phase —
-                    // otherwise the only way out of a stalled start is
-                    // force-quitting the app. tvOS gets this via Menu in
-                    // `onExitCommand`; macOS keeps its controls (and Escape)
-                    // during loading.
-                    if viewModel.isLoading {
-                        loadingCloseButton
-                    }
-
-                    if !viewModel.isLoading {
-                        // Invisible gestures (tap-to-toggle, double-tap skip,
-                        // hold-2×, edge swipes, pinch) live in a dedicated
-                        // layer under the button overlay.
-                        MobilePlayerGestureLayer(
-                            viewModel: viewModel,
-                            onDismiss: { dismissPlayer() }
-                        )
-                        MobilePlayerControls(
-                            viewModel: viewModel,
-                            orientationCoordinator: orientationCoordinator,
-                            onDismiss: { dismissPlayer() }
-                        )
-                    }
-                    #endif
-
-                    #if os(tvOS)
-                    if let identity = remoteIdentityNotice {
-                        RemotePlaybackIdentityNotice(identity: identity)
+                        // Speed-indicator chip shown only while a seek session is
+                        // active. The overlay/scrubber is suppressed during the
+                        // session (so the capture view keeps focus), so this chip
+                        // is the sole source of visual feedback until Select
+                        // commits or Menu cancels.
+                        if viewModel.isHoldSeeking {
+                            HoldSeekIndicator(
+                                rate: viewModel.holdSeekRate,
+                                previewTime: viewModel.scrubPreviewTime,
+                                duration: viewModel.duration,
+                                previewImage: viewModel.scrubPreviewImage
+                            )
                             .transition(.opacity)
-                    } else if let notice = viewModel.activeNotice {
-                        PlayerNoticeOverlay(notice: notice)
-                    }
-                    #else
-                    if let notice = viewModel.activeNotice {
-                        PlayerNoticeOverlay(notice: notice)
-                    }
-                    #endif
-                }
+                            .allowsHitTesting(false)
+                        }
+                        #else
+                        // The full controls overlay (and its close button) only
+                        // mounts once the decoder opens the file, so a standalone
+                        // close control has to cover the load/buffer phase —
+                        // otherwise the only way out of a stalled start is
+                        // force-quitting the app. tvOS gets this via Menu in
+                        // `onExitCommand`; macOS keeps its controls (and Escape)
+                        // during loading.
+                        if viewModel.isLoading {
+                            loadingCloseButton
+                        }
 
-                if viewModel.isLoading || viewModel.isBuffering {
-                    PlayerBufferingCapsule()
+                        if !viewModel.isLoading {
+                            // Invisible gestures (tap-to-toggle, double-tap skip,
+                            // hold-2×, edge swipes, pinch) live in a dedicated
+                            // layer under the button overlay.
+                            MobilePlayerGestureLayer(
+                                viewModel: viewModel,
+                                onDismiss: { dismissPlayer() }
+                            )
+                            MobilePlayerControls(
+                                viewModel: viewModel,
+                                orientationCoordinator: orientationCoordinator,
+                                onDismiss: { dismissPlayer() }
+                            )
+                        }
+                        #endif
+
+                        #if os(tvOS)
+                        if let identity = remoteIdentityNotice {
+                            RemotePlaybackIdentityNotice(identity: identity)
+                                .transition(.opacity)
+                        } else if let notice = viewModel.activeNotice {
+                            PlayerNoticeOverlay(notice: notice)
+                        }
+                        #else
+                        if let notice = viewModel.activeNotice {
+                            PlayerNoticeOverlay(notice: notice)
+                        }
+                        #endif
+                    }
+
+                    if viewModel.isLoading || viewModel.isBuffering {
+                        PlayerBufferingCapsule()
+                    }
                 }
             }
         }
@@ -535,9 +541,8 @@ struct PlayerView: View {
     /// `MobilePlayerGestureLayer`, mounted above this surface.
     ///
     /// Aether owns native/software route selection behind this one surface.
-    @ViewBuilder
-    private func playerSurface(ignoresSafeArea: Bool = true) -> some View {
-        let surface = AetherPlayerSurface(engine: viewModel.aetherEngine)
+    private func playerSurface() -> some View {
+        AetherPlayerSurface(engine: viewModel.aetherEngine)
             .background(Color.black)
             .overlay {
                 AetherSubtitleOverlay(
@@ -553,11 +558,6 @@ struct PlayerView: View {
                     subtitleSyncMs: viewModel.settings.subtitleSyncMs
                 )
             }
-        if ignoresSafeArea {
-            surface.ignoresSafeArea()
-        } else {
-            surface
-        }
     }
 
     #if !os(tvOS)
@@ -622,10 +622,9 @@ private enum PlayerNextUpFocusTarget: Hashable {
     case autoPlay
 }
 
-private struct PlayerNextUpScreen<MiniPlayer: View>: View {
+private struct PlayerNextUpScreen: View {
     let viewModel: PlayerViewModel
     let onBack: () -> Void
-    @ViewBuilder let miniPlayer: () -> MiniPlayer
     @FocusState private var focusedTarget: PlayerNextUpFocusTarget?
     @State private var onDeckFocusRequest = 0
     @State private var didRequestInitialActionFocus = false
@@ -650,6 +649,9 @@ private struct PlayerNextUpScreen<MiniPlayer: View>: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .defaultScrollAnchor(.top)
                 .scrollClipDisabled()
+                .transformAnchorPreference(key: PlayerPreviewBoundsKey.self, value: .bounds) {
+                    $0.viewport = $1
+                }
                 #else
                 screenContent(maxMainWidth: mainContentWidth(for: proxy))
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
@@ -723,20 +725,16 @@ private struct PlayerNextUpScreen<MiniPlayer: View>: View {
             }
             .frame(maxWidth: .infinity)
         }
+        .transformAnchorPreference(key: PlayerPreviewBoundsKey.self, value: .bounds) {
+            $0.viewport = $1
+        }
         #endif
     }
 
     private var miniPlayerPane: some View {
-        ZStack {
-            miniPlayer()
-        }
+        Color.clear
         .aspectRatio(16 / 9, contentMode: .fit)
-        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .stroke(.white.opacity(0.16), lineWidth: 1)
-        )
-        .shadow(color: .black.opacity(0.55), radius: 34, y: 18)
+        .anchorPreference(key: PlayerPreviewBoundsKey.self, value: .bounds) { .init(bounds: $0) }
         .allowsHitTesting(false)
         .accessibilityHidden(true)
     }

--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -623,7 +623,7 @@ private enum PlayerNextUpFocusTarget: Hashable {
     case autoPlay
 }
 
-private struct PlayerNextUpScreen: View {
+struct PlayerNextUpScreen: View {
     let viewModel: PlayerViewModel
     let onBack: () -> Void
     @FocusState private var focusedTarget: PlayerNextUpFocusTarget?
@@ -729,7 +729,7 @@ private struct PlayerNextUpScreen: View {
     }
 
     #if !os(tvOS)
-    private var mobileNextUpPanel: some View {
+    var mobileNextUpPanel: some View {
         VStack(spacing: 10) {
             eyebrow
             if let episode = viewModel.nextUpEpisode {

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -2333,7 +2333,11 @@ class PlayerViewModel {
     }
 
     private func updateNextUpPresentation(for movieTime: Double) {
-        guard !hasReachedEndOfFile else { return }
+        // A retained native host must not reopen the outgoing episode's
+        // postroll before the successor has presented its own first frame.
+        guard !hasReachedEndOfFile,
+              let epoch = activeAetherLoadEpoch,
+              startedAetherLoadEpoch == epoch else { return }
         if showNextUpScreen {
             updateNextUpCountdownForActivePlayback(at: movieTime)
             return
@@ -2511,9 +2515,27 @@ class PlayerViewModel {
     }
 
     func playNextEpisodeNow() {
-        guard let nextUpEpisode else { return }
+        let contentId: String
+        switch PlayerNextUpPlaybackAction.resolve(
+            candidateId: nextUpEpisode?.contentId,
+            currentId: lastLoadRequest?.contentId
+        ) {
+        case .unavailable:
+            return
+        case .expand:
+            // Presentation only: no prepare, load, seek, or play command.
+            // Preserve a preview that is already playing, paused or buffering.
+            cancelNextUpCountdown()
+            nextUpAutoplayCancelled = true
+            nextUpPromptDismissed = true
+            nextUpScreenVideoEnded = false
+            showNextUpScreen = false
+            return
+        case .load(let id):
+            contentId = id
+        }
         var request = LoadRequest(
-            contentId: nextUpEpisode.contentId,
+            contentId: contentId,
             preferredFileId: nil,
             preferredAudioTrackIndex: nil,
             preferredSubtitleTrackIndex: nil,

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -320,6 +320,9 @@ class PlayerViewModel {
     var bufferedAheadSeconds: Double = 0
     var playbackStats: PlaybackStats = .empty
     var showNextUpScreen = false
+    /// A Next Up load keeps its preview until the successor's own startup
+    /// milestone. Repeated actions cannot reload it or expand an unready frame.
+    private(set) var isNextUpTransitioning = false
     var nextUpEpisode: PlayerNextUpEpisode?
     var nextUpOnDeckItems: [PlayerOnDeckItem] = []
     var isLoadingNextUpEpisode = false
@@ -1357,6 +1360,16 @@ class PlayerViewModel {
         guard startedAetherLoadEpoch != epoch else { return }
         startedAetherLoadEpoch = epoch
         handleFileLoaded()
+        if isNextUpTransitioning {
+            isNextUpTransitioning = false
+            showNextUpScreen = false
+            nextUpEpisode = nil
+            nextUpOnDeckItems = []
+            if let detail = currentWatchDetail {
+                loadNextUpCandidate(for: detail)
+                loadNextUpOnDeckItems(for: detail)
+            }
+        }
         if activePreparedProtocolV3 != nil {
             pendingProtocolV3FirstFrameEpoch = epoch
             completeProtocolV3FirstFrameIfCommitted(epoch)
@@ -2395,6 +2408,7 @@ class PlayerViewModel {
     private func startNextUpCountdownIfNeeded() {
         cancelNextUpCountdown()
         guard showNextUpScreen,
+              !isNextUpTransitioning,
               settings.autoPlayNextEpisode,
               nextUpEpisode != nil,
               !nextUpAutoplayCancelled else {
@@ -2424,6 +2438,7 @@ class PlayerViewModel {
 
     private func updateNextUpCountdownForActivePlayback(at movieTime: Double) {
         guard showNextUpScreen,
+              !isNextUpTransitioning,
               !nextUpScreenVideoEnded,
               settings.autoPlayNextEpisode,
               nextUpEpisode != nil,
@@ -2475,7 +2490,7 @@ class PlayerViewModel {
         // An autoplay load failure may restore the postroll after disposing
         // the old playback pipeline. There is no current episode to resume in
         // that state, so let the shell fall back to closing the player.
-        guard hasActiveAetherSession else { return false }
+        guard hasActiveAetherSession, !isNextUpTransitioning else { return false }
 
         let shouldResumeAfterEnd = nextUpScreenVideoEnded || hasReachedEndOfFile
         nextUpAutoplayCancelled = true
@@ -2518,9 +2533,10 @@ class PlayerViewModel {
         let contentId: String
         switch PlayerNextUpPlaybackAction.resolve(
             candidateId: nextUpEpisode?.contentId,
-            currentId: lastLoadRequest?.contentId
+            currentId: lastLoadRequest?.contentId,
+            awaitingPicture: isNextUpTransitioning
         ) {
-        case .unavailable:
+        case .unavailable, .waitForPicture:
             return
         case .expand:
             // Presentation only: no prepare, load, seek, or play command.
@@ -3513,9 +3529,11 @@ class PlayerViewModel {
         // it, both because its content is stale and because the tvOS controls
         // host stays mounted through `isLoading` whenever this flag is up.
         isHUDPresented = false
-        showNextUpScreen = false
-        nextUpEpisode = nil
-        nextUpOnDeckItems = []
+        showNextUpScreen = isNextUpTransitioning
+        if !isNextUpTransitioning {
+            nextUpEpisode = nil
+            nextUpOnDeckItems = []
+        }
         isLoadingNextUpEpisode = false
         isLoadingNextUpOnDeck = false
         nextUpLookupError = nil
@@ -3680,6 +3698,7 @@ class PlayerViewModel {
         #if os(tvOS)
         PosterImageCache.trimDecodedMemory()
         #endif
+        isNextUpTransitioning = origin == .autoplay && showNextUpScreen
         let currentItemCompleted = PlayerNextUpCompletionPolicy.shouldFinalizeAsCompleted(
             isNextUpPresented: showNextUpScreen,
             hasReachedEndOfFile: hasReachedEndOfFile,
@@ -3870,8 +3889,13 @@ class PlayerViewModel {
                 // server to resolve a next episode against.
                 if request.offlineDownloadId == nil {
                     self.pushNowPlayingArtwork(contentId: prepared.watchDetail.contentId)
-                    self.loadNextUpCandidate(for: prepared.watchDetail)
-                    self.loadNextUpOnDeckItems(for: prepared.watchDetail)
+                    // The panel still describes the successor being loaded.
+                    // Fetch its following episode only once it has a picture,
+                    // otherwise the visible Play Now target can jump again.
+                    if !self.isNextUpTransitioning {
+                        self.loadNextUpCandidate(for: prepared.watchDetail)
+                        self.loadNextUpOnDeckItems(for: prepared.watchDetail)
+                    }
                 }
                 self.qualityOptions = ApplePlaybackQuality.playbackOptions(
                     serverQualities: prepared.protocolV3?.plan.availableQualities ?? [],
@@ -4067,6 +4091,7 @@ class PlayerViewModel {
     /// `error` overlay.
     @MainActor
     private func handleBeginFreshLoadFailure(error: Error, origin: LoadOrigin) {
+        isNextUpTransitioning = false
         let message: String = {
             if case BeginFreshLoadError.startSessionTimeout = error {
                 return "The server didn't respond in time."

--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -57,7 +57,7 @@ packages:
   # reviewed revision; Package.resolved also freezes its binary dependencies.
   AetherEngine:
     url: https://github.com/blurbery/AetherEngine
-    revision: e238d1d2da52b58bffd7f8135bb2b04e32915cee
+    revision: 53ec6c9771a8df326abb23c7d98692b95b18b2c1
   Nuke:
     url: https://github.com/kean/Nuke
     from: "12.8.0"

--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -57,7 +57,7 @@ packages:
   # reviewed revision; Package.resolved also freezes its binary dependencies.
   AetherEngine:
     url: https://github.com/blurbery/AetherEngine
-    revision: 53ec6c9771a8df326abb23c7d98692b95b18b2c1
+    revision: 653be639441d3f7d06332a2f995950497ad62e0f
   Nuke:
     url: https://github.com/kean/Nuke
     from: "12.8.0"


### PR DESCRIPTION
## Problem

The next episode could start with audio but no picture after Next Up. Backing out and opening the episode again restored the picture. I could reproduce this when the countdown completed and when pressing Play Now. On iOS, a playing preview could turn black as it expanded.

This follows #221. Keeping the native player alive was part of the fix, but the SwiftUI video surface could still be destroyed and recreated between the preview and full-screen branches. Retained native state could also replay the previous episode's end-of-file event into the successor load.

## What I changed

- Keep one `AetherPlayerSurface` in the view hierarchy. Next Up changes its bounds, position and clipping instead of creating another video view. Expansion uses the existing picture and playback position, with a 0.3-second animation that respects Reduce Motion.
- If the requested episode is already playing, Play Now only expands the surface. It does not reload, seek or restart the engine.
- If the successor has not started, request one load and keep the Next Up presentation until that load reports its own first frame. Repeated actions while loading do not start more loads. Audio-only playback uses the playing milestone instead.
- Retire the previous load epoch before starting the next one. Ignore stale progress and completion events, and delay fetching the following candidate until the successor has a picture.
- Make the iOS Next Up preview smaller. Put the primary controls beside it in landscape/wide layouts and below it in portrait. Only the optional On Deck section scrolls; reaching Play Now should not require scrolling the whole screen.
- Preserve the existing tvOS focus structure and clip its retained preview to the scroll viewport. Keep error overlays, paused playback and the surface's full-screen accessibility exposure intact.

No server, database, authentication, deployment or unrelated navigation changes are included.

### Engine dependency

The AetherEngine pin moves from `e238d1d2da52b58bffd7f8135bb2b04e32915cee` to [`653be639441d3f7d06332a2f995950497ad62e0f`](https://github.com/blurbery/AetherEngine/commit/653be639441d3f7d06332a2f995950497ad62e0f). This stays on the existing 6.34.0-based patch line; it is not an unrelated engine version upgrade.

The handover patch retires the old observers and published EOF/time/readiness state without detaching the retained item and layer. Async native callbacks are fenced by their session. The native URL/HLS bypass now consumes the same pending in-place handover flag as the other native path. Normal stop still tears down playback; same-content recovery keeps its existing contract.

## Verification and measured regressions

I tested the installed iOS simulator app against a real server. Both paths now worked in manual testing:

- Countdown completed: the next episode showed a picture.
- Play Now pressed before the countdown completed: the next episode showed a picture and the transition worked smoothly.

These are simulator observations, not physical iPhone or Apple TV certification. Private server addresses, account information, media details and live-session captures are deliberately excluded from this PR.

### Before/after lifecycle measurements

These are event counts and identity assertions, not FPS or device-latency benchmarks.

| Check | Before / negative control | With the fix |
| --- | --- | --- |
| Preview/full-screen video host | Legacy two-branch harness replaces the actual Aether view | 40 transitions, 1 actual Aether view, 0 replacements |
| Expanding an already-playing native preview | Structural replacement reproduced separately | Same view, AVPlayer, AVPlayerItem and layer; 0 item changes; playback clock does not rewind |
| Native URL successor handover | 2 current-item changes, including 1 nil item | 1 item change, 0 nil items |
| Retained EOF state | Previous EOF replays into a new subscription | No stale EOF replay |
| Queued previous-item EOF callback | Old callback escapes the handover boundary | Callback is ignored |
| Repeated Next Up actions | Duplicate-load risk | 100 resolver calls produce 1 load decision |
| Paused preview resize | Covered by the new native fixture test | Stays paused, no item change or position reset |

The decoded-video test uses the existing bundled H.264/AAC fixture. It waits for an actual ready-for-display layer before expansion, then verifies the successor's first-frame latch and retained view/player/layer. The CI simulator's native URL route is selected explicitly so this test exercises AVPlayer rather than silently falling back to software decoding.

The mobile layout test measures the real production action panel at 568×320, 844×390, 390×844 and 1024×768 logical points, with a long optional shelf competing for space. All four keep the action panel within the requested viewport. Portrait preview width is capped at 260 points. This does not claim coverage of every Dynamic Type size or localization.

### CI results

Latest CI follow-up: [validation at `bfb9058`](https://github.com/Silo-Server/silo-apple/actions/runs/33715397674) passed. The complete iOS suite executed 1,174 tests with 1 existing skip and 0 failures, including both corrected navigation tests. Apple TV and macOS builds passed. The separate synthetic playback-recording test passed and the video was uploaded. CodeRabbit is green and its baseline-failure thread is resolved. The earlier results below are retained for comparison.

| Run | Result |
| --- | --- |
| [AetherEngine validation](https://github.com/blurbery/AetherEngine/actions/runs/33710488685) | 1,961 tests in 282 suites passed; iOS, tvOS, visionOS and macOS builds and transport probe passed |
| Engine negative controls in the same run | Each of the 3 new engine tests failed independently against the old `e238d1d…` production implementation and passed with the patch |
| [Silo application validation at `1a24cb4`](https://github.com/blurbery/silo-apple/actions/runs/33711266780) | iOS compiled; all 5 surface tests and the new completion-policy tests passed; tvOS and macOS builds passed |
| Silo complete iOS suite | 1,174 tests executed, 1 skipped, 3 existing assertion failures in 2 navigation tests; not a green full suite |
| [Unchanged upstream comparison](https://github.com/blurbery/silo-apple/actions/runs/33711266983) | Checked out exact upstream `8948ca88d8d765fbf15c147773d8af2d28b8f0ed`: 1,165 tests, 1 skipped, the same 3 assertion failures |
| [Evidence-capture run at `1577bc7`](https://github.com/blurbery/silo-apple/actions/runs/33712365506) | iOS compiled; all 5 surface tests passed; full suite again reported 1,174 tests, 1 skip and the same 3 baseline assertion failures; tvOS/macOS builds passed. I cancelled the run after the separate motion-recording step stalled; this is not a green workflow |

The earlier failures were three stale assertions in `UICustomizationPreferencesTests`: two in `testMainTabLibrarySnapshotRejectsPreviousProfileWithOverlappingId` and one in `testMainTabProjectionOnlyShowsCategoriesBackedByCurrentLibraries`. The application intentionally falls back to Home/Recommendations/Calendar when no library roots remain; `testMainTabProjectionFailsClosedAndFiltersUnavailableLibraries` already verifies that behavior. Commit `f9af6cc` aligns the stale expectations while preserving the checks that reject another profile's library, remove revoked pins, and return invalid selections to Home. Production navigation is unchanged. No tests are skipped or quarantined to bypass these failures; the complete suite still fails the workflow on any test failure.

The first follow-up run then failed before compilation because its hosted runner had no usable iPhone simulator destination. Commit `bfb9058` prepares a simulator matching the selected Xcode SDK and reuses its explicit ID for the build, tests, and recording. Missing runtimes are downloaded only when needed. Setup and recording each have a ten-minute limit. All of this validation runs on GitHub-hosted machines.

For reproducibility, the completed engine suite reported 63.273 seconds and the Silo suite at `1577bc7` reported 55.008 seconds of test execution (72.518 seconds elapsed). These are runner test timings, not app startup or transition performance claims.

## Evidence and remaining checks

- [Completed synthetic test results and logs](https://github.com/blurbery/silo-apple/actions/runs/33711266780/artifacts/9877278766) include the native lifecycle assertions and mobile geometry results.
- [Before/after screenshots, full-viewport layout images, test results and logs at `1577bc7`](https://github.com/blurbery/silo-apple/actions/runs/33712365506/artifacts/9877713041) are uploaded. I inspected the decoded test-pattern screenshots: the preview shows frame 4 at 0.167 seconds; the expanded surface shows frame 24 at 1.000 seconds. The accompanying test asserts the same view, player, item and layer across expansion. The images and identity assertions support continuity; still images alone do not prove the animation is smooth.
- The synthetic motion recording now completes successfully. The [latest iOS evidence artifact](https://github.com/Silo-Server/silo-apple/actions/runs/33715397674/artifacts/9878560188) contains `preview-transition.mp4`, the full-suite result bundle, and the separate passing playback-recording test result. Earlier failed capture attempts remain documented above as historical results.
- Evidence is uploaded through GitHub Actions, not committed as PR-only media assets. Validation artifacts have 7-day retention; the explicitly approved public-source simulator bundle has 3-day retention. Reviewers can rerun the workflow after expiry.
- Physical Apple TV/iPhone verification remains needed, especially HDR/Dolby Vision, HDMI refresh changes, PiP and AirPlay. The automated tests and native builds reduce regression risk but cannot prove every device/codec combination.

The playback app code has been saved and the two reported manual transition paths are confirmed working.

## AI disclosure

I orchestrated OpenAI Codex desktop using `gpt-5.6-sol` with `ultra` reasoning for the investigation, implementation, regression tests and this write-up. I directed the work and manually tested the countdown and Play Now paths in the simulator.

The CI follow-up was AI-assisted in Codex desktop using GitHub CLI, Git, `swiftc`, Ruby, Bash, and `jq`. This task did not expose its exact model identifier. Adversarial review compared the corrected expectations with the existing fallback tests and confirmed that stale/revoked library rejection and the full-suite failure gate remain intact; workflow YAML, shell syntax, and runtime-selection edge cases were checked locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added responsive Next Up layouts for mobile, tvOS, and wider screens.
  - Keeps the video player visible and persistent while previewing, expanding, or transitioning to the next episode.
  - Added clearer Next Up actions, countdown controls, loading states, and accessibility support.

- **Bug Fixes**
  - Prevented the post-roll preview from disappearing while the next episode loads.
  - Improved autoplay and “Play Now” behavior when content is still preparing.
  - Reduced unnecessary player resets during episode changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->