### PR TITLE
fix(tvos): replace detail menus with instant popovers

### DIFF
--- a/iosApp/iosApp/tvOS/Screens/Detail/TVActionPopoverMenu.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVActionPopoverMenu.swift
@@ -86,8 +86,34 @@ struct TVActionPopoverMenu: View {
             // engine not having moved yet.
             if didClaimFocus { onClose() }
         }
-        .accessibilityElement(children: .contain)
+        // VoiceOver: the composite is one adjustable button. Its value is
+        // the highlighted row (what Select will commit), swipe up/down moves
+        // the highlight, and activate commits it. Rows stay hidden so the
+        // cursor cannot land on a label that does not react to Select.
+        .accessibilityElement(children: .ignore)
         .accessibilityLabel(title)
+        .accessibilityValue(highlightedAccessibilityValue)
+        .accessibilityAddTraits([.isButton, .updatesFrequently])
+        .accessibilityAdjustableAction { direction in
+            switch direction {
+            case .increment: moveHighlight(by: 1)
+            case .decrement: moveHighlight(by: -1)
+            @unknown default: break
+            }
+        }
+        .accessibilityAction(.default, commitHighlighted)
+        .accessibilityAction(.escape, onClose)
+    }
+
+    private var highlightedAccessibilityValue: String {
+        guard let item = items.first(where: { $0.id == highlightedId }) else { return "" }
+        var parts = [item.title]
+        if let detail = item.detail, !detail.isEmpty { parts.append(detail) }
+        if item.isSelected { parts.append("selected") }
+        if let index = items.firstIndex(where: { $0.id == item.id }) {
+            parts.append("\(index + 1) of \(items.count)")
+        }
+        return parts.joined(separator: ", ")
     }
 
     private var header: some View {
@@ -134,16 +160,11 @@ struct TVActionPopoverMenu: View {
     private static let rowHeightEstimate: CGFloat = 72
 
     private func handleMove(_ direction: MoveCommandDirection) {
-        let enabled = items.filter(\.isEnabled)
-        guard !enabled.isEmpty else { return }
-        let index = enabled.firstIndex { $0.id == highlightedId } ?? 0
         switch direction {
         case .up:
-            guard index > 0 else { return }
-            highlightedId = enabled[index - 1].id
+            moveHighlight(by: -1)
         case .down:
-            guard index < enabled.count - 1 else { return }
-            highlightedId = enabled[index + 1].id
+            moveHighlight(by: 1)
         case .left, .right:
             // Lateral moves leave the menu: close and let the next press
             // land on the row's neighbour. Consuming them here would
@@ -152,6 +173,15 @@ struct TVActionPopoverMenu: View {
         @unknown default:
             break
         }
+    }
+
+    private func moveHighlight(by delta: Int) {
+        let enabled = items.filter(\.isEnabled)
+        guard !enabled.isEmpty else { return }
+        let index = enabled.firstIndex { $0.id == highlightedId } ?? 0
+        let next = index + delta
+        guard enabled.indices.contains(next) else { return }
+        highlightedId = enabled[next].id
     }
 
     /// A `@FocusState` write in `onAppear` lands only if the engine already
@@ -218,17 +248,11 @@ private struct TVActionPopoverRow: View {
                 .fill(isHighlighted ? Color.white : Color.clear)
         )
         .animation(reduceMotion ? nil : ContinuumTheme.springAnimation, value: isHighlighted)
-        .accessibilityLabel(accessibilityText)
-        .accessibilityAddTraits(item.isSelected ? .isSelected : [])
+        .accessibilityHidden(true)
     }
 
     private var foreground: Color {
         isHighlighted ? .continuumBackground : .white.opacity(0.9)
-    }
-
-    private var accessibilityText: String {
-        guard let detail = item.detail, !detail.isEmpty else { return item.title }
-        return "\(item.title), \(detail)"
     }
 }
 
@@ -277,9 +301,45 @@ private struct TVActionPopoverHostModifier: ViewModifier {
     /// disabled. While disabled, nothing under the page can take focus, so
     /// the popover is the engine's only candidate: that is the focus lock.
     @State private var isOpen = false
+    /// Measured height of the open panel. Zero until the first layout; the
+    /// panel is then placed below the anchor, which is right for every
+    /// short list and re-evaluates once the real height is known.
+    @State private var panelHeight: CGFloat = 0
 
     private static let anchorGap: CGFloat = 14
     private static let screenInset: CGFloat = 48
+
+    private struct Placement {
+        let x: CGFloat
+        let y: CGFloat
+        let opensUpward: Bool
+    }
+
+    /// Below the anchor when it fits, otherwise above it; if neither side
+    /// has room, pinned to the bottom inset so the last row is on screen.
+    /// Horizontal position tracks the anchor's leading edge and is clamped
+    /// to the screen inset.
+    private static func placement(
+        anchor: CGRect,
+        panelHeight: CGFloat,
+        in size: CGSize
+    ) -> Placement {
+        let x = min(
+            anchor.minX,
+            max(screenInset, size.width - screenInset - TVActionPopoverMenu.width)
+        )
+        let below = anchor.maxY + anchorGap
+        let fitsBelow = below + panelHeight <= size.height - screenInset
+        if fitsBelow || panelHeight == 0 {
+            return Placement(x: x, y: below, opensUpward: false)
+        }
+        let above = anchor.minY - anchorGap - panelHeight
+        if above >= screenInset {
+            return Placement(x: x, y: above, opensUpward: true)
+        }
+        let pinned = max(screenInset, size.height - screenInset - panelHeight)
+        return Placement(x: x, y: pinned, opensUpward: false)
+    }
 
     func body(content: Content) -> some View {
         content
@@ -287,11 +347,17 @@ private struct TVActionPopoverHostModifier: ViewModifier {
             .onPreferenceChange(TVActionPopoverPreferenceKey.self) { requests in
                 let open = !requests.isEmpty
                 if open != isOpen { isOpen = open }
+                if !open { panelHeight = 0 }
             }
             .overlayPreferenceValue(TVActionPopoverPreferenceKey.self) { requests in
                 GeometryReader { geo in
                     if let request = requests.last {
                         let anchor = geo[request.anchor]
+                        let placement = Self.placement(
+                            anchor: anchor,
+                            panelHeight: panelHeight,
+                            in: geo.size
+                        )
                         // Layout padding, never `.offset`: tvOS resolves
                         // focus from layout frames, and an offset panel
                         // would keep its focus frame at the origin.
@@ -304,21 +370,22 @@ private struct TVActionPopoverHostModifier: ViewModifier {
                             )
                             .id(request.id)
                             .fixedSize()
-                            .padding(
-                                .leading,
-                                min(
-                                    anchor.minX,
-                                    max(
-                                        Self.screenInset,
-                                        geo.size.width - Self.screenInset - TVActionPopoverMenu.width
-                                    )
-                                )
-                            )
-                            .padding(.top, anchor.maxY + Self.anchorGap)
+                            .onGeometryChange(for: CGFloat.self) { proxy in
+                                proxy.size.height
+                            } action: { height in
+                                panelHeight = height
+                            }
+                            .padding(.leading, placement.x)
+                            .padding(.top, placement.y)
                             .transition(
                                 reduceMotion
                                     ? .opacity
-                                    : .opacity.combined(with: .scale(scale: 0.96, anchor: .top))
+                                    : .opacity.combined(
+                                        with: .scale(
+                                            scale: 0.96,
+                                            anchor: placement.opensUpward ? .bottom : .top
+                                        )
+                                    )
                             )
                         }
                         .frame(width: geo.size.width, height: geo.size.height, alignment: .topLeading)

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVActionPopoverMenu.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVActionPopoverMenu.swift
@@ -1,0 +1,398 @@
+#if os(tvOS)
+import SwiftUI
+import UIKit
+
+/// One row in an app-owned action popover.
+struct TVActionPopoverItem: Identifiable, Equatable {
+    let id: String
+    let title: String
+    var detail: String? = nil
+    var systemImage: String? = nil
+    var isSelected = false
+    var isEnabled = true
+}
+
+/// Anchored popover that replaces the system `Menu` on the detail action
+/// row. tvOS presents a `Menu` as a context-menu interaction whose spring
+/// present and dismiss each run over a second, and the interaction owns
+/// input until the dismiss spring completes. That was the 1–2 s dead zone
+/// after confirming a Version/Audio/Subtitle choice.
+///
+/// The popover is one composite focus item (docs/tvos-focus.md): the panel
+/// itself is the only focusable, rows are passive labels, and d-pad up/down
+/// moves an internal highlight. Select commits the highlighted row; Menu/Back
+/// closes. Both hand focus straight back to the trigger, so the next d-pad
+/// press lands on the row with no system animation to wait out.
+struct TVActionPopoverMenu: View {
+    let title: String
+    let items: [TVActionPopoverItem]
+    let onSelect: (TVActionPopoverItem) -> Void
+    let onClose: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @FocusState private var panelFocused: Bool
+    @State private var highlightedId: String?
+    @State private var didClaimFocus = false
+    @State private var focusClaim: Task<Void, Never>?
+
+    static let width: CGFloat = 560
+    private static let maxRows = 7
+    private static let shape = RoundedRectangle(
+        cornerRadius: ContinuumTheme.Skyline.dropdownCornerRadius,
+        style: .continuous
+    )
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            rows
+        }
+        .padding(ContinuumTheme.Skyline.dropdownPadding)
+        .frame(width: Self.width, alignment: .leading)
+        // Native tvOS context-menu look: Liquid Glass with a dark tint so
+        // the page shows through, plus a faint lip so the edge reads on
+        // bright backdrops.
+        .siloGlass(in: Self.shape, tint: Color.black.opacity(0.45))
+        .overlay(Self.shape.strokeBorder(Color.white.opacity(0.10), lineWidth: 1))
+        .shadow(color: .black.opacity(0.45), radius: 32, y: 18)
+        .contentShape(Self.shape)
+        .focusable(true)
+        .focused($panelFocused)
+        .focusEffectDisabled()
+        .onMoveCommand(perform: handleMove)
+        .onTapGesture(perform: commitHighlighted)
+        .onExitCommand(perform: onClose)
+        .background(
+            TVActionPopoverMenuPressCatcher(onExit: onClose)
+                .frame(width: 0, height: 0)
+        )
+        .onAppear {
+            highlightedId = items.first(where: { $0.isSelected && $0.isEnabled })?.id
+                ?? items.first(where: \.isEnabled)?.id
+            claimFocus()
+        }
+        .onDisappear {
+            focusClaim?.cancel()
+        }
+        .onChange(of: panelFocused) { _, focused in
+            if focused {
+                didClaimFocus = true
+                return
+            }
+            // The panel is the only focus owner while open. Losing focus
+            // after it was held (a cover, the watchdog, an engine repair)
+            // means the popover is stale; close instead of lingering
+            // unfocusable. A false before the claim landed is just the
+            // engine not having moved yet.
+            if didClaimFocus { onClose() }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(title)
+    }
+
+    private var header: some View {
+        Text(title.uppercased())
+            .font(.system(size: ContinuumTheme.Skyline.dropdownHeaderSize, design: .monospaced))
+            .tracking(ContinuumTheme.Skyline.dropdownHeaderSize * 0.26)
+            .foregroundStyle(Color.white.opacity(0.38))
+            .lineLimit(1)
+            .padding(.horizontal, 16)
+            .padding(.top, 8)
+            .padding(.bottom, 10)
+            .accessibilityHidden(true)
+    }
+
+    @ViewBuilder
+    private var rows: some View {
+        let list = VStack(alignment: .leading, spacing: 2) {
+            ForEach(items) { item in
+                TVActionPopoverRow(
+                    item: item,
+                    isHighlighted: item.id == highlightedId
+                )
+                .id(item.id)
+            }
+        }
+        if items.count > Self.maxRows {
+            ScrollViewReader { proxy in
+                ScrollView(.vertical, showsIndicators: false) {
+                    list
+                }
+                .frame(maxHeight: Self.rowHeightEstimate * CGFloat(Self.maxRows))
+                .onChange(of: highlightedId) { _, id in
+                    guard let id else { return }
+                    withAnimation(reduceMotion ? nil : .easeOut(duration: 0.18)) {
+                        proxy.scrollTo(id, anchor: .center)
+                    }
+                }
+            }
+        } else {
+            list
+        }
+    }
+
+    private static let rowHeightEstimate: CGFloat = 72
+
+    private func handleMove(_ direction: MoveCommandDirection) {
+        let enabled = items.filter(\.isEnabled)
+        guard !enabled.isEmpty else { return }
+        let index = enabled.firstIndex { $0.id == highlightedId } ?? 0
+        switch direction {
+        case .up:
+            guard index > 0 else { return }
+            highlightedId = enabled[index - 1].id
+        case .down:
+            guard index < enabled.count - 1 else { return }
+            highlightedId = enabled[index + 1].id
+        case .left, .right:
+            // Lateral moves leave the menu: close and let the next press
+            // land on the row's neighbour. Consuming them here would
+            // trap the user in a one-column list.
+            onClose()
+        @unknown default:
+            break
+        }
+    }
+
+    /// A `@FocusState` write in `onAppear` lands only if the engine already
+    /// knows the new focusable. Re-assert across a few turns, the same way
+    /// `TVCascadeSelector.claimPanelFocus` does, and stop as soon as it
+    /// sticks or the user has moved on.
+    private func claimFocus() {
+        focusClaim?.cancel()
+        panelFocused = true
+        focusClaim = Task { @MainActor in
+            for attempt in 0..<6 {
+                if attempt == 0 {
+                    await Task.yield()
+                } else {
+                    try? await Task.sleep(nanoseconds: 32_000_000)
+                }
+                if Task.isCancelled || didClaimFocus || panelFocused { return }
+                panelFocused = true
+            }
+        }
+    }
+
+    private func commitHighlighted() {
+        guard let item = items.first(where: { $0.id == highlightedId }),
+              item.isEnabled else { return }
+        onSelect(item)
+    }
+}
+
+private struct TVActionPopoverRow: View {
+    let item: TVActionPopoverItem
+    let isHighlighted: Bool
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        HStack(spacing: 14) {
+            Image(systemName: item.isSelected ? "checkmark" : (item.systemImage ?? "checkmark"))
+                .font(.system(size: 20, weight: .bold))
+                .frame(width: 26)
+                .opacity(item.isSelected || item.systemImage != nil ? 1 : 0)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.title)
+                    .font(.system(size: ContinuumTheme.Skyline.dropdownRowTextSize, weight: .semibold))
+                    .lineLimit(1)
+                if let detail = item.detail, !detail.isEmpty {
+                    Text(detail)
+                        .font(.system(size: 17, weight: .medium))
+                        .foregroundStyle(foreground.opacity(0.7))
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer(minLength: 0)
+        }
+        .foregroundStyle(foreground)
+        .opacity(item.isEnabled ? 1 : 0.4)
+        .padding(.horizontal, ContinuumTheme.Skyline.cascadeRowPaddingHorizontal)
+        .padding(.vertical, 13)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: ContinuumTheme.Skyline.cascadeRowCornerRadius, style: .continuous)
+                .fill(isHighlighted ? Color.white : Color.clear)
+        )
+        .animation(reduceMotion ? nil : ContinuumTheme.springAnimation, value: isHighlighted)
+        .accessibilityLabel(accessibilityText)
+        .accessibilityAddTraits(item.isSelected ? .isSelected : [])
+    }
+
+    private var foreground: Color {
+        isHighlighted ? .continuumBackground : .white.opacity(0.9)
+    }
+
+    private var accessibilityText: String {
+        guard let detail = item.detail, !detail.isEmpty else { return item.title }
+        return "\(item.title), \(detail)"
+    }
+}
+
+// MARK: - Page-level hosting
+
+/// A request to show a popover, published by `TVCircleMenuButton` through
+/// `TVActionPopoverPreferenceKey` and rendered by `tvActionPopoverHost()`.
+///
+/// The trigger sits inside the hero's clipped editorial column and the page
+/// scroll view, so drawing the popover as the trigger's own overlay clips it
+/// and lets later siblings (season chips, episode rail) paint over it. The
+/// host draws it above the whole page instead, anchored to the trigger's
+/// bounds.
+struct TVActionPopoverRequest: Equatable {
+    let id: UUID
+    let anchor: Anchor<CGRect>
+    let title: String
+    let items: [TVActionPopoverItem]
+    let onSelect: (TVActionPopoverItem) -> Void
+    let onClose: () -> Void
+
+    /// Identity only: closures are not comparable, and a request is the same
+    /// request while its id holds. Items are read live from the trigger.
+    static func == (lhs: Self, rhs: Self) -> Bool { lhs.id == rhs.id }
+}
+
+struct TVActionPopoverPreferenceKey: PreferenceKey {
+    static let defaultValue: [TVActionPopoverRequest] = []
+
+    static func reduce(value: inout [TVActionPopoverRequest], nextValue: () -> [TVActionPopoverRequest]) {
+        value.append(contentsOf: nextValue())
+    }
+}
+
+extension View {
+    /// Render any open `TVCircleMenuButton` popover above this view. Apply
+    /// once per detail page, outside the page scroll view.
+    func tvActionPopoverHost() -> some View {
+        modifier(TVActionPopoverHostModifier())
+    }
+}
+
+private struct TVActionPopoverHostModifier: ViewModifier {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    /// Mirrors "a popover is open" out of the preference so the page can be
+    /// disabled. While disabled, nothing under the page can take focus, so
+    /// the popover is the engine's only candidate: that is the focus lock.
+    @State private var isOpen = false
+
+    private static let anchorGap: CGFloat = 14
+    private static let screenInset: CGFloat = 48
+
+    func body(content: Content) -> some View {
+        content
+            .disabled(isOpen)
+            .onPreferenceChange(TVActionPopoverPreferenceKey.self) { requests in
+                let open = !requests.isEmpty
+                if open != isOpen { isOpen = open }
+            }
+            .overlayPreferenceValue(TVActionPopoverPreferenceKey.self) { requests in
+                GeometryReader { geo in
+                    if let request = requests.last {
+                        let anchor = geo[request.anchor]
+                        // Layout padding, never `.offset`: tvOS resolves
+                        // focus from layout frames, and an offset panel
+                        // would keep its focus frame at the origin.
+                        ZStack(alignment: .topLeading) {
+                            TVActionPopoverMenu(
+                                title: request.title,
+                                items: request.items,
+                                onSelect: request.onSelect,
+                                onClose: request.onClose
+                            )
+                            .id(request.id)
+                            .fixedSize()
+                            .padding(
+                                .leading,
+                                min(
+                                    anchor.minX,
+                                    max(
+                                        Self.screenInset,
+                                        geo.size.width - Self.screenInset - TVActionPopoverMenu.width
+                                    )
+                                )
+                            )
+                            .padding(.top, anchor.maxY + Self.anchorGap)
+                            .transition(
+                                reduceMotion
+                                    ? .opacity
+                                    : .opacity.combined(with: .scale(scale: 0.96, anchor: .top))
+                            )
+                        }
+                        .frame(width: geo.size.width, height: geo.size.height, alignment: .topLeading)
+                    }
+                }
+                .ignoresSafeArea()
+                .animation(
+                    reduceMotion ? nil : .easeOut(duration: ContinuumTheme.Skyline.cascadeOpenDuration),
+                    value: requests.last?.id
+                )
+            }
+    }
+}
+
+/// Window-level Menu press catcher. SwiftUI's `onExitCommand` only fires
+/// while the popover itself holds focus; a Menu press that races a focus
+/// move would otherwise pop the detail page. Same pattern as the top bar.
+private struct TVActionPopoverMenuPressCatcher: UIViewRepresentable {
+    var onExit: () -> Void
+
+    func makeUIView(context: Context) -> TVActionPopoverMenuPressUIView {
+        let view = TVActionPopoverMenuPressUIView()
+        view.onExit = onExit
+        return view
+    }
+
+    func updateUIView(_ uiView: TVActionPopoverMenuPressUIView, context: Context) {
+        uiView.onExit = onExit
+    }
+}
+
+private final class TVActionPopoverMenuPressUIView: UIView, UIGestureRecognizerDelegate {
+    var onExit: () -> Void = {}
+
+    private weak var attachedWindow: UIWindow?
+    private var recognizer: UITapGestureRecognizer?
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        attachRecognizerIfNeeded()
+    }
+
+    deinit {
+        detachRecognizer()
+    }
+
+    private func attachRecognizerIfNeeded() {
+        guard attachedWindow !== window else { return }
+        detachRecognizer()
+        guard let window else { return }
+        let recognizer = UITapGestureRecognizer(target: self, action: #selector(handleMenuPress(_:)))
+        recognizer.allowedPressTypes = [NSNumber(value: UIPress.PressType.menu.rawValue)]
+        recognizer.cancelsTouchesInView = true
+        recognizer.delegate = self
+        window.addGestureRecognizer(recognizer)
+        attachedWindow = window
+        self.recognizer = recognizer
+    }
+
+    private func detachRecognizer() {
+        if let recognizer, let attachedWindow {
+            attachedWindow.removeGestureRecognizer(recognizer)
+        }
+        recognizer = nil
+        attachedWindow = nil
+    }
+
+    @objc private func handleMenuPress(_ recognizer: UITapGestureRecognizer) {
+        guard recognizer.state == .ended else { return }
+        onExit()
+    }
+
+    override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        window != nil
+    }
+}
+#endif

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVDetailActions.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVDetailActions.swift
@@ -1,5 +1,6 @@
 #if os(tvOS)
 import SwiftUI
+import UIKit
 
 // MARK: - Primary pill
 
@@ -151,58 +152,122 @@ private struct TVSecondaryPillLabel: View {
 
 // MARK: - Circle menu button
 
-/// Circle-shaped overflow/"more" button that opens a `Menu`. Same visual
-/// footprint as `TVCircleActionButton` — used in the hero action row to
-/// keep secondary navigation actions (Go to Series, Go to Season, etc.)
-/// one tap away without crowding the primary row.
-struct TVCircleMenuButton<MenuContent: View>: View {
+/// Circle-shaped button that opens an app-owned `TVActionPopoverMenu`
+/// anchored below it. Same visual footprint as `TVCircleActionButton`.
+///
+/// This deliberately does not use the system `Menu`: on tvOS that is a
+/// context-menu interaction with ~1 s present and ~1.2 s dismiss springs,
+/// and it swallows d-pad input until the dismiss completes. The popover
+/// closes synchronously and hands focus straight back to this button.
+struct TVCircleMenuButton: View {
     let icon: String
     /// Short label revealed while focused ("Versions", "More"). Nil keeps the
     /// button a fixed icon-only circle.
     let title: String?
     let accessibilityLabel: String
     let stabilizesFocusMotion: Bool
-    @ViewBuilder let menu: () -> MenuContent
+    /// Header shown inside the popover. Defaults to `title`.
+    let menuTitle: String?
+    let items: () -> [TVActionPopoverItem]
+    let onSelect: (TVActionPopoverItem) -> Void
 
+    @Environment(\.isEnabled) private var isEnabled
     @FocusState private var isFocused: Bool
+    @State private var isPresented = false
+    @State private var presentationId = UUID()
+    @State private var isPressed = false
+    @State private var focusReturn: Task<Void, Never>?
 
     init(
         icon: String = "ellipsis",
         title: String? = nil,
         accessibilityLabel: String,
         stabilizesFocusMotion: Bool = false,
-        @ViewBuilder menu: @escaping () -> MenuContent
+        menuTitle: String? = nil,
+        items: @escaping () -> [TVActionPopoverItem],
+        onSelect: @escaping (TVActionPopoverItem) -> Void
     ) {
         self.icon = icon
         self.title = title
         self.accessibilityLabel = accessibilityLabel
         self.stabilizesFocusMotion = stabilizesFocusMotion
-        self.menu = menu
+        self.menuTitle = menuTitle
+        self.items = items
+        self.onSelect = onSelect
     }
 
     var body: some View {
         TVCirclePillSurface(
             icon: icon,
             title: title,
-            isFocused: isFocused,
-            isPressed: false,
+            isFocused: isFocused || isPresented,
+            isPressed: isPressed,
             stabilizesFocusMotion: stabilizesFocusMotion
         )
         .accessibilityHidden(true)
         .overlay {
-            // The Menu is only the focus/press host. Its UIKit-backed button
-            // applies label size changes without animating them, so it must
-            // not own the pill's geometry; the surface above does. It stays
-            // the accessibility element so VoiceOver activation opens it.
-            Menu {
-                menu()
-            } label: {
+            // The Button is only the focus/press host so the surface owns
+            // the pill's geometry. It stays the accessibility element so
+            // VoiceOver activation opens the popover.
+            Button(action: open) {
                 Color.clear
             }
-            .menuStyle(.button)
-            .buttonStyle(TVCircleFocusHostButtonStyle(isPressed: nil))
+            .buttonStyle(TVCircleFocusHostButtonStyle(isPressed: $isPressed))
             .focused($isFocused)
             .accessibilityLabel(accessibilityLabel)
+        }
+        // The popover itself is drawn by the page-level `tvActionPopoverHost()`
+        // so it escapes the hero clip and paints above the rest of the page.
+        // Only the request travels up; focus returns here via `isFocused`.
+        .anchorPreference(key: TVActionPopoverPreferenceKey.self, value: .bounds) { anchor in
+            guard isPresented else { return [] }
+            return [
+                TVActionPopoverRequest(
+                    id: presentationId,
+                    anchor: anchor,
+                    title: menuTitle ?? title ?? accessibilityLabel,
+                    items: items(),
+                    onSelect: { item in
+                        close()
+                        onSelect(item)
+                    },
+                    onClose: close
+                )
+            ]
+        }
+        .onDisappear {
+            focusReturn?.cancel()
+            isPresented = false
+        }
+    }
+
+    private func open() {
+        guard isEnabled, !isPresented else { return }
+        presentationId = UUID()
+        isPresented = true
+    }
+
+    private func close() {
+        guard isPresented else { return }
+        isPresented = false
+        returnFocus()
+    }
+
+    /// The page is disabled while the popover is open and re-enables one
+    /// render after the request clears, so a synchronous focus write here
+    /// is dropped. Re-assert across a few turns until it sticks.
+    private func returnFocus() {
+        focusReturn?.cancel()
+        focusReturn = Task { @MainActor in
+            for attempt in 0..<8 {
+                if attempt == 0 {
+                    await Task.yield()
+                } else {
+                    try? await Task.sleep(nanoseconds: 32_000_000)
+                }
+                if Task.isCancelled || isFocused || isPresented { return }
+                isFocused = true
+            }
         }
     }
 }

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVMovieDetailView.swift
@@ -144,6 +144,7 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
                     similarSectionId: similarSectionScrollId
                 )
                 .onPlayPauseCommand(perform: playFocusedEpisodeOrCurrent)
+                .tvActionPopoverHost()
             }
         }
     }
