### PR TITLE
fix(tvos): place Start Over right after the Resume button

### DIFF
--- a/iosApp/iosApp/tvOS/Screens/Detail/TVDetailActions.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVDetailActions.swift
@@ -287,8 +287,8 @@ struct TVDetailActionRow<PlaybackSelectors: View, MoreMenu: View>: View {
 
     private enum ActionID: Hashable {
         case play
-        case playbackSelectors
         case startOver
+        case playbackSelectors
         case watchlist
         case more
     }
@@ -350,11 +350,6 @@ struct TVDetailActionRow<PlaybackSelectors: View, MoreMenu: View>: View {
                     }
                 }
 
-                actionSlot {
-                    playbackSelectors()
-                        .focused($playbackSelectorsFocused)
-                }
-
                 if let onStartOver {
                     actionSlot {
                         TVCircleActionButton(
@@ -366,6 +361,11 @@ struct TVDetailActionRow<PlaybackSelectors: View, MoreMenu: View>: View {
                         )
                         .focused($focusedAction, equals: .startOver)
                     }
+                }
+
+                actionSlot {
+                    playbackSelectors()
+                        .focused($playbackSelectorsFocused)
                 }
             }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On tvOS movie, episode, season, and series detail pages, the "Start Over" circle button rendered after the version/audio/subtitle selectors, so it sat in the middle of the action row instead of next to the Resume button it belongs with.

## Solution

Reorder the slots in `TVDetailActionRow` (`iosApp/iosApp/tvOS/Screens/Detail/TVDetailActions.swift`) so the Start Over button is the first control after the primary Play/Resume pill, followed by the playback selectors, Watchlist, and More. The `ActionID` enum order was updated to match. No focus logic changed; the row still relies on the native focus graph.

## Validation

Code-only reorder inside an existing `HStack`; no Xcode toolchain available in this environment, so not built locally. Please verify on a tvOS simulator with an in-progress item.

## Risks

Low. Only affects control order on tvOS detail pages where `onStartOver` is provided.

## AI disclosure

Written by Claude Fable 5.1 running as a Cursor Cloud Agent. No other AI tooling was used.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8e94454-a728-483d-b718-5e75a05db9c4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8e94454-a728-483d-b718-5e75a05db9c4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the focus order on TV show detail screens so playback selection appears after the optional Start Over action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->