### PR TITLE
feat(tvos): show season/episode code in Series episode carousel

### DIFF
--- a/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
@@ -727,10 +727,16 @@ private struct EpisodeCardLabel: View {
         return isFocused ? .continuumOnSurface : Color.continuumOnSurface.opacity(0.92)
     }
 
+    /// "S01E02 · Pilot" — the same code Home puts on episode cards, so the
+    /// Series carousel makes each episode's position obvious at a glance.
     private var compactEpisodeTitle: String? {
+        let code = EpisodeCardCaption.code(
+            season: episode.seasonNumber,
+            episode: episode.episodeNumber
+        )
         guard let title = episode.title?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !title.isEmpty else { return nil }
-        return title
+              !title.isEmpty else { return code }
+        return "\(code) · \(title)"
     }
 
     private var episodeMetadataLine: String? {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On the tvOS Series page, the episode carousel captioned each card with only the episode title (or nothing when the title was missing). There was no way to tell which episode a card was without focusing it, even though Home already labels episode cards with `S01E02 · Title`.

## Solution

`TVEpisodeRail`'s compact caption (used when `hidesEpisodeTitle` is true, i.e. the Series carousel) now reads `S17E02 · Title`, using the shared `EpisodeCardCaption.code(season:episode:)` helper so the zero-padded format matches Home. When an episode has no title, the card shows the code alone instead of an empty caption.

The caption remains single-line and tail-truncated, so card heights and carousel offsets are unchanged. The accessibility label already spoke "Season X, Episode Y" and is untouched, as are the legacy season/episode detail rails.

## Validation

- Reviewed by inspection: `EpisodeListItem.seasonNumber`/`episodeNumber` are non-optional `Int`, and `EpisodeCardCaption` lives in `iosApp/Components`, which is compiled into every target.
- Not built: the `mac-builder` host was unreachable from the cloud agent environment. Please run the `SiloTV` scheme once and check the caption on a series with long episode titles before merging.

## Risks

Low. One private computed property changed in a tvOS-only file.

## AI disclosure

Written by Claude Fable 5.1 (`claude-fable-5-1-thinking`) running as a Cursor Cloud Agent. No other AI tooling was used.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a06934-6365-71a2-af33-7a7c828f2d77?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a06934-6365-71a2-af33-7a7c828f2d77&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Episode cards now display season and episode codes, such as `S01E02`, before the episode title.
  * Episodes without titles display the season and episode code alone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->