### PR TITLE
fix(player): keep embedded stream 0 selectable and align the signature preview

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -15,7 +15,7 @@ The authoritative dependency lock is
 
 | Component | Exact revision | Shipped form | License |
 | --- | --- | --- | --- |
-| AetherEngine 6.67.2 + Silo handover patch | `745de1ccdc4b226adccdf18f03a28071f0e972d5` | Swift package target linked into each host app | LGPL-3.0-only with AetherEngine's Apple Store / DRM exception |
+| AetherEngine 6.67.2 + Silo handover patches | `745de1ccdc4b226adccdf18f03a28071f0e972d5` | Swift package target linked into each host app | LGPL-3.0-only with AetherEngine's Apple Store / DRM exception |
 | FFmpegBuild 3.0.0 | `421e13be7061de67d91b85ac34a6b22a002b164f` | Nine separately embedded dynamic frameworks | See the component table below |
 | LibDovi 2.1.0 | `0d7cce1d6836a30d13a3a2326e50a153af53f014` | Static `Dovi.xcframework` linked through AetherEngine | MIT packaging; embedded libdovi is MIT |
 | Nuke and NukeUI 13.2.0 | `30f7a7e72e0607d304fbf69c799474bd5fb6d1ce` | Swift package targets linked into each host app | MIT |
@@ -32,10 +32,12 @@ Copyright (C) 2026 Vincent Herbst.
 
 AetherEngine is licensed under GNU LGPL version 3 with its upstream Apple
 Store / DRM exception. Silo builds a published fork revision: upstream release
-`6.67.2` plus one commit that lets a host request the in-place native item
-handover on a foreground episode change through `prepareForItemReplacement()`.
-That modification is published under the LGPL on the fork branch below, which
-satisfies the license's source obligation for modified code. The bundled
+`6.67.2` plus two commits: one lets a host request the in-place native item
+handover on a foreground episode change through `prepareForItemReplacement()`,
+and one makes the remote-HLS bypass honour that handover instead of dropping
+the item across the swap. Both modifications are published under the LGPL on
+the fork branch below, which satisfies the license's source obligation for
+modified code. The bundled
 acknowledgements include AetherEngine's complete license and exception plus
 the GNU GPL version 3 text incorporated by LGPLv3.
 

--- a/iosApp/Tests/DetailVersionSelectionTests.swift
+++ b/iosApp/Tests/DetailVersionSelectionTests.swift
@@ -464,6 +464,47 @@ final class DetailVersionSelectionTests: XCTestCase {
         XCTAssertEqual(label, "Auto: English · SRT", "embedded stream 0 must remain a preview candidate; got \(label)")
     }
 
