### PR TITLE
fix(player): resolve the initial subtitle intent in combined ordinal order

### DIFF
--- a/iosApp/Silo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iosApp/Silo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,12 @@
 {
-  "originHash" : "b7c5b14da80f57c3689e219e5a42cefed8e7994487f250297681a712439324ca",
+  "originHash" : "efcbb8a8efc97001346ee5252ee308ec44f23fbdfba44fb63c2541dc6b1c51c8",
   "pins" : [
     {
       "identity" : "aetherengine",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/blurbery/AetherEngine",
+      "location" : "https://github.com/Silo-Server/AetherEngine",
       "state" : {
-        "revision" : "653be639441d3f7d06332a2f995950497ad62e0f"
+        "revision" : "dfe11a08489fc6486b233773655a652f15f6ff4a"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/superuser404notfound/FFmpegBuild",
       "state" : {
-        "revision" : "b2185fa842b829cd53d182a5e9a53182c1d9c84c",
-        "version" : "2.4.3"
+        "revision" : "421e13be7061de67d91b85ac34a6b22a002b164f",
+        "version" : "3.0.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/superuser404notfound/LibDovi",
       "state" : {
-        "revision" : "89be93431c2a5f2e54fb77e93059071b8d2ddb3a",
-        "version" : "2.0.0"
+        "revision" : "0d7cce1d6836a30d13a3a2326e50a153af53f014",
+        "version" : "2.1.0"
       }
     },
     {

--- a/iosApp/Silo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iosApp/Silo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,12 @@
 {
-  "originHash" : "efcbb8a8efc97001346ee5252ee308ec44f23fbdfba44fb63c2541dc6b1c51c8",
+  "originHash" : "b7c5b14da80f57c3689e219e5a42cefed8e7994487f250297681a712439324ca",
   "pins" : [
     {
       "identity" : "aetherengine",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Silo-Server/AetherEngine",
+      "location" : "https://github.com/blurbery/AetherEngine",
       "state" : {
-        "revision" : "dfe11a08489fc6486b233773655a652f15f6ff4a"
+        "revision" : "653be639441d3f7d06332a2f995950497ad62e0f"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/superuser404notfound/FFmpegBuild",
       "state" : {
-        "revision" : "421e13be7061de67d91b85ac34a6b22a002b164f",
-        "version" : "3.0.0"
+        "revision" : "b2185fa842b829cd53d182a5e9a53182c1d9c84c",
+        "version" : "2.4.3"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/superuser404notfound/LibDovi",
       "state" : {
-        "revision" : "0d7cce1d6836a30d13a3a2326e50a153af53f014",
-        "version" : "2.1.0"
+        "revision" : "89be93431c2a5f2e54fb77e93059071b8d2ddb3a",
+        "version" : "2.0.0"
       }
     },
     {

--- a/iosApp/Tests/DetailVersionSelectionTests.swift
+++ b/iosApp/Tests/DetailVersionSelectionTests.swift
@@ -441,6 +441,29 @@ final class DetailVersionSelectionTests: XCTestCase {
         XCTAssertEqual(label, "Auto: English · ASS", "preview must follow the external-first order playback uses; got \(label)")
     }
 
+    func testAutoSubtitlePreviewSkipsEmbeddedTracksWithoutAnIndex() {
+        // An embedded track without a stream index cannot be selected by the
+        // plan and is dropped from playback candidates; the preview must not
+        // name it either.
+        let versions = decodedVersions("""
+        [
+          {
+            "file_id": 1,
+            "subtitle_tracks": [
+              { "codec": "subrip", "language": "eng", "title": "Broken" },
+              { "index": 3, "codec": "ass", "language": "eng" }
+            ]
+          }
+        ]
+        """)
+        let label = DetailPlaybackFormatting.subtitleValueLabel(
+            version: versions[0],
+            selectedSubtitleTrackIndex: nil,
+            autoContext: .init(preferredLanguage: "en", mode: "always", audioLanguage: "ja")
+        )
+        XCTAssertEqual(label, "Auto: English · ASS", "index-less embedded track must be skipped; got \(label)")
+    }
+
     func testSubtitleLabelsIncludeTypeAndLanguage() {
         let versions = decodedVersions("""
         [

--- a/iosApp/Tests/DetailVersionSelectionTests.swift
+++ b/iosApp/Tests/DetailVersionSelectionTests.swift
@@ -418,6 +418,29 @@ final class DetailVersionSelectionTests: XCTestCase {
         )
     }
 
+    func testAutoSubtitlePreviewMatchesPlaybackCombinedOrder() {
+        // Catalog lists the embedded English track first; Protocol V3 resolves
+        // in combined order (externals first), so playback starts the external
+        // one. The detail "Auto:" preview must name that same track.
+        let versions = decodedVersions("""
+        [
+          {
+            "file_id": 1,
+            "subtitle_tracks": [
+              { "index": 2, "codec": "subrip", "language": "eng" },
+              { "index": 7, "codec": "ass", "language": "eng", "external": true, "external_path": "movie.en.ass" }
+            ]
+          }
+        ]
+        """)
+        let label = DetailPlaybackFormatting.subtitleValueLabel(
+            version: versions[0],
+            selectedSubtitleTrackIndex: nil,
+            autoContext: .init(preferredLanguage: "en", mode: "always", audioLanguage: "ja")
+        )
+        XCTAssertEqual(label, "Auto: English · ASS", "preview must follow the external-first order playback uses; got \(label)")
+    }
+
     func testSubtitleLabelsIncludeTypeAndLanguage() {
         let versions = decodedVersions("""
         [

--- a/iosApp/Tests/PlaybackProtocolV3Tests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3Tests.swift
@@ -871,9 +871,12 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         )
 
         // The same preference over the plan inventory must land on the same ordinal.
-        let candidates = SubtitleTrackCandidates.playerTracks(from: version.subtitleTracks ?? [])
+        let indexed = SubtitleTrackCandidates.indexedPlayerTracks(from: version.subtitleTracks ?? [])
+        XCTAssertEqual(indexed.map(\.ordinal), [0, 1, 2, 3], "ordinals follow the combined order, not catalog offsets")
+        let candidates = indexed.map(\.track)
         XCTAssertEqual(candidates.map(\.isExternal), [true, true, false, false])
         XCTAssertEqual(candidates.map(\.srcId), [0, 1, nil, nil])
+        XCTAssertEqual(candidates.map(\.ffIndex), [nil, nil, 3, 4])
     }
 
     func testInitialAutoSubtitleIntentIsFrozenIntoProtocolV3Plan() {

--- a/iosApp/Tests/PlaybackProtocolV3Tests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3Tests.swift
@@ -837,6 +837,45 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         XCTAssertFalse(renewal.startFromBeginning)
     }
 
+    func testInitialAutoSubtitleIntentResolvesInCombinedOrdinalOrder() {
+        // Watch detail lists embedded tracks before externals; the V3 combined
+        // ordinal space and the plan inventory list externals first. With two
+        // English full-dialogue tracks the resolver's first match must be the
+        // same track on both sides, or the post-load policy replans (a full
+        // engine reload) on every episode start.
+        let version = makeVersion(
+            container: "mkv",
+            videoCodec: "h264",
+            audioCodec: "aac",
+            subtitleTracks: [
+                makeSubtitle(index: 3, codec: "subrip", external: false, path: nil),
+                makeSubtitle(index: 4, codec: "subrip", external: false, path: nil, hearingImpaired: true),
+                makeSubtitle(index: nil, codec: "srt", external: true, path: "a.en.srt"),
+                makeSubtitle(index: nil, codec: "srt", external: true, path: "b.en.srt")
+            ]
+        )
+        let intent = PlaybackSessionBridge.initialProtocolV3SubtitleIntent(
+            version: version,
+            explicitFFmpegIndex: nil,
+            explicitCombinedIndex: nil,
+            preferredLanguage: "en",
+            mode: .always,
+            showForced: false,
+            trackSignature: nil,
+            currentAudioLanguage: "ja"
+        )
+        XCTAssertEqual(
+            intent,
+            PlaybackSessionBridge.InitialProtocolV3SubtitleIntent(ffmpegStreamIndex: nil, combinedIndex: 0),
+            "first external English track is combined ordinal 0 and must win over the embedded one at ordinal 2"
+        )
+
+        // The same preference over the plan inventory must land on the same ordinal.
+        let candidates = SubtitleTrackCandidates.playerTracks(from: version.subtitleTracks ?? [])
+        XCTAssertEqual(candidates.map(\.isExternal), [true, true, false, false])
+        XCTAssertEqual(candidates.map(\.srcId), [0, 1, nil, nil])
+    }
+
     func testInitialAutoSubtitleIntentIsFrozenIntoProtocolV3Plan() {
         let version = makeVersion(
             container: "mkv",

--- a/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
+++ b/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
@@ -351,7 +351,27 @@ enum DetailPlaybackFormatting {
         version: FileVersion?,
         context: SubtitleAutoContext
     ) -> (track: SubtitleTrack, ordinal: Int)? {
-        let tracks = version?.subtitleTracks ?? []
+        let catalog = Array((version?.subtitleTracks ?? []).enumerated())
+        guard !catalog.isEmpty else { return nil }
+        // Search in the Protocol V3 combined order (externals first) that
+        // `SubtitleTrackCandidates` and the plan inventory use, so a first-match
+        // tie resolves to the same track playback will start. The returned
+        // ordinal stays the catalog offset so "Track N" labels line up with
+        // `subtitleOptions`.
+        let ordered = catalog.filter { $0.element.external == true }
+            + catalog.filter { $0.element.external != true }
+        guard let pick = autoResolvedSubtitle(in: ordered.map(\.element), context: context) else {
+            return nil
+        }
+        return (pick.track, ordered[pick.ordinal].offset)
+    }
+
+    /// `autoResolvedSubtitle(version:context:)` over an already ordered list;
+    /// `ordinal` is the position in `tracks`.
+    private static func autoResolvedSubtitle(
+        in tracks: [SubtitleTrack],
+        context: SubtitleAutoContext
+    ) -> (track: SubtitleTrack, ordinal: Int)? {
         guard !tracks.isEmpty else { return nil }
 
         let mode = SubtitleMode(rawValue: context.mode ?? "") ?? .auto

--- a/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
+++ b/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
@@ -358,8 +358,13 @@ enum DetailPlaybackFormatting {
         // tie resolves to the same track playback will start. The returned
         // ordinal stays the catalog offset so "Track N" labels line up with
         // `subtitleOptions`.
-        let ordered = catalog.filter { $0.element.external == true }
-            + catalog.filter { $0.element.external != true }
+        // `SubtitleTrackCandidates` drops embedded tracks with no stream index
+        // because the plan cannot select them; the preview must not name one.
+        let ordered = (
+            catalog.filter { $0.element.external == true }
+                + catalog.filter { $0.element.external != true }
+        ).filter { $0.element.external == true || $0.element.index != nil }
+        guard !ordered.isEmpty else { return nil }
         guard let pick = autoResolvedSubtitle(in: ordered.map(\.element), context: context) else {
             return nil
         }

--- a/iosApp/iosApp/Screens/Detail/SubtitleTrackCandidates.swift
+++ b/iosApp/iosApp/Screens/Detail/SubtitleTrackCandidates.swift
@@ -11,14 +11,15 @@ import Foundation
 /// disagreement forced a `subtitle_track_changed` replan, and a full engine
 /// reload, on every episode start.
 enum SubtitleTrackCandidates {
+    /// `ordinal` is the position in the returned combined order, not the
+    /// catalog offset the track came from.
     static func indexedPlayerTracks(
         from tracks: [SubtitleTrack]
     ) -> [(ordinal: Int, track: PlayerTrack)] {
         var externalOrdinal = 0
-        let indexed = Array(tracks.enumerated())
-        let combinedOrder = indexed.filter { $0.element.external == true }
-            + indexed.filter { $0.element.external != true }
-        return combinedOrder.compactMap { ordinal, track in
+        let combinedOrder = tracks.filter { $0.external == true }
+            + tracks.filter { $0.external != true }
+        return combinedOrder.enumerated().compactMap { ordinal, track in
             let isExternal = track.external == true
             let trackId: Int64
             let sourceIndex: Int?

--- a/iosApp/iosApp/Screens/Detail/SubtitleTrackCandidates.swift
+++ b/iosApp/iosApp/Screens/Detail/SubtitleTrackCandidates.swift
@@ -2,12 +2,23 @@ import Foundation
 
 /// Maps detail payload subtitle metadata into the exact candidate shape the
 /// player's auto resolver consumes.
+///
+/// Candidates are ordered external-first to match the Protocol V3 combined
+/// ordinal space (externals, then embedded, then downloaded). The watch detail
+/// lists embedded tracks before externals, and the resolver is first-match
+/// within a track class, so resolving in catalog order picks a different
+/// track than the post-load resolver does over the plan inventory. That
+/// disagreement forced a `subtitle_track_changed` replan, and a full engine
+/// reload, on every episode start.
 enum SubtitleTrackCandidates {
     static func indexedPlayerTracks(
         from tracks: [SubtitleTrack]
     ) -> [(ordinal: Int, track: PlayerTrack)] {
         var externalOrdinal = 0
-        return tracks.enumerated().compactMap { ordinal, track in
+        let indexed = Array(tracks.enumerated())
+        let combinedOrder = indexed.filter { $0.element.external == true }
+            + indexed.filter { $0.element.external != true }
+        return combinedOrder.compactMap { ordinal, track in
             let isExternal = track.external == true
             let trackId: Int64
             let sourceIndex: Int?

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -7250,7 +7250,9 @@ class PlayerViewModel {
                 inventory: activePreparedProtocolV3.plan.subtitle.inventory
             )
         }
-        let planIndex = activePreparedProtocolV3.plan.selectedTracks.subtitle?.index
+        // The plan may name the selected subtitle by stable identity alone;
+        // resolve it through the inventory so an identical pick never replans.
+        let planIndex = activePreparedProtocolV3.plan.selectedSubtitleCombinedIndex
         guard combinedIndex != planIndex else {
             return false
         }

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -7250,9 +7250,15 @@ class PlayerViewModel {
                 inventory: activePreparedProtocolV3.plan.subtitle.inventory
             )
         }
-        guard combinedIndex != activePreparedProtocolV3.plan.selectedTracks.subtitle?.index else {
+        let planIndex = activePreparedProtocolV3.plan.selectedTracks.subtitle?.index
+        guard combinedIndex != planIndex else {
             return false
         }
+        // A replan here is a full engine reload on top of a picture that is
+        // already playing, so the decision has to be visible in the log.
+        Self.logger.info(
+            "[CMP-SUB] auto policy disagrees with plan: pick=\(track.map { String($0.trackId) } ?? "off", privacy: .public) combined=\(combinedIndex.map(String.init) ?? "off", privacy: .public) planIndex=\(planIndex.map(String.init) ?? "off", privacy: .public) planMode=\(activePreparedProtocolV3.plan.subtitle.mode, privacy: .public)"
+        )
         // Inventory arrives as soon as the engine starts loading, before the
         // start's server transition has committed. A replan staged then rolls
         // that transition back and retires the session the engine is opening.

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -7252,7 +7252,11 @@ class PlayerViewModel {
         }
         // The plan may name the selected subtitle by stable identity alone;
         // resolve it through the inventory so an identical pick never replans.
-        let planIndex = activePreparedProtocolV3.plan.selectedSubtitleCombinedIndex
+        // An `off` plan can keep a stale identity, and `off` means nothing is
+        // selected regardless (mirrors `subtitlePickerTracks`).
+        let planIndex = activePreparedProtocolV3.plan.subtitle.mode == PlaybackProtocolV3.SubtitleMode.off
+            ? nil
+            : activePreparedProtocolV3.plan.selectedSubtitleCombinedIndex
         guard combinedIndex != planIndex else {
             return false
         }


### PR DESCRIPTION
## Problem

Every Protocol V3 episode start loaded the engine twice. The pre-start subtitle intent in `PlaybackSessionBridge.initialProtocolV3SubtitleIntent` resolved over the watch detail, which lists embedded tracks before externals. The post-load caption policy in `PlayerViewModel` resolved over the plan inventory, which lists externals first. `SubtitleAutoResolver` is first-match within a track class, so a file with two same-language full-dialogue tracks picked a different track on each side. The client then issued a `subtitle_track_changed` replan and a full engine reload on top of a picture that was already playing. This was most visible on Next Up autoplay, where it read as a rough transition.

## Solution

`SubtitleTrackCandidates` now orders catalog tracks external-first to match the combined ordinal space the server documents in `BuildSubtitleInventoryV3` (externals, then embedded, then downloaded). Both passes now land on the same track and the replan never fires. The auto policy logs one info line when it still disagrees with the plan, so a recurrence is visible in the unified log.

## Validation

- tvOS Simulator, same series, before and after: two `NativeAVPlayerHost` sessions per episode with a replan ~15 ms after adoption, versus one session and no replan.
- Focused suites `PlaybackProtocolV3Tests`, `SubtitleAutoResolverTests`, `PlayerNextUpCompletionPolicyTests` pass (71 tests), including a new regression test that pins the ordering with two English tracks.

## Risks

- Files with several same-language candidates may now start on the first external track where they previously started on the first embedded one. That is the ordering the server already used for its own plan, so this aligns the client with the plan rather than changing which track the server would pick.

## Follow-up

- Compare Android's initial subtitle intent for the same ordering assumption.

Split out of #246 at review request.

## AI disclosure

Drafted with Claude Fable 5.1 (`claude-fable-5-1`) via Claude Code (desktop app). Diagnosis from simulator logs, fix, test, and validation performed in-session; reviewed by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automatic subtitle selection for external English tracks in playback and subtitle previews.
  - Corrected subtitle ordering so external and embedded tracks are evaluated consistently, ensuring the intended subtitle is selected.
  - Improved handling and diagnostics when the resolved subtitle differs from the active playback selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->