@@ -206,47 +207,74 @@ struct TVMovieDetailView<BelowSynopsis: View>: View {
 
     // MARK: - More menu
 
-    @ViewBuilder
+    private enum MoreAction: String {
+        case favorite, watched, trailers, season, series
+    }
+
     private var moreMenu: some View {
         TVCircleMenuButton(
             title: "More",
             accessibilityLabel: "More options",
-            stabilizesFocusMotion: true
-        ) {
-            Button(action: onToggleFavorite) {
-                Label(
-                    isFavorite ? "Remove from Favorites" : "Add to Favorites",
-                    systemImage: isFavorite ? "heart.fill" : "heart"
-                )
-            }
-            Button(action: onToggleWatched) {
-                Label(
-                    isWatched ? watchedLabelUnmark : watchedLabelMark,
-                    systemImage: isWatched ? "checkmark.circle.fill" : "checkmark.circle"
-                )
-            }
-            if supportsTrailerFetch {
-                Button(action: onFindTrailers) {
-                    Label("Find Trailers", systemImage: "film.stack")
+            stabilizesFocusMotion: true,
+            items: {
+                var items: [TVActionPopoverItem] = [
+                    TVActionPopoverItem(
+                        id: MoreAction.favorite.rawValue,
+                        title: isFavorite ? "Remove from Favorites" : "Add to Favorites",
+                        systemImage: isFavorite ? "heart.fill" : "heart"
+                    ),
+                    TVActionPopoverItem(
+                        id: MoreAction.watched.rawValue,
+                        title: isWatched ? watchedLabelUnmark : watchedLabelMark,
+                        systemImage: isWatched ? "checkmark.circle.fill" : "checkmark.circle"
+                    ),
+                ]
+                if supportsTrailerFetch {
+                    items.append(TVActionPopoverItem(
+                        id: MoreAction.trailers.rawValue,
+                        title: "Find Trailers",
+                        systemImage: "film.stack"
+                    ))
+                }
+                if detail.seriesId != nil,
+                   let seasonNumber = detail.seasonNumber,
+                   seasonNumber > 0 {
+                    items.append(TVActionPopoverItem(
+                        id: MoreAction.season.rawValue,
+                        title: "Go to Season",
+                        systemImage: "square.stack"
+                    ))
+                }
+                if detail.seriesId != nil {
+                    items.append(TVActionPopoverItem(
+                        id: MoreAction.series.rawValue,
+                        title: "Go to Series",
+                        systemImage: "tv"
+                    ))
+                }
+                return items
+            },
+            onSelect: { item in
+                switch MoreAction(rawValue: item.id) {
+                case .favorite:
+                    onToggleFavorite()
+                case .watched:
+                    onToggleWatched()
+                case .trailers:
+                    onFindTrailers()
+                case .season:
+                    if let seriesId = detail.seriesId, let seasonNumber = detail.seasonNumber {
+                        onNavigateToItem("\(seriesId)-S\(seasonNumber)")
+                    }
+                case .series:
+                    if let seriesId = detail.seriesId {
+                        onNavigateToItem(seriesId)
+                    }
+                case .none:
+                    break
                 }
             }
-            if let seriesId = detail.seriesId,
-               let seasonNumber = detail.seasonNumber,
-               seasonNumber > 0 {
-                Button {
-                    onNavigateToItem("\(seriesId)-S\(seasonNumber)")
-                } label: {
-                    Label("Go to Season", systemImage: "square.stack")
-                }
-            }
-            if let seriesId = detail.seriesId {
-                Button {
-                    onNavigateToItem(seriesId)
-                } label: {
-                    Label("Go to Series", systemImage: "tv")
-                }
-            }
-        }
+        )
     }
 
     private var watchedLabelMark: String {

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVPlaybackSelectorRow.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVPlaybackSelectorRow.swift
@@ -36,25 +36,33 @@ struct TVPlaybackActionSelectors: View {
             icon: "square.stack",
             title: "Versions",
             accessibilityLabel: "Version, \(versionValue)",
-            stabilizesFocusMotion: true
-        ) {
-            Button { onSelectVersion(nil) } label: {
-                menuItem(
-                    title: "Auto",
-                    detail: "Best match for this device",
-                    isSelected: selectedVersionFileId == nil
-                )
-            }
-            ForEach(versions) { version in
-                Button { onSelectVersion(version.fileId) } label: {
-                    menuItem(
+            stabilizesFocusMotion: true,
+            menuTitle: "Version",
+            items: {
+                [
+                    TVActionPopoverItem(
+                        id: "auto",
+                        title: "Auto",
+                        detail: "Best match for this device",
+                        isSelected: selectedVersionFileId == nil
+                    )
+                ] + versions.map { version in
+                    TVActionPopoverItem(
+                        id: "file-\(version.fileId)",
                         title: DetailPlaybackFormatting.versionShortLabel(version),
                         detail: versionDetail(version),
                         isSelected: selectedVersionFileId == version.fileId
                     )
                 }
+            },
+            onSelect: { item in
+                if item.id == "auto" {
+                    onSelectVersion(nil)
+                } else if let fileId = Int(item.id.dropFirst("file-".count)) {
+                    onSelectVersion(fileId)
+                }
             }
-        }
+        )
         .disabled(currentVersion == nil || versions.isEmpty)
     }
 
@@ -63,25 +71,33 @@ struct TVPlaybackActionSelectors: View {
             icon: "speaker.wave.2",
             title: "Audio Tracks",
             accessibilityLabel: "Audio, \(audioValue)",
-            stabilizesFocusMotion: true
-        ) {
-            Button { onSelectAudioTrack(nil) } label: {
-                menuItem(
-                    title: "Auto",
-                    detail: "Use your Playback audio preference",
-                    isSelected: selectedAudioTrackIndex == nil
-                )
-            }
-            ForEach(audioOptions) { option in
-                Button { onSelectAudioTrack(option.ordinal) } label: {
-                    menuItem(
+            stabilizesFocusMotion: true,
+            menuTitle: "Audio",
+            items: {
+                [
+                    TVActionPopoverItem(
+                        id: "auto",
+                        title: "Auto",
+                        detail: "Use your Playback audio preference",
+                        isSelected: selectedAudioTrackIndex == nil
+                    )
+                ] + audioOptions.map { option in
+                    TVActionPopoverItem(
+                        id: "track-\(option.ordinal)",
                         title: option.title,
                         detail: option.detail,
                         isSelected: option.isSelected
                     )
                 }
+            },
+            onSelect: { item in
+                if item.id == "auto" {
+                    onSelectAudioTrack(nil)
+                } else if let ordinal = Int(item.id.dropFirst("track-".count)) {
+                    onSelectAudioTrack(ordinal)
+                }
             }
-        }
+        )
         .disabled(currentVersion == nil || audioOptions.isEmpty)
     }
 
@@ -90,43 +106,47 @@ struct TVPlaybackActionSelectors: View {
             icon: "captions.bubble",
             title: "Subtitles",
             accessibilityLabel: "Subtitles, \(subtitleValue)",
-            stabilizesFocusMotion: true
-        ) {
-            Button { onSelectSubtitleTrack(nil) } label: {
-                menuItem(
-                    title: "Auto",
-                    detail: "Use your subtitle preferences",
-                    isSelected: selectedSubtitleTrackIndex == nil
-                )
-            }
-            Button { onSelectSubtitleTrack(-1) } label: {
-                menuItem(
-                    title: "Off",
-                    detail: "Start without subtitles",
-                    isSelected: selectedSubtitleTrackIndex == -1
-                )
-            }
-            ForEach(subtitleOptions) { option in
-                if option.isSelectable, let selectionIndex = option.selectionIndex {
-                    Button { onSelectSubtitleTrack(selectionIndex) } label: {
-                        menuItem(
-                            title: option.title,
-                            detail: option.detail,
-                            isSelected: option.isSelected
-                        )
+            stabilizesFocusMotion: true,
+            menuTitle: "Subtitles",
+            items: {
+                [
+                    TVActionPopoverItem(
+                        id: "auto",
+                        title: "Auto",
+                        detail: "Use your subtitle preferences",
+                        isSelected: selectedSubtitleTrackIndex == nil
+                    ),
+                    TVActionPopoverItem(
+                        id: "off",
+                        title: "Off",
+                        detail: "Start without subtitles",
+                        isSelected: selectedSubtitleTrackIndex == -1
+                    ),
+                ] + subtitleOptions.map { option in
+                    TVActionPopoverItem(
+                        id: "sub-\(option.stableId)",
+                        title: option.title,
+                        detail: option.detail,
+                        isSelected: option.isSelected,
+                        isEnabled: option.isSelectable && option.selectionIndex != nil
+                    )
+                }
+            },
+            onSelect: { item in
+                switch item.id {
+                case "auto":
+                    onSelectSubtitleTrack(nil)
+                case "off":
+                    onSelectSubtitleTrack(-1)
+                default:
+                    let stableId = String(item.id.dropFirst("sub-".count))
+                    if let option = subtitleOptions.first(where: { $0.stableId == stableId }),
+                       let selectionIndex = option.selectionIndex {
+                        onSelectSubtitleTrack(selectionIndex)
                     }
-                } else {
-                    Button { } label: {
-                        menuItem(
-                            title: option.title,
-                            detail: option.detail,
-                            isSelected: false
-                        )
-                    }
-                    .disabled(true)
                 }
             }
-        }
+        )
         .disabled(currentVersion == nil)
     }
 
@@ -181,16 +201,6 @@ struct TVPlaybackActionSelectors: View {
 
     private func versionDetail(_ version: FileVersion) -> String {
         DetailPlaybackFormatting.versionDetailLabel(version)
-    }
-
-    @ViewBuilder
-    private func menuItem(title: String, detail: String, isSelected: Bool) -> some View {
-        let label = detail.isEmpty ? title : "\(title) — \(detail)"
-        if isSelected {
-            Label(label, systemImage: "checkmark")
-        } else {
-            Text(label)
-        }
     }
 }
 

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeasonDetailView.swift
@@ -120,6 +120,7 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
                 episodeSectionId: episodeSectionScrollId,
                 heroId: heroScrollId
             )
+            .tvActionPopoverHost()
         }
     }
 
@@ -183,29 +184,46 @@ struct TVSeasonDetailView<BelowSynopsis: View>: View {
         )
     }
 
-    @ViewBuilder
+    private enum MoreAction: String {
+        case favorite, watched, series
+    }
+
     private var moreMenu: some View {
-        TVCircleMenuButton(title: "More", accessibilityLabel: "More options") {
-            Button(action: onToggleFavorite) {
-                Label(
-                    isFavorite ? "Remove from Favorites" : "Add to Favorites",
-                    systemImage: isFavorite ? "heart.fill" : "heart"
-                )
-            }
-            Button(action: onToggleWatched) {
-                Label(
-                    isWatched ? "Mark Season Unwatched" : "Mark Season Watched",
-                    systemImage: isWatched ? "checkmark.circle.fill" : "checkmark.circle"
-                )
-            }
-            if let seriesId = detail.seriesId {
-                Button {
-                    onNavigateToItem(seriesId)
-                } label: {
-                    Label("Go to Series", systemImage: "tv")
+        TVCircleMenuButton(
+            title: "More",
+            accessibilityLabel: "More options",
+            items: {
+                var items: [TVActionPopoverItem] = [
+                    TVActionPopoverItem(
+                        id: MoreAction.favorite.rawValue,
+                        title: isFavorite ? "Remove from Favorites" : "Add to Favorites",
+                        systemImage: isFavorite ? "heart.fill" : "heart"
+                    ),
+                    TVActionPopoverItem(
+                        id: MoreAction.watched.rawValue,
+                        title: isWatched ? "Mark Season Unwatched" : "Mark Season Watched",
+                        systemImage: isWatched ? "checkmark.circle.fill" : "checkmark.circle"
+                    ),
+                ]
+                if detail.seriesId != nil {
+                    items.append(TVActionPopoverItem(
+                        id: MoreAction.series.rawValue,
+                        title: "Go to Series",
+                        systemImage: "tv"
+                    ))
+                }
+                return items
+            },
+            onSelect: { item in
+                switch MoreAction(rawValue: item.id) {
+                case .favorite: onToggleFavorite()
+                case .watched: onToggleWatched()
+                case .series:
+                    if let seriesId = detail.seriesId { onNavigateToItem(seriesId) }
+                case .none: break
                 }
             }
-        }
+        )
     }
 
     private var nextUpEpisode: EpisodeListItem? {

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -316,6 +316,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                     episodeSectionId: episodeSectionScrollId,
                     heroId: heroScrollId
                 )
+                .tvActionPopoverHost()
             }
         }
         .onAppear {
@@ -1138,37 +1139,55 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         )
     }
 
+    private enum MoreAction: String {
+        case overview, favorite, watched, trailers
+    }
+
     private var moreMenu: some View {
         TVCircleMenuButton(
             title: "More",
             accessibilityLabel: "More options",
-            stabilizesFocusMotion: true
-        ) {
-            if !isShowingSeriesOverview {
-                Button(action: showSeriesOverview) {
-                    Label("Show Series Info", systemImage: "info.circle")
+            stabilizesFocusMotion: true,
+            items: {
+                var items: [TVActionPopoverItem] = []
+                if !isShowingSeriesOverview {
+                    items.append(TVActionPopoverItem(
+                        id: MoreAction.overview.rawValue,
+                        title: "Show Series Info",
+                        systemImage: "info.circle"
+                    ))
                 }
-            }
-            Button(action: onToggleFavorite) {
-                Label(
-                    isFavorite ? "Remove from Favorites" : "Add to Favorites",
+                items.append(TVActionPopoverItem(
+                    id: MoreAction.favorite.rawValue,
+                    title: isFavorite ? "Remove from Favorites" : "Add to Favorites",
                     systemImage: isFavorite ? "heart.fill" : "heart"
-                )
-            }
-            if selectedSeason != nil {
-                Button(action: onToggleWatched) {
-                    Label(
-                        isWatched ? "Mark Season Unwatched" : "Mark Season Watched",
+                ))
+                if selectedSeason != nil {
+                    items.append(TVActionPopoverItem(
+                        id: MoreAction.watched.rawValue,
+                        title: isWatched ? "Mark Season Unwatched" : "Mark Season Watched",
                         systemImage: isWatched ? "checkmark.circle.fill" : "checkmark.circle"
-                    )
+                    ))
+                }
+                if supportsTrailerFetch {
+                    items.append(TVActionPopoverItem(
+                        id: MoreAction.trailers.rawValue,
+                        title: "Find Trailers",
+                        systemImage: "film.stack"
+                    ))
+                }
+                return items
+            },
+            onSelect: { item in
+                switch MoreAction(rawValue: item.id) {
+                case .overview: showSeriesOverview()
+                case .favorite: onToggleFavorite()
+                case .watched: onToggleWatched()
+                case .trailers: onFindTrailers()
+                case .none: break
                 }
             }
-            if supportsTrailerFetch {
-                Button(action: onFindTrailers) {
-                    Label("Find Trailers", systemImage: "film.stack")
-                }
-            }
-        }
+        )
     }
 
     // MARK: - Episode state and version selection


### PR DESCRIPTION
## Summary

- Replace tvOS detail action menus with an instant popover presentation.
- Simplify playback and season selectors so their focused controls remain directly activatable, including VoiceOver support.
- Consolidate tvOS focus guidance around native focus sections, scopes, and composite controls.
- Simplify iOS control reconnect handling and remove the unused Apple push display-token flow.

AI disclosure: Generated with GPT-5 using the Codex agent harness.

## Testing

- Not run.