### PR TITLE
feat(tvos): polish detail page actions and fix Next Up dismissal on Home

### DIFF
--- a/iosApp/Tests/DetailDismissalNavigationTests.swift
+++ b/iosApp/Tests/DetailDismissalNavigationTests.swift
@@ -101,6 +101,18 @@ final class DetailDismissalNavigationTests: XCTestCase {
         XCTAssertEqual(model.preferredInitialSeason(seasons: seasons)?.seasonNumber, 1)
     }
 
+    func testPreferredInitialSeasonFallsBackToUnplayedSpecials() throws {
+        let seasons = try JSONDecoder().decode([Season].self, from: Data(#"""
+        [
+          {"contentId":"specials","seasonNumber":0,"isSpecials":true,"episodeCount":1},
+          {"contentId":"season-1","seasonNumber":1,"episodeCount":8,"userData":{"played":true,"watchedCount":8}},
+          {"contentId":"season-2","seasonNumber":2,"episodeCount":8,"userData":{"played":true,"watchedCount":8}}
+        ]
+        """#.utf8))
+        let model = ItemDetailViewModel()
+        XCTAssertEqual(model.preferredInitialSeason(seasons: seasons)?.seasonNumber, 0)
+    }
+
     private func resumeLoadFixture() throws -> (ItemDetail, SeasonsResponse, EpisodesResponse) {
         let decoder = JSONDecoder()
         return (

--- a/iosApp/Tests/HomeSectionsMutationTests.swift
+++ b/iosApp/Tests/HomeSectionsMutationTests.swift
@@ -116,6 +116,67 @@ final class HomeSectionsMutationTests: XCTestCase {
     }
 
     @MainActor
+    func testNextUpCardDismissesOnNextUpSurfaceAndClearsBothRows() async throws {
+        // A Next Up episode merged into Continue Watching has a series but no
+        // progress row. It must not be sent to the continue_watching surface
+        // with a fabricated timestamp, which the server would never match.
+        let target = try makeItem(contentId: "target", progressUpdatedAt: nil, seriesId: "series-1")
+        let other = try makeItem(contentId: "other")
+        let sections = [
+            makeSection(id: "continue", type: "continue_watching", totalCount: 2, items: [target, other]),
+            makeSection(id: "next", type: "next_up", totalCount: 1, items: [target]),
+            makeSection(id: "trending", type: "trending", totalCount: 1, items: [target]),
+        ]
+        ResponseCache.shared.set(SectionsResponse(sections: sections), for: CacheKey.homeSections)
+        defer { ResponseCache.shared.remove(CacheKey.homeSections) }
+
+        var continueWatchingCalls = 0
+        var receivedContentId: String?
+        var receivedSeriesId: String?
+        let viewModel = HomeViewModel(
+            dismissContinueWatching: { _, _ in
+                continueWatchingCalls += 1
+            },
+            dismissNextUp: { contentId, seriesId in
+                receivedContentId = contentId
+                receivedSeriesId = seriesId
+            }
+        )
+
+        await viewModel.dismissContinueWatchingItem(target)
+
+        let cached: SectionsResponse? = ResponseCache.shared.get(CacheKey.homeSections)
+        XCTAssertEqual(continueWatchingCalls, 0)
+        XCTAssertEqual(receivedContentId, "target")
+        XCTAssertEqual(receivedSeriesId, "series-1")
+        XCTAssertEqual(viewModel.sections.map { $0.items.map(\.contentId) }, [["other"], [], ["target"]])
+        XCTAssertEqual(cached?.sections.map { $0.items.map(\.contentId) }, [["other"], [], ["target"]])
+        XCTAssertNil(viewModel.actionError)
+    }
+
+    @MainActor
+    func testCardWithoutProgressOrSeriesIsLeftInPlace() async throws {
+        let target = try makeItem(contentId: "target", progressUpdatedAt: nil, seriesId: nil)
+        let sections = [
+            makeSection(id: "continue", type: "continue_watching", totalCount: 1, items: [target]),
+        ]
+        ResponseCache.shared.set(SectionsResponse(sections: sections), for: CacheKey.homeSections)
+        defer { ResponseCache.shared.remove(CacheKey.homeSections) }
+
+        let viewModel = HomeViewModel(
+            dismissContinueWatching: { _, _ in XCTFail("unexpected continue_watching dismissal") },
+            dismissNextUp: { _, _ in XCTFail("unexpected next_up dismissal") }
+        )
+
+        await viewModel.dismissContinueWatchingItem(target)
+
+        let cached: SectionsResponse? = ResponseCache.shared.get(CacheKey.homeSections)
+        XCTAssertEqual(viewModel.sections[0].items.map(\.contentId), ["target"])
+        XCTAssertEqual(cached?.sections[0].items.map(\.contentId), ["target"])
+        XCTAssertNil(viewModel.actionError)
+    }
+
+    @MainActor
     func testFailedDismissalPreservesStateAndSurfacesError() async throws {
         let target = try makeItem(contentId: "target")
         let sections = [
@@ -204,16 +265,24 @@ final class HomeSectionsMutationTests: XCTestCase {
         XCTAssertTrue(viewModel.isShowingActionError)
     }
 
-    private func makeItem(contentId: String) throws -> SectionItem {
-        let json = """
-        {
-          "contentId": "\(contentId)",
-          "type": "movie",
-          "title": "Test Item",
-          "progressUpdatedAt": "2026-07-10T12:00:00Z"
+    private func makeItem(
+        contentId: String,
+        progressUpdatedAt: String? = "2026-07-10T12:00:00Z",
+        seriesId: String? = nil
+    ) throws -> SectionItem {
+        var fields: [String: Any] = [
+            "contentId": contentId,
+            "type": "movie",
+            "title": "Test Item",
+        ]
+        if let progressUpdatedAt {
+            fields["progressUpdatedAt"] = progressUpdatedAt
         }
-        """
-        return try JSONDecoder().decode(SectionItem.self, from: Data(json.utf8))
+        if let seriesId {
+            fields["seriesId"] = seriesId
+        }
+        let data = try JSONSerialization.data(withJSONObject: fields)
+        return try JSONDecoder().decode(SectionItem.self, from: data)
     }
 
     private func makeSection(

--- a/iosApp/iosApp/Networking/ContinuumAPI.swift
+++ b/iosApp/iosApp/Networking/ContinuumAPI.swift
@@ -468,6 +468,15 @@ actor ContinuumAPI {
         try await http.delete("/api/v1/home/dismissals/continue_watching/\(contentId)")
     }
 
+    /// Next Up episodes carry no progress row, so the server keys their
+    /// dismissal on the parent series instead of `progress_updated_at`.
+    func dismissNextUpItem(contentId: String, seriesId: String) async throws {
+        try await http.putVoid(
+            "/api/v1/home/dismissals/next_up/\(contentId)",
+            body: NextUpDismissalBody(seriesId: seriesId)
+        )
+    }
+
     func librarySections(libraryId: Int) async throws -> SectionsResponse {
         try await http.get("/api/v1/library/\(libraryId)/sections", query: await imageSizeQuery)
     }
@@ -1086,4 +1095,8 @@ enum APIError: LocalizedError {
 
 private struct HomeDismissalBody: Encodable {
     let progressUpdatedAt: String
+}
+
+private struct NextUpDismissalBody: Encodable {
+    let seriesId: String
 }

--- a/iosApp/iosApp/Networking/Models.swift
+++ b/iosApp/iosApp/Networking/Models.swift
@@ -724,11 +724,12 @@ struct Season: Codable, Identifiable, Hashable {
 }
 
 extension Array where Element == Season {
+    /// Specials lead, then numbered seasons ascending.
     func sortedForDisplay() -> [Season] {
         sorted { lhs, rhs in
             let lhsSpecials = lhs.isSpecials == true || lhs.seasonNumber == 0
             let rhsSpecials = rhs.isSpecials == true || rhs.seasonNumber == 0
-            if lhsSpecials != rhsSpecials { return !lhsSpecials }
+            if lhsSpecials != rhsSpecials { return lhsSpecials }
             if lhs.seasonNumber != rhs.seasonNumber { return lhs.seasonNumber < rhs.seasonNumber }
             if (lhs.title ?? "") != (rhs.title ?? "") { return (lhs.title ?? "") < (rhs.title ?? "") }
             return lhs.contentId < rhs.contentId

--- a/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
@@ -1031,13 +1031,15 @@ class ItemDetailViewModel {
             return partial
         }
         // Specials sort first for display, but a fresh series should open on
-        // its first numbered season rather than the specials bucket.
+        // its first numbered season rather than the specials bucket. Once
+        // every numbered season is played, an unplayed Specials still wins
+        // over a fully watched one.
         let regular = seasons.filter { !($0.isSpecials == true || $0.seasonNumber == 0) }
-        let candidates = regular.isEmpty ? seasons : regular
-        if let firstUnplayed = candidates.first(where: { !($0.userData?.played ?? false) }) {
+        let isUnplayed: (Season) -> Bool = { !($0.userData?.played ?? false) }
+        if let firstUnplayed = regular.first(where: isUnplayed) ?? seasons.first(where: isUnplayed) {
             return firstUnplayed
         }
-        return candidates.first
+        return regular.first ?? seasons.first
     }
 
     func selectSeason(

--- a/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
@@ -890,10 +890,14 @@ class ItemDetailViewModel {
         }) {
             return partial
         }
-        if let firstUnplayed = seasons.first(where: { !($0.userData?.played ?? false) }) {
+        // Specials sort first for display, but a fresh series should open on
+        // its first numbered season rather than the specials bucket.
+        let regular = seasons.filter { !($0.isSpecials == true || $0.seasonNumber == 0) }
+        let candidates = regular.isEmpty ? seasons : regular
+        if let firstUnplayed = candidates.first(where: { !($0.userData?.played ?? false) }) {
             return firstUnplayed
         }
-        return seasons.first
+        return candidates.first
     }
 
     func selectSeason(

--- a/iosApp/iosApp/Screens/Home/HomeSectionsMutation.swift
+++ b/iosApp/iosApp/Screens/Home/HomeSectionsMutation.swift
@@ -24,6 +24,19 @@ enum HomeSectionsMutation {
         )
     }
 
+    /// Removes a dismissed Next Up episode. The server surfaces Next Up both
+    /// as its own row and merged into Continue Watching, so both must drop it.
+    static func removingNextUpItem(
+        contentId: String,
+        from sections: [ResolvedSection]
+    ) -> [ResolvedSection] {
+        removingItem(
+            contentId: contentId,
+            from: sections,
+            sectionTypes: completedItemSectionTypes
+        )
+    }
+
     /// Removes a newly completed item from rows whose membership is derived
     /// from playback state. Other Home rows can still show the same title.
     static func removingCompletedItem(

--- a/iosApp/iosApp/Screens/Home/HomeViewModel.swift
+++ b/iosApp/iosApp/Screens/Home/HomeViewModel.swift
@@ -158,6 +158,7 @@ class HomeViewModel {
         _ contentId: String,
         _ progressUpdatedAt: String
     ) async throws -> Void
+    typealias DismissNextUp = (_ contentId: String, _ seriesId: String) async throws -> Void
     typealias SetWatched = (_ contentId: String, _ played: Bool) async throws -> Void
     typealias FetchHomeSections = () async throws -> SectionsResponse
 
@@ -174,6 +175,7 @@ class HomeViewModel {
     private var pendingContinueWatchingDismissals = Set<String>()
     private var pendingWatchedUpdates = Set<String>()
     private let dismissContinueWatching: DismissContinueWatching
+    private let dismissNextUp: DismissNextUp
     private let updateWatchedState: SetWatched
     private let fetchHomeSections: FetchHomeSections
 
@@ -200,6 +202,12 @@ class HomeViewModel {
                 progressUpdatedAt: progressUpdatedAt
             )
         },
+        dismissNextUp: @escaping DismissNextUp = { contentId, seriesId in
+            try await ContinuumAPI.shared.dismissNextUpItem(
+                contentId: contentId,
+                seriesId: seriesId
+            )
+        },
         setWatched: @escaping SetWatched = { contentId, played in
             try await ContinuumAPI.shared.setWatched(contentId: contentId, played: played)
         },
@@ -208,6 +216,7 @@ class HomeViewModel {
         }
     ) {
         self.dismissContinueWatching = dismissContinueWatching
+        self.dismissNextUp = dismissNextUp
         self.updateWatchedState = setWatched
         self.fetchHomeSections = fetchHomeSections
 
@@ -245,35 +254,66 @@ class HomeViewModel {
         isRefreshing = false
     }
 
+    /// The Continue Watching row mixes two kinds of cards, and the server keys
+    /// their dismissals differently. In-progress items are dismissed against
+    /// their exact `progress_updated_at`, so resuming playback re-surfaces
+    /// them. Next Up episodes have no progress row; they are dismissed on the
+    /// `next_up` surface keyed by series. Sending a fabricated timestamp for
+    /// a Next Up card is accepted by the server but never matches anything,
+    /// so the card returns on the next fresh fetch.
     func dismissContinueWatchingItem(_ item: SectionItem) async {
+        let removal: (
+            request: () async throws -> Void,
+            mutate: (_ sections: [ResolvedSection]) -> [ResolvedSection]
+        )
+        if let progressUpdatedAt = item.progressUpdatedAt {
+            removal = (
+                request: { [dismissContinueWatching] in
+                    try await dismissContinueWatching(item.contentId, progressUpdatedAt)
+                },
+                mutate: { sections in
+                    HomeSectionsMutation.removingContinueWatchingItem(
+                        contentId: item.contentId,
+                        from: sections
+                    )
+                }
+            )
+        } else if let seriesId = item.seriesId, !seriesId.isEmpty {
+            removal = (
+                request: { [dismissNextUp] in
+                    try await dismissNextUp(item.contentId, seriesId)
+                },
+                mutate: { sections in
+                    HomeSectionsMutation.removingNextUpItem(
+                        contentId: item.contentId,
+                        from: sections
+                    )
+                }
+            )
+        } else {
+            // Neither surface can represent this card. Leave it in place rather
+            // than hide it locally and have it reappear after relaunch.
+            return
+        }
+
         guard pendingContinueWatchingDismissals.insert(item.contentId).inserted else {
             return
         }
         defer { pendingContinueWatchingDismissals.remove(item.contentId) }
 
         actionError = nil
-        let progressUpdatedAt = item.progressUpdatedAt
-            ?? ISO8601DateFormatter().string(from: Date())
 
         do {
-            try await dismissContinueWatching(item.contentId, progressUpdatedAt)
+            try await removal.request()
 
             // A Home request that started before the dismissal can contain the
             // removed item. Invalidate that generation before committing the
             // authoritative local/cache update so a late response cannot put it
             // back on screen.
             StartupContentPrefetcher.invalidateHomeSectionsInFlight()
-            sections = HomeSectionsMutation.removingContinueWatchingItem(
-                contentId: item.contentId,
-                from: sections
-            )
+            sections = removal.mutate(sections)
             ResponseCache.shared.update(CacheKey.homeSections, as: SectionsResponse.self) { response in
-                response = SectionsResponse(
-                    sections: HomeSectionsMutation.removingContinueWatchingItem(
-                        contentId: item.contentId,
-                        from: response.sections
-                    )
-                )
+                response = SectionsResponse(sections: removal.mutate(response.sections))
             }
         } catch {
             actionError = ErrorState(error)

--- a/iosApp/iosApp/Theme/ContinuumButtonStyles.swift
+++ b/iosApp/iosApp/Theme/ContinuumButtonStyles.swift
@@ -7,8 +7,9 @@ import SwiftUI
 /// press-scale tick — no stray focus chrome leaking in.
 ///
 /// Individual components that need their own focus visuals should opt in
-/// with a locally-scoped `ButtonStyle` (e.g. `TVPillButtonStyle`,
-/// `TVCircleButtonStyle`) — never with `.buttonStyle(.plain)` on tvOS,
+/// with a locally-scoped `ButtonStyle` (e.g. `TVPillButtonStyle`, or the
+/// invisible focus host behind `TVCircleActionButton`) — never with
+/// `.buttonStyle(.plain)` on tvOS,
 /// which still triggers the system highlight on `Button` bounds.
 struct ContinuumFlatButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {

--- a/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
+++ b/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
@@ -941,15 +941,13 @@ final class TVFocusMarqueeModel {
         }
         // Mirrors ItemDetailViewModel.preferredInitialSeason: specials lead
         // the display order, but a fresh series opens on its first numbered
-        // season.
+        // season, and an unplayed Specials beats a fully watched numbered one.
         let regular = seasons.filter { !($0.isSpecials == true || $0.seasonNumber == 0) }
-        let candidates = regular.isEmpty ? seasons : regular
-        if let firstUnplayed = candidates.first(where: {
-            !($0.userData?.played ?? false)
-        }) {
+        let isUnplayed: (Season) -> Bool = { !($0.userData?.played ?? false) }
+        if let firstUnplayed = regular.first(where: isUnplayed) ?? seasons.first(where: isUnplayed) {
             return firstUnplayed
         }
-        return candidates.first
+        return regular.first ?? seasons.first
     }
 
     private func sampleTintIfNeeded(for urlString: String?) {

--- a/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
+++ b/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
@@ -939,12 +939,17 @@ final class TVFocusMarqueeModel {
         }) {
             return partial
         }
-        if let firstUnplayed = seasons.first(where: {
+        // Mirrors ItemDetailViewModel.preferredInitialSeason: specials lead
+        // the display order, but a fresh series opens on its first numbered
+        // season.
+        let regular = seasons.filter { !($0.isSpecials == true || $0.seasonNumber == 0) }
+        let candidates = regular.isEmpty ? seasons : regular
+        if let firstUnplayed = candidates.first(where: {
             !($0.userData?.played ?? false)
         }) {
             return firstUnplayed
         }
-        return seasons.first
+        return candidates.first
     }
 
     private func sampleTintIfNeeded(for urlString: String?) {

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVDetailActions.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVDetailActions.swift
@@ -157,46 +157,61 @@ private struct TVSecondaryPillLabel: View {
 /// one tap away without crowding the primary row.
 struct TVCircleMenuButton<MenuContent: View>: View {
     let icon: String
+    /// Short label revealed while focused ("Versions", "More"). Nil keeps the
+    /// button a fixed icon-only circle.
+    let title: String?
     let accessibilityLabel: String
     let stabilizesFocusMotion: Bool
     @ViewBuilder let menu: () -> MenuContent
 
+    @FocusState private var isFocused: Bool
+
     init(
         icon: String = "ellipsis",
+        title: String? = nil,
         accessibilityLabel: String,
         stabilizesFocusMotion: Bool = false,
         @ViewBuilder menu: @escaping () -> MenuContent
     ) {
         self.icon = icon
+        self.title = title
         self.accessibilityLabel = accessibilityLabel
         self.stabilizesFocusMotion = stabilizesFocusMotion
         self.menu = menu
     }
 
     var body: some View {
-        Menu {
-            menu()
-        } label: {
-            Image(systemName: icon)
-                .font(.system(size: 31, weight: .semibold))
-                .frame(width: 38, height: 38, alignment: .center)
-                .contentTransition(.symbolEffect(.replace))
-        }
-        .menuStyle(.button)
-        .buttonStyle(
-            TVCircleButtonStyle(
-                stabilizesFocusMotion: stabilizesFocusMotion
-            )
+        TVCirclePillSurface(
+            icon: icon,
+            title: title,
+            isFocused: isFocused,
+            isPressed: false,
+            stabilizesFocusMotion: stabilizesFocusMotion
         )
+        .overlay {
+            // The Menu is only the focus/press host. Its UIKit-backed button
+            // applies label size changes without animating them, so it must
+            // not own the pill's geometry; the surface above does.
+            Menu {
+                menu()
+            } label: {
+                Color.clear
+            }
+            .menuStyle(.button)
+            .buttonStyle(TVCircleFocusHostButtonStyle(isPressed: nil))
+            .focused($isFocused)
+        }
+        .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel)
+        .accessibilityAddTraits(.isButton)
     }
 }
 
 // MARK: - Circle button
 
-/// Compact icon-only secondary action circle. Infuse keeps these small
-/// and quiet so the primary play button dominates; we do the same. Used
-/// for Favorite / Watchlist / Info in the hero row.
+/// Compact secondary action circle: icon-only at rest so the primary play
+/// button dominates, expanding to icon + title while focused. Used for
+/// Start Over / Watchlist in the hero row.
 struct TVCircleActionButton: View {
     let icon: String
     let iconActive: String?
@@ -205,6 +220,9 @@ struct TVCircleActionButton: View {
     let accessibilityLabel: String
     let stabilizesFocusMotion: Bool
     let action: () -> Void
+
+    @FocusState private var isFocused: Bool
+    @State private var isPressed = false
 
     init(
         icon: String,
@@ -230,19 +248,134 @@ struct TVCircleActionButton: View {
     }
 
     var body: some View {
-        Button(action: action) {
-            Image(systemName: resolvedIcon)
+        TVCirclePillSurface(
+            icon: resolvedIcon,
+            title: title,
+            isFocused: isFocused,
+            isPressed: isPressed,
+            stabilizesFocusMotion: stabilizesFocusMotion
+        )
+        .overlay {
+            Button(action: action) {
+                Color.clear
+            }
+            .buttonStyle(TVCircleFocusHostButtonStyle(isPressed: $isPressed))
+            .focused($isFocused)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityAddTraits(.isButton)
+    }
+}
+
+/// The visible pill for `TVCircleMenuButton` / `TVCircleActionButton`.
+/// Icon-only circle at rest; while focused the title fades in beside the
+/// icon and the capsule widens to fit, reflowing the row with it.
+///
+/// Pure SwiftUI on purpose: the focusable control sits in an overlay so no
+/// UIKit-backed host can snap the width. `isFocused` drives an `isExpanded`
+/// state written inside `withAnimation`, which puts the width change and
+/// the neighbours' reflow into one transaction.
+private struct TVCirclePillSurface: View {
+    let icon: String
+    let title: String?
+    let isFocused: Bool
+    let isPressed: Bool
+    let stabilizesFocusMotion: Bool
+
+    @State private var isExpanded = false
+
+    private var canExpand: Bool {
+        guard let title else { return false }
+        return !title.isEmpty
+    }
+
+    var body: some View {
+        HStack(spacing: 14) {
+            Image(systemName: icon)
                 .font(.system(size: 31, weight: .semibold))
                 .frame(width: 38, height: 38, alignment: .center)
                 .contentTransition(.symbolEffect(.replace))
+            if isExpanded, let title {
+                Text(title)
+                    .font(.system(size: 26, weight: .semibold))
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+                    // Fade in once the capsule has started opening; fade out
+                    // fast so no text is visible while it closes. The clip
+                    // below is the backstop.
+                    .transition(
+                        .asymmetric(
+                            insertion: .opacity.animation(
+                                TVCircleFocusMotion.reveal.delay(0.06)
+                            ),
+                            removal: .opacity.animation(TVCircleFocusMotion.dismiss)
+                        )
+                    )
+            }
         }
-        .buttonStyle(
-            TVCircleButtonStyle(
-                stabilizesFocusMotion: stabilizesFocusMotion
+        .padding(.horizontal, isExpanded ? 28 : 0)
+        .foregroundColor(isFocused ? .black : .white)
+        // A 76×76 capsule is a circle; the title widens it into a pill
+        // without changing the row height.
+        .frame(minWidth: 76)
+        .frame(height: 76)
+        .background(
+            Capsule().fill(
+                isFocused ? .white : Color.white.opacity(0.10)
             )
         )
-        .accessibilityLabel(accessibilityLabel)
+        .clipShape(Capsule())
+        .scaleEffect(scale)
+        .shadow(
+            color: .black.opacity(isFocused ? 0.34 : 0.0),
+            radius: isFocused ? 16 : 0,
+            y: isFocused ? 6 : 0
+        )
+        .animation(TVCircleFocusMotion.resize, value: isFocused)
+        .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: isPressed)
+        .onChange(of: isFocused, initial: true) { _, focused in
+            let expanded = focused && canExpand
+            guard expanded != isExpanded else { return }
+            withAnimation(TVCircleFocusMotion.resize) {
+                isExpanded = expanded
+            }
+        }
     }
+
+    private var scale: CGFloat {
+        let base: CGFloat = isFocused && !stabilizesFocusMotion ? 1.1 : 1.0
+        return isPressed ? base * 0.95 : base
+    }
+}
+
+/// Invisible, full-size focus and press host laid over `TVCirclePillSurface`.
+/// Suppresses the system focus halo (the surface paints its own) and mirrors
+/// the press state out so the surface can react to it.
+private struct TVCircleFocusHostButtonStyle: ButtonStyle {
+    let isPressed: Binding<Bool>?
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .contentShape(Capsule())
+            .focusEffectDisabled()
+            .onChange(of: configuration.isPressed) { _, pressed in
+                isPressed?.wrappedValue = pressed
+            }
+    }
+}
+
+/// One motion vocabulary for the expanding circles so the capsule, the
+/// row reflow, and the title all move together.
+enum TVCircleFocusMotion {
+    /// Capsule width and neighbor reflow. A plain smooth ease; springs read
+    /// as wobble on a 10-foot UI.
+    static let resize = Animation.smooth(duration: 0.28, extraBounce: 0)
+    /// Title arriving with the capsule.
+    static let reveal = Animation.easeOut(duration: 0.18)
+    /// Title leaving ahead of the capsule shrink.
+    static let dismiss = Animation.easeIn(duration: 0.08)
 }
 
 // MARK: - Detail action row
@@ -279,8 +412,8 @@ struct TVDetailActionRow<PlaybackSelectors: View, MoreMenu: View>: View {
     let playFocused: FocusState<Bool>.Binding
     let rowFocused: FocusState<Bool>.Binding
     /// Opt-in treatment used by the redesigned Movie and Series pages. Play
-    /// stays a labeled pill; secondary actions retain fixed icon-only circles
-    /// so focus changes never move the row or its neighboring controls.
+    /// stays a labeled pill and no control scales on focus; secondary circles
+    /// still widen to reveal their title, reflowing the row horizontally only.
     var stabilizesFocusMotion = false
     /// Series reserves one compact width across Play/Resume episode labels.
     /// Movies leave this nil so short labels use their natural pill width.
@@ -603,48 +736,4 @@ private struct TVPillButtonBody: View {
 
 }
 
-// MARK: - Circle ButtonStyle
-
-struct TVCircleButtonStyle: ButtonStyle {
-    var stabilizesFocusMotion = false
-
-    func makeBody(configuration: Configuration) -> some View {
-        TVCircleButtonBody(
-            configuration: configuration,
-            stabilizesFocusMotion: stabilizesFocusMotion
-        )
-    }
-}
-
-private struct TVCircleButtonBody: View {
-    let configuration: ButtonStyleConfiguration
-    let stabilizesFocusMotion: Bool
-
-    @Environment(\.isFocused) private var isFocused
-
-    var body: some View {
-        configuration.label
-            .foregroundColor(isFocused ? .black : .white)
-            .frame(width: 76, height: 76)
-            .background(
-                Circle().fill(
-                    isFocused ? .white : Color.white.opacity(0.10)
-                )
-            )
-            .scaleEffect(scale)
-            .shadow(
-                color: .black.opacity(isFocused ? 0.34 : 0.0),
-                radius: isFocused ? 16 : 0,
-                y: isFocused ? 6 : 0
-            )
-            .focusEffectDisabled()
-            .animation(.easeInOut(duration: 0.18), value: isFocused)
-            .animation(.easeOut(duration: ContinuumTheme.fastDuration), value: configuration.isPressed)
-    }
-
-    private var scale: CGFloat {
-        let base: CGFloat = isFocused && !stabilizesFocusMotion ? 1.1 : 1.0
-        return configuration.isPressed ? base * 0.95 : base
-    }
-}
 #endif

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVDetailActions.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVDetailActions.swift
@@ -188,10 +188,12 @@ struct TVCircleMenuButton<MenuContent: View>: View {
             isPressed: false,
             stabilizesFocusMotion: stabilizesFocusMotion
         )
+        .accessibilityHidden(true)
         .overlay {
             // The Menu is only the focus/press host. Its UIKit-backed button
             // applies label size changes without animating them, so it must
-            // not own the pill's geometry; the surface above does.
+            // not own the pill's geometry; the surface above does. It stays
+            // the accessibility element so VoiceOver activation opens it.
             Menu {
                 menu()
             } label: {
@@ -200,10 +202,8 @@ struct TVCircleMenuButton<MenuContent: View>: View {
             .menuStyle(.button)
             .buttonStyle(TVCircleFocusHostButtonStyle(isPressed: nil))
             .focused($isFocused)
+            .accessibilityLabel(accessibilityLabel)
         }
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(accessibilityLabel)
-        .accessibilityAddTraits(.isButton)
     }
 }
 
@@ -255,16 +255,17 @@ struct TVCircleActionButton: View {
             isPressed: isPressed,
             stabilizesFocusMotion: stabilizesFocusMotion
         )
+        .accessibilityHidden(true)
         .overlay {
+            // The Button stays the accessibility element so VoiceOver
+            // activation runs `action`; the surface is decorative.
             Button(action: action) {
                 Color.clear
             }
             .buttonStyle(TVCircleFocusHostButtonStyle(isPressed: $isPressed))
             .focused($isFocused)
+            .accessibilityLabel(accessibilityLabel)
         }
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(accessibilityLabel)
-        .accessibilityAddTraits(.isButton)
     }
 }
 

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVDetailHero.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVDetailHero.swift
@@ -9,7 +9,9 @@ import NukeUI
 enum TVDetailLayout {
     static let horizontalInset: CGFloat = 100
     static let heroHeight: CGFloat = 690
-    static let heroTopInset: CGFloat = 88
+    /// Shared title baseline for every detail page. Sits low enough that the
+    /// first rail below the 690pt hero bottoms out just above the safe area.
+    static let heroTopInset: CGFloat = 116
     static let heroContentWidth: CGFloat = 1_080
     static let bodySectionSpacing: CGFloat = 64
     static let sectionHeaderSpacing: CGFloat = 14

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
@@ -209,6 +209,7 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
     @ViewBuilder
     private var moreMenu: some View {
         TVCircleMenuButton(
+            title: "More",
             accessibilityLabel: "More options",
             stabilizesFocusMotion: true
         ) {

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVPlaybackSelectorRow.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVPlaybackSelectorRow.swift
@@ -33,7 +33,8 @@ struct TVPlaybackActionSelectors: View {
 
     private var versionMenu: some View {
         TVCircleMenuButton(
-            icon: "movieclapper",
+            icon: "square.stack",
+            title: "Versions",
             accessibilityLabel: "Version, \(versionValue)",
             stabilizesFocusMotion: true
         ) {
@@ -60,6 +61,7 @@ struct TVPlaybackActionSelectors: View {
     private var audioMenu: some View {
         TVCircleMenuButton(
             icon: "speaker.wave.2",
+            title: "Audio Tracks",
             accessibilityLabel: "Audio, \(audioValue)",
             stabilizesFocusMotion: true
         ) {
@@ -86,6 +88,7 @@ struct TVPlaybackActionSelectors: View {
     private var subtitleMenu: some View {
         TVCircleMenuButton(
             icon: "captions.bubble",
+            title: "Subtitles",
             accessibilityLabel: "Subtitles, \(subtitleValue)",
             stabilizesFocusMotion: true
         ) {

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
@@ -185,7 +185,7 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
 
     @ViewBuilder
     private var moreMenu: some View {
-        TVCircleMenuButton(accessibilityLabel: "More options") {
+        TVCircleMenuButton(title: "More", accessibilityLabel: "More options") {
             Button(action: onToggleFavorite) {
                 Label(
                     isFavorite ? "Remove from Favorites" : "Add to Favorites",

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -201,7 +201,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     @ObservedObject private var profilePrefsStore = ProfilePrefsStore.shared
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    private let showModeId = "series-show-overview"
+    private let noSeasonModeId = "series-season-none"
     private let episodeSectionScrollId = "series-episode-section"
     private let castSectionScrollId = "series-cast-section"
     private let heroScrollId = "series-hero"
@@ -481,15 +481,6 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         ScrollViewReader { proxy in
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 12) {
-                    TVSeriesModeTab(
-                        title: "Show",
-                        isSelected: isShowingSeriesOverview,
-                        rendersFocusedAppearance: presentedFocusedModeId == showModeId,
-                        action: showSeriesOverview
-                    )
-                    .id(showModeId)
-                    .focused($focusedModeId, equals: showModeId)
-
                     ForEach(seasons) { season in
                         TVSeriesModeTab(
                             title: seasonLabel(season),
@@ -571,12 +562,13 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         }
     }
 
+    /// The season pill stays selected while the hero shows series info, since
+    /// the rail below still lists that season's episodes.
     private var selectedModeId: String {
-        guard !isShowingSeriesOverview else { return showModeId }
-        return seasonTransitionTargetId
+        seasonTransitionTargetId
             ?? visibleSeasonId
             ?? selectedSeason?.id
-            ?? showModeId
+            ?? noSeasonModeId
     }
 
     private func showSeriesOverview() {
@@ -773,16 +765,14 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                   focusedModeId == modeId,
                   modeId != selectedModeId else { return }
 
-            if modeId == showModeId {
-                showSeriesOverview()
-            } else if let season = seasons.first(where: { $0.id == modeId }) {
+            if let season = seasons.first(where: { $0.id == modeId }) {
                 activateSeason(season)
             }
         }
     }
 
     private var seasonPageReadinessKey: String {
-        let seasonId = selectedSeason?.id ?? "series-season-none"
+        let seasonId = selectedSeason?.id ?? noSeasonModeId
         let loadingState = isLoadingEpisodes ? "loading" : "ready"
         let episodeIds = episodes.map(\.contentId).joined(separator: "|")
         return "\(seasonId):\(loadingState):\(episodeIds)"
@@ -790,7 +780,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
 
     private var currentSeasonPageSnapshot: SeasonPageSnapshot {
         SeasonPageSnapshot(
-            seasonId: selectedSeason?.id ?? "series-season-none",
+            seasonId: selectedSeason?.id ?? noSeasonModeId,
             episodes: episodes,
             currentContentId: displayedEpisode?.contentId,
             isLoading: isLoadingEpisodes
@@ -1092,6 +1082,11 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
             accessibilityLabel: "More options",
             stabilizesFocusMotion: true
         ) {
+            if !isShowingSeriesOverview {
+                Button(action: showSeriesOverview) {
+                    Label("Show Series Info", systemImage: "info.circle")
+                }
+            }
             Button(action: onToggleFavorite) {
                 Label(
                     isFavorite ? "Remove from Favorites" : "Add to Favorites",

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -32,17 +32,24 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
 
     /// Owns only the outer vertical UIScrollView. Locking this concrete scroll
     /// view leaves every nested horizontal season/episode rail fully native.
-    /// Its return animator can be stopped at the presentation position when a
-    /// rapid Down reverses direction, so an old trip to the hero cannot win.
+    ///
+    /// Every page-level trip — the return to the hero and the descent that
+    /// centers the Cast section — runs through this one animator slot. A new
+    /// trip stops the current one at its presentation position first, so a
+    /// rapid reversal in either direction continues from where the page
+    /// visibly is instead of letting two animations race to the finish.
     private final class PageScrollCoordinator {
         weak var scrollView: UIScrollView?
-        private var returnAnimator: UIViewPropertyAnimator?
+        /// Marker view laid out behind the Cast section; its frame converted
+        /// into the scroll view gives the centering target in content space.
+        weak var supportingAnchorView: UIView?
+        private var pageAnimator: UIViewPropertyAnimator?
         private var animationGeneration = 0
         private(set) var primaryOwnsViewport = false
 
         func attach(_ scrollView: UIScrollView) {
             guard self.scrollView !== scrollView else { return }
-            stopReturnAnimation()
+            stopPageAnimation()
             self.scrollView = scrollView
             if primaryOwnsViewport {
                 pinTopAndLock()
@@ -51,7 +58,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
 
         func enterPrimary(animated: Bool, reduceMotion: Bool) {
             primaryOwnsViewport = true
-            stopReturnAnimation()
+            stopPageAnimation()
             guard let scrollView else { return }
 
             scrollView.isScrollEnabled = true
@@ -64,6 +71,55 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                 return
             }
 
+            animatePage(to: target) { [weak self, weak scrollView] in
+                guard let self, self.primaryOwnsViewport, let scrollView else { return }
+                scrollView.setContentOffset(
+                    self.topOffset(in: scrollView),
+                    animated: false
+                )
+                scrollView.isScrollEnabled = false
+            }
+        }
+
+        /// Centers the Cast section after focus leaves the fixed top viewport.
+        /// Runs in the same animator slot as the return trip so that an Up
+        /// press mid-descent stops this motion where it is and the return
+        /// starts from that exact offset.
+        func revealSupporting(reduceMotion: Bool) {
+            primaryOwnsViewport = false
+            stopPageAnimation()
+            guard let scrollView, let supportingAnchorView else { return }
+
+            scrollView.isScrollEnabled = true
+            let target = centeredOffset(for: supportingAnchorView, in: scrollView)
+            guard !reduceMotion,
+                  abs(scrollView.contentOffset.y - target.y) > 0.5 else {
+                scrollView.setContentOffset(target, animated: false)
+                return
+            }
+
+            // No settle write here. The model offset is already at `target`
+            // once the animation block runs, so the focus engine's own reveal
+            // for the Cast card sees it as visible and stays quiet, while a
+            // later move on to Trailers or Similar must be allowed to win.
+            animatePage(to: target) {}
+        }
+
+        func releasePrimary() {
+            primaryOwnsViewport = false
+            stopPageAnimation()
+            scrollView?.isScrollEnabled = true
+        }
+
+        func detach() {
+            primaryOwnsViewport = false
+            stopPageAnimation()
+            scrollView?.isScrollEnabled = true
+            scrollView = nil
+        }
+
+        private func animatePage(to target: CGPoint, onSettle: @escaping () -> Void) {
+            guard let scrollView else { return }
             animationGeneration &+= 1
             let generation = animationGeneration
             let timing = UICubicTimingParameters(
@@ -74,36 +130,16 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                 duration: 0.55,
                 timingParameters: timing
             )
-            returnAnimator = animator
+            pageAnimator = animator
             animator.addAnimations { [weak scrollView] in
                 scrollView?.setContentOffset(target, animated: false)
             }
-            animator.addCompletion { [weak self, weak scrollView] _ in
-                guard let self,
-                      self.animationGeneration == generation,
-                      self.primaryOwnsViewport,
-                      let scrollView else { return }
-                self.returnAnimator = nil
-                scrollView.setContentOffset(
-                    self.topOffset(in: scrollView),
-                    animated: false
-                )
-                scrollView.isScrollEnabled = false
+            animator.addCompletion { [weak self] _ in
+                guard let self, self.animationGeneration == generation else { return }
+                self.pageAnimator = nil
+                onSettle()
             }
             animator.startAnimation()
-        }
-
-        func releasePrimary() {
-            primaryOwnsViewport = false
-            stopReturnAnimation()
-            scrollView?.isScrollEnabled = true
-        }
-
-        func detach() {
-            primaryOwnsViewport = false
-            stopReturnAnimation()
-            scrollView?.isScrollEnabled = true
-            scrollView = nil
         }
 
         private func pinTopAndLock() {
@@ -112,15 +148,15 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
             scrollView.isScrollEnabled = false
         }
 
-        private func stopReturnAnimation() {
+        private func stopPageAnimation() {
             animationGeneration &+= 1
-            guard let returnAnimator else { return }
-            self.returnAnimator = nil
-            if returnAnimator.state == .active {
-                returnAnimator.stopAnimation(false)
-                returnAnimator.finishAnimation(at: .current)
+            guard let pageAnimator else { return }
+            self.pageAnimator = nil
+            if pageAnimator.state == .active {
+                pageAnimator.stopAnimation(false)
+                pageAnimator.finishAnimation(at: .current)
             } else {
-                returnAnimator.stopAnimation(true)
+                pageAnimator.stopAnimation(true)
             }
         }
 
@@ -128,6 +164,25 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
             CGPoint(
                 x: scrollView.contentOffset.x,
                 y: -scrollView.adjustedContentInset.top
+            )
+        }
+
+        /// Equivalent of `scrollTo(id, anchor: .center)` for the anchor view,
+        /// clamped to the scrollable range like the SwiftUI proxy does.
+        private func centeredOffset(for anchor: UIView, in scrollView: UIScrollView) -> CGPoint {
+            let rect = scrollView.convert(anchor.bounds, from: anchor)
+            let viewportHeight = scrollView.bounds.height
+            let minY = -scrollView.adjustedContentInset.top
+            let maxY = max(
+                minY,
+                scrollView.contentSize.height
+                    + scrollView.adjustedContentInset.bottom
+                    - viewportHeight
+            )
+            let centered = rect.midY - viewportHeight / 2
+            return CGPoint(
+                x: scrollView.contentOffset.x,
+                y: min(max(centered, minY), maxY)
             )
         }
     }
@@ -238,13 +293,11 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                 }
                 .onChange(of: supportingRailFocusRequest) { _, request in
                     guard request > 0, hasCast else { return }
-                    if reduceMotion {
-                        scrollProxy.scrollTo(castSectionScrollId, anchor: .center)
-                    } else {
-                        withAnimation(.smooth(duration: 0.55, extraBounce: 0)) {
-                            scrollProxy.scrollTo(castSectionScrollId, anchor: .center)
-                        }
-                    }
+                    // Drive this through the coordinator rather than the
+                    // SwiftUI proxy: a proxy animation cannot be cancelled, so
+                    // a quick Up used to run it against the return trip and
+                    // the page snapped when the loser finished.
+                    pageScrollCoordinator.revealSupporting(reduceMotion: reduceMotion)
                 }
                 .ignoresSafeArea()
                 .focusScope(detailFocusNamespace)
@@ -1208,6 +1261,11 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
             )
         }
         .padding(.top, 20)
+        .background {
+            TVSeriesAnchorResolver { anchorView in
+                pageScrollCoordinator.supportingAnchorView = anchorView
+            }
+        }
     }
 
     private var hasCast: Bool {
@@ -1277,6 +1335,25 @@ private struct TVSeriesPageScrollResolver: UIViewRepresentable {
                 }
             }
         }
+    }
+}
+
+/// Invisible marker laid out behind a page section. Its UIView frame is what
+/// the page coordinator converts into scroll content space to center that
+/// section without going through the SwiftUI scroll proxy.
+private struct TVSeriesAnchorResolver: UIViewRepresentable {
+    let onResolve: (UIView) -> Void
+
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        view.isUserInteractionEnabled = false
+        view.backgroundColor = .clear
+        onResolve(view)
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        onResolve(uiView)
     }
 }
 

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -337,10 +337,11 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                 showForcedSubtitles: matchingPlaybackDetail?.effectiveShowForcedSubtitles ?? false
             ),
             backdropHeight: TVDetailLayout.heroHeight,
-            // Keep the mode/season row at its approved fixed anchor. The hero
-            // stays 620 points tall even when the controls move independently.
-            heroHeight: 620,
-            heroTopInset: 46,
+            // The hero shares the standard height and title inset with Movie
+            // so the first viewport bottoms out on the episode rail: the season
+            // row lands at ~690 and the rail finishes just above the bottom
+            // safe area with Cast & Crew fully below the fold.
+            heroHeight: TVDetailLayout.heroHeight,
             editorialContentWidth: TVDetailLayout.heroContentWidth,
             // Raise only the controls by 20 points. The 112-point synopsis slot
             // remains unchanged, so episode copy still renders three full lines.
@@ -1079,6 +1080,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
 
     private var moreMenu: some View {
         TVCircleMenuButton(
+            title: "More",
             accessibilityLabel: "More options",
             stabilizesFocusMotion: true
         ) {

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -58,12 +58,19 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
 
         func enterPrimary(animated: Bool, reduceMotion: Bool) {
             primaryOwnsViewport = true
+            // Moves between rows inside the fixed viewport (Season row <->
+            // Episodes) ask for `animated: false` because the page should
+            // already be resting at the top. On a double Up from Cast the
+            // first press's return trip is still mid-flight; jumping now is
+            // the snap. Finish that trip as an animation from wherever the
+            // page visibly is instead.
+            let continuesInFlightTrip = pageAnimator?.state == .active
             stopPageAnimation()
             guard let scrollView else { return }
 
             scrollView.isScrollEnabled = true
             let target = topOffset(in: scrollView)
-            guard animated,
+            guard animated || continuesInFlightTrip,
                   !reduceMotion,
                   abs(scrollView.contentOffset.y - target.y) > 0.5 else {
                 scrollView.setContentOffset(target, animated: false)


### PR DESCRIPTION
Supersedes #232, which covered only the first commit on this branch.

## Problem

Two separate issues on Apple TV.

**Detail page.** The series mode row had a "Show" pill that only toggled the hero between series-level and episode-level info, but it read like a season and took the first focus slot. Specials sorted last, series and movie heroes used different geometry so the first rail landed inconsistently, and the secondary action circles gave no label until you opened them.

**Home.** Removing an unstarted next-episode card from Continue Watching only hid it locally; it came back after relaunch. The Continue Watching row mixes in Next Up episodes that have no `progress_updated_at`. The client fabricated a "now" timestamp and sent it to the `continue_watching` dismissal surface. The server accepted it but the timestamp never matched a progress row, so the next fresh fetch restored the card. This has been reachable since #90 (2026-07-16), which replaced a silent no-op guard with the fabricated timestamp.

## Solution

**Detail page** (`c65f1e9e`, `41497ad5`)
- Remove the Show pill; expose the same toggle as "Show Series Info" in the more menu while the hero is in episode mode. The selected season pill stays highlighted in both modes.
- Sort Specials first in the season row; initial selection still prefers the first numbered season.
- Series hero uses the shared 690pt height and 116pt title inset, matching movies.
- Secondary action circles expand into labeled pills on focus (Versions, Audio Tracks, Subtitles, Start Over, Watchlist, More). The pill is pure SwiftUI with the Menu/Button as an invisible focus host, because the Menu's UIKit-backed label snapped its width instead of animating.
- Version selector icon is now `square.stack`.

**Home dismissal** (`01c8f18e`)
- Route by card kind, matching Android and the server contract in `HandleUpsertDismissal`: progress-backed cards keep using `continue_watching`; series-backed cards without progress go to `PUT /api/v1/home/dismissals/next_up/{id}` with `series_id`; cards with neither are left in place instead of hidden locally.
- The Next Up path also clears the standalone Next Up row locally and in `ResponseCache`.
- New `ContinuumAPI.dismissNextUpItem` and `HomeSectionsMutation.removingNextUpItem`. No server change needed.

## Validation

- `xcodebuild test -scheme Silo -only-testing:SiloTests/HomeSectionsMutationTests` on iPhone 17 Pro simulator: 11 tests, 0 failures. Two new tests cover the Next Up routing and the no-surface case.
- Detail page changes were exercised manually on tvOS during the earlier commits. Before/after screenshots for the pill and hero changes are not attached yet.

## Risks and follow-up

- Cards with neither `progress_updated_at` nor `series_id` still show "Remove from Continue Watching" in the menu but the action is now a no-op. Hiding the menu item for those requires plumbing through the card layers; left for a follow-up.
- Related but separate: every progress heartbeat rewrites `updated_at` server-side even when position is unchanged, so a late player flush landing after a dismissal will re-surface the item. That is a server fix, not covered here.

## AI disclosure

Written with Claude Fable 5.1 (`claude-fable-5-1`) in Cursor. Earlier commits on this branch were co-authored with a Cursor Cloud Agent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Next Up dismissal with updates to Home sections and cached content.
  - Added “Show Series Info” to tvOS detail menus.
  - Added expanding, title-revealing tvOS action buttons.
  - Added clearer labels for More, Versions, Audio Tracks, and Subtitles.

- **Improvements**
  - Improved Continue Watching resume navigation and initial season selection.
  - Specials now appear before numbered seasons and can be selected when appropriate.
  - Refined tvOS detail layout spacing, scrolling, focus behavior, and series information presentation.

- **Tests**
  - Added coverage for Next Up dismissal, cache updates, playback refresh, and season selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->