### PR TITLE
fix(notifications): use a long-lived display token for push enrichment

### DIFF
--- a/iosApp/Tests/ApplePushRegistrationTests.swift
+++ b/iosApp/Tests/ApplePushRegistrationTests.swift
@@ -129,6 +129,62 @@ final class ApplePushRegistrationTests: XCTestCase {
         XCTAssertEqual(content.userInfo["silo_url"] as? String, "/item/episode-1")
     }
 
+    func testDisplayAuthStatePrefersDisplayTokenOverAccessToken() {
+        let withDisplay = ApplePushDisplayAuthState(
+            serverURL: "https://silo.example.test",
+            profileID: "profile-1",
+            accessToken: "expired-access",
+            profileToken: "",
+            displayToken: " display-token "
+        )
+        XCTAssertTrue(withDisplay.isUsable)
+        XCTAssertEqual(withDisplay.bearerToken, "display-token")
+
+        // Older servers return no display token: the access token still works.
+        let legacy = ApplePushDisplayAuthState(
+            serverURL: "https://silo.example.test",
+            profileID: "profile-1",
+            accessToken: "access",
+            profileToken: ""
+        )
+        XCTAssertTrue(legacy.isUsable)
+        XCTAssertEqual(legacy.bearerToken, "access")
+
+        // A display token alone is enough: the access mirror may be gone
+        // after a refresh race while the registration token remains valid.
+        let displayOnly = ApplePushDisplayAuthState(
+            serverURL: "https://silo.example.test",
+            profileID: "profile-1",
+            accessToken: "",
+            profileToken: "",
+            displayToken: "display-token"
+        )
+        XCTAssertTrue(displayOnly.isUsable)
+
+        let neither = ApplePushDisplayAuthState(
+            serverURL: "https://silo.example.test",
+            profileID: "profile-1",
+            accessToken: "  ",
+            profileToken: ""
+        )
+        XCTAssertFalse(neither.isUsable)
+    }
+
+    func testRegistrationResponseDecodesOptionalDisplayToken() throws {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+        let modern = try decoder.decode(ApplePushRegistrationResponse.self, from: Data("""
+        {"id":"push-1","server_device_id":"dev-1","enabled":true,"push_mode":"private_push","display_token":"tok","display_token_expires_at":"2026-10-03T00:00:00Z"}
+        """.utf8))
+        XCTAssertEqual(modern.displayToken, "tok")
+
+        let legacy = try decoder.decode(ApplePushRegistrationResponse.self, from: Data("""
+        {"id":"push-1","server_device_id":"dev-1","enabled":true,"push_mode":"private_push"}
+        """.utf8))
+        XCTAssertNil(legacy.displayToken)
+    }
+
     func testNotificationDisplayURLMapsToAppDeepLink() throws {
         let itemURL = try XCTUnwrap(ApplePushDeepLinkCoordinator.deepLinkURL(from: [
             "silo_url": "/item/episode-1"

--- a/iosApp/Tests/ApplePushRegistrationTests.swift
+++ b/iosApp/Tests/ApplePushRegistrationTests.swift
@@ -178,11 +178,20 @@ final class ApplePushRegistrationTests: XCTestCase {
         {"id":"push-1","server_device_id":"dev-1","enabled":true,"push_mode":"private_push","display_token":"tok","display_token_expires_at":"2026-10-03T00:00:00Z"}
         """.utf8))
         XCTAssertEqual(modern.displayToken, "tok")
+        XCTAssertEqual(modern.displayTokenExpiresAt, "2026-10-03T00:00:00Z")
 
         let legacy = try decoder.decode(ApplePushRegistrationResponse.self, from: Data("""
         {"id":"push-1","server_device_id":"dev-1","enabled":true,"push_mode":"private_push"}
         """.utf8))
         XCTAssertNil(legacy.displayToken)
+        XCTAssertNil(legacy.displayTokenExpiresAt)
+    }
+
+    func testDisplayTokenExpiryParsesWithAndWithoutFractionalSeconds() throws {
+        let plain = try XCTUnwrap(ApplePushDisplayTokenStore.parseExpiry("2026-10-03T00:00:00Z"))
+        let fractional = try XCTUnwrap(ApplePushDisplayTokenStore.parseExpiry("2026-10-03T00:00:00.250Z"))
+        XCTAssertEqual(fractional.timeIntervalSince(plain), 0.25, accuracy: 0.001)
+        XCTAssertNil(ApplePushDisplayTokenStore.parseExpiry("not-a-date"))
     }
 
     func testNotificationDisplayURLMapsToAppDeepLink() throws {

--- a/iosApp/Tests/ApplePushRegistrationTests.swift
+++ b/iosApp/Tests/ApplePushRegistrationTests.swift
@@ -168,6 +168,14 @@ final class ApplePushRegistrationTests: XCTestCase {
             profileToken: ""
         )
         XCTAssertFalse(neither.isUsable)
+
+        // A rejected display token falls back to the access token once;
+        // without a distinct access token there is nothing to retry with.
+        let fallback = try? XCTUnwrap(withDisplay.accessTokenFallback)
+        XCTAssertEqual(fallback?.bearerToken, "expired-access")
+        XCTAssertEqual(fallback?.displayToken, "")
+        XCTAssertNil(legacy.accessTokenFallback)
+        XCTAssertNil(displayOnly.accessTokenFallback)
     }
 
     func testRegistrationResponseDecodesOptionalDisplayToken() throws {

--- a/iosApp/iosApp/Networking/TokenStore.swift
+++ b/iosApp/iosApp/Networking/TokenStore.swift
@@ -1123,7 +1123,10 @@ actor TokenStore {
     /// The display token is bound to one session, server, and profile, so it
     /// dies with any of them; the next registration mints a fresh one.
     private func clearApplePushDisplayToken() {
-        profileKeychain.delete(SharedStorage.applePushDisplayTokenAccount)
+        // Metadata is removed only once the Keychain item is gone, so a
+        // failed delete leaves the token paired with its real expiry and
+        // issuing server rather than looking freshly issued.
+        guard profileKeychain.delete(SharedStorage.applePushDisplayTokenAccount) else { return }
         defaults.removeObject(forKey: SharedStorage.applePushDisplayTokenExpiresAtKey)
         defaults.removeObject(forKey: SharedStorage.applePushDisplayTokenServerIdKey)
     }

--- a/iosApp/iosApp/Networking/TokenStore.swift
+++ b/iosApp/iosApp/Networking/TokenStore.swift
@@ -1116,6 +1116,7 @@ actor TokenStore {
         // The display token is bound to this session and profile, so it dies
         // with them; the next registration mints a fresh one.
         profileKeychain.delete(SharedStorage.applePushDisplayTokenAccount)
+        defaults.removeObject(forKey: SharedStorage.applePushDisplayTokenExpiresAtKey)
         lastMirroredAccessToken = nil
         lastMirroredProfileToken = nil
     }

--- a/iosApp/iosApp/Networking/TokenStore.swift
+++ b/iosApp/iosApp/Networking/TokenStore.swift
@@ -237,6 +237,7 @@ actor TokenStore {
         if serverId == activeServerId { return }
         persistentCredentialGenerationID = UUID()
         activeServerId = serverId
+        clearApplePushDisplayToken()
         cachedAccessToken = nil
         cachedRefreshToken = nil
         cachedProfileToken = nil
@@ -253,6 +254,7 @@ actor TokenStore {
         if serverId == activeServerId { return }
         persistentCredentialGenerationID = UUID()
         activeServerId = serverId
+        clearApplePushDisplayToken()
         cachedAccessToken = nil
         cachedRefreshToken = nil
         cachedProfileToken = nil
@@ -969,6 +971,13 @@ actor TokenStore {
         }
         guard persisted else { return false }
         cachedProfileToken = profileToken
+        // The display token was minted for the previous profile. Drop it
+        // before the new profile id is visible so the extension cannot pair
+        // the new context with the old credential; the next registration
+        // mints a replacement.
+        if defaults.string(forKey: profileIdDefaultsKey) != profileID {
+            clearApplePushDisplayToken()
+        }
         defaults.set(profileID, forKey: profileIdDefaultsKey)
         mirrorActiveTokensForExtension()
         return true
@@ -997,6 +1006,7 @@ actor TokenStore {
         }
         defaults.removeObject(forKey: profileIdDefaultsKey)
         cachedProfileToken = nil
+        clearApplePushDisplayToken()
         mirrorActiveTokensForExtension()
         return true
     }
@@ -1110,13 +1120,17 @@ actor TokenStore {
         }
     }
 
+    /// The display token is bound to one session, server, and profile, so it
+    /// dies with any of them; the next registration mints a fresh one.
+    private func clearApplePushDisplayToken() {
+        profileKeychain.delete(SharedStorage.applePushDisplayTokenAccount)
+        defaults.removeObject(forKey: SharedStorage.applePushDisplayTokenExpiresAtKey)
+    }
+
     private func clearMirroredTokensForExtension() {
         accountKeychain.delete(SharedStorage.mirroredAccessTokenAccount)
         profileKeychain.delete(SharedStorage.mirroredProfileTokenAccount)
-        // The display token is bound to this session and profile, so it dies
-        // with them; the next registration mints a fresh one.
-        profileKeychain.delete(SharedStorage.applePushDisplayTokenAccount)
-        defaults.removeObject(forKey: SharedStorage.applePushDisplayTokenExpiresAtKey)
+        clearApplePushDisplayToken()
         lastMirroredAccessToken = nil
         lastMirroredProfileToken = nil
     }

--- a/iosApp/iosApp/Networking/TokenStore.swift
+++ b/iosApp/iosApp/Networking/TokenStore.swift
@@ -1113,6 +1113,9 @@ actor TokenStore {
     private func clearMirroredTokensForExtension() {
         accountKeychain.delete(SharedStorage.mirroredAccessTokenAccount)
         profileKeychain.delete(SharedStorage.mirroredProfileTokenAccount)
+        // The display token is bound to this session and profile, so it dies
+        // with them; the next registration mints a fresh one.
+        profileKeychain.delete(SharedStorage.applePushDisplayTokenAccount)
         lastMirroredAccessToken = nil
         lastMirroredProfileToken = nil
     }

--- a/iosApp/iosApp/Networking/TokenStore.swift
+++ b/iosApp/iosApp/Networking/TokenStore.swift
@@ -237,7 +237,7 @@ actor TokenStore {
         if serverId == activeServerId { return }
         persistentCredentialGenerationID = UUID()
         activeServerId = serverId
-        clearApplePushDisplayToken()
+        clearApplePushDisplayTokenIfIssued(forServerOtherThan: serverId)
         cachedAccessToken = nil
         cachedRefreshToken = nil
         cachedProfileToken = nil
@@ -254,7 +254,7 @@ actor TokenStore {
         if serverId == activeServerId { return }
         persistentCredentialGenerationID = UUID()
         activeServerId = serverId
-        clearApplePushDisplayToken()
+        clearApplePushDisplayTokenIfIssued(forServerOtherThan: serverId)
         cachedAccessToken = nil
         cachedRefreshToken = nil
         cachedProfileToken = nil
@@ -1125,6 +1125,21 @@ actor TokenStore {
     private func clearApplePushDisplayToken() {
         profileKeychain.delete(SharedStorage.applePushDisplayTokenAccount)
         defaults.removeObject(forKey: SharedStorage.applePushDisplayTokenExpiresAtKey)
+        defaults.removeObject(forKey: SharedStorage.applePushDisplayTokenServerIdKey)
+    }
+
+    /// Server retargeting happens both on a real switch and when the actor
+    /// hydrates the persisted server on a cold launch (`activeServerId` starts
+    /// empty). Only the former invalidates the display token, so compare
+    /// against the server the token was issued for rather than the actor's
+    /// previous state. A token with no recorded server predates this key and
+    /// is cleared to be safe.
+    private func clearApplePushDisplayTokenIfIssued(forServerOtherThan serverId: String) {
+        guard profileKeychain.get(SharedStorage.applePushDisplayTokenAccount) != nil else { return }
+        let issuedFor = defaults.string(forKey: SharedStorage.applePushDisplayTokenServerIdKey) ?? ""
+        if issuedFor.isEmpty || issuedFor != serverId {
+            clearApplePushDisplayToken()
+        }
     }
 
     private func clearMirroredTokensForExtension() {

--- a/iosApp/iosApp/Notifications/ApplePushDisplayMetadata.swift
+++ b/iosApp/iosApp/Notifications/ApplePushDisplayMetadata.swift
@@ -47,11 +47,32 @@ struct ApplePushDisplayAuthState: Equatable {
     /// has no PIN; required by the server for PIN-protected profiles, whose
     /// display fetches otherwise 403 with `profile_unverified`.
     let profileToken: String
+    /// Long-lived display token from Apple push registration. Preferred over
+    /// `accessToken`: the extension cannot refresh an expired access token,
+    /// and access tokens expire within hours while pushes arrive whenever.
+    /// Empty on servers that predate the token; the access token then
+    /// remains the credential.
+    let displayToken: String
+
+    init(serverURL: String, profileID: String, accessToken: String, profileToken: String, displayToken: String = "") {
+        self.serverURL = serverURL
+        self.profileID = profileID
+        self.accessToken = accessToken
+        self.profileToken = profileToken
+        self.displayToken = displayToken
+    }
 
     var isUsable: Bool {
         !serverURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
         !profileID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
-        !accessToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        !bearerToken.isEmpty
+    }
+
+    /// The credential sent as `Authorization: Bearer`.
+    var bearerToken: String {
+        let display = displayToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !display.isEmpty { return display }
+        return accessToken.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }
 
@@ -93,7 +114,8 @@ struct ApplePushDisplayStateReader {
             serverURL: defaults.string(forKey: SharedStorage.serverUrlKey) ?? "",
             profileID: defaults.string(forKey: SharedStorage.profileIdKey) ?? "",
             accessToken: keychain.get(SharedStorage.mirroredAccessTokenAccount) ?? "",
-            profileToken: keychain.get(SharedStorage.mirroredProfileTokenAccount) ?? ""
+            profileToken: keychain.get(SharedStorage.mirroredProfileTokenAccount) ?? "",
+            displayToken: keychain.get(SharedStorage.applePushDisplayTokenAccount) ?? ""
         )
         return state.isUsable ? state : nil
     }
@@ -118,7 +140,7 @@ final class ApplePushDisplayClient {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.timeoutInterval = 4
-        request.setValue("Bearer \(state.accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("Bearer \(state.bearerToken)", forHTTPHeaderField: "Authorization")
         request.setValue(state.profileID, forHTTPHeaderField: "X-Profile-Id")
         if !state.profileToken.isEmpty {
             request.setValue(state.profileToken, forHTTPHeaderField: "X-Profile-Token")

--- a/iosApp/iosApp/Notifications/ApplePushDisplayMetadata.swift
+++ b/iosApp/iosApp/Notifications/ApplePushDisplayMetadata.swift
@@ -74,6 +74,22 @@ struct ApplePushDisplayAuthState: Equatable {
         if !display.isEmpty { return display }
         return accessToken.trimmingCharacters(in: .whitespacesAndNewlines)
     }
+
+    /// The same state with the display token dropped, so the mirrored
+    /// access token becomes the bearer. `nil` when there is no distinct
+    /// access token to fall back to.
+    var accessTokenFallback: ApplePushDisplayAuthState? {
+        let access = accessToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !displayToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty, !access.isEmpty else {
+            return nil
+        }
+        return ApplePushDisplayAuthState(
+            serverURL: serverURL,
+            profileID: profileID,
+            accessToken: access,
+            profileToken: profileToken
+        )
+    }
 }
 
 enum ApplePushDisplayWire {
@@ -133,7 +149,22 @@ final class ApplePushDisplayClient {
         self.session = session
     }
 
+    /// Fetches display metadata with the preferred credential. When the
+    /// display token is rejected (expired past the app's renewal window, or
+    /// revoked) and a mirrored access token exists, retries once with it:
+    /// background work may have refreshed the access token while the app
+    /// never foregrounded to renew the display token. Both fetches share
+    /// the extension's short time budget.
     func fetchDisplay(deliveryID: String, state: ApplePushDisplayAuthState) async throws -> ApplePushDisplayResponse {
+        do {
+            return try await fetchDisplayOnce(deliveryID: deliveryID, state: state)
+        } catch ApplePushDisplayClientError.badStatus(let status) where status == 401 || status == 403 {
+            guard let fallback = state.accessTokenFallback, !Task.isCancelled else { throw ApplePushDisplayClientError.badStatus(status) }
+            return try await fetchDisplayOnce(deliveryID: deliveryID, state: fallback)
+        }
+    }
+
+    private func fetchDisplayOnce(deliveryID: String, state: ApplePushDisplayAuthState) async throws -> ApplePushDisplayResponse {
         guard let url = ApplePushDisplayWire.displayURL(serverURL: state.serverURL, deliveryID: deliveryID) else {
             throw ApplePushDisplayClientError.invalidURL
         }

--- a/iosApp/iosApp/Notifications/ApplePushRegistration.swift
+++ b/iosApp/iosApp/Notifications/ApplePushRegistration.swift
@@ -37,30 +37,44 @@ struct ApplePushDisplayTokenStore {
     var now: () -> Date = Date.init
 
     /// `true` when a token is stored and is not within `renewalLeadTime` of
-    /// its expiry. A token without a parseable expiry counts as current.
+    /// its expiry. A token with no recorded expiry, or one that fails to
+    /// parse, is treated as needing renewal: the metadata is written only
+    /// alongside a successful Keychain write, so its absence means the
+    /// token's state is unknown and a fresh registration is the safe move.
     func hasCurrentToken() -> Bool {
         let stored = keychain.get(SharedStorage.applePushDisplayTokenAccount) ?? ""
         guard !stored.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return false }
         guard let raw = defaults.string(forKey: SharedStorage.applePushDisplayTokenExpiresAtKey),
               let expiresAt = Self.parseExpiry(raw) else {
-            return true
+            return false
         }
         return expiresAt.timeIntervalSince(now()) > Self.renewalLeadTime
     }
 
     /// Returns `true` when the token was written, or when there was nothing
     /// to write and any stale token was removed.
+    ///
+    /// Metadata only follows a Keychain mutation that succeeded. If the write
+    /// or delete fails, the previous token and its expiry stay paired, so
+    /// `hasCurrentToken()` keeps reporting the old token's real state and
+    /// registration retries on the next foreground instead of treating a
+    /// stale credential as current.
     @discardableResult
     func store(_ token: String?, expiresAt: String?, serverId: String) -> Bool {
         let trimmed = token?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard !trimmed.isEmpty else {
-            defaults.removeObject(forKey: SharedStorage.applePushDisplayTokenExpiresAtKey)
-            defaults.removeObject(forKey: SharedStorage.applePushDisplayTokenServerIdKey)
-            return keychain.delete(SharedStorage.applePushDisplayTokenAccount)
+            let removed = keychain.delete(SharedStorage.applePushDisplayTokenAccount)
+            if removed {
+                defaults.removeObject(forKey: SharedStorage.applePushDisplayTokenExpiresAtKey)
+                defaults.removeObject(forKey: SharedStorage.applePushDisplayTokenServerIdKey)
+            }
+            return removed
         }
         let written = keychain.set(trimmed, for: SharedStorage.applePushDisplayTokenAccount)
-        defaults.set(written ? expiresAt : nil, forKey: SharedStorage.applePushDisplayTokenExpiresAtKey)
-        defaults.set(written ? serverId : nil, forKey: SharedStorage.applePushDisplayTokenServerIdKey)
+        if written {
+            defaults.set(expiresAt, forKey: SharedStorage.applePushDisplayTokenExpiresAtKey)
+            defaults.set(serverId, forKey: SharedStorage.applePushDisplayTokenServerIdKey)
+        }
         return written
     }
 

--- a/iosApp/iosApp/Notifications/ApplePushRegistration.swift
+++ b/iosApp/iosApp/Notifications/ApplePushRegistration.swift
@@ -17,6 +17,32 @@ struct ApplePushRegistrationResponse: Decodable {
     let serverDeviceId: String
     let enabled: Bool
     let pushMode: String
+    /// Long-lived, profile-scoped token for the Notification Service
+    /// extension's display fetch. Absent on older servers.
+    let displayToken: String?
+}
+
+/// Persists the registration's display token where the Notification Service
+/// extension reads it. Kept separate from `TokenStore`'s access/profile
+/// mirrors because it is minted per registration, not per sign-in.
+struct ApplePushDisplayTokenStore {
+    var keychain: SharedKeychain = SharedKeychain(audience: TokenStore.profileCredentialAudience)
+
+    /// Returns `true` when the token was written, or when there was nothing
+    /// to write and any stale token was removed.
+    func hasToken() -> Bool {
+        let stored = keychain.get(SharedStorage.applePushDisplayTokenAccount) ?? ""
+        return !stored.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    @discardableResult
+    func store(_ token: String?) -> Bool {
+        let trimmed = token?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !trimmed.isEmpty else {
+            return keychain.delete(SharedStorage.applePushDisplayTokenAccount)
+        }
+        return keychain.set(trimmed, for: SharedStorage.applePushDisplayTokenAccount)
+    }
 }
 
 enum ApplePushRegistrationWire {
@@ -97,6 +123,8 @@ final class ApplePushRegistrationCoordinator {
     private var inFlightFingerprint: String?
     private var lastSuccessfulFingerprint: String?
     private var endpointUnsupportedForContext: String?
+    private var displayTokenUnavailableForFingerprint: String?
+    private let displayTokenStore = ApplePushDisplayTokenStore()
 
     private init() {}
 
@@ -157,9 +185,18 @@ final class ApplePushRegistrationCoordinator {
 
         let request = makeRegistrationRequest(deviceToken: lastDeviceToken)
         let fingerprint = registrationFingerprint(for: request)
-        guard fingerprint != lastSuccessfulFingerprint,
-              fingerprint != inFlightFingerprint,
+        guard fingerprint != inFlightFingerprint,
               fingerprint != endpointUnsupportedForContext else {
+            return
+        }
+        // Registration is normally deduplicated per fingerprint for the
+        // process lifetime. The display token is the exception: a session
+        // sign-out clears it (TokenStore) without changing the fingerprint,
+        // and a server upgrade starts returning one for an unchanged
+        // registration. Re-register while the slot is empty so the extension
+        // regains its credential without waiting for a token or profile change.
+        if fingerprint == lastSuccessfulFingerprint,
+           displayTokenStore.hasToken() || displayTokenUnavailableForFingerprint == fingerprint {
             return
         }
 
@@ -173,7 +210,13 @@ final class ApplePushRegistrationCoordinator {
             )
             lastSuccessfulFingerprint = fingerprint
             endpointUnsupportedForContext = nil
-            Self.logger.info("Registered APNs token with Silo server_device_id=\(response.serverDeviceId, privacy: .private) enabled=\(response.enabled, privacy: .public)")
+            // Always store, even when nil: a server downgrade or a profile
+            // switch to an older server must not leave a token issued for a
+            // different profile in the extension's slot.
+            let storedDisplayToken = displayTokenStore.store(response.displayToken)
+            // Older servers never return one; stop retrying for this context.
+            displayTokenUnavailableForFingerprint = response.displayToken == nil ? fingerprint : nil
+            Self.logger.info("Registered APNs token with Silo server_device_id=\(response.serverDeviceId, privacy: .private) enabled=\(response.enabled, privacy: .public) displayToken=\(response.displayToken != nil, privacy: .public) stored=\(storedDisplayToken, privacy: .public)")
         } catch HTTPError.http(let statusCode, _) where statusCode == 404 || statusCode == 405 {
             endpointUnsupportedForContext = fingerprint
             Self.logger.info("Apple push device endpoint is not available on this Silo server yet")

--- a/iosApp/iosApp/Notifications/ApplePushRegistration.swift
+++ b/iosApp/iosApp/Notifications/ApplePushRegistration.swift
@@ -51,14 +51,16 @@ struct ApplePushDisplayTokenStore {
     /// Returns `true` when the token was written, or when there was nothing
     /// to write and any stale token was removed.
     @discardableResult
-    func store(_ token: String?, expiresAt: String?) -> Bool {
+    func store(_ token: String?, expiresAt: String?, serverId: String) -> Bool {
         let trimmed = token?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard !trimmed.isEmpty else {
             defaults.removeObject(forKey: SharedStorage.applePushDisplayTokenExpiresAtKey)
+            defaults.removeObject(forKey: SharedStorage.applePushDisplayTokenServerIdKey)
             return keychain.delete(SharedStorage.applePushDisplayTokenAccount)
         }
         let written = keychain.set(trimmed, for: SharedStorage.applePushDisplayTokenAccount)
         defaults.set(written ? expiresAt : nil, forKey: SharedStorage.applePushDisplayTokenExpiresAtKey)
+        defaults.set(written ? serverId : nil, forKey: SharedStorage.applePushDisplayTokenServerIdKey)
         return written
     }
 
@@ -262,7 +264,11 @@ final class ApplePushRegistrationCoordinator {
             // Always store, even when nil: a server downgrade or a profile
             // switch to an older server must not leave a token issued for a
             // different profile in the extension's slot.
-            let storedDisplayToken = displayTokenStore.store(response.displayToken, expiresAt: response.displayTokenExpiresAt)
+            let storedDisplayToken = displayTokenStore.store(
+                response.displayToken,
+                expiresAt: response.displayTokenExpiresAt,
+                serverId: identityBefore?.account.serverId ?? ""
+            )
             // Older servers return none; back off for this context for a while.
             displayTokenUnavailable = response.displayToken == nil ? (fingerprint, Date()) : nil
             Self.logger.info("Registered APNs token with Silo server_device_id=\(response.serverDeviceId, privacy: .private) enabled=\(response.enabled, privacy: .public) displayToken=\(response.displayToken != nil, privacy: .public) stored=\(storedDisplayToken, privacy: .public)")

--- a/iosApp/iosApp/Notifications/ApplePushRegistration.swift
+++ b/iosApp/iosApp/Notifications/ApplePushRegistration.swift
@@ -20,28 +20,53 @@ struct ApplePushRegistrationResponse: Decodable {
     /// Long-lived, profile-scoped token for the Notification Service
     /// extension's display fetch. Absent on older servers.
     let displayToken: String?
+    /// RFC 3339 expiry of `displayToken`. Absent with it.
+    let displayTokenExpiresAt: String?
 }
 
 /// Persists the registration's display token where the Notification Service
 /// extension reads it. Kept separate from `TokenStore`'s access/profile
 /// mirrors because it is minted per registration, not per sign-in.
 struct ApplePushDisplayTokenStore {
+    /// Renew this far ahead of expiry so a token never lapses between two
+    /// foregrounds; the server's default lifetime is 30 days.
+    static let renewalLeadTime: TimeInterval = 7 * 24 * 60 * 60
+
     var keychain: SharedKeychain = SharedKeychain(audience: TokenStore.profileCredentialAudience)
+    var defaults: SharedDefaults = .shared
+    var now: () -> Date = Date.init
+
+    /// `true` when a token is stored and is not within `renewalLeadTime` of
+    /// its expiry. A token without a parseable expiry counts as current.
+    func hasCurrentToken() -> Bool {
+        let stored = keychain.get(SharedStorage.applePushDisplayTokenAccount) ?? ""
+        guard !stored.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return false }
+        guard let raw = defaults.string(forKey: SharedStorage.applePushDisplayTokenExpiresAtKey),
+              let expiresAt = Self.parseExpiry(raw) else {
+            return true
+        }
+        return expiresAt.timeIntervalSince(now()) > Self.renewalLeadTime
+    }
 
     /// Returns `true` when the token was written, or when there was nothing
     /// to write and any stale token was removed.
-    func hasToken() -> Bool {
-        let stored = keychain.get(SharedStorage.applePushDisplayTokenAccount) ?? ""
-        return !stored.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-    }
-
     @discardableResult
-    func store(_ token: String?) -> Bool {
+    func store(_ token: String?, expiresAt: String?) -> Bool {
         let trimmed = token?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard !trimmed.isEmpty else {
+            defaults.removeObject(forKey: SharedStorage.applePushDisplayTokenExpiresAtKey)
             return keychain.delete(SharedStorage.applePushDisplayTokenAccount)
         }
-        return keychain.set(trimmed, for: SharedStorage.applePushDisplayTokenAccount)
+        let written = keychain.set(trimmed, for: SharedStorage.applePushDisplayTokenAccount)
+        defaults.set(written ? expiresAt : nil, forKey: SharedStorage.applePushDisplayTokenExpiresAtKey)
+        return written
+    }
+
+    static func parseExpiry(_ raw: String) -> Date? {
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = fractional.date(from: raw) { return date }
+        return ISO8601DateFormatter().date(from: raw)
     }
 }
 
@@ -123,7 +148,11 @@ final class ApplePushRegistrationCoordinator {
     private var inFlightFingerprint: String?
     private var lastSuccessfulFingerprint: String?
     private var endpointUnsupportedForContext: String?
-    private var displayTokenUnavailableForFingerprint: String?
+    /// Fingerprint the server last answered without a display token, and
+    /// when. Time-bounded rather than process-lifetime so a server upgrade
+    /// is noticed by a long-resident app.
+    private var displayTokenUnavailable: (fingerprint: String, at: Date)?
+    private static let displayTokenUnavailableRetryInterval: TimeInterval = 6 * 60 * 60
     private let displayTokenStore = ApplePushDisplayTokenStore()
 
     private init() {}
@@ -192,12 +221,17 @@ final class ApplePushRegistrationCoordinator {
         // Registration is normally deduplicated per fingerprint for the
         // process lifetime. The display token is the exception: a session
         // sign-out clears it (TokenStore) without changing the fingerprint,
-        // and a server upgrade starts returning one for an unchanged
-        // registration. Re-register while the slot is empty so the extension
-        // regains its credential without waiting for a token or profile change.
-        if fingerprint == lastSuccessfulFingerprint,
-           displayTokenStore.hasToken() || displayTokenUnavailableForFingerprint == fingerprint {
-            return
+        // it expires on its own schedule, and a server upgrade starts
+        // returning one for an unchanged registration. Re-register while the
+        // slot is empty or near expiry so the extension keeps a live
+        // credential without waiting for a token or profile change.
+        if fingerprint == lastSuccessfulFingerprint {
+            if displayTokenStore.hasCurrentToken() { return }
+            if let unavailable = displayTokenUnavailable,
+               unavailable.fingerprint == fingerprint,
+               Date().timeIntervalSince(unavailable.at) < Self.displayTokenUnavailableRetryInterval {
+                return
+            }
         }
 
         inFlightFingerprint = fingerprint
@@ -213,9 +247,9 @@ final class ApplePushRegistrationCoordinator {
             // Always store, even when nil: a server downgrade or a profile
             // switch to an older server must not leave a token issued for a
             // different profile in the extension's slot.
-            let storedDisplayToken = displayTokenStore.store(response.displayToken)
-            // Older servers never return one; stop retrying for this context.
-            displayTokenUnavailableForFingerprint = response.displayToken == nil ? fingerprint : nil
+            let storedDisplayToken = displayTokenStore.store(response.displayToken, expiresAt: response.displayTokenExpiresAt)
+            // Older servers return none; back off for this context for a while.
+            displayTokenUnavailable = response.displayToken == nil ? (fingerprint, Date()) : nil
             Self.logger.info("Registered APNs token with Silo server_device_id=\(response.serverDeviceId, privacy: .private) enabled=\(response.enabled, privacy: .public) displayToken=\(response.displayToken != nil, privacy: .public) stored=\(storedDisplayToken, privacy: .public)")
         } catch HTTPError.http(let statusCode, _) where statusCode == 404 || statusCode == 405 {
             endpointUnsupportedForContext = fingerprint

--- a/iosApp/iosApp/Notifications/ApplePushRegistration.swift
+++ b/iosApp/iosApp/Notifications/ApplePushRegistration.swift
@@ -135,6 +135,11 @@ enum ApplePushRegistrationWire {
     }
 }
 
+struct ApplePushRegistrationIdentity: Equatable {
+    let account: RefreshAccountIdentity
+    let profileID: String
+}
+
 @MainActor
 final class ApplePushRegistrationCoordinator {
     static let shared = ApplePushRegistrationCoordinator()
@@ -237,11 +242,21 @@ final class ApplePushRegistrationCoordinator {
         inFlightFingerprint = fingerprint
         defer { inFlightFingerprint = nil }
 
+        // Snapshot the identity the registration is for. The response may
+        // land after a sign-out, server switch, or profile change has already
+        // cleared the display-token slot for the new context; writing the
+        // old context's token into it would resurrect a revoked credential.
+        let identityBefore = await Self.currentIdentity()
+
         do {
             let response: ApplePushRegistrationResponse = try await HTTPClient.shared.post(
                 ApplePushRegistrationWire.endpoint,
                 body: request
             )
+            guard await Self.currentIdentity() == identityBefore else {
+                Self.logger.info("Discarding Apple push registration response: identity changed while in flight")
+                return
+            }
             lastSuccessfulFingerprint = fingerprint
             endpointUnsupportedForContext = nil
             // Always store, even when nil: a server downgrade or a profile
@@ -257,6 +272,17 @@ final class ApplePushRegistrationCoordinator {
         } catch {
             Self.logger.error("Apple push device registration failed: \(String(describing: error), privacy: .public)")
         }
+    }
+
+    /// The account (server + credential generation) and profile a
+    /// registration belongs to. Any change, including a sign-out and
+    /// sign-in to the same server, produces a different value.
+    private static func currentIdentity() async -> ApplePushRegistrationIdentity? {
+        guard let account = await TokenStore.shared.refreshAccountIdentity() else { return nil }
+        return ApplePushRegistrationIdentity(
+            account: account,
+            profileID: await TokenStore.shared.getProfileId() ?? ""
+        )
     }
 
     private func makeRegistrationRequest(deviceToken: Data) -> ApplePushRegistrationRequest {

--- a/iosApp/iosApp/Shared/SharedStorage.swift
+++ b/iosApp/iosApp/Shared/SharedStorage.swift
@@ -30,6 +30,12 @@ enum SharedStorage {
     static let mirroredAccessTokenAccount = "com.continuum.topshelf.accessToken"
     static let mirroredProfileTokenAccount = "com.continuum.topshelf.profileToken"
 
+    /// Long-lived, profile-scoped token the server returns from Apple push
+    /// registration. The Notification Service extension prefers it over the
+    /// mirrored access token because it cannot refresh an expired one.
+    /// Written by `ApplePushRegistrationCoordinator`, cleared with the mirrors.
+    static let applePushDisplayTokenAccount = "com.continuum.push.displayToken"
+
     static func accessTokenAccount(for serverID: String) -> String {
         "com.continuum.\(serverID).accessToken"
     }

--- a/iosApp/iosApp/Shared/SharedStorage.swift
+++ b/iosApp/iosApp/Shared/SharedStorage.swift
@@ -39,6 +39,11 @@ enum SharedStorage {
     /// used by the app to renew it before the extension starts sending an
     /// expired credential. Not read by the extension.
     static let applePushDisplayTokenExpiresAtKey = "applePush.displayTokenExpiresAt"
+    /// App Group defaults key: registry id of the server the stored display
+    /// token was minted for. `TokenStore` clears the token only when the
+    /// active server actually changes, not when the actor rehydrates the
+    /// same persisted server on a cold launch.
+    static let applePushDisplayTokenServerIdKey = "applePush.displayTokenServerId"
 
     static func accessTokenAccount(for serverID: String) -> String {
         "com.continuum.\(serverID).accessToken"

--- a/iosApp/iosApp/Shared/SharedStorage.swift
+++ b/iosApp/iosApp/Shared/SharedStorage.swift
@@ -35,6 +35,10 @@ enum SharedStorage {
     /// mirrored access token because it cannot refresh an expired one.
     /// Written by `ApplePushRegistrationCoordinator`, cleared with the mirrors.
     static let applePushDisplayTokenAccount = "com.continuum.push.displayToken"
+    /// App Group defaults key: RFC 3339 expiry of the stored display token,
+    /// used by the app to renew it before the extension starts sending an
+    /// expired credential. Not read by the extension.
+    static let applePushDisplayTokenExpiresAtKey = "applePush.displayTokenExpiresAt"
 
     static func accessTokenAccount(for serverID: String) -> String {
         "com.continuum.\(serverID).accessToken"


### PR DESCRIPTION
## Problem

iOS notifications from production show "New notification available" instead of the episode text. The Notification Service extension enriches the alert by calling the server's display endpoint with the access token the app mirrors into the shared Keychain. The extension cannot refresh that token, and access tokens expire after hours, so any push that lands while the phone is idle gets a 401 and keeps the generic body. Production logs from 2026-09-04 01:52 UTC show 3 of 4 display fetches from the extension returning 401.

## Solution

- Apple push registration now stores the `display_token` the server returns in a new shared Keychain slot, `SharedStorage.applePushDisplayTokenAccount`, scoped to the current-user audience like the profile token.
- The extension prefers that token as the bearer credential and falls back to the mirrored access token on servers that do not return one, so behavior on older servers is unchanged. If the display token is rejected with 401 or 403, it retries once with the access token.
- `TokenStore` clears the slot whenever it clears the other mirrored tokens, and also on profile activation, profile deactivation, and server switch, so the extension never pairs a new context with a token minted for a previous one.
- The issuing server id is stored with the token so a cold-launch retarget to the same server keeps it.
- A registration response that arrives after the account or profile identity changed is discarded, so a late response cannot write a revoked token back into the slot.
- `ApplePushRegistrationCoordinator` re-registers when the slot is empty or the stored token is within a week of its expiry, even if the registration fingerprint is unchanged, so a session change, token expiry, or server upgrade restores the token without waiting for a device token or profile change. The expiry from `display_token_expires_at` is kept in App Group defaults. On a server that answers without a token, discovery retries after six hours.

Requires the server change in Silo-Server/silo-server#929. Without it the app behaves exactly as before.

## Validation

- `xcodebuild build` for scheme `Silo` on iPhone 17 Pro simulator succeeds, including the `SiloNotificationService` extension.
- `SiloTests/ApplePushRegistrationTests` passes, with three new tests: display-token preference and fallback in `ApplePushDisplayAuthState`, decoding the optional `display_token` fields, and expiry parsing with and without fractional seconds.
- Not verified end to end on a device against a server running the companion PR.

## Risks

- The display token lives as long as the refresh token. It only unlocks notification text for its own profile and is revoked with the session.
- No UI change, so no screenshots.

## AI disclosure

Written with Claude Code using model `claude-fable-5-1`. The author reviewed the change and ran the validation above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
