### PR TITLE
Season selector navigation

### DIFF
--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -201,7 +201,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     @ObservedObject private var profilePrefsStore = ProfilePrefsStore.shared
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    private let showModeId = "series-show-overview"
+    private let noSeasonModeId = "series-season-none"
     private let episodeSectionScrollId = "series-episode-section"
     private let castSectionScrollId = "series-cast-section"
     private let heroScrollId = "series-hero"
@@ -481,15 +481,6 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         ScrollViewReader { proxy in
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 12) {
-                    TVSeriesModeTab(
-                        title: "Show",
-                        isSelected: isShowingSeriesOverview,
-                        rendersFocusedAppearance: presentedFocusedModeId == showModeId,
-                        action: showSeriesOverview
-                    )
-                    .id(showModeId)
-                    .focused($focusedModeId, equals: showModeId)
-
                     ForEach(seasons) { season in
                         TVSeriesModeTab(
                             title: seasonLabel(season),
@@ -571,12 +562,13 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         }
     }
 
+    /// The season pill stays selected while the hero shows series info, since
+    /// the rail below still lists that season's episodes.
     private var selectedModeId: String {
-        guard !isShowingSeriesOverview else { return showModeId }
-        return seasonTransitionTargetId
+        seasonTransitionTargetId
             ?? visibleSeasonId
             ?? selectedSeason?.id
-            ?? showModeId
+            ?? noSeasonModeId
     }
 
     private func showSeriesOverview() {
@@ -773,16 +765,14 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                   focusedModeId == modeId,
                   modeId != selectedModeId else { return }
 
-            if modeId == showModeId {
-                showSeriesOverview()
-            } else if let season = seasons.first(where: { $0.id == modeId }) {
+            if let season = seasons.first(where: { $0.id == modeId }) {
                 activateSeason(season)
             }
         }
     }
 
     private var seasonPageReadinessKey: String {
-        let seasonId = selectedSeason?.id ?? "series-season-none"
+        let seasonId = selectedSeason?.id ?? noSeasonModeId
         let loadingState = isLoadingEpisodes ? "loading" : "ready"
         let episodeIds = episodes.map(\.contentId).joined(separator: "|")
         return "\(seasonId):\(loadingState):\(episodeIds)"
@@ -790,7 +780,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
 
     private var currentSeasonPageSnapshot: SeasonPageSnapshot {
         SeasonPageSnapshot(
-            seasonId: selectedSeason?.id ?? "series-season-none",
+            seasonId: selectedSeason?.id ?? noSeasonModeId,
             episodes: episodes,
             currentContentId: displayedEpisode?.contentId,
             isLoading: isLoadingEpisodes
@@ -1092,6 +1082,11 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
             accessibilityLabel: "More options",
             stabilizesFocusMotion: true
         ) {
+            if !isShowingSeriesOverview {
+                Button(action: showSeriesOverview) {
+                    Label("Show Series Info", systemImage: "info.circle")
+                }
+            }
             Button(action: onToggleFavorite) {
                 Label(
                     isFavorite ? "Remove from Favorites" : "Add to Favorites",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This pull request contains changes generated by a Cursor Cloud Agent
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c17bfc82-1bec-45eb-9acc-119c83913cfb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c17bfc82-1bec-45eb-9acc-119c83913cfb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **Show Series Info** option to the More menu when viewing an episode or season.
  - Season selection remains available while viewing series overview content.
- **Changes**
  - Series overview content no longer uses a separate Show mode tab.
  - Mode activation now focuses on season-based viewing, including cases where no season is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->