### PR TITLE
fix(playback): reload rotated media authorization

### DIFF
--- a/iosApp/Tests/AetherPlaybackBoundaryTests.swift
+++ b/iosApp/Tests/AetherPlaybackBoundaryTests.swift
@@ -181,6 +181,32 @@ final class AetherPlaybackBoundaryTests: XCTestCase {
         ))
     }
 
+    func testPeriodicProgressReloadsOnlyAfterSuccessWithChangedAuthorization() {
+        let active = ["Authorization": "Bearer old-token"]
+        let refreshed = ["authorization": "Bearer new-token"]
+
+        XCTAssertTrue(AetherAuthenticationRecoveryPolicy.shouldReloadAfterProgress(
+            .success,
+            activeHeaders: active,
+            currentHeaders: refreshed
+        ))
+        XCTAssertFalse(AetherAuthenticationRecoveryPolicy.shouldReloadAfterProgress(
+            .success,
+            activeHeaders: refreshed,
+            currentHeaders: refreshed
+        ))
+        XCTAssertFalse(AetherAuthenticationRecoveryPolicy.shouldReloadAfterProgress(
+            .missingSession,
+            activeHeaders: active,
+            currentHeaders: refreshed
+        ))
+        XCTAssertFalse(AetherAuthenticationRecoveryPolicy.shouldReloadAfterProgress(
+            .transientFailure,
+            activeHeaders: active,
+            currentHeaders: refreshed
+        ))
+    }
+
     func testHeaderAuthenticatedStreamRejectsAbsoluteAndNonMediaRoutes() {
         for raw in [
             "https://dev.example.test/api/v1/stream/session-1",

--- a/iosApp/iosApp/Screens/Player/AetherLoadSpec.swift
+++ b/iosApp/iosApp/Screens/Player/AetherLoadSpec.swift
@@ -70,6 +70,17 @@ enum AetherAuthenticationRecoveryPolicy {
         return authorizationHeader(in: failedHeaders) != refreshed
     }
 
+    static func shouldReloadAfterProgress(
+        _ result: PlaybackProgressReportResult,
+        activeHeaders: [String: String],
+        currentHeaders: [String: String]
+    ) -> Bool {
+        result == .success && shouldReload(
+            failedHeaders: activeHeaders,
+            refreshedHeaders: currentHeaders
+        )
+    }
+
     private static func authorizationHeader(in headers: [String: String]) -> String? {
         headers.first { key, _ in
             key.caseInsensitiveCompare("Authorization") == .orderedSame

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -1484,8 +1484,69 @@ class PlayerViewModel {
     private func attemptProtocolV3AuthenticationReload(
         after failure: PlaybackErrorInfo
     ) -> Bool {
-        guard AetherAuthenticationRecoveryPolicy.isExpiredBearerFailure(failure),
+        guard AetherAuthenticationRecoveryPolicy.isExpiredBearerFailure(failure) else {
+            return false
+        }
+        return beginProtocolV3AuthenticationReload(
+            fallbackClassification: failure.kind.rawValue,
+            fallbackMessage: failure.message
+        )
+    }
+
+    /// The periodic progress request uses the live API credential and owns its
+    /// refresh. If that request rotated the bearer, rebuild Aether before its
+    /// next source request can reuse the credential frozen at asset creation.
+    private func attemptProtocolV3AuthenticationReloadAfterProgress(
+        _ result: PlaybackProgressReportResult
+    ) async {
+        guard result == .success,
               protocolV3ReplanTask == nil,
+              let protocolV3 = activePreparedProtocolV3,
+              protocolV3.serverFeatures.contains(
+                  PlaybackProtocolV3.headerAuthenticatedMediaFeature
+              ),
+              let sessionId = activePlaybackSessionId,
+              let failedSpec = aetherPlaybackController.activeSpec,
+              failedSpec.planID == protocolV3.plan.planId,
+              failedSpec.sessionID == sessionId,
+              committedProtocolV3LoadEpoch != nil,
+              let session = await sessionBridge.committedProtocolV3Session(
+                  planId: protocolV3.plan.planId,
+                  sessionId: sessionId
+              ),
+              let streamRequest = await makeStreamRequest(
+                  session: session,
+                  additionalHeaders: protocolV3.plan.stream.headers,
+                  requiresHeaderAuthenticatedMedia: true,
+                  allowsAuthorizedMediaOrigins:
+                      protocolV3.negotiatedAuthorizedMediaOrigins
+              ),
+              activePlaybackSessionId == sessionId,
+              activePreparedProtocolV3?.plan.planId == protocolV3.plan.planId,
+              aetherPlaybackController.activeSpec?.planID == failedSpec.planID,
+              aetherPlaybackController.activeSpec?.sessionID == sessionId,
+              AetherAuthenticationRecoveryPolicy.shouldReloadAfterProgress(
+                  result,
+                  activeHeaders: failedSpec.options.httpHeaders,
+                  currentHeaders: streamRequest.headers
+              ) else {
+            return
+        }
+
+        _ = beginProtocolV3AuthenticationReload(
+            fallbackClassification: "authorization_rotated",
+            fallbackMessage: "Playback authorization changed while media was active.",
+            refreshedStreamRequest: streamRequest
+        )
+    }
+
+    @discardableResult
+    private func beginProtocolV3AuthenticationReload(
+        fallbackClassification: String,
+        fallbackMessage: String,
+        refreshedStreamRequest: StreamRequest? = nil
+    ) -> Bool {
+        guard protocolV3ReplanTask == nil,
               let protocolV3 = activePreparedProtocolV3,
               protocolV3.serverFeatures.contains(
                   PlaybackProtocolV3.headerAuthenticatedMediaFeature
@@ -1500,11 +1561,17 @@ class PlayerViewModel {
             return false
         }
 
+        if let refreshedStreamRequest,
+           !AetherAuthenticationRecoveryPolicy.shouldReload(
+               failedHeaders: failedSpec.options.httpHeaders,
+               refreshedHeaders: refreshedStreamRequest.headers
+           ) {
+            return false
+        }
+
         let planId = protocolV3.plan.planId
         let resumePosition = currentTime.isFinite ? max(0, currentTime) : 0
         let failedHeaders = failedSpec.options.httpHeaders
-        let fallbackClassification = failure.kind.rawValue
-        let fallbackMessage = failure.message
 
         progressTask?.cancel()
         progressTask = nil
@@ -1514,9 +1581,15 @@ class PlayerViewModel {
         streamLoadGeneration &+= 1
         let recoveryGeneration = streamLoadGeneration
 
-        Self.logger.warning(
-            "Protocol V3 media credential expired; refreshing and reloading plan \(planId, privacy: .public) at source position \(resumePosition, privacy: .public)"
-        )
+        if refreshedStreamRequest == nil {
+            Self.logger.warning(
+                "Protocol V3 media credential expired; refreshing and reloading plan \(planId, privacy: .public) at source position \(resumePosition, privacy: .public)"
+            )
+        } else {
+            Self.logger.info(
+                "Protocol V3 media credential rotated; proactively reloading plan \(planId, privacy: .public) at source position \(resumePosition, privacy: .public)"
+            )
+        }
 
         protocolV3ReplanTask = Task { @MainActor [weak self] in
             guard let self, !self.isDisposed else { return }
@@ -1550,13 +1623,15 @@ class PlayerViewModel {
             }
 
             do {
-                // This request uses the normal API transport, whose 401 path
-                // refreshes TokenStore before retrying. Its result is otherwise
-                // best-effort; the header comparison below is authoritative.
-                _ = await self.sessionBridge.reportProgress(
-                    position: resumePosition,
-                    isPaused: !self.aetherPlaybackController.shouldPlayWhenReady
-                )
+                if refreshedStreamRequest == nil {
+                    // This request uses the normal API transport, whose 401 path
+                    // refreshes TokenStore before retrying. Its result is otherwise
+                    // best-effort; the header comparison below is authoritative.
+                    _ = await self.sessionBridge.reportProgress(
+                        position: resumePosition,
+                        isPaused: !self.aetherPlaybackController.shouldPlayWhenReady
+                    )
+                }
                 try self.requireCurrentStreamLoad(recoveryGeneration)
                 guard self.activePlaybackSessionId == sessionId,
                       self.activePreparedProtocolV3?.plan.planId == planId,
@@ -1575,14 +1650,20 @@ class PlayerViewModel {
                     activeQualityId: self.activeQualityId,
                     protocolV3: protocolV3
                 )
-                guard let streamRequest = await self.makeStreamRequest(
-                    session: session,
-                    additionalHeaders: protocolV3.plan.stream.headers,
-                    requiresHeaderAuthenticatedMedia: true,
-                    allowsAuthorizedMediaOrigins:
-                        protocolV3.negotiatedAuthorizedMediaOrigins
-                ) else {
-                    throw AetherLoadSpec.ValidationError.invalidStreamURL(session.streamUrl)
+                let streamRequest: StreamRequest
+                if let refreshedStreamRequest {
+                    streamRequest = refreshedStreamRequest
+                } else {
+                    guard let resolved = await self.makeStreamRequest(
+                        session: session,
+                        additionalHeaders: protocolV3.plan.stream.headers,
+                        requiresHeaderAuthenticatedMedia: true,
+                        allowsAuthorizedMediaOrigins:
+                            protocolV3.negotiatedAuthorizedMediaOrigins
+                    ) else {
+                        throw AetherLoadSpec.ValidationError.invalidStreamURL(session.streamUrl)
+                    }
+                    streamRequest = resolved
                 }
                 try self.requireCurrentStreamLoad(recoveryGeneration)
                 guard AetherAuthenticationRecoveryPolicy.shouldReload(
@@ -7187,6 +7268,8 @@ class PlayerViewModel {
                         reason: "progress",
                         observedPosition: self.currentTime
                     )
+                } else {
+                    await self.attemptProtocolV3AuthenticationReloadAfterProgress(result)
                 }
             }
         }


### PR DESCRIPTION
## Problem

Protocol V3 playback freezes its Authorization header when Aether creates the media asset. A periodic progress request can refresh the account bearer successfully while the active media reader continues using the old bearer. In the production tvOS capture, that sequence led to repeated media 401 responses, a generic Aether read failure, and a loading indicator that never recovered.

The app already had bounded same-plan recovery for typed authentication failures, but the current Aether reader does not preserve a midstream HTTP 401 through its VOD failure path. The client therefore could not recognize this specific failure in time.

I audited upstream Aether from the pinned 6.34.0 lineage through 6.64.0. None of those changes adds midstream bearer refresh or preserves a VOD media 401 as a typed authentication failure. The relevant comparison is https://github.com/blurbery/AetherEngine/compare/6.34.0...6.64.0.

## Solution

After each successful periodic progress report, rebuild the current authenticated stream request and compare its Authorization header with the header on the active Aether load. If the bearer changed, reuse the existing bounded same-plan authentication reload at the current playback position.

The reload remains limited to negotiated header-authenticated Protocol V3 playback, revalidates the active plan and session after suspension points, and keeps the existing reactive 401 recovery path. Failed progress reports and unchanged credentials do not trigger a reload.

This PR does not update the Aether dependency.

## Validation

- Regenerated the Xcode project with xcodegen.
- Ran AetherPlaybackBoundaryTests on an iPhone 17 Pro simulator: 49 tests executed, 1 existing skip, 0 failures.
- Built the SiloTV scheme for the Apple TV 4K simulator successfully.
- Ran git diff --check successfully.
- Completed the required ponytail review: Lean already. Ship.

## Risk and follow-up

The proactive reload can cause one brief playback interruption when a bearer rotates, but only after the API transport has successfully refreshed it and only when the active media header differs. A future Aether release that exposes typed midstream HTTP failures could make the proactive check unnecessary, but 6.64.0 does not.

## AI disclosure

Developed with OpenAI Codex model gpt-5.6-sol in the T3 Code Codex harness. Claude Opus through CLIProxy was consulted during diagnosis but returned no usable assessment. Validation used XcodeGen, xcodebuild, Git, and GitHub CLI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved playback recovery when streaming authorization expires or changes.
  - Playback can now refresh credentials proactively after successful progress updates, helping prevent interruptions.
  - Avoids unnecessary reloads when credentials remain unchanged.
  - Handles missing sessions and temporary progress-check failures without triggering inappropriate reloads.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->