### PR TITLE
fix(ios): enlarge Continue Watching cards

### DIFF
--- a/iosApp/iosApp/Screens/Home/Feed/HomeFeedKit.swift
+++ b/iosApp/iosApp/Screens/Home/Feed/HomeFeedKit.swift
@@ -19,11 +19,12 @@ enum HomeFeedMetrics {
     static let posterWidth: CGFloat = 132
     /// Poster Wall trades size for count.
     static let densePosterWidth: CGFloat = 104
-    /// 16:9 still used by resume rows. Tuned so a still row shows the same
-    /// "two cards plus a peek" as a poster row — at 210 the stills were
-    /// noticeably less dense than the 132pt posters directly below them, which
-    /// made the page rhythm feel inconsistent as you scrolled.
-    static let stillWidth: CGFloat = 184
+    /// 16:9 still used by resume rows. Continue Watching is the row people
+    /// act on most, so it reads as "one card plus a peek" rather than matching
+    /// the poster rows' density — at 184 the stills felt like thumbnails and
+    /// the progress rail was hard to read. Android's backdrop card is 280dp.
+    /// Scaled by the Poster Size setting at the call site.
+    static let stillWidth: CGFloat = 240
     /// Runway under the last row so captions clear the floating tab bar.
     static let bottomRunway: CGFloat = 96
 


### PR DESCRIPTION
## Problem

Continue Watching cards on iPhone are too small. The Home feed rewrite in #106 set the 16:9 resume still width to 184pt so the row matched the density of the 132pt poster rows. At that size the cards read as thumbnails and the progress rail is hard to see. The Poster Size setting was already applied to these cards, so the base value was the issue.

## Solution

Raise the base still width in `HomeFeedMetrics.stillWidth` from 184pt to 240pt and update the comment. The Poster Size scale still applies at the call site.

| Poster Size | Before | After |
|---|---|---|
| Compact | 158pt | 206pt |
| Standard | 184pt | 240pt |
| Large | 221pt | 288pt |

Android's equivalent backdrop card is 280dp, also scaled by its poster size setting, so this moves the platforms closer together.

## Validation

- iOS simulator build (iPhone 17 Pro) succeeded.
- Signed build installed and launched on a physical iPhone via the Studio deploy helper.
- No screenshots captured. Before/after images to follow if requested.

## Risks

- Cosmetic only. If 240pt feels too wide at Large, 220pt is the next step down.

## AI disclosure

Written with Claude Fable 5.1 (`claude-fable-5-1`) via Claude Code. No other AI tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased the width of resume cards on the home feed.
  * Updated sizing documentation to reflect the larger 16:9 card layout and poster scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->