### PR TITLE
perf(tvos): swap the hero backdrop as soon as the row scroll has visibly settled

### DIFF
--- a/iosApp/iosApp/Theme/ContinuumTheme.swift
+++ b/iosApp/iosApp/Theme/ContinuumTheme.swift
@@ -275,6 +275,11 @@ struct ContinuumTheme {
         static let marqueeRestDebounceMilliseconds = 150
         /// Backdrop + tint crossfade between rested selections (§4.2).
         static let marqueeCrossfadeDuration: Double = 0.24
+        /// Longest a row-change scroll may hold the backdrop swap. The hold
+        /// keeps the crossfade out of the row animation, but the band's
+        /// scroll phase stays non-idle for over a second after a single
+        /// move, so the swap releases once the visible motion has finished.
+        static let marqueeBackdropHoldCapMilliseconds = 320
         /// Neighbouring cards on either side of a rested selection whose
         /// backdrop bytes are pulled into the disk cache at low priority,
         /// so the next rest skips the network round trip.

--- a/iosApp/iosApp/tvOS/Caching/PosterImageCache.swift
+++ b/iosApp/iosApp/tvOS/Caching/PosterImageCache.swift
@@ -276,6 +276,15 @@ enum PosterImageCache {
     /// is a straight memory-cache hit with no second decode.
     static func prefetchHeroBackdrops(_ urls: [URL]) {
         guard !urls.isEmpty else { return }
+        prefetcher.startPrefetching(with: urls.map { heroBackdropRequest(for: $0) })
+    }
+
+    /// The exact request `TVRootHeroBackdrop` issues for a hero backdrop, so
+    /// a warm decode and the display share one memory-cache key.
+    static func heroBackdropRequest(
+        for url: URL,
+        priority: ImageRequest.Priority = .normal
+    ) -> ImageRequest {
         let pointSize = TVBackdropArtworkLayout.artworkSize(
             forViewportWidth: TVBackdropArtworkLayout.viewportWidth
         )
@@ -283,7 +292,21 @@ enum PosterImageCache {
             width: pointSize.width * displayScale,
             height: pointSize.height * displayScale
         )
-        prefetcher.startPrefetching(with: urls.map { displayRequest(url: $0, pixelSize: pixelSize) })
+        return displayRequest(url: url, pixelSize: pixelSize, priority: priority)
+    }
+
+    /// Fetch and decode one hero backdrop at display size and sample its
+    /// tint, concurrently. Used by the marquee while a row-change scroll
+    /// holds the visible swap: the user is waiting on exactly this image, so
+    /// it runs at high priority and cancels with the caller's task.
+    static func warmHeroBackdrop(_ url: URL) async {
+        async let image: Void = {
+            _ = try? await ImagePipeline.shared.image(
+                for: heroBackdropRequest(for: url, priority: .high)
+            )
+        }()
+        async let tint: Void = { _ = await HeroBackdropPalette.tintColor(for: url) }()
+        _ = await (image, tint)
     }
     #endif
 }

--- a/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
+++ b/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
@@ -69,6 +69,10 @@ struct TVMarqueeContent: Equatable {
     /// The previewed item's content id — keys the low-priority detail
     /// enrichment (§9 backfill). `nil` for collections.
     let contentId: String?
+    /// Stable identity of the source row (`ResolvedSection.id`). Row
+    /// changes are detected on this, never on the display title, which
+    /// adjacent sections may share. `nil` for previews without a section.
+    let rowId: String?
     /// The source row's title (`Continue Watching`). Not rendered — the
     /// row's own header names the source — but kept for the VoiceOver
     /// description and presentation identity.
@@ -122,6 +126,7 @@ struct TVMarqueeContent: Equatable {
 extension TVMarqueeContent {
     init(
         item: SectionItem,
+        rowId: String? = nil,
         rowTitle: String,
         isContinueWatching: Bool = false
     ) {
@@ -165,6 +170,7 @@ extension TVMarqueeContent {
         self.init(
             id: "\(rowTitle)#\(item.contentId)",
             contentId: item.contentId,
+            rowId: rowId,
             eyebrow: rowTitle,
             // Episodes headline with their series (`SEVERANCE`); the
             // episode itself moves to the meta line per §5.4.
@@ -206,6 +212,7 @@ extension TVMarqueeContent {
         self.init(
             id: "\(rowTitle)#collection:\(collection.id)",
             contentId: nil,
+            rowId: nil,
             eyebrow: rowTitle,
             title: collection.name,
             logoUrl: nil,
@@ -707,26 +714,35 @@ final class TVFocusMarqueeModel {
         // visible swap, so the rest gate would only delay the warm-up. The
         // band's scroll phase lingers non-idle after the move, so a Left/
         // Right roll inside the new row must still see the rest gate: only
-        // a change of row (the eyebrow carries the row title) counts.
-        let isRowChange = isBackdropDeferred && candidate.eyebrow != content?.eyebrow
+        // a change of row identity counts, never the display title, which
+        // adjacent sections may share.
+        let isRowChange = isBackdropDeferred
+            && candidate.rowId != nil
+            && candidate.rowId != content?.rowId
         cancelBackdropWork()
         content = candidate
-        // Without the rest gate, episode backdrops (resolved from detail)
-        // have nothing to warm until enrichment starts, so start it now.
-        loadEnrichment(for: candidate, deferNetwork: !isRowChange)
         pendingNeighborBackdropURLs = neighborBackdropURLs
         if isRowChange {
-            // Each move starts a fresh row animation, so the cap restarts.
-            armBackdropHoldCap()
-            rest(on: candidate)
+            restForRowChange(on: candidate)
             return
         }
+        loadEnrichment(for: candidate, deferNetwork: true)
         backdropTask = Task { [weak self] in
             try? await Task.sleep(for: .milliseconds(ContinuumTheme.Skyline.marqueeRestDebounceMilliseconds))
             guard !Task.isCancelled, let self,
                   self.isActive, self.content == candidate else { return }
             self.rest(on: candidate)
         }
+    }
+
+    /// The row band's scroll is the gate for `candidate`: restart the hold
+    /// cap for this move, start enrichment without the network debounce
+    /// (episode backdrops resolve from detail, so until it starts there is
+    /// nothing to warm), and rest immediately.
+    private func restForRowChange(on candidate: TVMarqueeContent) {
+        armBackdropHoldCap()
+        loadEnrichment(for: candidate, deferNetwork: false)
+        rest(on: candidate)
     }
 
     /// Focus has settled on `candidate`: allow its backdrop through and
@@ -800,9 +816,10 @@ final class TVFocusMarqueeModel {
         if deferred {
             armBackdropHoldCap()
             // The scroll started after the focus report: the row band is
-            // now the gate, so stop waiting out the rest debounce and begin
-            // warming the new backdrop while the band animates.
-            if backdropTask != nil, let content { rest(on: content) }
+            // now the gate, so stop waiting out the rest debounce and the
+            // enrichment debounce, and begin warming the new backdrop
+            // while the band animates.
+            if backdropTask != nil, let content { restForRowChange(on: content) }
         } else {
             backdropHoldCapTask?.cancel()
             backdropHoldCapTask = nil

--- a/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
+++ b/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
@@ -648,6 +648,12 @@ final class TVFocusMarqueeModel {
     private var backdropTask: Task<Void, Never>?
     private var tintTask: Task<Void, Never>?
     private var enrichTask: Task<Void, Never>?
+    /// Decodes a held backdrop (and samples its tint) while the row band is
+    /// still scrolling, so releasing the hold is a memory-cache hit.
+    private var backdropWarmTask: Task<Void, Never>?
+    private var warmedDeferredBackdropURL: String?
+    /// Neighbour backdrops queued by `preview`, warmed once focus rests.
+    private var pendingNeighborBackdropURLs: [String] = []
     /// The content whose backdrop may be shown. `nil` while a previewed
     /// selection has not rested yet, so enrichment landing early cannot
     /// swap the backdrop ahead of the 150 ms gate.
@@ -659,6 +665,14 @@ final class TVFocusMarqueeModel {
     /// for GPU time, so the swap waits for the scroll to settle.
     private var isBackdropDeferred = false
     private var hasDeferredBackdropUpdate = false
+    /// Releases a held swap once the visible row animation has had time to
+    /// finish. The band's scroll phase can stay non-idle for over a second
+    /// after a single row move, long after the motion the hold protects.
+    private var backdropHoldCapTask: Task<Void, Never>?
+    /// True once the cap has elapsed for the current row move, so a swap
+    /// that becomes ready afterwards (episode backdrop from detail) applies
+    /// at once instead of waiting for the scroll phase to report idle.
+    private var backdropHoldCapElapsed = false
     private var enrichmentState: TVHeroEnrichmentState = .notStarted
     private var lastSampledTintURL: String?
     /// Per-item enrichment cache so scrubbing back over a row never
@@ -692,14 +706,32 @@ final class TVFocusMarqueeModel {
         cancelBackdropWork()
         content = candidate
         loadEnrichment(for: candidate, deferNetwork: true)
+        pendingNeighborBackdropURLs = neighborBackdropURLs
+        // A row change is one discrete move whose scroll already holds the
+        // visible swap, so the rest gate would only delay the warm-up.
+        if isBackdropDeferred {
+            // Each move starts a fresh row animation, so the cap restarts.
+            armBackdropHoldCap()
+            rest(on: candidate)
+            return
+        }
         backdropTask = Task { [weak self] in
             try? await Task.sleep(for: .milliseconds(ContinuumTheme.Skyline.marqueeRestDebounceMilliseconds))
             guard !Task.isCancelled, let self,
                   self.isActive, self.content == candidate else { return }
-            self.backdropContentID = candidate.id
-            self.updateBackdropIfReady()
-            PosterImageCache.warmNeighborBackdrops(neighborBackdropURLs)
+            self.rest(on: candidate)
         }
+    }
+
+    /// Focus has settled on `candidate`: allow its backdrop through and
+    /// warm the cards beside it.
+    private func rest(on candidate: TVMarqueeContent) {
+        backdropTask?.cancel()
+        backdropTask = nil
+        backdropContentID = candidate.id
+        updateBackdropIfReady()
+        PosterImageCache.warmNeighborBackdrops(pendingNeighborBackdropURLs)
+        pendingNeighborBackdropURLs = []
     }
 
     /// Feed left the screen: stop every in-flight task and warmup. `content`
@@ -713,6 +745,9 @@ final class TVFocusMarqueeModel {
         // previous artwork until the user scrolled the band again.
         isBackdropDeferred = false
         hasDeferredBackdropUpdate = false
+        backdropHoldCapTask?.cancel()
+        backdropHoldCapTask = nil
+        backdropHoldCapElapsed = false
         PosterImageCache.cancelNeighborBackdropWarmup()
         cancelBackdropWork()
         enrichTask?.cancel()
@@ -742,8 +777,11 @@ final class TVFocusMarqueeModel {
     private func cancelBackdropWork() {
         backdropTask?.cancel()
         tintTask?.cancel()
+        backdropWarmTask?.cancel()
         backdropTask = nil
         tintTask = nil
+        backdropWarmTask = nil
+        warmedDeferredBackdropURL = nil
         backdropContentID = nil
         lastSampledTintURL = nil
     }
@@ -753,16 +791,50 @@ final class TVFocusMarqueeModel {
     func setBackdropDeferred(_ deferred: Bool) {
         guard isBackdropDeferred != deferred else { return }
         isBackdropDeferred = deferred
-        if !deferred, hasDeferredBackdropUpdate {
-            hasDeferredBackdropUpdate = false
-            updateBackdropIfReady()
+        if deferred {
+            armBackdropHoldCap()
+            // The scroll started after the focus report: the row band is
+            // now the gate, so stop waiting out the rest debounce and begin
+            // warming the new backdrop while the band animates.
+            if backdropTask != nil, let content { rest(on: content) }
+        } else {
+            backdropHoldCapTask?.cancel()
+            backdropHoldCapTask = nil
+            backdropHoldCapElapsed = false
+            releaseDeferredBackdrop()
         }
     }
 
-    private func updateBackdropIfReady() {
+    /// Restart the hold cap for a new row move. The scroll phase can stay
+    /// non-idle across several quick moves, so the cap is per move rather
+    /// than per scroll.
+    private func armBackdropHoldCap() {
+        backdropHoldCapTask?.cancel()
+        backdropHoldCapElapsed = false
+        backdropHoldCapTask = Task { [weak self] in
+            try? await Task.sleep(
+                for: .milliseconds(ContinuumTheme.Skyline.marqueeBackdropHoldCapMilliseconds)
+            )
+            guard !Task.isCancelled, let self, self.isBackdropDeferred else { return }
+            self.backdropHoldCapElapsed = true
+            self.releaseDeferredBackdrop()
+        }
+    }
+
+    /// Apply the latest held swap, if any. Safe while the hold is still set:
+    /// a later update during the same scroll is held again until the phase
+    /// change or the next cap.
+    private func releaseDeferredBackdrop() {
+        guard hasDeferredBackdropUpdate else { return }
+        hasDeferredBackdropUpdate = false
+        updateBackdropIfReady(ignoringHold: true)
+    }
+
+    private func updateBackdropIfReady(ignoringHold: Bool = false) {
         guard isActive, let content, backdropContentID == content.id else { return }
-        if isBackdropDeferred {
+        if isBackdropDeferred, !ignoringHold, !backdropHoldCapElapsed {
             hasDeferredBackdropUpdate = true
+            warmDeferredBackdrop()
             return
         }
         if let artwork = resolvedArtwork {
@@ -773,6 +845,25 @@ final class TVFocusMarqueeModel {
             tintColor = .continuumBackground
             tintTask?.cancel()
             lastSampledTintURL = nil
+        }
+    }
+
+    /// The hold only exists to keep the crossfade's compositing out of the
+    /// row-change animation. The expensive half of a swap — the fetch, the
+    /// hero-size decode, and the palette sample — runs on the pipeline's
+    /// background queues, so start it now instead of after the scroll
+    /// settles. When the hold lifts the swap reads both from memory and the
+    /// crossfade begins on the same frame. Row changes are single moves, so
+    /// this is at most one warm per rested row change.
+    private func warmDeferredBackdrop() {
+        guard let artwork = resolvedArtwork,
+              artwork.url != displayedArtwork?.url,
+              artwork.url != warmedDeferredBackdropURL,
+              let url = URL(string: artwork.url) else { return }
+        warmedDeferredBackdropURL = artwork.url
+        backdropWarmTask?.cancel()
+        backdropWarmTask = Task {
+            await PosterImageCache.warmHeroBackdrop(url)
         }
     }
 

--- a/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
+++ b/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
@@ -703,13 +703,19 @@ final class TVFocusMarqueeModel {
     /// next stop skips the network round trip and only pays one decode.
     func preview(_ candidate: TVMarqueeContent, neighborBackdropURLs: [String] = []) {
         guard isActive, candidate != content else { return }
+        // A row change is one discrete move whose scroll already holds the
+        // visible swap, so the rest gate would only delay the warm-up. The
+        // band's scroll phase lingers non-idle after the move, so a Left/
+        // Right roll inside the new row must still see the rest gate: only
+        // a change of row (the eyebrow carries the row title) counts.
+        let isRowChange = isBackdropDeferred && candidate.eyebrow != content?.eyebrow
         cancelBackdropWork()
         content = candidate
-        loadEnrichment(for: candidate, deferNetwork: true)
+        // Without the rest gate, episode backdrops (resolved from detail)
+        // have nothing to warm until enrichment starts, so start it now.
+        loadEnrichment(for: candidate, deferNetwork: !isRowChange)
         pendingNeighborBackdropURLs = neighborBackdropURLs
-        // A row change is one discrete move whose scroll already holds the
-        // visible swap, so the rest gate would only delay the warm-up.
-        if isBackdropDeferred {
+        if isRowChange {
             // Each move starts a fresh row animation, so the cap restarts.
             armBackdropHoldCap()
             rest(on: candidate)

--- a/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
+++ b/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
@@ -237,6 +237,7 @@ struct TVSkylineSectionFeed: View {
         marqueeModel.preview(
             TVMarqueeContent(
                 item: item,
+                rowId: section.id,
                 rowTitle: section.title,
                 isContinueWatching: section.isContinueWatchingSection
             ),
@@ -275,6 +276,7 @@ struct TVSkylineSectionFeed: View {
         marqueeModel.seed(
             TVMarqueeContent(
                 item: item,
+                rowId: section.id,
                 rowTitle: section.title,
                 isContinueWatching: section.isContinueWatchingSection
             )


### PR DESCRIPTION
## Problem

On the tvOS Skyline landings (Home and library Browse), moving up or down a row took 1–2 s for the hero backdrop to update, while moving left or right took about 150 ms.

The swap was held until the row band's `onScrollPhaseChange` reported `.idle`, added in 51b65115 to keep the crossfade out of the row animation. On device the phase stays non-idle for well over a second after a single 300 ms row move, and several quick moves keep it non-idle the whole time. Only after the release did the fetch, hero-size decode, and tint sample begin, so every vertical move paid the scroll wait plus a cold load.

## Solution

- Warm the held backdrop at the exact display request, with its tint, while the row animates, so the release is a memory-cache hit.
- Skip the 150 ms rest debounce when a row scroll already gates the swap. Horizontal rolls keep the debounce.
- Cap the hold at 320 ms, re-armed on every move. Once the cap elapses, swaps that become ready afterwards (episode backdrops resolved from detail) apply immediately instead of waiting for idle.
- Add `heroBackdropRequest` so the startup prefetch, the warm-up, and the display view share one cache key.

The GPU-contention guard from 51b65115 still applies for the duration of the visible row animation.

## Validation

Measured on a physical Apple TV 4K (2nd generation) with temporary timing prints, since removed:

| | Before | After |
|---|---|---|
| Focus to backdrop painted, vertical move | 1.1–3.0 s | 350–580 ms |
| Fetch + decode + tint sample | 50–200 ms | 50–200 ms |

The image pipeline was never the bottleneck; the wait was entirely the scroll-phase hold. Episode rows and rapid multi-row runs were covered in the final session with no outliers.

- `xcodebuild` SiloTV for the tvOS simulator succeeds.
- Signed device build installed, launched, and exercised on the living room Apple TV.

## Risks

- If a row animation ever runs longer than 320 ms the crossfade could overlap its tail. The constant lives in `ContinuumTheme.Skyline` with the other marquee timings.
- Android's marquee uses the same 150 ms rest gate but has no scroll hold, so no coordinated change is needed.

## AI disclosure

Written with Claude Code using `claude-fable-5-1[1m]` (Claude Fable 5.1). Diagnosis used on-device timing logs captured through `devicectl` console streaming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved tvOS hero and backdrop image loading by preloading artwork before it is needed.
  * Backdrop transitions during row scrolling are now smoother, with ready artwork appearing sooner.
  * Added a brief maximum hold time for backdrop swaps to keep navigation responsive.
  * Improved color tint preparation for prefetched hero artwork.
  * Refined backdrop updates during navigation to respond more quickly when moving between rows while avoiding unnecessary updates during same-row movement.
  * Added gradual top and bottom fade effects to row content for smoother scrolling transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->