### PR TITLE
fix(ios): restore quick-play on Continue Watching still cards

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -2331,12 +2331,13 @@ struct MainTabView: View {
                 // regression (see forums thread 807208).
         case .personDetail(let personId):
             PersonDetailView(personId: personId)
-        case .player(let contentId, let startFromBeginning, let resumePosition):
+        case .player(let contentId, let startFromBeginning, let resumePosition, let prefersLastUsedVersion):
             #if os(macOS)
             PlayerView(
                 contentId: contentId,
                 startFromBeginning: startFromBeginning,
-                resumePositionOverride: resumePosition
+                resumePositionOverride: resumePosition,
+                prefersLastUsedVersion: prefersLastUsedVersion
             )
             #else
             // Player is presented as a full-screen cover (see MainTabView)

--- a/iosApp/iosApp/Navigation/AppRouter.swift
+++ b/iosApp/iosApp/Navigation/AppRouter.swift
@@ -266,7 +266,8 @@ class AppRouter {
             navigate(to: .player(
                 contentId: contentId,
                 startFromBeginning: startFromBeginning,
-                resumePosition: resumePosition
+                resumePosition: resumePosition,
+                prefersLastUsedVersion: prefersLastUsedVersion
             ))
         }
         #else

--- a/iosApp/iosApp/Navigation/Route.swift
+++ b/iosApp/iosApp/Navigation/Route.swift
@@ -24,7 +24,16 @@ enum Route: Hashable {
         tvSeed: TVItemDetailRouteSeed? = nil
     )
     case personDetail(personId: Int)
-    case player(contentId: String, startFromBeginning: Bool, resumePosition: Double?)
+    /// `prefersLastUsedVersion` is the Continue Watching resume intent: pick
+    /// the server's last-used file before the profile-wide quality
+    /// preference. Audio and subtitle memory ride on the server's
+    /// `effective_*` fields and need no extra flag.
+    case player(
+        contentId: String,
+        startFromBeginning: Bool,
+        resumePosition: Double?,
+        prefersLastUsedVersion: Bool = false
+    )
     case playerWithFile(
         contentId: String,
         fileId: Int,

--- a/iosApp/iosApp/Screens/Home/Feed/HomeFeedKit.swift
+++ b/iosApp/iosApp/Screens/Home/Feed/HomeFeedKit.swift
@@ -447,6 +447,7 @@ struct HomeStillCard: View {
     /// Optimistic watched state, shared with the menu — see `HomePosterCard`.
     @State private var playedOverride: Bool?
     @EnvironmentObject private var overlayStore: OverlayPrefsStore
+    @Environment(AppRouter.self) private var router
 
     private var isPlayed: Bool { playedOverride ?? (item.userState?.played == true) }
 
@@ -533,13 +534,7 @@ struct HomeStillCard: View {
                 .stroke(.white.opacity(0.08), lineWidth: 0.5)
         )
         .overlay(alignment: .center) {
-            Image(systemName: "play.fill")
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(.white.opacity(0.9))
-                .frame(width: 28, height: 28)
-                .background(Circle().fill(.black.opacity(0.32)))
-                .overlay(Circle().stroke(.white.opacity(0.38), lineWidth: 0.75))
-                .allowsHitTesting(false)
+            playBadge
         }
         // A watched item can sit in Continue Watching again on a rewatch —
         // the check says "you've finished this before" alongside the rail's
@@ -556,6 +551,39 @@ struct HomeStillCard: View {
             DownloadedBadgeOverlay(contentId: item.contentId, padding: 6)
                 .padding(.bottom, 10)
         }
+    }
+
+    /// Quick-start affordance. Tapping the badge plays (or resumes) the item
+    /// directly instead of opening its detail page; the rest of the still
+    /// keeps the detail tap. Sized as a real touch target rather than a
+    /// decorative glyph so a thumb lands on it reliably.
+    @ViewBuilder
+    private var playBadge: some View {
+        let badge = Image(systemName: "play.fill")
+            .font(.system(size: 14, weight: .semibold))
+            .foregroundStyle(.white.opacity(0.9))
+            .frame(width: 36, height: 36)
+            .background(Circle().fill(.black.opacity(0.32)))
+            .overlay(Circle().stroke(.white.opacity(0.38), lineWidth: 0.75))
+            .contentShape(Circle())
+
+        if SiloMediaType.isDirectlyPlayable(item.type) {
+            Button(action: playItem) { badge }
+                .buttonStyle(.plain)
+                .accessibilityLabel((item.positionSeconds ?? 0) > 0 ? "Resume" : "Play")
+        } else {
+            badge.allowsHitTesting(false)
+        }
+    }
+
+    private func playItem() {
+        router.presentPlayer(
+            contentId: item.contentId,
+            resumePosition: item.positionSeconds,
+            prefersLastUsedVersion: opensResumeContext,
+            posterURL: item.posterUrl,
+            backdropURL: item.backdropUrl
+        )
     }
 
     private var caption: some View {

--- a/iosApp/iosApp/Screens/Home/Feed/HomeFeedKit.swift
+++ b/iosApp/iosApp/Screens/Home/Feed/HomeFeedKit.swift
@@ -134,6 +134,10 @@ private struct HomeCardTap<Label: View>: View {
     let contentId: String
     let accessibilityLabel: String
     var continueWatchingItem: SectionItem? = nil
+    /// Secondary action surfaced to VoiceOver. The card collapses its
+    /// children into one element, so a nested play button would otherwise
+    /// vanish from the accessibility tree.
+    var accessibilityPlayAction: (name: String, perform: () -> Void)? = nil
     @ViewBuilder var label: () -> Label
 
     @Environment(AppRouter.self) private var router
@@ -156,6 +160,19 @@ private struct HomeCardTap<Label: View>: View {
         .buttonStyle(.plain)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel)
+        .modifier(OptionalAccessibilityAction(action: accessibilityPlayAction))
+    }
+}
+
+private struct OptionalAccessibilityAction: ViewModifier {
+    let action: (name: String, perform: () -> Void)?
+
+    func body(content: Content) -> some View {
+        if let action {
+            content.accessibilityAction(named: Text(action.name), action.perform)
+        } else {
+            content
+        }
     }
 }
 
@@ -468,7 +485,10 @@ struct HomeStillCard: View {
         HomeCardTap(
             contentId: item.contentId,
             accessibilityLabel: accessibilityDescription,
-            continueWatchingItem: opensResumeContext ? item : nil
+            continueWatchingItem: opensResumeContext ? item : nil,
+            accessibilityPlayAction: isDirectlyPlayable
+                ? (name: playActionName, perform: playItem)
+                : nil
         ) {
             VStack(alignment: .leading, spacing: 8) {
                 artwork
@@ -567,14 +587,18 @@ struct HomeStillCard: View {
             .overlay(Circle().stroke(.white.opacity(0.38), lineWidth: 0.75))
             .contentShape(Circle())
 
-        if SiloMediaType.isDirectlyPlayable(item.type) {
+        if isDirectlyPlayable {
             Button(action: playItem) { badge }
                 .buttonStyle(.plain)
-                .accessibilityLabel((item.positionSeconds ?? 0) > 0 ? "Resume" : "Play")
+                .accessibilityLabel(playActionName)
         } else {
             badge.allowsHitTesting(false)
         }
     }
+
+    private var isDirectlyPlayable: Bool { SiloMediaType.isDirectlyPlayable(item.type) }
+
+    private var playActionName: String { (item.positionSeconds ?? 0) > 0 ? "Resume" : "Play" }
 
     private func playItem() {
         router.presentPlayer(

--- a/iosApp/iosApp/macOS/PlayerView.swift
+++ b/iosApp/iosApp/macOS/PlayerView.swift
@@ -9,6 +9,9 @@ struct PlayerView: View {
     let preferredSubtitleTrackIndex: Int?
     let startFromBeginning: Bool
     let resumePositionOverride: Double?
+    /// Continue Watching resume intent: select the server's last-used file
+    /// before the profile-wide quality preference.
+    let prefersLastUsedVersion: Bool
     /// Set when the caller wants offline playback of a completed download.
     /// Routes the prepare through `OfflinePlaybackBuilder` (stored manifest
     /// + local media file, no server session) so playback works with no
@@ -27,6 +30,7 @@ struct PlayerView: View {
         preferredSubtitleTrackIndex: Int? = nil,
         startFromBeginning: Bool = false,
         resumePositionOverride: Double? = nil,
+        prefersLastUsedVersion: Bool = false,
         offlineDownloadId: String? = nil
     ) {
         self.contentId = contentId
@@ -35,6 +39,7 @@ struct PlayerView: View {
         self.preferredSubtitleTrackIndex = preferredSubtitleTrackIndex
         self.startFromBeginning = startFromBeginning
         self.resumePositionOverride = resumePositionOverride
+        self.prefersLastUsedVersion = prefersLastUsedVersion
         self.offlineDownloadId = offlineDownloadId
     }
 
@@ -106,6 +111,7 @@ struct PlayerView: View {
                 preferredSubtitleTrackIndex: preferredSubtitleTrackIndex,
                 startFromBeginning: startFromBeginning,
                 resumePositionOverride: resumePositionOverride,
+                prefersLastUsedVersion: prefersLastUsedVersion,
                 offlineDownloadId: offlineDownloadId
             )
         }

--- a/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
@@ -1384,11 +1384,12 @@ struct TVMainTabView: View {
             ItemDetailView(contentId: contentId, tvSeed: tvSeed)
         case .personDetail(let personId):
             PersonDetailView(personId: personId)
-        case .player(let contentId, let startFromBeginning, let resumePosition):
+        case .player(let contentId, let startFromBeginning, let resumePosition, let prefersLastUsedVersion):
             PlayerView(
                 contentId: contentId,
                 startFromBeginning: startFromBeginning,
-                resumePositionOverride: resumePosition
+                resumePositionOverride: resumePosition,
+                prefersLastUsedVersion: prefersLastUsedVersion
             )
         case .playerWithFile(let contentId, let fileId, let audioTrackIndex, let subtitleTrackIndex, let startFromBeginning, let resumePosition):
             PlayerView(


### PR DESCRIPTION
## Problem

The play badge on Continue Watching and Next Up cards used to quick-start the item. After the Home feed rewrite (`a95d8fc5`) the new `HomeStillCard` kept the glyph but marked it `allowsHitTesting(false)`, and the row-level play action in `MediaRow` was already tvOS-only, so on iOS the badge did nothing. It was also small (28pt) and easy to miss with a thumb.

## Solution

In `HomeFeedKit.swift`, the badge is now a plain-style `Button` that calls `router.presentPlayer` with the item's resume position, mirroring what `SectionRow.playItem` already does on tvOS. The rest of the still keeps the detail tap.

- Only directly playable types (movie, episode, audiobook) get the button. Other types keep the decorative glyph.
- Badge grows from 28pt to 36pt with a 14pt glyph, and the hit area is the full circle.
- Accessibility label is "Resume" when there is progress, otherwise "Play".

Poster-shaped cards in resume rows (audiobooks) have no badge and are unchanged.

## Validation

- `Silo` scheme builds on iPhone 17 Pro simulator with `CODE_SIGNING_ALLOWED=NO`.
- `SiloMac` scheme builds (the file is shared with macOS).
- Not exercised in a simulator; no before/after screenshots captured.

## Risks

Low. Change is confined to one view. The tap target sits at the centre of the still, so the detail tap area shrinks by the badge's footprint.

## AI disclosure

Written with Claude Code using model `claude-fable-5-1[1m]` (Claude Fable 5.1). No other AI tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a tappable play button to supported home feed content.
  - Users can play or resume content directly from the content card.
  - Playback retains the selected content, resume position, preferences, and artwork.
  - Unsupported content types continue to display a non-interactive play badge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->