### PR TITLE
fix(ios): playback controls, Next Up, detail navigation and Home

### DIFF
--- a/.github/workflows/player-regression.yml
+++ b/.github/workflows/player-regression.yml
@@ -57,6 +57,7 @@ jobs:
           set -o pipefail
           xcodebuild "$ACTION" -project iosApp/Silo.xcodeproj -scheme "$SCHEME" \
             -destination "$DESTINATION" -derivedDataPath /tmp/silo-derived \
+            -parallel-testing-enabled NO \
             -resultBundlePath /tmp/player-validation.xcresult \
             CODE_SIGNING_ALLOWED=NO | tee /tmp/player-validation.log
       - name: Record synthetic preview expansion and successor playback
@@ -72,6 +73,7 @@ jobs:
           xcodebuild test-without-building -project iosApp/Silo.xcodeproj -scheme Silo \
             -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
             -derivedDataPath /tmp/silo-derived \
+            -parallel-testing-enabled NO \
             -only-testing:SiloTests/PlayerSurfaceLayoutTests/testPlayingPreviewExpandsWithoutReplacingItemOrLosingItsLayer \
             -resultBundlePath /tmp/preview-recording.xcresult CODE_SIGNING_ALLOWED=NO
       - name: Upload validation evidence

--- a/.github/workflows/player-regression.yml
+++ b/.github/workflows/player-regression.yml
@@ -87,3 +87,13 @@ jobs:
             /tmp/preview-transition.mp4
             /tmp/preview-recording.xcresult
           retention-days: 7
+      - name: Package simulator tests for focused visual verification
+        if: matrix.action == 'test' && !cancelled()
+        run: ditto -c -k --keepParent /tmp/silo-derived/Build/Products /tmp/Silo-simulator-tests.zip
+      - name: Upload compiled simulator tests
+        if: matrix.action == 'test' && !cancelled()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Silo-simulator-tests
+          path: /tmp/Silo-simulator-tests.zip
+          retention-days: 3

--- a/.github/workflows/player-regression.yml
+++ b/.github/workflows/player-regression.yml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         include: >-
-          ${{ fromJSON((inputs.ios_only || github.head_ref == 'fix/detail-dismiss-navigation') &&
+          ${{ fromJSON(inputs.ios_only &&
             '[{"scheme":"Silo","destination":"platform=iOS Simulator,name=iPhone 17 Pro","action":"test"}]' ||
             '[{"scheme":"Silo","destination":"platform=iOS Simulator,name=iPhone 17 Pro","action":"test"},
               {"scheme":"SiloTV","destination":"generic/platform=tvOS Simulator","action":"build"},

--- a/.github/workflows/player-regression.yml
+++ b/.github/workflows/player-regression.yml
@@ -11,12 +11,17 @@ on:
   push:
     branches: [fix/next-up-persistent-surface]
   workflow_dispatch:
+    inputs:
+      baseline_ref:
+        description: Optional unchanged upstream commit for a comparative full-suite run
+        type: string
+        required: false
 
 permissions:
   contents: read
 
 concurrency:
-  group: player-regression-${{ github.ref }}
+  group: player-regression-${{ github.ref }}-${{ inputs.baseline_ref || 'head' }}
   cancel-in-progress: true
 
 jobs:
@@ -40,6 +45,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+          ref: ${{ inputs.baseline_ref || github.sha }}
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '26.3'
@@ -48,7 +54,8 @@ jobs:
           curl -fsSL -o /tmp/xcodegen.zip https://github.com/yonaskolb/XcodeGen/releases/download/2.43.0/xcodegen.zip
           unzip -q /tmp/xcodegen.zip -d /tmp/xcodegen-dist
           /tmp/xcodegen-dist/xcodegen/bin/xcodegen generate --spec iosApp/project.yml
-      - name: Validate player
+      - name: Build player
+        id: build
         env:
           SCHEME: ${{ matrix.scheme }}
           DESTINATION: ${{ matrix.destination }}
@@ -60,16 +67,36 @@ jobs:
             # required by Keychain. No certificate or release secret is used.
             xcodebuild build-for-testing -project iosApp/Silo.xcodeproj -scheme "$SCHEME" \
               -destination "$DESTINATION" -derivedDataPath /tmp/silo-derived \
-              CODE_SIGNING_ALLOWED=YES CODE_SIGN_IDENTITY=-
-            ACTION=test-without-building
+              CODE_SIGNING_ALLOWED=YES CODE_SIGN_IDENTITY=- | tee /tmp/player-build.log
+          else
+            xcodebuild build -project iosApp/Silo.xcodeproj -scheme "$SCHEME" \
+              -destination "$DESTINATION" -derivedDataPath /tmp/silo-derived \
+              -resultBundlePath /tmp/player-validation.xcresult \
+              CODE_SIGNING_ALLOWED=NO | tee /tmp/player-validation.log
           fi
-          xcodebuild "$ACTION" -project iosApp/Silo.xcodeproj -scheme "$SCHEME" \
-            -destination "$DESTINATION" -derivedDataPath /tmp/silo-derived \
+      - name: Package simulator tests for focused visual verification
+        if: matrix.action == 'test' && !inputs.baseline_ref
+        run: ditto -c -k --keepParent /tmp/silo-derived/Build/Products /tmp/Silo-simulator-tests.zip
+      - name: Upload compiled simulator tests
+        if: matrix.action == 'test' && !inputs.baseline_ref
+        uses: actions/upload-artifact@v4
+        with:
+          name: Silo-simulator-tests
+          path: /tmp/Silo-simulator-tests.zip
+          retention-days: 3
+      - name: Run complete iOS suite
+        if: matrix.action == 'test'
+        timeout-minutes: 12
+        run: |
+          set -o pipefail
+          xcodebuild test-without-building -project iosApp/Silo.xcodeproj -scheme Silo \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath /tmp/silo-derived \
             -parallel-testing-enabled NO \
+            -test-timeouts-enabled YES -maximum-test-execution-time-allowance 60 \
             -resultBundlePath /tmp/player-validation.xcresult \
-            CODE_SIGNING_ALLOWED=NO | tee /tmp/player-validation.log
+            CODE_SIGNING_ALLOWED=YES CODE_SIGN_IDENTITY=- | tee /tmp/player-validation.log
       - name: Record synthetic preview expansion and successor playback
-        if: matrix.action == 'test' && !cancelled()
+        if: matrix.action == 'test' && !inputs.baseline_ref && steps.build.outcome == 'success' && !cancelled()
         shell: bash
         run: |
           set -euo pipefail
@@ -83,25 +110,16 @@ jobs:
             -derivedDataPath /tmp/silo-derived \
             -parallel-testing-enabled NO \
             -only-testing:SiloTests/PlayerSurfaceLayoutTests/testPlayingPreviewExpandsWithoutReplacingItemOrLosingItsLayer \
-            -resultBundlePath /tmp/preview-recording.xcresult CODE_SIGNING_ALLOWED=NO
+            -resultBundlePath /tmp/preview-recording.xcresult CODE_SIGNING_ALLOWED=YES CODE_SIGN_IDENTITY=-
       - name: Upload validation evidence
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: player-validation-${{ matrix.scheme }}
           path: |
+            /tmp/player-build.log
             /tmp/player-validation.log
             /tmp/player-validation.xcresult
             /tmp/preview-transition.mp4
             /tmp/preview-recording.xcresult
           retention-days: 7
-      - name: Package simulator tests for focused visual verification
-        if: matrix.action == 'test' && !cancelled()
-        run: ditto -c -k --keepParent /tmp/silo-derived/Build/Products /tmp/Silo-simulator-tests.zip
-      - name: Upload compiled simulator tests
-        if: matrix.action == 'test' && !cancelled()
-        uses: actions/upload-artifact@v4
-        with:
-          name: Silo-simulator-tests
-          path: /tmp/Silo-simulator-tests.zip
-          retention-days: 3

--- a/.github/workflows/player-regression.yml
+++ b/.github/workflows/player-regression.yml
@@ -102,15 +102,29 @@ jobs:
           set -euo pipefail
           # Reuse the compiled test bundle. This records only the bounded
           # synthetic-video test, not a second build or the full test suite.
-          xcrun simctl io booted recordVideo /tmp/preview-transition.mp4 &
+          # XCTest can shut down the simulator after the full suite. Boot the
+          # exact recording destination before starting the recorder.
+          simulator_id=$(xcrun simctl list devices available --json | jq -er \
+            '[.devices[][] | select(.name == "iPhone 17 Pro")][0].udid')
+          simulator_state=$(xcrun simctl list devices available --json | jq -r \
+            --arg id "$simulator_id" '.devices[][] | select(.udid == $id) | .state')
+          if [ "$simulator_state" != Booted ]; then
+            xcrun simctl boot "$simulator_id"
+          fi
+          xcrun simctl bootstatus "$simulator_id" -b
+          xcrun simctl io "$simulator_id" recordVideo /tmp/preview-transition.mp4 &
           recorder_pid=$!
           trap 'kill -INT "$recorder_pid" 2>/dev/null || true; wait "$recorder_pid" || true' EXIT
           xcodebuild test-without-building -project iosApp/Silo.xcodeproj -scheme Silo \
-            -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+            -destination "platform=iOS Simulator,id=$simulator_id" \
             -derivedDataPath /tmp/silo-derived \
             -parallel-testing-enabled NO \
             -only-testing:SiloTests/PlayerSurfaceLayoutTests/testPlayingPreviewExpandsWithoutReplacingItemOrLosingItsLayer \
             -resultBundlePath /tmp/preview-recording.xcresult CODE_SIGNING_ALLOWED=YES CODE_SIGN_IDENTITY=-
+          kill -INT "$recorder_pid"
+          wait "$recorder_pid"
+          trap - EXIT
+          test -s /tmp/preview-transition.mp4
       - name: Upload validation evidence
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/player-regression.yml
+++ b/.github/workflows/player-regression.yml
@@ -49,6 +49,35 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '26.3'
+      - name: Prepare iOS simulator
+        if: matrix.action == 'test'
+        timeout-minutes: 10
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Hosted images do not always have a usable pre-created device.
+          # Match the selected Xcode SDK and reuse one explicit destination.
+          runtime_version=$(xcrun --sdk iphonesimulator --show-sdk-version)
+          find_runtime() {
+            xcrun simctl list runtimes --json | jq -r --arg version "$runtime_version" \
+              '[.runtimes[] | select(.isAvailable and .version == $version and
+                (.identifier | startswith("com.apple.CoreSimulator.SimRuntime.iOS-")))][0].identifier // empty'
+          }
+          runtime_id=$(find_runtime)
+          if [ -z "$runtime_id" ]; then
+            xcodebuild -downloadPlatform iOS -buildVersion "$runtime_version"
+            runtime_id=$(find_runtime)
+          fi
+          if [ -z "$runtime_id" ]; then
+            echo "::error::No available iOS $runtime_version simulator runtime"
+            exit 1
+          fi
+          simulator_id=$(xcrun simctl create Silo-Player-Regression \
+            com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro "$runtime_id")
+          echo "SILO_SIMULATOR_ID=$simulator_id" >> "$GITHUB_ENV"
+          echo "SILO_TEST_DESTINATION=platform=iOS Simulator,id=$simulator_id" >> "$GITHUB_ENV"
+          xcrun simctl boot "$simulator_id"
+          xcrun simctl bootstatus "$simulator_id" -b
       - name: Generate Xcode project
         run: |
           curl -fsSL -o /tmp/xcodegen.zip https://github.com/yonaskolb/XcodeGen/releases/download/2.43.0/xcodegen.zip
@@ -66,7 +95,7 @@ jobs:
             # Simulator-only ad-hoc signing supplies the application identifier
             # required by Keychain. No certificate or release secret is used.
             xcodebuild build-for-testing -project iosApp/Silo.xcodeproj -scheme "$SCHEME" \
-              -destination "$DESTINATION" -derivedDataPath /tmp/silo-derived \
+              -destination "$SILO_TEST_DESTINATION" -derivedDataPath /tmp/silo-derived \
               CODE_SIGNING_ALLOWED=YES CODE_SIGN_IDENTITY=- | tee /tmp/player-build.log
           else
             xcodebuild build -project iosApp/Silo.xcodeproj -scheme "$SCHEME" \
@@ -90,13 +119,14 @@ jobs:
         run: |
           set -o pipefail
           xcodebuild test-without-building -project iosApp/Silo.xcodeproj -scheme Silo \
-            -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath /tmp/silo-derived \
+            -destination "$SILO_TEST_DESTINATION" -derivedDataPath /tmp/silo-derived \
             -parallel-testing-enabled NO \
             -test-timeouts-enabled YES -maximum-test-execution-time-allowance 60 \
             -resultBundlePath /tmp/player-validation.xcresult \
             CODE_SIGNING_ALLOWED=YES CODE_SIGN_IDENTITY=- | tee /tmp/player-validation.log
       - name: Record synthetic preview expansion and successor playback
         if: matrix.action == 'test' && !inputs.baseline_ref && steps.build.outcome == 'success' && !cancelled()
+        timeout-minutes: 10
         shell: bash
         run: |
           set -euo pipefail
@@ -104,8 +134,7 @@ jobs:
           # synthetic-video test, not a second build or the full test suite.
           # XCTest can shut down the simulator after the full suite. Boot the
           # exact recording destination before starting the recorder.
-          simulator_id=$(xcrun simctl list devices available --json | jq -er \
-            '[.devices[][] | select(.name == "iPhone 17 Pro")][0].udid')
+          simulator_id="$SILO_SIMULATOR_ID"
           simulator_state=$(xcrun simctl list devices available --json | jq -r \
             --arg id "$simulator_id" '.devices[][] | select(.udid == $id) | .state')
           if [ "$simulator_state" != Booted ]; then

--- a/.github/workflows/player-regression.yml
+++ b/.github/workflows/player-regression.yml
@@ -59,6 +59,21 @@ jobs:
             -destination "$DESTINATION" -derivedDataPath /tmp/silo-derived \
             -resultBundlePath /tmp/player-validation.xcresult \
             CODE_SIGNING_ALLOWED=NO | tee /tmp/player-validation.log
+      - name: Record synthetic preview expansion and successor playback
+        if: matrix.action == 'test'
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Reuse the compiled test bundle. This records only the bounded
+          # synthetic-video test, not a second build or the full test suite.
+          xcrun simctl io booted recordVideo /tmp/preview-transition.mp4 &
+          recorder_pid=$!
+          trap 'kill -INT "$recorder_pid" 2>/dev/null || true; wait "$recorder_pid" || true' EXIT
+          xcodebuild test-without-building -project iosApp/Silo.xcodeproj -scheme Silo \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+            -derivedDataPath /tmp/silo-derived \
+            -only-testing:SiloTests/PlayerSurfaceLayoutTests/testPlayingPreviewExpandsWithoutReplacingItemOrLosingItsLayer \
+            -resultBundlePath /tmp/preview-recording.xcresult CODE_SIGNING_ALLOWED=NO
       - name: Upload validation evidence
         if: always()
         uses: actions/upload-artifact@v4
@@ -67,4 +82,6 @@ jobs:
           path: |
             /tmp/player-validation.log
             /tmp/player-validation.xcresult
+            /tmp/preview-transition.mp4
+            /tmp/preview-recording.xcresult
           retention-days: 7

--- a/.github/workflows/player-regression.yml
+++ b/.github/workflows/player-regression.yml
@@ -1,0 +1,70 @@
+name: Player regression
+
+on:
+  pull_request:
+    paths:
+      - 'iosApp/iosApp/Screens/Player/**'
+      - 'iosApp/Tests/**'
+      - 'iosApp/project.yml'
+      - 'iosApp/**/Package.resolved'
+      - '.github/workflows/player-regression.yml'
+  push:
+    branches: [fix/next-up-persistent-surface]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: player-regression-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: macos-15
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - scheme: Silo
+            destination: 'platform=iOS Simulator,name=iPhone 17 Pro'
+            action: test
+          - scheme: SiloTV
+            destination: 'generic/platform=tvOS Simulator'
+            action: build
+          - scheme: SiloMac
+            destination: 'generic/platform=macOS'
+            action: build
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.3'
+      - name: Generate Xcode project
+        run: |
+          curl -fsSL -o /tmp/xcodegen.zip https://github.com/yonaskolb/XcodeGen/releases/download/2.43.0/xcodegen.zip
+          unzip -q /tmp/xcodegen.zip -d /tmp/xcodegen-dist
+          /tmp/xcodegen-dist/xcodegen/bin/xcodegen generate --spec iosApp/project.yml
+      - name: Validate player
+        env:
+          SCHEME: ${{ matrix.scheme }}
+          DESTINATION: ${{ matrix.destination }}
+          ACTION: ${{ matrix.action }}
+        run: |
+          set -o pipefail
+          xcodebuild "$ACTION" -project iosApp/Silo.xcodeproj -scheme "$SCHEME" \
+            -destination "$DESTINATION" -derivedDataPath /tmp/silo-derived \
+            -resultBundlePath /tmp/player-validation.xcresult \
+            CODE_SIGNING_ALLOWED=NO | tee /tmp/player-validation.log
+      - name: Upload validation evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: player-validation-${{ matrix.scheme }}
+          path: |
+            /tmp/player-validation.log
+            /tmp/player-validation.xcresult
+          retention-days: 7

--- a/.github/workflows/player-regression.yml
+++ b/.github/workflows/player-regression.yml
@@ -20,6 +20,10 @@ on:
         description: Also record a synthetic playback clip after a manually requested build
         type: boolean
         default: false
+      ios_only:
+        description: Build and validate only the iOS simulator app for an iOS-only change
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -35,16 +39,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - scheme: Silo
-            destination: 'platform=iOS Simulator,name=iPhone 17 Pro'
-            action: test
-          - scheme: SiloTV
-            destination: 'generic/platform=tvOS Simulator'
-            action: build
-          - scheme: SiloMac
-            destination: 'generic/platform=macOS'
-            action: build
+        include: >-
+          ${{ fromJSON(inputs.ios_only &&
+            '[{"scheme":"Silo","destination":"platform=iOS Simulator,name=iPhone 17 Pro","action":"test"}]' ||
+            '[{"scheme":"Silo","destination":"platform=iOS Simulator,name=iPhone 17 Pro","action":"test"},
+              {"scheme":"SiloTV","destination":"generic/platform=tvOS Simulator","action":"build"},
+              {"scheme":"SiloMac","destination":"generic/platform=macOS","action":"build"}]') }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/player-regression.yml
+++ b/.github/workflows/player-regression.yml
@@ -16,6 +16,10 @@ on:
         description: Optional unchanged upstream commit for a comparative full-suite run
         type: string
         required: false
+      record_preview:
+        description: Also record a synthetic playback clip after a manually requested build
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -96,7 +100,8 @@ jobs:
             -resultBundlePath /tmp/player-validation.xcresult \
             CODE_SIGNING_ALLOWED=YES CODE_SIGN_IDENTITY=- | tee /tmp/player-validation.log
       - name: Record synthetic preview expansion and successor playback
-        if: matrix.action == 'test' && !inputs.baseline_ref && steps.build.outcome == 'success' && !cancelled()
+        if: matrix.action == 'test' && !inputs.baseline_ref && steps.build.outcome == 'success' && !cancelled() && (github.event_name != 'workflow_dispatch' || inputs.record_preview)
+        timeout-minutes: 4
         shell: bash
         run: |
           set -euo pipefail
@@ -119,6 +124,8 @@ jobs:
             -destination "platform=iOS Simulator,id=$simulator_id" \
             -derivedDataPath /tmp/silo-derived \
             -parallel-testing-enabled NO \
+            -destination-timeout 60 \
+            -test-timeouts-enabled YES -maximum-test-execution-time-allowance 60 \
             -only-testing:SiloTests/PlayerSurfaceLayoutTests/testPlayingPreviewExpandsWithoutReplacingItemOrLosingItsLayer \
             -resultBundlePath /tmp/preview-recording.xcresult CODE_SIGNING_ALLOWED=YES CODE_SIGN_IDENTITY=-
           kill -INT "$recorder_pid"

--- a/.github/workflows/player-regression.yml
+++ b/.github/workflows/player-regression.yml
@@ -55,13 +55,21 @@ jobs:
           ACTION: ${{ matrix.action }}
         run: |
           set -o pipefail
+          if [ "$ACTION" = test ]; then
+            # Simulator-only ad-hoc signing supplies the application identifier
+            # required by Keychain. No certificate or release secret is used.
+            xcodebuild build-for-testing -project iosApp/Silo.xcodeproj -scheme "$SCHEME" \
+              -destination "$DESTINATION" -derivedDataPath /tmp/silo-derived \
+              CODE_SIGNING_ALLOWED=YES CODE_SIGN_IDENTITY=-
+            ACTION=test-without-building
+          fi
           xcodebuild "$ACTION" -project iosApp/Silo.xcodeproj -scheme "$SCHEME" \
             -destination "$DESTINATION" -derivedDataPath /tmp/silo-derived \
             -parallel-testing-enabled NO \
             -resultBundlePath /tmp/player-validation.xcresult \
             CODE_SIGNING_ALLOWED=NO | tee /tmp/player-validation.log
       - name: Record synthetic preview expansion and successor playback
-        if: matrix.action == 'test'
+        if: matrix.action == 'test' && !cancelled()
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/player-regression.yml
+++ b/.github/workflows/player-regression.yml
@@ -84,7 +84,10 @@ jobs:
           xcrun simctl bootstatus "$simulator_id" -b
       - name: Generate Xcode project
         run: |
+          set -euo pipefail
           curl -fsSL -o /tmp/xcodegen.zip https://github.com/yonaskolb/XcodeGen/releases/download/2.43.0/xcodegen.zip
+          # Pin the official 2.43.0 release asset before unpacking/executing it.
+          echo "a4847ed77d3341a4d24049bc4424a3babca4c94ff1dcaaee923eaca2b32c678f  /tmp/xcodegen.zip" | shasum -a 256 -c -
           unzip -q /tmp/xcodegen.zip -d /tmp/xcodegen-dist
           /tmp/xcodegen-dist/xcodegen/bin/xcodegen generate --spec iosApp/project.yml
       - name: Build player

--- a/iosApp/Resources/OpenSourceLicenses/README.txt
+++ b/iosApp/Resources/OpenSourceLicenses/README.txt
@@ -6,9 +6,9 @@ texts are bundled beside this file and are available from Settings > About >
 Open Source Licenses.
 
 AetherEngine
-  Revision: e238d1d2da52b58bffd7f8135bb2b04e32915cee (release 6.34.0 + native item handoff fix)
+  Revision: 53ec6c9771a8df326abb23c7d98692b95b18b2c1 (release 6.34.0 + native item handoff and session retirement fixes)
   License: GNU LGPL version 3 with the upstream Apple Store / DRM exception
-  Source: https://github.com/blurbery/AetherEngine/tree/e238d1d2da52b58bffd7f8135bb2b04e32915cee
+  Source: https://github.com/blurbery/AetherEngine/tree/53ec6c9771a8df326abb23c7d98692b95b18b2c1
   Rebuild: the Package.swift and source tree at that revision
 
 FFmpegBuild and embedded media frameworks

--- a/iosApp/Resources/OpenSourceLicenses/README.txt
+++ b/iosApp/Resources/OpenSourceLicenses/README.txt
@@ -6,9 +6,9 @@ texts are bundled beside this file and are available from Settings > About >
 Open Source Licenses.
 
 AetherEngine
-  Revision: 53ec6c9771a8df326abb23c7d98692b95b18b2c1 (release 6.34.0 + native item handoff and session retirement fixes)
+  Revision: 653be639441d3f7d06332a2f995950497ad62e0f (release 6.34.0 + native item handoff and session retirement fixes)
   License: GNU LGPL version 3 with the upstream Apple Store / DRM exception
-  Source: https://github.com/blurbery/AetherEngine/tree/53ec6c9771a8df326abb23c7d98692b95b18b2c1
+  Source: https://github.com/blurbery/AetherEngine/tree/653be639441d3f7d06332a2f995950497ad62e0f
   Rebuild: the Package.swift and source tree at that revision
 
 FFmpegBuild and embedded media frameworks

--- a/iosApp/Silo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iosApp/Silo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,7 +5,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/blurbery/AetherEngine",
       "state" : {
-        "revision" : "53ec6c9771a8df326abb23c7d98692b95b18b2c1"
+        "revision" : "653be639441d3f7d06332a2f995950497ad62e0f"
       }
     },
     {

--- a/iosApp/Silo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iosApp/Silo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,7 +5,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/blurbery/AetherEngine",
       "state" : {
-        "revision" : "e238d1d2da52b58bffd7f8135bb2b04e32915cee"
+        "revision" : "53ec6c9771a8df326abb23c7d98692b95b18b2c1"
       }
     },
     {

--- a/iosApp/Tests/DetailDismissalNavigationTests.swift
+++ b/iosApp/Tests/DetailDismissalNavigationTests.swift
@@ -1,6 +1,24 @@
 import SwiftUI
+import Observation
 import XCTest
 @testable import Silo
+
+private actor ContinueWatchingResponseGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func open() {
+        isOpen = true
+        let pending = waiters
+        waiters.removeAll()
+        for waiter in pending { waiter.resume() }
+    }
+}
 
 @MainActor
 final class DetailDismissalNavigationTests: XCTestCase {
@@ -81,6 +99,200 @@ final class DetailDismissalNavigationTests: XCTestCase {
         XCTAssertEqual(model.preferredInitialSeason(seasons: seasons)?.seasonNumber, 1)
         model.initialResumeSeasonNumber = nil
         XCTAssertEqual(model.preferredInitialSeason(seasons: seasons)?.seasonNumber, 1)
+    }
+
+    private func resumeLoadFixture() throws -> (ItemDetail, SeasonsResponse, EpisodesResponse) {
+        let decoder = JSONDecoder()
+        return (
+            try decoder.decode(ItemDetail.self, from: Data(#"{"contentId":"resume-speed-series","type":"series","title":"Synthetic series"}"#.utf8)),
+            try decoder.decode(SeasonsResponse.self, from: Data(#"{"seasons":[{"contentId":"resume-speed-season","seasonNumber":3,"episodeCount":2}]}"#.utf8)),
+            try decoder.decode(EpisodesResponse.self, from: Data(#"{"episodes":[{"contentId":"resume-speed-e2","seasonNumber":3,"episodeNumber":2},{"contentId":"resume-speed-e1","seasonNumber":3,"episodeNumber":1}]}"#.utf8))
+        )
+    }
+
+    private func clearResumeLoadFixture() {
+        ResponseCache.shared.removeAll(withPrefix: "item:resume-speed-series")
+    }
+
+    func testContinueWatchingCachedSeasonAndEpisodesPaintWithoutAwaitingNetwork() throws {
+        let (detail, seasons, episodes) = try resumeLoadFixture()
+        defer { clearResumeLoadFixture() }
+        ResponseCache.shared.set(detail, for: CacheKey.itemDetail(detail.contentId))
+        ResponseCache.shared.set(seasons, for: CacheKey.itemSeasons(detail.contentId))
+        ResponseCache.shared.set(episodes, for: CacheKey.itemEpisodes(seriesId: detail.contentId, seasonNumber: 3))
+        let model = ItemDetailViewModel()
+        model.initialResumeSeasonNumber = 3
+        model.hydrateFromCache(contentId: detail.contentId)
+        XCTAssertEqual(model.selectedSeason?.seasonNumber, 3)
+        XCTAssertEqual(model.episodes.map(\.episodeNumber), [1, 2])
+        XCTAssertEqual(model.episodesBySeason[3], model.episodes)
+        XCTAssertFalse(model.isLoadingEpisodes)
+
+        let posterModel = ItemDetailViewModel()
+        posterModel.hydrateFromCache(contentId: detail.contentId)
+        XCTAssertNil(posterModel.selectedSeason, "Poster initialization must remain unchanged")
+        XCTAssertTrue(posterModel.episodes.isEmpty)
+    }
+
+    func testContinueWatchingRequestsBothResourcesBeforeEitherResponseReturns() async throws {
+        let (detail, seasons, episodes) = try resumeLoadFixture()
+        defer { clearResumeLoadFixture() }
+        let seasonStarted = expectation(description: "Seasons dispatched")
+        let episodesStarted = expectation(description: "Episodes dispatched")
+        let gate = ContinueWatchingResponseGate()
+        let model = ItemDetailViewModel()
+        let load = Task {
+            await model.loadContinueWatchingStructure(
+                contentId: detail.contentId, seasonNumber: 3,
+                fetchSeasons: { _ in
+                    seasonStarted.fulfill()
+                    await gate.wait()
+                    return seasons
+                },
+                fetchEpisodes: { _, number in
+                    XCTAssertEqual(number, 3)
+                    episodesStarted.fulfill()
+                    await gate.wait()
+                    return episodes
+                }
+            )
+        }
+        await fulfillment(of: [seasonStarted, episodesStarted], timeout: 2)
+        await gate.open()
+        await load.value
+        XCTAssertEqual(model.selectedSeason?.seasonNumber, 3)
+        XCTAssertEqual(model.episodes.map(\.episodeNumber), [1, 2])
+    }
+
+    func testContinueWatchingRefreshDoesNotRebuildUnchangedScrollContent() async throws {
+        let (detail, seasons, episodes) = try resumeLoadFixture()
+        defer { clearResumeLoadFixture() }
+        let model = ItemDetailViewModel()
+        model.seasons = seasons.seasons
+        model.selectedSeason = seasons.seasons[0]
+        model.episodes = episodes.episodes.sorted { $0.episodeNumber < $1.episodeNumber }
+        model.episodesBySeason[3] = model.episodes
+        let changed = expectation(description: "Unchanged scroll content must not be republished")
+        changed.isInverted = true
+        withObservationTracking {
+            _ = model.seasons
+            _ = model.selectedSeason
+            _ = model.episodes
+            _ = model.episodesBySeason
+            _ = model.isLoadingEpisodes
+        } onChange: {
+            changed.fulfill()
+        }
+        await model.loadContinueWatchingStructure(
+            contentId: detail.contentId, seasonNumber: 3,
+            fetchSeasons: { _ in seasons }, fetchEpisodes: { _, _ in episodes }
+        )
+        await fulfillment(of: [changed], timeout: 0.05)
+        XCTAssertFalse(model.isLoadingEpisodes)
+    }
+
+    func testContinueWatchingEntryCannotOverwriteASeasonTapWhileRequestsArePending() async throws {
+        let (detail, seasons, episodes) = try resumeLoadFixture()
+        defer { clearResumeLoadFixture() }
+        let started = expectation(description: "Entry request started")
+        let gate = ContinueWatchingResponseGate()
+        let model = ItemDetailViewModel()
+        model.initialResumeSeasonNumber = 3
+        // A cached manually selected page uses the existing instant tap path.
+        let manualSeason = try JSONDecoder().decode(Season.self, from: Data(
+            #"{"contentId":"manual-season","seasonNumber":1,"episodeCount":0}"#.utf8
+        ))
+        model.episodesBySeason[1] = []
+        let load = Task {
+            await model.loadContinueWatchingStructure(
+                contentId: detail.contentId, seasonNumber: 3,
+                fetchSeasons: { _ in
+                    started.fulfill()
+                    await gate.wait()
+                    return seasons
+                }, fetchEpisodes: { _, _ in episodes }
+            )
+        }
+        await fulfillment(of: [started], timeout: 2)
+        await model.selectSeason(manualSeason)
+        await gate.open()
+        await load.value
+        XCTAssertEqual(model.selectedSeason?.seasonNumber, 1)
+        XCTAssertTrue(model.episodes.isEmpty)
+        XCTAssertNil(model.initialResumeSeasonNumber)
+    }
+
+    func testContinueWatchingFailedRefreshKeepsTheCachedPageAndCancellationPublishesNothing() async throws {
+        let (detail, seasons, episodes) = try resumeLoadFixture()
+        defer { clearResumeLoadFixture() }
+        let model = ItemDetailViewModel()
+        model.seasons = seasons.seasons
+        model.selectedSeason = seasons.seasons[0]
+        model.episodes = episodes.episodes
+        await model.loadContinueWatchingStructure(
+            contentId: detail.contentId, seasonNumber: 3,
+            fetchSeasons: { _ in throw URLError(.notConnectedToInternet) },
+            fetchEpisodes: { _, _ in throw URLError(.notConnectedToInternet) }
+        )
+        XCTAssertEqual(model.episodes, episodes.episodes)
+        XCTAssertEqual(model.selectedSeason?.seasonNumber, 3)
+        XCTAssertFalse(model.isLoadingEpisodes)
+
+        let started = expectation(description: "Cancellable request started")
+        let gate = ContinueWatchingResponseGate()
+        let cancelledModel = ItemDetailViewModel()
+        let load = Task {
+            await cancelledModel.loadContinueWatchingStructure(
+                contentId: detail.contentId, seasonNumber: 3,
+                fetchSeasons: { _ in
+                    started.fulfill()
+                    await gate.wait()
+                    return seasons
+                }, fetchEpisodes: { _, _ in episodes }
+            )
+        }
+        await fulfillment(of: [started], timeout: 2)
+        load.cancel()
+        await gate.open()
+        await load.value
+        XCTAssertTrue(cancelledModel.seasons.isEmpty)
+        XCTAssertTrue(cancelledModel.episodes.isEmpty)
+        XCTAssertNil(cancelledModel.selectedSeason)
+    }
+
+    func testContinueWatchingHierarchyRequestBenchmark() async throws {
+        let (detail, seasons, episodes) = try resumeLoadFixture()
+        defer { clearResumeLoadFixture() }
+        let clock = ContinuousClock()
+        var serialMilliseconds: [Double] = []
+        var resumeMilliseconds: [Double] = []
+        let fetchSeasons: @Sendable (String) async throws -> SeasonsResponse = { _ in
+            try await Task.sleep(for: .milliseconds(150))
+            return seasons
+        }
+        let fetchEpisodes: @Sendable (String, Int) async throws -> EpisodesResponse = { _, _ in
+            try await Task.sleep(for: .milliseconds(150))
+            return episodes
+        }
+        func milliseconds(_ duration: Duration) -> Double {
+            Double(duration.components.seconds) * 1000 + Double(duration.components.attoseconds) / 1e15
+        }
+        for _ in 0..<5 {
+            let serialStart = clock.now
+            _ = try await fetchSeasons(detail.contentId)
+            _ = try await fetchEpisodes(detail.contentId, 3)
+            serialMilliseconds.append(milliseconds(serialStart.duration(to: clock.now)))
+            let model = ItemDetailViewModel()
+            let resumeStart = clock.now
+            await model.loadContinueWatchingStructure(
+                contentId: detail.contentId, seasonNumber: 3,
+                fetchSeasons: fetchSeasons, fetchEpisodes: fetchEpisodes
+            )
+            resumeMilliseconds.append(milliseconds(resumeStart.duration(to: clock.now)))
+            XCTAssertEqual(model.episodes.count, 2)
+        }
+        // Synthetic hierarchy latency only, not server timing or a scroll-FPS claim.
+        print("CW hierarchy benchmark; 5 repetitions; 150ms per resource; serial-ms=\(serialMilliseconds); resume-ms=\(resumeMilliseconds)")
     }
 
     func testRotationLockCapturesTheExactScreenOrientation() {

--- a/iosApp/Tests/DetailDismissalNavigationTests.swift
+++ b/iosApp/Tests/DetailDismissalNavigationTests.swift
@@ -386,10 +386,33 @@ final class DetailDismissalNavigationTests: XCTestCase {
         state.deactivate()
         XCTAssertFalse(state.isLocked)
         XCTAssertEqual(PlayerOrientationCoordinator.orientationMask(
-            isPlayerActive: state.isPlayerActive, lockedOrientation: state.lockedOrientation
+            isPlayerActive: state.isPlayerActive, lockedOrientation: state.lockedOrientation,
+            browsingOrientations: .portrait
         ), .portrait)
         state.activate()
         XCTAssertFalse(state.isLocked)
+    }
+
+    func testPersistedLandscapeLockOpensTheSessionLockedAndMapsBackToTheRemoteMode() {
+        var state = PlayerRotationState()
+        state.activate(lockedOrientation: .landscapeRight)
+        XCTAssertTrue(state.isLocked)
+        XCTAssertEqual(state.persistedOrientationMode, .landscapeLocked)
+        state.toggleLock(at: .landscapeRight)
+        XCTAssertEqual(state.persistedOrientationMode, .rotateFreely)
+        // A portrait lock has no remote representation; leave the stored mode alone.
+        state.toggleLock(at: .portrait)
+        XCTAssertNil(state.persistedOrientationMode)
+        state.manuallyRotate(to: .landscapeLeft)
+        XCTAssertEqual(state.persistedOrientationMode, .landscapeLocked)
+    }
+
+    func testBrowsingStaysPortraitOnPhoneAndRotatesOnPad() {
+        XCTAssertEqual(PlayerOrientationCoordinator.browsingOrientations(isPad: false), .portrait)
+        XCTAssertEqual(PlayerOrientationCoordinator.browsingOrientations(isPad: true), .allButUpsideDown)
+        XCTAssertEqual(PlayerOrientationCoordinator.geometryMask(
+            isPlayerActive: false, preferredOrientation: .landscape, browsingOrientations: .allButUpsideDown
+        ), .landscape)
     }
 
     func testManualRotationDoesNotImplicitlyEnableTheLock() {
@@ -423,7 +446,7 @@ final class DetailDismissalNavigationTests: XCTestCase {
     func testAQueuedVideoRotationCannotUnlockBrowsingPages() {
         for mask: UIInterfaceOrientationMask in [.portrait, .landscape, .landscapeLeft, .landscapeRight, .all] {
             XCTAssertEqual(PlayerOrientationCoordinator.geometryMask(
-                isPlayerActive: false, preferredOrientation: mask
+                isPlayerActive: false, preferredOrientation: mask, browsingOrientations: .portrait
             ), .portrait)
         }
     }
@@ -437,7 +460,9 @@ final class DetailDismissalNavigationTests: XCTestCase {
     }
 
     func testLeavingVideoRestoresPortraitEvenWhenTheDeviceStaysLandscape() {
-        let browsing = PlayerOrientationCoordinator.orientationMask(isPlayerActive: false)
+        let browsing = PlayerOrientationCoordinator.orientationMask(
+            isPlayerActive: false, browsingOrientations: .portrait
+        )
         XCTAssertEqual(browsing, .portrait)
         XCTAssertFalse(browsing.contains(.landscapeLeft))
         XCTAssertFalse(browsing.contains(.landscapeRight))

--- a/iosApp/Tests/DetailDismissalNavigationTests.swift
+++ b/iosApp/Tests/DetailDismissalNavigationTests.swift
@@ -4,6 +4,67 @@ import XCTest
 
 @MainActor
 final class DetailDismissalNavigationTests: XCTestCase {
+    func testRotationLockCapturesTheExactScreenOrientation() {
+        for orientation: UIInterfaceOrientationMask in [.portrait, .landscapeLeft, .landscapeRight] {
+            var state = PlayerRotationState()
+            state.activate()
+            state.toggleLock(at: orientation)
+            XCTAssertTrue(state.isLocked)
+            XCTAssertEqual(PlayerOrientationCoordinator.orientationMask(
+                isPlayerActive: state.isPlayerActive, lockedOrientation: state.lockedOrientation
+            ), orientation)
+            XCTAssertEqual(PlayerOrientationCoordinator.geometryMask(
+                isPlayerActive: state.isPlayerActive, preferredOrientation: .allButUpsideDown,
+                lockedOrientation: state.lockedOrientation
+            ), orientation)
+        }
+    }
+
+    func testManualRotationWorksWhileLockedAndKeepsTheNewOrientationLocked() {
+        var state = PlayerRotationState()
+        state.activate()
+        state.toggleLock(at: .portrait)
+        for target: UIInterfaceOrientationMask in [.landscapeRight, .portrait, .landscapeLeft, .portrait] {
+            state.manuallyRotate(to: target)
+            XCTAssertTrue(state.isLocked)
+            XCTAssertEqual(PlayerOrientationCoordinator.geometryMask(
+                isPlayerActive: state.isPlayerActive, preferredOrientation: target,
+                lockedOrientation: state.lockedOrientation
+            ), target)
+        }
+    }
+
+    func testUnlockingRestoresPhoneRotationAndClosingClearsTheSessionLock() {
+        var state = PlayerRotationState()
+        state.activate()
+        state.toggleLock(at: .landscapeRight)
+        state.toggleLock(at: .landscapeRight)
+        XCTAssertFalse(state.isLocked)
+        XCTAssertEqual(PlayerOrientationCoordinator.orientationMask(
+            isPlayerActive: state.isPlayerActive, lockedOrientation: state.lockedOrientation
+        ), .allButUpsideDown)
+        state.toggleLock(at: .landscapeLeft)
+        state.deactivate()
+        XCTAssertFalse(state.isLocked)
+        XCTAssertEqual(PlayerOrientationCoordinator.orientationMask(
+            isPlayerActive: state.isPlayerActive, lockedOrientation: state.lockedOrientation
+        ), .portrait)
+        state.activate()
+        XCTAssertFalse(state.isLocked)
+    }
+
+    func testManualRotationDoesNotImplicitlyEnableTheLock() {
+        var state = PlayerRotationState()
+        state.activate()
+        state.manuallyRotate(to: .landscapeRight)
+        state.manuallyRotate(to: .portrait)
+        XCTAssertFalse(state.isLocked)
+        state.deactivate()
+        state.toggleLock(at: .landscapeRight)
+        state.manuallyRotate(to: .landscapeLeft)
+        XCTAssertFalse(state.isLocked)
+    }
+
     func testRotationPillFollowsTheActualInterfaceOrientation() {
         XCTAssertEqual(PlayerScreenOrientation(interfaceOrientation: .portrait)?.toggled, .landscape)
         XCTAssertEqual(PlayerScreenOrientation(interfaceOrientation: .landscapeLeft)?.toggled, .portrait)

--- a/iosApp/Tests/DetailDismissalNavigationTests.swift
+++ b/iosApp/Tests/DetailDismissalNavigationTests.swift
@@ -1,0 +1,133 @@
+import SwiftUI
+import XCTest
+@testable import Silo
+
+@MainActor
+final class DetailDismissalNavigationTests: XCTestCase {
+    func testPlayerFromDetailHasOneOwnerAndReturnsToTheSameNestedPage() throws {
+        let router = AppRouter()
+        router.presentItemDetail(contentId: "series")
+        router.navigate(to: .personDetail(personId: 42))
+        router.presentItemDetail(contentId: "movie")
+        let detail = try XCTUnwrap(router.presentedItemDetail)
+        router.presentPlayer(contentId: "movie")
+        let player = try XCTUnwrap(router.presentedPlayer)
+
+        XCTAssertNil(router.playerPresentation(forDetailID: nil))
+        XCTAssertEqual(router.playerPresentation(forDetailID: detail.id)?.id, player.id)
+        XCTAssertNil(router.playerPresentation(forDetailID: UUID()))
+        router.dismissPlayerPresentation(id: player.id)
+        XCTAssertNil(router.presentedPlayer)
+        XCTAssertEqual(router.presentedItemDetail?.id, detail.id)
+        XCTAssertEqual(router.presentedItemDetail?.contentId, "series")
+        XCTAssertEqual(router.itemDetailPath.count, 2)
+    }
+
+    func testRootPlayerDoesNotCreateOrDismissAnUnrelatedDetail() throws {
+        let router = AppRouter()
+        router.presentPlayer(contentId: "movie")
+        let player = try XCTUnwrap(router.playerPresentation(forDetailID: nil))
+        XCTAssertNil(player.detailPresentationID)
+        router.dismissPlayerPresentation(id: player.id)
+        XCTAssertNil(router.presentedItemDetail)
+        XCTAssertTrue(router.itemDetailPath.isEmpty)
+    }
+
+    func testOfflinePlayerPreservesItsDetailOwner() throws {
+        let router = AppRouter()
+        router.presentItemDetail(contentId: "movie")
+        let detail = try XCTUnwrap(router.presentedItemDetail)
+        router.presentOfflinePlayer(downloadId: "download", contentId: "movie")
+        let player = try XCTUnwrap(router.presentedPlayer)
+        XCTAssertEqual(player.detailPresentationID, detail.id)
+        XCTAssertEqual(player.offlineDownloadId, "download")
+        router.dismissPlayerPresentation(id: player.id)
+        XCTAssertEqual(router.presentedItemDetail?.id, detail.id)
+    }
+
+    func testOutgoingPlayerCannotDismissANewerPresentation() throws {
+        let router = AppRouter()
+        router.presentPlayer(contentId: "first")
+        let first = try XCTUnwrap(router.presentedPlayer)
+        router.presentPlayer(contentId: "second")
+        let second = try XCTUnwrap(router.presentedPlayer)
+        router.dismissPlayerPresentation(id: first.id)
+        XCTAssertEqual(router.presentedPlayer?.id, second.id)
+    }
+
+    func testReopenedPiPPayloadRetainsOwnerAndPlaybackChoices() throws {
+        let router = AppRouter()
+        router.presentItemDetail(contentId: "series")
+        router.presentPlayer(contentId: "episode", fileId: 7, audioTrackIndex: 2,
+                             subtitleTrackIndex: 3, resumePosition: 120)
+        let original = try XCTUnwrap(router.presentedPlayer)
+        let reopened = original.reopened()
+        XCTAssertNotEqual(reopened.id, original.id)
+        XCTAssertEqual(reopened.detailPresentationID, original.detailPresentationID)
+        XCTAssertEqual(reopened.contentId, original.contentId)
+        XCTAssertEqual(reopened.fileId, original.fileId)
+        XCTAssertEqual(reopened.audioTrackIndex, original.audioTrackIndex)
+        XCTAssertEqual(reopened.subtitleTrackIndex, original.subtitleTrackIndex)
+        XCTAssertEqual(reopened.resumePosition, original.resumePosition)
+    }
+
+    func testActorPullGoesBackOnePageWithoutClosingTheSheet() throws {
+        let router = AppRouter()
+        router.presentItemDetail(contentId: "series")
+        let detail = try XCTUnwrap(router.presentedItemDetail)
+        router.presentItemDetail(contentId: "episode")
+        router.navigate(to: .personDetail(personId: 42))
+        router.goBackInItemDetail()
+        XCTAssertEqual(router.itemDetailPath.count, 1)
+        XCTAssertEqual(router.presentedItemDetail?.id, detail.id)
+        router.goBackInItemDetail()
+        router.goBackInItemDetail()
+        XCTAssertTrue(router.itemDetailPath.isEmpty)
+        XCTAssertEqual(router.presentedItemDetail?.id, detail.id)
+    }
+
+    func testLateSheetDismissCallbackCannotClearAnOpenDetailOrItsPlayer() throws {
+        let router = AppRouter()
+        router.presentItemDetail(contentId: "series")
+        router.navigate(to: .personDetail(personId: 42))
+        router.presentPlayer(contentId: "episode")
+        let detail = router.presentedItemDetail
+        let player = router.presentedPlayer
+        router.itemDetailPresentationDidDismiss()
+        XCTAssertEqual(router.presentedItemDetail, detail)
+        XCTAssertEqual(router.presentedPlayer, player)
+        XCTAssertEqual(router.itemDetailPath.count, 1)
+    }
+
+    func testDismissedSheetClearsOnlyItsNestedPath() {
+        let router = AppRouter()
+        router.presentItemDetail(contentId: "series")
+        router.navigate(to: .personDetail(personId: 42))
+        router.presentedItemDetail = nil // SwiftUI's sheet binding clears first.
+        router.itemDetailPresentationDidDismiss()
+        XCTAssertTrue(router.itemDetailPath.isEmpty)
+    }
+
+    func testTopHandoffIncludesBounceWithoutWaitingForAnIdlePhase() {
+        for offset in [-95.0, -60.0, -59.0] {
+            XCTAssertTrue(DetailDismissalPolicy.isAtTop(offset: offset, topInset: 60))
+        }
+        XCTAssertFalse(DetailDismissalPolicy.isAtTop(offset: -58, topInset: 60))
+        XCTAssertFalse(DetailDismissalPolicy.isAtTop(offset: 400, topInset: 60))
+    }
+
+    func testBackGestureDoesNotStealHorizontalUpwardOrMidPageScrolling() {
+        XCTAssertTrue(DetailDismissalPolicy.canBeginBack(isAtTop: true, velocity: .init(x: 10, y: 200)))
+        XCTAssertFalse(DetailDismissalPolicy.canBeginBack(isAtTop: false, velocity: .init(x: 0, y: 500)))
+        XCTAssertFalse(DetailDismissalPolicy.canBeginBack(isAtTop: true, velocity: .init(x: 500, y: 20)))
+        XCTAssertFalse(DetailDismissalPolicy.canBeginBack(isAtTop: true, velocity: .init(x: 0, y: -500)))
+    }
+
+    func testBackRequiresADecisivePullAndAllowsCancel() {
+        XCTAssertTrue(DetailDismissalPolicy.shouldCompleteBack(translation: .init(x: 0, y: 110), velocity: .zero))
+        XCTAssertTrue(DetailDismissalPolicy.shouldCompleteBack(translation: .init(x: 5, y: 40), velocity: .init(x: 0, y: 950)))
+        XCTAssertFalse(DetailDismissalPolicy.shouldCompleteBack(translation: .init(x: 0, y: 20), velocity: .zero))
+        XCTAssertFalse(DetailDismissalPolicy.shouldCompleteBack(translation: .init(x: 0, y: -10), velocity: .zero))
+        XCTAssertFalse(DetailDismissalPolicy.shouldCompleteBack(translation: .init(x: 120, y: 110), velocity: .zero))
+    }
+}

--- a/iosApp/Tests/DetailDismissalNavigationTests.swift
+++ b/iosApp/Tests/DetailDismissalNavigationTests.swift
@@ -4,41 +4,40 @@ import XCTest
 
 @MainActor
 final class DetailDismissalNavigationTests: XCTestCase {
-    func testRotationPillAlternatesExactOrientationsForEitherSavedMode() {
-        for mode in [PlayerOrientationMode.rotateFreely, .landscapeLocked] {
-            var orientation = PlayerScreenOrientation.landscape
-            for index in 0..<20 {
-                orientation = orientation.toggled
-                let expected: UIInterfaceOrientationMask = index.isMultiple(of: 2) ? .portrait : .landscape
-                XCTAssertEqual(PlayerOrientationCoordinator.orientationMask(
-                    isPlayerActive: true, playerMode: mode, requestedOrientation: orientation
-                ), expected)
-            }
+    func testRotationPillFollowsTheActualInterfaceOrientation() {
+        XCTAssertEqual(PlayerScreenOrientation(interfaceOrientation: .portrait)?.toggled, .landscape)
+        XCTAssertEqual(PlayerScreenOrientation(interfaceOrientation: .landscapeLeft)?.toggled, .portrait)
+        XCTAssertEqual(PlayerScreenOrientation(interfaceOrientation: .landscapeRight)?.toggled, .portrait)
+        XCTAssertNil(PlayerScreenOrientation(interfaceOrientation: .unknown))
+    }
+
+    func testManualRotationRequestsDoNotLockSubsequentPhoneRotation() {
+        for orientation in [PlayerScreenOrientation.portrait, .landscape] {
+            XCTAssertEqual(PlayerOrientationCoordinator.geometryMask(
+                isPlayerActive: true, preferredOrientation: orientation.mask
+            ), orientation.mask)
+            XCTAssertEqual(PlayerOrientationCoordinator.orientationMask(isPlayerActive: true), .allButUpsideDown)
         }
     }
 
-    func testPlayerRotationOverrideCannotUnlockBrowsingPages() {
-        for orientation in [PlayerScreenOrientation.portrait, .landscape] {
-            XCTAssertEqual(PlayerOrientationCoordinator.orientationMask(
-                isPlayerActive: false, playerMode: .rotateFreely, requestedOrientation: orientation
+    func testAQueuedVideoRotationCannotUnlockBrowsingPages() {
+        for mask: UIInterfaceOrientationMask in [.portrait, .landscape, .landscapeLeft, .landscapeRight, .all] {
+            XCTAssertEqual(PlayerOrientationCoordinator.geometryMask(
+                isPlayerActive: false, preferredOrientation: mask
             ), .portrait)
         }
     }
 
-    func testBrowsingIsPortraitRegardlessOfTheSavedPlayerMode() {
-        for mode in [PlayerOrientationMode.rotateFreely, .landscapeLocked] {
-            XCTAssertEqual(PlayerOrientationCoordinator.orientationMask(isPlayerActive: false, playerMode: mode), .portrait)
-        }
-    }
-
-    func testVideoStillAllowsLandscapeAndRespectsItsRotationSetting() {
-        XCTAssertEqual(PlayerOrientationCoordinator.orientationMask(isPlayerActive: true, playerMode: .landscapeLocked), .landscape)
-        XCTAssertEqual(PlayerOrientationCoordinator.orientationMask(isPlayerActive: true, playerMode: .rotateFreely), .allButUpsideDown)
+    func testVideoAllowsPortraitAndBothLandscapeDirections() {
+        let playback = PlayerOrientationCoordinator.orientationMask(isPlayerActive: true)
+        XCTAssertTrue(playback.contains(.portrait))
+        XCTAssertTrue(playback.contains(.landscapeLeft))
+        XCTAssertTrue(playback.contains(.landscapeRight))
+        XCTAssertFalse(playback.contains(.portraitUpsideDown))
     }
 
     func testLeavingVideoRestoresPortraitEvenWhenTheDeviceStaysLandscape() {
-        XCTAssertTrue(PlayerOrientationCoordinator.orientationMask(isPlayerActive: true, playerMode: .landscapeLocked).contains(.landscapeLeft))
-        let browsing = PlayerOrientationCoordinator.orientationMask(isPlayerActive: false, playerMode: .landscapeLocked)
+        let browsing = PlayerOrientationCoordinator.orientationMask(isPlayerActive: false)
         XCTAssertEqual(browsing, .portrait)
         XCTAssertFalse(browsing.contains(.landscapeLeft))
         XCTAssertFalse(browsing.contains(.landscapeRight))

--- a/iosApp/Tests/DetailDismissalNavigationTests.swift
+++ b/iosApp/Tests/DetailDismissalNavigationTests.swift
@@ -4,20 +4,28 @@ import XCTest
 
 @MainActor
 final class DetailDismissalNavigationTests: XCTestCase {
-    func testRotationControlsFollowTransportVisibilityExceptOnTheNextUpControlScreen() {
+    func testRotationControlsWaitForTapAndFollowTransportVisibilityInEveryPhase() async throws {
         let model = PlayerViewModel()
         defer { model.cleanup() }
-        model.isLoading = false
-        model.showControls = false
-        XCTAssertFalse(model.shouldShowMobileRotationControls)
-        model.showControls = true
-        XCTAssertTrue(model.shouldShowMobileRotationControls)
-        model.dismissControls()
-        XCTAssertFalse(model.shouldShowMobileRotationControls)
-        model.showNextUpScreen = true
-        XCTAssertTrue(model.shouldShowMobileRotationControls)
-        model.showNextUpScreen = false
-        XCTAssertFalse(model.shouldShowMobileRotationControls)
+        for phase in ["loading", "playing", "next-up", "error"] {
+            model.isLoading = phase == "loading"
+            model.showNextUpScreen = phase == "next-up"
+            model.error = phase == "error" ? "Synthetic playback error" : nil
+            XCTAssertFalse(model.shouldShowMobileRotationControls, "Hidden before a tap during \(phase)")
+            model.toggleControls()
+            XCTAssertTrue(model.shouldShowMobileRotationControls, "A tap reveals both buttons during \(phase)")
+            model.toggleControls()
+            XCTAssertFalse(model.shouldShowMobileRotationControls, "A second tap hides both buttons during \(phase)")
+            model.revealControls()
+            model.dismissControls()
+            XCTAssertFalse(model.shouldShowMobileRotationControls, "Dismissal hides both buttons during \(phase)")
+        }
+        model.error = nil
+        model.isPlaying = true
+        model.toggleControls()
+        try await Task.sleep(for: .milliseconds(5300))
+        XCTAssertFalse(model.showControls)
+        XCTAssertFalse(model.shouldShowMobileRotationControls, "Both buttons auto-hide with transport")
     }
 
     func testRotationLockCapturesTheExactScreenOrientation() {

--- a/iosApp/Tests/DetailDismissalNavigationTests.swift
+++ b/iosApp/Tests/DetailDismissalNavigationTests.swift
@@ -4,6 +4,46 @@ import XCTest
 
 @MainActor
 final class DetailDismissalNavigationTests: XCTestCase {
+    func testRotationPillAlternatesExactOrientationsForEitherSavedMode() {
+        for mode in [PlayerOrientationMode.rotateFreely, .landscapeLocked] {
+            var orientation = PlayerScreenOrientation.landscape
+            for index in 0..<20 {
+                orientation = orientation.toggled
+                let expected: UIInterfaceOrientationMask = index.isMultiple(of: 2) ? .portrait : .landscape
+                XCTAssertEqual(PlayerOrientationCoordinator.orientationMask(
+                    isPlayerActive: true, playerMode: mode, requestedOrientation: orientation
+                ), expected)
+            }
+        }
+    }
+
+    func testPlayerRotationOverrideCannotUnlockBrowsingPages() {
+        for orientation in [PlayerScreenOrientation.portrait, .landscape] {
+            XCTAssertEqual(PlayerOrientationCoordinator.orientationMask(
+                isPlayerActive: false, playerMode: .rotateFreely, requestedOrientation: orientation
+            ), .portrait)
+        }
+    }
+
+    func testBrowsingIsPortraitRegardlessOfTheSavedPlayerMode() {
+        for mode in [PlayerOrientationMode.rotateFreely, .landscapeLocked] {
+            XCTAssertEqual(PlayerOrientationCoordinator.orientationMask(isPlayerActive: false, playerMode: mode), .portrait)
+        }
+    }
+
+    func testVideoStillAllowsLandscapeAndRespectsItsRotationSetting() {
+        XCTAssertEqual(PlayerOrientationCoordinator.orientationMask(isPlayerActive: true, playerMode: .landscapeLocked), .landscape)
+        XCTAssertEqual(PlayerOrientationCoordinator.orientationMask(isPlayerActive: true, playerMode: .rotateFreely), .allButUpsideDown)
+    }
+
+    func testLeavingVideoRestoresPortraitEvenWhenTheDeviceStaysLandscape() {
+        XCTAssertTrue(PlayerOrientationCoordinator.orientationMask(isPlayerActive: true, playerMode: .landscapeLocked).contains(.landscapeLeft))
+        let browsing = PlayerOrientationCoordinator.orientationMask(isPlayerActive: false, playerMode: .landscapeLocked)
+        XCTAssertEqual(browsing, .portrait)
+        XCTAssertFalse(browsing.contains(.landscapeLeft))
+        XCTAssertFalse(browsing.contains(.landscapeRight))
+    }
+
     func testPlayerFromDetailHasOneOwnerAndReturnsToTheSameNestedPage() throws {
         let router = AppRouter()
         router.presentItemDetail(contentId: "series")

--- a/iosApp/Tests/DetailDismissalNavigationTests.swift
+++ b/iosApp/Tests/DetailDismissalNavigationTests.swift
@@ -4,6 +4,22 @@ import XCTest
 
 @MainActor
 final class DetailDismissalNavigationTests: XCTestCase {
+    func testRotationControlsFollowTransportVisibilityExceptOnTheNextUpControlScreen() {
+        let model = PlayerViewModel()
+        defer { model.cleanup() }
+        model.isLoading = false
+        model.showControls = false
+        XCTAssertFalse(model.shouldShowMobileRotationControls)
+        model.showControls = true
+        XCTAssertTrue(model.shouldShowMobileRotationControls)
+        model.dismissControls()
+        XCTAssertFalse(model.shouldShowMobileRotationControls)
+        model.showNextUpScreen = true
+        XCTAssertTrue(model.shouldShowMobileRotationControls)
+        model.showNextUpScreen = false
+        XCTAssertFalse(model.shouldShowMobileRotationControls)
+    }
+
     func testRotationLockCapturesTheExactScreenOrientation() {
         for orientation: UIInterfaceOrientationMask in [.portrait, .landscapeLeft, .landscapeRight] {
             var state = PlayerRotationState()

--- a/iosApp/Tests/DetailDismissalNavigationTests.swift
+++ b/iosApp/Tests/DetailDismissalNavigationTests.swift
@@ -4,28 +4,83 @@ import XCTest
 
 @MainActor
 final class DetailDismissalNavigationTests: XCTestCase {
-    func testRotationControlsWaitForTapAndFollowTransportVisibilityInEveryPhase() async throws {
+    func testCloseAndRotationControlsWaitForTapInEveryPhase() async throws {
         let model = PlayerViewModel()
         defer { model.cleanup() }
         for phase in ["loading", "playing", "next-up", "error"] {
             model.isLoading = phase == "loading"
             model.showNextUpScreen = phase == "next-up"
             model.error = phase == "error" ? "Synthetic playback error" : nil
-            XCTAssertFalse(model.shouldShowMobileRotationControls, "Hidden before a tap during \(phase)")
+            XCTAssertFalse(model.shouldShowMobilePlayerChrome, "Close/rotate/lock stay hidden before a tap during \(phase)")
             model.toggleControls()
-            XCTAssertTrue(model.shouldShowMobileRotationControls, "A tap reveals both buttons during \(phase)")
+            XCTAssertTrue(model.shouldShowMobilePlayerChrome, "A tap reveals all chrome during \(phase)")
             model.toggleControls()
-            XCTAssertFalse(model.shouldShowMobileRotationControls, "A second tap hides both buttons during \(phase)")
+            XCTAssertFalse(model.shouldShowMobilePlayerChrome, "A second tap hides all chrome during \(phase)")
             model.revealControls()
             model.dismissControls()
-            XCTAssertFalse(model.shouldShowMobileRotationControls, "Dismissal hides both buttons during \(phase)")
+            XCTAssertFalse(model.shouldShowMobilePlayerChrome, "Dismissal hides all chrome during \(phase)")
         }
         model.error = nil
         model.isPlaying = true
         model.toggleControls()
         try await Task.sleep(for: .milliseconds(5300))
         XCTAssertFalse(model.showControls)
-        XCTAssertFalse(model.shouldShowMobileRotationControls, "Both buttons auto-hide with transport")
+        XCTAssertFalse(model.shouldShowMobilePlayerChrome, "Close/rotate/lock auto-hide with transport")
+    }
+
+    func testContinueWatchingOpensTheExistingSeriesCardWithTheExactResumeContext() throws {
+        let item = try JSONDecoder().decode(SectionItem.self, from: Data(
+            #"{"contentId":"episode-s3e2","type":"episode","title":"Second chapter","seriesId":"series","seriesTitle":"A sample series","seasonNumber":3,"episodeNumber":2,"positionSeconds":450,"durationSeconds":2700}"#.utf8
+        ))
+        let router = AppRouter()
+        router.presentContinueWatchingDetail(for: item)
+        let presentation = try XCTUnwrap(router.presentedItemDetail)
+        XCTAssertEqual(presentation.contentId, "series")
+        XCTAssertEqual(presentation.resumeContext?.episodeContentId, "episode-s3e2")
+        XCTAssertEqual(presentation.resumeContext?.seasonNumber, 3)
+        XCTAssertTrue(router.itemDetailPath.isEmpty, "No intermediate episode page may be pushed")
+        XCTAssertNil(router.presentedPlayer, "Opening the card must not start playback")
+        router.dismissItemDetail()
+        router.presentItemDetail(contentId: "series")
+        XCTAssertEqual(router.presentedItemDetail?.contentId, presentation.contentId)
+        XCTAssertNil(router.presentedItemDetail?.resumeContext, "A poster open retains its existing defaults")
+    }
+
+    func testContinueWatchingKeepsMoviesAndMissingParentFallbacksUnchanged() throws {
+        let items = try JSONDecoder().decode([SectionItem].self, from: Data(#"""
+        [
+          {"contentId":"movie","type":"movie","title":"Movie"},
+          {"contentId":"episode","type":"episode","title":"Episode","seriesId":"   "},
+          {"contentId":"audio","type":"audiobook","title":"Audio"}
+        ]
+        """#.utf8))
+        let router = AppRouter()
+        for item in items {
+            router.presentContinueWatchingDetail(for: item)
+            XCTAssertEqual(router.presentedItemDetail?.contentId, item.contentId)
+            XCTAssertNil(router.presentedItemDetail?.resumeContext)
+            router.dismissItemDetail()
+        }
+    }
+
+    func testContinueWatchingSeasonIntentWinsWithoutChangingPosterDefaults() throws {
+        let seasons = try JSONDecoder().decode([Season].self, from: Data(#"""
+        [
+          {"contentId":"season-1","seasonNumber":1,"episodeCount":8},
+          {"contentId":"season-3","seasonNumber":3,"episodeCount":8},
+          {"contentId":"specials","seasonNumber":0,"episodeCount":1}
+        ]
+        """#.utf8))
+        let model = ItemDetailViewModel()
+        XCTAssertEqual(model.preferredInitialSeason(seasons: seasons)?.seasonNumber, 1)
+        model.initialResumeSeasonNumber = 3
+        XCTAssertEqual(model.preferredInitialSeason(seasons: seasons)?.seasonNumber, 3)
+        model.initialResumeSeasonNumber = 0
+        XCTAssertEqual(model.preferredInitialSeason(seasons: seasons)?.seasonNumber, 0)
+        model.initialResumeSeasonNumber = 99
+        XCTAssertEqual(model.preferredInitialSeason(seasons: seasons)?.seasonNumber, 1)
+        model.initialResumeSeasonNumber = nil
+        XCTAssertEqual(model.preferredInitialSeason(seasons: seasons)?.seasonNumber, 1)
     }
 
     func testRotationLockCapturesTheExactScreenOrientation() {

--- a/iosApp/Tests/DetailDismissalNavigationTests.swift
+++ b/iosApp/Tests/DetailDismissalNavigationTests.swift
@@ -191,6 +191,51 @@ final class DetailDismissalNavigationTests: XCTestCase {
         XCTAssertFalse(model.isLoadingEpisodes)
     }
 
+    func testContinueWatchingHierarchySuccessDoesNotConsumePendingCatalogIntent() async throws {
+        let (detail, seasons, episodes) = try resumeLoadFixture()
+        defer { clearResumeLoadFixture() }
+        let model = ItemDetailViewModel()
+        model.initialResumeSeasonNumber = 3
+        let loaded = await model.loadContinueWatchingStructure(
+            contentId: detail.contentId, seasonNumber: model.initialResumeSeasonNumber,
+            fetchSeasons: { _ in seasons }, fetchEpisodes: { _, _ in episodes }
+        )
+        XCTAssertTrue(loaded)
+        XCTAssertEqual(model.selectedSeason?.seasonNumber, 3)
+        XCTAssertEqual(model.initialResumeSeasonNumber, 3,
+                       "Hierarchy success alone must not consume the intent while catalog can still fail")
+        XCTAssertNil(model.detail, "This response arrived before a successful catalog load")
+    }
+
+    func testContinueWatchingHierarchyFailuresRetainTheRequestedSeasonForRetry() async throws {
+        let (detail, seasons, episodes) = try resumeLoadFixture()
+        defer { clearResumeLoadFixture() }
+        for failedResource in ["seasons", "episodes", "both"] {
+            let model = ItemDetailViewModel()
+            model.initialResumeSeasonNumber = 3
+            let loaded = await model.loadContinueWatchingStructure(
+                contentId: detail.contentId, seasonNumber: model.initialResumeSeasonNumber,
+                fetchSeasons: { _ in
+                    if failedResource != "episodes" { throw URLError(.notConnectedToInternet) }
+                    return seasons
+                },
+                fetchEpisodes: { _, _ in
+                    if failedResource != "seasons" { throw URLError(.notConnectedToInternet) }
+                    return episodes
+                }
+            )
+            XCTAssertFalse(loaded)
+            XCTAssertEqual(model.initialResumeSeasonNumber, 3)
+            let retried = await model.loadContinueWatchingStructure(
+                contentId: detail.contentId, seasonNumber: model.initialResumeSeasonNumber,
+                fetchSeasons: { _ in seasons }, fetchEpisodes: { _, _ in episodes }
+            )
+            XCTAssertTrue(retried)
+            XCTAssertEqual(model.selectedSeason?.seasonNumber, 3)
+            XCTAssertEqual(model.episodes.map(\.episodeNumber), [1, 2])
+        }
+    }
+
     func testContinueWatchingEntryCannotOverwriteASeasonTapWhileRequestsArePending() async throws {
         let (detail, seasons, episodes) = try resumeLoadFixture()
         defer { clearResumeLoadFixture() }
@@ -241,6 +286,7 @@ final class DetailDismissalNavigationTests: XCTestCase {
         let started = expectation(description: "Cancellable request started")
         let gate = ContinueWatchingResponseGate()
         let cancelledModel = ItemDetailViewModel()
+        cancelledModel.initialResumeSeasonNumber = 3
         let load = Task {
             await cancelledModel.loadContinueWatchingStructure(
                 contentId: detail.contentId, seasonNumber: 3,
@@ -258,6 +304,8 @@ final class DetailDismissalNavigationTests: XCTestCase {
         XCTAssertTrue(cancelledModel.seasons.isEmpty)
         XCTAssertTrue(cancelledModel.episodes.isEmpty)
         XCTAssertNil(cancelledModel.selectedSeason)
+        XCTAssertEqual(cancelledModel.initialResumeSeasonNumber, 3,
+                       "Cancellation must not consume the pending resume entry")
     }
 
     func testContinueWatchingHierarchyRequestBenchmark() async throws {

--- a/iosApp/Tests/HomeSectionsMutationTests.swift
+++ b/iosApp/Tests/HomeSectionsMutationTests.swift
@@ -204,6 +204,72 @@ final class HomeSectionsMutationTests: XCTestCase {
         XCTAssertTrue(viewModel.isShowingActionError)
     }
 
+    @MainActor
+    func testPlaybackWriteRefreshReloadsResumeAndSuccessorWithoutManualRefresh() async throws {
+        for (contentId, position) in [("episode-one", 450), ("episode-two", 30)] {
+            let oldItem = try makeItem(contentId: "episode-one")
+            let stale = SectionsResponse(sections: [makeSection(
+                id: "continue", type: "continue_watching", totalCount: 1, items: [oldItem]
+            )])
+            let updated = try JSONDecoder().decode(SectionItem.self, from: Data(
+                "{\"contentId\":\"\(contentId)\",\"type\":\"episode\",\"title\":\"Synthetic episode\",\"positionSeconds\":\(position),\"durationSeconds\":1200}".utf8
+            ))
+            let fresh = SectionsResponse(sections: [makeSection(
+                id: "continue", type: "continue_watching", totalCount: 1, items: [updated]
+            )])
+            ResponseCache.shared.set(stale, for: CacheKey.homeSections)
+            let model = HomeViewModel(fetchHomeSections: { fresh })
+            let refresh = StartupContentPrefetcher.homeRefreshAfterPlaybackWrite()
+            let received = expectation(description: "Home refresh after \(contentId) progress write")
+            let observer = NotificationCenter.default.addObserver(
+                forName: .homeSectionsShouldRefresh, object: nil, queue: .main
+            ) { _ in
+                MainActor.assumeIsolated {
+                    let cached: SectionsResponse? = ResponseCache.shared.get(CacheKey.homeSections)
+                    XCTAssertNil(cached, "Invalidate stale cache before notifying the visible Home view")
+                    Task { @MainActor in
+                        await model.loadSections()
+                        received.fulfill()
+                    }
+                }
+            }
+            defer {
+                NotificationCenter.default.removeObserver(observer)
+                ResponseCache.shared.remove(CacheKey.homeSections)
+            }
+            // Capturing the completion must not refresh before the write.
+            XCTAssertEqual(model.sections.first?.items.first?.contentId, "episode-one")
+            XCTAssertNotNil(ResponseCache.shared.get(CacheKey.homeSections, as: SectionsResponse.self))
+            refresh()
+            await fulfillment(of: [received], timeout: 2)
+            XCTAssertEqual(model.sections.first?.items.first?.contentId, contentId)
+            XCTAssertEqual(model.sections.first?.items.first?.positionSeconds, Double(position))
+        }
+    }
+
+    @MainActor
+    func testLatePlaybackWriteCannotInvalidateAnotherProfileHome() throws {
+        let refresh = StartupContentPrefetcher.homeRefreshAfterPlaybackWrite()
+        StartupContentPrefetcher.resetProfileScopedPrefetches()
+        let current = SectionsResponse(sections: [makeSection(
+            id: "new-profile", type: "continue_watching", totalCount: 1,
+            items: [try makeItem(contentId: "new-profile-item")]
+        )])
+        ResponseCache.shared.set(current, for: CacheKey.homeSections)
+        var notifications = 0
+        let observer = NotificationCenter.default.addObserver(
+            forName: .homeSectionsShouldRefresh, object: nil, queue: .main
+        ) { _ in MainActor.assumeIsolated { notifications += 1 } }
+        defer {
+            NotificationCenter.default.removeObserver(observer)
+            ResponseCache.shared.remove(CacheKey.homeSections)
+        }
+        refresh()
+        XCTAssertEqual(notifications, 0)
+        let cached: SectionsResponse? = ResponseCache.shared.get(CacheKey.homeSections)
+        XCTAssertEqual(cached?.sections.first?.items.first?.contentId, "new-profile-item")
+    }
+
     private func makeItem(contentId: String) throws -> SectionItem {
         let json = """
         {

--- a/iosApp/Tests/HorizontalMediaRailTests.swift
+++ b/iosApp/Tests/HorizontalMediaRailTests.swift
@@ -1,0 +1,142 @@
+import SwiftUI
+import UIKit
+import XCTest
+@testable import Silo
+
+@MainActor
+final class HorizontalMediaRailTests: XCTestCase {
+    private final class Frames {
+        var cards: [String: CGRect] = [:]
+    }
+
+    private final class ScrollDelegate: NSObject, UIScrollViewDelegate {}
+
+    private func scrollViews(in view: UIView) -> [UIScrollView] {
+        (view as? UIScrollView).map { [$0] } ?? view.subviews.flatMap { scrollViews(in: $0) }
+    }
+
+    private func allScrollViews(in view: UIView) -> [UIScrollView] {
+        let current = (view as? UIScrollView).map { [$0] } ?? []
+        return current + view.subviews.flatMap { allScrollViews(in: $0) }
+    }
+
+    private func makeWindow<Content: View>(_ content: Content) -> UIWindow {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.windowScene = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first
+        window.rootViewController = UIHostingController(rootView: content)
+        window.isHidden = false
+        return window
+    }
+
+    private func settle(_ window: UIWindow) async throws {
+        window.layoutIfNeeded()
+        try await Task.sleep(for: .milliseconds(100))
+        window.layoutIfNeeded()
+    }
+
+    private func items() throws -> [SectionItem] {
+        try JSONDecoder().decode([SectionItem].self, from: Data(#"""
+        [
+          {"contentId":"fixture-movie","type":"movie","title":"A sample movie","year":2026,"positionSeconds":600,"durationSeconds":6000},
+          {"contentId":"fixture-episode","type":"episode","title":"Another chapter","seriesTitle":"A sample series","seasonNumber":1,"episodeNumber":2}
+        ]
+        """#.utf8))
+    }
+
+    func testNativeBoundsAffectOnlyTheNearestRail() {
+        let page = UIScrollView()
+        page.alwaysBounceVertical = true
+        let rail = UIScrollView()
+        rail.alwaysBounceHorizontal = true
+        rail.alwaysBounceVertical = true
+        rail.decelerationRate = .fast
+        rail.isPagingEnabled = true
+        rail.contentSize = CGSize(width: 1800, height: 200)
+        rail.contentOffset = CGPoint(x: 120, y: 0)
+        let delegate = ScrollDelegate()
+        rail.delegate = delegate
+        let content = UIView()
+        page.addSubview(rail)
+        rail.addSubview(content)
+        content.addSubview(PhoneMediaRailBoundsView())
+
+        XCTAssertFalse(rail.bouncesHorizontally)
+        XCTAssertFalse(rail.bouncesVertically)
+        XCTAssertFalse(rail.alwaysBounceHorizontal)
+        XCTAssertFalse(rail.alwaysBounceVertical)
+        XCTAssertTrue(rail.isDirectionalLockEnabled)
+        XCTAssertTrue(rail.isScrollEnabled)
+        XCTAssertTrue(rail.isPagingEnabled)
+        XCTAssertEqual(rail.decelerationRate, .fast)
+        XCTAssertEqual(rail.contentOffset.x, 120)
+        XCTAssertTrue(rail.delegate === delegate)
+        XCTAssertTrue(page.bouncesVertically)
+        XCTAssertTrue(page.alwaysBounceVertical)
+        XCTAssertFalse(page.isDirectionalLockEnabled)
+    }
+
+    func testContinueWatchingKeepsEqualCardHeightsWithMissingProgress() async throws {
+        let items = try items()
+        XCTAssertNotNil(HomeFeedMeta.resumeCaption(for: items[0]))
+        XCTAssertNil(HomeFeedMeta.resumeCaption(for: items[1]))
+        for typeSize in [DynamicTypeSize.large, .accessibility1] {
+            let frames = Frames()
+            let content = HStack(alignment: HorizontalMediaRailLayout.cardAlignment, spacing: 10) {
+                ForEach(items) { item in
+                    HomeStillCard(item: item, width: 170)
+                        .onGeometryChange(for: CGRect.self) { $0.frame(in: .named("cards")) } action: {
+                            frames.cards[item.contentId] = $0
+                        }
+                }
+            }
+            .coordinateSpace(name: "cards")
+            .environment(AppRouter())
+            .environmentObject(OverlayPrefsStore())
+            .environment(\.dynamicTypeSize, typeSize)
+            let window = makeWindow(content)
+            defer { window.isHidden = true; window.rootViewController = nil }
+            try await settle(window)
+            let movie = try XCTUnwrap(frames.cards[items[0].contentId])
+            let episode = try XCTUnwrap(frames.cards[items[1].contentId])
+            XCTAssertGreaterThan(movie.height, 100)
+            XCTAssertEqual(movie.minY, episode.minY, accuracy: 0.5)
+            XCTAssertEqual(movie.height, episode.height, accuracy: 0.5)
+        }
+    }
+
+    func testRealHomeRowsUseNativeBoundsWithoutDisablingThePageBounce() async throws {
+        let items = try items()
+        let posters = try (0..<6).map { index in
+            try JSONDecoder().decode(SectionItem.self, from: Data(
+                "{\"contentId\":\"fixture-poster-\(index)\",\"type\":\"movie\",\"title\":\"Sample \(index)\"}".utf8
+            ))
+        }
+        let rows = ["continue_watching", "trending"].map { kind in
+            ResolvedSection(id: kind, sectionType: kind, title: "Synthetic \(kind)",
+                            featured: nil, itemLimit: nil, totalCount: nil,
+                            isCustom: nil, customized: nil,
+                            items: kind == "continue_watching" ? items : posters)
+        }
+        let window = makeWindow(ScrollView(.vertical) {
+            VStack {
+                ForEach(rows) { HomeFeedRow(section: $0) }
+                Color.clear.frame(height: 1000)
+            }
+        }.environment(AppRouter()).environmentObject(OverlayPrefsStore()))
+        defer { window.isHidden = true; window.rootViewController = nil }
+        try await settle(window)
+        let page = try XCTUnwrap(scrollViews(in: window).first)
+        let rails = allScrollViews(in: page).filter { $0 !== page }
+        XCTAssertEqual(rails.count, 2)
+        XCTAssertTrue(page.bouncesVertically)
+        XCTAssertEqual(HorizontalMediaRailLayout.scrollAnchor, .leading)
+        XCTAssertEqual(HorizontalMediaRailLayout.cardAlignment, .top)
+        for rail in rails {
+            XCTAssertFalse(rail.bouncesHorizontally)
+            XCTAssertFalse(rail.bouncesVertically)
+            XCTAssertTrue(rail.isScrollEnabled)
+            XCTAssertTrue(rail.isDirectionalLockEnabled)
+            XCTAssertEqual(rail.contentOffset.x, -rail.adjustedContentInset.left, accuracy: 1)
+        }
+    }
+}

--- a/iosApp/Tests/HorizontalMediaRailTests.swift
+++ b/iosApp/Tests/HorizontalMediaRailTests.swift
@@ -83,7 +83,7 @@ final class HorizontalMediaRailTests: XCTestCase {
             let frames = Frames()
             let content = HStack(alignment: HorizontalMediaRailLayout.cardAlignment, spacing: 10) {
                 ForEach(items) { item in
-                    HomeStillCard(item: item, width: 170)
+                    HomeStillCard(item: item, width: 170, opensResumeContext: true)
                         .onGeometryChange(for: CGRect.self) { $0.frame(in: .named("cards")) } action: {
                             frames.cards[item.contentId] = $0
                         }
@@ -101,6 +101,37 @@ final class HorizontalMediaRailTests: XCTestCase {
             XCTAssertGreaterThan(movie.height, 100)
             XCTAssertEqual(movie.minY, episode.minY, accuracy: 0.5)
             XCTAssertEqual(movie.height, episode.height, accuracy: 0.5)
+        }
+    }
+
+    func testOnlyContinueWatchingReservesAMissingResumeCaption() async throws {
+        for item in try items() {
+            let frames = Frames()
+            let content = HStack(alignment: .top, spacing: 10) {
+                HomeStillCard(item: item, width: 170)
+                    .onGeometryChange(for: CGRect.self) { $0.frame(in: .named("cards")) } action: {
+                        frames.cards["ordinary"] = $0
+                    }
+                HomeStillCard(item: item, width: 170, opensResumeContext: true)
+                    .onGeometryChange(for: CGRect.self) { $0.frame(in: .named("cards")) } action: {
+                        frames.cards["resume"] = $0
+                    }
+            }
+            .coordinateSpace(name: "cards")
+            .environment(AppRouter())
+            .environmentObject(OverlayPrefsStore())
+            let window = makeWindow(content)
+            defer { window.isHidden = true; window.rootViewController = nil }
+            try await settle(window)
+            let ordinary = try XCTUnwrap(frames.cards["ordinary"])
+            let resume = try XCTUnwrap(frames.cards["resume"])
+            if HomeFeedMeta.resumeCaption(for: item) == nil {
+                XCTAssertGreaterThan(resume.height, ordinary.height + 5,
+                                     "Next Up must not reserve an invisible Continue Watching caption")
+            } else {
+                XCTAssertEqual(resume.height, ordinary.height, accuracy: 0.5,
+                               "A visible progress caption must remain on either card")
+            }
         }
     }
 

--- a/iosApp/Tests/HorizontalMediaRailTests.swift
+++ b/iosApp/Tests/HorizontalMediaRailTests.swift
@@ -104,7 +104,7 @@ final class HorizontalMediaRailTests: XCTestCase {
         }
     }
 
-    func testRealHomeRowsUseNativeBoundsWithoutDisablingThePageBounce() async throws {
+    func testRealHomeRowsKeepTheirBoundsAndPositionAfterDetailReturn() async throws {
         let items = try items()
         let posters = try (0..<6).map { index in
             try JSONDecoder().decode(SectionItem.self, from: Data(
@@ -117,12 +117,13 @@ final class HorizontalMediaRailTests: XCTestCase {
                             isCustom: nil, customized: nil,
                             items: kind == "continue_watching" ? items : posters)
         }
+        let router = AppRouter()
         let window = makeWindow(ScrollView(.vertical) {
             VStack {
                 ForEach(rows) { HomeFeedRow(section: $0) }
                 Color.clear.frame(height: 1000)
             }
-        }.environment(AppRouter()).environmentObject(OverlayPrefsStore()))
+        }.environment(router).environmentObject(OverlayPrefsStore()))
         defer { window.isHidden = true; window.rootViewController = nil }
         try await settle(window)
         let page = try XCTUnwrap(scrollViews(in: window).first)
@@ -137,6 +138,22 @@ final class HorizontalMediaRailTests: XCTestCase {
             XCTAssertTrue(rail.isScrollEnabled)
             XCTAssertTrue(rail.isDirectionalLockEnabled)
             XCTAssertEqual(rail.contentOffset.x, -rail.adjustedContentInset.left, accuracy: 1)
+        }
+        let posterRail = try XCTUnwrap(rails.max(by: { $0.contentSize.width < $1.contentSize.width }))
+        for offset in [-posterRail.adjustedContentInset.left, 142 - posterRail.adjustedContentInset.left] {
+            posterRail.setContentOffset(CGPoint(x: offset, y: 0), animated: false)
+            try await settle(window)
+            let before = posterRail.contentOffset.x
+            router.presentItemDetail(contentId: posters[4].contentId, browseSource: ItemDetailBrowseSource(
+                originID: "home:trending", contentIDs: posters.map(\.contentId)
+            ))
+            try await settle(window)
+            XCTAssertEqual(posterRail.contentOffset.x, before, accuracy: 1)
+            router.dismissItemDetail()
+            try await settle(window)
+            XCTAssertEqual(posterRail.contentOffset.x, before, accuracy: 1)
+            XCTAssertFalse(posterRail.bouncesHorizontally)
+            XCTAssertTrue(page.bouncesVertically)
         }
     }
 }

--- a/iosApp/Tests/PlayerNextUpCompletionPolicyTests.swift
+++ b/iosApp/Tests/PlayerNextUpCompletionPolicyTests.swift
@@ -2,6 +2,36 @@ import XCTest
 @testable import Silo
 
 final class PlayerNextUpCompletionPolicyTests: XCTestCase {
+    func testAlreadyPlayingOrLoadingCandidateOnlyExpands() {
+        XCTAssertEqual(
+            PlayerNextUpPlaybackAction.resolve(candidateId: "episode-b", currentId: "episode-b"),
+            .expand
+        )
+    }
+
+    func testEarlyNextAndRepeatedCountdownProduceOneLoad() {
+        var currentId = "episode-a"
+        var loads = 0
+        for _ in 0..<100 {
+            switch PlayerNextUpPlaybackAction.resolve(candidateId: "episode-b", currentId: currentId) {
+            case .load(let id):
+                loads += 1
+                // beginFreshLoad sets lastLoadRequest synchronously, before awaits.
+                currentId = id
+            case .expand, .unavailable:
+                break
+            }
+        }
+        XCTAssertEqual(loads, 1)
+    }
+
+    func testMissingCandidateDoesNotReloadCurrentEpisode() {
+        XCTAssertEqual(
+            PlayerNextUpPlaybackAction.resolve(candidateId: nil, currentId: "episode-a"),
+            .unavailable
+        )
+    }
+
     func testEarlyManualPresentationPreservesCurrentPosition() {
         let position = PlayerNextUpCompletionPolicy.progressPosition(
             isNextUpPresented: true,

--- a/iosApp/Tests/PlayerNextUpCompletionPolicyTests.swift
+++ b/iosApp/Tests/PlayerNextUpCompletionPolicyTests.swift
@@ -18,7 +18,7 @@ final class PlayerNextUpCompletionPolicyTests: XCTestCase {
                 loads += 1
                 // beginFreshLoad sets lastLoadRequest synchronously, before awaits.
                 currentId = id
-            case .expand, .unavailable:
+            case .expand, .unavailable, .waitForPicture:
                 break
             }
         }
@@ -29,6 +29,21 @@ final class PlayerNextUpCompletionPolicyTests: XCTestCase {
         XCTAssertEqual(
             PlayerNextUpPlaybackAction.resolve(candidateId: nil, currentId: "episode-a"),
             .unavailable
+        )
+    }
+
+    func testEarlyRepeatedPlayNowWaitsForTheSuccessorsPicture() {
+        for candidate in ["episode-b", "episode-c", nil] {
+            XCTAssertEqual(
+                PlayerNextUpPlaybackAction.resolve(
+                    candidateId: candidate, currentId: "episode-b", awaitingPicture: true
+                ),
+                .waitForPicture
+            )
+        }
+        XCTAssertEqual(
+            PlayerNextUpPlaybackAction.resolve(candidateId: "episode-b", currentId: "episode-b"),
+            .expand
         )
     }
 

--- a/iosApp/Tests/PlayerSurfaceLayoutTests.swift
+++ b/iosApp/Tests/PlayerSurfaceLayoutTests.swift
@@ -10,6 +10,7 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
     @Observable final class Presentation {
         var preview = false
         var hasPreviewBounds = true
+        var viewport: CGSize?
     }
 
     private struct Harness: View {
@@ -48,6 +49,7 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
                     }
                 }
             }
+            .frame(width: presentation.viewport?.width, height: presentation.viewport?.height)
             .transaction { $0.disablesAnimations = reduceMotion }
         }
     }
@@ -236,6 +238,26 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(player.currentTime().seconds, position)
         XCTAssertEqual(itemChanges, 0)
         attachFrame("After expansion - same synthetic video item")
+
+        // The rotation pill changes scene geometry, not playback. Exercise
+        // both resulting viewport shapes on the live native video surface.
+        // Actual UIKit rotation/button delivery is checked interactively.
+        for size in [CGSize(width: 390, height: 844), CGSize(width: 844, height: 390)] {
+            let previousPosition = player.currentTime().seconds
+            presentation.viewport = size
+            try await settle(window)
+            XCTAssertTrue(surfaces(in: window).first === surface)
+            XCTAssertTrue(engine.currentAVPlayer === player)
+            XCTAssertTrue(player.currentItem === item)
+            XCTAssertTrue(layer.superlayer === surface.layer)
+            XCTAssertTrue(layer.isReadyForDisplay)
+            XCTAssertEqual(surface.bounds.width, size.width, accuracy: 1)
+            XCTAssertEqual(surface.bounds.height, size.height, accuracy: 1)
+            XCTAssertGreaterThanOrEqual(player.currentTime().seconds, previousPosition)
+            XCTAssertEqual(itemChanges, 0)
+        }
+        presentation.viewport = nil
+        try await settle(window)
 
         engine.pause()
         let pausedPosition = player.currentTime().seconds

--- a/iosApp/Tests/PlayerSurfaceLayoutTests.swift
+++ b/iosApp/Tests/PlayerSurfaceLayoutTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 @MainActor
 final class PlayerSurfaceLayoutTests: XCTestCase {
-    @Observable private final class Presentation {
+    @Observable final class Presentation {
         var preview = false
         var hasPreviewBounds = true
     }

--- a/iosApp/Tests/PlayerSurfaceLayoutTests.swift
+++ b/iosApp/Tests/PlayerSurfaceLayoutTests.swift
@@ -17,6 +17,7 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
         let engine: AetherEngine
         var legacy = false
         var reduceMotion = true
+        var nextUpModel: PlayerViewModel?
 
         var body: some View {
             Group {
@@ -34,7 +35,9 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
                     } content: {
                         ZStack {
                             Color.black.ignoresSafeArea()
-                            if presentation.preview && presentation.hasPreviewBounds {
+                            if presentation.preview, let nextUpModel {
+                                PlayerNextUpScreen(viewModel: nextUpModel, onBack: {})
+                            } else if presentation.preview && presentation.hasPreviewBounds {
                                 Color.clear
                                     .frame(width: 240, height: 135)
                                     .anchorPreference(key: PlayerPreviewBoundsKey.self, value: .bounds) {
@@ -75,7 +78,19 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
         var panel = CGRect.zero
     }
 
+    private func nextUpFixture() throws -> PlayerViewModel {
+        let episode = try JSONDecoder().decode(EpisodeListItem.self, from: Data(
+            #"{"contentId":"synthetic-episode-b","seasonNumber":1,"episodeNumber":2,"title":"The next chapter"}"#.utf8
+        ))
+        let model = PlayerViewModel()
+        model.nextUpEpisode = PlayerNextUpEpisode(episode: episode, seriesId: "synthetic-series", seriesTitle: "Playback regression fixture")
+        model.nextUpCountdownSeconds = 5
+        return model
+    }
+
     func testMobileActionsStayVisibleBesideOrBelowTheSmallerPreview() async throws {
+        let model = try nextUpFixture()
+        defer { model.cleanup() }
         for size in [CGSize(width: 568, height: 320), CGSize(width: 844, height: 390),
                      CGSize(width: 390, height: 844), CGSize(width: 1024, height: 768)] {
             let frames = MobileFrames()
@@ -83,9 +98,9 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
                 Color.black.aspectRatio(16 / 9, contentMode: .fit)
                     .onGeometryChange(for: CGRect.self) { $0.frame(in: .named("mobile-layout")) } action: { frames.preview = $0 }
             } panel: {
-                // Reserve more than the compact metadata + two action rows
-                // need, with a long On Deck shelf competing for space below.
-                Color.blue.frame(height: 240)
+                // Measure the real production metadata/buttons, with a long
+                // On Deck shelf competing for the remaining space below.
+                PlayerNextUpScreen(viewModel: model, onBack: {}).mobileNextUpPanel
                     .onGeometryChange(for: CGRect.self) { $0.frame(in: .named("mobile-layout")) } action: { frames.panel = $0 }
             } extras: {
                 Color.gray.frame(height: 1000)
@@ -95,6 +110,13 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
             defer { window.isHidden = true; window.rootViewController = nil }
             try await settle(window)
             print("Mobile layout \(size): preview=\(frames.preview), actions=\(frames.panel)")
+            let snapshot = UIGraphicsImageRenderer(bounds: window.bounds).image { _ in
+                window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
+            }
+            let attachment = XCTAttachment(image: snapshot)
+            attachment.name = "Next Up controls \(Int(size.width))x\(Int(size.height))"
+            attachment.lifetime = .keepAlways
+            add(attachment)
             XCTAssertGreaterThan(frames.panel.height, 0)
             XCTAssertGreaterThanOrEqual(frames.panel.minY, 0)
             XCTAssertLessThanOrEqual(frames.panel.maxY, size.height)
@@ -165,8 +187,9 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
         let engine = try AetherEngine()
         let presentation = Presentation()
         presentation.preview = true
-        let window = makeWindow(Harness(presentation: presentation, engine: engine, reduceMotion: false))
-        defer { window.isHidden = true; window.rootViewController = nil; engine.stop() }
+        let model = try nextUpFixture()
+        let window = makeWindow(Harness(presentation: presentation, engine: engine, reduceMotion: false, nextUpModel: model))
+        defer { window.isHidden = true; window.rootViewController = nil; engine.stop(); model.cleanup() }
         try await settle(window)
         let surface = try XCTUnwrap(surfaces(in: window).first)
         let url = try XCTUnwrap(Bundle(for: Self.self).url(forResource: "v3_h264_aac", withExtension: "mp4"))

--- a/iosApp/Tests/PlayerSurfaceLayoutTests.swift
+++ b/iosApp/Tests/PlayerSurfaceLayoutTests.swift
@@ -110,9 +110,12 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
             defer { window.isHidden = true; window.rootViewController = nil }
             try await settle(window)
             print("Mobile layout \(size): preview=\(frames.preview), actions=\(frames.panel)")
-            let snapshot = UIGraphicsImageRenderer(bounds: window.bounds).image { _ in
-                window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
-            }
+            // Render the requested viewport, not the host simulator's fixed
+            // window size (which would crop portrait/iPad proof images).
+            let renderer = ImageRenderer(content: layout
+                .frame(width: size.width, height: size.height)
+                .coordinateSpace(name: "mobile-layout").ignoresSafeArea())
+            let snapshot = try XCTUnwrap(renderer.uiImage)
             let attachment = XCTAttachment(image: snapshot)
             attachment.name = "Next Up controls \(Int(size.width))x\(Int(size.height))"
             attachment.lifetime = .keepAlways
@@ -208,6 +211,16 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
             try await Task.sleep(for: .milliseconds(50))
         }
         XCTAssertTrue(layer.isReadyForDisplay, "The synthetic video must actually have a picture before expansion")
+        func attachFrame(_ name: String) {
+            let snapshot = UIGraphicsImageRenderer(bounds: window.bounds).image { _ in
+                window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
+            }
+            let attachment = XCTAttachment(image: snapshot)
+            attachment.name = name
+            attachment.lifetime = .keepAlways
+            add(attachment)
+        }
+        attachFrame("Before expansion - playing synthetic preview")
         let position = player.currentTime().seconds
         var itemChanges = 0
         let observation = player.publisher(for: \.currentItem, options: [.new]).sink { _ in itemChanges += 1 }
@@ -222,6 +235,7 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
         XCTAssertTrue(layer.isReadyForDisplay)
         XCTAssertGreaterThanOrEqual(player.currentTime().seconds, position)
         XCTAssertEqual(itemChanges, 0)
+        attachFrame("After expansion - same synthetic video item")
 
         engine.pause()
         let pausedPosition = player.currentTime().seconds

--- a/iosApp/Tests/PlayerSurfaceLayoutTests.swift
+++ b/iosApp/Tests/PlayerSurfaceLayoutTests.swift
@@ -79,6 +79,15 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
         var preview = CGRect.zero
         var panel = CGRect.zero
         var rotation = CGRect.zero
+        var viewport = CGRect.zero
+        var extrasAppeared = false
+    }
+
+    private struct MeasuredFramesKey: PreferenceKey {
+        static var defaultValue: [String: CGRect] { [:] }
+        static func reduce(value: inout [String: CGRect], nextValue: () -> [String: CGRect]) {
+            value.merge(nextValue(), uniquingKeysWith: { _, new in new })
+        }
     }
 
     private func nextUpFixture() throws -> PlayerViewModel {
@@ -91,7 +100,7 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
         return model
     }
 
-    func testMobileActionsStayVisibleBesideOrBelowTheSmallerPreview() async throws {
+    func testMobileActionsStayBelowThePreviewAndFitBothOrientations() async throws {
         let model = try nextUpFixture()
         defer { model.cleanup() }
         for size in [CGSize(width: 568, height: 320), CGSize(width: 844, height: 390),
@@ -101,12 +110,12 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
                 Color.black.aspectRatio(16 / 9, contentMode: .fit)
                     .onGeometryChange(for: CGRect.self) { $0.frame(in: .named("mobile-layout")) } action: { frames.preview = $0 }
             } panel: { compact in
-                // Measure the real production metadata/buttons, with a long
-                // On Deck shelf competing for the remaining space below.
+                // Measure the real production metadata/buttons.
                 PlayerNextUpScreen(viewModel: model, onBack: {}).mobileNextUpPanel(compact: compact)
                     .onGeometryChange(for: CGRect.self) { $0.frame(in: .named("mobile-layout")) } action: { frames.panel = $0 }
             } extras: {
                 Color.gray.frame(height: 1000)
+                    .onAppear { frames.extrasAppeared = true }
             }
             let viewport = layout
                 .frame(width: size.width, height: size.height - MobilePlayerRotationControls.topClearance)
@@ -129,13 +138,76 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
             XCTAssertGreaterThanOrEqual(frames.panel.minY, MobilePlayerRotationControls.topClearance)
             XCTAssertLessThanOrEqual(frames.panel.maxY, size.height)
             XCTAssertLessThanOrEqual(frames.panel.maxX, size.width)
-            if size.width > size.height {
-                XCTAssertGreaterThan(frames.panel.minX, frames.preview.maxX)
-            } else {
-                XCTAssertGreaterThan(frames.panel.minY, frames.preview.maxY)
-                XCTAssertLessThanOrEqual(frames.preview.width, 260)
-            }
+            XCTAssertGreaterThan(frames.panel.minY, frames.preview.maxY)
+            XCTAssertGreaterThan(frames.preview.height, 30)
+            XCTAssertLessThanOrEqual(frames.preview.width, 300)
+            XCTAssertEqual(frames.preview.midX, frames.panel.midX, accuracy: 1)
+            XCTAssertFalse(frames.extrasAppeared, "iOS must not mount an On Deck shelf")
         }
+    }
+
+    func testFullNextUpScreenFitsArtworkAndPopulatedOnDeckDataThroughRepeatedRotation() async throws {
+        let model = try nextUpFixture()
+        // A non-nil still exercises the complete background-artwork branch.
+        // Empty URL paints its placeholder without contacting any server.
+        let episode = try JSONDecoder().decode(EpisodeListItem.self, from: Data(
+            #"{"contentId":"synthetic-episode","seasonNumber":1,"episodeNumber":2,"title":"A longer episode title for a narrow screen","stillUrl":""}"#.utf8
+        ))
+        model.nextUpEpisode = PlayerNextUpEpisode(episode: episode, seriesId: "fixture", seriesTitle: "Synthetic series title")
+        model.nextUpOnDeckItems = try (0..<8).map { index in
+            let item = try JSONDecoder().decode(SectionItem.self, from: Data(
+                "{\"contentId\":\"fixture-deck-\(index)\",\"type\":\"movie\",\"title\":\"On Deck fixture \(index)\"}".utf8
+            ))
+            return PlayerOnDeckItem(item: item)
+        }
+        let state = Presentation()
+        state.viewport = CGSize(width: 390, height: 844)
+        let frames = MobileFrames()
+        let viewport = FullNextUpHarness(presentation: state, model: model)
+            .overlayPreferenceValue(PlayerPreviewBoundsKey.self) { anchors in
+                GeometryReader { proxy in
+                    Color.clear.preference(key: MeasuredFramesKey.self, value: [
+                        "preview": anchors.bounds.map { proxy[$0] } ?? .zero,
+                        "panel": anchors.actions.map { proxy[$0] } ?? .zero,
+                        "viewport": CGRect(origin: .zero, size: proxy.size)
+                    ])
+                }
+            }
+            .onPreferenceChange(MeasuredFramesKey.self) { value in
+                frames.preview = value["preview"] ?? .zero
+                frames.panel = value["panel"] ?? .zero
+                frames.viewport = value["viewport"] ?? .zero
+            }
+        let window = makeWindow(viewport)
+        defer { window.isHidden = true; window.rootViewController = nil; model.cleanup() }
+        for size in [CGSize(width: 390, height: 844), CGSize(width: 844, height: 390),
+                     CGSize(width: 568, height: 320), CGSize(width: 390, height: 844),
+                     CGSize(width: 844, height: 390), CGSize(width: 1024, height: 768)] {
+            state.viewport = size
+            try await settle(window)
+            XCTAssertGreaterThan(frames.preview.height, 30)
+            XCTAssertGreaterThan(frames.panel.height, 0)
+            XCTAssertGreaterThan(frames.panel.minY, frames.preview.maxY)
+            XCTAssertGreaterThanOrEqual(frames.preview.minY, MobilePlayerRotationControls.topClearance)
+            XCTAssertGreaterThanOrEqual(frames.panel.minX, 0)
+            XCTAssertLessThanOrEqual(frames.panel.maxX, frames.viewport.width + 1)
+            XCTAssertLessThanOrEqual(frames.panel.maxY, frames.viewport.height + 1)
+            XCTAssertEqual(frames.preview.midX, frames.panel.midX, accuracy: 1)
+            XCTAssertFalse(hasScrollView(in: window), "On Deck must not render on iOS")
+        }
+    }
+
+    private struct FullNextUpHarness: View {
+        let presentation: Presentation
+        let model: PlayerViewModel
+        var body: some View {
+            PlayerNextUpScreen(viewModel: model, onBack: {})
+                .frame(width: presentation.viewport?.width, height: presentation.viewport?.height)
+        }
+    }
+
+    private func hasScrollView(in view: UIView) -> Bool {
+        view is UIScrollView || view.subviews.contains { hasScrollView(in: $0) }
     }
 
     func testPersistentRotationPillKeepsItsSizeAndTopRightPosition() async throws {
@@ -262,6 +334,21 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
         var itemChanges = 0
         let observation = player.publisher(for: \.currentItem, options: [.new]).sink { _ in itemChanges += 1 }
         defer { observation.cancel() }
+        // Resize the actual playing Next Up screen before expanding it, not
+        // just an isolated panel. The preview must remain the same ready layer.
+        for size in [CGSize(width: 390, height: 844), CGSize(width: 844, height: 390),
+                     CGSize(width: 390, height: 844)] {
+            presentation.viewport = size
+            try await settle(window)
+            XCTAssertTrue(surfaces(in: window).first === surface)
+            XCTAssertTrue(engine.currentAVPlayer === player)
+            XCTAssertTrue(player.currentItem === item)
+            XCTAssertTrue(layer.superlayer === surface.layer)
+            XCTAssertTrue(layer.isReadyForDisplay)
+            XCTAssertGreaterThan(surface.bounds.height, 30)
+            XCTAssertEqual(itemChanges, 0)
+        }
+        presentation.viewport = nil
         presentation.preview = false
         try await settle(window)
         try await Task.sleep(for: .milliseconds(350))

--- a/iosApp/Tests/PlayerSurfaceLayoutTests.swift
+++ b/iosApp/Tests/PlayerSurfaceLayoutTests.swift
@@ -81,19 +81,20 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
             let frames = MobileFrames()
             let layout = PlayerNextUpMobileLayout {
                 Color.black.aspectRatio(16 / 9, contentMode: .fit)
-                    .onGeometryChange(for: CGRect.self) { $0.frame(in: .global) } action: { frames.preview = $0 }
+                    .onGeometryChange(for: CGRect.self) { $0.frame(in: .named("mobile-layout")) } action: { frames.preview = $0 }
             } panel: {
                 // Reserve more than the compact metadata + two action rows
                 // need, with a long On Deck shelf competing for space below.
                 Color.blue.frame(height: 240)
-                    .onGeometryChange(for: CGRect.self) { $0.frame(in: .global) } action: { frames.panel = $0 }
+                    .onGeometryChange(for: CGRect.self) { $0.frame(in: .named("mobile-layout")) } action: { frames.panel = $0 }
             } extras: {
                 Color.gray.frame(height: 1000)
             }
-            let window = makeWindow(layout, attachToScene: false)
-            window.frame = CGRect(origin: .zero, size: size)
+            let window = makeWindow(layout.frame(width: size.width, height: size.height)
+                .coordinateSpace(name: "mobile-layout").ignoresSafeArea())
             defer { window.isHidden = true; window.rootViewController = nil }
             try await settle(window)
+            print("Mobile layout \(size): preview=\(frames.preview), actions=\(frames.panel)")
             XCTAssertGreaterThan(frames.panel.height, 0)
             XCTAssertGreaterThanOrEqual(frames.panel.minY, 0)
             XCTAssertLessThanOrEqual(frames.panel.maxY, size.height)
@@ -169,7 +170,12 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
         try await settle(window)
         let surface = try XCTUnwrap(surfaces(in: window).first)
         let url = try XCTUnwrap(Bundle(for: Self.self).url(forResource: "v3_h264_aac", withExtension: "mp4"))
-        try await engine.load(url: url)
+        // Hosted CI simulators report no VideoToolbox hardware decoder and
+        // the normal probe chooses software. Use the native URL route to
+        // exercise AVPlayer/layer retention with the same local MP4 fixture.
+        var options = LoadOptions()
+        options.nativeRemoteHLS = true
+        try await engine.load(url: url, options: options)
         engine.play()
         let player = try XCTUnwrap(engine.currentAVPlayer)
         let item = try XCTUnwrap(player.currentItem)
@@ -214,7 +220,7 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
         presentation.hasPreviewBounds = false
         presentation.preview = true
         engine.prepareForItemReplacement()
-        try await engine.load(url: url)
+        try await engine.load(url: url, options: options)
         presentation.hasPreviewBounds = true
         engine.play()
         let successorDeadline = ContinuousClock.now + .seconds(15)

--- a/iosApp/Tests/PlayerSurfaceLayoutTests.swift
+++ b/iosApp/Tests/PlayerSurfaceLayoutTests.swift
@@ -217,7 +217,7 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
             let frames = MobileFrames()
             let viewport = Color.black
                 .overlay(alignment: .topTrailing) {
-                    MobilePlayerRotationControls(orientationCoordinator: .shared)
+                    MobilePlayerRotationControls(orientationCoordinator: .shared, isVisible: true)
                         .onGeometryChange(for: CGRect.self) {
                             $0.frame(in: .named("rotation-layout"))
                         } action: { frames.rotation = $0 }

--- a/iosApp/Tests/PlayerSurfaceLayoutTests.swift
+++ b/iosApp/Tests/PlayerSurfaceLayoutTests.swift
@@ -45,7 +45,7 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
                     }
                 }
             }
-            .environment(\.accessibilityReduceMotion, reduceMotion)
+            .transaction { $0.disablesAnimations = reduceMotion }
         }
     }
 

--- a/iosApp/Tests/PlayerSurfaceLayoutTests.swift
+++ b/iosApp/Tests/PlayerSurfaceLayoutTests.swift
@@ -210,6 +210,38 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
         view is UIScrollView || view.subviews.contains { hasScrollView(in: $0) }
     }
 
+    func testPlayerGlassButtonsMatchTheDetailControlSize() async throws {
+        for size in [CGSize(width: 390, height: 844), CGSize(width: 844, height: 390)] {
+            let frames = MobileFrames()
+            let viewport = HStack {
+                Button {} label: {
+                    Image(systemName: "xmark").frame(width: ContinuumTheme.topBarIconHitSize)
+                }
+                .buttonStyle(MobilePlayerGlassButtonStyle())
+                .onGeometryChange(for: CGRect.self) { $0.frame(in: .named("button-sizing")) } action: { frames.preview = $0 }
+                Button {} label: {
+                    Label("Audio & Subtitles", systemImage: "captions.bubble").padding(.horizontal, 12)
+                }
+                .buttonStyle(MobilePlayerGlassButtonStyle())
+                .onGeometryChange(for: CGRect.self) { $0.frame(in: .named("button-sizing")) } action: { frames.panel = $0 }
+                Menu { Button("Auto") {} } label: { Image(systemName: "slider.horizontal.3") }
+                    .menuStyle(.button)
+                    .buttonStyle(MobilePlayerGlassButtonStyle())
+                    .onGeometryChange(for: CGRect.self) { $0.frame(in: .named("button-sizing")) } action: { frames.rotation = $0 }
+            }
+            .frame(width: size.width, height: size.height)
+            .coordinateSpace(name: "button-sizing")
+            let window = makeWindow(viewport)
+            defer { window.isHidden = true; window.rootViewController = nil }
+            try await settle(window)
+            XCTAssertEqual(frames.preview.width, 44, accuracy: 0.5)
+            for frame in [frames.preview, frames.panel, frames.rotation] {
+                XCTAssertEqual(frame.height, ContinuumTheme.topBarIconHitSize, accuracy: 0.5)
+                XCTAssertGreaterThanOrEqual(frame.width, ContinuumTheme.topBarIconHitSize)
+            }
+        }
+    }
+
     func testPersistentRotationPillKeepsItsSizeAndTopRightPosition() async throws {
         XCTAssertNotNil(UIImage(systemName: "rectangle.landscape.rotate"))
         for size in [CGSize(width: 390, height: 844), CGSize(width: 844, height: 390),

--- a/iosApp/Tests/PlayerSurfaceLayoutTests.swift
+++ b/iosApp/Tests/PlayerSurfaceLayoutTests.swift
@@ -60,12 +60,51 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
         window.layoutIfNeeded()
     }
 
-    private func makeWindow(_ harness: Harness) -> UIWindow {
+    private func makeWindow<Content: View>(_ content: Content, attachToScene: Bool = true) -> UIWindow {
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 844, height: 390))
-        window.windowScene = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first
-        window.rootViewController = UIHostingController(rootView: harness)
+        if attachToScene {
+            window.windowScene = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first
+        }
+        window.rootViewController = UIHostingController(rootView: content)
         window.isHidden = false
         return window
+    }
+
+    private final class MobileFrames {
+        var preview = CGRect.zero
+        var panel = CGRect.zero
+    }
+
+    func testMobileActionsStayVisibleBesideOrBelowTheSmallerPreview() async throws {
+        for size in [CGSize(width: 568, height: 320), CGSize(width: 844, height: 390),
+                     CGSize(width: 390, height: 844), CGSize(width: 1024, height: 768)] {
+            let frames = MobileFrames()
+            let layout = PlayerNextUpMobileLayout {
+                Color.black.aspectRatio(16 / 9, contentMode: .fit)
+                    .onGeometryChange(for: CGRect.self) { $0.frame(in: .global) } action: { frames.preview = $0 }
+            } panel: {
+                // Reserve more than the compact metadata + two action rows
+                // need, with a long On Deck shelf competing for space below.
+                Color.blue.frame(height: 240)
+                    .onGeometryChange(for: CGRect.self) { $0.frame(in: .global) } action: { frames.panel = $0 }
+            } extras: {
+                Color.gray.frame(height: 1000)
+            }
+            let window = makeWindow(layout, attachToScene: false)
+            window.frame = CGRect(origin: .zero, size: size)
+            defer { window.isHidden = true; window.rootViewController = nil }
+            try await settle(window)
+            XCTAssertGreaterThan(frames.panel.height, 0)
+            XCTAssertGreaterThanOrEqual(frames.panel.minY, 0)
+            XCTAssertLessThanOrEqual(frames.panel.maxY, size.height)
+            XCTAssertLessThanOrEqual(frames.panel.maxX, size.width)
+            if size.width > size.height {
+                XCTAssertGreaterThan(frames.panel.minX, frames.preview.maxX)
+            } else {
+                XCTAssertGreaterThan(frames.panel.minY, frames.preview.maxY)
+                XCTAssertLessThanOrEqual(frames.preview.width, 260)
+            }
+        }
     }
 
     func testTwentyPreviewCyclesKeepOneActualAetherView() async throws {

--- a/iosApp/Tests/PlayerSurfaceLayoutTests.swift
+++ b/iosApp/Tests/PlayerSurfaceLayoutTests.swift
@@ -1,0 +1,168 @@
+import AetherEngine
+import AVFoundation
+import Combine
+import SwiftUI
+import XCTest
+@testable import Silo
+
+@MainActor
+final class PlayerSurfaceLayoutTests: XCTestCase {
+    @Observable private final class Presentation {
+        var preview = false
+        var hasPreviewBounds = true
+    }
+
+    private struct Harness: View {
+        let presentation: Presentation
+        let engine: AetherEngine
+        var legacy = false
+        var reduceMotion = true
+
+        var body: some View {
+            Group {
+                if legacy {
+                    // Negative control: the two structural branches used by
+                    // PlayerView before this fix really do recreate the host.
+                    if presentation.preview {
+                        VStack { AetherPlayerSurface(engine: engine).frame(width: 240, height: 135) }
+                    } else {
+                        AetherPlayerSurface(engine: engine)
+                    }
+                } else {
+                    PlayerSurfaceLayout(isPreview: presentation.preview) {
+                        AetherPlayerSurface(engine: engine)
+                    } content: {
+                        ZStack {
+                            Color.black.ignoresSafeArea()
+                            if presentation.preview && presentation.hasPreviewBounds {
+                                Color.clear
+                                    .frame(width: 240, height: 135)
+                                    .anchorPreference(key: PlayerPreviewBoundsKey.self, value: .bounds) {
+                                        .init(bounds: $0)
+                                    }
+                            }
+                        }
+                    }
+                }
+            }
+            .environment(\.accessibilityReduceMotion, reduceMotion)
+        }
+    }
+
+    private func surfaces(in view: UIView) -> [AetherPlayerView] {
+        (view as? AetherPlayerView).map { [$0] } ?? view.subviews.flatMap { surfaces(in: $0) }
+    }
+
+    private func settle(_ window: UIWindow) async throws {
+        window.setNeedsLayout()
+        window.layoutIfNeeded()
+        try await Task.sleep(for: .milliseconds(40))
+        window.layoutIfNeeded()
+    }
+
+    private func makeWindow(_ harness: Harness) -> UIWindow {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 844, height: 390))
+        window.windowScene = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first
+        window.rootViewController = UIHostingController(rootView: harness)
+        window.isHidden = false
+        return window
+    }
+
+    func testTwentyPreviewCyclesKeepOneActualAetherView() async throws {
+        let engine = try AetherEngine()
+        let presentation = Presentation()
+        let window = makeWindow(Harness(presentation: presentation, engine: engine))
+        defer { window.isHidden = true; window.rootViewController = nil; engine.stop() }
+        try await settle(window)
+        let original = try XCTUnwrap(surfaces(in: window).first)
+        for _ in 0..<20 {
+            presentation.preview = true
+            try await settle(window)
+            XCTAssertEqual(surfaces(in: window).count, 1)
+            XCTAssertTrue(surfaces(in: window).first === original)
+            XCTAssertEqual(original.bounds.width, 240, accuracy: 1)
+            XCTAssertEqual(original.bounds.height, 135, accuracy: 1)
+            presentation.preview = false
+            try await settle(window)
+            XCTAssertTrue(surfaces(in: window).first === original)
+            XCTAssertGreaterThan(original.bounds.width, 240)
+        }
+        print("Preview lifecycle: 40 transitions, 1 Aether view, 0 replacements")
+    }
+
+    func testEarlyExpansionAndMissingPreviewGeometryKeepTheSurface() async throws {
+        let engine = try AetherEngine()
+        let presentation = Presentation()
+        let window = makeWindow(Harness(presentation: presentation, engine: engine))
+        defer { window.isHidden = true; window.rootViewController = nil; engine.stop() }
+        try await settle(window)
+        let original = try XCTUnwrap(surfaces(in: window).first)
+        presentation.hasPreviewBounds = false
+        presentation.preview = true
+        try await settle(window)
+        XCTAssertTrue(surfaces(in: window).first === original)
+        presentation.preview = false
+        presentation.preview = true
+        presentation.preview = false
+        try await settle(window)
+        XCTAssertEqual(surfaces(in: window).count, 1)
+        XCTAssertTrue(surfaces(in: window).first === original)
+    }
+
+    func testLegacyNegativeControlRecreatesTheVideoView() async throws {
+        let engine = try AetherEngine()
+        let presentation = Presentation()
+        let window = makeWindow(Harness(presentation: presentation, engine: engine, legacy: true))
+        defer { window.isHidden = true; window.rootViewController = nil; engine.stop() }
+        try await settle(window)
+        let original = try XCTUnwrap(surfaces(in: window).first)
+        presentation.preview = true
+        try await settle(window)
+        XCTAssertFalse(surfaces(in: window).first === original)
+    }
+
+    func testPlayingPreviewExpandsWithoutReplacingItemOrLosingItsLayer() async throws {
+        let engine = try AetherEngine()
+        let presentation = Presentation()
+        presentation.preview = true
+        let window = makeWindow(Harness(presentation: presentation, engine: engine, reduceMotion: false))
+        defer { window.isHidden = true; window.rootViewController = nil; engine.stop() }
+        try await settle(window)
+        let surface = try XCTUnwrap(surfaces(in: window).first)
+        let url = try XCTUnwrap(Bundle(for: Self.self).url(forResource: "v3_h264_aac", withExtension: "mp4"))
+        try await engine.load(url: url)
+        engine.play()
+        let player = try XCTUnwrap(engine.currentAVPlayer)
+        let item = try XCTUnwrap(player.currentItem)
+        let layer = try XCTUnwrap(surface.layer.sublayers?.compactMap { $0 as? AVPlayerLayer }.first)
+        let deadline = ContinuousClock.now + .seconds(15)
+        while !layer.isReadyForDisplay && ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        XCTAssertTrue(layer.isReadyForDisplay, "The synthetic video must actually have a picture before expansion")
+        let position = player.currentTime().seconds
+        var itemChanges = 0
+        let observation = player.publisher(for: \.currentItem, options: [.new]).sink { _ in itemChanges += 1 }
+        defer { observation.cancel() }
+        presentation.preview = false
+        try await settle(window)
+        try await Task.sleep(for: .milliseconds(350))
+        XCTAssertTrue(surfaces(in: window).first === surface)
+        XCTAssertTrue(engine.currentAVPlayer === player)
+        XCTAssertTrue(player.currentItem === item)
+        XCTAssertTrue(layer.superlayer === surface.layer)
+        XCTAssertTrue(layer.isReadyForDisplay)
+        XCTAssertGreaterThanOrEqual(player.currentTime().seconds, position)
+        XCTAssertEqual(itemChanges, 0)
+
+        engine.pause()
+        let pausedPosition = player.currentTime().seconds
+        presentation.preview = true
+        try await settle(window)
+        presentation.preview = false
+        try await settle(window)
+        XCTAssertEqual(player.rate, 0, "Resizing must not resume a paused preview")
+        XCTAssertEqual(player.currentTime().seconds, pausedPosition, accuracy: 0.1)
+        XCTAssertEqual(itemChanges, 0)
+    }
+}

--- a/iosApp/Tests/PlayerSurfaceLayoutTests.swift
+++ b/iosApp/Tests/PlayerSurfaceLayoutTests.swift
@@ -78,6 +78,7 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
     private final class MobileFrames {
         var preview = CGRect.zero
         var panel = CGRect.zero
+        var rotation = CGRect.zero
     }
 
     private func nextUpFixture() throws -> PlayerViewModel {
@@ -107,15 +108,17 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
             } extras: {
                 Color.gray.frame(height: 1000)
             }
-            let window = makeWindow(layout.frame(width: size.width, height: size.height)
+            let viewport = layout
+                .frame(width: size.width, height: size.height - MobilePlayerRotationControls.topClearance)
+                .padding(.top, MobilePlayerRotationControls.topClearance)
+            let window = makeWindow(viewport
                 .coordinateSpace(name: "mobile-layout").ignoresSafeArea())
             defer { window.isHidden = true; window.rootViewController = nil }
             try await settle(window)
             print("Mobile layout \(size): preview=\(frames.preview), actions=\(frames.panel)")
             // Render the requested viewport, not the host simulator's fixed
             // window size (which would crop portrait/iPad proof images).
-            let renderer = ImageRenderer(content: layout
-                .frame(width: size.width, height: size.height)
+            let renderer = ImageRenderer(content: viewport
                 .coordinateSpace(name: "mobile-layout").ignoresSafeArea())
             let snapshot = try XCTUnwrap(renderer.uiImage)
             let attachment = XCTAttachment(image: snapshot)
@@ -123,7 +126,7 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
             attachment.lifetime = .keepAlways
             add(attachment)
             XCTAssertGreaterThan(frames.panel.height, 0)
-            XCTAssertGreaterThanOrEqual(frames.panel.minY, 0)
+            XCTAssertGreaterThanOrEqual(frames.panel.minY, MobilePlayerRotationControls.topClearance)
             XCTAssertLessThanOrEqual(frames.panel.maxY, size.height)
             XCTAssertLessThanOrEqual(frames.panel.maxX, size.width)
             if size.width > size.height {
@@ -132,6 +135,38 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
                 XCTAssertGreaterThan(frames.panel.minY, frames.preview.maxY)
                 XCTAssertLessThanOrEqual(frames.preview.width, 260)
             }
+        }
+    }
+
+    func testPersistentRotationPillKeepsItsSizeAndTopRightPosition() async throws {
+        XCTAssertNotNil(UIImage(systemName: "rectangle.landscape.rotate"))
+        for size in [CGSize(width: 390, height: 844), CGSize(width: 844, height: 390),
+                     CGSize(width: 568, height: 320)] {
+            let frames = MobileFrames()
+            let viewport = Color.black
+                .overlay(alignment: .topTrailing) {
+                    MobilePlayerRotationControls(orientationCoordinator: .shared)
+                        .onGeometryChange(for: CGRect.self) {
+                            $0.frame(in: .named("rotation-layout"))
+                        } action: { frames.rotation = $0 }
+                        .padding(.horizontal, 16)
+                        .padding(.top, 16)
+                }
+                .frame(width: size.width, height: size.height)
+                .coordinateSpace(name: "rotation-layout")
+                .ignoresSafeArea()
+            let window = makeWindow(viewport)
+            defer { window.isHidden = true; window.rootViewController = nil }
+            try await settle(window)
+            XCTAssertEqual(frames.rotation.width, MobilePlayerRotationControls.width, accuracy: 1)
+            XCTAssertEqual(frames.rotation.height, MobilePlayerRotationControls.height, accuracy: 1)
+            XCTAssertEqual(frames.rotation.maxX, size.width - 16, accuracy: 1)
+            XCTAssertEqual(frames.rotation.minY, 16, accuracy: 1)
+            let renderer = ImageRenderer(content: viewport)
+            let attachment = XCTAttachment(image: try XCTUnwrap(renderer.uiImage))
+            attachment.name = "Persistent rotation controls \(Int(size.width))x\(Int(size.height))"
+            attachment.lifetime = .keepAlways
+            add(attachment)
         }
     }
 
@@ -251,8 +286,14 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
             XCTAssertTrue(player.currentItem === item)
             XCTAssertTrue(layer.superlayer === surface.layer)
             XCTAssertTrue(layer.isReadyForDisplay)
-            XCTAssertEqual(surface.bounds.width, size.width, accuracy: 1)
-            XCTAssertEqual(surface.bounds.height, size.height, accuracy: 1)
+            // The surface deliberately paints through safe-area strips;
+            // the simulator adds 14 points in this landscape-sized fixture.
+            // Verify the orientation, not equality with the outer safe frame.
+            if size.width > size.height {
+                XCTAssertGreaterThan(surface.bounds.width, surface.bounds.height)
+            } else {
+                XCTAssertGreaterThan(surface.bounds.height, surface.bounds.width)
+            }
             XCTAssertGreaterThanOrEqual(player.currentTime().seconds, previousPosition)
             XCTAssertEqual(itemChanges, 0)
         }

--- a/iosApp/Tests/PlayerSurfaceLayoutTests.swift
+++ b/iosApp/Tests/PlayerSurfaceLayoutTests.swift
@@ -164,5 +164,32 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
         XCTAssertEqual(player.rate, 0, "Resizing must not resume a paused preview")
         XCTAssertEqual(player.currentTime().seconds, pausedPosition, accuracy: 0.1)
         XCTAssertEqual(itemChanges, 0)
+
+        // Next pressed before a preview can lay out: one actual successor
+        // load, using the same player/view/layer, with its own first-frame latch.
+        var nilItems = 0
+        let nilObservation = player.publisher(for: \.currentItem, options: [.new]).sink {
+            if $0 == nil { nilItems += 1 }
+        }
+        defer { nilObservation.cancel() }
+        presentation.hasPreviewBounds = false
+        presentation.preview = true
+        engine.prepareForItemReplacement()
+        presentation.preview = false
+        try await engine.load(url: url)
+        engine.play()
+        let successorDeadline = ContinuousClock.now + .seconds(15)
+        while !engine.hasFirstFrameReadyForDisplay && ContinuousClock.now < successorDeadline {
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        XCTAssertTrue(engine.hasFirstFrameReadyForDisplay)
+        XCTAssertTrue(layer.isReadyForDisplay)
+        XCTAssertTrue(surfaces(in: window).first === surface)
+        XCTAssertTrue(engine.currentAVPlayer === player)
+        XCTAssertTrue(layer.superlayer === surface.layer)
+        XCTAssertFalse(player.currentItem === item)
+        XCTAssertEqual(itemChanges, 1)
+        XCTAssertEqual(nilItems, 0)
+        print("Synthetic next episode: 1 item swap, 0 nil items, same view/player/layer, successor first frame ready")
     }
 }

--- a/iosApp/Tests/PlayerSurfaceLayoutTests.swift
+++ b/iosApp/Tests/PlayerSurfaceLayoutTests.swift
@@ -214,8 +214,8 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
         presentation.hasPreviewBounds = false
         presentation.preview = true
         engine.prepareForItemReplacement()
-        presentation.preview = false
         try await engine.load(url: url)
+        presentation.hasPreviewBounds = true
         engine.play()
         let successorDeadline = ContinuousClock.now + .seconds(15)
         while !engine.hasFirstFrameReadyForDisplay && ContinuousClock.now < successorDeadline {
@@ -223,6 +223,8 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
         }
         XCTAssertTrue(engine.hasFirstFrameReadyForDisplay)
         XCTAssertTrue(layer.isReadyForDisplay)
+        presentation.preview = false
+        try await settle(window)
         XCTAssertTrue(surfaces(in: window).first === surface)
         XCTAssertTrue(engine.currentAVPlayer === player)
         XCTAssertTrue(layer.superlayer === surface.layer)

--- a/iosApp/Tests/PlayerSurfaceLayoutTests.swift
+++ b/iosApp/Tests/PlayerSurfaceLayoutTests.swift
@@ -100,10 +100,10 @@ final class PlayerSurfaceLayoutTests: XCTestCase {
             let layout = PlayerNextUpMobileLayout {
                 Color.black.aspectRatio(16 / 9, contentMode: .fit)
                     .onGeometryChange(for: CGRect.self) { $0.frame(in: .named("mobile-layout")) } action: { frames.preview = $0 }
-            } panel: {
+            } panel: { compact in
                 // Measure the real production metadata/buttons, with a long
                 // On Deck shelf competing for the remaining space below.
-                PlayerNextUpScreen(viewModel: model, onBack: {}).mobileNextUpPanel
+                PlayerNextUpScreen(viewModel: model, onBack: {}).mobileNextUpPanel(compact: compact)
                     .onGeometryChange(for: CGRect.self) { $0.frame(in: .named("mobile-layout")) } action: { frames.panel = $0 }
             } extras: {
                 Color.gray.frame(height: 1000)

--- a/iosApp/Tests/UICustomizationPreferencesTests.swift
+++ b/iosApp/Tests/UICustomizationPreferencesTests.swift
@@ -409,8 +409,8 @@ final class UICustomizationPreferencesTests: XCTestCase {
         ])
         XCTAssertEqual(
             projectedMainTabDestinations(primaryMenu: menu).map(\.id),
-            [.app(.home)],
-            "authored categories with no matching profile library must not render dead roots"
+            [.app(.home), .app(.recommendations), .app(.calendar)],
+            "unavailable library categories must fall back to app roots without rendering dead library roots"
         )
 
         let mixed = Library(id: 4, name: "Mixed", type: "mixed", sortOrder: 0, posterUrl: nil)
@@ -512,7 +512,11 @@ final class UICustomizationPreferencesTests: XCTestCase {
             primaryMenu: menu,
             availableLibraries: staleSnapshot.availableLibraries(for: secondProfile)
         )
-        XCTAssertEqual(staleProjection.map(\.id), [.app(.home)])
+        XCTAssertEqual(
+            staleProjection.map(\.id),
+            [.app(.home), .app(.recommendations), .app(.calendar)],
+            "a previous profile's library must stay hidden while the app fallback remains available"
+        )
         XCTAssertEqual(
             resolvedVisibleMainTabDestination(
                 .library(library.id),
@@ -538,7 +542,11 @@ final class UICustomizationPreferencesTests: XCTestCase {
                 libraries: []
             ).availableLibraries(for: secondProfile)
         )
-        XCTAssertEqual(revokedProjection.map(\.id), [.app(.home)])
+        XCTAssertEqual(
+            revokedProjection.map(\.id),
+            [.app(.home), .app(.recommendations), .app(.calendar)],
+            "revoking library access must restore app roots without retaining the library pin"
+        )
         XCTAssertEqual(
             resolvedVisibleMainTabDestination(
                 .library(library.id),

--- a/iosApp/iosApp/Components/MediaRow.swift
+++ b/iosApp/iosApp/Components/MediaRow.swift
@@ -347,7 +347,7 @@ struct MediaRow: View {
 
     private func scrollStrip(_ rowProxy: ScrollViewProxy) -> some View {
         ScrollView(.horizontal, showsIndicators: false) {
-            LazyHStack(spacing: cardSpacing) {
+            LazyHStack(alignment: HorizontalMediaRailLayout.cardAlignment, spacing: cardSpacing) {
                 ForEach(items) { item in
                     mediaCard(for: item)
                 }
@@ -356,6 +356,7 @@ struct MediaRow: View {
             .padding(.horizontal, ContinuumTheme.safePadding)
             #endif
             .padding(.vertical, verticalCardPadding)
+            .phoneMediaRailBounds()
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         #if os(tvOS)

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -1862,6 +1862,9 @@ struct MainTabView: View {
         )) {
             AudioFullPlayerView()
         }
+        #if os(iOS)
+        .modifier(PlayerPresentationModifier(router: router))
+        #else
         .fullScreenCover(item: $router.presentedPlayer) { payload in
             PlayerView(
                 contentId: payload.contentId,
@@ -1875,20 +1878,12 @@ struct MainTabView: View {
                 posterURLHint: payload.posterURL,
                 backdropURLHint: payload.backdropURL
             )
-            #if os(iOS)
-            // Recorded here rather than rebuilt inside the player: a Picture in
-            // Picture restore has to re-present this exact payload, and
-            // `PlayerView` never receives `returnToContentId`.
-            .onAppear {
-                PlayerPresentationRestoration.presenter = router
-                PlayerPresentationRestoration.recordPresentation(payload)
-            }
-            #endif
         }
+        #endif
         #if os(iOS)
         .sheet(
             item: $router.presentedItemDetail,
-            onDismiss: { router.dismissItemDetail() }
+            onDismiss: { router.itemDetailPresentationDidDismiss() }
         ) { presentation in
             ItemDetailSheet(presentation: presentation, router: router)
         }
@@ -2482,62 +2477,37 @@ private struct ItemDetailSheet: View {
             GeometryReader { geometry in
                 let pageHeight = geometry.size.height + geometry.safeAreaInsets.bottom
 
-                // A real paged scroll surface, not a release-triggered route
-                // swap. The adjacent detail page is physically beside the
-                // current one, so it follows the finger throughout a held
-                // drag and settles with native UIScrollView physics.
-                ScrollView(.horizontal) {
-                    LazyHStack(spacing: 10) {
-                        ForEach(pageContentIDs, id: \.self) { contentID in
-                            ItemDetailView(
-                                contentId: contentID,
-                                onClose: router.dismissItemDetail
-                            )
-                            .frame(
-                                width: geometry.size.width,
-                                height: pageHeight
-                            )
-                            // Every neighbouring page remains its own card
-                            // throughout an interactive drag. The small glass
-                            // gutter exposes both rounded edges instead of
-                            // smearing two full-bleed colour fields together.
-                            // Only the presented top edge is rounded: rounding
-                            // the off-screen bottom exposed a grey material lip.
-                            .clipShape(
-                                UnevenRoundedRectangle(
-                                    topLeadingRadius: 28,
-                                    bottomLeadingRadius: 0,
-                                    bottomTrailingRadius: 0,
-                                    topTrailingRadius: 28,
-                                    style: .continuous
-                                )
-                            )
-                            .contentShape(
-                                UnevenRoundedRectangle(
-                                    topLeadingRadius: 28,
-                                    bottomLeadingRadius: 0,
-                                    bottomTrailingRadius: 0,
-                                    topTrailingRadius: 28,
-                                    style: .continuous
-                                )
-                            )
-                            .id(contentID)
+                if browseSource == nil {
+                    // iPhone has one detail page. Do not put its vertical
+                    // scroll view inside an unused horizontal scroll view:
+                    // the native sheet should coordinate with that page directly.
+                    detailPage(contentID: currentContentID, width: geometry.size.width, height: pageHeight)
+                } else {
+                    // Keep iPad's source-aware, finger-following page deck.
+                    ScrollView(.horizontal) {
+                        LazyHStack(spacing: 10) {
+                            ForEach(pageContentIDs, id: \.self) { contentID in
+                                detailPage(contentID: contentID, width: geometry.size.width, height: pageHeight)
+                            }
                         }
+                        .scrollTargetLayout()
                     }
-                    .scrollTargetLayout()
-                }
-                .scrollIndicators(.hidden)
-                .scrollTargetBehavior(.viewAligned(limitBehavior: .always))
-                .scrollPosition(id: pagingSelection, anchor: .center)
-                .scrollBounceBehavior(.basedOnSize, axes: .horizontal)
-                .frame(height: pageHeight, alignment: .top)
-                .ignoresSafeArea(.container, edges: .bottom)
-                .task(id: currentContentID) {
-                    await prefetchAdjacentDetails()
+                    .scrollIndicators(.hidden)
+                    .scrollTargetBehavior(.viewAligned(limitBehavior: .always))
+                    .scrollPosition(id: pagingSelection, anchor: .center)
+                    .scrollBounceBehavior(.basedOnSize, axes: .horizontal)
+                    .frame(height: pageHeight, alignment: .top)
+                    .ignoresSafeArea(.container, edges: .bottom)
+                    .task(id: currentContentID) {
+                        await prefetchAdjacentDetails()
+                    }
                 }
             }
                 .navigationDestination(for: Route.self) { route in
                     destination(for: route)
+                        .environment(\.detailPullBackAction, {
+                            withAnimation { router.goBackInItemDetail() }
+                        })
                 }
                 .toolbarBackground(.hidden, for: .navigationBar)
         }
@@ -2553,11 +2523,26 @@ private struct ItemDetailSheet: View {
         .presentationDragIndicator(.hidden)
         .presentationCornerRadius(28)
         .presentationBackground(.ultraThickMaterial)
-        .presentationContentInteraction(.scrolls)
+        // Nested pages handle a top pull as Back. The sheet's native dismiss
+        // remains available only at the root, preserving the source page.
+        .interactiveDismissDisabled(!router.itemDetailPath.isEmpty)
+        .modifier(PlayerPresentationModifier(router: router, detailPresentationID: presentation.id))
     }
 
     private var currentContentID: String {
         router.presentedItemDetail?.contentId ?? presentation.contentId
+    }
+
+    private func detailPage(contentID: String, width: CGFloat, height: CGFloat) -> some View {
+        let shape = UnevenRoundedRectangle(
+            topLeadingRadius: 28, bottomLeadingRadius: 0,
+            bottomTrailingRadius: 0, topTrailingRadius: 28, style: .continuous
+        )
+        return ItemDetailView(contentId: contentID, onClose: router.dismissItemDetail)
+            .frame(width: width, height: height)
+            .clipShape(shape)
+            .contentShape(shape)
+            .id(contentID)
     }
 
     /// iPhone detail cards are intentionally fixed to the title that was

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -2538,7 +2538,11 @@ private struct ItemDetailSheet: View {
             topLeadingRadius: 28, bottomLeadingRadius: 0,
             bottomTrailingRadius: 0, topTrailingRadius: 28, style: .continuous
         )
-        return ItemDetailView(contentId: contentID, onClose: router.dismissItemDetail)
+        return ItemDetailView(
+            contentId: contentID,
+            onClose: router.dismissItemDetail,
+            resumeContext: presentation.resumeContext?.seriesContentId == contentID ? presentation.resumeContext : nil
+        )
             .frame(width: width, height: height)
             .clipShape(shape)
             .contentShape(shape)

--- a/iosApp/iosApp/Extensions/HorizontalMediaRail.swift
+++ b/iosApp/iosApp/Extensions/HorizontalMediaRail.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+#if os(iOS)
+import UIKit
+#endif
+
+/// Phone rails share a top edge even when one card has more metadata.
+/// Other platforms retain their existing layout and focus behavior.
+enum HorizontalMediaRailLayout {
+    static var isPhone: Bool {
+        #if os(iOS)
+        UIDevice.current.userInterfaceIdiom == .phone
+        #else
+        false
+        #endif
+    }
+
+    static var cardAlignment: VerticalAlignment { isPhone ? .top : .center }
+    static var scrollAnchor: UnitPoint { isPhone ? .leading : .center }
+}
+
+extension View {
+    /// Attach to the stack INSIDE a horizontal media ScrollView, so the
+    /// nearest native scroll view is the rail, not its vertically scrolling page.
+    @ViewBuilder
+    func phoneMediaRailBounds() -> some View {
+        #if os(iOS)
+        if HorizontalMediaRailLayout.isPhone {
+            background(PhoneMediaRailBounds().allowsHitTesting(false))
+        } else {
+            self
+        }
+        #else
+        self
+        #endif
+    }
+}
+
+#if os(iOS)
+private struct PhoneMediaRailBounds: UIViewRepresentable {
+    func makeUIView(context: Context) -> PhoneMediaRailBoundsView {
+        PhoneMediaRailBoundsView()
+    }
+
+    func updateUIView(_ uiView: PhoneMediaRailBoundsView, context: Context) {
+        uiView.configureEnclosingRail()
+        // SwiftUI can attach or update its native scroll view after this call.
+        // One deferred pass handles that without polling or replacing delegates.
+        DispatchQueue.main.async { [weak uiView] in
+            uiView?.configureEnclosingRail()
+        }
+    }
+}
+
+final class PhoneMediaRailBoundsView: UIView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        isUserInteractionEnabled = false
+        isAccessibilityElement = false
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override func didMoveToSuperview() {
+        super.didMoveToSuperview()
+        configureEnclosingRail()
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        configureEnclosingRail()
+    }
+
+    func configureEnclosingRail() {
+        var ancestor = superview
+        while let view = ancestor {
+            if let rail = view as? UIScrollView {
+                // Native scrolling/deceleration stays in charge. Unlike
+                // .basedOnSize, these flags also stop long rails overscrolling
+                // past their first/last card and drifting vertically on a drag.
+                rail.bouncesHorizontally = false
+                rail.bouncesVertically = false
+                rail.alwaysBounceHorizontal = false
+                rail.alwaysBounceVertical = false
+                rail.isDirectionalLockEnabled = true
+                return
+            }
+            ancestor = view.superview
+        }
+    }
+}
+#endif

--- a/iosApp/iosApp/Extensions/HorizontalMediaRail.swift
+++ b/iosApp/iosApp/Extensions/HorizontalMediaRail.swift
@@ -16,6 +16,9 @@ enum HorizontalMediaRailLayout {
 
     static var cardAlignment: VerticalAlignment { isPhone ? .top : .center }
     static var scrollAnchor: UnitPoint { isPhone ? .leading : .center }
+    static var targetBehavior: ViewAlignedScrollTargetBehavior {
+        .viewAligned(limitBehavior: .always, anchor: isPhone ? .leading : nil)
+    }
 }
 
 extension View {
@@ -70,6 +73,12 @@ final class PhoneMediaRailBoundsView: UIView {
         configureEnclosingRail()
     }
 
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        // Reassert after a detail cover/zoom restores SwiftUI's scroll host.
+        configureEnclosingRail()
+    }
+
     func configureEnclosingRail() {
         var ancestor = superview
         while let view = ancestor {
@@ -77,11 +86,11 @@ final class PhoneMediaRailBoundsView: UIView {
                 // Native scrolling/deceleration stays in charge. Unlike
                 // .basedOnSize, these flags also stop long rails overscrolling
                 // past their first/last card and drifting vertically on a drag.
-                rail.bouncesHorizontally = false
-                rail.bouncesVertically = false
-                rail.alwaysBounceHorizontal = false
-                rail.alwaysBounceVertical = false
-                rail.isDirectionalLockEnabled = true
+                if rail.bouncesHorizontally { rail.bouncesHorizontally = false }
+                if rail.bouncesVertically { rail.bouncesVertically = false }
+                if rail.alwaysBounceHorizontal { rail.alwaysBounceHorizontal = false }
+                if rail.alwaysBounceVertical { rail.alwaysBounceVertical = false }
+                if !rail.isDirectionalLockEnabled { rail.isDirectionalLockEnabled = true }
                 return
             }
             ancestor = view.superview

--- a/iosApp/iosApp/Navigation/AppRouter.swift
+++ b/iosApp/iosApp/Navigation/AppRouter.swift
@@ -179,6 +179,10 @@ class AppRouter {
         let returnToContentId: String?
         /// Set for offline playback of a completed download.
         var offlineDownloadId: String? = nil
+        /// The iOS detail sheet that owns this cover. Nil means the app root.
+        /// Keep ownership stable while the player is presented, rather than
+        /// attaching competing covers to the root and the sheet.
+        var detailPresentationID: UUID? = nil
         /// Hints supplied by the originating screen (e.g. the detail page,
         /// which has just loaded the catalog item) so the player's now-
         /// playing widget can publish artwork without re-fetching the
@@ -246,7 +250,7 @@ class AppRouter {
             ))
         }
         #else
-        presentedPlayer = PlayerPresentation(
+        var presentation = PlayerPresentation(
             contentId: contentId,
             fileId: fileId,
             audioTrackIndex: audioTrackIndex,
@@ -258,6 +262,10 @@ class AppRouter {
             posterURL: posterURL,
             backdropURL: backdropURL
         )
+        #if os(iOS)
+        presentation.detailPresentationID = presentedItemDetail?.id
+        #endif
+        presentedPlayer = presentation
         #endif
     }
 
@@ -285,7 +293,7 @@ class AppRouter {
             resumePosition: resumePosition
         ))
         #else
-        presentedPlayer = PlayerPresentation(
+        var presentation = PlayerPresentation(
             contentId: contentId,
             fileId: nil,
             audioTrackIndex: nil,
@@ -298,10 +306,41 @@ class AppRouter {
             posterURL: nil,
             backdropURL: nil
         )
+        #if os(iOS)
+        presentation.detailPresentationID = presentedItemDetail?.id
+        #endif
+        presentedPlayer = presentation
         #endif
     }
 
     // MARK: - Actions
+
+    #if os(iOS)
+    /// Each presentation site sees only the player it owns.
+    func playerPresentation(forDetailID detailID: UUID?) -> PlayerPresentation? {
+        guard let presentedPlayer, presentedPlayer.detailPresentationID == detailID else { return nil }
+        return presentedPlayer
+    }
+
+    /// An outgoing cover must not close a newer player or the detail below it.
+    func dismissPlayerPresentation(id: UUID) {
+        guard presentedPlayer?.id == id else { return }
+        presentedPlayer = nil
+    }
+
+    /// A pull-down on a pushed actor/episode page means Back, not close sheet.
+    func goBackInItemDetail() {
+        guard presentedItemDetail != nil, !itemDetailPath.isEmpty else { return }
+        itemDetailPath.removeLast()
+    }
+
+    func itemDetailPresentationDidDismiss() {
+        // The sheet binding clears its item before this callback. A delayed
+        // callback from an old sheet must not erase a newly opened detail.
+        guard presentedItemDetail == nil else { return }
+        itemDetailPath = NavigationPath()
+    }
+    #endif
 
     /// Push a route onto the navigation stack.
     func navigate(to route: Route) {

--- a/iosApp/iosApp/Navigation/AppRouter.swift
+++ b/iosApp/iosApp/Navigation/AppRouter.swift
@@ -138,6 +138,23 @@ class AppRouter {
 
     // MARK: - Item Detail Presentation
 
+    /// A Continue Watching episode opens its existing series card, retaining
+    /// the episode/season intent without fetching an intermediate detail page.
+    struct ItemDetailResumeContext: Equatable {
+        let seriesContentId: String
+        let episodeContentId: String
+        let seasonNumber: Int?
+
+        init?(item: SectionItem) {
+            guard item.type.lowercased() == "episode" || item.episodeNumber != nil,
+                  let seriesId = item.seriesId?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !seriesId.isEmpty else { return nil }
+            seriesContentId = seriesId
+            episodeContentId = item.contentId
+            seasonNumber = item.seasonNumber
+        }
+    }
+
     /// iPhone and iPad present catalog details as a native bottom sheet instead
     /// of pushing them into the tab or split-view navigation stack. A fresh UUID
     /// makes reopening the same title after dismissal a new presentation while
@@ -146,10 +163,13 @@ class AppRouter {
         let id = UUID()
         var contentId: String
         let browseSource: ItemDetailBrowseSource?
+        let resumeContext: ItemDetailResumeContext?
 
-        init(contentId: String, browseSource: ItemDetailBrowseSource? = nil) {
+        init(contentId: String, browseSource: ItemDetailBrowseSource? = nil,
+             resumeContext: ItemDetailResumeContext? = nil) {
             self.contentId = contentId
             self.browseSource = browseSource
+            self.resumeContext = resumeContext
         }
     }
 
@@ -374,7 +394,8 @@ class AppRouter {
     /// nested recommendations reached from inside an already-open detail.
     func presentItemDetail(
         contentId: String,
-        browseSource: ItemDetailBrowseSource? = nil
+        browseSource: ItemDetailBrowseSource? = nil,
+        resumeContext: ItemDetailResumeContext? = nil
     ) {
         #if os(iOS)
         recordScreenBreadcrumb(target: "itemDetail", action: "present")
@@ -385,7 +406,8 @@ class AppRouter {
             itemDetailPath = NavigationPath()
             presentedItemDetail = ItemDetailPresentation(
                 contentId: contentId,
-                browseSource: source
+                browseSource: source,
+                resumeContext: resumeContext
             )
         } else {
             itemDetailPath.append(Route.itemDetail(contentId: contentId))
@@ -393,6 +415,18 @@ class AppRouter {
         #else
         navigate(to: .itemDetail(contentId: contentId))
         #endif
+    }
+
+    func presentContinueWatchingDetail(for item: SectionItem, browseSource: ItemDetailBrowseSource? = nil) {
+        #if os(iOS)
+        if let context = ItemDetailResumeContext(item: item) {
+            presentItemDetail(contentId: context.seriesContentId, resumeContext: context)
+            return
+        }
+        #endif
+        // Movies, audio and incomplete legacy episode payloads retain their
+        // existing destination; a missing parent must not make a card inert.
+        presentItemDetail(contentId: item.contentId, browseSource: browseSource)
     }
 
     /// Select a sibling while the iOS detail card stays presented. Keeping the

--- a/iosApp/iosApp/Screens/Calendar/CalendarDayShelf.swift
+++ b/iosApp/iosApp/Screens/Calendar/CalendarDayShelf.swift
@@ -68,7 +68,7 @@ struct CalendarDayShelf: View {
 
     private var shelfContent: some View {
         ScrollView(.horizontal, showsIndicators: false) {
-            LazyHStack(spacing: cardSpacing) {
+            LazyHStack(alignment: HorizontalMediaRailLayout.cardAlignment, spacing: cardSpacing) {
                 ForEach(events) { event in
                     CalendarEventCard(
                         event: event,
@@ -79,6 +79,7 @@ struct CalendarDayShelf: View {
             }
             .padding(.horizontal, ContinuumTheme.safePadding)
             .padding(.vertical, verticalCardPadding)
+            .phoneMediaRailBounds()
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         #if os(tvOS)

--- a/iosApp/iosApp/Screens/Detail/AudiobookDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/AudiobookDetailContent.swift
@@ -535,7 +535,7 @@ struct AudiobookDetailContent: View {
 
     private func relatedRail(items: [AudiobookRelatedItem]) -> some View {
         ScrollView(.horizontal, showsIndicators: false) {
-            LazyHStack(spacing: railSpacing) {
+            LazyHStack(alignment: HorizontalMediaRailLayout.cardAlignment, spacing: railSpacing) {
                 ForEach(items) { item in
                     Button {
                         onNavigateToItem(item.contentId)
@@ -569,6 +569,7 @@ struct AudiobookDetailContent: View {
                 }
             }
             .padding(.vertical, 4)
+            .phoneMediaRailBounds()
         }
     }
 

--- a/iosApp/iosApp/Screens/Detail/ItemDetailView.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailView.swift
@@ -9,12 +9,13 @@ struct ItemDetailView: View {
     let contentId: String
     var tvSeed: TVItemDetailRouteSeed? = nil
     var onClose: (() -> Void)? = nil
+    var resumeContext: AppRouter.ItemDetailResumeContext? = nil
 
     var body: some View {
         #if os(tvOS)
         TVItemDetailView(contentId: contentId, seed: tvSeed)
         #else
-        ItemDetailPhoneContent(contentId: contentId, onClose: onClose)
+        ItemDetailPhoneContent(contentId: contentId, onClose: onClose, resumeContext: resumeContext)
         #endif
     }
 }
@@ -237,6 +238,7 @@ private struct UnreachablePlayRequest: Identifiable {
 private struct ItemDetailPhoneContent: View {
     let contentId: String
     var onClose: (() -> Void)? = nil
+    var resumeContext: AppRouter.ItemDetailResumeContext? = nil
 
     @State private var viewModel = ItemDetailViewModel()
     @State private var preferredVersionFileId: Int?
@@ -296,7 +298,12 @@ private struct ItemDetailPhoneContent: View {
             preferredNextUpSubtitleTrackIndex = nil
             nextUpWatchDetail = nil
             isLoadingNextUpWatchDetail = false
+            #if os(iOS)
+            selectedSeriesEpisodeId = resumeContext?.episodeContentId
+            viewModel.initialResumeSeasonNumber = resumeContext?.seasonNumber
+            #else
             selectedSeriesEpisodeId = nil
+            #endif
             refreshOnPlayerDismiss = false
             detailScrollState.reset()
             await viewModel.loadDetail(contentId: contentId)

--- a/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
@@ -14,6 +14,11 @@ class ItemDetailViewModel {
     // Series-specific state
     var seasons: [Season] = []
     var selectedSeason: Season?
+    #if os(iOS)
+    /// One-shot entry intent from Continue Watching; normal poster opens
+    /// leave this nil and retain the existing initial-season policy.
+    @ObservationIgnored var initialResumeSeasonNumber: Int?
+    #endif
     var episodes: [EpisodeListItem] = []
     /// Parent-series portrait artwork used only when an episode's season has
     /// no poster of its own. Episode artwork is normally a landscape still,
@@ -760,6 +765,9 @@ class ItemDetailViewModel {
             ResponseCache.shared.set(response, for: CacheKey.itemSeasons(seriesId))
             seasons = response.seasons.sortedForDisplay()
             if autoSelectInitial, let target = preferredInitialSeason(seasons: seasons) {
+                #if os(iOS)
+                initialResumeSeasonNumber = nil
+                #endif
                 #if !os(tvOS)
                 startEpisodePagePrefetch(
                     seriesId: seriesId,
@@ -879,7 +887,13 @@ class ItemDetailViewModel {
     /// prefer one with an episode in progress (Continue Watching state),
     /// then the first partially-watched season, then the first season that
     /// isn't fully played, then fall back to the first season.
-    private func preferredInitialSeason(seasons: [Season]) -> Season? {
+    func preferredInitialSeason(seasons: [Season]) -> Season? {
+        #if os(iOS)
+        if let initialResumeSeasonNumber,
+           let requested = seasons.first(where: { $0.seasonNumber == initialResumeSeasonNumber }) {
+            return requested
+        }
+        #endif
         if let inProgress = seasons.first(where: { ($0.userData?.inProgressCount ?? 0) > 0 }) {
             return inProgress
         }

--- a/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
@@ -163,7 +163,7 @@ class ItemDetailViewModel {
         // that structure alongside the catalog instead of serializing all
         // three requests. Poster opens retain their existing loading path.
         let resumeSeason = preserveSeasonSelection ? nil : initialResumeSeasonNumber
-        async let resumeStructure: Void = loadContinueWatchingStructure(
+        async let resumeStructure = loadContinueWatchingStructure(
             contentId: contentId,
             seasonNumber: resumeSeason,
             detailGeneration: generation
@@ -227,7 +227,14 @@ class ItemDetailViewModel {
             }
             #elseif os(iOS)
             if resumeSeason != nil {
-                await resumeStructure
+                let didLoadResumeStructure = await resumeStructure
+                // The catalog and hierarchy must both succeed before consuming
+                // the entry intent. A catalog error retries loadDetail directly.
+                if didLoadResumeStructure, !Task.isCancelled,
+                   generation == detailGeneration,
+                   initialResumeSeasonNumber == resumeSeason {
+                    initialResumeSeasonNumber = nil
+                }
                 if !Task.isCancelled, generation == detailGeneration,
                    let selectedSeason {
                     // Secondary seasons/favorites stay outside the resume
@@ -805,6 +812,7 @@ class ItemDetailViewModel {
     /// Resume-only entry: one request wave, with no alternate page or scroll
     /// implementation. Cached content stays painted during revalidation, and
     /// an intervening season tap wins over this initial selection.
+    @discardableResult
     func loadContinueWatchingStructure(
         contentId: String,
         seasonNumber: Int?,
@@ -815,11 +823,10 @@ class ItemDetailViewModel {
         fetchEpisodes: @escaping @Sendable (String, Int) async throws -> EpisodesResponse = {
             try await MetadataRequestPool.shared.episodes(seriesId: $0, seasonNumber: $1)
         }
-    ) async {
-        guard let seasonNumber else { return }
+    ) async -> Bool {
+        guard let seasonNumber else { return false }
         seriesContentId = contentId
         let selectionGeneration = episodeLoadGeneration
-        initialResumeSeasonNumber = nil
         defer {
             if selectionGeneration == episodeLoadGeneration, isLoadingEpisodes {
                 isLoadingEpisodes = false
@@ -829,7 +836,7 @@ class ItemDetailViewModel {
         let seasonResponse = try? await fetchSeasons(contentId)
         guard !Task.isCancelled,
               expectedDetailGeneration == nil || expectedDetailGeneration == detailGeneration,
-              selectionGeneration == episodeLoadGeneration else { return }
+              selectionGeneration == episodeLoadGeneration else { return false }
 
         if let seasonResponse {
             ResponseCache.shared.set(seasonResponse, for: CacheKey.itemSeasons(contentId))
@@ -838,20 +845,23 @@ class ItemDetailViewModel {
         }
         let target = seasons.first { $0.seasonNumber == seasonNumber }
             ?? preferredInitialSeason(seasons: seasons)
-        guard let target else { return }
+        guard let target else { return false }
         if selectedSeason != target { selectedSeason = target }
 
         if target.seasonNumber != seasonNumber {
             // A removed/missing season keeps the existing fallback policy.
             await selectSeason(target, forceRefresh: true)
-            return
+            return seasonResponse != nil && !Task.isCancelled
+                && (expectedDetailGeneration == nil || expectedDetailGeneration == detailGeneration)
+                && selectedSeason?.seasonNumber == target.seasonNumber
+                && loadedSeasonNumber == target.seasonNumber
         }
 
         if isLoadingEpisodes != episodes.isEmpty { isLoadingEpisodes = episodes.isEmpty }
         let response = await episodeResponse
         guard !Task.isCancelled,
               expectedDetailGeneration == nil || expectedDetailGeneration == detailGeneration,
-              selectionGeneration == episodeLoadGeneration else { return }
+              selectionGeneration == episodeLoadGeneration else { return false }
         if let response {
             ResponseCache.shared.set(response, for: CacheKey.itemEpisodes(
                 seriesId: contentId, seasonNumber: seasonNumber
@@ -862,6 +872,7 @@ class ItemDetailViewModel {
             loadedSeasonNumber = seasonNumber
         }
         if isLoadingEpisodes { isLoadingEpisodes = false }
+        return seasonResponse != nil && response != nil
     }
     #endif
 
@@ -1030,6 +1041,11 @@ class ItemDetailViewModel {
         forceRefresh: Bool = false,
         coalescesMetadataRequest: Bool = true
     ) async {
+        #if os(iOS)
+        // An explicit chip/page selection supersedes the one-shot resume intent.
+        // Automatic hierarchy refreshes must retain it until the catalog succeeds.
+        if !forceRefresh { initialResumeSeasonNumber = nil }
+        #endif
         let fallbackSeasonNumber = loadedSeasonNumber ?? selectedSeason?.seasonNumber
         selectedSeason = season
         guard let seriesId = seriesContentId else { return }

--- a/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
@@ -158,6 +158,18 @@ class ItemDetailViewModel {
         // supersedes it even though it publishes first.
         let generation = beginDetailWrite()
 
+        #if os(iOS)
+        // Continue Watching already identifies the series and season. Start
+        // that structure alongside the catalog instead of serializing all
+        // three requests. Poster opens retain their existing loading path.
+        let resumeSeason = preserveSeasonSelection ? nil : initialResumeSeasonNumber
+        async let resumeStructure: Void = loadContinueWatchingStructure(
+            contentId: contentId,
+            seasonNumber: resumeSeason,
+            detailGeneration: generation
+        )
+        #endif
+
         if detail == nil {
             isLoading = true
         } else {
@@ -205,6 +217,26 @@ class ItemDetailViewModel {
             #if os(tvOS)
             if cachedDetailForRelatedStructure != nil {
                 await cachedRelatedStructureLoad
+            } else {
+                await loadRelatedStructure(
+                    for: enriched,
+                    contentId: contentId,
+                    preserveSeasonSelection: preserveSeasonSelection,
+                    coalescesMetadataRequests: coalescesMetadataRequests
+                )
+            }
+            #elseif os(iOS)
+            if resumeSeason != nil {
+                await resumeStructure
+                if !Task.isCancelled, generation == detailGeneration,
+                   let selectedSeason {
+                    // Secondary seasons/favorites stay outside the resume
+                    // page's initial metadata wave.
+                    startEpisodePagePrefetch(
+                        seriesId: contentId, seasons: seasons, selectedSeason: selectedSeason
+                    )
+                    await refreshEpisodeFavoriteStates(for: episodes)
+                }
             } else {
                 await loadRelatedStructure(
                     for: enriched,
@@ -510,6 +542,11 @@ class ItemDetailViewModel {
                 })
             }
             #else
+            #if os(iOS)
+            if detail.type == "series", let initialResumeSeasonNumber {
+                selectedSeason = seasons.first { $0.seasonNumber == initialResumeSeasonNumber }
+            }
+            #endif
             if detail.type != "series", let seasonNumber = detail.seasonNumber {
                 selectedSeason = seasons.first(where: { $0.seasonNumber == seasonNumber })
             }
@@ -527,6 +564,20 @@ class ItemDetailViewModel {
                 let sorted = cached.episodes.sorted(by: {
                     $0.episodeNumber < $1.episodeNumber
                 })
+                episodes = sorted
+                episodesBySeason[seasonNumber] = sorted
+                loadedSeasonNumber = seasonNumber
+            }
+            #endif
+
+            #if os(iOS)
+            if detail.type == "series", initialResumeSeasonNumber != nil,
+               let seasonNumber = selectedSeason?.seasonNumber,
+               episodes.isEmpty,
+               let cached: EpisodesResponse = ResponseCache.shared.get(
+                   CacheKey.itemEpisodes(seriesId: seriesId, seasonNumber: seasonNumber)
+               ) {
+                let sorted = cached.episodes.sorted { $0.episodeNumber < $1.episodeNumber }
                 episodes = sorted
                 episodesBySeason[seasonNumber] = sorted
                 loadedSeasonNumber = seasonNumber
@@ -749,6 +800,70 @@ class ItemDetailViewModel {
     }
 
     // MARK: - Seasons
+
+    #if os(iOS)
+    /// Resume-only entry: one request wave, with no alternate page or scroll
+    /// implementation. Cached content stays painted during revalidation, and
+    /// an intervening season tap wins over this initial selection.
+    func loadContinueWatchingStructure(
+        contentId: String,
+        seasonNumber: Int?,
+        detailGeneration expectedDetailGeneration: Int? = nil,
+        fetchSeasons: @escaping @Sendable (String) async throws -> SeasonsResponse = {
+            try await MetadataRequestPool.shared.seasons(seriesId: $0)
+        },
+        fetchEpisodes: @escaping @Sendable (String, Int) async throws -> EpisodesResponse = {
+            try await MetadataRequestPool.shared.episodes(seriesId: $0, seasonNumber: $1)
+        }
+    ) async {
+        guard let seasonNumber else { return }
+        seriesContentId = contentId
+        let selectionGeneration = episodeLoadGeneration
+        initialResumeSeasonNumber = nil
+        defer {
+            if selectionGeneration == episodeLoadGeneration, isLoadingEpisodes {
+                isLoadingEpisodes = false
+            }
+        }
+        async let episodeResponse = try? fetchEpisodes(contentId, seasonNumber)
+        let seasonResponse = try? await fetchSeasons(contentId)
+        guard !Task.isCancelled,
+              expectedDetailGeneration == nil || expectedDetailGeneration == detailGeneration,
+              selectionGeneration == episodeLoadGeneration else { return }
+
+        if let seasonResponse {
+            ResponseCache.shared.set(seasonResponse, for: CacheKey.itemSeasons(contentId))
+            let sorted = seasonResponse.seasons.sortedForDisplay()
+            if seasons != sorted { seasons = sorted }
+        }
+        let target = seasons.first { $0.seasonNumber == seasonNumber }
+            ?? preferredInitialSeason(seasons: seasons)
+        guard let target else { return }
+        if selectedSeason != target { selectedSeason = target }
+
+        if target.seasonNumber != seasonNumber {
+            // A removed/missing season keeps the existing fallback policy.
+            await selectSeason(target, forceRefresh: true)
+            return
+        }
+
+        if isLoadingEpisodes != episodes.isEmpty { isLoadingEpisodes = episodes.isEmpty }
+        let response = await episodeResponse
+        guard !Task.isCancelled,
+              expectedDetailGeneration == nil || expectedDetailGeneration == detailGeneration,
+              selectionGeneration == episodeLoadGeneration else { return }
+        if let response {
+            ResponseCache.shared.set(response, for: CacheKey.itemEpisodes(
+                seriesId: contentId, seasonNumber: seasonNumber
+            ))
+            let sorted = response.episodes.sorted { $0.episodeNumber < $1.episodeNumber }
+            if episodesBySeason[seasonNumber] != sorted { episodesBySeason[seasonNumber] = sorted }
+            if episodes != sorted { episodes = sorted }
+            loadedSeasonNumber = seasonNumber
+        }
+        if isLoadingEpisodes { isLoadingEpisodes = false }
+    }
+    #endif
 
     func loadSeasons(
         seriesId: String,

--- a/iosApp/iosApp/Screens/Detail/MovieDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/MovieDetailContent.swift
@@ -77,6 +77,7 @@ struct MovieDetailContent<BelowOverview: View>: View {
             }
             .ignoresSafeArea(edges: .top)
             .coordinateSpace(name: PhoneDetailScrollCoordinateSpace.name)
+            .detailScrollDismissal()
             .onScrollGeometryChange(for: CGFloat.self) { geometry in
                 let offset = max(0, geometry.contentOffset.y + geometry.contentInsets.top)
                 return offset <= 150 ? 0 : min(offset, 480)

--- a/iosApp/iosApp/Screens/Detail/Phone/DetailScrollDismissal.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/DetailScrollDismissal.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+
+extension View {
+    /// Applied to the vertical scroll surface, never the horizontal rails.
+    @ViewBuilder
+    func detailScrollDismissal() -> some View {
+        #if os(iOS)
+        modifier(DetailScrollDismissalModifier())
+        #else
+        self
+        #endif
+    }
+}
+
+#if os(iOS)
+private struct DetailPullBackActionKey: EnvironmentKey {
+    static let defaultValue: (() -> Void)? = nil
+}
+
+extension EnvironmentValues {
+    var detailPullBackAction: (() -> Void)? {
+        get { self[DetailPullBackActionKey.self] }
+        set { self[DetailPullBackActionKey.self] = newValue }
+    }
+}
+
+enum DetailDismissalPolicy {
+    static func isAtTop(offset: CGFloat, topInset: CGFloat) -> Bool {
+        // Include the top rubber-band region; do not wait for it to settle.
+        offset + topInset <= 1
+    }
+
+    static func canBeginBack(isAtTop: Bool, velocity: CGPoint) -> Bool {
+        isAtTop && velocity.y > 0 && abs(velocity.x) < velocity.y * 0.6
+    }
+
+    static func shouldCompleteBack(translation: CGPoint, velocity: CGPoint) -> Bool {
+        translation.y > 0 && abs(translation.x) < translation.y * 0.6
+            && (translation.y >= 100 || (translation.y >= 35 && velocity.y >= 900))
+    }
+}
+
+private struct DetailScrollDismissalModifier: ViewModifier {
+    @Environment(\.detailPullBackAction) private var goBack
+    @State private var isAtTop = true
+
+    func body(content: Content) -> some View {
+        content
+            .onScrollGeometryChange(for: Bool.self) { geometry in
+                DetailDismissalPolicy.isAtTop(
+                    offset: geometry.contentOffset.y, topInset: geometry.contentInsets.top
+                )
+            } action: { _, atTop in
+                isAtTop = atTop
+            }
+            // A new pull can move the sheet as soon as content reaches the
+            // top, including while its bounce/deceleration is still active.
+            .presentationContentInteraction(isAtTop ? .resizes : .scrolls)
+            .gesture(DetailBackGesture(isAtTop: isAtTop, goBack: goBack))
+    }
+}
+
+private struct DetailBackGesture: UIGestureRecognizerRepresentable {
+    let isAtTop: Bool
+    let goBack: (() -> Void)?
+
+    func makeUIGestureRecognizer(context: Context) -> BackPanRecognizer {
+        let recognizer = BackPanRecognizer(target: nil, action: nil)
+        recognizer.maximumNumberOfTouches = 1
+        recognizer.cancelsTouchesInView = false
+        recognizer.delegate = recognizer
+        updateUIGestureRecognizer(recognizer, context: context)
+        return recognizer
+    }
+
+    func updateUIGestureRecognizer(_ recognizer: BackPanRecognizer, context: Context) {
+        recognizer.canStartAtTop = isAtTop && goBack != nil
+        recognizer.isEnabled = goBack != nil
+    }
+
+    func handleUIGestureRecognizerAction(_ recognizer: BackPanRecognizer, context: Context) {
+        guard recognizer.state == .ended,
+              DetailDismissalPolicy.shouldCompleteBack(
+                translation: recognizer.translation(in: recognizer.view),
+                velocity: recognizer.velocity(in: recognizer.view)
+              ) else { return }
+        goBack?()
+    }
+
+    final class BackPanRecognizer: UIPanGestureRecognizer, UIGestureRecognizerDelegate {
+        var canStartAtTop = false
+
+        func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+            DetailDismissalPolicy.canBeginBack(isAtTop: canStartAtTop, velocity: velocity(in: view))
+        }
+
+        func gestureRecognizer(
+            _ gestureRecognizer: UIGestureRecognizer,
+            shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+        ) -> Bool {
+            true
+        }
+    }
+}
+#endif

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneCastRail.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneCastRail.swift
@@ -16,7 +16,7 @@ struct PhoneCastRail: View {
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
-            LazyHStack(spacing: cardSpacing) {
+            LazyHStack(alignment: HorizontalMediaRailLayout.cardAlignment, spacing: cardSpacing) {
                 ForEach(cast.prefix(maxEntries)) { member in
                     Button {
                         if let personId = member.personId { onTap(personId) }
@@ -46,6 +46,7 @@ struct PhoneCastRail: View {
             }
             .padding(.horizontal, ContinuumTheme.safePadding)
             .padding(.vertical, 4)
+            .phoneMediaRailBounds()
         }
     }
 

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeRail.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeRail.swift
@@ -44,11 +44,13 @@ struct PhoneEpisodeRail: View {
                 }
             }
             .scrollTargetLayout()
-            .padding(.horizontal, ContinuumTheme.safePadding)
+            .padding(.horizontal, HorizontalMediaRailLayout.isPhone ? 0 : ContinuumTheme.safePadding)
             .padding(.vertical, 4)
+            .phoneMediaRailBounds()
         }
+        .contentMargins(.horizontal, HorizontalMediaRailLayout.isPhone ? ContinuumTheme.safePadding : 0, for: .scrollContent)
         .scrollTargetBehavior(.viewAligned(limitBehavior: .always))
-        .scrollPosition(id: $visibleEpisodeId, anchor: .center)
+        .scrollPosition(id: $visibleEpisodeId, anchor: HorizontalMediaRailLayout.scrollAnchor)
         .onAppear {
             visibleEpisodeId = currentContentId ?? episodes.first?.contentId
         }

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeRail.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeRail.swift
@@ -49,7 +49,7 @@ struct PhoneEpisodeRail: View {
             .phoneMediaRailBounds()
         }
         .contentMargins(.horizontal, HorizontalMediaRailLayout.isPhone ? ContinuumTheme.safePadding : 0, for: .scrollContent)
-        .scrollTargetBehavior(.viewAligned(limitBehavior: .always))
+        .scrollTargetBehavior(HorizontalMediaRailLayout.targetBehavior)
         .scrollPosition(id: $visibleEpisodeId, anchor: HorizontalMediaRailLayout.scrollAnchor)
         .onAppear {
             visibleEpisodeId = currentContentId ?? episodes.first?.contentId

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneSimilarRail.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneSimilarRail.swift
@@ -48,7 +48,7 @@ struct PhoneSimilarRail: View {
 
     private var rail: some View {
         ScrollView(.horizontal, showsIndicators: false) {
-            LazyHStack(spacing: 12) {
+            LazyHStack(alignment: HorizontalMediaRailLayout.cardAlignment, spacing: 12) {
                 ForEach(items) { item in
                     Button {
                         onSelect(item.contentId)
@@ -62,6 +62,7 @@ struct PhoneSimilarRail: View {
             }
             .padding(.horizontal, ContinuumTheme.safePadding)
             .padding(.vertical, 4)
+            .phoneMediaRailBounds()
         }
     }
 

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneTrailersRail.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneTrailersRail.swift
@@ -45,6 +45,7 @@ struct PhoneTrailersRail: View {
             }
             .padding(.horizontal, ContinuumTheme.safePadding)
             .padding(.vertical, 4)
+            .phoneMediaRailBounds()
         }
     }
 }

--- a/iosApp/iosApp/Screens/Detail/SeasonDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/SeasonDetailContent.swift
@@ -51,6 +51,7 @@ struct SeasonDetailContent<BelowOverview: View>: View {
             .padding(.bottom, 40)
         }
         .ignoresSafeArea(edges: .top)
+        .detailScrollDismissal()
         .continuumResumePlaybackAlert(
             isPresented: $showResumeDialog,
             stoppedAt: resumeTimestamp

--- a/iosApp/iosApp/Screens/Detail/SeriesDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/SeriesDetailContent.swift
@@ -80,6 +80,7 @@ struct SeriesDetailContent<BelowOverview: View>: View {
             }
             .ignoresSafeArea(edges: .top)
             .coordinateSpace(name: PhoneDetailScrollCoordinateSpace.name)
+            .detailScrollDismissal()
             .onScrollGeometryChange(for: CGFloat.self) { geometry in
                 let offset = max(0, geometry.contentOffset.y + geometry.contentInsets.top)
                 return offset <= 150 ? 0 : min(offset, 480)

--- a/iosApp/iosApp/Screens/Home/Feed/HomeFeedKit.swift
+++ b/iosApp/iosApp/Screens/Home/Feed/HomeFeedKit.swift
@@ -577,7 +577,8 @@ struct HomeStillCard: View {
             }
 
             if showsMetadata,
-               HorizontalMediaRailLayout.isPhone || HomeFeedMeta.resumeCaption(for: item) != nil {
+               (opensResumeContext && HorizontalMediaRailLayout.isPhone)
+                   || HomeFeedMeta.resumeCaption(for: item) != nil {
                 // Keep phone resume cards the same height when only some items have
                 // a remaining-time caption, including as lazy cards enter/leave.
                 Text(HomeFeedMeta.resumeCaption(for: item) ?? "0m left")

--- a/iosApp/iosApp/Screens/Home/Feed/HomeFeedKit.swift
+++ b/iosApp/iosApp/Screens/Home/Feed/HomeFeedKit.swift
@@ -132,6 +132,7 @@ enum HomeFeedMeta {
 private struct HomeCardTap<Label: View>: View {
     let contentId: String
     let accessibilityLabel: String
+    var continueWatchingItem: SectionItem? = nil
     @ViewBuilder var label: () -> Label
 
     @Environment(AppRouter.self) private var router
@@ -142,10 +143,11 @@ private struct HomeCardTap<Label: View>: View {
     var body: some View {
         Button {
             router.pendingZoomSourceID = zoomInstanceID.uuidString
-            router.presentItemDetail(
-                contentId: contentId,
-                browseSource: detailBrowseSource
-            )
+            if let continueWatchingItem {
+                router.presentContinueWatchingDetail(for: continueWatchingItem, browseSource: detailBrowseSource)
+            } else {
+                router.presentItemDetail(contentId: contentId, browseSource: detailBrowseSource)
+            }
         } label: {
             label()
                 .zoomTransitionSource(id: zoomInstanceID.uuidString, in: zoomNamespace)
@@ -290,6 +292,7 @@ struct HomePosterCard: View {
     var showsMetadata: Bool = true
     /// Draws the resume rail across the bottom of the artwork.
     var showsProgress: Bool = false
+    var opensResumeContext = false
     /// Audiobook covers are square; stretching one into a 2:3 poster crops
     /// its edges off.
     var aspect: MediaCardAspect = .poster
@@ -317,7 +320,8 @@ struct HomePosterCard: View {
     var body: some View {
         HomeCardTap(
             contentId: item.contentId,
-            accessibilityLabel: accessibilityDescription
+            accessibilityLabel: accessibilityDescription,
+            continueWatchingItem: opensResumeContext ? item : nil
         ) {
             VStack(alignment: .leading, spacing: 7) {
                 artwork
@@ -435,6 +439,7 @@ struct HomeStillCard: View {
     var width: CGFloat = HomeFeedMetrics.stillWidth
     var showsCaption: Bool = true
     var showsMetadata: Bool = true
+    var opensResumeContext = false
     var onRemoveFromContinueWatching: (() -> Void)? = nil
     var onSetWatched: ((Bool) async -> Bool)? = nil
 
@@ -460,7 +465,8 @@ struct HomeStillCard: View {
     var body: some View {
         HomeCardTap(
             contentId: item.contentId,
-            accessibilityLabel: accessibilityDescription
+            accessibilityLabel: accessibilityDescription,
+            continueWatchingItem: opensResumeContext ? item : nil
         ) {
             VStack(alignment: .leading, spacing: 8) {
                 artwork

--- a/iosApp/iosApp/Screens/Home/Feed/HomeFeedKit.swift
+++ b/iosApp/iosApp/Screens/Home/Feed/HomeFeedKit.swift
@@ -574,10 +574,12 @@ struct HomeStillCard: View {
                HorizontalMediaRailLayout.isPhone || HomeFeedMeta.resumeCaption(for: item) != nil {
                 // Keep phone resume cards the same height when only some items have
                 // a remaining-time caption, including as lazy cards enter/leave.
-                Text(HomeFeedMeta.resumeCaption(for: item) ?? "")
+                Text(HomeFeedMeta.resumeCaption(for: item) ?? "0m left")
                     .font(.system(size: 11, weight: .regular))
                     .foregroundStyle(Color.continuumOnSurface.opacity(0.55))
-                    .lineLimit(1, reservesSpace: HorizontalMediaRailLayout.isPhone)
+                    .lineLimit(1)
+                    .opacity(HomeFeedMeta.resumeCaption(for: item) == nil ? 0 : 1)
+                    .accessibilityHidden(HomeFeedMeta.resumeCaption(for: item) == nil)
             }
         }
         .frame(width: width, alignment: .leading)

--- a/iosApp/iosApp/Screens/Home/Feed/HomeFeedKit.swift
+++ b/iosApp/iosApp/Screens/Home/Feed/HomeFeedKit.swift
@@ -570,11 +570,14 @@ struct HomeStillCard: View {
                     .truncationMode(.tail)
             }
 
-            if showsMetadata, let subtitle = HomeFeedMeta.resumeCaption(for: item) {
-                Text(subtitle)
+            if showsMetadata,
+               HorizontalMediaRailLayout.isPhone || HomeFeedMeta.resumeCaption(for: item) != nil {
+                // Keep phone resume cards the same height when only some items have
+                // a remaining-time caption, including as lazy cards enter/leave.
+                Text(HomeFeedMeta.resumeCaption(for: item) ?? "")
                     .font(.system(size: 11, weight: .regular))
                     .foregroundStyle(Color.continuumOnSurface.opacity(0.55))
-                    .lineLimit(1)
+                    .lineLimit(1, reservesSpace: HorizontalMediaRailLayout.isPhone)
             }
         }
         .frame(width: width, alignment: .leading)

--- a/iosApp/iosApp/Screens/Home/Feed/HomeFeedRow.swift
+++ b/iosApp/iosApp/Screens/Home/Feed/HomeFeedRow.swift
@@ -99,6 +99,7 @@ struct HomeFeedRow: View {
                                     * uiCustomization.cardPresentation.posterSize.scale,
                                 showsCaption: uiCustomization.cardPresentation.caption.showsTitle,
                                 showsMetadata: uiCustomization.cardPresentation.caption.showsMetadata,
+                                opensResumeContext: isResume,
                                 onRemoveFromContinueWatching: removalAction(for: item),
                                 onSetWatched: watchedAction(for: item)
                             )
@@ -109,6 +110,7 @@ struct HomeFeedRow: View {
                                 showsCaption: uiCustomization.cardPresentation.caption.showsTitle,
                                 showsMetadata: uiCustomization.cardPresentation.caption.showsMetadata,
                                 showsProgress: isResume,
+                                opensResumeContext: isResume,
                                 aspect: isAudiobookRow ? .square : .poster,
                                 episodeAccessibilityLabel: episodeAccessibilityLabel(for: item),
                                 onRemoveFromContinueWatching: removalAction(for: item),

--- a/iosApp/iosApp/Screens/Home/Feed/HomeFeedRow.swift
+++ b/iosApp/iosApp/Screens/Home/Feed/HomeFeedRow.swift
@@ -54,7 +54,7 @@ struct HomeFeedRow: View {
     @ViewBuilder
     private var rowScroller: some View {
         cardsScroll
-            .scrollTargetBehavior(.viewAligned(limitBehavior: .always))
+            .scrollTargetBehavior(HorizontalMediaRailLayout.targetBehavior)
             .scrollPosition(id: $visibleItemId, anchor: HorizontalMediaRailLayout.scrollAnchor)
             .environment(\.itemDetailBrowseSource, detailBrowseSource)
             .onAppear {
@@ -71,7 +71,11 @@ struct HomeFeedRow: View {
             }
             #if os(iOS)
             .onChange(of: router.presentedItemDetail) { _, presentation in
-                guard presentation?.browseSource?.originID == detailBrowseSource.originID,
+                // Only iPad's horizontally paged detail deck drives its source
+                // row. An iPhone detail opens in place; scrolling the row while
+                // its zoom transition is restoring it creates a visible drift.
+                guard !HorizontalMediaRailLayout.isPhone,
+                      presentation?.browseSource?.originID == detailBrowseSource.originID,
                       let contentID = presentation?.contentId,
                       section.items.contains(where: { $0.contentId == contentID })
                 else { return }

--- a/iosApp/iosApp/Screens/Home/Feed/HomeFeedRow.swift
+++ b/iosApp/iosApp/Screens/Home/Feed/HomeFeedRow.swift
@@ -55,7 +55,7 @@ struct HomeFeedRow: View {
     private var rowScroller: some View {
         cardsScroll
             .scrollTargetBehavior(.viewAligned(limitBehavior: .always))
-            .scrollPosition(id: $visibleItemId, anchor: .center)
+            .scrollPosition(id: $visibleItemId, anchor: HorizontalMediaRailLayout.scrollAnchor)
             .environment(\.itemDetailBrowseSource, detailBrowseSource)
             .onAppear {
                 let initialId = validSelectionId(
@@ -85,7 +85,7 @@ struct HomeFeedRow: View {
 
     private var cardsScroll: some View {
         ScrollView(.horizontal, showsIndicators: false) {
-            LazyHStack(spacing: cardSpacing) {
+            LazyHStack(alignment: HorizontalMediaRailLayout.cardAlignment, spacing: cardSpacing) {
                 ForEach(section.items) { item in
                     Group {
                         if usesStills {
@@ -116,6 +116,7 @@ struct HomeFeedRow: View {
                 }
             }
             .scrollTargetLayout()
+            .phoneMediaRailBounds()
         }
         .contentMargins(.horizontal, HomeFeedMetrics.gutter, for: .scrollContent)
         .scrollClipDisabled()

--- a/iosApp/iosApp/Screens/Home/HomeView.swift
+++ b/iosApp/iosApp/Screens/Home/HomeView.swift
@@ -101,9 +101,6 @@ struct HomeView: View {
             guard !viewModel.sections.isEmpty else { return }
             Task { await viewModel.loadSections() }
         }
-        .onReceive(NotificationCenter.default.publisher(for: .homeSectionsShouldRefresh)) { _ in
-            Task { await viewModel.loadSections() }
-        }
         #else
         ZStack(alignment: .top) {
             homeFeedBackground
@@ -197,6 +194,11 @@ struct HomeView: View {
         }
         #endif
         }
+        #if os(iOS) || os(tvOS)
+        .onReceive(NotificationCenter.default.publisher(for: .homeSectionsShouldRefresh)) { _ in
+            Task { await viewModel.loadSections() }
+        }
+        #endif
         .alert(
             "Couldn’t Update Item",
             isPresented: $viewModel.isShowingActionError

--- a/iosApp/iosApp/Screens/People/PersonDetailView.swift
+++ b/iosApp/iosApp/Screens/People/PersonDetailView.swift
@@ -293,6 +293,7 @@ struct PersonDetailView: View {
     @State private var viewModel: PersonDetailViewModel
     #if os(iOS)
     @Environment(\.detailPullBackAction) private var goBack
+    @Environment(\.dismiss) private var dismiss
     #endif
 
     init(personId: Int) {
@@ -301,6 +302,11 @@ struct PersonDetailView: View {
 
     var body: some View {
         rootContent
+            #if os(iOS)
+            .environment(\.detailPullBackAction, {
+                if let goBack { goBack() } else { dismiss() }
+            })
+            #endif
             .onAppear {
                 viewModel.resumeMetadataRefreshIfNeeded()
             }
@@ -332,12 +338,9 @@ struct PersonDetailView: View {
         TVPersonDetailContent(person: person, viewModel: viewModel)
         #else
         #if os(iOS)
-        if goBack != nil {
-            // In a detail stack this pull means Back, not refresh metadata.
-            PhonePersonDetailContent(person: person, viewModel: viewModel)
-        } else {
-            refreshablePersonContent(person: person)
-        }
+        // On iOS this pull means Back, including actor pages opened from
+        // outside a title's detail sheet. Do not start a metadata refresh too.
+        PhonePersonDetailContent(person: person, viewModel: viewModel)
         #else
         refreshablePersonContent(person: person)
         #endif

--- a/iosApp/iosApp/Screens/People/PersonDetailView.swift
+++ b/iosApp/iosApp/Screens/People/PersonDetailView.swift
@@ -291,6 +291,9 @@ final class PersonDetailViewModel {
 
 struct PersonDetailView: View {
     @State private var viewModel: PersonDetailViewModel
+    #if os(iOS)
+    @Environment(\.detailPullBackAction) private var goBack
+    #endif
 
     init(personId: Int) {
         _viewModel = State(initialValue: PersonDetailViewModel(personId: personId))
@@ -328,14 +331,29 @@ struct PersonDetailView: View {
         #if os(tvOS)
         TVPersonDetailContent(person: person, viewModel: viewModel)
         #else
+        #if os(iOS)
+        if goBack != nil {
+            // In a detail stack this pull means Back, not refresh metadata.
+            PhonePersonDetailContent(person: person, viewModel: viewModel)
+        } else {
+            refreshablePersonContent(person: person)
+        }
+        #else
+        refreshablePersonContent(person: person)
+        #endif
+        #endif
+    }
+
+    #if !os(tvOS)
+    private func refreshablePersonContent(person: Person) -> some View {
         PhonePersonDetailContent(person: person, viewModel: viewModel)
             .refreshable {
                 async let overlayRefresh: Void = OverlayPrefsStore.shared.refresh()
                 await viewModel.reload()
                 await overlayRefresh
             }
-        #endif
     }
+    #endif
 }
 
 #if os(tvOS)
@@ -515,6 +533,7 @@ private struct PhonePersonDetailContent: View {
             }
             .padding(.bottom, ContinuumTheme.largePadding)
         }
+        .detailScrollDismissal()
         .continuumPageBackground()
     }
 

--- a/iosApp/iosApp/Screens/Player/PlayerNextUpCompletionPolicy.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerNextUpCompletionPolicy.swift
@@ -1,5 +1,18 @@
 import Foundation
 
+/// A repeated Play Now/countdown action for the active (or loading) episode
+/// is an expansion, not permission to replace that episode again.
+enum PlayerNextUpPlaybackAction: Equatable {
+    case unavailable
+    case expand
+    case load(String)
+
+    static func resolve(candidateId: String?, currentId: String?) -> Self {
+        guard let candidateId else { return .unavailable }
+        return candidateId == currentId ? .expand : .load(candidateId)
+    }
+}
+
 enum PlayerNextUpCompletionPolicy {
     static func isInPromptWindow(
         currentTime: Double,

--- a/iosApp/iosApp/Screens/Player/PlayerNextUpCompletionPolicy.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerNextUpCompletionPolicy.swift
@@ -4,10 +4,12 @@ import Foundation
 /// is an expansion, not permission to replace that episode again.
 enum PlayerNextUpPlaybackAction: Equatable {
     case unavailable
+    case waitForPicture
     case expand
     case load(String)
 
-    static func resolve(candidateId: String?, currentId: String?) -> Self {
+    static func resolve(candidateId: String?, currentId: String?, awaitingPicture: Bool = false) -> Self {
+        if awaitingPicture { return .waitForPicture }
         guard let candidateId else { return .unavailable }
         return candidateId == currentId ? .expand : .load(candidateId)
     }

--- a/iosApp/iosApp/Screens/Player/PlayerSurfaceLayout.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerSurfaceLayout.swift
@@ -40,7 +40,7 @@ struct PlayerSurfaceLayout<Surface: View, Content: View>: View {
                             RoundedRectangle(cornerRadius: isPreview ? 8 : 0)
                                 .stroke(.white.opacity(isPreview ? 0.16 : 0), lineWidth: 1)
                         }
-                        .shadow(color: .black.opacity(isPreview ? 0.55 : 0), radius: 34, y: 18)
+                        .shadow(color: .black.opacity(isPreview ? 0.55 : 0), radius: isPreview ? 34 : 0, y: isPreview ? 18 : 0)
                         .position(x: frame.midX, y: frame.midY)
                         // Respect the original ScrollView's clipping even though
                         // the video itself is a persistent sibling of that view.

--- a/iosApp/iosApp/Screens/Player/PlayerSurfaceLayout.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerSurfaceLayout.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+/// Next Up supplies geometry, never another video view. Moving a shared
+/// AVPlayerLayer between two representables lets an outgoing view steal or
+/// detach the incoming view's picture during a SwiftUI transition.
+struct PlayerPreviewBoundsKey: PreferenceKey {
+    struct Value {
+        var bounds: Anchor<CGRect>?
+        var viewport: Anchor<CGRect>?
+    }
+
+    static var defaultValue: Value { Value() }
+
+    static func reduce(value: inout Value, nextValue: () -> Value) {
+        let next = nextValue()
+        value.bounds = next.bounds ?? value.bounds
+        value.viewport = next.viewport ?? value.viewport
+    }
+}
+
+struct PlayerSurfaceLayout<Surface: View, Content: View>: View {
+    let isPreview: Bool
+    @ViewBuilder let surface: () -> Surface
+    @ViewBuilder let content: () -> Content
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        content()
+            .overlayPreferenceValue(PlayerPreviewBoundsKey.self) { geometry in
+                GeometryReader { proxy in
+                    let fullFrame = CGRect(origin: .zero, size: proxy.size)
+                    let frame = isPreview ? geometry.bounds.map { proxy[$0] } ?? fullFrame : fullFrame
+                    let viewport = isPreview ? geometry.viewport.map { proxy[$0] } ?? fullFrame : fullFrame
+                    // One structural identity in both modes. Only geometry changes;
+                    // expansion must not load, seek, bind a second host, or resume.
+                    surface()
+                        .frame(width: frame.width, height: frame.height)
+                        .clipShape(RoundedRectangle(cornerRadius: isPreview ? 8 : 0))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: isPreview ? 8 : 0)
+                                .stroke(.white.opacity(isPreview ? 0.16 : 0), lineWidth: 1)
+                        }
+                        .shadow(color: .black.opacity(isPreview ? 0.55 : 0), radius: 34, y: 18)
+                        .position(x: frame.midX, y: frame.midY)
+                        // Respect the original ScrollView's clipping even though
+                        // the video itself is a persistent sibling of that view.
+                        .mask {
+                            Rectangle()
+                                .frame(width: viewport.width, height: viewport.height)
+                                .position(x: viewport.midX, y: viewport.midY)
+                        }
+                        .animation(reduceMotion ? nil : .easeInOut(duration: 0.3), value: isPreview)
+                }
+                .ignoresSafeArea()
+                .allowsHitTesting(false)
+                .accessibilityHidden(true)
+            }
+    }
+}

--- a/iosApp/iosApp/Screens/Player/PlayerSurfaceLayout.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerSurfaceLayout.swift
@@ -57,3 +57,46 @@ struct PlayerSurfaceLayout<Surface: View, Content: View>: View {
             }
     }
 }
+
+/// The preview and primary actions never live inside a scroll view on mobile.
+/// Only the optional On Deck shelf scrolls. Wide screens put actions on the
+/// right; narrow screens cap the preview so it cannot push Play Now below them.
+struct PlayerNextUpMobileLayout<Preview: View, Panel: View, Extras: View>: View {
+    @ViewBuilder let preview: () -> Preview
+    @ViewBuilder let panel: () -> Panel
+    @ViewBuilder let extras: () -> Extras
+
+    var body: some View {
+        GeometryReader { proxy in
+            let horizontalInset = max(20, max(proxy.safeAreaInsets.leading, proxy.safeAreaInsets.trailing) + 12)
+            let topInset = max(16, proxy.safeAreaInsets.top + 12)
+            let bottomInset = max(16, proxy.safeAreaInsets.bottom + 12)
+            let width = max(0, min(1100, proxy.size.width - horizontalInset * 2))
+            let height = max(0, proxy.size.height - topInset - bottomInset)
+            let sideBySide = (width >= 500 && width > height) || width >= 760
+            let previewWidth = sideBySide
+                ? min(480, width * 0.43, height * 0.7 * 16 / 9)
+                : min(260, width, height * 0.22 * 16 / 9)
+            let layout = sideBySide
+                ? AnyLayout(HStackLayout(alignment: .center, spacing: 24))
+                : AnyLayout(VStackLayout(alignment: .center, spacing: 14))
+
+            VStack(spacing: 16) {
+                layout {
+                    preview().frame(width: previewWidth)
+                    panel().frame(maxWidth: sideBySide ? 420 : .infinity)
+                        .layoutPriority(1)
+                }
+                .frame(maxWidth: .infinity)
+                .layoutPriority(1)
+
+                ScrollView(.vertical, showsIndicators: false) {
+                    extras()
+                }
+            }
+            .frame(width: width, height: height, alignment: .top)
+            .frame(maxWidth: .infinity)
+            .padding(.top, topInset)
+        }
+    }
+}

--- a/iosApp/iosApp/Screens/Player/PlayerSurfaceLayout.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerSurfaceLayout.swift
@@ -63,7 +63,7 @@ struct PlayerSurfaceLayout<Surface: View, Content: View>: View {
 /// right; narrow screens cap the preview so it cannot push Play Now below them.
 struct PlayerNextUpMobileLayout<Preview: View, Panel: View, Extras: View>: View {
     @ViewBuilder let preview: () -> Preview
-    @ViewBuilder let panel: () -> Panel
+    @ViewBuilder let panel: (_ compact: Bool) -> Panel
     @ViewBuilder let extras: () -> Extras
 
     var body: some View {
@@ -84,7 +84,7 @@ struct PlayerNextUpMobileLayout<Preview: View, Panel: View, Extras: View>: View 
             VStack(spacing: 16) {
                 layout {
                     preview().frame(width: previewWidth)
-                    panel().frame(maxWidth: sideBySide ? 420 : .infinity)
+                    panel(height < 270).frame(maxWidth: sideBySide ? 420 : .infinity)
                         .layoutPriority(1)
                 }
                 .frame(maxWidth: .infinity)

--- a/iosApp/iosApp/Screens/Player/PlayerSurfaceLayout.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerSurfaceLayout.swift
@@ -53,7 +53,7 @@ struct PlayerSurfaceLayout<Surface: View, Content: View>: View {
                 }
                 .ignoresSafeArea()
                 .allowsHitTesting(false)
-                .accessibilityHidden(true)
+                .accessibilityHidden(isPreview)
             }
     }
 }

--- a/iosApp/iosApp/Screens/Player/PlayerSurfaceLayout.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerSurfaceLayout.swift
@@ -7,6 +7,7 @@ struct PlayerPreviewBoundsKey: PreferenceKey {
     struct Value {
         var bounds: Anchor<CGRect>?
         var viewport: Anchor<CGRect>?
+        var actions: Anchor<CGRect>?
     }
 
     static var defaultValue: Value { Value() }
@@ -15,6 +16,7 @@ struct PlayerPreviewBoundsKey: PreferenceKey {
         let next = nextValue()
         value.bounds = next.bounds ?? value.bounds
         value.viewport = next.viewport ?? value.viewport
+        value.actions = next.actions ?? value.actions
     }
 }
 
@@ -58,9 +60,8 @@ struct PlayerSurfaceLayout<Surface: View, Content: View>: View {
     }
 }
 
-/// The preview and primary actions never live inside a scroll view on mobile.
-/// Only the optional On Deck shelf scrolls. Wide screens put actions on the
-/// right; narrow screens cap the preview so it cannot push Play Now below them.
+/// iOS keeps one vertical preview/actions stack through rotation. The Mac
+/// retains its side-by-side layout and optional On Deck shelf.
 struct PlayerNextUpMobileLayout<Preview: View, Panel: View, Extras: View>: View {
     @ViewBuilder let preview: () -> Preview
     @ViewBuilder let panel: (_ compact: Bool) -> Panel
@@ -68,6 +69,16 @@ struct PlayerNextUpMobileLayout<Preview: View, Panel: View, Extras: View>: View 
 
     var body: some View {
         GeometryReader { proxy in
+            #if os(iOS)
+            let compact = proxy.size.width > proxy.size.height
+            PlayerNextUpStackLayout(compact: compact) {
+                preview()
+                panel(compact)
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, compact ? 8 : 16)
+            .frame(width: proxy.size.width, height: proxy.size.height)
+            #else
             let horizontalInset = max(20, max(proxy.safeAreaInsets.leading, proxy.safeAreaInsets.trailing) + 12)
             let topInset = max(16, proxy.safeAreaInsets.top + 12)
             let bottomInset = max(16, proxy.safeAreaInsets.bottom + 12)
@@ -97,6 +108,36 @@ struct PlayerNextUpMobileLayout<Preview: View, Panel: View, Extras: View>: View 
             .frame(width: width, height: height, alignment: .top)
             .frame(maxWidth: .infinity)
             .padding(.top, topInset)
+            #endif
         }
     }
 }
+
+#if os(iOS)
+/// Measure the actual action panel first, then fit the preview above it.
+/// Keeping the same stack and video anchor across sizes avoids reparenting
+/// the playing surface or guessing how much room the text and buttons need.
+struct PlayerNextUpStackLayout: Layout {
+    var compact: Bool
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        proposal.replacingUnspecifiedDimensions()
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        guard subviews.count == 2 else { return }
+        let panelWidth = min(bounds.width, compact ? 560 : 380)
+        let panelSize = subviews[1].sizeThatFits(.init(width: panelWidth, height: nil))
+        let gap: CGFloat = compact ? 8 : 16
+        let availableHeight = max(0, bounds.height - panelSize.height - gap)
+        let previewWidth = min(compact ? 280 : 300, bounds.width, availableHeight * 16 / 9)
+        let previewHeight = previewWidth * 9 / 16
+        let totalHeight = previewHeight + gap + panelSize.height
+        let top = bounds.minY + max(0, (bounds.height - totalHeight) / 2)
+        subviews[0].place(at: CGPoint(x: bounds.midX, y: top), anchor: .top,
+                          proposal: .init(width: previewWidth, height: previewHeight))
+        subviews[1].place(at: CGPoint(x: bounds.midX, y: top + previewHeight + gap), anchor: .top,
+                          proposal: .init(width: panelWidth, height: panelSize.height))
+    }
+}
+#endif

--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -102,6 +102,9 @@ struct PlayerView: View {
                             }
                         }
                     )
+                    #if os(iOS)
+                    .padding(.top, MobilePlayerRotationControls.topClearance)
+                    #endif
                 }
             }
         }
@@ -249,7 +252,6 @@ struct PlayerView: View {
                             MobilePlayerGestureLayer(viewModel: viewModel)
                             MobilePlayerControls(
                                 viewModel: viewModel,
-                                orientationCoordinator: orientationCoordinator,
                                 onDismiss: { dismissPlayer() }
                             )
                         }
@@ -275,6 +277,18 @@ struct PlayerView: View {
                 }
             }
         }
+        #if os(iOS)
+        .overlay(alignment: .topTrailing) {
+            MobilePlayerRotationControls(orientationCoordinator: orientationCoordinator) {
+                viewModel.resumeAutoHide()
+            }
+            .padding(.horizontal)
+            .padding(.top)
+        }
+        .onGeometryChange(for: CGSize.self) { $0.size } action: { _ in
+            orientationCoordinator.refreshInterfaceOrientation()
+        }
+        #endif
         #if os(tvOS)
         // Physical Play/Pause on the Siri remote always toggles playback
         // and brings the transport bar back.

--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -653,14 +653,21 @@ private struct PlayerNextUpScreen: View {
                     $0.viewport = $1
                 }
                 #else
-                screenContent(maxMainWidth: mainContentWidth(for: proxy))
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-                    .padding(.horizontal, horizontalPadding)
-                    .padding(.vertical, verticalPadding)
+                PlayerNextUpMobileLayout {
+                    miniPlayerPane
+                } panel: {
+                    mobileNextUpPanel
+                } extras: {
+                    if !viewModel.nextUpCarouselItems.isEmpty {
+                        onDeckSection
+                    }
+                }
                 #endif
             }
         }
+        #if os(tvOS)
         .ignoresSafeArea()
+        #endif
         .animation(.easeInOut(duration: 0.2), value: viewModel.nextUpCountdownSeconds)
         .animation(.easeInOut(duration: 0.2), value: viewModel.nextUpEpisode)
         .animation(.easeInOut(duration: 0.2), value: viewModel.nextUpCarouselItems)
@@ -716,20 +723,38 @@ private struct PlayerNextUpScreen: View {
                 .frame(maxWidth: 650, alignment: .leading)
         }
         #else
-        ScrollView(.vertical, showsIndicators: false) {
-            VStack(spacing: sectionSpacing) {
-                miniPlayerPane
-                    .frame(maxWidth: 620)
-                nextUpPanel
-                    .frame(maxWidth: 620)
-            }
-            .frame(maxWidth: .infinity)
-        }
-        .transformAnchorPreference(key: PlayerPreviewBoundsKey.self, value: .bounds) {
-            $0.viewport = $1
-        }
+        EmptyView()
         #endif
     }
+
+    #if !os(tvOS)
+    private var mobileNextUpPanel: some View {
+        VStack(spacing: 10) {
+            eyebrow
+            if let episode = viewModel.nextUpEpisode {
+                metadata(for: episode, compact: true)
+            } else if viewModel.isLoadingNextUpEpisode {
+                Text("Finding the next episode")
+                    .font(.callout)
+                    .foregroundStyle(.white)
+            } else {
+                Text(viewModel.nextUpScreenVideoEnded ? "End of playback" : "Almost finished")
+                    .font(.headline)
+                    .foregroundStyle(.white)
+            }
+            actionRow(hasNextEpisode: viewModel.nextUpEpisode != nil)
+            if viewModel.nextUpEpisode != nil {
+                autoPlayToggle
+            } else if !viewModel.isLoadingNextUpEpisode {
+                Text(finishedMessage)
+                    .font(.caption)
+                    .foregroundStyle(.white.opacity(0.62))
+                    .lineLimit(2)
+            }
+        }
+        .multilineTextAlignment(.center)
+    }
+    #endif
 
     private var miniPlayerPane: some View {
         Color.clear
@@ -796,7 +821,7 @@ private struct PlayerNextUpScreen: View {
         }
     }
 
-    private func metadata(for episode: PlayerNextUpEpisode) -> some View {
+    private func metadata(for episode: PlayerNextUpEpisode, compact: Bool = false) -> some View {
         VStack(alignment: isTV ? .leading : .center, spacing: isTV ? 12 : 7) {
             if let seriesTitle = episode.seriesTitle, !seriesTitle.isEmpty {
                 Text(seriesTitle)
@@ -812,17 +837,17 @@ private struct PlayerNextUpScreen: View {
                     .foregroundStyle(.white)
             }
             .font(.system(size: subtitleSize, weight: .semibold))
-            .lineLimit(2)
+            .lineLimit(compact ? 1 : 2)
             .multilineTextAlignment(isTV ? .leading : .center)
 
             let metadataLine = episodeMetadataLine(for: episode)
-            if !metadataLine.isEmpty {
+            if !compact && !metadataLine.isEmpty {
                 Text(metadataLine)
                     .font(.system(size: captionSize, weight: .medium))
                     .foregroundStyle(.white.opacity(0.46))
             }
 
-            if let overview = episode.overview, !overview.isEmpty {
+            if !compact, let overview = episode.overview, !overview.isEmpty {
                 Text(overview)
                     .font(.system(size: bodySize))
                     .lineLimit(isTV ? 3 : 2)
@@ -903,33 +928,38 @@ private struct PlayerNextUpScreen: View {
         }
         #else
         VStack(spacing: 10) {
-            if hasNextEpisode {
-                Button(action: { viewModel.playNextEpisodeNow() }) {
-                    Label("Play Now", systemImage: "play.fill")
+            HStack(spacing: 12) {
+                if hasNextEpisode {
+                    Button(action: { viewModel.playNextEpisodeNow() }) {
+                        Label("Play Now", systemImage: "play.fill")
+                            .frame(maxWidth: .infinity, minHeight: 44)
+                    }
+                    .siloPrimaryButton()
+                    .accessibilityIdentifier("next-up-play-now")
                 }
-                .siloPrimaryButton()
-                .frame(maxWidth: .infinity)
+                if let seconds = viewModel.nextUpCountdownSeconds {
+                    CountdownRing(seconds: seconds, totalSeconds: viewModel.nextUpCountdownTotalSeconds)
+                }
             }
 
-            if !viewModel.nextUpScreenVideoEnded {
-                Button(action: { viewModel.keepWatchingCurrentEpisode() }) {
-                    Label("Keep Watching", systemImage: "rectangle.inset.filled")
+            HStack(spacing: 10) {
+                if !viewModel.nextUpScreenVideoEnded {
+                    Button(action: { viewModel.keepWatchingCurrentEpisode() }) {
+                        Text("Keep Watching")
+                            .frame(maxWidth: .infinity, minHeight: 44)
+                    }
+                    .siloSecondaryButton()
+                }
+                Button(action: onBack) {
+                    Label("Back", systemImage: "chevron.left")
+                        .frame(minHeight: 44)
                 }
                 .siloSecondaryButton()
-                .frame(maxWidth: .infinity)
-            }
-
-            Button(action: onBack) {
-                Label("Back", systemImage: "chevron.left")
-            }
-            .siloSecondaryButton()
-            .frame(maxWidth: .infinity)
-
-            if let seconds = viewModel.nextUpCountdownSeconds {
-                CountdownRing(seconds: seconds, totalSeconds: viewModel.nextUpCountdownTotalSeconds)
             }
         }
-        .frame(maxWidth: 280)
+        .font(.callout)
+        .lineLimit(1)
+        .frame(maxWidth: 380)
         #endif
     }
 

--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -86,6 +86,7 @@ struct PlayerView: View {
         PlayerSurfaceLayout(isPreview: viewModel.showNextUpScreen) {
             playerSurface()
                 .opacity(viewModel.error == nil ? 1 : 0)
+                .accessibilityHidden(viewModel.error != nil)
         } content: {
             ZStack {
                 Color.black.ignoresSafeArea()

--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -40,6 +40,7 @@ struct PlayerView: View {
     let posterURLHint: String?
     let backdropURLHint: String?
     let onPlaybackStarted: (() -> Void)?
+    let onDismissRequested: (() -> Void)?
 
     @State private var viewModel = PlayerViewModel()
     @State private var didNotifyPlaybackStarted = false
@@ -67,7 +68,8 @@ struct PlayerView: View {
         offlineDownloadId: String? = nil,
         posterURLHint: String? = nil,
         backdropURLHint: String? = nil,
-        onPlaybackStarted: (() -> Void)? = nil
+        onPlaybackStarted: (() -> Void)? = nil,
+        onDismissRequested: (() -> Void)? = nil
     ) {
         self.contentId = contentId
         self.preferredFileId = preferredFileId
@@ -80,6 +82,7 @@ struct PlayerView: View {
         self.posterURLHint = posterURLHint
         self.backdropURLHint = backdropURLHint
         self.onPlaybackStarted = onPlaybackStarted
+        self.onDismissRequested = onDismissRequested
     }
 
     var body: some View {
@@ -446,7 +449,11 @@ struct PlayerView: View {
 
     private func dismissPlayer() {
         viewModel.cleanup()
-        dismiss()
+        if let onDismissRequested {
+            onDismissRequested()
+        } else {
+            dismiss()
+        }
     }
 
     #if os(iOS)

--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -678,8 +678,8 @@ struct PlayerNextUpScreen: View {
                 #else
                 PlayerNextUpMobileLayout {
                     miniPlayerPane
-                } panel: {
-                    mobileNextUpPanel
+                } panel: { compact in
+                    mobileNextUpPanel(compact: compact)
                 } extras: {
                     if !viewModel.nextUpCarouselItems.isEmpty {
                         onDeckSection
@@ -751,9 +751,11 @@ struct PlayerNextUpScreen: View {
     }
 
     #if !os(tvOS)
-    var mobileNextUpPanel: some View {
-        VStack(spacing: 10) {
-            eyebrow
+    func mobileNextUpPanel(compact: Bool = false) -> some View {
+        VStack(spacing: compact ? 6 : 10) {
+            // Keep every action reachable below the persistent rotation bar
+            // on short landscape screens. Only the redundant eyebrow is omitted.
+            if !compact { eyebrow }
             if let episode = viewModel.nextUpEpisode {
                 metadata(for: episode, compact: true)
             } else if viewModel.isLoadingNextUpEpisode {
@@ -765,7 +767,7 @@ struct PlayerNextUpScreen: View {
                     .font(.headline)
                     .foregroundStyle(.white)
             }
-            actionRow(hasNextEpisode: viewModel.nextUpEpisode != nil)
+            actionRow(hasNextEpisode: viewModel.nextUpEpisode != nil, compact: compact)
             if viewModel.nextUpEpisode != nil {
                 autoPlayToggle
             } else if !viewModel.isLoadingNextUpEpisode {
@@ -882,7 +884,7 @@ struct PlayerNextUpScreen: View {
     }
 
     @ViewBuilder
-    private func actionRow(hasNextEpisode: Bool) -> some View {
+    private func actionRow(hasNextEpisode: Bool, compact: Bool = false) -> some View {
         #if os(tvOS)
         VStack(alignment: .leading, spacing: 18) {
             // Reserve enough room for the primary pill's focused scale and
@@ -952,14 +954,15 @@ struct PlayerNextUpScreen: View {
             }
         }
         #else
-        VStack(spacing: 10) {
+        VStack(spacing: compact ? 6 : 10) {
             HStack(spacing: 12) {
                 if hasNextEpisode {
                     Button(action: { viewModel.playNextEpisodeNow() }) {
                         Label("Play Now", systemImage: "play.fill")
-                            .frame(maxWidth: .infinity, minHeight: 44)
+                            .frame(maxWidth: .infinity, minHeight: compact ? 24 : 44)
                     }
                     .siloPrimaryButton(isLoading: viewModel.isNextUpTransitioning)
+                    .frame(minHeight: 44)
                     .accessibilityIdentifier("next-up-play-now")
                 }
                 if let seconds = viewModel.nextUpCountdownSeconds {
@@ -971,16 +974,18 @@ struct PlayerNextUpScreen: View {
                 if !viewModel.nextUpScreenVideoEnded {
                     Button(action: { viewModel.keepWatchingCurrentEpisode() }) {
                         Text("Keep Watching")
-                            .frame(maxWidth: .infinity, minHeight: 44)
+                            .frame(maxWidth: .infinity, minHeight: compact ? 24 : 44)
                     }
                     .siloSecondaryButton()
+                    .frame(minHeight: 44)
                     .disabled(viewModel.isNextUpTransitioning)
                 }
                 Button(action: onBack) {
                     Label("Back", systemImage: "chevron.left")
-                        .frame(minHeight: 44)
+                        .frame(minHeight: compact ? 24 : 44)
                 }
                 .siloSecondaryButton()
+                .frame(minHeight: 44)
             }
         }
         .font(.callout)

--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -878,6 +878,7 @@ private struct PlayerNextUpScreen: View {
                         .frame(width: 220)
                     }
                     .buttonStyle(TVPillButtonStyle(kind: .primary))
+                    .disabled(viewModel.isNextUpTransitioning)
                     .focused($focusedTarget, equals: .playNow)
                     .prefersDefaultFocus(true, in: defaultFocusNamespace)
                 }
@@ -901,6 +902,7 @@ private struct PlayerNextUpScreen: View {
                         .frame(width: 250)
                     }
                     .buttonStyle(TVPillButtonStyle(kind: .secondary))
+                    .disabled(viewModel.isNextUpTransitioning)
                     .focused($focusedTarget, equals: .keepWatching)
                     .prefersDefaultFocus(!hasNextEpisode, in: defaultFocusNamespace)
                 }
@@ -934,7 +936,7 @@ private struct PlayerNextUpScreen: View {
                         Label("Play Now", systemImage: "play.fill")
                             .frame(maxWidth: .infinity, minHeight: 44)
                     }
-                    .siloPrimaryButton()
+                    .siloPrimaryButton(isLoading: viewModel.isNextUpTransitioning)
                     .accessibilityIdentifier("next-up-play-now")
                 }
                 if let seconds = viewModel.nextUpCountdownSeconds {
@@ -949,6 +951,7 @@ private struct PlayerNextUpScreen: View {
                             .frame(maxWidth: .infinity, minHeight: 44)
                     }
                     .siloSecondaryButton()
+                    .disabled(viewModel.isNextUpTransitioning)
                 }
                 Button(action: onBack) {
                     Label("Back", systemImage: "chevron.left")

--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -109,6 +109,9 @@ struct PlayerView: View {
             ZStack(alignment: .top) {
                 if let error = viewModel.error {
                     errorView(error)
+                    #if os(iOS)
+                    loadingCloseButton
+                    #endif
                 } else {
                     if !viewModel.showNextUpScreen {
 
@@ -243,10 +246,7 @@ struct PlayerView: View {
                             // Invisible gestures (tap-to-toggle, double-tap skip,
                             // hold-2×, edge swipes, pinch) live in a dedicated
                             // layer under the button overlay.
-                            MobilePlayerGestureLayer(
-                                viewModel: viewModel,
-                                onDismiss: { dismissPlayer() }
-                            )
+                            MobilePlayerGestureLayer(viewModel: viewModel)
                             MobilePlayerControls(
                                 viewModel: viewModel,
                                 orientationCoordinator: orientationCoordinator,
@@ -578,11 +578,12 @@ struct PlayerView: View {
                 Image(systemName: "xmark")
                     .font(.system(size: 14, weight: .semibold))
                     .foregroundStyle(.white)
-                    .frame(width: 40, height: 40)
+                    .frame(width: 44, height: 44)
             }
             .buttonStyle(.glass)
             .buttonBorderShape(.circle)
             .accessibilityLabel("Close Player")
+            .accessibilityIdentifier("player.close")
 
             Spacer()
         }

--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -102,9 +102,6 @@ struct PlayerView: View {
                             }
                         }
                     )
-                    #if os(iOS)
-                    .padding(.top, MobilePlayerRotationControls.topClearance)
-                    #endif
                 }
             }
         }
@@ -116,6 +113,9 @@ struct PlayerView: View {
                     loadingCloseButton
                     #endif
                 } else {
+                    #if os(iOS)
+                    if viewModel.showNextUpScreen { loadingCloseButton }
+                    #endif
                     if !viewModel.showNextUpScreen {
 
                         #if os(tvOS)
@@ -279,7 +279,10 @@ struct PlayerView: View {
         }
         #if os(iOS)
         .overlay(alignment: .topTrailing) {
-            MobilePlayerRotationControls(orientationCoordinator: orientationCoordinator) {
+            MobilePlayerRotationControls(
+                orientationCoordinator: orientationCoordinator,
+                isVisible: viewModel.shouldShowMobileRotationControls
+            ) {
                 viewModel.resumeAutoHide()
             }
             .padding(.horizontal)
@@ -660,7 +663,9 @@ struct PlayerNextUpScreen: View {
         GeometryReader { proxy in
             ZStack {
                 Color.black.ignoresSafeArea()
+                #if !os(iOS)
                 backgroundImage
+                #endif
 
                 #if os(tvOS)
                 ScrollView(.vertical, showsIndicators: false) {
@@ -680,13 +685,26 @@ struct PlayerNextUpScreen: View {
                     miniPlayerPane
                 } panel: { compact in
                     mobileNextUpPanel(compact: compact)
+                        .anchorPreference(key: PlayerPreviewBoundsKey.self, value: .bounds) { .init(actions: $0) }
                 } extras: {
+                    #if !os(iOS)
                     if !viewModel.nextUpCarouselItems.isEmpty {
                         onDeckSection
                     }
+                    #endif
                 }
+                #if os(iOS)
+                .padding(.top, MobilePlayerRotationControls.topClearance)
+                #endif
                 #endif
             }
+            #if os(iOS)
+            // Artwork is decoration, not a sibling allowed to enlarge this
+            // ZStack's ideal size. Pin the entire screen to the real viewport.
+            .frame(width: proxy.size.width, height: proxy.size.height)
+            .background { backgroundImage }
+            .clipped()
+            #endif
         }
         #if os(tvOS)
         .ignoresSafeArea()
@@ -769,7 +787,11 @@ struct PlayerNextUpScreen: View {
             }
             actionRow(hasNextEpisode: viewModel.nextUpEpisode != nil, compact: compact)
             if viewModel.nextUpEpisode != nil {
+                #if os(iOS)
+                if !compact { autoPlayToggle }
+                #else
                 autoPlayToggle
+                #endif
             } else if !viewModel.isLoadingNextUpEpisode {
                 Text(finishedMessage)
                     .font(.caption)
@@ -986,11 +1008,18 @@ struct PlayerNextUpScreen: View {
                 }
                 .siloSecondaryButton()
                 .frame(minHeight: 44)
+                #if os(iOS)
+                if compact && hasNextEpisode { autoPlayToggle }
+                #endif
             }
         }
         .font(.callout)
         .lineLimit(1)
+        #if os(iOS)
+        .frame(maxWidth: compact ? 560 : 380)
+        #else
         .frame(maxWidth: 380)
+        #endif
         #endif
     }
 
@@ -1044,6 +1073,15 @@ struct PlayerNextUpScreen: View {
     }
 
     private var finishedMessage: String {
+        #if os(iOS)
+        if viewModel.nextUpStartError != nil {
+            return "Couldn't start the next episode. Try again or go back."
+        }
+        if viewModel.nextUpLookupError != nil {
+            return "Couldn't load the next episode. Go back to choose something else."
+        }
+        return "No next episode is available."
+        #else
         if let startError = viewModel.nextUpStartError {
             let suffix = viewModel.nextUpCarouselItems.isEmpty
                 ? "Try again or go back."
@@ -1057,6 +1095,7 @@ struct PlayerNextUpScreen: View {
             return "No next episode is available."
         }
         return "No next episode is available. Pick something from On Deck instead."
+        #endif
     }
 
     private func focusPreferredAction() {

--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -83,185 +83,191 @@ struct PlayerView: View {
     }
 
     var body: some View {
-        ZStack(alignment: .top) {
-            Color.black.ignoresSafeArea()
-
-            if let error = viewModel.error {
-                errorView(error)
-            } else {
-                if viewModel.showNextUpScreen {
+        PlayerSurfaceLayout(isPreview: viewModel.showNextUpScreen) {
+            playerSurface()
+                .opacity(viewModel.error == nil ? 1 : 0)
+        } content: {
+            ZStack {
+                Color.black.ignoresSafeArea()
+                if viewModel.showNextUpScreen && viewModel.error == nil {
                     PlayerNextUpScreen(
                         viewModel: viewModel,
                         onBack: {
                             if !viewModel.keepWatchingCurrentEpisode() {
                                 dismissPlayer()
                             }
-                        },
-                        miniPlayer: { playerSurface(ignoresSafeArea: false) }
+                        }
                     )
-                    .transition(.opacity)
+                }
+            }
+        }
+        .overlay(alignment: .top) {
+            ZStack(alignment: .top) {
+                if let error = viewModel.error {
+                    errorView(error)
                 } else {
-                    playerSurface()
+                    if !viewModel.showNextUpScreen {
 
-                    #if os(tvOS)
-                    // Focus sink with UIKit-backed press capture. Mounted
-                    // whenever the transport overlay is hidden OR a seek
-                    // session is active — in both cases it's the sole target
-                    // for the Siri Remote.
-                    //
-                    // Two modes:
-                    //   • Not in seek mode: Tap Left/Right = quick skip,
-                    //     Tap Down = open the player menu, Tap Up = reveal the
-                    //     full transport HUD, Tap Select = pause and
-                    //     enter the focused timeline,
-                    //     Hold Left/Right = enter seek mode.
-                    //   • In seek mode: Tap Left/Right = adjust rate along
-                    //     the signed ladder, Tap Select = commit + exit,
-                    //     Menu = cancel + exit (handled in onExitCommand).
-                    //     Taps against Up/Down are ignored; holds are no-ops.
-                    // Never while the HUD is presented: the sink and the HUD's
-                    // focus graph would be two owners for the same presses
-                    // (docs/tvos-focus.md), and the sink's Down handler
-                    // force-switches the HUD tab underneath the user.
-                    if !viewModel.isLoading && !viewModel.isHUDPresented &&
-                        (!(viewModel.showIntroSkip || viewModel.showCreditsSkip) || viewModel.isHoldSeeking) &&
-                        (!viewModel.showControls || viewModel.isHoldSeeking) {
-                        TVPressCaptureView(
-                            onArrowTap: { direction in
-                                if viewModel.isHoldSeeking {
+                        #if os(tvOS)
+                        // Focus sink with UIKit-backed press capture. Mounted
+                        // whenever the transport overlay is hidden OR a seek
+                        // session is active — in both cases it's the sole target
+                        // for the Siri Remote.
+                        //
+                        // Two modes:
+                        //   • Not in seek mode: Tap Left/Right = quick skip,
+                        //     Tap Down = open the player menu, Tap Up = reveal the
+                        //     full transport HUD, Tap Select = pause and
+                        //     enter the focused timeline,
+                        //     Hold Left/Right = enter seek mode.
+                        //   • In seek mode: Tap Left/Right = adjust rate along
+                        //     the signed ladder, Tap Select = commit + exit,
+                        //     Menu = cancel + exit (handled in onExitCommand).
+                        //     Taps against Up/Down are ignored; holds are no-ops.
+                        // Never while the HUD is presented: the sink and the HUD's
+                        // focus graph would be two owners for the same presses
+                        // (docs/tvos-focus.md), and the sink's Down handler
+                        // force-switches the HUD tab underneath the user.
+                        if !viewModel.isLoading && !viewModel.isHUDPresented &&
+                            (!(viewModel.showIntroSkip || viewModel.showCreditsSkip) || viewModel.isHoldSeeking) &&
+                            (!viewModel.showControls || viewModel.isHoldSeeking) {
+                            TVPressCaptureView(
+                                onArrowTap: { direction in
+                                    if viewModel.isHoldSeeking {
+                                        switch direction {
+                                        case .left:  viewModel.adjustHoldSeekRate(delta: -1)
+                                        case .right: viewModel.adjustHoldSeekRate(delta: +1)
+                                        case .up, .down: break
+                                        }
+                                    } else {
+                                        switch direction {
+                                        case .left:  viewModel.skipBackward()
+                                        case .right: viewModel.skipForward()
+                                        case .down:  viewModel.openSettingsHUD()
+                                        case .up:    viewModel.revealControls()
+                                        }
+                                    }
+                                },
+                                onArrowHoldBegin: { direction in
+                                    // Only Left / Right enter seek mode. Hold on
+                                    // Up / Down is ignored so it can't be
+                                    // accidentally triggered while skipping.
                                     switch direction {
-                                    case .left:  viewModel.adjustHoldSeekRate(delta: -1)
-                                    case .right: viewModel.adjustHoldSeekRate(delta: +1)
+                                    case .left:  viewModel.beginHoldSeek(forward: false)
+                                    case .right: viewModel.beginHoldSeek(forward: true)
                                     case .up, .down: break
                                     }
-                                } else {
-                                    switch direction {
-                                    case .left:  viewModel.skipBackward()
-                                    case .right: viewModel.skipForward()
-                                    case .down:  viewModel.openSettingsHUD()
-                                    case .up:    viewModel.revealControls()
+                                },
+                                onDirectionalPressBegan: {
+                                    timelinePreviewContactCanToggle = false
+                                },
+                                onTouchSurfaceContactBegan: {
+                                    handleTimelinePreviewContactBegan()
+                                },
+                                onTouchSurfaceContactEnded: {
+                                    handleTimelinePreviewContactEnded()
+                                },
+                                onTouchSurfaceContactCancelled: {
+                                    handleTimelinePreviewContactCancelled()
+                                },
+                                onSelect: {
+                                    if viewModel.isHoldSeeking {
+                                        viewModel.commitHoldSeek()
+                                    } else if viewModel.isPlaying {
+                                        timelinePreviewContactCanToggle = false
+                                        hideTimelinePreview(immediately: true)
+                                        viewModel.pauseForTimelineSelection()
+                                        timelineSelectionRequest = UUID()
+                                    } else {
+                                        viewModel.revealControls()
                                     }
                                 }
-                            },
-                            onArrowHoldBegin: { direction in
-                                // Only Left / Right enter seek mode. Hold on
-                                // Up / Down is ignored so it can't be
-                                // accidentally triggered while skipping.
-                                switch direction {
-                                case .left:  viewModel.beginHoldSeek(forward: false)
-                                case .right: viewModel.beginHoldSeek(forward: true)
-                                case .up, .down: break
-                                }
-                            },
-                            onDirectionalPressBegan: {
-                                timelinePreviewContactCanToggle = false
-                            },
-                            onTouchSurfaceContactBegan: {
-                                handleTimelinePreviewContactBegan()
-                            },
-                            onTouchSurfaceContactEnded: {
-                                handleTimelinePreviewContactEnded()
-                            },
-                            onTouchSurfaceContactCancelled: {
-                                handleTimelinePreviewContactCancelled()
-                            },
-                            onSelect: {
-                                if viewModel.isHoldSeeking {
-                                    viewModel.commitHoldSeek()
-                                } else if viewModel.isPlaying {
-                                    timelinePreviewContactCanToggle = false
-                                    hideTimelinePreview(immediately: true)
-                                    viewModel.pauseForTimelineSelection()
-                                    timelineSelectionRequest = UUID()
-                                } else {
-                                    viewModel.revealControls()
-                                }
-                            }
-                        )
-                        .ignoresSafeArea()
-                    }
+                            )
+                            .ignoresSafeArea()
+                        }
 
-                    // `isLoading` also covers Protocol V3 replans (track or
-                    // quality changes made *from inside the HUD*). Unmounting
-                    // here for those would destroy the HUD's @State/@FocusState
-                    // mid-press and reseed focus on a reset tab, so the HUD
-                    // keeps its host mounted through a replan. A replacement
-                    // load closes the HUD in `resetPublishedLoadState`, so
-                    // cold starts and item changes still unmount as before.
-                    if (!viewModel.isLoading || viewModel.isHUDPresented) && !viewModel.isHoldSeeking {
-                        TVPlayerControls(
-                            viewModel: viewModel,
-                            showsTimelinePreview: isTimelinePreviewVisible,
-                            timeDisplayMode: timelineTimeDisplayMode,
-                            timelineSelectionRequest: timelineSelectionRequest,
-                            onToggleTimeDisplayMode: {
-                                withAnimation(.easeOut(duration: ContinuumTheme.fastDuration)) {
-                                    timelineTimeDisplayMode.toggle()
-                                }
-                            },
-                            onDismiss: { dismissPlayer() }
-                        )
-                    }
+                        // `isLoading` also covers Protocol V3 replans (track or
+                        // quality changes made *from inside the HUD*). Unmounting
+                        // here for those would destroy the HUD's @State/@FocusState
+                        // mid-press and reseed focus on a reset tab, so the HUD
+                        // keeps its host mounted through a replan. A replacement
+                        // load closes the HUD in `resetPublishedLoadState`, so
+                        // cold starts and item changes still unmount as before.
+                        if (!viewModel.isLoading || viewModel.isHUDPresented) && !viewModel.isHoldSeeking {
+                            TVPlayerControls(
+                                viewModel: viewModel,
+                                showsTimelinePreview: isTimelinePreviewVisible,
+                                timeDisplayMode: timelineTimeDisplayMode,
+                                timelineSelectionRequest: timelineSelectionRequest,
+                                onToggleTimeDisplayMode: {
+                                    withAnimation(.easeOut(duration: ContinuumTheme.fastDuration)) {
+                                        timelineTimeDisplayMode.toggle()
+                                    }
+                                },
+                                onDismiss: { dismissPlayer() }
+                            )
+                        }
 
-                    // Speed-indicator chip shown only while a seek session is
-                    // active. The overlay/scrubber is suppressed during the
-                    // session (so the capture view keeps focus), so this chip
-                    // is the sole source of visual feedback until Select
-                    // commits or Menu cancels.
-                    if viewModel.isHoldSeeking {
-                        HoldSeekIndicator(
-                            rate: viewModel.holdSeekRate,
-                            previewTime: viewModel.scrubPreviewTime,
-                            duration: viewModel.duration,
-                            previewImage: viewModel.scrubPreviewImage
-                        )
-                        .transition(.opacity)
-                        .allowsHitTesting(false)
-                    }
-                    #else
-                    // The full controls overlay (and its close button) only
-                    // mounts once the decoder opens the file, so a standalone
-                    // close control has to cover the load/buffer phase —
-                    // otherwise the only way out of a stalled start is
-                    // force-quitting the app. tvOS gets this via Menu in
-                    // `onExitCommand`; macOS keeps its controls (and Escape)
-                    // during loading.
-                    if viewModel.isLoading {
-                        loadingCloseButton
-                    }
-
-                    if !viewModel.isLoading {
-                        // Invisible gestures (tap-to-toggle, double-tap skip,
-                        // hold-2×, edge swipes, pinch) live in a dedicated
-                        // layer under the button overlay.
-                        MobilePlayerGestureLayer(
-                            viewModel: viewModel,
-                            onDismiss: { dismissPlayer() }
-                        )
-                        MobilePlayerControls(
-                            viewModel: viewModel,
-                            orientationCoordinator: orientationCoordinator,
-                            onDismiss: { dismissPlayer() }
-                        )
-                    }
-                    #endif
-
-                    #if os(tvOS)
-                    if let identity = remoteIdentityNotice {
-                        RemotePlaybackIdentityNotice(identity: identity)
+                        // Speed-indicator chip shown only while a seek session is
+                        // active. The overlay/scrubber is suppressed during the
+                        // session (so the capture view keeps focus), so this chip
+                        // is the sole source of visual feedback until Select
+                        // commits or Menu cancels.
+                        if viewModel.isHoldSeeking {
+                            HoldSeekIndicator(
+                                rate: viewModel.holdSeekRate,
+                                previewTime: viewModel.scrubPreviewTime,
+                                duration: viewModel.duration,
+                                previewImage: viewModel.scrubPreviewImage
+                            )
                             .transition(.opacity)
-                    } else if let notice = viewModel.activeNotice {
-                        PlayerNoticeOverlay(notice: notice)
-                    }
-                    #else
-                    if let notice = viewModel.activeNotice {
-                        PlayerNoticeOverlay(notice: notice)
-                    }
-                    #endif
-                }
+                            .allowsHitTesting(false)
+                        }
+                        #else
+                        // The full controls overlay (and its close button) only
+                        // mounts once the decoder opens the file, so a standalone
+                        // close control has to cover the load/buffer phase —
+                        // otherwise the only way out of a stalled start is
+                        // force-quitting the app. tvOS gets this via Menu in
+                        // `onExitCommand`; macOS keeps its controls (and Escape)
+                        // during loading.
+                        if viewModel.isLoading {
+                            loadingCloseButton
+                        }
 
-                if viewModel.isLoading || viewModel.isBuffering {
-                    PlayerBufferingCapsule()
+                        if !viewModel.isLoading {
+                            // Invisible gestures (tap-to-toggle, double-tap skip,
+                            // hold-2×, edge swipes, pinch) live in a dedicated
+                            // layer under the button overlay.
+                            MobilePlayerGestureLayer(
+                                viewModel: viewModel,
+                                onDismiss: { dismissPlayer() }
+                            )
+                            MobilePlayerControls(
+                                viewModel: viewModel,
+                                orientationCoordinator: orientationCoordinator,
+                                onDismiss: { dismissPlayer() }
+                            )
+                        }
+                        #endif
+
+                        #if os(tvOS)
+                        if let identity = remoteIdentityNotice {
+                            RemotePlaybackIdentityNotice(identity: identity)
+                                .transition(.opacity)
+                        } else if let notice = viewModel.activeNotice {
+                            PlayerNoticeOverlay(notice: notice)
+                        }
+                        #else
+                        if let notice = viewModel.activeNotice {
+                            PlayerNoticeOverlay(notice: notice)
+                        }
+                        #endif
+                    }
+
+                    if viewModel.isLoading || viewModel.isBuffering {
+                        PlayerBufferingCapsule()
+                    }
                 }
             }
         }
@@ -535,9 +541,8 @@ struct PlayerView: View {
     /// `MobilePlayerGestureLayer`, mounted above this surface.
     ///
     /// Aether owns native/software route selection behind this one surface.
-    @ViewBuilder
-    private func playerSurface(ignoresSafeArea: Bool = true) -> some View {
-        let surface = AetherPlayerSurface(engine: viewModel.aetherEngine)
+    private func playerSurface() -> some View {
+        AetherPlayerSurface(engine: viewModel.aetherEngine)
             .background(Color.black)
             .overlay {
                 AetherSubtitleOverlay(
@@ -553,11 +558,6 @@ struct PlayerView: View {
                     subtitleSyncMs: viewModel.settings.subtitleSyncMs
                 )
             }
-        if ignoresSafeArea {
-            surface.ignoresSafeArea()
-        } else {
-            surface
-        }
     }
 
     #if !os(tvOS)
@@ -622,10 +622,9 @@ private enum PlayerNextUpFocusTarget: Hashable {
     case autoPlay
 }
 
-private struct PlayerNextUpScreen<MiniPlayer: View>: View {
+private struct PlayerNextUpScreen: View {
     let viewModel: PlayerViewModel
     let onBack: () -> Void
-    @ViewBuilder let miniPlayer: () -> MiniPlayer
     @FocusState private var focusedTarget: PlayerNextUpFocusTarget?
     @State private var onDeckFocusRequest = 0
     @State private var didRequestInitialActionFocus = false
@@ -650,6 +649,9 @@ private struct PlayerNextUpScreen<MiniPlayer: View>: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .defaultScrollAnchor(.top)
                 .scrollClipDisabled()
+                .transformAnchorPreference(key: PlayerPreviewBoundsKey.self, value: .bounds) {
+                    $0.viewport = $1
+                }
                 #else
                 screenContent(maxMainWidth: mainContentWidth(for: proxy))
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
@@ -723,20 +725,16 @@ private struct PlayerNextUpScreen<MiniPlayer: View>: View {
             }
             .frame(maxWidth: .infinity)
         }
+        .transformAnchorPreference(key: PlayerPreviewBoundsKey.self, value: .bounds) {
+            $0.viewport = $1
+        }
         #endif
     }
 
     private var miniPlayerPane: some View {
-        ZStack {
-            miniPlayer()
-        }
+        Color.clear
         .aspectRatio(16 / 9, contentMode: .fit)
-        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .stroke(.white.opacity(0.16), lineWidth: 1)
-        )
-        .shadow(color: .black.opacity(0.55), radius: 34, y: 18)
+        .anchorPreference(key: PlayerPreviewBoundsKey.self, value: .bounds) { .init(bounds: $0) }
         .allowsHitTesting(false)
         .accessibilityHidden(true)
     }

--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -245,9 +245,8 @@ struct PlayerView: View {
                         #else
                         // The full controls overlay (and its close button) only
                         // mounts once the decoder opens the file, so a standalone
-                        // close control has to cover the load/buffer phase —
-                        // otherwise the only way out of a stalled start is
-                        // force-quitting the app. tvOS gets this via Menu in
+                        // close control must remain available through a tap
+                        // during the load/buffer phase. tvOS gets this via Menu in
                         // `onExitCommand`; macOS keeps its controls (and Escape)
                         // during loading.
                         if viewModel.isLoading {
@@ -290,7 +289,7 @@ struct PlayerView: View {
         .overlay(alignment: .topTrailing) {
             MobilePlayerRotationControls(
                 orientationCoordinator: orientationCoordinator,
-                isVisible: viewModel.shouldShowMobileRotationControls
+                isVisible: viewModel.shouldShowMobilePlayerChrome
             ) {
                 viewModel.resumeAutoHide()
             }
@@ -595,8 +594,8 @@ struct PlayerView: View {
     }
 
     #if !os(tvOS)
-    /// Close control shown while the player is still loading/buffering, in
-    /// the same spot (and glass style) as the close button in
+    /// Tap-to-reveal close control while loading and on Next Up, in
+    /// the same spot, size and glass style as the close button in
     /// `MobilePlayerControls`' top strip so the two read as one control.
     private var loadingCloseButton: some View {
         HStack {
@@ -604,10 +603,14 @@ struct PlayerView: View {
                 Image(systemName: "xmark")
                     .font(.system(size: 14, weight: .semibold))
                     .foregroundStyle(.white)
-                    .frame(width: 44, height: 44)
+                    .frame(width: ContinuumTheme.topBarIconHitSize, height: ContinuumTheme.topBarIconHitSize)
             }
+            #if os(iOS)
+            .buttonStyle(MobilePlayerGlassButtonStyle())
+            #else
             .buttonStyle(.glass)
             .buttonBorderShape(.circle)
+            #endif
             .accessibilityLabel("Close Player")
             .accessibilityIdentifier("player.close")
 
@@ -616,6 +619,9 @@ struct PlayerView: View {
         .padding(.horizontal)
         .padding(.top)
         .transition(.opacity)
+        #if os(iOS)
+        .modifier(MobilePlayerChromeVisibility(isVisible: viewModel.shouldShowMobilePlayerChrome))
+        #endif
     }
     #endif
 

--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -93,6 +93,15 @@ struct PlayerView: View {
         } content: {
             ZStack {
                 Color.black.ignoresSafeArea()
+                    #if os(iOS)
+                    .onTapGesture {
+                        // Loaded playback uses MobilePlayerGestureLayer.
+                        // Keep tap-to-reveal available before it mounts too.
+                        if viewModel.isLoading || viewModel.error != nil {
+                            viewModel.toggleControls()
+                        }
+                    }
+                    #endif
                 if viewModel.showNextUpScreen && viewModel.error == nil {
                     PlayerNextUpScreen(
                         viewModel: viewModel,
@@ -663,6 +672,11 @@ struct PlayerNextUpScreen: View {
         GeometryReader { proxy in
             ZStack {
                 Color.black.ignoresSafeArea()
+                    #if os(iOS)
+                    // A background tap reveals/dismisses the rotation pill
+                    // without intercepting Play Now, Back, or Auto Play.
+                    .onTapGesture { viewModel.toggleControls() }
+                    #endif
                 #if !os(iOS)
                 backgroundImage
                 #endif
@@ -771,7 +785,7 @@ struct PlayerNextUpScreen: View {
     #if !os(tvOS)
     func mobileNextUpPanel(compact: Bool = false) -> some View {
         VStack(spacing: compact ? 6 : 10) {
-            // Keep every action reachable below the persistent rotation bar
+            // Keep every action reachable below the rotation bar's reserved area
             // on short landscape screens. Only the redundant eyebrow is omitted.
             if !compact { eyebrow }
             if let episode = viewModel.nextUpEpisode {

--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -623,7 +623,7 @@ private enum PlayerNextUpFocusTarget: Hashable {
     case autoPlay
 }
 
-private struct PlayerNextUpScreen: View {
+struct PlayerNextUpScreen: View {
     let viewModel: PlayerViewModel
     let onBack: () -> Void
     @FocusState private var focusedTarget: PlayerNextUpFocusTarget?
@@ -729,7 +729,7 @@ private struct PlayerNextUpScreen: View {
     }
 
     #if !os(tvOS)
-    private var mobileNextUpPanel: some View {
+    var mobileNextUpPanel: some View {
         VStack(spacing: 10) {
             eyebrow
             if let episode = viewModel.nextUpEpisode {

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -280,9 +280,9 @@ class PlayerViewModel {
     var error: String?
     var showControls = false
     #if os(iOS)
-    var shouldShowMobileRotationControls: Bool {
+    var shouldShowMobilePlayerChrome: Bool {
         // Loading and Next Up must not independently reveal player chrome.
-        // The rotation pill follows the same tap/auto-hide state as transport.
+        // Close and rotation follow the same tap/auto-hide state as transport.
         showControls
     }
     #endif

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -281,7 +281,9 @@ class PlayerViewModel {
     var showControls = false
     #if os(iOS)
     var shouldShowMobileRotationControls: Bool {
-        showControls || showNextUpScreen || isLoading || error != nil
+        // Loading and Next Up must not independently reveal player chrome.
+        // The rotation pill follows the same tap/auto-hide state as transport.
+        showControls
     }
     #endif
     var activeNotice: PlayerNotice?

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -2333,7 +2333,11 @@ class PlayerViewModel {
     }
 
     private func updateNextUpPresentation(for movieTime: Double) {
-        guard !hasReachedEndOfFile else { return }
+        // A retained native host must not reopen the outgoing episode's
+        // postroll before the successor has presented its own first frame.
+        guard !hasReachedEndOfFile,
+              let epoch = activeAetherLoadEpoch,
+              startedAetherLoadEpoch == epoch else { return }
         if showNextUpScreen {
             updateNextUpCountdownForActivePlayback(at: movieTime)
             return
@@ -2511,9 +2515,27 @@ class PlayerViewModel {
     }
 
     func playNextEpisodeNow() {
-        guard let nextUpEpisode else { return }
+        let contentId: String
+        switch PlayerNextUpPlaybackAction.resolve(
+            candidateId: nextUpEpisode?.contentId,
+            currentId: lastLoadRequest?.contentId
+        ) {
+        case .unavailable:
+            return
+        case .expand:
+            // Presentation only: no prepare, load, seek, or play command.
+            // Preserve a preview that is already playing, paused or buffering.
+            cancelNextUpCountdown()
+            nextUpAutoplayCancelled = true
+            nextUpPromptDismissed = true
+            nextUpScreenVideoEnded = false
+            showNextUpScreen = false
+            return
+        case .load(let id):
+            contentId = id
+        }
         var request = LoadRequest(
-            contentId: nextUpEpisode.contentId,
+            contentId: contentId,
             preferredFileId: nil,
             preferredAudioTrackIndex: nil,
             preferredSubtitleTrackIndex: nil,

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -279,6 +279,11 @@ class PlayerViewModel {
     var bufferingProgress: Double?
     var error: String?
     var showControls = false
+    #if os(iOS)
+    var shouldShowMobileRotationControls: Bool {
+        showControls || showNextUpScreen || isLoading || error != nil
+    }
+    #endif
     var activeNotice: PlayerNotice?
     var remoteDismissToken: UUID?
     var audioTracks: [PlayerTrack] = []
@@ -907,6 +912,10 @@ class PlayerViewModel {
     /// apply to the end-of-playback screen.
     private var nextUpPromptDismissed = false
     private(set) var contentIdsNeedingDetailRefresh: Set<String> = []
+    #if os(iOS)
+    @ObservationIgnored
+    private var refreshHomeAfterPlaybackWrite: (@MainActor () -> Void)?
+    #endif
     /// Items that crossed the same completion boundary used by the final
     /// server progress report. The tvOS detail page consumes this only after
     /// that report has finished so it can move its editorial selection to the
@@ -3406,12 +3415,18 @@ class PlayerViewModel {
                currentTime >= 0 {
                 let priorNaturalEndProgressTask = naturalEndProgressTask
                 let endPosition = currentTime
+                #if os(iOS)
+                let refreshHome = refreshHomeAfterPlaybackWrite
+                #endif
                 naturalEndProgressTask = Task { [sessionBridge] in
                     await priorNaturalEndProgressTask?.value
-                    _ = await sessionBridge.reportProgress(
+                    let result = await sessionBridge.reportProgress(
                         position: endPosition,
                         isPaused: true
                     )
+                    #if os(iOS)
+                    if result == .success { refreshHome?() }
+                    #endif
                 }
             }
         }
@@ -3695,6 +3710,11 @@ class PlayerViewModel {
         origin: LoadOrigin = .userInitiated
     ) {
         guard !isDisposed else { return }
+        #if os(iOS)
+        if refreshHomeAfterPlaybackWrite == nil {
+            refreshHomeAfterPlaybackWrite = StartupContentPrefetcher.homeRefreshAfterPlaybackWrite()
+        }
+        #endif
         #if os(tvOS)
         PosterImageCache.trimDecodedMemory()
         #endif
@@ -3774,6 +3794,9 @@ class PlayerViewModel {
                 } else {
                     await self.sessionBridge.reportProgress(position: snapshotPosition, isPaused: true)
                 }
+                #if os(iOS)
+                self.refreshHomeAfterPlaybackWrite?()
+                #endif
             }
             guard !Task.isCancelled,
                   !self.isDisposed,
@@ -6106,6 +6129,9 @@ class PlayerViewModel {
             if stopServerSessionOnTeardown {
                 await sessionBridge.stopSession(position: finalPosition, isPaused: true)
             }
+            #if os(iOS)
+            refreshHomeAfterPlaybackWrite?()
+            #endif
         }
     }
 

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -320,6 +320,9 @@ class PlayerViewModel {
     var bufferedAheadSeconds: Double = 0
     var playbackStats: PlaybackStats = .empty
     var showNextUpScreen = false
+    /// A Next Up load keeps its preview until the successor's own startup
+    /// milestone. Repeated actions cannot reload it or expand an unready frame.
+    private(set) var isNextUpTransitioning = false
     var nextUpEpisode: PlayerNextUpEpisode?
     var nextUpOnDeckItems: [PlayerOnDeckItem] = []
     var isLoadingNextUpEpisode = false
@@ -1357,6 +1360,16 @@ class PlayerViewModel {
         guard startedAetherLoadEpoch != epoch else { return }
         startedAetherLoadEpoch = epoch
         handleFileLoaded()
+        if isNextUpTransitioning {
+            isNextUpTransitioning = false
+            showNextUpScreen = false
+            nextUpEpisode = nil
+            nextUpOnDeckItems = []
+            if let detail = currentWatchDetail {
+                loadNextUpCandidate(for: detail)
+                loadNextUpOnDeckItems(for: detail)
+            }
+        }
         if activePreparedProtocolV3 != nil {
             pendingProtocolV3FirstFrameEpoch = epoch
             completeProtocolV3FirstFrameIfCommitted(epoch)
@@ -2395,6 +2408,7 @@ class PlayerViewModel {
     private func startNextUpCountdownIfNeeded() {
         cancelNextUpCountdown()
         guard showNextUpScreen,
+              !isNextUpTransitioning,
               settings.autoPlayNextEpisode,
               nextUpEpisode != nil,
               !nextUpAutoplayCancelled else {
@@ -2424,6 +2438,7 @@ class PlayerViewModel {
 
     private func updateNextUpCountdownForActivePlayback(at movieTime: Double) {
         guard showNextUpScreen,
+              !isNextUpTransitioning,
               !nextUpScreenVideoEnded,
               settings.autoPlayNextEpisode,
               nextUpEpisode != nil,
@@ -2475,7 +2490,7 @@ class PlayerViewModel {
         // An autoplay load failure may restore the postroll after disposing
         // the old playback pipeline. There is no current episode to resume in
         // that state, so let the shell fall back to closing the player.
-        guard hasActiveAetherSession else { return false }
+        guard hasActiveAetherSession, !isNextUpTransitioning else { return false }
 
         let shouldResumeAfterEnd = nextUpScreenVideoEnded || hasReachedEndOfFile
         nextUpAutoplayCancelled = true
@@ -2518,9 +2533,10 @@ class PlayerViewModel {
         let contentId: String
         switch PlayerNextUpPlaybackAction.resolve(
             candidateId: nextUpEpisode?.contentId,
-            currentId: lastLoadRequest?.contentId
+            currentId: lastLoadRequest?.contentId,
+            awaitingPicture: isNextUpTransitioning
         ) {
-        case .unavailable:
+        case .unavailable, .waitForPicture:
             return
         case .expand:
             // Presentation only: no prepare, load, seek, or play command.
@@ -3513,9 +3529,11 @@ class PlayerViewModel {
         // it, both because its content is stale and because the tvOS controls
         // host stays mounted through `isLoading` whenever this flag is up.
         isHUDPresented = false
-        showNextUpScreen = false
-        nextUpEpisode = nil
-        nextUpOnDeckItems = []
+        showNextUpScreen = isNextUpTransitioning
+        if !isNextUpTransitioning {
+            nextUpEpisode = nil
+            nextUpOnDeckItems = []
+        }
         isLoadingNextUpEpisode = false
         isLoadingNextUpOnDeck = false
         nextUpLookupError = nil
@@ -3680,6 +3698,7 @@ class PlayerViewModel {
         #if os(tvOS)
         PosterImageCache.trimDecodedMemory()
         #endif
+        isNextUpTransitioning = origin == .autoplay && showNextUpScreen
         let currentItemCompleted = PlayerNextUpCompletionPolicy.shouldFinalizeAsCompleted(
             isNextUpPresented: showNextUpScreen,
             hasReachedEndOfFile: hasReachedEndOfFile,
@@ -3870,8 +3889,13 @@ class PlayerViewModel {
                 // server to resolve a next episode against.
                 if request.offlineDownloadId == nil {
                     self.pushNowPlayingArtwork(contentId: prepared.watchDetail.contentId)
-                    self.loadNextUpCandidate(for: prepared.watchDetail)
-                    self.loadNextUpOnDeckItems(for: prepared.watchDetail)
+                    // The panel still describes the successor being loaded.
+                    // Fetch its following episode only once it has a picture,
+                    // otherwise the visible Play Now target can jump again.
+                    if !self.isNextUpTransitioning {
+                        self.loadNextUpCandidate(for: prepared.watchDetail)
+                        self.loadNextUpOnDeckItems(for: prepared.watchDetail)
+                    }
                 }
                 self.qualityOptions = ApplePlaybackQuality.playbackOptions(
                     serverQualities: prepared.protocolV3?.plan.availableQualities ?? [],
@@ -4067,6 +4091,7 @@ class PlayerViewModel {
     /// `error` overlay.
     @MainActor
     private func handleBeginFreshLoadFailure(error: Error, origin: LoadOrigin) {
+        isNextUpTransitioning = false
         let message: String = {
             if case BeginFreshLoadError.startSessionTimeout = error {
                 return "The server didn't respond in time."

--- a/iosApp/iosApp/Screens/Player/iOS/MobilePlayerControls.swift
+++ b/iosApp/iosApp/Screens/Player/iOS/MobilePlayerControls.swift
@@ -865,15 +865,15 @@ struct MobilePlayerControls: View {
     }
 }
 
-/// Always mounted at the player's top-right, independently of transport
-/// auto-hide, loading, errors, and Next Up. Fixed glyphs and equal tap areas
-/// keep the lock centred when the screen rotates or the lock changes state.
+/// Top-right chrome follows the transport visibility during playback; Next
+/// Up keeps its own controls visible. Equal tap areas keep the lock centred.
 struct MobilePlayerRotationControls: View {
     static let width: CGFloat = 128
     static let height: CGFloat = 52
     static let topClearance: CGFloat = height + 32
 
     let orientationCoordinator: PlayerOrientationCoordinator
+    var isVisible = true
     var onInteraction: () -> Void = {}
 
     var body: some View {
@@ -905,6 +905,10 @@ struct MobilePlayerRotationControls: View {
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
         .siloGlass(in: Capsule(), interactive: true)
+        .opacity(isVisible ? 1 : 0)
+        .allowsHitTesting(isVisible)
+        .accessibilityHidden(!isVisible)
+        .animation(.easeOut(duration: 0.18), value: isVisible)
     }
 
     private func icon(_ symbol: String) -> some View {

--- a/iosApp/iosApp/Screens/Player/iOS/MobilePlayerControls.swift
+++ b/iosApp/iosApp/Screens/Player/iOS/MobilePlayerControls.swift
@@ -151,8 +151,8 @@ struct MobilePlayerControls: View {
                 if !compact { titleBlock }
                 Spacer(minLength: 0)
                 if !compact { externalPlaybackControls }
-                // The persistent rotation pill is a sibling overlay, not
-                // part of the controls that fade. Reserve its exact width.
+                // The rotation pill is a sibling overlay that fades with
+                // these controls. Reserve its exact width to avoid overlap.
                 Color.clear
                     .frame(width: MobilePlayerRotationControls.width,
                            height: MobilePlayerRotationControls.height)
@@ -873,7 +873,7 @@ struct MobilePlayerRotationControls: View {
     static let topClearance: CGFloat = height + 32
 
     let orientationCoordinator: PlayerOrientationCoordinator
-    var isVisible = true
+    let isVisible: Bool
     var onInteraction: () -> Void = {}
 
     var body: some View {

--- a/iosApp/iosApp/Screens/Player/iOS/MobilePlayerControls.swift
+++ b/iosApp/iosApp/Screens/Player/iOS/MobilePlayerControls.swift
@@ -8,7 +8,7 @@ import SwiftUI
 /// - Bottom stack: time row (elapsed / status chips / remaining), capsule
 ///   scrubber with buffered range + intro tint + chapter ticks + scrub
 ///   preview bubble, then a labeled action row (Quality menu, Audio &
-///   Subtitles sheet, Chapters menu, orientation Lock, More → settings sheet)
+///   Subtitles sheet, Chapters menu, rotation pill, More → settings sheet)
 ///
 /// The whole thing is wrapped in a tap-to-toggle gesture; auto-hide after 3 s
 /// of inactivity. The view is stateful only for sheet presentation and the
@@ -69,6 +69,9 @@ struct MobilePlayerControls: View {
                         .padding(.bottom, 2)
                         .frame(width: proxy.size.width, height: proxy.size.height)
                         .animation(.easeOut(duration: 0.18), value: viewModel.isScrubbing)
+                    }
+                    .onChange(of: proxy.size, initial: true) { _, _ in
+                        orientationCoordinator.refreshInterfaceOrientation()
                     }
                 }
                 .transition(.opacity)
@@ -500,12 +503,12 @@ struct MobilePlayerControls: View {
 
     private enum ActionRowStyle {
         case full      // labeled pills, value on the Quality pill
-        case compact   // shorter labels, lock folds to a circle
-        case icons     // circles everywhere except the Quality value pill
+        case compact   // shorter labels
+        case icons     // icon controls; Quality and rotation remain pills
     }
 
     /// Labeled pill row. `ViewThatFits` tries the full labels first, then
-    /// compact ones, then icon circles, so the row never truncates or wraps
+    /// compact ones, then icon controls, so the row never truncates or wraps
     /// — an iPhone in portrait with chapters present lands on `.icons`.
     private var actionRow: some View {
         ViewThatFits(in: .horizontal) {
@@ -541,7 +544,7 @@ struct MobilePlayerControls: View {
                     .accessibilityLabel("Chapters")
             }
 
-            lockControl(compact: style != .full)
+            rotationPill(compact: style == .icons)
 
             controlButton(systemName: "ellipsis") {
                 activeSheet = .settings
@@ -709,25 +712,32 @@ struct MobilePlayerControls: View {
         }
     }
 
-    private func lockControl(compact: Bool) -> some View {
-        let isLocked = orientationCoordinator.isLandscapeLocked
-        return Group {
-            if compact {
-                controlButton(systemName: isLocked ? "lock.fill" : "lock.open") {
-                    orientationCoordinator.togglePlayerMode()
-                }
-            } else {
-                actionPill(systemImage: isLocked ? "lock.fill" : "lock.open", title: "Lock") {
-                    orientationCoordinator.togglePlayerMode()
+    private func rotationPill(compact: Bool) -> some View {
+        let target = orientationCoordinator.nextPlayerOrientation
+        return Button {
+            orientationCoordinator.togglePlayerOrientation()
+            viewModel.resumeAutoHide()
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: target.symbolName)
+                    .font(.system(size: 14, weight: .semibold))
+                if compact {
+                    Image(systemName: "arrow.triangle.2.circlepath")
+                        .font(.system(size: 10, weight: .semibold))
+                } else {
+                    Text(target.title)
+                        .font(.system(size: 12, weight: .semibold))
                 }
             }
+            .foregroundStyle(.white)
+            .padding(.horizontal, 12)
+            .frame(minWidth: 56, minHeight: 44)
         }
-        .accessibilityLabel(isLocked ? "Landscape Locked" : "Rotate Freely")
-        .accessibilityHint(
-            isLocked
-                ? "Allows portrait rotation during playback"
-                : "Locks playback to landscape"
-        )
+        .buttonStyle(.glass)
+        .buttonBorderShape(.capsule)
+        .accessibilityLabel("Rotate to \(target.title)")
+        .accessibilityHint("Rotates the screen without interrupting playback")
+        .accessibilityIdentifier("player.rotate")
     }
 
     private func actionPill(

--- a/iosApp/iosApp/Screens/Player/iOS/MobilePlayerControls.swift
+++ b/iosApp/iosApp/Screens/Player/iOS/MobilePlayerControls.swift
@@ -553,6 +553,7 @@ struct MobilePlayerControls: View {
             }
 
             rotationPill(compact: style == .icons)
+            rotationLockButton
 
             controlButton(systemName: "ellipsis") {
                 activeSheet = .settings
@@ -748,6 +749,20 @@ struct MobilePlayerControls: View {
         .accessibilityIdentifier("player.rotate")
     }
 
+    private var rotationLockButton: some View {
+        let isLocked = orientationCoordinator.isRotationLocked
+        return controlButton(systemName: isLocked ? "lock.fill" : "lock.open", size: 44) {
+            orientationCoordinator.toggleRotationLock()
+            viewModel.resumeAutoHide()
+        }
+        .accessibilityLabel(isLocked ? "Unlock screen rotation" : "Lock screen rotation")
+        .accessibilityValue(isLocked ? "Locked" : "Unlocked")
+        .accessibilityHint(isLocked
+            ? "Allows video to follow phone orientation"
+            : "Stops phone movement rotating video. The rotate button still works")
+        .accessibilityIdentifier("player.rotation-lock")
+    }
+
     private func actionPill(
         systemImage: String,
         title: String,
@@ -856,12 +871,12 @@ struct MobilePlayerControls: View {
 
     // MARK: - Helpers
 
-    private func controlButton(systemName: String, action: @escaping () -> Void) -> some View {
+    private func controlButton(systemName: String, size: CGFloat = 40, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Image(systemName: systemName)
                 .font(.system(size: 14, weight: .semibold))
                 .foregroundStyle(.white)
-                .frame(width: 40, height: 40)
+                .frame(width: size, height: size)
         }
         // `.circle` keeps each glass control a compact circle instead of the
         // default wider capsule so rows of controls stay dense.

--- a/iosApp/iosApp/Screens/Player/iOS/MobilePlayerControls.swift
+++ b/iosApp/iosApp/Screens/Player/iOS/MobilePlayerControls.swift
@@ -150,8 +150,16 @@ struct MobilePlayerControls: View {
 
     private var topStrip: some View {
         HStack(alignment: .center, spacing: 12) {
-            controlButton(systemName: "xmark", action: onDismiss)
-                .accessibilityLabel("Close Player")
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.white)
+                    .frame(width: 44, height: 44)
+            }
+            .buttonStyle(.glass)
+            .buttonBorderShape(.circle)
+            .accessibilityLabel("Close Player")
+            .accessibilityIdentifier("player.close")
 
             titleBlock
 

--- a/iosApp/iosApp/Screens/Player/iOS/MobilePlayerControls.swift
+++ b/iosApp/iosApp/Screens/Player/iOS/MobilePlayerControls.swift
@@ -8,7 +8,7 @@ import SwiftUI
 /// - Bottom stack: time row (elapsed / status chips / remaining), capsule
 ///   scrubber with buffered range + intro tint + chapter ticks + scrub
 ///   preview bubble, then a labeled action row (Quality menu, Audio &
-///   Subtitles sheet, Chapters menu, rotation pill, More → settings sheet)
+///   Subtitles sheet, Chapters menu, More → settings sheet)
 ///
 /// The whole thing is wrapped in a tap-to-toggle gesture; auto-hide after 3 s
 /// of inactivity. The view is stateful only for sheet presentation and the
@@ -17,7 +17,6 @@ import SwiftUI
 /// swipes) live in `MobilePlayerGestureLayer` underneath this overlay.
 struct MobilePlayerControls: View {
     let viewModel: PlayerViewModel
-    let orientationCoordinator: PlayerOrientationCoordinator
     let onDismiss: () -> Void
 
     @State private var activeSheet: PlayerSheet?
@@ -53,7 +52,7 @@ struct MobilePlayerControls: View {
                             .onTapGesture { viewModel.toggleControls() }
 
                         VStack(spacing: 0) {
-                            topStrip
+                            topStrip(compact: proxy.size.width < proxy.size.height)
                                 .opacity(recedingOpacity)
                             Spacer()
                             centerCluster
@@ -69,9 +68,6 @@ struct MobilePlayerControls: View {
                         .padding(.bottom, 2)
                         .frame(width: proxy.size.width, height: proxy.size.height)
                         .animation(.easeOut(duration: 0.18), value: viewModel.isScrubbing)
-                    }
-                    .onChange(of: proxy.size, initial: true) { _, _ in
-                        orientationCoordinator.refreshInterfaceOrientation()
                     }
                 }
                 .transition(.opacity)
@@ -148,52 +144,74 @@ struct MobilePlayerControls: View {
 
     // MARK: - Top strip
 
-    private var topStrip: some View {
-        HStack(alignment: .center, spacing: 12) {
-            Button(action: onDismiss) {
-                Image(systemName: "xmark")
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(.white)
-                    .frame(width: 44, height: 44)
+    private func topStrip(compact: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .center, spacing: 12) {
+                closeButton
+                if !compact { titleBlock }
+                Spacer(minLength: 0)
+                if !compact { externalPlaybackControls }
+                // The persistent rotation pill is a sibling overlay, not
+                // part of the controls that fade. Reserve its exact width.
+                Color.clear
+                    .frame(width: MobilePlayerRotationControls.width,
+                           height: MobilePlayerRotationControls.height)
+                    .allowsHitTesting(false)
+                    .accessibilityHidden(true)
             }
-            .buttonStyle(.glass)
-            .buttonBorderShape(.circle)
-            .accessibilityLabel("Close Player")
-            .accessibilityIdentifier("player.close")
-
-            titleBlock
-
-            Spacer(minLength: 12)
-
-            if pictureInPicture.isSupported, pictureInPicture.hasSource {
-                controlButton(
-                    systemName: pictureInPicture.isActive ? "pip.exit" : "pip.enter"
-                ) {
-                    pictureInPicture.toggle()
+            if compact {
+                HStack(spacing: 12) {
+                    titleBlock
+                    Spacer(minLength: 12)
+                    externalPlaybackControls
                 }
-                // AVKit can report `possible == false` during the final active
-                // transition; the user must still be able to stop PiP.
-                .disabled(!pictureInPicture.isPossible && !pictureInPicture.isActive)
-                .accessibilityLabel(
-                    pictureInPicture.isActive
-                        ? "Stop Picture in Picture"
-                        : "Start Picture in Picture"
-                )
             }
+        }
+    }
 
-            if viewModel.supportsExternalPlayback {
-                AirPlayRoutePicker { isPresentingRoutes in
-                    // The route sheet is a UIKit presentation the auto-hide
-                    // timer knows nothing about; pin the controls so it can't
-                    // dismantle the picker mid-selection.
-                    if isPresentingRoutes {
-                        viewModel.pinControlsVisible()
-                    } else {
-                        viewModel.resumeAutoHide()
-                    }
-                }
+    private var closeButton: some View {
+        Button(action: onDismiss) {
+            Image(systemName: "xmark")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(.white)
                 .frame(width: 44, height: 44)
+        }
+        .buttonStyle(.glass)
+        .buttonBorderShape(.circle)
+        .accessibilityLabel("Close Player")
+        .accessibilityIdentifier("player.close")
+    }
+
+    @ViewBuilder
+    private var externalPlaybackControls: some View {
+        if pictureInPicture.isSupported, pictureInPicture.hasSource {
+            controlButton(
+                systemName: pictureInPicture.isActive ? "pip.exit" : "pip.enter"
+            ) {
+                pictureInPicture.toggle()
             }
+            // AVKit can report `possible == false` during the final active
+            // transition; the user must still be able to stop PiP.
+            .disabled(!pictureInPicture.isPossible && !pictureInPicture.isActive)
+            .accessibilityLabel(
+                pictureInPicture.isActive
+                    ? "Stop Picture in Picture"
+                    : "Start Picture in Picture"
+            )
+        }
+
+        if viewModel.supportsExternalPlayback {
+            AirPlayRoutePicker { isPresentingRoutes in
+                // The route sheet is a UIKit presentation the auto-hide
+                // timer knows nothing about; pin the controls so it can't
+                // dismantle the picker mid-selection.
+                if isPresentingRoutes {
+                    viewModel.pinControlsVisible()
+                } else {
+                    viewModel.resumeAutoHide()
+                }
+            }
+            .frame(width: 44, height: 44)
         }
     }
 
@@ -512,7 +530,7 @@ struct MobilePlayerControls: View {
     private enum ActionRowStyle {
         case full      // labeled pills, value on the Quality pill
         case compact   // shorter labels
-        case icons     // icon controls; Quality and rotation remain pills
+        case icons     // icon controls; Quality remains a pill
     }
 
     /// Labeled pill row. `ViewThatFits` tries the full labels first, then
@@ -551,9 +569,6 @@ struct MobilePlayerControls: View {
                 chaptersMenu(style: style)
                     .accessibilityLabel("Chapters")
             }
-
-            rotationPill(compact: style == .icons)
-            rotationLockButton
 
             controlButton(systemName: "ellipsis") {
                 activeSheet = .settings
@@ -721,48 +736,6 @@ struct MobilePlayerControls: View {
         }
     }
 
-    private func rotationPill(compact: Bool) -> some View {
-        let target = orientationCoordinator.nextPlayerOrientation
-        return Button {
-            orientationCoordinator.togglePlayerOrientation()
-            viewModel.resumeAutoHide()
-        } label: {
-            HStack(spacing: 6) {
-                Image(systemName: target.symbolName)
-                    .font(.system(size: 14, weight: .semibold))
-                if compact {
-                    Image(systemName: "arrow.triangle.2.circlepath")
-                        .font(.system(size: 10, weight: .semibold))
-                } else {
-                    Text(target.title)
-                        .font(.system(size: 12, weight: .semibold))
-                }
-            }
-            .foregroundStyle(.white)
-            .padding(.horizontal, 12)
-            .frame(minWidth: 56, minHeight: 44)
-        }
-        .buttonStyle(.glass)
-        .buttonBorderShape(.capsule)
-        .accessibilityLabel("Rotate to \(target.title)")
-        .accessibilityHint("Rotates the screen without interrupting playback")
-        .accessibilityIdentifier("player.rotate")
-    }
-
-    private var rotationLockButton: some View {
-        let isLocked = orientationCoordinator.isRotationLocked
-        return controlButton(systemName: isLocked ? "lock.fill" : "lock.open", size: 44) {
-            orientationCoordinator.toggleRotationLock()
-            viewModel.resumeAutoHide()
-        }
-        .accessibilityLabel(isLocked ? "Unlock screen rotation" : "Lock screen rotation")
-        .accessibilityValue(isLocked ? "Locked" : "Unlocked")
-        .accessibilityHint(isLocked
-            ? "Allows video to follow phone orientation"
-            : "Stops phone movement rotating video. The rotate button still works")
-        .accessibilityIdentifier("player.rotation-lock")
-    }
-
     private func actionPill(
         systemImage: String,
         title: String,
@@ -871,12 +844,12 @@ struct MobilePlayerControls: View {
 
     // MARK: - Helpers
 
-    private func controlButton(systemName: String, size: CGFloat = 40, action: @escaping () -> Void) -> some View {
+    private func controlButton(systemName: String, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Image(systemName: systemName)
                 .font(.system(size: 14, weight: .semibold))
                 .foregroundStyle(.white)
-                .frame(width: size, height: size)
+                .frame(width: 40, height: 40)
         }
         // `.circle` keeps each glass control a compact circle instead of the
         // default wider capsule so rows of controls stay dense.
@@ -889,6 +862,58 @@ struct MobilePlayerControls: View {
     private enum PlayerSheet: Identifiable {
         case tracks, aiSubtitles, subtitleSearch, settings
         var id: Self { self }
+    }
+}
+
+/// Always mounted at the player's top-right, independently of transport
+/// auto-hide, loading, errors, and Next Up. Fixed glyphs and equal tap areas
+/// keep the lock centred when the screen rotates or the lock changes state.
+struct MobilePlayerRotationControls: View {
+    static let width: CGFloat = 128
+    static let height: CGFloat = 52
+    static let topClearance: CGFloat = height + 32
+
+    let orientationCoordinator: PlayerOrientationCoordinator
+    var onInteraction: () -> Void = {}
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Button {
+                orientationCoordinator.togglePlayerOrientation()
+                onInteraction()
+            } label: {
+                icon("rectangle.landscape.rotate")
+            }
+            .accessibilityLabel("Rotate to \(orientationCoordinator.nextPlayerOrientation.title)")
+            .accessibilityHint("Rotates the screen without interrupting playback")
+            .accessibilityIdentifier("player.rotate")
+
+            Button {
+                orientationCoordinator.toggleRotationLock()
+                onInteraction()
+            } label: {
+                icon(orientationCoordinator.isRotationLocked ? "lock" : "lock.open")
+            }
+            .accessibilityLabel(orientationCoordinator.isRotationLocked ? "Unlock screen rotation" : "Lock screen rotation")
+            .accessibilityValue(orientationCoordinator.isRotationLocked ? "Locked" : "Unlocked")
+            .accessibilityHint(orientationCoordinator.isRotationLocked
+                ? "Allows video to follow phone orientation"
+                : "Stops phone movement rotating video. The rotate button still works")
+            .accessibilityIdentifier("player.rotation-lock")
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .siloGlass(in: Capsule(), interactive: true)
+    }
+
+    private func icon(_ symbol: String) -> some View {
+        Image(systemName: symbol)
+            .font(.system(size: 24, weight: .medium))
+            .foregroundStyle(.white)
+            .frame(width: 32, height: 32)
+            .frame(width: 52, height: 44)
+            .contentShape(Rectangle())
     }
 }
 #endif

--- a/iosApp/iosApp/Screens/Player/iOS/MobilePlayerControls.swift
+++ b/iosApp/iosApp/Screens/Player/iOS/MobilePlayerControls.swift
@@ -174,10 +174,9 @@ struct MobilePlayerControls: View {
             Image(systemName: "xmark")
                 .font(.system(size: 14, weight: .semibold))
                 .foregroundStyle(.white)
-                .frame(width: 44, height: 44)
+                .frame(width: ContinuumTheme.topBarIconHitSize, height: ContinuumTheme.topBarIconHitSize)
         }
-        .buttonStyle(.glass)
-        .buttonBorderShape(.circle)
+        .buttonStyle(MobilePlayerGlassButtonStyle())
         .accessibilityLabel("Close Player")
         .accessibilityIdentifier("player.close")
     }
@@ -211,7 +210,8 @@ struct MobilePlayerControls: View {
                     viewModel.resumeAutoHide()
                 }
             }
-            .frame(width: 44, height: 44)
+            .frame(width: ContinuumTheme.topBarIconHitSize, height: ContinuumTheme.topBarIconHitSize)
+            .siloGlass(in: Circle(), interactive: true)
         }
     }
 
@@ -260,10 +260,8 @@ struct MobilePlayerControls: View {
 
     // MARK: - Center
 
-    /// Fixed circle sizes keep the three buttons proportioned as a family
-    /// (content-driven glass sizing made the play disc balloon relative to
-    /// the skips). The play/pause disc is white prominent glass with a dark
-    /// glyph rather than accent-tinted.
+    /// Every circle matches the detail page's 44pt close/remote controls.
+    /// Play/pause keeps its white tint without becoming a larger disc.
     private var centerCluster: some View {
         HStack(spacing: 36) {
             Button {
@@ -272,26 +270,23 @@ struct MobilePlayerControls: View {
                 Image(systemName: "gobackward.10")
                     .font(.system(size: 20, weight: .medium))
                     .foregroundStyle(.white)
-                    .frame(width: 50, height: 50)
+                    .frame(width: ContinuumTheme.topBarIconHitSize, height: ContinuumTheme.topBarIconHitSize)
             }
-            .buttonStyle(.glass)
-            .buttonBorderShape(.circle)
+            .buttonStyle(MobilePlayerGlassButtonStyle())
             .accessibilityLabel("Skip Back 10 Seconds")
 
             Button {
                 viewModel.togglePlayPause()
             } label: {
                 Image(systemName: viewModel.isPlaying ? "pause.fill" : "play.fill")
-                    .font(.system(size: 26, weight: .semibold))
+                    .font(.system(size: 20, weight: .semibold))
                     .foregroundStyle(.black.opacity(0.85))
                     // play.fill reads left-heavy inside a circle;
                     // nudge it toward the optical center.
                     .offset(x: viewModel.isPlaying ? 0 : 1.5)
-                    .frame(width: 64, height: 64)
+                    .frame(width: ContinuumTheme.topBarIconHitSize, height: ContinuumTheme.topBarIconHitSize)
             }
-            .buttonStyle(.glassProminent)
-            .buttonBorderShape(.circle)
-            .tint(.white.opacity(0.9))
+            .buttonStyle(MobilePlayerGlassButtonStyle(tint: .white.opacity(0.9)))
             .accessibilityLabel(viewModel.isPlaying ? "Pause" : "Play")
 
             Button {
@@ -300,10 +295,9 @@ struct MobilePlayerControls: View {
                 Image(systemName: "goforward.10")
                     .font(.system(size: 20, weight: .medium))
                     .foregroundStyle(.white)
-                    .frame(width: 50, height: 50)
+                    .frame(width: ContinuumTheme.topBarIconHitSize, height: ContinuumTheme.topBarIconHitSize)
             }
-            .buttonStyle(.glass)
-            .buttonBorderShape(.circle)
+            .buttonStyle(MobilePlayerGlassButtonStyle())
             .accessibilityLabel("Skip Forward 10 Seconds")
         }
     }
@@ -613,21 +607,16 @@ struct MobilePlayerControls: View {
             }
             .foregroundStyle(.white)
             .padding(.horizontal, 12)
-            .frame(height: 34)
+            .frame(height: ContinuumTheme.topBarIconHitSize)
         }
         .menuStyle(.button)
         // Keep Auto at the top, reading down.
         .menuOrder(.fixed)
 
-        return Group {
-            // The prominent style flags a non-Auto quality cap at a glance.
-            if viewModel.activeQualityId == ApplePlaybackQuality.autoId {
-                menu.buttonStyle(.glass)
-            } else {
-                menu.buttonStyle(.glassProminent)
-            }
-        }
-        .buttonBorderShape(.capsule)
+        return menu
+        .buttonStyle(MobilePlayerGlassButtonStyle(
+            tint: viewModel.activeQualityId == ApplePlaybackQuality.autoId ? nil : .accentColor
+        ))
         .accessibilityLabel("Playback Quality")
         .accessibilityValue(qualityValueText)
     }
@@ -706,8 +695,7 @@ struct MobilePlayerControls: View {
         .menuStyle(.button)
         // Keep Chapter 1 at the top, reading down.
         .menuOrder(.fixed)
-        .buttonStyle(.glass)
-        .buttonBorderShape(style == .icons ? .circle : .capsule)
+        .buttonStyle(MobilePlayerGlassButtonStyle())
     }
 
     private func chapterMenuTitle(_ chapter: PlayerChapterInfo) -> String {
@@ -727,12 +715,12 @@ struct MobilePlayerControls: View {
             }
             .foregroundStyle(.white)
             .padding(.horizontal, 12)
-            .frame(height: 34)
+            .frame(height: ContinuumTheme.topBarIconHitSize)
         } else {
             Image(systemName: systemImage)
                 .font(.system(size: 14, weight: .semibold))
                 .foregroundStyle(.white)
-                .frame(width: 40, height: 40)
+                .frame(width: ContinuumTheme.topBarIconHitSize, height: ContinuumTheme.topBarIconHitSize)
         }
     }
 
@@ -750,10 +738,9 @@ struct MobilePlayerControls: View {
             }
             .foregroundStyle(.white)
             .padding(.horizontal, 12)
-            .frame(height: 34)
+            .frame(height: ContinuumTheme.topBarIconHitSize)
         }
-        .buttonStyle(.glass)
-        .buttonBorderShape(.capsule)
+        .buttonStyle(MobilePlayerGlassButtonStyle())
     }
 
     // MARK: - Intro skip
@@ -774,10 +761,9 @@ struct MobilePlayerControls: View {
                             Image(systemName: "xmark")
                                 .font(.system(size: 14, weight: .semibold))
                                 .foregroundStyle(.white)
-                                .frame(width: 38, height: 38)
+                                .frame(width: ContinuumTheme.topBarIconHitSize, height: ContinuumTheme.topBarIconHitSize)
                         }
-                        .buttonStyle(.glass)
-                        .buttonBorderShape(.circle)
+                        .buttonStyle(MobilePlayerGlassButtonStyle())
                         .accessibilityLabel("Cancel Auto-Skip Intro")
                     }
 
@@ -796,13 +782,12 @@ struct MobilePlayerControls: View {
                         .font(.system(size: 14, weight: .semibold))
                         .foregroundStyle(.black.opacity(0.85))
                         .padding(.horizontal, 16)
-                        .padding(.vertical, 9)
+                        .frame(height: ContinuumTheme.topBarIconHitSize)
                     }
                     // White prominent glass with a dark glyph, matching the
                     // play/pause disc — accent-tinted prominent reads as an
                     // app-colored web button over video.
-                    .buttonStyle(.glassProminent)
-                    .tint(.white.opacity(0.9))
+                    .buttonStyle(MobilePlayerGlassButtonStyle(tint: .white.opacity(0.9)))
                     .accessibilityLabel(
                         viewModel.introAutoSkipCountdownSeconds == nil ? "Skip Intro" : "Skip Intro Now"
                     )
@@ -829,10 +814,9 @@ struct MobilePlayerControls: View {
                         .font(.system(size: 14, weight: .semibold))
                         .foregroundStyle(.black.opacity(0.85))
                         .padding(.horizontal, 16)
-                        .padding(.vertical, 9)
+                        .frame(height: ContinuumTheme.topBarIconHitSize)
                 }
-                .buttonStyle(.glassProminent)
-                .tint(.white.opacity(0.9))
+                .buttonStyle(MobilePlayerGlassButtonStyle(tint: .white.opacity(0.9)))
                 .accessibilityLabel("Skip Credits")
             }
             .padding(.horizontal, 24)
@@ -849,12 +833,9 @@ struct MobilePlayerControls: View {
             Image(systemName: systemName)
                 .font(.system(size: 14, weight: .semibold))
                 .foregroundStyle(.white)
-                .frame(width: 40, height: 40)
+                .frame(width: ContinuumTheme.topBarIconHitSize, height: ContinuumTheme.topBarIconHitSize)
         }
-        // `.circle` keeps each glass control a compact circle instead of the
-        // default wider capsule so rows of controls stay dense.
-        .buttonStyle(.glass)
-        .buttonBorderShape(.circle)
+        .buttonStyle(MobilePlayerGlassButtonStyle())
     }
 
     // MARK: - Sheet identifier
@@ -865,11 +846,40 @@ struct MobilePlayerControls: View {
     }
 }
 
-/// Top-right chrome follows the transport visibility during playback; Next
-/// Up keeps its own controls visible. Equal tap areas keep the lock centred.
+/// Match detail chrome without the extra padding added by native glass
+/// button styles. A 44pt square is circular; longer labels form a 44pt pill.
+struct MobilePlayerGlassButtonStyle: ButtonStyle {
+    var tint: Color? = nil
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .frame(minWidth: ContinuumTheme.topBarIconHitSize)
+            .frame(height: ContinuumTheme.topBarIconHitSize)
+            .opacity(configuration.isPressed ? 0.75 : 1)
+            .contentShape(Capsule())
+            .siloGlass(in: Capsule(), tint: tint, interactive: true)
+    }
+}
+
+/// Close and rotation controls share the same visibility, hit testing and
+/// accessibility state, including while loading and on Next Up.
+struct MobilePlayerChromeVisibility: ViewModifier {
+    let isVisible: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .opacity(isVisible ? 1 : 0)
+            .allowsHitTesting(isVisible)
+            .accessibilityHidden(!isVisible)
+            .animation(.easeOut(duration: 0.18), value: isVisible)
+    }
+}
+
+/// Top-right chrome follows transport visibility in every playback phase.
+/// Equal tap areas keep the lock centred through rotation.
 struct MobilePlayerRotationControls: View {
-    static let width: CGFloat = 128
-    static let height: CGFloat = 52
+    static let height = ContinuumTheme.topBarIconHitSize
+    static let width = height * 2 + 24
     static let topClearance: CGFloat = height + 32
 
     let orientationCoordinator: PlayerOrientationCoordinator
@@ -903,12 +913,8 @@ struct MobilePlayerRotationControls: View {
         }
         .buttonStyle(.plain)
         .padding(.horizontal, 8)
-        .padding(.vertical, 4)
         .siloGlass(in: Capsule(), interactive: true)
-        .opacity(isVisible ? 1 : 0)
-        .allowsHitTesting(isVisible)
-        .accessibilityHidden(!isVisible)
-        .animation(.easeOut(duration: 0.18), value: isVisible)
+        .modifier(MobilePlayerChromeVisibility(isVisible: isVisible))
     }
 
     private func icon(_ symbol: String) -> some View {
@@ -916,7 +922,7 @@ struct MobilePlayerRotationControls: View {
             .font(.system(size: 24, weight: .medium))
             .foregroundStyle(.white)
             .frame(width: 32, height: 32)
-            .frame(width: 52, height: 44)
+            .frame(width: ContinuumTheme.topBarIconHitSize, height: ContinuumTheme.topBarIconHitSize)
             .contentShape(Rectangle())
     }
 }

--- a/iosApp/iosApp/Screens/Player/iOS/MobilePlayerGestureLayer.swift
+++ b/iosApp/iosApp/Screens/Player/iOS/MobilePlayerGestureLayer.swift
@@ -11,15 +11,16 @@ import SwiftUI
 /// - touch & hold          → 2× playback while held (chip at top center)
 /// - drag on left edge     → screen brightness (vertical gauge)
 /// - drag on right edge    → player volume (vertical gauge)
-/// - downward swipe center → dismiss the player
 /// - pinch                 → cycle video gravity (fit / fill / stretch)
+///
+/// Center drags never dismiss playback. Exit is an explicit close-button
+/// action; edge brightness/volume gestures remain available.
 ///
 /// The layer is mounted only while playback is loaded. When the controls
 /// overlay is visible its scrim sits above this layer and captures touches,
 /// so these gestures apply to the "clean" viewing state.
 struct MobilePlayerGestureLayer: View {
     let viewModel: PlayerViewModel
-    let onDismiss: () -> Void
 
     private enum EdgeAdjustment { case brightness, volume }
 
@@ -32,7 +33,7 @@ struct MobilePlayerGestureLayer: View {
     @State private var skipFlashHideTask: Task<Void, Never>?
 
     /// Which edge gauge the in-flight drag is adjusting, decided once from
-    /// the drag's start location. Nil for center drags (dismiss candidates).
+    /// the drag's start location. Nil for center drags, which do nothing.
     @State private var activeAdjustment: EdgeAdjustment?
     /// Brightness/volume value captured when the drag began; the drag
     /// applies a delta on top so the level never jumps to the touch point.
@@ -79,7 +80,7 @@ struct MobilePlayerGestureLayer: View {
                             viewModel.endHoldFastForward()
                         }
                     }
-                    .simultaneousGesture(edgeAndDismissDrag(in: size))
+                    .simultaneousGesture(edgeAdjustmentDrag(in: size))
                     .simultaneousGesture(videoGravityPinchGesture)
 
                 feedbackOverlays(in: size)
@@ -130,7 +131,7 @@ struct MobilePlayerGestureLayer: View {
         }
     }
 
-    private func edgeAndDismissDrag(in size: CGSize) -> some Gesture {
+    private func edgeAdjustmentDrag(in size: CGSize) -> some Gesture {
         DragGesture(minimumDistance: 14)
             .onChanged { value in
                 if dragBaseline == nil {
@@ -160,15 +161,8 @@ struct MobilePlayerGestureLayer: View {
                     viewModel.applyUserVolume(Float(fraction))
                 }
             }
-            .onEnded { value in
-                if activeAdjustment == nil {
-                    // Center drag: a decisive, mostly-vertical downward swipe
-                    // dismisses the player.
-                    if value.translation.height > 140,
-                       abs(value.translation.width) < value.translation.height * 0.6 {
-                        onDismiss()
-                    }
-                } else {
+            .onEnded { _ in
+                if activeAdjustment != nil {
                     scheduleGaugeHide()
                 }
                 activeAdjustment = nil

--- a/iosApp/iosApp/Screens/Player/iOS/PlayerOrientationCoordinator.swift
+++ b/iosApp/iosApp/Screens/Player/iOS/PlayerOrientationCoordinator.swift
@@ -25,7 +25,6 @@ enum PlayerScreenOrientation: Equatable {
 
     var toggled: Self { self == .portrait ? .landscape : .portrait }
     var title: String { self == .portrait ? "Portrait" : "Landscape" }
-    var symbolName: String { self == .portrait ? "rectangle.portrait" : "rectangle" }
     var mask: UIInterfaceOrientationMask { self == .portrait ? .portrait : .landscape }
 }
 

--- a/iosApp/iosApp/Screens/Player/iOS/PlayerOrientationCoordinator.swift
+++ b/iosApp/iosApp/Screens/Player/iOS/PlayerOrientationCoordinator.swift
@@ -28,16 +28,26 @@ enum PlayerScreenOrientation: Equatable {
     var mask: UIInterfaceOrientationMask { self == .portrait ? .portrait : .landscape }
 }
 
-/// Session-only policy. Locking captures an exact orientation (including the
-/// landscape side); explicit rotation moves that lock without unlocking it.
+/// Locking captures an exact orientation (including the landscape side);
+/// explicit rotation moves that lock without unlocking it. The landscape lock
+/// is persisted through `player.orientation_mode`, so a new session starts
+/// locked when the last one was.
 struct PlayerRotationState {
     private(set) var isPlayerActive = false
     private(set) var lockedOrientation: UIInterfaceOrientationMask?
     var isLocked: Bool { lockedOrientation != nil }
 
-    mutating func activate() {
+    mutating func activate(lockedOrientation: UIInterfaceOrientationMask? = nil) {
         isPlayerActive = true
-        lockedOrientation = nil
+        self.lockedOrientation = lockedOrientation
+    }
+
+    /// The persisted mode this state maps to: locked to a landscape side is
+    /// `landscapeLocked`; unlocked is `rotateFreely`. A portrait lock has no
+    /// remote representation and leaves the stored mode unchanged.
+    var persistedOrientationMode: PlayerOrientationMode? {
+        guard let lockedOrientation else { return .rotateFreely }
+        return lockedOrientation.isSubset(of: .landscape) ? .landscapeLocked : nil
     }
 
     mutating func deactivate() {
@@ -62,7 +72,16 @@ struct PlayerRotationState {
 @Observable
 final class PlayerOrientationCoordinator {
     static let shared = PlayerOrientationCoordinator()
-    static let appDefaultOrientations: UIInterfaceOrientationMask = .portrait
+
+    /// Browsing is portrait-only on iPhone. iPad keeps every orientation its
+    /// Info.plist advertises so the split view and detail deck can rotate.
+    static var appDefaultOrientations: UIInterfaceOrientationMask {
+        browsingOrientations(isPad: UIDevice.current.userInterfaceIdiom == .pad)
+    }
+
+    static func browsingOrientations(isPad: Bool) -> UIInterfaceOrientationMask {
+        isPad ? .allButUpsideDown : .portrait
+    }
 
     private var rotationState = PlayerRotationState()
     private(set) var observedOrientation: PlayerScreenOrientation = .portrait
@@ -75,20 +94,23 @@ final class PlayerOrientationCoordinator {
     }
 
     static func orientationMask(
-        isPlayerActive: Bool, lockedOrientation: UIInterfaceOrientationMask? = nil
+        isPlayerActive: Bool, lockedOrientation: UIInterfaceOrientationMask? = nil,
+        browsingOrientations: UIInterfaceOrientationMask = appDefaultOrientations
     ) -> UIInterfaceOrientationMask {
         // Info.plist must continue advertising landscape so video can use it.
-        // The delegate restricts every non-player page to portrait at runtime.
-        guard isPlayerActive else { return appDefaultOrientations }
+        // The delegate restricts iPhone non-player pages to portrait at runtime.
+        guard isPlayerActive else { return browsingOrientations }
         // Only the separate lock button restricts device-driven rotation.
         return lockedOrientation ?? .allButUpsideDown
     }
 
     static func geometryMask(
         isPlayerActive: Bool, preferredOrientation: UIInterfaceOrientationMask?,
-        lockedOrientation: UIInterfaceOrientationMask? = nil
+        lockedOrientation: UIInterfaceOrientationMask? = nil,
+        browsingOrientations: UIInterfaceOrientationMask = appDefaultOrientations
     ) -> UIInterfaceOrientationMask {
-        let allowed = orientationMask(isPlayerActive: isPlayerActive, lockedOrientation: lockedOrientation)
+        let allowed = orientationMask(isPlayerActive: isPlayerActive, lockedOrientation: lockedOrientation,
+                                      browsingOrientations: browsingOrientations)
         let requested = preferredOrientation?.intersection(allowed) ?? allowed
         // A queued landscape request cannot rotate a page after video exits.
         return requested.isEmpty ? allowed : requested
@@ -98,13 +120,27 @@ final class PlayerOrientationCoordinator {
 
     func activatePlayer() {
         refreshInterfaceOrientation()
-        rotationState.activate()
-        applyCurrentPolicy(preferredOrientation: deviceOrientationMask())
+        // `player.orientation_mode` is the remote-persisted lock. Landscape
+        // locked means the session opens locked to the preferred landscape
+        // side; rotate freely means the lock starts off.
+        let persistedLock: UIInterfaceOrientationMask? =
+            PlayerSettings.shared.playerOrientationMode.isLandscapeLocked ? preferredLandscapeMask() : nil
+        rotationState.activate(lockedOrientation: persistedLock)
+        applyCurrentPolicy(preferredOrientation: persistedLock ?? deviceOrientationMask())
     }
 
     func deactivatePlayer() {
         rotationState.deactivate()
-        applyCurrentPolicy(preferredOrientation: .portrait)
+        applyCurrentPolicy(preferredOrientation: Self.appDefaultOrientations.contains(.portrait)
+            ? .portrait : Self.appDefaultOrientations)
+    }
+
+    /// Write the lock back to `player.orientation_mode` so it survives the
+    /// session and stays aligned with Android and the settings contract.
+    private func persistRotationLock() {
+        guard let mode = rotationState.persistedOrientationMode,
+              PlayerSettings.shared.playerOrientationMode != mode else { return }
+        PlayerSettings.shared.setPlayerOrientationMode(mode)
     }
 
     var nextPlayerOrientation: PlayerScreenOrientation {
@@ -125,6 +161,7 @@ final class PlayerOrientationCoordinator {
         let target = nextPlayerOrientation
         let mask: UIInterfaceOrientationMask = target == .landscape ? preferredLandscapeMask() : .portrait
         rotationState.manuallyRotate(to: mask)
+        persistRotationLock()
         applyCurrentPolicy(preferredOrientation: mask)
     }
 
@@ -133,6 +170,7 @@ final class PlayerOrientationCoordinator {
         refreshInterfaceOrientation()
         let currentMask = currentInterfaceOrientation().flatMap(Self.exactMask) ?? observedOrientation.mask
         rotationState.toggleLock(at: currentMask)
+        persistRotationLock()
         applyCurrentPolicy(preferredOrientation: rotationState.lockedOrientation ?? deviceOrientationMask())
     }
 

--- a/iosApp/iosApp/Screens/Player/iOS/PlayerOrientationCoordinator.swift
+++ b/iosApp/iosApp/Screens/Player/iOS/PlayerOrientationCoordinator.swift
@@ -17,6 +17,12 @@ enum PlayerScreenOrientation: Equatable {
     case portrait
     case landscape
 
+    init?(interfaceOrientation: UIInterfaceOrientation) {
+        if interfaceOrientation.isLandscape { self = .landscape }
+        else if interfaceOrientation.isPortrait { self = .portrait }
+        else { return nil }
+    }
+
     var toggled: Self { self == .portrait ? .landscape : .portrait }
     var title: String { self == .portrait ? "Portrait" : "Landscape" }
     var symbolName: String { self == .portrait ? "rectangle.portrait" : "rectangle" }
@@ -31,105 +37,75 @@ final class PlayerOrientationCoordinator {
     static let shared = PlayerOrientationCoordinator()
     static let appDefaultOrientations: UIInterfaceOrientationMask = .portrait
 
-    private(set) var playerMode = PlayerSettings.shared.playerOrientationMode
     private(set) var isPlayerActive = false
-    private(set) var requestedOrientation: PlayerScreenOrientation?
     private(set) var observedOrientation: PlayerScreenOrientation = .portrait
 
     var supportedOrientations: UIInterfaceOrientationMask {
-        Self.orientationMask(isPlayerActive: isPlayerActive, playerMode: playerMode,
-                             requestedOrientation: requestedOrientation)
+        Self.orientationMask(isPlayerActive: isPlayerActive)
     }
 
-    static func orientationMask(
-        isPlayerActive: Bool, playerMode: PlayerOrientationMode,
-        requestedOrientation: PlayerScreenOrientation? = nil
-    ) -> UIInterfaceOrientationMask {
-        guard isPlayerActive else { return appDefaultOrientations }
-        if let requestedOrientation { return requestedOrientation.mask }
+    static func orientationMask(isPlayerActive: Bool) -> UIInterfaceOrientationMask {
         // Info.plist must continue advertising landscape so video can use it.
         // The delegate restricts every non-player page to portrait at runtime.
-        return playerMode.isLandscapeLocked ? .landscape : .allButUpsideDown
+        // The rotation pill is a one-time geometry request, never a lock;
+        // physical phone rotation stays enabled throughout playback.
+        isPlayerActive ? .allButUpsideDown : appDefaultOrientations
+    }
+
+    static func geometryMask(
+        isPlayerActive: Bool, preferredOrientation: UIInterfaceOrientationMask?
+    ) -> UIInterfaceOrientationMask {
+        let allowed = orientationMask(isPlayerActive: isPlayerActive)
+        let requested = preferredOrientation?.intersection(allowed) ?? allowed
+        // A queued landscape request cannot rotate a page after video exits.
+        return requested.isEmpty ? allowed : requested
     }
 
     private init() {}
 
-    var isLandscapeLocked: Bool {
-        playerMode.isLandscapeLocked
-    }
-
     func activatePlayer() {
-        playerMode = PlayerSettings.shared.playerOrientationMode
-        requestedOrientation = nil
         refreshInterfaceOrientation()
         isPlayerActive = true
-        applyCurrentPolicy(rotateIntoLandscape: playerMode.isLandscapeLocked)
+        applyCurrentPolicy(preferredOrientation:
+            UIDevice.current.orientation.isLandscape ? preferredLandscapeMask() : .portrait)
     }
 
     func deactivatePlayer() {
         isPlayerActive = false
-        requestedOrientation = nil
-        applyCurrentPolicy(rotateIntoLandscape: false, attemptDeviceRotation: true)
+        applyCurrentPolicy(preferredOrientation: .portrait)
     }
 
     var nextPlayerOrientation: PlayerScreenOrientation {
-        (requestedOrientation ?? observedOrientation).toggled
+        observedOrientation.toggled
     }
 
     func refreshInterfaceOrientation() {
-        guard let current = currentInterfaceOrientation(), current != .unknown else { return }
-        observedOrientation = current.isLandscape ? .landscape : .portrait
+        guard let current = currentInterfaceOrientation(),
+              let orientation = PlayerScreenOrientation(interfaceOrientation: current) else { return }
+        observedOrientation = orientation
     }
 
-    /// An explicit rotation for this playback session, without changing the
-    /// profile's saved auto-rotation setting or reloading the video.
+    /// Read the real interface orientation for every tap. A geometry request
+    /// rotates now, without restricting subsequent device-driven rotation,
+    /// changing saved settings, or touching the video session.
     func togglePlayerOrientation() {
         guard isPlayerActive else { return }
         refreshInterfaceOrientation()
         let target = nextPlayerOrientation
-        requestedOrientation = target
-        applyCurrentPolicy(rotateIntoLandscape: target == .landscape, attemptDeviceRotation: true)
+        applyCurrentPolicy(preferredOrientation: target == .landscape ? preferredLandscapeMask() : .portrait)
     }
 
-    func togglePlayerMode() {
-        setPlayerMode(playerMode.isLandscapeLocked ? .rotateFreely : .landscapeLocked)
-    }
-
-    func setPlayerMode(_ mode: PlayerOrientationMode) {
-        guard playerMode != mode || requestedOrientation != nil else { return }
-        requestedOrientation = nil
-        playerMode = mode
-        PlayerSettings.shared.setPlayerOrientationMode(mode)
-        guard isPlayerActive else { return }
-        applyCurrentPolicy(
-            rotateIntoLandscape: mode.isLandscapeLocked,
-            attemptDeviceRotation: !mode.isLandscapeLocked
-        )
-    }
-
-    private func applyCurrentPolicy(
-        rotateIntoLandscape: Bool,
-        attemptDeviceRotation: Bool = false
-    ) {
+    private func applyCurrentPolicy(preferredOrientation: UIInterfaceOrientationMask) {
         if Thread.isMainThread {
-            updateOrientationPolicy(
-                rotateIntoLandscape: rotateIntoLandscape,
-                attemptDeviceRotation: attemptDeviceRotation
-            )
+            updateOrientationPolicy(preferredOrientation: preferredOrientation)
         } else {
             DispatchQueue.main.async { [weak self] in
-                self?.updateOrientationPolicy(
-                    rotateIntoLandscape: rotateIntoLandscape,
-                    attemptDeviceRotation: attemptDeviceRotation
-                )
+                self?.updateOrientationPolicy(preferredOrientation: preferredOrientation)
             }
         }
     }
 
-    private func updateOrientationPolicy(
-        rotateIntoLandscape: Bool,
-        attemptDeviceRotation: Bool
-    ) {
+    private func updateOrientationPolicy(preferredOrientation: UIInterfaceOrientationMask) {
         let scenes = activeWindowScenes()
         for scene in scenes {
             for window in scene.windows {
@@ -138,16 +114,12 @@ final class PlayerOrientationCoordinator {
             }
         }
 
-        // `requestGeometryUpdate(.iOS(interfaceOrientations:))` is the iOS 16+
-        // replacement for the deprecated `attemptRotationToDeviceOrientation`
-        // — it rotates the device on its own once `notifyOrientationChange`
-        // has refreshed each VC's `supportedInterfaceOrientations`. The
-        // `attemptDeviceRotation` flag is therefore only meaningful as a
-        // signal that a follow-up policy refresh is desired post-rotate.
-        let geometryMask = rotateIntoLandscape ? preferredLandscapeMask() : supportedOrientations
+        let geometryMask = Self.geometryMask(isPlayerActive: isPlayerActive,
+                                             preferredOrientation: preferredOrientation)
         guard let scene = scenes.first else { return }
         scene.requestGeometryUpdate(.iOS(interfaceOrientations: geometryMask)) { [weak self] _ in
-            guard attemptDeviceRotation, let self else { return }
+            guard let self else { return }
+            self.refreshInterfaceOrientation()
             for window in scene.windows {
                 guard let rootViewController = window.rootViewController else { continue }
                 self.notifyOrientationChange(for: rootViewController)

--- a/iosApp/iosApp/Screens/Player/iOS/PlayerOrientationCoordinator.swift
+++ b/iosApp/iosApp/Screens/Player/iOS/PlayerOrientationCoordinator.swift
@@ -13,20 +13,43 @@ final class SiloAppDelegate: NSObject, UIApplicationDelegate {
     }
 }
 
-/// Centralized orientation policy for the iPhone player shell. Playback code
+enum PlayerScreenOrientation: Equatable {
+    case portrait
+    case landscape
+
+    var toggled: Self { self == .portrait ? .landscape : .portrait }
+    var title: String { self == .portrait ? "Portrait" : "Landscape" }
+    var symbolName: String { self == .portrait ? "rectangle.portrait" : "rectangle" }
+    var mask: UIInterfaceOrientationMask { self == .portrait ? .portrait : .landscape }
+}
+
+/// Centralized orientation policy for the iOS app and player shell. Playback code
 /// should stay unaware of this; the coordinator only manages UIKit masks and
 /// scene geometry updates while the full-screen player is visible.
 @Observable
 final class PlayerOrientationCoordinator {
     static let shared = PlayerOrientationCoordinator()
-    static let appDefaultOrientations: UIInterfaceOrientationMask = .allButUpsideDown
+    static let appDefaultOrientations: UIInterfaceOrientationMask = .portrait
 
     private(set) var playerMode = PlayerSettings.shared.playerOrientationMode
     private(set) var isPlayerActive = false
+    private(set) var requestedOrientation: PlayerScreenOrientation?
+    private(set) var observedOrientation: PlayerScreenOrientation = .portrait
 
     var supportedOrientations: UIInterfaceOrientationMask {
-        guard isPlayerActive else { return Self.appDefaultOrientations }
-        return playerMode.isLandscapeLocked ? .landscape : Self.appDefaultOrientations
+        Self.orientationMask(isPlayerActive: isPlayerActive, playerMode: playerMode,
+                             requestedOrientation: requestedOrientation)
+    }
+
+    static func orientationMask(
+        isPlayerActive: Bool, playerMode: PlayerOrientationMode,
+        requestedOrientation: PlayerScreenOrientation? = nil
+    ) -> UIInterfaceOrientationMask {
+        guard isPlayerActive else { return appDefaultOrientations }
+        if let requestedOrientation { return requestedOrientation.mask }
+        // Info.plist must continue advertising landscape so video can use it.
+        // The delegate restricts every non-player page to portrait at runtime.
+        return playerMode.isLandscapeLocked ? .landscape : .allButUpsideDown
     }
 
     private init() {}
@@ -37,13 +60,35 @@ final class PlayerOrientationCoordinator {
 
     func activatePlayer() {
         playerMode = PlayerSettings.shared.playerOrientationMode
+        requestedOrientation = nil
+        refreshInterfaceOrientation()
         isPlayerActive = true
         applyCurrentPolicy(rotateIntoLandscape: playerMode.isLandscapeLocked)
     }
 
     func deactivatePlayer() {
         isPlayerActive = false
+        requestedOrientation = nil
         applyCurrentPolicy(rotateIntoLandscape: false, attemptDeviceRotation: true)
+    }
+
+    var nextPlayerOrientation: PlayerScreenOrientation {
+        (requestedOrientation ?? observedOrientation).toggled
+    }
+
+    func refreshInterfaceOrientation() {
+        guard let current = currentInterfaceOrientation(), current != .unknown else { return }
+        observedOrientation = current.isLandscape ? .landscape : .portrait
+    }
+
+    /// An explicit rotation for this playback session, without changing the
+    /// profile's saved auto-rotation setting or reloading the video.
+    func togglePlayerOrientation() {
+        guard isPlayerActive else { return }
+        refreshInterfaceOrientation()
+        let target = nextPlayerOrientation
+        requestedOrientation = target
+        applyCurrentPolicy(rotateIntoLandscape: target == .landscape, attemptDeviceRotation: true)
     }
 
     func togglePlayerMode() {
@@ -51,7 +96,8 @@ final class PlayerOrientationCoordinator {
     }
 
     func setPlayerMode(_ mode: PlayerOrientationMode) {
-        guard playerMode != mode else { return }
+        guard playerMode != mode || requestedOrientation != nil else { return }
+        requestedOrientation = nil
         playerMode = mode
         PlayerSettings.shared.setPlayerOrientationMode(mode)
         guard isPlayerActive else { return }

--- a/iosApp/iosApp/Screens/Player/iOS/PlayerOrientationCoordinator.swift
+++ b/iosApp/iosApp/Screens/Player/iOS/PlayerOrientationCoordinator.swift
@@ -29,6 +29,34 @@ enum PlayerScreenOrientation: Equatable {
     var mask: UIInterfaceOrientationMask { self == .portrait ? .portrait : .landscape }
 }
 
+/// Session-only policy. Locking captures an exact orientation (including the
+/// landscape side); explicit rotation moves that lock without unlocking it.
+struct PlayerRotationState {
+    private(set) var isPlayerActive = false
+    private(set) var lockedOrientation: UIInterfaceOrientationMask?
+    var isLocked: Bool { lockedOrientation != nil }
+
+    mutating func activate() {
+        isPlayerActive = true
+        lockedOrientation = nil
+    }
+
+    mutating func deactivate() {
+        isPlayerActive = false
+        lockedOrientation = nil
+    }
+
+    mutating func toggleLock(at orientation: UIInterfaceOrientationMask) {
+        guard isPlayerActive else { return }
+        lockedOrientation = isLocked ? nil : orientation
+    }
+
+    mutating func manuallyRotate(to orientation: UIInterfaceOrientationMask) {
+        guard isPlayerActive, isLocked else { return }
+        lockedOrientation = orientation
+    }
+}
+
 /// Centralized orientation policy for the iOS app and player shell. Playback code
 /// should stay unaware of this; the coordinator only manages UIKit masks and
 /// scene geometry updates while the full-screen player is visible.
@@ -37,25 +65,31 @@ final class PlayerOrientationCoordinator {
     static let shared = PlayerOrientationCoordinator()
     static let appDefaultOrientations: UIInterfaceOrientationMask = .portrait
 
-    private(set) var isPlayerActive = false
+    private var rotationState = PlayerRotationState()
     private(set) var observedOrientation: PlayerScreenOrientation = .portrait
+    var isPlayerActive: Bool { rotationState.isPlayerActive }
+    var isRotationLocked: Bool { rotationState.isLocked }
 
     var supportedOrientations: UIInterfaceOrientationMask {
-        Self.orientationMask(isPlayerActive: isPlayerActive)
+        Self.orientationMask(isPlayerActive: isPlayerActive,
+                             lockedOrientation: rotationState.lockedOrientation)
     }
 
-    static func orientationMask(isPlayerActive: Bool) -> UIInterfaceOrientationMask {
+    static func orientationMask(
+        isPlayerActive: Bool, lockedOrientation: UIInterfaceOrientationMask? = nil
+    ) -> UIInterfaceOrientationMask {
         // Info.plist must continue advertising landscape so video can use it.
         // The delegate restricts every non-player page to portrait at runtime.
-        // The rotation pill is a one-time geometry request, never a lock;
-        // physical phone rotation stays enabled throughout playback.
-        isPlayerActive ? .allButUpsideDown : appDefaultOrientations
+        guard isPlayerActive else { return appDefaultOrientations }
+        // Only the separate lock button restricts device-driven rotation.
+        return lockedOrientation ?? .allButUpsideDown
     }
 
     static func geometryMask(
-        isPlayerActive: Bool, preferredOrientation: UIInterfaceOrientationMask?
+        isPlayerActive: Bool, preferredOrientation: UIInterfaceOrientationMask?,
+        lockedOrientation: UIInterfaceOrientationMask? = nil
     ) -> UIInterfaceOrientationMask {
-        let allowed = orientationMask(isPlayerActive: isPlayerActive)
+        let allowed = orientationMask(isPlayerActive: isPlayerActive, lockedOrientation: lockedOrientation)
         let requested = preferredOrientation?.intersection(allowed) ?? allowed
         // A queued landscape request cannot rotate a page after video exits.
         return requested.isEmpty ? allowed : requested
@@ -65,13 +99,12 @@ final class PlayerOrientationCoordinator {
 
     func activatePlayer() {
         refreshInterfaceOrientation()
-        isPlayerActive = true
-        applyCurrentPolicy(preferredOrientation:
-            UIDevice.current.orientation.isLandscape ? preferredLandscapeMask() : .portrait)
+        rotationState.activate()
+        applyCurrentPolicy(preferredOrientation: deviceOrientationMask())
     }
 
     func deactivatePlayer() {
-        isPlayerActive = false
+        rotationState.deactivate()
         applyCurrentPolicy(preferredOrientation: .portrait)
     }
 
@@ -85,14 +118,23 @@ final class PlayerOrientationCoordinator {
         observedOrientation = orientation
     }
 
-    /// Read the real interface orientation for every tap. A geometry request
-    /// rotates now, without restricting subsequent device-driven rotation,
-    /// changing saved settings, or touching the video session.
+    /// Read the real interface orientation for every tap. Explicit rotation
+    /// works with the lock on or off, without touching the video session.
     func togglePlayerOrientation() {
         guard isPlayerActive else { return }
         refreshInterfaceOrientation()
         let target = nextPlayerOrientation
-        applyCurrentPolicy(preferredOrientation: target == .landscape ? preferredLandscapeMask() : .portrait)
+        let mask: UIInterfaceOrientationMask = target == .landscape ? preferredLandscapeMask() : .portrait
+        rotationState.manuallyRotate(to: mask)
+        applyCurrentPolicy(preferredOrientation: mask)
+    }
+
+    func toggleRotationLock() {
+        guard isPlayerActive else { return }
+        refreshInterfaceOrientation()
+        let currentMask = currentInterfaceOrientation().flatMap(Self.exactMask) ?? observedOrientation.mask
+        rotationState.toggleLock(at: currentMask)
+        applyCurrentPolicy(preferredOrientation: rotationState.lockedOrientation ?? deviceOrientationMask())
     }
 
     private func applyCurrentPolicy(preferredOrientation: UIInterfaceOrientationMask) {
@@ -115,7 +157,8 @@ final class PlayerOrientationCoordinator {
         }
 
         let geometryMask = Self.geometryMask(isPlayerActive: isPlayerActive,
-                                             preferredOrientation: preferredOrientation)
+                                             preferredOrientation: preferredOrientation,
+                                             lockedOrientation: rotationState.lockedOrientation)
         guard let scene = scenes.first else { return }
         scene.requestGeometryUpdate(.iOS(interfaceOrientations: geometryMask)) { [weak self] _ in
             guard let self else { return }
@@ -171,6 +214,24 @@ final class PlayerOrientationCoordinator {
             return .landscapeLeft
         default:
             return .landscapeRight
+        }
+    }
+
+    private static func exactMask(for orientation: UIInterfaceOrientation) -> UIInterfaceOrientationMask? {
+        switch orientation {
+        case .portrait: return .portrait
+        case .landscapeLeft: return .landscapeLeft
+        case .landscapeRight: return .landscapeRight
+        default: return nil
+        }
+    }
+
+    private func deviceOrientationMask() -> UIInterfaceOrientationMask {
+        switch UIDevice.current.orientation {
+        case .portrait: return .portrait
+        case .landscapeLeft: return .landscapeRight
+        case .landscapeRight: return .landscapeLeft
+        default: return currentInterfaceOrientation().flatMap(Self.exactMask) ?? .portrait
         }
     }
 

--- a/iosApp/iosApp/Screens/Player/iOS/PlayerPresentationModifier.swift
+++ b/iosApp/iosApp/Screens/Player/iOS/PlayerPresentationModifier.swift
@@ -1,0 +1,39 @@
+#if os(iOS)
+import SwiftUI
+
+/// Mount this at the app root and on the detail sheet. A payload selects one
+/// owner, so exiting playback cannot take the underlying detail with it.
+struct PlayerPresentationModifier: ViewModifier {
+    @Bindable var router: AppRouter
+    var detailPresentationID: UUID? = nil
+
+    func body(content: Content) -> some View {
+        let payload = router.playerPresentation(forDetailID: detailPresentationID)
+        content.fullScreenCover(item: Binding(
+            get: { router.playerPresentation(forDetailID: detailPresentationID) },
+            set: { replacement in
+                guard replacement == nil, let id = payload?.id else { return }
+                router.dismissPlayerPresentation(id: id)
+            }
+        )) { presentation in
+            PlayerView(
+                contentId: presentation.contentId,
+                preferredFileId: presentation.fileId,
+                preferredAudioTrackIndex: presentation.audioTrackIndex,
+                preferredSubtitleTrackIndex: presentation.subtitleTrackIndex,
+                startFromBeginning: presentation.startFromBeginning,
+                resumePositionOverride: presentation.resumePosition,
+                prefersLastUsedVersion: presentation.prefersLastUsedVersion,
+                offlineDownloadId: presentation.offlineDownloadId,
+                posterURLHint: presentation.posterURL,
+                backdropURLHint: presentation.backdropURL,
+                onDismissRequested: { router.dismissPlayerPresentation(id: presentation.id) }
+            )
+            .onAppear {
+                PlayerPresentationRestoration.presenter = router
+                PlayerPresentationRestoration.recordPresentation(presentation)
+            }
+        }
+    }
+}
+#endif

--- a/iosApp/iosApp/Screens/Player/iOS/PlayerPresentationModifier.swift
+++ b/iosApp/iosApp/Screens/Player/iOS/PlayerPresentationModifier.swift
@@ -29,6 +29,9 @@ struct PlayerPresentationModifier: ViewModifier {
                 backdropURLHint: presentation.backdropURL,
                 onDismissRequested: { router.dismissPlayerPresentation(id: presentation.id) }
             )
+            // Playback exits through its X button, never a downward gesture.
+            // This affects only the player cover, not the underlying detail.
+            .interactiveDismissDisabled()
             .onAppear {
                 PlayerPresentationRestoration.presenter = router
                 PlayerPresentationRestoration.recordPresentation(presentation)

--- a/iosApp/iosApp/Screens/Player/iOS/PlayerPresentationRestoration.swift
+++ b/iosApp/iosApp/Screens/Player/iOS/PlayerPresentationRestoration.swift
@@ -51,7 +51,11 @@ enum PlayerPresentationRestoration {
         pendingAdoption = (viewModel, payload.contentId)
         // A fresh identity is what makes `fullScreenCover(item:)` re-present
         // even if the router is still holding the outgoing payload.
-        presenter.presentedPlayer = payload.reopened()
+        var reopened = payload.reopened()
+        // The user may have closed the original detail while PiP was active.
+        // Restore above the currently visible owner, never an absent sheet.
+        reopened.detailPresentationID = presenter.presentedItemDetail?.id
+        presenter.presentedPlayer = reopened
         return true
     }
 
@@ -88,6 +92,7 @@ extension AppRouter.PlayerPresentation {
             prefersLastUsedVersion: prefersLastUsedVersion,
             returnToContentId: returnToContentId,
             offlineDownloadId: offlineDownloadId,
+            detailPresentationID: detailPresentationID,
             posterURL: posterURL,
             backdropURL: backdropURL
         )

--- a/iosApp/iosApp/Screens/Requests/Components/RequestCardRail.swift
+++ b/iosApp/iosApp/Screens/Requests/Components/RequestCardRail.swift
@@ -47,6 +47,7 @@ struct RequestCardRail<Item: Identifiable, Card: View>: View {
                     card(item)
                 }
             }
+            .phoneMediaRailBounds()
         }
         #endif
     }

--- a/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
+++ b/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
@@ -140,6 +140,19 @@ enum StartupContentPrefetcher {
         homeSectionsTask = nil
     }
 
+    /// Capture the active profile/server generation when a player is created.
+    /// Call only AFTER its progress write completes. A late previous-profile
+    /// player must never invalidate or refresh the new profile's Home cache.
+    static func homeRefreshAfterPlaybackWrite() -> @MainActor () -> Void {
+        let generation = profileScopedGeneration
+        return {
+            guard generation == profileScopedGeneration else { return }
+            invalidateHomeSectionsInFlight()
+            ResponseCache.shared.remove(CacheKey.homeSections)
+            NotificationCenter.default.post(name: .homeSectionsShouldRefresh, object: nil)
+        }
+    }
+
     static func fetchHomeSections() async throws -> SectionsResponse {
         let profileGeneration = profileScopedGeneration
         let homeGeneration = homeSectionsGeneration

--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -57,7 +57,7 @@ packages:
   # reviewed revision; Package.resolved also freezes its binary dependencies.
   AetherEngine:
     url: https://github.com/blurbery/AetherEngine
-    revision: e238d1d2da52b58bffd7f8135bb2b04e32915cee
+    revision: 53ec6c9771a8df326abb23c7d98692b95b18b2c1
   Nuke:
     url: https://github.com/kean/Nuke
     from: "12.8.0"

--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -57,7 +57,7 @@ packages:
   # reviewed revision; Package.resolved also freezes its binary dependencies.
   AetherEngine:
     url: https://github.com/blurbery/AetherEngine
-    revision: 53ec6c9771a8df326abb23c7d98692b95b18b2c1
+    revision: 653be639441d3f7d06332a2f995950497ad62e0f
   Nuke:
     url: https://github.com/kean/Nuke
     from: "12.8.0"


### PR DESCRIPTION
## Problem

After fixing the next-episode black screen in #227, I worked through the remaining iOS playback and browsing issues. The player could close the detail page underneath it, rotation controls moved or stayed visible after the rest of the controls disappeared, Next Up actions could run off-screen, and Home could show misaligned rows or stale Continue Watching progress. Opening a Continue Watching episode also went through a different detail page from opening its series poster.

This PR contains that iOS follow-up work, including the in-player controls. It does not replace #227 or turn that playback-engine fix into a general UI PR.

### Full included scope

- [x] Immediate detail-page pull-down at the top, without waiting for scrolling/bounce to settle.
- [x] Actor/nested-page pull-down goes Back one page instead of closing the entire detail stack.
- [x] X-only playback exit, returning to the originating detail; no centre swipe-to-close video.
- [x] iPhone browsing pages locked to portrait; orientation changes allowed only in video playback. iPad browsing keeps rotating.
- [x] Manual player rotation that follows the actual interface orientation.
- [x] Separate screen-orientation lock, persisted through `player.orientation_mode`; manual rotation still works while locked.
- [x] Video continues through device/manual rotation without reloading or replacing the current item.
- [x] Fixed rotate icon and centred lock in a stable top-right glass pill.
- [x] X/rotate/lock hidden until a tap and hidden with the other controls, including while loading.
- [x] Consistent 44-point player glass controls, matching the detail X/remote controls.
- [x] Resized end-of-episode preview with Play Now/countdown below it in both portrait and landscape.
- [x] iOS On Deck removed from the end-of-playback screen; actions fit short landscape viewports.
- [x] Leading-edge horizontal-rail alignment, no vertical drift, and stable position after detail return.
- [x] Equal-height/top-aligned Continue Watching cards when resume captions differ.
- [x] Home refreshes resume position and the next episode after playback writes, without manual refresh.
- [x] Continue Watching uses the existing movie/series experience and retains the exact resume season/episode.
- [x] Faster Continue Watching hydration and concurrent hierarchy loading; unchanged data does not republish scrolling content.
- [x] Regression tests, synthetic visual evidence, and measured loading comparison.

I checked the published head against every saved follow-up commit: all 15 commits from `ace2a57` through `4b7ca9e` are included, plus the merge retaining the parent's existing validation corrections. There are no saved follow-up code changes outside this PR.

## Dependency and review boundary

- Target: `Silo-Server/silo-apple:main`.
- **Depends on #227. Please merge #227 first.** It remains a separate PR and has not been changed by this submission.
- GitHub's `main` comparison temporarily includes the unmerged parent commits. The [follow-up-only comparison](https://github.com/blurbery/silo-apple/compare/bfb9058fedb055027b1f7c16cac23cb597a33c61...a844f84f926ffdffd726c03a48423857a9b55595) is the review boundary for this work: 35 files, 2,166 insertions and 318 deletions.
- Parent revision: `bfb9058fedb055027b1f7c16cac23cb597a33c61`. Initial submitted revision: `24e60b9f0b89a0b9e37b1171eccb5648ba962261`. Review-fix head: `a844f84f926ffdffd726c03a48423857a9b55595`. Maintainer follow-up head: `2984feff` (persisted orientation lock, iPad browsing rotation, full-platform CI matrix).
- I kept the related iOS fixes together because they were developed and tested as one follow-up. The original persistent video surface, native engine handover and AetherEngine dependency update belong to #227, not to this incremental diff.
- If #227 is squash-merged, the branch will need its dependency history reconciled before this PR can merge. A merge commit preserving that ancestry lets GitHub exclude the parent commits automatically.

## What I changed and why

### In-player controls, orientation and exit

- Browsing stays portrait on iPhone; iPad keeps every orientation Info.plist advertises. Only the video player allows device-driven portrait/landscape rotation on iPhone. The coordinator reads the actual interface orientation before a manual rotation and rejects queued landscape requests after playback closes.
- Added separate rotate and orientation-lock controls in a fixed top-right glass pill. The rotate icon remains `rectangle.landscape.rotate`; it does not change into a different symbol or label in portrait. Locking captures the exact landscape side where applicable. Manual rotation still works while locked and moves the lock to the new orientation; unlocking restores device-driven rotation. The lock reads and writes the existing remote `player.orientation_mode` setting, so a landscape lock survives the session and stays aligned with Android.
- Rotation only changes interface geometry. It does not load, seek, pause or replace the playing video. The retained surface from #227 continues to own playback through the resize.
- Close, rotate and lock now follow the same `showControls` state as transport controls. They start hidden, including during loading and Next Up, appear on a tap, and hide with the normal control dismissal/auto-hide path. Loading or Next Up no longer forces the rotation pill to remain visible independently.
- Removed the centre downward-swipe playback-dismiss action. Playback exits through the top-left glass X. Brightness/volume edge drags, seeking, hold-speed and video-gravity gestures keep their existing roles.
- Standardized player glass controls on the detail page's 44-point control height and icon hit target. Text pills remain wider where their labels require it; the rotation group is 112 × 44 points. This includes the play/pause and skip controls, which previously used different sizes.

### Next Up that fits iOS in both orientations

The earlier layout could place actions beside the preview in a narrow viewport, or let background artwork/On Deck content affect the available space. That produced clipped buttons and a layout that changed structure during rotation.

I removed On Deck from the iOS end-of-playback screen and kept one vertical preview/actions stack. Play Now and its countdown/action panel stay below the preview in portrait and landscape. A measured layout reserves room for the real text/buttons first, then fits the preview into the remaining height. It reserves the top-control clearance and bounds the background to the viewport. The existing video anchor remains in place through rotation and preview expansion.

The Mac's side-by-side/On Deck path and the Apple TV layout are not redesigned by this follow-up.

### Detail dismissal and returning from playback

- Removed the unused horizontal detail scroller on iPhone. Its extra scroll container and the sheet's unconditional scroll-first interaction made a second pull feel as though it had to wait for the first scroll to settle. iPad retains its existing source-aware detail deck.
- The vertical detail scroll surface now hands a pull to the sheet as soon as it reaches the top, including the rubber-band region. It does not wait for an idle scroll phase.
- Pulling down on a nested actor/detail page means Back by one level, not dismissal of the whole detail sheet. Actor pages opened outside that sheet use their own dismiss action. Direction and completion thresholds preserve horizontal, upward and mid-page scrolling and allow an incomplete pull to cancel.
- Gave each player cover one explicit owner: the detail sheet that launched it, or the app root. X dismissal returns to that same page/path. Offline playback and PiP restoration retain that ownership. Stale player/sheet dismissal callbacks cannot close a newer presentation.

### Home alignment and current playback state

- iPhone horizontal rails align to the leading edge instead of recentering cards. The native rail keeps responsibility for dragging and deceleration, but cannot bounce horizontally past its bounds or drift vertically. The bridge changes only the nearest rail; it does not replace delegates or disable the outer page's vertical scrolling.
- Applied the same rail policy to shared media rows and the relevant Home, episode, cast, similar, trailer, calendar and request rails. Non-phone behavior retains its existing alignment.
- Continue Watching cards align at the top and reserve consistent caption height when one item has remaining-time metadata and another does not. Returning from an iPhone detail no longer drives a competing row-position animation.
- Home now receives playback refresh notifications on iOS. The player refreshes after its progress-write/teardown paths rather than relying on a manual refresh. Natural-end refresh is gated on a successful progress report. A captured profile/server generation prevents a late old-player callback from invalidating another profile's Home cache.

### Continue Watching opens the existing series page, with the right episode

An episode from Continue Watching now presents its parent series through the same detail-card route as a series poster, while carrying the requested season and episode. For example, an S3E2 resume entry selects Season 3 and Episode 2 without first pushing a separate episode-detail screen. Movie/audiobook entries and incomplete legacy episode payloads keep their existing destinations. Ordinary poster opens keep their original selection policy.

I did not restyle the movie/series pages to achieve this. The follow-up's earlier dismissal/rail hooks remain, but the Continue Watching change reuses the existing card, native scrolling, glass and artwork layout. Render-time artwork parallax and the isolated/equatable glass nodes were already present in that shared page; this PR does not claim to have introduced those optimizations.

For resume entry, cached seasons and episodes now paint synchronously. The known season/episode hierarchy loads alongside the catalog request instead of waiting through the catalog → seasons → episodes chain. Unchanged hierarchy data is not republished, so a background refresh does not unnecessarily invalidate the scrolling content. Cancellation, failed refreshes and a season tap during loading preserve the appropriate current page/selection. Secondary season/favorite work stays outside the initial resume metadata wave.

## CodeRabbit follow-up

Current head: `a844f84f926ffdffd726c03a48423857a9b55595`.

I checked all five findings against the source and replied individually:

- Fixed the Continue Watching retry bug: hierarchy success cannot consume the requested season before catalog success. Cancellation/failure retains the intent; a manual season selection supersedes it. Added regression checks for early hierarchy success, each hierarchy failure followed by retry, and cancellation.
- Limited invisible resume-caption space to actual Continue Watching cards. Real progress captions still display on ordinary still cards. Updated the equal-height test to use the real resume configuration and added ordinary-versus-resume card geometry coverage.
- Pinned the official XcodeGen 2.43.0 archive SHA-256 before unpacking/execution. The matching archive passed a local check and a deliberately wrong digest failed. The release has no separate published digest/attestation; this pin detects replacement of the selected bytes, not publisher attestation.
- Kept compact Next Up metadata intentionally: adding overview/extra metadata would compete with the preview and actions in the bounded, non-scrolling layout. This is the requested iOS presentation, not a missing argument.
- Left the pre-existing tvOS post-cleanup invalidation race for a separate tvOS change. It exists at upstream `8948ca8`; the iOS path already uses the generation-guarded refresh helper. A tvOS follow-up should cover its complete detail/Home refresh block with tvOS validation.

The new changes do not touch the playing surface, rotation controls, playback engine, movie/series styling, or server/API behaviour. The existing concurrent hierarchy scheduling is retained. The new tests have not been run against a separate baseline build; the complete new-head suite is reported below.

CodeRabbit's docstring-coverage warning covers 166 touched functions, including inherited changes. I have documented the non-obvious lifecycle/ordering rules, but have not added boilerplate across the diff or disabled/lowered the warning. CodeRabbit completed its original five-finding review at `24e60b9`; its full re-review of `a844f84` is rate-limited and must not be reported as completed. In the individual threads, it acknowledged all three fixes and accepted the compact-metadata explanation; All five review discussions are now marked resolved: three implemented fixes, one intentional-layout decision, and the pre-existing tvOS concern closed as deferred/out of scope—not as a fixed bug. The tvOS follow-up remains documented here and in its review thread.

## Regression coverage

The earlier passing regression cases at `4b7ca9e51f37032dbcb6e51844546815e24aa684` covered the pre-review application source. The `24e60b9` merge then passed the full suite. The CodeRabbit follow-up adds the targeted coverage described above; its exact-head CI is reported separately below.

| Area | Tests and important checks |
| --- | --- |
| Control visibility | `testCloseAndRotationControlsWaitForTapInEveryPhase`: loading, playing, Next Up and error; tap/show/hide/dismiss and playing auto-hide |
| Size and placement | `testPlayerGlassButtonsMatchTheDetailControlSize`, `testPersistentRotationPillKeepsItsSizeAndTopRightPosition`: production buttons/Menu/pill geometry, fixed symbol and top-right position |
| Orientation policy | Exact portrait/left/right lock; manual rotation while locked; unlock/exit reset; actual-interface toggle direction; delayed requests cannot rotate browsing |
| Playback continuity | Existing retained-view/native-item tests plus orientation-sized preview layouts; paused state and current item remain stable |
| Next Up bounds | `testMobileActionsStayBelowThePreviewAndFitBothOrientations`, `testFullNextUpScreenFitsArtworkAndPopulatedOnDeckDataThroughRepeatedRotation`: actions below preview, populated On Deck data not rendered, long title/background branch, repeated size changes |
| Detail/player ownership | Root, nested, offline and PiP payloads; actor Back; stale player/sheet callbacks; top/bounce handoff; cancel and wrong-direction gestures |
| Native rails | `testNativeBoundsAffectOnlyTheNearestRail`, `testRealHomeRowsKeepTheirBoundsAndPositionAfterDetailReturn`, `testContinueWatchingKeepsEqualCardHeightsWithMissingProgress` |
| Home freshness | `testPlaybackWriteRefreshReloadsResumeAndSuccessorWithoutManualRefresh`, `testLatePlaybackWriteCannotInvalidateAnotherProfileHome` |
| Resume context | Exact series/season/episode route, unchanged poster defaults, Specials, missing-season fallback policy, movie/audio/missing-parent fallbacks |
| Resume loading | Synchronous cached hydration; both requests dispatched before either response returns; no observation invalidation for unchanged hierarchy; newer season tap wins; cached page survives errors; cancelled requests publish nothing |

## Test results and commands

| Revision / run | Confirmed result |
| --- | --- |
| [`4b7ca9e` iOS validation](https://github.com/blurbery/silo-apple/actions/runs/33727090260) | Build passed. 1,212 tests executed, 1 skipped, 3 assertion failures in 2 pre-existing navigation tests. All new Continue Watching, rail, layout and control tests above passed. Test execution: 51.104 seconds; elapsed suite time: 54.037 seconds. This workflow was **not green**. |
| [`b5bb85b` preceding iOS validation](https://github.com/blurbery/silo-apple/actions/runs/33724610417) | Build passed. 1,206 tests, 1 skip, the same 3 baseline failures. New route/control tests passed. |
| [Unchanged upstream baseline `8948ca8`](https://github.com/blurbery/silo-apple/actions/runs/33711266983) | The same 3 navigation assertion failures existed before this work. |
| [Parent #227 validation at `bfb9058`](https://github.com/Silo-Server/silo-apple/actions/runs/33715397674) | Parent PR reports the complete iOS suite green after correcting those stale expectations; its validation and provenance are documented in #227. This is not a substitute for testing this PR's head. |
| [Pre-review `24e60b9` validation](https://github.com/Silo-Server/silo-apple/actions/runs/33728852817) | **Passed.** Build, complete iOS suite and synthetic preview/playback recording succeeded. 1,212 tests executed, 1 skipped, 0 failures; test execution 51.546 seconds, elapsed suite time 54.553 seconds. The separate recorded playback test passed (1 test, 0 failures). |
| [Review-fix `a844f84` validation](https://github.com/Silo-Server/silo-apple/actions/runs/33730667625) | **Passed.** iOS build; 1,215 tests executed, 1 skipped, 0 failures. Test execution 55.723 seconds; elapsed suite time 70.642 seconds. All three new review-regression tests and the existing cancellation/manual-selection cases passed. The separate recorded playback check passed (1 test, 0 failures). Local Swift parsing, diff checks, workflow YAML/shell syntax, and positive/negative checksum checks passed too. |

The inherited test correction checks the existing Home/Recommendations/Calendar fallback while retaining assertions that reject stale/revoked library access. It does not change production navigation, skip tests or suppress failures. I verified it against the already-existing `testMainTabProjectionFailsClosedAndFiltersUnavailableLibraries` coverage.

Build/test environment: standard GitHub-hosted `macos-15`, Xcode 26.3, iPhone 17 Pro simulator, Debug test configuration. The workflow prepares an explicit simulator matching the selected SDK and reuses that destination. This follow-up PR's workflow selects iOS only; no new Apple TV/macOS behavior or latest-head validation on those platforms is claimed.

```sh
xcodebuild build-for-testing -project iosApp/Silo.xcodeproj -scheme Silo \
  -destination "$SILO_TEST_DESTINATION" -derivedDataPath /tmp/silo-derived \
  CODE_SIGNING_ALLOWED=YES CODE_SIGN_IDENTITY=-
xcodebuild test-without-building -project iosApp/Silo.xcodeproj -scheme Silo \
  -destination "$SILO_TEST_DESTINATION" -derivedDataPath /tmp/silo-derived \
  -parallel-testing-enabled NO -test-timeouts-enabled YES \
  -maximum-test-execution-time-allowance 60 \
  -resultBundlePath /tmp/player-validation.xcresult \
  CODE_SIGNING_ALLOWED=YES CODE_SIGN_IDENTITY=-
```

Local checks were limited to targeted Swift parsing, `git diff --check`, workflow YAML parsing and `bash -n` on its shell blocks. Full compilation/tests ran remotely. The installed simulator executable was checked against the downloaded CI build; login/app data were preserved during the test-build updates.

## Benchmarks

### Continue Watching hierarchy readiness

`testContinueWatchingHierarchyRequestBenchmark` runs five paired repetitions with two synthetic resource requests, each delayed by 150 ms. Its serial control models the old seasons-then-episodes scheduling; the changed arm calls the production resume hierarchy loader with the same injected responses. The earlier application source was `b5bb85b`; the measured implementation is `4b7ca9e`, unchanged in pre-review `24e60b9`. The review fix retains concurrent dispatch but changes intent consumption; this table is historical evidence, not a fresh measurement of `a844f84`.

**This is a within-run synthetic scheduling comparison, not a separate before-build device benchmark.** Catalog/image decoding, real-server latency, end-to-end page presentation and frame rate are excluded. The Debug simulator environment is not a physical-device performance claim.

| Repetition | Serial control (ms) | Resume loader (ms) |
| --- | ---: | ---: |
| 1 | 313.532 | 151.378 |
| 2 | 312.480 | 161.222 |
| 3 | 311.507 | 159.534 |
| 4 | 306.985 | 161.659 |
| 5 | 315.832 | 154.430 |
| Median | **312.480** | **159.534** |

Median waiting time fell **48.95%** for this controlled hierarchy workload. The raw arrays are printed in the linked `4b7ca9e` test log. A separate gate-based regression verifies overlap without using a timing threshold. Cache hydration and unchanged-data observation tests verify readiness/invalidation behavior rather than inventing a millisecond gain.

### Review-fix head recheck

The same five-pair, 150-ms-per-resource benchmark passed again at `a844f84` in [the final iOS run](https://github.com/Silo-Server/silo-apple/actions/runs/33730667625). Serial median: **312.466 ms**; resume-loader median: **159.494 ms**, a **48.96%** reduction within that controlled run. Raw serial values (ms): `318.223167, 312.465917, 310.741083, 314.977333, 310.20375`. Raw resume values (ms): `154.149625, 160.315583, 160.369333, 159.494458, 152.184417`. This confirms the concurrent scheduling remains effective after the intent fix; the same synthetic-workload/device-performance limitations above still apply.

### Geometry and lifecycle measurements

The action-layout test measures 568×320, 844×390, 390×844 and 1024×768 logical-point viewports. All keep the measured action panel below the preview and within the viewport; the populated end-screen test repeats portrait/landscape-sized layouts and verifies no iOS On Deck scroll view exists. The rotation pill measures 112×44 points, 16 points from the tested viewport's top/right edges. These are geometry assertions, not real-device rotation timing.

For the new dismissal, orientation-policy and control-visibility behavior, latency/FPS benchmarks are not applicable to the correctness claims. Real-device frame-time/energy profiling and end-to-end opening measurements were not run. I am not claiming a universal scrolling-speed improvement or that every regression is covered.

## Visual and manual evidence

- [Final review-fix validation at `a844f84`](https://github.com/Silo-Server/silo-apple/actions/runs/33730667625/artifacts/9884256123): passing full-suite result bundle/logs and the passing synthetic playback recording.
- [Before: #227's Next Up viewport screenshots](https://github.com/blurbery/silo-apple/actions/runs/33712365506/artifacts/9877713041).
- [After: follow-up screenshots, full result bundle and logs at `4b7ca9e`](https://github.com/blurbery/silo-apple/actions/runs/33727090260/artifacts/9882849501). Attachments include `Next Up controls` at the four tested sizes and `Persistent rotation controls` at portrait/landscape sizes. All use synthetic data, not private accounts or viewing history.
- I inspected the portrait and landscape action-panel exports. They use a black preview placeholder and SwiftUI ImageRenderer; they support layout/geometry review, not pixel-accurate reproduction of native Liquid Glass or a real-video smoothness claim.
- [Parent motion evidence](https://github.com/Silo-Server/silo-apple/actions/runs/33715397674/artifacts/9878560188) contains the synthetic native preview-expansion clip. It supports the inherited playback-continuity fix, not a claim that every new navigation/rotation gesture has been filmed. The submitted head's synthetic recording also passed; its clip, logs and result bundles are in the [final-head validation artifact](https://github.com/Silo-Server/silo-apple/actions/runs/33728852817/artifacts/9883532606).
- During the iterative iOS simulator checks, I confirmed the countdown and Play Now paths, the corrected detail pull-down, and the later controls/Next Up/Home behavior. The final Continue Watching loading change was installed for testing, but I have not recorded an exact-revision physical-device performance result.

Reproduction checks for review:

1. Open a detail, scroll down, flick to the top and immediately pull down again. At the root, dismiss the sheet; on an actor/nested page, go back one level.
2. Start playback from that detail. A centre downward drag must not exit. Reveal controls and use X: return to the same detail/path.
3. While video plays, rotate the phone and use the rotate button. Lock the orientation, turn the phone, then rotate manually. Playback must continue; manual rotation must still work. Exit and verify browsing is portrait.
4. Check loading, active playback and Next Up with controls hidden and revealed. X/rotate/lock must follow the same visibility state. Check both orientations and short landscape heights.
5. Reach Next Up. There must be no iOS On Deck shelf, and Play Now/countdown must remain below the preview and reachable without scrolling.
6. Scroll a Home rail, open a card and return. Its position/leading alignment must remain stable, with no vertical rail drift.
7. Stop an episode early, then finish one and advance. Home must refresh resume/successor state without pull-to-refresh. Repeat across a profile change to check stale callbacks do not affect the new profile.
8. Open a Continue Watching S3E2 entry. It must use the series card with Season 3/Episode 2 selected. Reopen warm, switch seasons during loading, and compare normal movie/series poster opens for unchanged behavior.

## Compatibility and remaining limitations

- Browsing portrait lock applies to iPhone only. iPad keeps landscape browsing and its detail paging path. Physical iPad/multitasking validation is still needed.
- No server/API schema, database, credentials, production configuration or deployment changes are included. No Android coordination is required for these client-only presentation changes.
- No additional engine version change beyond the dependency already reviewed in #227.
- The shared movie/series artwork/glass design remains; native dismissal and rail behavior are intentionally corrected by this follow-up.
- Physical-device orientation, all Dynamic Type/localization sizes, VoiceOver, PiP/AirPlay, HDR/Dolby Vision and all codec/device combinations are not exhaustively verified. Simulator smoothness is not a substitute for Release profiling on a device.
- Evidence artifacts have seven-day retention; the explicitly approved public-source simulator bundle has three-day retention. The workflow can regenerate them. No PR-only media assets are committed.
- Private server addresses, account details, media titles and live-session recordings are excluded from this PR.

## AI disclosure

AI-assisted with Sol Ultra. I directed the task and designed the work.

The follow-up used OpenAI Codex desktop with `gpt-5.6-sol` and `ultra` reasoning, Git/GitHub CLI, Swift/Xcode tooling, GitHub Actions and iOS Simulator. I directed the iteration and performed the manual simulator checks described above. Inherited changes and their separate AI/tooling provenance remain documented in #227.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Continue Watching now opens series details with the correct episode and season selected.
  * Added swipe-down dismissal for iPhone detail screens.
  * Improved player layouts, Next Up transitions, rotation controls, and presentation restoration.
  * Updated horizontal media rails for more consistent alignment and scrolling on iPhone.

* **Bug Fixes**
  * Home sections now refresh correctly after playback progress updates.
  * Improved player ownership and dismissal during nested navigation and picture-in-picture restoration.
  * iPhone player dismissal now uses explicit controls instead of a center swipe.

* **Tests**
  * Added regression coverage for player, navigation, media rails, Continue Watching, and home refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
