### PR TITLE
fix(ios): match launch screen to startup animation

### DIFF
--- a/iosApp/iosApp/Assets.xcassets/LaunchBackground.colorset/Contents.json
+++ b/iosApp/iosApp/Assets.xcassets/LaunchBackground.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -74,7 +74,10 @@
 		<string>remote-notification</string>
 	</array>
 	<key>UILaunchScreen</key>
-	<dict/>
+	<dict>
+		<key>UIColorName</key>
+		<string>LaunchBackground</string>
+	</dict>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>arm64</string>


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow fix

On iPhone, the system launch screen used the default white background in light mode. SwiftUI then painted the startup animation on black, causing a visible white-to-black flash during cold launch.

## Approach

Add an opaque black universal color asset named `LaunchBackground` and reference it through `UILaunchScreen.UIColorName`. This makes the system-owned launch screen match the existing black startup animation before SwiftUI begins drawing.

The change is limited to the iOS target. tvOS and macOS use separate plists, and no server or Android coordination is required.

## Validation

- `cd iosApp && xcodegen generate` — passed.
- `xcodebuild build -project Silo.xcodeproj -scheme Silo -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' CODE_SIGNING_ALLOWED=NO` — passed.
- `plutil -lint iosApp/iosApp/Info.plist`, asset JSON validation, and `git diff --check` — passed.
- Cold-launched the baseline and fixed builds on the same iPhone 17 Pro simulator. Before: the system launch surface was white. After: it remained black into the startup animation.
- Full XCTest run: 1,165 tests executed, 1 skipped, 14 failures. The same 14 failures reproduced on unchanged base commit `8948ca8` in an isolated worktree. They are pre-existing failures in `ProfileLaunchIdentityTests`, `ProfileLaunchMigrationTests`, `SettingValuesAPITests`, and `UICustomizationPreferencesTests`; the profile-related failures include unsigned-simulator keychain status `-34018`.

## Visual evidence

Before:
<img width="1206" height="2622" alt="silo-launch-before" src="https://github.com/user-attachments/assets/132228fc-3e3d-464f-a572-192f3be40479" />

After:
<img width="1206" height="2622" alt="silo-launch-after" src="https://github.com/user-attachments/assets/c2736a60-591d-4eb6-8078-d8fd4638d3d8" />


## Risks

Low. The only runtime change is the iOS system launch background color. The color is intentionally black in both light and dark appearance to match the existing startup animation.

## Follow-up

None.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: Codex desktop
- Tool(s): Codex desktop shell, XcodeBuildMCP, iOS Simulator, unified-computer-use
- Model(s): gpt-5.6-sol
- Involvement: AI-assisted
- Adversarial review: An independent Codex agent reviewed commit `e87cc54` against `8948ca8` for plist semantics, asset integration, platform scope, security, and regressions. No findings were reported.
