### PR TITLE
perf(tvos): bump Nuke to 13 and decode artwork at render size

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -18,7 +18,7 @@ The authoritative dependency lock is
 | AetherEngine 6.34.0 | `0ae80496ab6f3fda135f43ef195ff10961c0e625` | Swift package target linked into each host app | LGPL-3.0-only with AetherEngine's Apple Store / DRM exception |
 | FFmpegBuild 2.4.3 | `b2185fa842b829cd53d182a5e9a53182c1d9c84c` | Nine separately embedded dynamic frameworks | See the component table below |
 | LibDovi 2.0.0 | `89be93431c2a5f2e54fb77e93059071b8d2ddb3a` | Static `Dovi.xcframework` linked through AetherEngine | MIT packaging; embedded libdovi is MIT |
-| Nuke and NukeUI 12.9.0 | `83e19143355b02e9261edb2323b3e1e93287ebb9` | Swift package targets linked into each host app | MIT |
+| Nuke and NukeUI 13.2.0 | `30f7a7e72e0607d304fbf69c799474bd5fb6d1ce` | Swift package targets linked into each host app | MIT |
 
 SwiftPM also resolves SMBClient 0.3.1 because AetherEngine publishes an
 optional `AetherEngineSMB` product. Silo depends only on the `AetherEngine`
@@ -124,7 +124,7 @@ Nuke and NukeUI are distributed under the MIT license, Copyright (c)
 2015-2026 Alexander Grebenyuk.
 
 - Exact source:
-  <https://github.com/kean/Nuke/tree/83e19143355b02e9261edb2323b3e1e93287ebb9>
+  <https://github.com/kean/Nuke/tree/30f7a7e72e0607d304fbf69c799474bd5fb6d1ce>
 - Bundled text: `Nuke-MIT.txt`
 
 ## ThumbHash decoder

--- a/iosApp/Resources/OpenSourceLicenses/README.txt
+++ b/iosApp/Resources/OpenSourceLicenses/README.txt
@@ -54,9 +54,9 @@ LibDovi / libdovi
   packaging license and quietvoid's controlling MIT text are included here.
 
 Nuke and NukeUI
-  Revision: 83e19143355b02e9261edb2323b3e1e93287ebb9 (release 12.9.0)
+  Revision: 30f7a7e72e0607d304fbf69c799474bd5fb6d1ce (release 13.2.0)
   License: MIT
-  Source: https://github.com/kean/Nuke/tree/83e19143355b02e9261edb2323b3e1e93287ebb9
+  Source: https://github.com/kean/Nuke/tree/30f7a7e72e0607d304fbf69c799474bd5fb6d1ce
 
 ThumbHash decoder
   Revision: a652ce6ed691242f459f468f0a8756cda3b90a82

