### PR TITLE
fix(playback): keep the up-next session alive across an early caption replan

### DIFF
--- a/iosApp/Tests/PlaybackProtocolV3Tests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3Tests.swift
@@ -408,6 +408,42 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         XCTAssertEqual(observed, "session-allocated")
     }
 
+    func testReplanAgainstUncommittedStartKeepsTheSharedSession() {
+        // Up-next Play: the prior session was already stopped (nil), the start
+        // allocated S1, and a caption-policy replan for S1 arrives before the
+        // start commits. Rolling the start back must not DELETE S1.
+        XCTAssertFalse(
+            PlaybackSessionBridge.shouldRetireRolledBackCandidate(
+                candidateSessionId: "S1",
+                priorSessionId: nil,
+                retainingSessionId: "S1"
+            )
+        )
+        // A genuinely superseded candidate is still retired.
+        XCTAssertTrue(
+            PlaybackSessionBridge.shouldRetireRolledBackCandidate(
+                candidateSessionId: "S1",
+                priorSessionId: nil,
+                retainingSessionId: "S2"
+            )
+        )
+        XCTAssertTrue(
+            PlaybackSessionBridge.shouldRetireRolledBackCandidate(
+                candidateSessionId: "S1",
+                priorSessionId: "S0",
+                retainingSessionId: nil
+            )
+        )
+        // The committed prior session is never the bridge's to retire here.
+        XCTAssertFalse(
+            PlaybackSessionBridge.shouldRetireRolledBackCandidate(
+                candidateSessionId: "S0",
+                priorSessionId: "S0",
+                retainingSessionId: nil
+            )
+        )
+    }
+
     func testUncancelledStartDeliversToTheCallerAndNeverReclaims() async throws {
         let reclaimed = PlaybackTestActorBox<String>()
         let value = try await PlaybackCancellationShield.run {

--- a/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
@@ -529,7 +529,11 @@ actor PlaybackSessionBridge {
     ) {
         // A newer load superseding an uncommitted candidate restores the last
         // committed bridge state and retires the abandoned allocation first.
-        rollbackAnyPendingProtocolV3Transition()
+        // A replan issued against that uncommitted candidate reuses its
+        // session id, so the "abandoned" allocation is the one about to be
+        // staged again; retiring it would DELETE the session the engine is
+        // about to read from and strand playback in 404 backoff.
+        rollbackAnyPendingProtocolV3Transition(retainingSessionId: candidateSessionId)
         pendingProtocolV3Transition = PendingProtocolV3Transition(
             priorSessionId: sessionId,
             priorSession: currentSession,
@@ -632,15 +636,35 @@ actor PlaybackSessionBridge {
         rollbackAnyPendingProtocolV3Transition()
     }
 
-    private func rollbackAnyPendingProtocolV3Transition() {
+    /// `retainingSessionId` names a session the caller is about to stage again;
+    /// it is left alive on the server instead of being retired as abandoned.
+    private func rollbackAnyPendingProtocolV3Transition(
+        retainingSessionId: String? = nil
+    ) {
         guard let pending = pendingProtocolV3Transition else { return }
         pendingProtocolV3Transition = nil
         sessionId = pending.priorSessionId
         currentSession = pending.priorSession
         activeProtocolV3 = pending.priorProtocolV3
-        if pending.candidateSessionId != pending.priorSessionId {
+        if Self.shouldRetireRolledBackCandidate(
+            candidateSessionId: pending.candidateSessionId,
+            priorSessionId: pending.priorSessionId,
+            retainingSessionId: retainingSessionId
+        ) {
             stopStaleSession(pending.candidateSessionId)
         }
+    }
+
+    /// A rolled-back candidate is retired only when nothing else still owns
+    /// it: not the committed prior session it replaced, and not a transition
+    /// that is about to stage the same session id again (a replan against an
+    /// uncommitted start reuses the start's session).
+    static func shouldRetireRolledBackCandidate(
+        candidateSessionId: String,
+        priorSessionId: String?,
+        retainingSessionId: String?
+    ) -> Bool {
+        candidateSessionId != priorSessionId && candidateSessionId != retainingSessionId
     }
 
     private func adoptSession(_ session: PlaybackSessionResponse) {

--- a/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
@@ -521,6 +521,8 @@ actor PlaybackSessionBridge {
         }
     }
 
+    /// Records a server-issued candidate plan as pending until Aether commits
+    /// the matching load epoch, preserving the last committed state for rollback.
     private func stageProtocolV3Transition(
         candidateSessionId: String,
         candidatePlanId: String,

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -778,9 +778,13 @@ class PlayerViewModel {
     /// don't keep re-evaluating (and overriding the user) on every
     /// subsequent track-list update.
     private var prefsResolvedForCurrentItem: Bool = false
-    /// A caption-policy replan that arrived before the current V3 load
-    /// committed. Drained once the load's server transition commits.
-    private var hasDeferredAutoSubtitlePolicy = false
+    /// A caption pick that arrived before the current V3 load committed and
+    /// therefore could not replan yet. The resolved pick itself is kept, not
+    /// the preference snapshot that produced it: a system caption request
+    /// resolves from the OS language and would be lost if the generic
+    /// preference snapshot were rerun in its place. Drained once the load's
+    /// server transition commits.
+    private var deferredAutoSubtitlePick: SubtitleAutoSelection?
     private var resolvedServerUrl: String = ""
     private var currentWatchDetail: WatchDetail?
     private var currentSelectedVersion: FileVersion?
@@ -3692,7 +3696,7 @@ class PlayerViewModel {
             || preferredProtocolV3SubtitleIndex != nil
         prefsForCurrentItem = nil
         prefsResolvedForCurrentItem = false
-        hasDeferredAutoSubtitlePolicy = false
+        deferredAutoSubtitlePick = nil
     }
 
     private func resolvedAudioTrackIndexForResume() -> Int? {
@@ -7252,10 +7256,10 @@ class PlayerViewModel {
         // Inventory arrives as soon as the engine starts loading, before the
         // start's server transition has committed. A replan staged then rolls
         // that transition back and retires the session the engine is opening.
-        // Hold the policy until the load commits; the owning load task drains
+        // Hold the pick until the load commits; the owning load task drains
         // it through `reapplyDeferredAutoSubtitlePolicyIfNeeded`.
         guard committedProtocolV3LoadEpoch != nil else {
-            hasDeferredAutoSubtitlePolicy = true
+            deferredAutoSubtitlePick = track.map(SubtitleAutoSelection.select) ?? .disable
             return true
         }
 
@@ -7269,15 +7273,28 @@ class PlayerViewModel {
         return true
     }
 
-    /// Re-runs a caption policy pick that arrived while a V3 load was still
+    /// Replays the exact caption pick that arrived while a V3 load was still
     /// uncommitted. Call only after the load's server transition committed.
+    /// The track is re-resolved against the current inventory by id so a
+    /// pick from a superseded inventory cannot select a row that no longer
+    /// exists.
     private func reapplyDeferredAutoSubtitlePolicyIfNeeded() {
-        guard hasDeferredAutoSubtitlePolicy else { return }
-        hasDeferredAutoSubtitlePolicy = false
+        guard let pick = deferredAutoSubtitlePick else { return }
+        deferredAutoSubtitlePick = nil
         guard !isDisposed,
               activePreparedProtocolV3 != nil,
               committedProtocolV3LoadEpoch != nil else { return }
-        applyAutoSubtitlePreferencesIfNeeded(forceReevaluation: true)
+        switch pick {
+        case .noChange:
+            return
+        case .disable:
+            applyAutoSubtitle(.disable)
+        case .select(let deferredTrack):
+            guard let track = subtitleTracks.first(where: { $0.trackId == deferredTrack.trackId }) else {
+                return
+            }
+            applyAutoSubtitle(.select(track))
+        }
     }
 
     private func startProgressReporting() {

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -7277,11 +7277,13 @@ class PlayerViewModel {
     /// uncommitted. Call only after the load's server transition committed.
     /// The track is re-resolved against the current inventory by id so a
     /// pick from a superseded inventory cannot select a row that no longer
-    /// exists.
+    /// exists. A manual subtitle choice made while the pick was held wins;
+    /// the automatic pick is dropped rather than replayed over it.
     private func reapplyDeferredAutoSubtitlePolicyIfNeeded() {
         guard let pick = deferredAutoSubtitlePick else { return }
         deferredAutoSubtitlePick = nil
         guard !isDisposed,
+              !hasExplicitSubtitleChoice,
               activePreparedProtocolV3 != nil,
               committedProtocolV3LoadEpoch != nil else { return }
         switch pick {

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -778,6 +778,9 @@ class PlayerViewModel {
     /// don't keep re-evaluating (and overriding the user) on every
     /// subsequent track-list update.
     private var prefsResolvedForCurrentItem: Bool = false
+    /// A caption-policy replan that arrived before the current V3 load
+    /// committed. Drained once the load's server transition commits.
+    private var hasDeferredAutoSubtitlePolicy = false
     private var resolvedServerUrl: String = ""
     private var currentWatchDetail: WatchDetail?
     private var currentSelectedVersion: FileVersion?
@@ -1618,6 +1621,8 @@ class PlayerViewModel {
                     } else if let queuedTarget = self.pendingProtocolV3SeekReanchorPosition {
                         self.pendingProtocolV3SeekReanchorPosition = nil
                         self.commitSeek(to: queuedTarget, source: "queuedAuthReloadReanchor")
+                    } else {
+                        self.reapplyDeferredAutoSubtitlePolicyIfNeeded()
                     }
                 }
             }
@@ -1966,6 +1971,10 @@ class PlayerViewModel {
                     if !self.isDisposed, self.activePreparedProtocolV3 != nil {
                         self.commitSeek(to: queuedTarget, source: "queuedReanchor")
                     }
+                } else if currentStreamLoadGeneration == self.streamLoadGeneration {
+                    // Runs only once this task handle is cleared, so a policy
+                    // replan it issues is accepted rather than rejected as busy.
+                    self.reapplyDeferredAutoSubtitlePolicyIfNeeded()
                 }
             }
             do {
@@ -3683,6 +3692,7 @@ class PlayerViewModel {
             || preferredProtocolV3SubtitleIndex != nil
         prefsForCurrentItem = nil
         prefsResolvedForCurrentItem = false
+        hasDeferredAutoSubtitlePolicy = false
     }
 
     private func resolvedAudioTrackIndexForResume() -> Int? {
@@ -4058,6 +4068,8 @@ class PlayerViewModel {
                     // session after a failed load.
                     await self.realtimeClient.bind(sessionId: session.sessionId)
                     await self.sessionBridge.reportProtocolV3PlanExecutionStarted(prepared)
+                    try self.requireCurrentStreamLoad(currentStreamLoadGeneration)
+                    self.reapplyDeferredAutoSubtitlePolicyIfNeeded()
                 }
             } catch is CancellationError {
                 // Tear the abandoned Aether load down before retiring its
@@ -7237,6 +7249,15 @@ class PlayerViewModel {
         guard combinedIndex != activePreparedProtocolV3.plan.selectedTracks.subtitle?.index else {
             return false
         }
+        // Inventory arrives as soon as the engine starts loading, before the
+        // start's server transition has committed. A replan staged then rolls
+        // that transition back and retires the session the engine is opening.
+        // Hold the policy until the load commits; the owning load task drains
+        // it through `reapplyDeferredAutoSubtitlePolicyIfNeeded`.
+        guard committedProtocolV3LoadEpoch != nil else {
+            hasDeferredAutoSubtitlePolicy = true
+            return true
+        }
 
         selectedSubtitleId = track?.trackId
         lastLoadRequest?.preferredProtocolV3SubtitleIndex = combinedIndex
@@ -7246,6 +7267,17 @@ class PlayerViewModel {
             message: "Automatic caption policy selected a different subtitle track."
         )
         return true
+    }
+
+    /// Re-runs a caption policy pick that arrived while a V3 load was still
+    /// uncommitted. Call only after the load's server transition committed.
+    private func reapplyDeferredAutoSubtitlePolicyIfNeeded() {
+        guard hasDeferredAutoSubtitlePolicy else { return }
+        hasDeferredAutoSubtitlePolicy = false
+        guard !isDisposed,
+              activePreparedProtocolV3 != nil,
+              committedProtocolV3LoadEpoch != nil else { return }
+        applyAutoSubtitlePreferencesIfNeeded(forceReevaluation: true)
     }
 
     private func startProgressReporting() {


### PR DESCRIPTION
## Problem

Pressing Play on the Next Up screen on tvOS left the player on the "Loading…" capsule indefinitely. Two hosted diagnostics reports (tvOS, AppleTV11,1, Monarch: Legacy of Monsters) show the same sequence within about 400 ms of Play:

1. `POST /playback/start` 201, engine load gen N dispatched.
2. A `subtitle_track_changed` replan is issued about 15 ms later, before the start's Protocol V3 transition commits.
3. Staging that replan rolls the start's pending transition back. The rollback retires the "abandoned" candidate session with `DELETE /playback/{id}` even though the replan reused the same session id.
4. The engine opens media from the deleted session, gets 404s at non-zero offsets from the CDN, and treats them as transient: `rejected response status=404 … reconnecting (streak=9)`, `slow read: 57062ms`. Playback never starts until the user backs out.

The trigger is the automatic caption policy: the engine publishes its track inventory as soon as a load begins, and the client-side pick differed from the server's selected subtitle ordinal, so it replanned against an uncommitted start.

## Solution

- `PlaybackSessionBridge.stageProtocolV3Transition` no longer retires a rolled-back candidate when the new candidate is the same session. The retire decision is extracted into `shouldRetireRolledBackCandidate` with a unit test.
- `PlayerViewModel.replanAutomaticProtocolV3SubtitleSelection` defers the caption-policy replan until `committedProtocolV3LoadEpoch` is set. The deferred pick is drained once from the fresh-load commit, the replan task's defer, and the auth-reload defer.

## Validation

- New test `testReplanAgainstUncommittedStartKeepsTheSharedSession` passes on the iPhone 17 Pro simulator.
- Signed tvOS build installed and launched on the Living Room Apple TV via the paired mini; process verified. Behavioral confirmation of up-next playback on that TV is still pending from the reporter.

## Risks and follow-up

- A caption-policy replan now runs after first frame instead of before it, so a subtitle change from the automatic policy may be visible as a brief reload shortly after playback starts.
- AetherEngine treats a 404 at a non-zero offset as transient and retries for over a minute. That is what turned a fast failure into a hang and belongs in the engine repository.
- silo-android should be checked for the same stage-then-retire pattern.

## AI disclosure

Diagnosis and implementation by Claude Fable 5.1 (`claude-fable-5-1`) running in Claude Code, from hosted diagnostics reports SILO-AYAM8QBH and SILO-KERL6JJZ. Reviewed and deployed under Quick104's direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback session transitions during replanning to preserve sessions that remain in use.
  * Prevented premature retirement of playback sessions during rollback scenarios.
  * Improved subtitle-policy handling while playback loads or replans are pending.
  * Reapplied subtitle selections after playback commits, resolving them against the currently available tracks.
  * Ignored stale or unavailable subtitle tracks when applying deferred preferences.
  * Ensured manual subtitle selections take precedence over deferred automatic subtitle changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->