+    func testSubtitleOptionsKeepEmbeddedStreamZeroSelectable() {
+        // The wire omits a zero stream index. The selector, sanitization and
+        // persistence paths must all read an embedded nil index as stream 0
+        // so the user can pick it manually, not just via auto-resolution.
+        let versions = decodedVersions("""
+        [
+          {
+            "file_id": 1,
+            "subtitle_tracks": [
+              { "codec": "subrip", "language": "eng" },
+              { "codec": "srt", "language": "fra", "file_name": "/subs/fr.srt", "external": true }
+            ]
+          }
+        ]
+        """)
+        XCTAssertEqual(versions[0].subtitleTracks?[0].selectionIndex, 0)
+        XCTAssertNil(versions[0].subtitleTracks?[1].selectionIndex)
+
+        let options = DetailPlaybackFormatting.subtitleOptions(
+            version: versions[0],
+            selectedSubtitleTrackIndex: 0,
+            preferredLanguage: nil
+        )
+        guard let embedded = options.first(where: { $0.title == "English" }) else {
+            return XCTFail("missing embedded option")
+        }
+        XCTAssertEqual(embedded.selectionIndex, 0)
+        XCTAssertTrue(embedded.isSelectable)
+        XCTAssertTrue(embedded.isSelected)
+        XCTAssertFalse(embedded.detail.contains("Available in player"))
+
+        XCTAssertEqual(
+            DetailPlaybackFormatting.subtitleValueLabel(version: versions[0], selectedSubtitleTrackIndex: 0),
+            "English · SRT"
+        )
+        XCTAssertEqual(
+            TrackSelectionPersistence.subtitleRequest(version: versions[0], ffIndex: 0, showForced: nil)?.subtitleTrackIndex,
+            0
+        )
+    }
+
     func testSignatureSubtitlePreviewConsidersExternalTracks() {
         // A persisted signature that ties between an embedded and an external
         // track resolves to the external one in playback (combined order).

--- a/iosApp/Tests/DetailVersionSelectionTests.swift
+++ b/iosApp/Tests/DetailVersionSelectionTests.swift
@@ -441,17 +441,17 @@ final class DetailVersionSelectionTests: XCTestCase {
         XCTAssertEqual(label, "Auto: English · ASS", "preview must follow the external-first order playback uses; got \(label)")
     }
 
-    func testAutoSubtitlePreviewSkipsEmbeddedTracksWithoutAnIndex() {
-        // An embedded track without a stream index cannot be selected by the
-        // plan and is dropped from playback candidates; the preview must not
-        // name it either.
+    func testAutoSubtitlePreviewKeepsEmbeddedStreamZero() {
+        // The wire omits a zero stream index. An embedded row with no index is
+        // FFmpeg stream 0, which the plan can select, so the preview must
+        // still name it rather than falling through to a later track.
         let versions = decodedVersions("""
         [
           {
             "file_id": 1,
             "subtitle_tracks": [
-              { "codec": "subrip", "language": "eng", "title": "Broken" },
-              { "index": 3, "codec": "ass", "language": "eng" }
+              { "codec": "subrip", "language": "eng" },
+              { "index": 3, "codec": "ass", "language": "jpn" }
             ]
           }
         ]
@@ -461,7 +461,31 @@ final class DetailVersionSelectionTests: XCTestCase {
             selectedSubtitleTrackIndex: nil,
             autoContext: .init(preferredLanguage: "en", mode: "always", audioLanguage: "ja")
         )
-        XCTAssertEqual(label, "Auto: English · ASS", "index-less embedded track must be skipped; got \(label)")
+        XCTAssertEqual(label, "Auto: English · SRT", "embedded stream 0 must remain a preview candidate; got \(label)")
+    }
+
+    func testSignatureSubtitlePreviewConsidersExternalTracks() {
+        // A persisted signature that ties between an embedded and an external
+        // track resolves to the external one in playback (combined order).
+        // The preview's signature pass must consider externals too.
+        let versions = decodedVersions("""
+        [
+          {
+            "file_id": 1,
+            "subtitle_tracks": [
+              { "index": 2, "codec": "subrip", "language": "eng" },
+              { "index": 9, "codec": "ass", "language": "eng", "external": true, "external_path": "movie.en.ass" }
+            ]
+          }
+        ]
+        """)
+        let signature = SubtitleTrackSignature(source: nil, language: "en", codec: nil, label: nil, forced: false, hearingImpaired: false)
+        let label = DetailPlaybackFormatting.subtitleValueLabel(
+            version: versions[0],
+            selectedSubtitleTrackIndex: nil,
+            autoContext: .init(preferredLanguage: "en", mode: "auto", signature: signature, audioLanguage: "ja")
+        )
+        XCTAssertEqual(label, "Auto: English · ASS", "signature preview must include external tracks; got \(label)")
     }
 
     func testSubtitleLabelsIncludeTypeAndLanguage() {

--- a/iosApp/Tests/PlaybackProtocolV3Tests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3Tests.swift
@@ -879,6 +879,32 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         XCTAssertEqual(candidates.map(\.ffIndex), [nil, nil, 3, 4])
     }
 
+    func testInitialAutoSubtitleIntentKeepsEmbeddedStreamZero() {
+        // `index,omitempty` drops a zero stream index on the wire; an embedded
+        // row with no index is stream 0 and must stay a candidate.
+        let version = makeVersion(
+            container: "mkv",
+            videoCodec: "h264",
+            audioCodec: "aac",
+            subtitleTracks: [
+                makeSubtitle(index: nil, codec: "subrip", external: false, path: nil)
+            ]
+        )
+        XCTAssertEqual(
+            PlaybackSessionBridge.initialProtocolV3SubtitleIntent(
+                version: version,
+                explicitFFmpegIndex: nil,
+                explicitCombinedIndex: nil,
+                preferredLanguage: "en",
+                mode: .always,
+                showForced: false,
+                trackSignature: nil,
+                currentAudioLanguage: "ja"
+            ),
+            PlaybackSessionBridge.InitialProtocolV3SubtitleIntent(ffmpegStreamIndex: 0, combinedIndex: 0)
+        )
+    }
+
     func testInitialAutoSubtitleIntentIsFrozenIntoProtocolV3Plan() {
         let version = makeVersion(
             container: "mkv",

--- a/iosApp/iosApp/Networking/Models.swift
+++ b/iosApp/iosApp/Networking/Models.swift
@@ -994,6 +994,15 @@ struct SubtitleTrack: Codable, Identifiable, Hashable {
     let externalPath: String?
     var id: String { "\(index ?? -1)|\(externalPath ?? "")" }
 
+    /// The FFmpeg stream index the detail selector and player use to select
+    /// this track. The server emits `index,omitempty`, so an embedded track at
+    /// stream 0 arrives with no `index`; embedded is the only case where nil
+    /// means 0. External sidecars have no stream index and stay nil.
+    var selectionIndex: Int? {
+        if let index { return index }
+        return external == true ? nil : 0
+    }
+
     enum CodingKeys: String, CodingKey {
         case index
         case codec

--- a/iosApp/iosApp/Networking/TrackSelectionPersistence.swift
+++ b/iosApp/iosApp/Networking/TrackSelectionPersistence.swift
@@ -88,8 +88,9 @@ enum TrackSelectionPersistence {
     }
 
     /// Subtitle pick against server file metadata. `ffIndex` matches
-    /// `version.subtitleTracks[].index`; a negative value is the detail
-    /// page's explicit "Off".
+    /// `version.subtitleTracks[].selectionIndex` (an embedded track with no
+    /// wire index is stream 0); a negative value is the detail page's
+    /// explicit "Off".
     static func subtitleRequest(
         version: FileVersion,
         ffIndex: Int,
@@ -98,7 +99,7 @@ enum TrackSelectionPersistence {
         if ffIndex < 0 {
             return subtitleOffRequest(showForced: showForced)
         }
-        guard let track = version.subtitleTracks?.first(where: { $0.index == ffIndex }) else {
+        guard let track = version.subtitleTracks?.first(where: { $0.selectionIndex == ffIndex }) else {
             return nil
         }
         let isExternal = track.external ?? false

--- a/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
+++ b/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
@@ -305,7 +305,9 @@ enum DetailPlaybackFormatting {
         in tracks: [SubtitleTrack]
     ) -> SubtitleTrack? {
         var best: (SubtitleTrack, Int)?
-        for track in tracks where track.index != nil {
+        // Every row is a candidate, external ones included, exactly as the
+        // player's `SubtitleAutoResolver.bestSignatureMatch` scores them.
+        for track in tracks {
             var score = 0
             var strongSignal = false
             if let sigLang = sig.language, !sigLang.isEmpty,
@@ -358,13 +360,11 @@ enum DetailPlaybackFormatting {
         // tie resolves to the same track playback will start. The returned
         // ordinal stays the catalog offset so "Track N" labels line up with
         // `subtitleOptions`.
-        // `SubtitleTrackCandidates` drops embedded tracks with no stream index
-        // because the plan cannot select them; the preview must not name one.
-        let ordered = (
-            catalog.filter { $0.element.external == true }
-                + catalog.filter { $0.element.external != true }
-        ).filter { $0.element.external == true || $0.element.index != nil }
-        guard !ordered.isEmpty else { return nil }
+        // Same candidate set and order as `SubtitleTrackCandidates`: externals
+        // first, then embedded. An embedded row with no index is FFmpeg stream
+        // 0 (the wire omits a zero index), so it stays selectable.
+        let ordered = catalog.filter { $0.element.external == true }
+            + catalog.filter { $0.element.external != true }
         guard let pick = autoResolvedSubtitle(in: ordered.map(\.element), context: context) else {
             return nil
         }

--- a/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
+++ b/iosApp/iosApp/Screens/Detail/DetailPlaybackFormatting.swift
@@ -271,7 +271,7 @@ enum DetailPlaybackFormatting {
         if let signature,
            let tracks = version?.subtitleTracks,
            let match = bestSignatureMatch(signature, in: tracks) {
-            return match.index
+            return match.selectionIndex
         }
         if SubtitleMode(rawValue: mode ?? "") == .off {
             return -1
@@ -483,7 +483,9 @@ enum DetailPlaybackFormatting {
             )
         }
         return ordered.map { ordinal, track in
-            let index = track.index
+            // `selectionIndex` reads an embedded nil index as stream 0, so
+            // only external sidecars without a stream index are unselectable.
+            let index = track.selectionIndex
             let isSelectable = index != nil
             return SubtitleOption(
                 selectionIndex: index,
@@ -532,7 +534,7 @@ enum DetailPlaybackFormatting {
         if selectedSubtitleTrackIndex == -1 { return "Off" }
         guard let selectedSubtitleTrackIndex,
               let match = (version?.subtitleTracks ?? []).enumerated().first(where: { _, track in
-                  track.index == selectedSubtitleTrackIndex
+                  track.selectionIndex == selectedSubtitleTrackIndex
               }) else {
             // An explicit positive selection that doesn't resolve in this
             // version's track list (e.g. the displayed version was re-scoped):

--- a/iosApp/iosApp/Screens/Detail/ItemDetailView.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailView.swift
@@ -1009,7 +1009,7 @@ private struct ItemDetailPhoneContent: View {
         guard let version = effectiveVersion(for: detail, versionFileId: versionFileId) else {
             return nil
         }
-        let available = version.subtitleTracks?.compactMap(\.index) ?? []
+        let available = version.subtitleTracks?.compactMap(\.selectionIndex) ?? []
         return available.contains(candidate) ? candidate : nil
     }
 
@@ -1023,7 +1023,7 @@ private struct ItemDetailPhoneContent: View {
         guard let version = effectiveVersion(for: detail, versionFileId: versionFileId) else {
             return nil
         }
-        let available = version.subtitleTracks?.compactMap(\.index) ?? []
+        let available = version.subtitleTracks?.compactMap(\.selectionIndex) ?? []
         return available.contains(candidate) ? candidate : nil
     }
 

--- a/iosApp/iosApp/Screens/Detail/SubtitleTrackCandidates.swift
+++ b/iosApp/iosApp/Screens/Detail/SubtitleTrackCandidates.swift
@@ -28,7 +28,10 @@ enum SubtitleTrackCandidates {
                 trackId = SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: externalOrdinal)
                 externalOrdinal += 1
             } else {
-                guard let index = track.index else { return nil }
+                // The server emits `index,omitempty` on an Int, so an embedded
+                // track at FFmpeg stream 0 arrives with no index. Embedded is
+                // the only case where nil can mean 0; keep it selectable.
+                let index = track.index ?? 0
                 sourceIndex = nil
                 trackId = Int64(index)
             }
@@ -48,7 +51,7 @@ enum SubtitleTrackCandidates {
                     isHearingImpaired: track.hearingImpaired ?? false,
                     isExternal: isExternal,
                     isSelected: false,
-                    ffIndex: isExternal ? nil : track.index,
+                    ffIndex: isExternal ? nil : (track.index ?? 0),
                     srcId: sourceIndex
                 )
             )

--- a/iosApp/iosApp/Screens/Detail/SubtitleTrackCandidates.swift
+++ b/iosApp/iosApp/Screens/Detail/SubtitleTrackCandidates.swift
@@ -28,10 +28,9 @@ enum SubtitleTrackCandidates {
                 trackId = SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: externalOrdinal)
                 externalOrdinal += 1
             } else {
-                // The server emits `index,omitempty` on an Int, so an embedded
-                // track at FFmpeg stream 0 arrives with no index. Embedded is
-                // the only case where nil can mean 0; keep it selectable.
-                let index = track.index ?? 0
+                // Embedded tracks always resolve: `selectionIndex` reads a
+                // missing wire index (`index,omitempty`) as FFmpeg stream 0.
+                let index = track.selectionIndex ?? 0
                 sourceIndex = nil
                 trackId = Int64(index)
             }
@@ -51,7 +50,7 @@ enum SubtitleTrackCandidates {
                     isHearingImpaired: track.hearingImpaired ?? false,
                     isExternal: isExternal,
                     isSelected: false,
-                    ffIndex: isExternal ? nil : (track.index ?? 0),
+                    ffIndex: isExternal ? nil : track.selectionIndex,
                     srcId: sourceIndex
                 )
             )

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3PlanAdapter.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3PlanAdapter.swift
@@ -354,7 +354,7 @@ enum ApplePlaybackV3PlanAdapter {
         let embedded = tracks.filter { $0.external != true }
         let embeddedOrdinal = serverCombinedIndex - externalCount
         guard embedded.indices.contains(embeddedOrdinal) else { return nil }
-        return embedded[embeddedOrdinal].index ?? 0
+        return embedded[embeddedOrdinal].selectionIndex
     }
 
     static func ffmpegSubtitleStreamIndex(
@@ -375,7 +375,7 @@ enum ApplePlaybackV3PlanAdapter {
         }
         let embedded = (version.subtitleTracks ?? []).filter { $0.external != true }
         guard embedded.indices.contains(embeddedOrdinal) else { return nil }
-        return embedded[embeddedOrdinal].index ?? 0
+        return embedded[embeddedOrdinal].selectionIndex
     }
 
     /// Position of an FFmpeg stream index among the version's embedded subtitle
@@ -386,9 +386,7 @@ enum ApplePlaybackV3PlanAdapter {
     ) -> Int? {
         guard ffmpegStreamIndex >= 0 else { return nil }
         let embedded = (version.subtitleTracks ?? []).filter { $0.external != true }
-        // The wire omits a zero stream index (`index,omitempty`), so an
-        // embedded track with no index is FFmpeg stream 0.
-        return embedded.firstIndex { ($0.index ?? 0) == ffmpegStreamIndex }
+        return embedded.firstIndex { $0.selectionIndex == ffmpegStreamIndex }
     }
 
     private static func subtitleTrack(

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3PlanAdapter.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3PlanAdapter.swift
@@ -354,7 +354,7 @@ enum ApplePlaybackV3PlanAdapter {
         let embedded = tracks.filter { $0.external != true }
         let embeddedOrdinal = serverCombinedIndex - externalCount
         guard embedded.indices.contains(embeddedOrdinal) else { return nil }
-        return embedded[embeddedOrdinal].index
+        return embedded[embeddedOrdinal].index ?? 0
     }
 
     static func ffmpegSubtitleStreamIndex(
@@ -375,7 +375,7 @@ enum ApplePlaybackV3PlanAdapter {
         }
         let embedded = (version.subtitleTracks ?? []).filter { $0.external != true }
         guard embedded.indices.contains(embeddedOrdinal) else { return nil }
-        return embedded[embeddedOrdinal].index
+        return embedded[embeddedOrdinal].index ?? 0
     }
 
     /// Position of an FFmpeg stream index among the version's embedded subtitle
@@ -386,7 +386,9 @@ enum ApplePlaybackV3PlanAdapter {
     ) -> Int? {
         guard ffmpegStreamIndex >= 0 else { return nil }
         let embedded = (version.subtitleTracks ?? []).filter { $0.external != true }
-        return embedded.firstIndex { $0.index == ffmpegStreamIndex }
+        // The wire omits a zero stream index (`index,omitempty`), so an
+        // embedded track with no index is FFmpeg stream 0.
+        return embedded.firstIndex { ($0.index ?? 0) == ffmpegStreamIndex }
     }
 
     private static func subtitleTrack(

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
@@ -886,7 +886,7 @@ struct TVItemDetailView: View {
         guard let version = effectiveVersion(for: detail, versionFileId: versionFileId) else {
             return nil
         }
-        let available = version.subtitleTracks?.compactMap(\.index) ?? []
+        let available = version.subtitleTracks?.compactMap(\.selectionIndex) ?? []
         return available.contains(candidate) ? candidate : nil
     }
 


### PR DESCRIPTION
## Problem

Two gaps in #247, raised by review after it merged, plus one notices correction from #246. A follow-up review found the selector path still broken.

- The server emits `index,omitempty` on an `Int`, so an embedded subtitle at FFmpeg stream 0 arrives with no `index`. `SubtitleTrackCandidates` dropped it, the detail "Auto:" preview filtered it out, and the plan adapter could not map it to a combined ordinal. A file whose first embedded subtitle is stream 0 lost that track from auto-selection and from the preview.
- `DetailPlaybackFormatting.subtitleOptions` still used the raw nil index and set `isSelectable` to false, so the iOS and tvOS selectors disabled the row. The sanitization and persistence paths also rejected index 0 because they only inspected non-nil catalog indices. Users could not pick the track manually even after the auto path was fixed.
- The detail preview's persisted-signature pass skipped tracks without an `index`, which excludes every external sidecar, while playback's resolver scores them. A signature tie between an embedded and an external track previewed one and played the other.
- `THIRD_PARTY_NOTICES.md` described the fork revision as one commit; it carries two.

## Solution

- New `SubtitleTrack.selectionIndex` reads a nil embedded index as stream 0 and stays nil for external sidecars. External rows are the only case where nil means "no stream", and they are already keyed by `external`.
- `subtitleOptions`, the selected value label, `serverPreferredSubtitleIndex`, the iOS and tvOS `sanitizedSubtitleTrackIndex` helpers, `TrackSelectionPersistence.subtitleRequest`, `SubtitleTrackCandidates`, and the V3 plan adapter all use `selectionIndex`, so one definition covers the whole detail selection path.
- The preview's `bestSignatureMatch` considers every row, matching `SubtitleAutoResolver.bestSignatureMatch`.
- Notices name both fork patches.

## Validation

- `DetailVersionSelectionTests`, `PlaybackProtocolV3Tests`, `SubtitleAutoResolverTests` pass with four new cases: embedded stream 0 in the pre-start intent, in the preview, in the selector/value label/persistence path, and a signature tie including an external track.
- `SiloTV` scheme builds on the tvOS simulator.

## Risks

- Low. Only tracks that previously vanished from auto-selection or were disabled in the selector become selectable again.

## AI disclosure

Drafted with Claude Fable 5.1 (`claude-fable-5-1`) via Claude Code (desktop app). Reviewed by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
