### PR TITLE
chore(deps): move AetherEngine to a Silo-Server fork at 6.67.2 and fix its attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,4 +149,6 @@ must remove or replace the brand assets. Publishing a Silo-branded app to an app
 store requires written permission. See [TRADEMARK.md](TRADEMARK.md) for what's
 permitted — including referential use like "compatible with Silo."
 
-FFmpeg, Nuke, fastlane, and other third-party dependencies retain their own licenses. See [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
+Media playback is built on [AetherEngine](https://github.com/superuser404notfound/AetherEngine)
+by Vincent Herbst, used under LGPL-3.0 with its Apple Store / DRM exception.
+AetherEngine, FFmpeg, Nuke, fastlane, and other third-party dependencies retain their own licenses. See [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -15,7 +15,7 @@ The authoritative dependency lock is
 
 | Component | Exact revision | Shipped form | License |
 | --- | --- | --- | --- |
-| AetherEngine 6.67.2 + Silo handover patch | `dfe11a08489fc6486b233773655a652f15f6ff4a` | Swift package target linked into each host app | LGPL-3.0-only with AetherEngine's Apple Store / DRM exception |
+| AetherEngine 6.67.2 + Silo handover patch | `745de1ccdc4b226adccdf18f03a28071f0e972d5` | Swift package target linked into each host app | LGPL-3.0-only with AetherEngine's Apple Store / DRM exception |
 | FFmpegBuild 3.0.0 | `421e13be7061de67d91b85ac34a6b22a002b164f` | Nine separately embedded dynamic frameworks | See the component table below |
 | LibDovi 2.1.0 | `0d7cce1d6836a30d13a3a2326e50a153af53f014` | Static `Dovi.xcframework` linked through AetherEngine | MIT packaging; embedded libdovi is MIT |
 | Nuke and NukeUI 13.2.0 | `30f7a7e72e0607d304fbf69c799474bd5fb6d1ce` | Swift package targets linked into each host app | MIT |
@@ -39,7 +39,7 @@ satisfies the license's source obligation for modified code. The bundled
 acknowledgements include AetherEngine's complete license and exception plus
 the GNU GPL version 3 text incorporated by LGPLv3.
 
-- Exact source: <https://github.com/Silo-Server/AetherEngine/tree/dfe11a08489fc6486b233773655a652f15f6ff4a>
+- Exact source: <https://github.com/Silo-Server/AetherEngine/tree/745de1ccdc4b226adccdf18f03a28071f0e972d5>
   (fork branch `silo/host-requested-item-handover`)
 - Upstream base: <https://github.com/superuser404notfound/AetherEngine/tree/6.67.2>
 - Rebuild input: `Package.swift` and the source tree at that revision

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -15,7 +15,7 @@ The authoritative dependency lock is
 
 | Component | Exact revision | Shipped form | License |
 | --- | --- | --- | --- |
-| AetherEngine 6.34.0 | `0ae80496ab6f3fda135f43ef195ff10961c0e625` | Swift package target linked into each host app | LGPL-3.0-only with AetherEngine's Apple Store / DRM exception |
+| AetherEngine 6.34.0 + Silo handover patches | `653be639441d3f7d06332a2f995950497ad62e0f` | Swift package target linked into each host app | LGPL-3.0-only with AetherEngine's Apple Store / DRM exception |
 | FFmpegBuild 2.4.3 | `b2185fa842b829cd53d182a5e9a53182c1d9c84c` | Nine separately embedded dynamic frameworks | See the component table below |
 | LibDovi 2.0.0 | `89be93431c2a5f2e54fb77e93059071b8d2ddb3a` | Static `Dovi.xcframework` linked through AetherEngine | MIT packaging; embedded libdovi is MIT |
 | Nuke and NukeUI 13.2.0 | `30f7a7e72e0607d304fbf69c799474bd5fb6d1ce` | Swift package targets linked into each host app | MIT |
@@ -31,11 +31,17 @@ included here.
 Copyright (C) 2026 Vincent Herbst.
 
 AetherEngine is licensed under GNU LGPL version 3 with its upstream Apple
-Store / DRM exception. Silo uses the source unmodified at the exact revision
-above. The bundled acknowledgements include AetherEngine's complete license
-and exception plus the GNU GPL version 3 text incorporated by LGPLv3.
+Store / DRM exception. Silo builds a published fork revision: upstream release
+`6.34.0` plus five commits that retain native `AVPlayerItem`s across episode
+handover and add the `prepareForItemReplacement()` entry point Silo calls.
+Those modifications are published under the LGPL on the fork branch below,
+which satisfies the license's source obligation for modified code. The bundled
+acknowledgements include AetherEngine's complete license and exception plus
+the GNU GPL version 3 text incorporated by LGPLv3.
 
-- Exact source: <https://github.com/superuser404notfound/AetherEngine/tree/0ae80496ab6f3fda135f43ef195ff10961c0e625>
+- Exact source: <https://github.com/blurbery/AetherEngine/tree/653be639441d3f7d06332a2f995950497ad62e0f>
+  (fork branch `fix/native-handover-state`)
+- Upstream base: <https://github.com/superuser404notfound/AetherEngine/tree/6.34.0>
 - Rebuild input: `Package.swift` and the source tree at that revision
 - Bundled texts: `AetherEngine-LGPL-3.0-App-Store-Exception.txt`,
   `GPL-3.0.txt`
@@ -43,8 +49,9 @@ and exception plus the GNU GPL version 3 text incorporated by LGPLv3.
 The exception permits Apple App Store and TestFlight distribution despite
 store signing, DRM, and relinking restrictions. It does not waive source-code
 obligations: the exact-revision link above must stay current for each release,
-and any downstream modifications must be published under the LGPL. Silo ships
-the source unmodified, so the pointer is the whole obligation.
+and any downstream modifications must be published under the LGPL. The fork
+branch above is that publication; keep it public for as long as builds that
+link this revision are distributed.
 
 ## FFmpegBuild and its component libraries
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -15,9 +15,9 @@ The authoritative dependency lock is
 
 | Component | Exact revision | Shipped form | License |
 | --- | --- | --- | --- |
-| AetherEngine 6.34.0 + Silo handover patches | `653be639441d3f7d06332a2f995950497ad62e0f` | Swift package target linked into each host app | LGPL-3.0-only with AetherEngine's Apple Store / DRM exception |
-| FFmpegBuild 2.4.3 | `b2185fa842b829cd53d182a5e9a53182c1d9c84c` | Nine separately embedded dynamic frameworks | See the component table below |
-| LibDovi 2.0.0 | `89be93431c2a5f2e54fb77e93059071b8d2ddb3a` | Static `Dovi.xcframework` linked through AetherEngine | MIT packaging; embedded libdovi is MIT |
+| AetherEngine 6.67.2 + Silo handover patch | `dfe11a08489fc6486b233773655a652f15f6ff4a` | Swift package target linked into each host app | LGPL-3.0-only with AetherEngine's Apple Store / DRM exception |
+| FFmpegBuild 3.0.0 | `421e13be7061de67d91b85ac34a6b22a002b164f` | Nine separately embedded dynamic frameworks | See the component table below |
+| LibDovi 2.1.0 | `0d7cce1d6836a30d13a3a2326e50a153af53f014` | Static `Dovi.xcframework` linked through AetherEngine | MIT packaging; embedded libdovi is MIT |
 | Nuke and NukeUI 13.2.0 | `30f7a7e72e0607d304fbf69c799474bd5fb6d1ce` | Swift package targets linked into each host app | MIT |
 
 SwiftPM also resolves SMBClient 0.3.1 because AetherEngine publishes an
@@ -32,16 +32,16 @@ Copyright (C) 2026 Vincent Herbst.
 
 AetherEngine is licensed under GNU LGPL version 3 with its upstream Apple
 Store / DRM exception. Silo builds a published fork revision: upstream release
-`6.34.0` plus five commits that retain native `AVPlayerItem`s across episode
-handover and add the `prepareForItemReplacement()` entry point Silo calls.
-Those modifications are published under the LGPL on the fork branch below,
-which satisfies the license's source obligation for modified code. The bundled
+`6.67.2` plus one commit that lets a host request the in-place native item
+handover on a foreground episode change through `prepareForItemReplacement()`.
+That modification is published under the LGPL on the fork branch below, which
+satisfies the license's source obligation for modified code. The bundled
 acknowledgements include AetherEngine's complete license and exception plus
 the GNU GPL version 3 text incorporated by LGPLv3.
 
-- Exact source: <https://github.com/blurbery/AetherEngine/tree/653be639441d3f7d06332a2f995950497ad62e0f>
-  (fork branch `fix/native-handover-state`)
-- Upstream base: <https://github.com/superuser404notfound/AetherEngine/tree/6.34.0>
+- Exact source: <https://github.com/Silo-Server/AetherEngine/tree/dfe11a08489fc6486b233773655a652f15f6ff4a>
+  (fork branch `silo/host-requested-item-handover`)
+- Upstream base: <https://github.com/superuser404notfound/AetherEngine/tree/6.67.2>
 - Rebuild input: `Package.swift` and the source tree at that revision
 - Bundled texts: `AetherEngine-LGPL-3.0-App-Store-Exception.txt`,
   `GPL-3.0.txt`
@@ -61,22 +61,28 @@ dynamic frameworks:
 
 | Frameworks | Upstream input | License |
 | --- | --- | --- |
-| Libavcodec, Libavformat, Libavutil, Libswresample, Libswscale, Libavfilter | FFmpeg `n8.1.2` (currently `38b88335f99e76ed89ff3c93f877fdefce736c13`) | LGPL-2.1-or-later |
-| Libdav1d | dav1d `1.5.1` (currently `42b2b24fb8819f1ed3643aa9cf2a62f03868e3aa`) | BSD-2-Clause |
-| Libzimg | zimg `release-3.0.5` (currently `e5b0de6bebbcbc66732ed5afaafef6b2c7dfef87`) | WTFPL-2.0 |
-| Libzvbi | libzvbi `v0.2.44` (currently `5169a428d51c3ae8ff7b0897e8a687d8e05e37b5`) | LGPL-2.0-or-later, conveyed under LGPL-2.1; `src/ure.c` is MIT |
+| AetherLibavcodec, AetherLibavformat, AetherLibavutil, AetherLibswresample, AetherLibswscale, AetherLibavfilter | FFmpeg `n8.1.2` (currently `38b88335f99e76ed89ff3c93f877fdefce736c13`) | LGPL-2.1-or-later |
+| AetherLibdav1d | dav1d `1.5.4` (currently `54706fc6bc0cdecab7e9593974a4039cc038fca7`) | BSD-2-Clause |
+| AetherLibzimg | zimg `release-3.0.6` (currently `f819b14e8f39d1282400b0d9543e8ef73c1b2bbd`) | WTFPL-2.0 |
+| AetherLibzvbi | libzvbi `v0.2.45` (currently `d3a5ee9f2b047bf16cd1ee5ccf6ec05ee75409d0`) | LGPL-2.0-or-later, conveyed under LGPL-2.1; `src/ure.c` is MIT |
 
-The exact FFmpegBuild 2.4.3 `build.sh` is the rebuild recipe and patch record:
+FFmpegBuild 3.0.0 renamed every target, framework bundle, and install name
+with an `Aether` prefix so the build can coexist with another FFmpeg in the
+same app; the binaries are the same as 2.5.0. The exact FFmpegBuild 3.0.0
+`build.sh` is the rebuild recipe and patch record:
 
 - it builds FFmpeg with dynamic linkage and does not enable GPL, version-3,
   or nonfree FFmpeg components;
 - it removes libzvbi's three GPL-family source files (`packet-830.c`, `pdc.c`,
   and `exp-vtx.c`) before compilation and publishes the LGPL replacement stubs;
 - it records its FFmpeg, dav1d, zimg, and libzvbi tags and every downstream
-  patch applied to those sources.
+  patch applied to those sources;
+- it does not build the FFmpeg `concat` demuxer, which 2.5.0 removed.
 
-The commit IDs in the table are the tags' dereferenced values observed on
-2026-08-22. FFmpegBuild's script records tag names rather than immutable
+libzvbi 0.2.45 is the GHSA-86rm-g7qf-j2fh security update (out-of-bounds
+read, out-of-bounds write, integer underflow reachable through the teletext
+decoder). The commit IDs in the table are the tags' dereferenced values
+observed on 2026-09-04. FFmpegBuild's script records tag names rather than immutable
 upstream commit IDs; recording the dereferenced commits here pins them if the
 tags ever move. Forking the pinned FFmpegBuild revision is cheap,
 commit-immutable insurance if stronger provenance is ever wanted, but the
@@ -89,12 +95,12 @@ inventory against each release archive; debug evidence is not a release
 substitute.
 
 - Exact packaging source and rebuild script:
-  <https://github.com/superuser404notfound/FFmpegBuild/tree/b2185fa842b829cd53d182a5e9a53182c1d9c84c>
+  <https://github.com/superuser404notfound/FFmpegBuild/tree/421e13be7061de67d91b85ac34a6b22a002b164f>
 - Current upstream tag resolutions:
   [FFmpeg](https://github.com/FFmpeg/FFmpeg/tree/38b88335f99e76ed89ff3c93f877fdefce736c13),
-  [dav1d](https://code.videolan.org/videolan/dav1d/-/tree/42b2b24fb8819f1ed3643aa9cf2a62f03868e3aa),
-  [zimg](https://github.com/sekrit-twc/zimg/tree/e5b0de6bebbcbc66732ed5afaafef6b2c7dfef87),
-  and [libzvbi](https://github.com/zapping-vbi/zvbi/tree/5169a428d51c3ae8ff7b0897e8a687d8e05e37b5)
+  [dav1d](https://code.videolan.org/videolan/dav1d/-/tree/54706fc6bc0cdecab7e9593974a4039cc038fca7),
+  [zimg](https://github.com/sekrit-twc/zimg/tree/f819b14e8f39d1282400b0d9543e8ef73c1b2bbd),
+  and [libzvbi](https://github.com/zapping-vbi/zvbi/tree/d3a5ee9f2b047bf16cd1ee5ccf6ec05ee75409d0)
 - Bundled texts: `FFmpegBuild-LGPL-2.1.txt`,
   `dav1d-BSD-2-Clause.txt`, `zimg-WTFPL.txt`, `libzvbi-ure-MIT.txt`
 
@@ -106,23 +112,23 @@ a substitute for a final release archive scan.
 
 LibDovi's packaging and rebuild script are MIT licensed, Copyright (c) 2026
 Vincent Herbst. Its `Dovi.xcframework` contains the static `dolby_vision`
-3.3.2 crate built from dovi_tool tag `libdovi-3.3.2`, exact upstream revision
-`4fd2b2235c9f93582dd4a00e65ee34a07800afd7`, under the MIT license,
-Copyright (c) 2025 quietvoid.
+3.4.0 crate built from dovi_tool tag `libdovi-3.4.0`, exact upstream revision
+`d1abe0e27ff2c7ab3339614d06db9f8a058af6b2`, under the MIT license,
+Copyright (c) 2026 quietvoid.
 
 As with FFmpegBuild, LibDovi's rebuild script clones the tag name rather than
 an immutable commit. The commit above is the tag's value observed on
-2026-08-22; preserve the actual release source alongside the static library.
+2026-09-04; preserve the actual release source alongside the static library.
 LibDovi's packaging `LICENSE` describes the embedded crate as dual MIT or
-Apache-2.0, but the exact `libdovi-3.3.2` source's `LICENSE` and Cargo manifest
+Apache-2.0, but the exact `libdovi-3.4.0` source's `LICENSE` and Cargo manifest
 declare MIT. The bundled files reproduce the packaging license unmodified and
 also include quietvoid's controlling MIT text; this notice uses MIT for the
 embedded crate.
 
 - Exact packaging source and rebuild script:
-  <https://github.com/superuser404notfound/LibDovi/tree/89be93431c2a5f2e54fb77e93059071b8d2ddb3a>
+  <https://github.com/superuser404notfound/LibDovi/tree/0d7cce1d6836a30d13a3a2326e50a153af53f014>
 - Exact embedded crate source:
-  <https://github.com/quietvoid/dovi_tool/tree/4fd2b2235c9f93582dd4a00e65ee34a07800afd7/dolby_vision>
+  <https://github.com/quietvoid/dovi_tool/tree/d1abe0e27ff2c7ab3339614d06db9f8a058af6b2/dolby_vision>
 - Bundled texts: `LibDovi-Packaging-MIT.txt`, `libdovi-MIT.txt`
 
 ## Nuke and NukeUI

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -88,11 +88,13 @@ tags ever move. Forking the pinned FFmpegBuild revision is cheap,
 commit-immutable insurance if stronger provenance is ever wanted, but the
 exact-revision links satisfy the source pointer as they stand.
 
-The checked iOS debug app embeds exactly the nine frameworks in the table,
-and its FFmpeg configure strings contain `--enable-shared` without
-`--enable-gpl`, `--enable-version3`, or nonfree enablement. Repeat this
-inventory against each release archive; debug evidence is not a release
-substitute.
+A tvOS Simulator debug build against FFmpegBuild 3.0.0, inspected on
+2026-09-04, embeds exactly the nine `Aether`-prefixed frameworks in the table
+under `SiloTV.app/Frameworks/`, its `AetherLibavcodec` configure string
+contains `--enable-shared` without `--enable-gpl`, `--enable-version3`, or
+nonfree enablement, and the app binary exports no `avcodec_`/`avformat_`
+symbols of its own. Repeat this inventory against each release archive;
+debug evidence is not a release substitute.
 
 - Exact packaging source and rebuild script:
   <https://github.com/superuser404notfound/FFmpegBuild/tree/421e13be7061de67d91b85ac34a6b22a002b164f>

--- a/iosApp/Resources/OpenSourceLicenses/README.txt
+++ b/iosApp/Resources/OpenSourceLicenses/README.txt
@@ -6,11 +6,11 @@ texts are bundled beside this file and are available from Settings > About >
 Open Source Licenses.
 
 AetherEngine
-  Revision: dfe11a08489fc6486b233773655a652f15f6ff4a (upstream release
-  6.67.2 plus one Silo-published patch that lets the host request the
+  Revision: 745de1ccdc4b226adccdf18f03a28071f0e972d5 (upstream release
+  6.67.2 plus two Silo-published patches that let the host request the
   in-place native item handover on an episode change)
   License: GNU LGPL version 3 with the upstream Apple Store / DRM exception
-  Source (modified, as built): https://github.com/Silo-Server/AetherEngine/tree/dfe11a08489fc6486b233773655a652f15f6ff4a
+  Source (modified, as built): https://github.com/Silo-Server/AetherEngine/tree/745de1ccdc4b226adccdf18f03a28071f0e972d5
   Upstream base: https://github.com/superuser404notfound/AetherEngine/tree/6.67.2
   Rebuild: the Package.swift and source tree at that revision
 

--- a/iosApp/Resources/OpenSourceLicenses/README.txt
+++ b/iosApp/Resources/OpenSourceLicenses/README.txt
@@ -6,27 +6,27 @@ texts are bundled beside this file and are available from Settings > About >
 Open Source Licenses.
 
 AetherEngine
-  Revision: 653be639441d3f7d06332a2f995950497ad62e0f (upstream release
-  6.34.0 plus five Silo-published patches for native item handoff and
-  session retirement)
+  Revision: dfe11a08489fc6486b233773655a652f15f6ff4a (upstream release
+  6.67.2 plus one Silo-published patch that lets the host request the
+  in-place native item handover on an episode change)
   License: GNU LGPL version 3 with the upstream Apple Store / DRM exception
-  Source (modified, as built): https://github.com/blurbery/AetherEngine/tree/653be639441d3f7d06332a2f995950497ad62e0f
-  Upstream base: https://github.com/superuser404notfound/AetherEngine/tree/6.34.0
+  Source (modified, as built): https://github.com/Silo-Server/AetherEngine/tree/dfe11a08489fc6486b233773655a652f15f6ff4a
+  Upstream base: https://github.com/superuser404notfound/AetherEngine/tree/6.67.2
   Rebuild: the Package.swift and source tree at that revision
 
 FFmpegBuild and embedded media frameworks
-  Revision: b2185fa842b829cd53d182a5e9a53182c1d9c84c (release 2.4.3)
-  Source and rebuild script: https://github.com/superuser404notfound/FFmpegBuild/tree/b2185fa842b829cd53d182a5e9a53182c1d9c84c
+  Revision: 421e13be7061de67d91b85ac34a6b22a002b164f (release 3.0.0)
+  Source and rebuild script: https://github.com/superuser404notfound/FFmpegBuild/tree/421e13be7061de67d91b85ac34a6b22a002b164f
 
   Components built by that revision:
   - FFmpeg n8.1.2, currently 38b88335f99e76ed89ff3c93f877fdefce736c13:
     LGPL-2.1-or-later
-  - dav1d 1.5.1, currently 42b2b24fb8819f1ed3643aa9cf2a62f03868e3aa:
+  - dav1d 1.5.4, currently 54706fc6bc0cdecab7e9593974a4039cc038fca7:
     BSD-2-Clause
-  - zimg release-3.0.5, currently
-    e5b0de6bebbcbc66732ed5afaafef6b2c7dfef87: WTFPL-2.0
-  - libzvbi v0.2.44, currently
-    5169a428d51c3ae8ff7b0897e8a687d8e05e37b5: LGPL-2.0-or-later,
+  - zimg release-3.0.6, currently
+    f819b14e8f39d1282400b0d9543e8ef73c1b2bbd: WTFPL-2.0
+  - libzvbi v0.2.45, currently
+    d3a5ee9f2b047bf16cd1ee5ccf6ec05ee75409d0: LGPL-2.0-or-later,
     conveyed under LGPL-2.1;
     src/ure.c retains its MIT notice
 
@@ -34,24 +34,25 @@ FFmpegBuild and embedded media frameworks
   nonfree components. FFmpegBuild removes the three GPL libzvbi source files
   before compilation and publishes the replacement stubs and patches in its
   build.sh. The app embeds these nine libraries as separate dynamic
-  frameworks: Libavcodec, Libavformat, Libavutil, Libswresample, Libswscale,
-  Libavfilter, Libdav1d, Libzimg, and Libzvbi.
+  frameworks: AetherLibavcodec, AetherLibavformat, AetherLibavutil,
+  AetherLibswresample, AetherLibswscale, AetherLibavfilter, AetherLibdav1d,
+  AetherLibzimg, and AetherLibzvbi.
 
-  "Currently" records the tags' dereferenced values observed on 2026-08-22.
+  "Currently" records the tags' dereferenced values observed on 2026-09-04.
   FFmpegBuild's script records tag names rather than immutable upstream
   commit IDs; the dereferenced commits recorded here pin the exact sources if
   those tags ever move.
 
 LibDovi / libdovi
-  Packaging revision: 89be93431c2a5f2e54fb77e93059071b8d2ddb3a
-  (release 2.0.0)
+  Packaging revision: 0d7cce1d6836a30d13a3a2326e50a153af53f014
+  (release 2.1.0)
   Packaging license: MIT
-  Packaging source and rebuild script: https://github.com/superuser404notfound/LibDovi/tree/89be93431c2a5f2e54fb77e93059071b8d2ddb3a
-  Embedded crate: dolby_vision 3.3.2 from dovi_tool tag libdovi-3.3.2,
-  revision 4fd2b2235c9f93582dd4a00e65ee34a07800afd7, under MIT
-  Crate source: https://github.com/quietvoid/dovi_tool/tree/4fd2b2235c9f93582dd4a00e65ee34a07800afd7/dolby_vision
+  Packaging source and rebuild script: https://github.com/superuser404notfound/LibDovi/tree/0d7cce1d6836a30d13a3a2326e50a153af53f014
+  Embedded crate: dolby_vision 3.4.0 from dovi_tool tag libdovi-3.4.0,
+  revision d1abe0e27ff2c7ab3339614d06db9f8a058af6b2, under MIT
+  Crate source: https://github.com/quietvoid/dovi_tool/tree/d1abe0e27ff2c7ab3339614d06db9f8a058af6b2/dolby_vision
   The build script records the tag name, and the commit above is the tag value
-  observed on 2026-08-22; preserve the actual release source with the binary.
+  observed on 2026-09-04; preserve the actual release source with the binary.
   The packaging license calls the crate dual MIT/Apache, while this exact
   crate tag declares MIT in its LICENSE and Cargo manifest. Both the unchanged
   packaging license and quietvoid's controlling MIT text are included here.

--- a/iosApp/Resources/OpenSourceLicenses/README.txt
+++ b/iosApp/Resources/OpenSourceLicenses/README.txt
@@ -6,9 +6,12 @@ texts are bundled beside this file and are available from Settings > About >
 Open Source Licenses.
 
 AetherEngine
-  Revision: 653be639441d3f7d06332a2f995950497ad62e0f (release 6.34.0 + native item handoff and session retirement fixes)
+  Revision: 653be639441d3f7d06332a2f995950497ad62e0f (upstream release
+  6.34.0 plus five Silo-published patches for native item handoff and
+  session retirement)
   License: GNU LGPL version 3 with the upstream Apple Store / DRM exception
-  Source: https://github.com/blurbery/AetherEngine/tree/653be639441d3f7d06332a2f995950497ad62e0f
+  Source (modified, as built): https://github.com/blurbery/AetherEngine/tree/653be639441d3f7d06332a2f995950497ad62e0f
+  Upstream base: https://github.com/superuser404notfound/AetherEngine/tree/6.34.0
   Rebuild: the Package.swift and source tree at that revision
 
 FFmpegBuild and embedded media frameworks

--- a/iosApp/Resources/OpenSourceLicenses/libdovi-MIT.txt
+++ b/iosApp/Resources/OpenSourceLicenses/libdovi-MIT.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 quietvoid
+Copyright (c) 2026 quietvoid
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/iosApp/Silo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iosApp/Silo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,12 @@
 {
-  "originHash" : "b7c5b14da80f57c3689e219e5a42cefed8e7994487f250297681a712439324ca",
+  "originHash" : "efcbb8a8efc97001346ee5252ee308ec44f23fbdfba44fb63c2541dc6b1c51c8",
   "pins" : [
     {
       "identity" : "aetherengine",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/blurbery/AetherEngine",
+      "location" : "https://github.com/Silo-Server/AetherEngine",
       "state" : {
-        "revision" : "653be639441d3f7d06332a2f995950497ad62e0f"
+        "revision" : "dfe11a08489fc6486b233773655a652f15f6ff4a"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/superuser404notfound/FFmpegBuild",
       "state" : {
-        "revision" : "b2185fa842b829cd53d182a5e9a53182c1d9c84c",
-        "version" : "2.4.3"
+        "revision" : "421e13be7061de67d91b85ac34a6b22a002b164f",
+        "version" : "3.0.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/superuser404notfound/LibDovi",
       "state" : {
-        "revision" : "89be93431c2a5f2e54fb77e93059071b8d2ddb3a",
-        "version" : "2.0.0"
+        "revision" : "0d7cce1d6836a30d13a3a2326e50a153af53f014",
+        "version" : "2.1.0"
       }
     },
     {

--- a/iosApp/Silo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iosApp/Silo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Silo-Server/AetherEngine",
       "state" : {
-        "revision" : "dfe11a08489fc6486b233773655a652f15f6ff4a"
+        "revision" : "745de1ccdc4b226adccdf18f03a28071f0e972d5"
       }
     },
     {

--- a/iosApp/iosApp/Shared/AppleDecodeCapabilities.swift
+++ b/iosApp/iosApp/Shared/AppleDecodeCapabilities.swift
@@ -86,8 +86,8 @@ enum AppleDecodeCapabilities {
     /// detailed entry below because ordinary H.264 is also hardware-backed.
     static let softwareVideoCodecs = ["av1", "vp9", "mpeg2video", "vc1"]
 
-    /// The complete online video manifest of AetherEngine 6.34.0 at
-    /// 0ae80496 with FFmpegBuild 2.4.3. Aether routes H.264, HEVC, and
+    /// The complete online video manifest of AetherEngine 6.67.2 with
+    /// FFmpegBuild 3.0.0 (same FFmpeg n8.1.2 decoder set as 2.4.3). Aether routes H.264, HEVC, and
     /// hardware-decodable AV1 natively when the exact probed stream permits;
     /// every other decoder present in the build goes through libavcodec.
     static let aetherOriginalHTTPVideoCodecs = [

--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -57,7 +57,7 @@ packages:
   # reviewed revision; Package.resolved also freezes its binary dependencies.
   AetherEngine:
     url: https://github.com/Silo-Server/AetherEngine
-    revision: dfe11a08489fc6486b233773655a652f15f6ff4a
+    revision: 745de1ccdc4b226adccdf18f03a28071f0e972d5
   Nuke:
     url: https://github.com/kean/Nuke
     from: "13.2.0"

--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -56,8 +56,8 @@ packages:
   # The only media engine in the replacement player. Keep this at an exact
   # reviewed revision; Package.resolved also freezes its binary dependencies.
   AetherEngine:
-    url: https://github.com/blurbery/AetherEngine
-    revision: 653be639441d3f7d06332a2f995950497ad62e0f
+    url: https://github.com/Silo-Server/AetherEngine
+    revision: dfe11a08489fc6486b233773655a652f15f6ff4a
   Nuke:
     url: https://github.com/kean/Nuke
     from: "13.2.0"


### PR DESCRIPTION
## Problem

The app was pinned to a personal fork of AetherEngine (`blurbery/AetherEngine@653be639`) frozen at upstream 6.34.0 with five local commits, and the shipped attribution did not describe that honestly:

- `THIRD_PARTY_NOTICES.md` recorded upstream commit `0ae80496` and claimed "Silo ships the source unmodified", while the build linked a modified fork revision.
- The fork was 63 commits behind upstream. That left out the 6.50.0 fix for the local HLS origin answering any host on the network, and the libzvbi GHSA-86rm-g7qf-j2fh security update.
- `README.md` credited FFmpeg and Nuke but not AetherEngine.

## Solution

**Engine.** A new fork under the org, [Silo-Server/AetherEngine](https://github.com/Silo-Server/AetherEngine), branch `silo/host-requested-item-handover`, is upstream 6.67.2 plus one commit (`dfe11a08`) that re-implements the #221 fix against current upstream: `prepareForItemReplacement()` lets a host request the AE#158 in-place item handover on a foreground episode change, so the engine-hosted `AVPlayerLayer` never goes itemless during Next Up autoplay. The one-shot request is consumed by the next `load()`, cancelled by `stop()`, and ignored on a non-native outgoing session. The native host retires the outgoing session's publishers before the successor subscribes, and queued main-actor KVO hops drop on the session guard. Upstream still gates that handover on PiP only; Sodalite avoids the gap by rendering through AVKit, which Silo does not.

**App.** `project.yml` and `Package.resolved` move to the fork. FFmpegBuild resolves to 3.0.0, which renames the nine embedded frameworks with an `Aether` prefix and updates dav1d, zimg, and libzvbi. LibDovi resolves to 2.1.0. No Silo call sites change: every engine API Silo uses exists unchanged at 6.67.2, and Silo has no direct FFmpeg imports.

**Attribution.** `THIRD_PARTY_NOTICES.md` and the in-app acknowledgements now name the fork branch as the modified source, the upstream `6.67.2` tag as its base, the LGPL publication obligation for the patch, and the resolved revisions of every transitive binary with tag values dereferenced on 2026-09-04. quietvoid's libdovi MIT text is refreshed to the 3.4.0 crate. `README.md` credits AetherEngine and Vincent Herbst.

## Validation

- Fork: `swift test` runs 2626 tests; the one failure (`Issue458AudioLanguageMetadataTests`, an ICU locale expectation) fails identically on unmodified 6.67.2 with this Mac's Xcode 27 beta. `xcodebuild build -scheme AetherEngine -destination 'generic/platform=tvOS Simulator'` succeeds.
- App: `Silo` (iOS Simulator), `SiloTV` (tvOS Simulator), and `SiloMac` all build. `SiloTV` installed and launched on the local Apple TV simulator via the mac-builder helper.
- FFmpegBuild 3.0.0 artifact: the tvOS Simulator debug bundle embeds exactly the nine `Aether`-prefixed frameworks, `AetherLibavcodec` carries `--enable-shared` with no GPL, version3, or nonfree flags, and the app binary exports no FFmpeg symbols. Recorded in `THIRD_PARTY_NOTICES.md`.
- Simulator autoplay transition renders correctly on the new engine. A separate pre-existing double load on every episode start was found during this test and is fixed in #247.
- Bundled license texts diffed against FFmpegBuild 3.0.0 `LICENSES/` and LibDovi 2.1.0: LGPL-2.1 and dav1d identical; zimg differs by a trailing newline; the libzvbi `ure.c` file in FFmpegBuild carries an added header over the same MIT notice. Left as-is.
- **Not verified:** the tvOS episode autoplay transition on physical hardware, which is where #221 reproduced. A real Apple TV check is the release acceptance test for this change.

## Risks

- Behaviour shifts from 52 upstream releases, notably `playbackPhase` no longer reporting `.playing` before motion (6.52.0), live joins starting immediately by default (6.55.0), and the in-place swap contract rework in 6.56.3 that the handover path now runs through.
- The FFmpegBuild framework rename changes the release-archive inventory check in the notices.

## Follow-up

- Decide whether to offer the handover commit upstream. The fork branch is written to be submittable as-is.
- Submit the "Used by" entry to AetherEngine once this merges.

## AI disclosure

Drafted with Claude Fable 5.1 (`claude-fable-5-1`) via Claude Code (desktop app). Engine patch, dependency bump, notices, and validation performed in-session; reviewed by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated open-source license acknowledgements and third-party notices.
  * Refreshed attribution for the AetherEngine media playback engine, including its licensing details.
  * Updated documented component versions, source references, framework names, and verification information.
  * Updated Apple decoding capability documentation to reflect the current AetherEngine and FFmpegBuild releases.
  * Updated the bundled libdovi copyright year.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