--- a/iosApp/Silo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iosApp/Silo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "b7c5b14da80f57c3689e219e5a42cefed8e7994487f250297681a712439324ca",
   "pins" : [
     {
       "identity" : "aetherengine",
@@ -31,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kean/Nuke",
       "state" : {
-        "revision" : "83e19143355b02e9261edb2323b3e1e93287ebb9",
-        "version" : "12.9.0"
+        "revision" : "30f7a7e72e0607d304fbf69c799474bd5fb6d1ce",
+        "version" : "13.2.0"
       }
     },
     {
@@ -45,5 +46,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/iosApp/iosApp/Components/HeroBackdropPalette.swift
+++ b/iosApp/iosApp/Components/HeroBackdropPalette.swift
@@ -34,20 +34,11 @@ enum HeroBackdropPalette {
     /// if the image can't be loaded or sampled — callers should fall
     /// back to the app background.
     static func tintColor(for url: URL) async -> Color? {
-        // Downsample during decode: we only need an average color, so
-        // a 64×36 thumbnail is plenty of signal and avoids pulling the
-        // full backdrop into memory just to run CIAreaAverage on it.
-        let request = ImageRequest(
-            url: url,
-            processors: [
-                ImageProcessors.Resize(
-                    size: CGSize(width: 64, height: 36),
-                    contentMode: .aspectFill,
-                    upscale: false
-                )
-            ],
-            priority: .low
-        )
+        // Downsample during decode: we only need an average color, so a
+        // 64 px thumbnail is plenty of signal. ImageIO decodes it directly
+        // from the data, so the full w1920 backdrop is never decoded just
+        // to run CIAreaAverage on it.
+        let request = PosterImageCache.paletteSampleRequest(for: url)
 
         do {
             let image = try await ImagePipeline.shared.image(for: request)

--- a/iosApp/iosApp/Screens/Audio/AudioCoverPalette.swift
+++ b/iosApp/iosApp/Screens/Audio/AudioCoverPalette.swift
@@ -39,17 +39,9 @@ enum AudioCoverPaletteSampler {
 
     static func palette(for urlString: String?) async -> AudioCoverPalette? {
         guard let urlString, let url = URL(string: urlString) else { return nil }
-        let request = ImageRequest(
-            url: url,
-            processors: [
-                ImageProcessors.Resize(
-                    size: CGSize(width: 64, height: 64),
-                    contentMode: .aspectFill,
-                    upscale: false
-                )
-            ],
-            priority: .low
-        )
+        // 64 px ImageIO thumbnail: decoded straight from the data instead of
+        // decoding the full cover and resizing it.
+        let request = PosterImageCache.paletteSampleRequest(for: url)
         guard let image = try? await ImagePipeline.shared.image(for: request) else {
             return nil
         }

--- a/iosApp/iosApp/Screens/People/PersonDetailView.swift
+++ b/iosApp/iosApp/Screens/People/PersonDetailView.swift
@@ -135,7 +135,7 @@ final class PersonDetailViewModel {
             .compactMap(URL.init(string:))
         let newURLs = urls.filter { prefetchedPosterURLs.insert($0).inserted }
         guard !newURLs.isEmpty else { return }
-        PosterImageCache.prefetcher.startPrefetching(with: newURLs)
+        PosterImageCache.prefetchCardArtwork(newURLs)
     }
     #endif
 
@@ -277,7 +277,7 @@ final class PersonDetailViewModel {
     private func resetFilmography() {
         #if os(tvOS)
         if !prefetchedPosterURLs.isEmpty {
-            PosterImageCache.prefetcher.stopPrefetching(with: Array(prefetchedPosterURLs))
+            PosterImageCache.stopPrefetchingCardArtwork(Array(prefetchedPosterURLs))
             prefetchedPosterURLs.removeAll()
         }
         #endif

--- a/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
+++ b/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
@@ -714,17 +714,28 @@ enum StartupContentPrefetcher {
     }
 
     private static func prefetchHomeArtwork(for response: SectionsResponse) {
-        var urls: [URL] = []
+        // Each kind is warmed at the size its consumer reads synchronously:
+        // cards at the shared card thumbnail, the marquee logo at its native
+        // size, and first-row backdrops at the exact hero decode size. Warming
+        // full-size decodes instead used to cost ~4 MB per poster and ~8 MB
+        // per backdrop, which overflowed the 96 MB budget on 3 GB Apple TVs
+        // and evicted the very cards the warm-up was meant to paint.
+        var cardURLs: [URL] = []
+        var backdropURLs: [URL] = []
+        var logoURLs: [URL] = []
         var seen = Set<String>()
+        // Tracked separately: reading the arrays while one is bound as an
+        // `inout` bucket is an exclusivity violation.
+        var count = 0
 
-        func append(_ urlString: String?) {
-            guard urls.count < maxHomeArtworkURLs,
-                  let url = normalizedURL(from: urlString) else {
+        func append(_ urlString: String?, into bucket: inout [URL]) {
+            guard count < maxHomeArtworkURLs,
+                  let url = normalizedURL(from: urlString),
+                  seen.insert(url.absoluteString).inserted else {
                 return
             }
-            let key = url.absoluteString
-            guard seen.insert(key).inserted else { return }
-            urls.append(url)
+            bucket.append(url)
+            count += 1
         }
 
         // No client renders a featured hero anymore — featured sections show
@@ -736,33 +747,36 @@ enum StartupContentPrefetcher {
         // harmless.)
         let contentSections = response.sections.filter { !$0.items.isEmpty }
         if let firstRow = contentSections.first {
-            append(firstRow.items.first?.logoUrl)
+            append(firstRow.items.first?.logoUrl, into: &logoURLs)
             for item in firstRow.items {
                 if episodeSectionTypes.contains(firstRow.sectionType) {
                     // Episode thumbs already render the backdrop, so the card
                     // art and the first-row art are one fetch.
-                    append(item.backdropUrl ?? item.posterUrl)
+                    append(item.backdropUrl ?? item.posterUrl, into: &cardURLs)
                 } else {
-                    append(item.posterUrl)
-                    append(item.backdropUrl)
+                    append(item.posterUrl, into: &cardURLs)
+                    append(item.backdropUrl, into: &backdropURLs)
                 }
-                if urls.count >= maxHomeArtworkURLs { break }
+                if count >= maxHomeArtworkURLs { break }
             }
         }
         for section in contentSections.dropFirst() {
             for item in section.items {
                 if episodeSectionTypes.contains(section.sectionType) {
-                    append(item.backdropUrl ?? item.posterUrl)
+                    append(item.backdropUrl ?? item.posterUrl, into: &cardURLs)
                 } else {
-                    append(item.posterUrl)
+                    append(item.posterUrl, into: &cardURLs)
                 }
-                if urls.count >= maxHomeArtworkURLs { break }
+                if count >= maxHomeArtworkURLs { break }
             }
-            if urls.count >= maxHomeArtworkURLs { break }
+            if count >= maxHomeArtworkURLs { break }
         }
 
-        guard !urls.isEmpty else { return }
-        PosterImageCache.prefetcher.startPrefetching(with: urls)
+        PosterImageCache.prefetchOriginalArtwork(logoURLs)
+        PosterImageCache.prefetchCardArtwork(cardURLs)
+        #if os(tvOS)
+        PosterImageCache.prefetchHeroBackdrops(backdropURLs)
+        #endif
 
         // Warm the marquee's initial tint: tvOS seeds the marquee with the
         // first row's first item on cold entry, and a cached sample lets the
@@ -802,8 +816,7 @@ enum StartupContentPrefetcher {
             if urls.count >= maxCount { break }
         }
 
-        guard !urls.isEmpty else { return }
-        PosterImageCache.prefetcher.startPrefetching(with: urls)
+        PosterImageCache.prefetchCardArtwork(urls)
     }
 
     #if os(tvOS)
@@ -826,8 +839,7 @@ enum StartupContentPrefetcher {
             }
         }
 
-        guard !urls.isEmpty else { return }
-        PosterImageCache.prefetcher.startPrefetching(with: urls)
+        PosterImageCache.prefetchOriginalArtwork(urls)
     }
     #endif
 
@@ -845,8 +857,7 @@ enum StartupContentPrefetcher {
             urls.append(url)
         }
 
-        guard !urls.isEmpty else { return }
-        PosterImageCache.prefetcher.startPrefetching(with: urls)
+        PosterImageCache.prefetchCardArtwork(urls)
     }
 
     private static func prefetchProfileArtwork(for profiles: [UserProfile]) {
@@ -878,8 +889,7 @@ enum StartupContentPrefetcher {
             urls.append(url)
         }
 
-        guard !urls.isEmpty else { return }
-        PosterImageCache.prefetcher.startPrefetching(with: urls)
+        PosterImageCache.prefetchCardArtwork(urls)
     }
 
     private static func validateProfileScopedGeneration(_ generation: Int) throws {

--- a/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
+++ b/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
@@ -716,7 +716,7 @@ enum StartupContentPrefetcher {
     private static func prefetchHomeArtwork(for response: SectionsResponse) {
         // Each kind is warmed at the size its consumer reads synchronously:
         // cards at the shared card thumbnail, the marquee logo at its native
-        // size, and first-row backdrops at the exact hero decode size. Warming
+        // size, and the initial backdrop at the exact hero decode size. Warming
         // full-size decodes instead used to cost ~4 MB per poster and ~8 MB
         // per backdrop, which overflowed the 96 MB budget on 3 GB Apple TVs
         // and evicted the very cards the warm-up was meant to paint.
@@ -761,16 +761,23 @@ enum StartupContentPrefetcher {
         let contentSections = response.sections.filter { !$0.items.isEmpty }
         if let firstRow = contentSections.first {
             append(firstRow.items.first?.logoUrl, into: &logoURLs, seen: &seenLogos)
+            // Only the marquee's initial selection earns a hero-size decode.
+            // A w1920 backdrop is ~8 MB decoded, so warming the whole first
+            // row would spend the entire 96 MB tvOS budget on artwork the
+            // user may never rest on and evict the very cards this warm-up
+            // exists to paint. The neighbours the user is most likely to
+            // reach are pulled into the disk cache (bytes only) by
+            // `PosterImageCache.warmNeighborBackdrops` once the marquee
+            // rests, which removes the network round trip without a decode.
+            appendBackdrop(firstRow.items.first?.backdropUrl)
             for item in firstRow.items {
                 if episodeSectionTypes.contains(firstRow.sectionType) {
                     // Episode stills render the backdrop as the card art and
                     // the marquee shows the same image as the hero. One
                     // download, two decode sizes.
                     append(item.backdropUrl ?? item.posterUrl, into: &cardURLs, seen: &seenCards)
-                    appendBackdrop(item.backdropUrl)
                 } else {
                     append(item.posterUrl, into: &cardURLs, seen: &seenCards)
-                    appendBackdrop(item.backdropUrl)
                 }
                 if count >= maxHomeArtworkURLs { break }
             }

--- a/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
+++ b/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
@@ -723,12 +723,17 @@ enum StartupContentPrefetcher {
         var cardURLs: [URL] = []
         var backdropURLs: [URL] = []
         var logoURLs: [URL] = []
-        var seen = Set<String>()
+        // Deduplicated per bucket: the same URL is a different cache key as
+        // a card thumbnail and as the hero decode, so an episode still that
+        // is also the marquee backdrop legitimately belongs to both.
+        var seenCards = Set<String>()
+        var seenBackdrops = Set<String>()
+        var seenLogos = Set<String>()
         // Tracked separately: reading the arrays while one is bound as an
         // `inout` bucket is an exclusivity violation.
         var count = 0
 
-        func append(_ urlString: String?, into bucket: inout [URL]) {
+        func append(_ urlString: String?, into bucket: inout [URL], seen: inout Set<String>) {
             guard count < maxHomeArtworkURLs,
                   let url = normalizedURL(from: urlString),
                   seen.insert(url.absoluteString).inserted else {
@@ -736,6 +741,14 @@ enum StartupContentPrefetcher {
             }
             bucket.append(url)
             count += 1
+        }
+
+        /// Hero backdrops render only on tvOS; other platforms must not
+        /// spend their smaller budget on requests that are never started.
+        func appendBackdrop(_ urlString: String?) {
+            #if os(tvOS)
+            append(urlString, into: &backdropURLs, seen: &seenBackdrops)
+            #endif
         }
 
         // No client renders a featured hero anymore — featured sections show
@@ -747,15 +760,17 @@ enum StartupContentPrefetcher {
         // harmless.)
         let contentSections = response.sections.filter { !$0.items.isEmpty }
         if let firstRow = contentSections.first {
-            append(firstRow.items.first?.logoUrl, into: &logoURLs)
+            append(firstRow.items.first?.logoUrl, into: &logoURLs, seen: &seenLogos)
             for item in firstRow.items {
                 if episodeSectionTypes.contains(firstRow.sectionType) {
-                    // Episode thumbs already render the backdrop, so the card
-                    // art and the first-row art are one fetch.
-                    append(item.backdropUrl ?? item.posterUrl, into: &cardURLs)
+                    // Episode stills render the backdrop as the card art and
+                    // the marquee shows the same image as the hero. One
+                    // download, two decode sizes.
+                    append(item.backdropUrl ?? item.posterUrl, into: &cardURLs, seen: &seenCards)
+                    appendBackdrop(item.backdropUrl)
                 } else {
-                    append(item.posterUrl, into: &cardURLs)
-                    append(item.backdropUrl, into: &backdropURLs)
+                    append(item.posterUrl, into: &cardURLs, seen: &seenCards)
+                    appendBackdrop(item.backdropUrl)
                 }
                 if count >= maxHomeArtworkURLs { break }
             }
@@ -763,9 +778,9 @@ enum StartupContentPrefetcher {
         for section in contentSections.dropFirst() {
             for item in section.items {
                 if episodeSectionTypes.contains(section.sectionType) {
-                    append(item.backdropUrl ?? item.posterUrl, into: &cardURLs)
+                    append(item.backdropUrl ?? item.posterUrl, into: &cardURLs, seen: &seenCards)
                 } else {
-                    append(item.posterUrl, into: &cardURLs)
+                    append(item.posterUrl, into: &cardURLs, seen: &seenCards)
                 }
                 if count >= maxHomeArtworkURLs { break }
             }

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -9,6 +9,8 @@ struct SiloApp: App {
     init() {
         #if os(tvOS)
         ExitSentinel.shared.appDidLaunch()
+        // No-op unless launched with `-perfHitchLog`.
+        TVFrameHitchMonitor.installIfRequested()
         #endif
 
         // Install the shared Nuke-backed image cache before any SwiftUI view

--- a/iosApp/iosApp/tvOS/Caching/CachedAsyncImage.swift
+++ b/iosApp/iosApp/tvOS/Caching/CachedAsyncImage.swift
@@ -7,8 +7,9 @@ import Nuke
 ///
 /// - Reads from the shared `PosterImageCache` pipeline (persistent memory +
 ///   disk cache)
-/// - Downsamples to the target render size during decode so a 1080×1620
-///   poster isn't held in memory at full resolution just to draw at 260×390
+/// - Decodes straight to the target render size through ImageIO's thumbnail
+///   path, so a 780×1170 poster is never held in memory at full resolution
+///   (or decoded and then resized on the CPU) just to draw at 176×264
 /// - Cross-fades in with the same duration as the rest of the app
 /// - Shows a solid surface placeholder that blends with the grid background
 struct CachedAsyncImage: View {
@@ -56,12 +57,12 @@ struct CachedAsyncImage: View {
                         .onAppear(perform: notifyImageLoaded)
                 } else if state.error == nil, let warmedImage {
                     // The startup/grid prefetchers warm the memory cache under
-                    // the bare-URL key, while the request above is keyed by
-                    // URL + resize processor — a miss for Nuke's synchronous
-                    // first check. Painting the warmed full-size decode here
-                    // makes a prefetched card render finished on its first
-                    // frame; the downsampled result then swaps in with
-                    // identical pixels, so the handoff is invisible.
+                    // the shared card-size thumbnail key, while the request
+                    // above is keyed by the exact render size — a miss for
+                    // Nuke's synchronous first check. Painting the warmed
+                    // decode here makes a prefetched card render finished on
+                    // its first frame; it is at least as sharp as the card's
+                    // own decode, so the swap-in is invisible.
                     Image(platformImage: warmedImage)
                         .resizable()
                         .aspectRatio(contentMode: contentMode)
@@ -89,11 +90,11 @@ struct CachedAsyncImage: View {
         }
     }
 
-    /// Synchronous memory-cache lookup for the unprocessed URL the
+    /// Synchronous memory-cache lookup for the card-size decode the
     /// prefetchers warm. Cheap dictionary access — safe to call from `body`.
     private func prefetchedImage() -> PlatformImage? {
         guard let url = URL(string: url) else { return nil }
-        return ImagePipeline.shared.cache[ImageRequest(url: url)]?.image
+        return PosterImageCache.warmedCardImage(for: url)
     }
 
     private func notifyImageLoaded() {
@@ -110,12 +111,7 @@ struct CachedAsyncImage: View {
             width: size.width * displayScale,
             height: size.height * displayScale
         )
-        return ImageRequest(
-            url: url,
-            processors: [
-                ImageProcessors.Resize(size: pixelSize, contentMode: .aspectFill, upscale: false)
-            ]
-        )
+        return PosterImageCache.displayRequest(url: url, pixelSize: pixelSize)
     }
 
     private func placeholder(in size: CGSize) -> some View {

--- a/iosApp/iosApp/tvOS/Caching/PosterImageCache.swift
+++ b/iosApp/iosApp/tvOS/Caching/PosterImageCache.swift
@@ -13,12 +13,81 @@ import UIKit
 ///
 /// - A decoded memory cache sized for the platform's playback headroom
 /// - 1 GB on-disk data cache keyed by URL
-/// - Background decoding + downsampling to the actual render size
+/// - ImageIO thumbnail decoding straight to the render size, so a w780
+///   poster is never decoded at full resolution just to draw a 176 pt card
 /// - A prefetcher the grid can use to warm posters N rows ahead
 ///
 /// The pipeline is installed as the `ImagePipeline.shared` at first access so
 /// every `LazyImage` / `ImagePipeline.shared` caller picks it up automatically.
 enum PosterImageCache {
+    /// Longest edge, in pixels, of the decode the prefetchers park in the
+    /// memory cache for poster, still, cover, and portrait artwork. Larger
+    /// than any card on any surface, so the warmed decode always paints at
+    /// least as sharp as the card's own request, and small enough (about
+    /// 0.7 MB for a 2:3 poster) that a whole warmed feed fits the constrained
+    /// tvOS budget instead of evicting itself.
+    static let cardWarmMaxPixelSize: Float = 512
+
+    /// Longest edge, in pixels, for palette sampling decodes.
+    static let paletteSampleMaxPixelSize: Float = 64
+
+    // MARK: - Requests
+
+    /// Display request that decodes directly at `pixelSize` (aspect-fill
+    /// cover) through ImageIO's thumbnail path. Decoding at the target size
+    /// costs a fraction of the CPU and memory of decoding the full image and
+    /// resizing it, and the result needs no separate decompression pass.
+    /// ImageIO never upscales, so a small source stays at its native size.
+    static func displayRequest(url: URL, pixelSize: CGSize, priority: ImageRequest.Priority = .normal) -> ImageRequest {
+        var request = ImageRequest(url: url, priority: priority)
+        request.thumbnail = ImageRequest.ThumbnailOptions(
+            size: pixelSize,
+            unit: .pixels,
+            contentMode: .aspectFill
+        )
+        return request
+    }
+
+    /// The request the prefetchers warm for card artwork. Cards look this key
+    /// up synchronously on their first frame (`warmedCardImage(for:)`).
+    static func cardWarmRequest(for url: URL) -> ImageRequest {
+        var request = ImageRequest(url: url)
+        request.thumbnail = ImageRequest.ThumbnailOptions(maxPixelSize: cardWarmMaxPixelSize)
+        return request
+    }
+
+    /// Cheap request for average-color / palette sampling.
+    static func paletteSampleRequest(for url: URL) -> ImageRequest {
+        var request = ImageRequest(url: url, priority: .low)
+        request.thumbnail = ImageRequest.ThumbnailOptions(maxPixelSize: paletteSampleMaxPixelSize)
+        return request
+    }
+
+    /// Synchronous memory-cache lookup of a warmed card decode. Cheap
+    /// dictionary access, safe to call from a view body.
+    static func warmedCardImage(for url: URL) -> PlatformImage? {
+        ImagePipeline.shared.cache[cardWarmRequest(for: url)]?.image
+    }
+
+    /// Warm card artwork (posters, stills, covers, portraits, avatars) into
+    /// the memory cache at the shared card size.
+    static func prefetchCardArtwork(_ urls: [URL]) {
+        guard !urls.isEmpty else { return }
+        prefetcher.startPrefetching(with: urls.map(cardWarmRequest(for:)))
+    }
+
+    static func stopPrefetchingCardArtwork(_ urls: [URL]) {
+        guard !urls.isEmpty else { return }
+        prefetcher.stopPrefetching(with: urls.map(cardWarmRequest(for:)))
+    }
+
+    /// Warm full-size artwork under its bare-URL key. Only for art whose
+    /// consumers read the unprocessed decode synchronously (marquee logos).
+    static func prefetchOriginalArtwork(_ urls: [URL]) {
+        guard !urls.isEmpty else { return }
+        prefetcher.startPrefetching(with: urls)
+    }
+
     #if os(tvOS)
     /// A movie's cast rail is part of the first detail viewport, but its
     /// portraits used to begin loading only after SwiftUI mounted each card.
@@ -32,6 +101,12 @@ enum PosterImageCache {
 
     /// Call once at app launch before any SwiftUI view renders.
     static func install() {
+        #if DEBUG
+        // os_signpost intervals for every fetch, decode, and processing step
+        // (subsystem "com.github.kean.Nuke"). Visible in Instruments'
+        // os_signpost track and via `log stream` on a debug device build.
+        ImagePipeline.Configuration.isSignpostLoggingEnabled = true
+        #endif
         ImagePipeline.shared = makePipeline()
         installMemoryPressureObserverIfNeeded()
     }
@@ -45,6 +120,16 @@ enum PosterImageCache {
 
     private static func makePipeline() -> ImagePipeline {
         return ImagePipeline { config in
+            // Nuke's default loader also routes every response through a
+            // 150 MB Foundation URLCache, so each image was written to flash
+            // twice (URLCache + the DataCache below) and validated twice on
+            // every read. The DataCache is the only disk cache we want.
+            config.dataLoader = {
+                let session = URLSessionConfiguration.default
+                session.urlCache = nil
+                return DataLoader(configuration: session)
+            }()
+
             // Memory cache for decoded UIImages.
             let memoryCache = ImageCache()
             memoryCache.costLimit = decodedMemoryCacheBudgetBytes
@@ -57,7 +142,11 @@ enum PosterImageCache {
                 config.dataCache = dataCache
             }
 
-            // Decode on a background queue — never block the main thread.
+            // Thumbnail decodes do the whole decode + downsample in the
+            // decoding stage and skip decompression, so give that stage the
+            // two slots decompression used to have. Nuke's default of one
+            // serialises every poster in a freshly revealed row.
+            config.imageDecodingQueue.maxConcurrentOperationCount = 2
             config.imageDecompressingQueue.maxConcurrentOperationCount = 2
         }
     }
@@ -166,8 +255,18 @@ enum PosterImageCache {
             urls.append(url)
         }
 
+        prefetchCardArtwork(urls)
+    }
+
+    /// Warm the root hero backdrops the marquee will display, decoded at the
+    /// exact size `TVRootHeroBackdrop` requests so the first rested backdrop
+    /// is a straight memory-cache hit with no second decode.
+    static func prefetchHeroBackdrops(_ urls: [URL]) {
         guard !urls.isEmpty else { return }
-        prefetcher.startPrefetching(with: urls)
+        let pixelSize = TVBackdropArtworkLayout.artworkSize(
+            forViewportWidth: TVBackdropArtworkLayout.viewportWidth
+        )
+        prefetcher.startPrefetching(with: urls.map { displayRequest(url: $0, pixelSize: pixelSize) })
     }
     #endif
 }

--- a/iosApp/iosApp/tvOS/Caching/PosterImageCache.swift
+++ b/iosApp/iosApp/tvOS/Caching/PosterImageCache.swift
@@ -21,12 +21,25 @@ import UIKit
 /// every `LazyImage` / `ImagePipeline.shared` caller picks it up automatically.
 enum PosterImageCache {
     /// Longest edge, in pixels, of the decode the prefetchers park in the
-    /// memory cache for poster, still, cover, and portrait artwork. Larger
-    /// than any card on any surface, so the warmed decode always paints at
-    /// least as sharp as the card's own request, and small enough (about
-    /// 0.7 MB for a 2:3 poster) that a whole warmed feed fits the constrained
-    /// tvOS budget instead of evicting itself.
-    static let cardWarmMaxPixelSize: Float = 512
+    /// memory cache for poster, still, cover, and portrait artwork. Sized to
+    /// cover every Skyline landing card at the display's native scale
+    /// (Apple TV 4K renders at 2x: a 176 pt dense poster is 528 px tall), so
+    /// the warmed decode paints at least as sharp as the card's own request.
+    /// About 1.1 MB for a 2:3 poster at 2x, so a whole warmed feed still fits
+    /// the constrained tvOS budget instead of evicting itself. Library grid
+    /// cards are larger and keep their own decode.
+    static let cardWarmMaxPixelSize: Float = Float(320 * displayScale)
+
+    /// Native display scale used to turn point sizes into decode pixel sizes
+    /// off the main thread. `UITraitCollection.current` reports 0 outside a
+    /// UIKit context, so read the screen directly.
+    static let displayScale: CGFloat = {
+        #if canImport(UIKit)
+        return max(1, UIScreen.main.scale)
+        #else
+        return 2
+        #endif
+    }()
 
     /// Longest edge, in pixels, for palette sampling decodes.
     static let paletteSampleMaxPixelSize: Float = 64
@@ -263,8 +276,12 @@ enum PosterImageCache {
     /// is a straight memory-cache hit with no second decode.
     static func prefetchHeroBackdrops(_ urls: [URL]) {
         guard !urls.isEmpty else { return }
-        let pixelSize = TVBackdropArtworkLayout.artworkSize(
+        let pointSize = TVBackdropArtworkLayout.artworkSize(
             forViewportWidth: TVBackdropArtworkLayout.viewportWidth
+        )
+        let pixelSize = CGSize(
+            width: pointSize.width * displayScale,
+            height: pointSize.height * displayScale
         )
         prefetcher.startPrefetching(with: urls.map { displayRequest(url: $0, pixelSize: pixelSize) })
     }

--- a/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
+++ b/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
@@ -706,6 +706,13 @@ final class TVFocusMarqueeModel {
     /// is kept so `resume` can restore the same selection.
     func suspend() {
         isActive = false
+        // Drop any hold left over from an in-flight scroll. The feed can
+        // disappear mid-scroll without ever reporting `.idle`, and a feed
+        // that comes back already at rest has no phase change to release the
+        // hold — `resume` would then pin the restored selection behind the
+        // previous artwork until the user scrolled the band again.
+        isBackdropDeferred = false
+        hasDeferredBackdropUpdate = false
         PosterImageCache.cancelNeighborBackdropWarmup()
         cancelBackdropWork()
         enrichTask?.cancel()

--- a/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
+++ b/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
@@ -654,6 +654,11 @@ final class TVFocusMarqueeModel {
     private var backdropContentID: String?
     /// False while the feed is offscreen; every entry point is a no-op then.
     private var isActive = true
+    /// True while the host's row band is mid-scroll. Swapping the large
+    /// composited backdrop during the row-change animation competes with it
+    /// for GPU time, so the swap waits for the scroll to settle.
+    private var isBackdropDeferred = false
+    private var hasDeferredBackdropUpdate = false
     private var enrichmentState: TVHeroEnrichmentState = .notStarted
     private var lastSampledTintURL: String?
     /// Per-item enrichment cache so scrubbing back over a row never
@@ -736,8 +741,23 @@ final class TVFocusMarqueeModel {
         lastSampledTintURL = nil
     }
 
+    /// Hold backdrop swaps while `deferred` is true; the latest pending swap
+    /// applies as soon as the hold is released.
+    func setBackdropDeferred(_ deferred: Bool) {
+        guard isBackdropDeferred != deferred else { return }
+        isBackdropDeferred = deferred
+        if !deferred, hasDeferredBackdropUpdate {
+            hasDeferredBackdropUpdate = false
+            updateBackdropIfReady()
+        }
+    }
+
     private func updateBackdropIfReady() {
         guard isActive, let content, backdropContentID == content.id else { return }
+        if isBackdropDeferred {
+            hasDeferredBackdropUpdate = true
+            return
+        }
         if let artwork = resolvedArtwork {
             displayedArtwork = artwork
             sampleTintIfNeeded(for: artwork.url)

--- a/iosApp/iosApp/tvOS/Components/TVRootHeroBackdrop.swift
+++ b/iosApp/iosApp/tvOS/Components/TVRootHeroBackdrop.swift
@@ -6,6 +6,9 @@ import SwiftUI
 /// height from the available width keeps the artwork request, crop, and mask
 /// identical even when the detail hero itself is shorter than the viewport.
 enum TVBackdropArtworkLayout {
+    /// tvOS renders every screen into a 1920 pt wide logical canvas, so the
+    /// hero artwork size is fixed and can be computed off the main thread.
+    static let viewportWidth: CGFloat = 1920
     static let widthFraction: CGFloat = 0.64
     static let heightFraction: CGFloat = 0.70
 
@@ -79,9 +82,6 @@ struct TVRootHeroBackdrop: View {
     /// one — only artwork→artwork swaps get the ambient crossfade.
     @State private var hasDisplayedArtwork = false
 
-    /// Near-crisp by request (§ user direction). Bump a little only if the
-    /// server's backdrop is low-res enough to show compression artifacts.
-    private let artBlur: CGFloat = 0
     /// Full-width top scrim height so the menu bar stays legible over the
     /// bright art now sitting directly behind the tabs and profile avatar.
     private let topScrimHeight: CGFloat = 190
@@ -153,7 +153,6 @@ struct TVRootHeroBackdrop: View {
                 .id(artworkURL)
                 .frame(width: artworkSize.width, height: artworkSize.height)
                 .clipped()
-                .blur(radius: artBlur)
                 .mask { TVBackdropArtworkFadeMask() }
                 // Anchor the art block to the screen's top-right corner; the
                 // mask keeps only that corner opaque, so the corner reads as

--- a/iosApp/iosApp/tvOS/Components/TVRootHeroBackdrop.swift
+++ b/iosApp/iosApp/tvOS/Components/TVRootHeroBackdrop.swift
@@ -143,31 +143,36 @@ struct TVRootHeroBackdrop: View {
                 forViewportWidth: geometry.size.width
             )
 
-            if let artworkURL, !artworkURL.isEmpty {
-                AsyncImageView(
-                    url: artworkURL,
-                    thumbhash: artworkThumbhash,
-                    targetSize: artworkSize,
-                    contentMode: .fill
-                )
-                .id(artworkURL)
-                .frame(width: artworkSize.width, height: artworkSize.height)
-                .clipped()
-                .mask { TVBackdropArtworkFadeMask() }
-                // Anchor the art block to the screen's top-right corner; the
-                // mask keeps only that corner opaque, so the corner reads as
-                // fully painted with no gap and the art dissolves inward.
-                .frame(
-                    width: geometry.size.width,
-                    height: geometry.size.height,
-                    alignment: .topTrailing
-                )
-                .transition(
-                    reduceMotion || !hasDisplayedArtwork
-                        ? .identity
-                        : .opacity.animation(.easeInOut(duration: crossfadeDuration))
-                )
+            // The mask wraps the crossfading pair rather than each image, so
+            // a swap renders one masked offscreen pass instead of two
+            // full-resolution ones while both artworks are on screen.
+            ZStack {
+                if let artworkURL, !artworkURL.isEmpty {
+                    AsyncImageView(
+                        url: artworkURL,
+                        thumbhash: artworkThumbhash,
+                        targetSize: artworkSize,
+                        contentMode: .fill
+                    )
+                    .id(artworkURL)
+                    .transition(
+                        reduceMotion || !hasDisplayedArtwork
+                            ? .identity
+                            : .opacity.animation(.easeInOut(duration: crossfadeDuration))
+                    )
+                }
             }
+            .frame(width: artworkSize.width, height: artworkSize.height)
+            .clipped()
+            .mask { TVBackdropArtworkFadeMask() }
+            // Anchor the art block to the screen's top-right corner; the
+            // mask keeps only that corner opaque, so the corner reads as
+            // fully painted with no gap and the art dissolves inward.
+            .frame(
+                width: geometry.size.width,
+                height: geometry.size.height,
+                alignment: .topTrailing
+            )
         }
         .ignoresSafeArea()
     }

--- a/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
+++ b/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
@@ -133,6 +133,12 @@ struct TVSkylineSectionFeed: View {
                     .padding(.bottom, trailingPreviewPadding)
                 }
                 .scrollTargetBehavior(.viewAligned)
+                // Row changes animate the band; the marquee holds its backdrop
+                // swap until the scroll settles so the two never composite in
+                // the same frames.
+                .onScrollPhaseChange { _, phase in
+                    marqueeModel.setBackdropDeferred(phase != .idle)
+                }
                 // Animated ride home; the first card's focus claim is
                 // re-asserted by MediaRow until the scroll settles, so the
                 // animation can't lose the claim to mid-flight focus repairs.

--- a/iosApp/iosApp/tvOS/Debug/TVFrameHitchMonitor.swift
+++ b/iosApp/iosApp/tvOS/Debug/TVFrameHitchMonitor.swift
@@ -7,9 +7,10 @@ import os
 ///
 /// Enabled only when the process is launched with the `-perfHitchLog`
 /// argument (for example through `devicectl device process launch`), so a
-/// normal launch pays nothing. A `CADisplayLink` on the main run loop
-/// records every callback that arrives more than half a frame late — the
-/// signature of the main thread being busy through a vsync — and prints a
+/// normal launch pays nothing. A `CADisplayLink` on the main run loop flags a
+/// frame as a hitch when either the callback cadence skipped a vsync (the
+/// main thread was blocked, so intermediate callbacks were dropped) or the
+/// callback itself ran past the frame's display deadline. It prints a
 /// ten-second summary with the hitch count, total late time, and the worst
 /// single hitch. Lines go to stderr so a console-attached launch shows them
 /// without unified-log filtering, and to the `perf.hitch` os_log category.
@@ -54,13 +55,22 @@ final class TVFrameHitchMonitor {
             return
         }
 
-        let frameDuration = link.duration > 0 ? link.duration : 1.0 / 60.0
+        // Derive the frame period from the link's own schedule so adaptive
+        // refresh rates are handled; `duration` is undefined before the
+        // first callback.
+        let scheduled = link.targetTimestamp - now
+        let frameDuration = scheduled > 0 ? scheduled : 1.0 / 60.0
         let interval = now - lastTimestamp
         frameCount += 1
 
-        // Late by more than half a frame: the callback missed at least one
-        // vsync. Small jitter under that threshold is display-link noise.
-        let late = interval - frameDuration
+        // Two ways to miss a frame. A blocked main thread drops callbacks,
+        // so consecutive timestamps land more than one period apart. A
+        // callback that starts after its target display time has already
+        // lost that frame even when the cadence looks regular. Report the
+        // larger of the two; jitter under half a frame is display-link noise.
+        let skipped = interval - frameDuration
+        let overDeadline = CACurrentMediaTime() - link.targetTimestamp
+        let late = max(skipped, overDeadline)
         if late > frameDuration * 0.5 {
             hitchCount += 1
             lateTotal += late

--- a/iosApp/iosApp/tvOS/Debug/TVFrameHitchMonitor.swift
+++ b/iosApp/iosApp/tvOS/Debug/TVFrameHitchMonitor.swift
@@ -26,6 +26,7 @@ final class TVFrameHitchMonitor {
     private static let summaryInterval: CFTimeInterval = 10
 
     private let logger = Logger(subsystem: "com.continuum.app", category: "perf.hitch")
+    private let startTime = CACurrentMediaTime()
     private var displayLink: CADisplayLink?
     private var lastTimestamp: CFTimeInterval = 0
     private var summaryStart: CFTimeInterval = 0
@@ -92,8 +93,11 @@ final class TVFrameHitchMonitor {
     }
 
     private func emit(_ message: String) {
-        logger.notice("\(message, privacy: .public)")
-        FileHandle.standardError.write(Data("[perf.hitch] \(message)\n".utf8))
+        // Seconds since the monitor started, so hitches can be lined up with
+        // launch-phase work in the same console capture.
+        let stamped = String(format: "t+%.1fs %@", CACurrentMediaTime() - startTime, message)
+        logger.notice("\(stamped, privacy: .public)")
+        FileHandle.standardError.write(Data("[perf.hitch] \(stamped)\n".utf8))
     }
 }
 #endif

--- a/iosApp/iosApp/tvOS/Debug/TVFrameHitchMonitor.swift
+++ b/iosApp/iosApp/tvOS/Debug/TVFrameHitchMonitor.swift
@@ -1,0 +1,89 @@
+#if os(tvOS)
+import Foundation
+import QuartzCore
+import os
+
+/// Opt-in main-thread frame hitch logger for on-device performance work.
+///
+/// Enabled only when the process is launched with the `-perfHitchLog`
+/// argument (for example through `devicectl device process launch`), so a
+/// normal launch pays nothing. A `CADisplayLink` on the main run loop
+/// records every callback that arrives more than half a frame late — the
+/// signature of the main thread being busy through a vsync — and prints a
+/// ten-second summary with the hitch count, total late time, and the worst
+/// single hitch. Lines go to stderr so a console-attached launch shows them
+/// without unified-log filtering, and to the `perf.hitch` os_log category.
+///
+/// This measures main-thread hitches only. Render-server commit hitches need
+/// Instruments' Animation Hitches template, which requires a wired or
+/// Xcode-paired connection this monitor is meant to stand in for.
+@MainActor
+final class TVFrameHitchMonitor {
+    static let shared = TVFrameHitchMonitor()
+
+    private static let launchArgument = "-perfHitchLog"
+    private static let summaryInterval: CFTimeInterval = 10
+
+    private let logger = Logger(subsystem: "com.continuum.app", category: "perf.hitch")
+    private var displayLink: CADisplayLink?
+    private var lastTimestamp: CFTimeInterval = 0
+    private var summaryStart: CFTimeInterval = 0
+    private var frameCount = 0
+    private var hitchCount = 0
+    private var lateTotal: CFTimeInterval = 0
+    private var lateMax: CFTimeInterval = 0
+
+    static func installIfRequested() {
+        guard CommandLine.arguments.contains(launchArgument) else { return }
+        shared.start()
+    }
+
+    private func start() {
+        guard displayLink == nil else { return }
+        let link = CADisplayLink(target: self, selector: #selector(tick(_:)))
+        link.add(to: .main, forMode: .common)
+        displayLink = link
+        emit("monitor started")
+    }
+
+    @objc private func tick(_ link: CADisplayLink) {
+        let now = link.timestamp
+        defer { lastTimestamp = now }
+        guard lastTimestamp > 0 else {
+            summaryStart = now
+            return
+        }
+
+        let frameDuration = link.duration > 0 ? link.duration : 1.0 / 60.0
+        let interval = now - lastTimestamp
+        frameCount += 1
+
+        // Late by more than half a frame: the callback missed at least one
+        // vsync. Small jitter under that threshold is display-link noise.
+        let late = interval - frameDuration
+        if late > frameDuration * 0.5 {
+            hitchCount += 1
+            lateTotal += late
+            lateMax = max(lateMax, late)
+            emit(String(format: "hitch %.1f ms late (interval %.1f ms)", late * 1000, interval * 1000))
+        }
+
+        if now - summaryStart >= Self.summaryInterval {
+            emit(String(
+                format: "summary %ds: %d frames, %d hitches, %.1f ms late total, worst %.1f ms",
+                Int(now - summaryStart), frameCount, hitchCount, lateTotal * 1000, lateMax * 1000
+            ))
+            summaryStart = now
+            frameCount = 0
+            hitchCount = 0
+            lateTotal = 0
+            lateMax = 0
+        }
+    }
+
+    private func emit(_ message: String) {
+        logger.notice("\(message, privacy: .public)")
+        FileHandle.standardError.write(Data("[perf.hitch] \(message)\n".utf8))
+    }
+}
+#endif

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
@@ -1210,9 +1210,7 @@ struct TVItemDetailView: View {
             let stillURLs = response.episodes.compactMap { episode in
                 episode.stillUrl.flatMap(URL.init(string:))
             }
-            if !stillURLs.isEmpty {
-                PosterImageCache.prefetcher.startPrefetching(with: stillURLs)
-            }
+            PosterImageCache.prefetchCardArtwork(stillURLs)
 
             let sorted = response.episodes.sorted {
                 $0.episodeNumber < $1.episodeNumber

--- a/iosApp/iosApp/tvOS/Screens/Libraries/TVLibraryGridViewModel.swift
+++ b/iosApp/iosApp/tvOS/Screens/Libraries/TVLibraryGridViewModel.swift
@@ -176,8 +176,8 @@ final class TVLibraryGridViewModel {
         let staleURLs = prefetchedPosterURLs.subtracting(desiredURLs)
         let newURLs = urls.filter { !prefetchedPosterURLs.contains($0) }
         prefetchedPosterURLs = desiredURLs
-        posterPrefetcher.stopPrefetching(with: Array(staleURLs))
-        posterPrefetcher.startPrefetching(with: newURLs)
+        posterPrefetcher.stopPrefetching(with: staleURLs.map(PosterImageCache.cardWarmRequest(for:)))
+        posterPrefetcher.startPrefetching(with: newURLs.map(PosterImageCache.cardWarmRequest(for:)))
     }
 
     func cancelPosterPrefetch() {

--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -60,7 +60,7 @@ packages:
     revision: 653be639441d3f7d06332a2f995950497ad62e0f
   Nuke:
     url: https://github.com/kean/Nuke
-    from: "12.8.0"
+    from: "13.2.0"
 
 targets:
   Silo:


### PR DESCRIPTION
## Problem

Several users report a laggy tvOS home screen on hardware that is fine for the maintainer's 2nd generation Apple TV 4K. The image path explains most of it:

- Every card decoded its w780 poster at full size (about 4 MB decoded), then resized it on the CPU to draw a 176 pt card. Hero backdrops did the same from w1920 (about 8 MB decoded).
- The startup and grid prefetchers parked those full-size decodes in a memory cache with a 96 MB budget on 3 GB Apple TVs. A warmed feed evicted itself, so "warm" cards still paid a full decode on scroll.
- Nuke's default data loader also wrote every image through a 150 MB Foundation `URLCache` on top of Nuke's 1 GB disk cache, so each image hit flash twice.
- Nuke was pinned to 12.x, whose pipeline still runs on `DispatchQueue` and `OperationQueue`.

## Solution

- Bump Nuke from 12.9.0 to 13.2.0. Nuke 13 moves the pipeline onto Swift Concurrency and fixes prefetcher cancellation, priority propagation, and a `LazyImage` off-screen priority bug. No app source changes were required for the bump itself.
- Decode cards, hero backdrops, and palette samples through ImageIO thumbnails at the requested pixel size (`PosterImageCache.displayRequest`). This replaces `ImageProcessors.Resize`, skips the decompression pass, and never upscales.
- Warm card artwork at one shared thumbnail size and hero backdrops at their exact display size, so the first-frame paint of a prefetched card or backdrop is a real memory-cache hit.
- Give the decode queue two slots, since thumbnail decodes now do the work decompression used to.
- Disable the duplicate `URLCache`, matching Nuke's own `withDataCache` recipe.
- Remove a constant `.blur(radius: 0)` layer from the hero backdrop.
- Add `TVFrameHitchMonitor`, an opt-in main-thread frame hitch logger enabled only by the `-perfHitchLog` launch argument. Debug builds also enable Nuke's `os_signpost` logging.

## Validation

- `Silo` (iOS), `SiloTV` (tvOS), and `SiloMac` all build.
- Signed Release and Debug builds were installed on a 2nd generation Apple TV 4K and driven through an identical 24-press remote sequence across the home rows with the hitch monitor attached.

| Build | Hitches during 20 s of navigation | Worst hitch |
|---|---|---|
| Debug | 31 | 100 ms |
| Release | 3 | 25 ms |

The Release hitches were single dropped frames. One run per build, so treat counts as indicative.

A second commit holds the hero backdrop crossfade until the row-change scroll settles. Slow vertical row moves showed zero main-thread hitches on Release, so the remaining slow-then-fast feel was the crossfade competing with the scroll on the GPU. Confirmed on the same Apple TV: row scrolling is smooth with that build.

No before-and-after screenshots are attached. The change alters decode paths, not layout; the on-device check confirmed posters and the hero render sharp with no visible swap.

## Risks

- ImageIO thumbnails honor EXIF orientation via `createThumbnailWithTransform`. Artwork with unusual orientation metadata should be spot-checked.
- Nuke 13 adds a default `maximumDecodedImageSize` cap based on device memory. It is above every size this app requests, but very large custom artwork would now be downscaled during decode.
- The `URLCache` removal means HTTP cache validators are no longer used for images. Nuke's data cache is keyed by URL, which is how the app already treated artwork.

## Follow-up

- Both builds show a single 300 to 400 ms stall at first home paint after cold launch. That is the next target and needs a Time Profiler trace over a wired or Xcode-paired connection.
- Remaining single-frame drops on row changes need the same trace to attribute.

## AI disclosure

Written with Claude Code using model `claude-fable-5-1` (Claude Fable 5.1). Build, on-device deployment, and measurement were driven by the agent through the repository's mac-builder and physical-tvOS tooling. No other AI tooling was used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved artwork loading, caching, prefetching, and thumbnail decoding across iOS and tvOS.
  * Improved display consistency for posters, backdrops, logos, cast artwork, and season images.
  * Added more efficient palette sampling for hero and audio artwork.
  * Reduced unnecessary backdrop updates while scrolling on tvOS.

* **Visual Updates**
  * Updated tvOS hero backdrops to use a fixed display width.
  * Removed the blur effect from tvOS hero backdrops.

* **Diagnostics**
  * Added an optional tvOS frame-performance monitor for detecting and logging display hitches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
