### PR TITLE
fix(player): select native subtitles and preserve sidecar timing

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -15,7 +15,7 @@ The authoritative dependency lock is
 
 | Component | Exact revision | Shipped form | License |
 | --- | --- | --- | --- |
-| AetherEngine 6.67.2 + Silo handover patches | `745de1ccdc4b226adccdf18f03a28071f0e972d5` | Swift package target linked into each host app | LGPL-3.0-only with AetherEngine's Apple Store / DRM exception |
+| AetherEngine 6.67.2 + Silo handover/subtitle patches | `f68ad1309001d879ad69f95dd03b9c57410550b1` | Swift package target linked into each host app | LGPL-3.0-only with AetherEngine's Apple Store / DRM exception |
 | FFmpegBuild 3.0.0 | `421e13be7061de67d91b85ac34a6b22a002b164f` | Nine separately embedded dynamic frameworks | See the component table below |
 | LibDovi 2.1.0 | `0d7cce1d6836a30d13a3a2326e50a153af53f014` | Static `Dovi.xcframework` linked through AetherEngine | MIT packaging; embedded libdovi is MIT |
 | Nuke and NukeUI 13.2.0 | `30f7a7e72e0607d304fbf69c799474bd5fb6d1ce` | Swift package targets linked into each host app | MIT |
@@ -32,16 +32,18 @@ Copyright (C) 2026 Vincent Herbst.
 
 AetherEngine is licensed under GNU LGPL version 3 with its upstream Apple
 Store / DRM exception. Silo builds a published fork revision: upstream release
-`6.67.2` plus two commits: one lets a host request the in-place native item
+`6.67.2` plus three commits: one lets a host request the in-place native item
 handover on a foreground episode change through `prepareForItemReplacement()`,
 and one makes the remote-HLS bypass honour that handover instead of dropping
-the item across the swap. Both modifications are published under the LGPL on
+the item across the swap. The third preserves complete native subtitle renditions
+and maps external subtitle timing after an upstream media reanchor. These modifications
+are published under the LGPL on
 the fork branch below, which satisfies the license's source obligation for
 modified code. The bundled
 acknowledgements include AetherEngine's complete license and exception plus
 the GNU GPL version 3 text incorporated by LGPLv3.
 
-- Exact source: <https://github.com/Silo-Server/AetherEngine/tree/745de1ccdc4b226adccdf18f03a28071f0e972d5>
+- Exact source: <https://github.com/Silo-Server/AetherEngine/tree/f68ad1309001d879ad69f95dd03b9c57410550b1>
   (fork branch `silo/host-requested-item-handover`)
 - Upstream base: <https://github.com/superuser404notfound/AetherEngine/tree/6.67.2>
 - Rebuild input: `Package.swift` and the source tree at that revision

--- a/iosApp/Silo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iosApp/Silo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Silo-Server/AetherEngine",
       "state" : {
-        "revision" : "745de1ccdc4b226adccdf18f03a28071f0e972d5"
+        "revision" : "f68ad1309001d879ad69f95dd03b9c57410550b1"
       }
     },
     {

--- a/iosApp/Tests/AetherPlaybackBoundaryTests.swift
+++ b/iosApp/Tests/AetherPlaybackBoundaryTests.swift
@@ -1093,6 +1093,40 @@ final class AetherPlaybackBoundaryTests: XCTestCase {
         )
     }
 
+    func testMissingEmbeddedStreamIsRejectedBeforePlanCommit() throws {
+        let controller = try AetherPlaybackController()
+        defer { controller.stop() }
+        XCTAssertThrowsError(try controller.validateEmbeddedSubtitleSelection(11)) { error in
+            XCTAssertTrue(error is AetherPlaybackController.EmbeddedSubtitleSelectionError)
+        }
+    }
+
+    /// Opt-in local fixture: two embedded SRT tracks, with the second stream
+    /// at FFmpeg index 3 and text "Native track 2". No sidecar is registered.
+    func testOriginalHTTPSelectsExactEmbeddedSubtitleWithoutSidecar() async throws {
+        guard let rawURL = ProcessInfo.processInfo.environment["SILO_AETHER_EMBEDDED_FIXTURE_URL"],
+              let url = URL(string: rawURL) else {
+            throw XCTSkip("Set SILO_AETHER_EMBEDDED_FIXTURE_URL to the local two-track MKV fixture")
+        }
+        let controller = try AetherPlaybackController()
+        defer { controller.stop() }
+        let spec = try AetherLoadSpec(directURL: url, headers: [:], startPosition: 0, audioOnly: false)
+        XCTAssertTrue(spec.options.externalSubtitles.isEmpty)
+        let epoch = controller.beginLoad(spec)
+        try await controller.finishLoad(epoch)
+        try controller.validateEmbeddedSubtitleSelection(3)
+        controller.selectSubtitleTrack(id: 3)
+        controller.play()
+        let deadline = Date().addingTimeInterval(15)
+        while !controller.engine.subtitleCues.contains(where: { $0.text == "Native track 2" }),
+              Date() < deadline {
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        XCTAssertEqual(controller.engine.activeSubtitleTrackIndex, 3)
+        XCTAssertTrue(controller.engine.subtitleCues.contains(where: { $0.text == "Native track 2" }))
+        XCTAssertFalse(controller.engine.subtitleCues.contains(where: { $0.text == "Native track 1" }))
+    }
+
     func testControllerConstructsOnlyAetherEngine() throws {
         let controller = try AetherPlaybackController()
         XCTAssertEqual(controller.engine.state, .idle)

--- a/iosApp/Tests/AetherPlaybackBoundaryTests.swift
+++ b/iosApp/Tests/AetherPlaybackBoundaryTests.swift
@@ -1127,6 +1127,26 @@ final class AetherPlaybackBoundaryTests: XCTestCase {
         XCTAssertFalse(controller.engine.subtitleCues.contains(where: { $0.text == "Native track 1" }))
     }
 
+    func testMovieTimelineUsesExternalTrackStateWithoutRequiringAnAlias() throws {
+        let controller = try AetherPlaybackController()
+        defer { controller.stop() }
+        let raw = controller.engine.addExternalSubtitleTrack(
+            ExternalSubtitleTrack(url: URL(fileURLWithPath: "/tmp/unaliased-subtitle.srt")))
+        XCTAssertFalse(controller.containsSubtitle(appTrackID: Int64(raw.id)))
+        XCTAssertTrue(controller.subtitleUsesMovieTimeline(appTrackID: Int64(raw.id), slot: .primary))
+        XCTAssertTrue(controller.subtitleUsesMovieTimeline(appTrackID: Int64(raw.id), slot: .secondary))
+        controller.engine.selectSubtitleTrack(index: raw.id)
+        XCTAssertTrue(controller.subtitleUsesMovieTimeline(appTrackID: nil, slot: .primary))
+        XCTAssertFalse(controller.subtitleUsesMovieTimeline(appTrackID: nil, slot: .secondary))
+        XCTAssertFalse(controller.subtitleUsesMovieTimeline(appTrackID: 3, slot: .primary))
+        XCTAssertFalse(controller.subtitleUsesMovieTimeline(
+            appTrackID: SubtitleTrackIdSpace.makeAILiveTrackId(0), slot: .primary))
+        let alias = SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: 4)
+        controller.addExternalSubtitleTrack(
+            ExternalSubtitleTrack(url: URL(fileURLWithPath: "/tmp/aliased-subtitle.srt")), appTrackID: alias)
+        XCTAssertTrue(controller.subtitleUsesMovieTimeline(appTrackID: alias, slot: .primary))
+    }
+
     func testControllerConstructsOnlyAetherEngine() throws {
         let controller = try AetherPlaybackController()
         XCTAssertEqual(controller.engine.state, .idle)

--- a/iosApp/Tests/Fixtures/PlaybackV3/SOURCE
+++ b/iosApp/Tests/Fixtures/PlaybackV3/SOURCE
@@ -1,5 +1,5 @@
 Source: silo-server internal/playback/testdata/protocol_v3
-Server commit: 2f9df5327f2728a266ad826ded36dac7d030d62b
+Server commit: 5afc5bdd616e4f9c304889c8cadc4c6d31fbc7b7
 Server pull request: https://github.com/Silo-Server/silo-server/pull/938
 Vendored: 2026-09-04
 

--- a/iosApp/Tests/Fixtures/PlaybackV3/SOURCE
+++ b/iosApp/Tests/Fixtures/PlaybackV3/SOURCE
@@ -1,11 +1,11 @@
 Source: silo-server internal/playback/testdata/protocol_v3
-Server ref: main
-Server commit: 745b767f73088309953972de9ea23f33d854496e
-Vendored: 2026-08-25
+Server commit: 2f9df5327f2728a266ad826ded36dac7d030d62b
+Server pull request: https://github.com/Silo-Server/silo-server/pull/938
+Vendored: 2026-09-04
 
-All nine files come from internal/playback/testdata/protocol_v3. Six of them are
+All nine JSON files come from internal/playback/testdata/protocol_v3. Six are
 also published byte-identically under docs/design/schemas/playback-v3/v3/fixtures/valid;
 attempt_keys.json, conformance_matrix.json and subtitle_inventory.json exist only
 under testdata, so the testdata directory is the single copy source.
 
-Refresh these files from the exact server commit above, then regenerate Silo.xcodeproj with cd iosApp && xcodegen generate.
+Refresh these files together from the server, then regenerate Silo.xcodeproj with cd iosApp && xcodegen generate.

--- a/iosApp/Tests/Fixtures/PlaybackV3/attempt_keys.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/attempt_keys.json
@@ -1,10 +1,10 @@
 [
   {
     "name": "hls_burn_in_sorted_transformations_and_pcm_mutations",
-    "server_plan_attempt_key": "v3:27ee8bdc3ff5b1d7",
-    "replan_echo": "v3:27ee8bdc3ff5b1d7",
+    "server_plan_attempt_key": "v3:a1531ef7c1bd7f75",
+    "replan_echo": "v3:a1531ef7c1bd7f75",
     "attempted_plan_keys": [
-      "v3:27ee8bdc3ff5b1d7"
+      "v3:a1531ef7c1bd7f75"
     ],
     "expected_server_action": "reject_already_attempted_plan"
   },

--- a/iosApp/Tests/Fixtures/PlaybackV3/capability_response.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/capability_response.json
@@ -6,11 +6,13 @@
   "features": [
     "playback_plan_v3",
     "neutral_playback_v3_contract_v1",
+    "embedded_subtitles_v1",
     "layout_aware_passthrough",
     "playback_route_diagnostics",
     "device_quirks_v1",
     "seek_reanchor_v1",
     "output_change_v1",
+    "output_display_evidence_v1",
     "direct_stream_resume_v1",
     "header_authenticated_media_v1",
     "authorized_media_origins_v1",
@@ -28,7 +30,7 @@
     {
       "name": "audio_to_aac",
       "executor": "server",
-      "recipe_version": "2",
+      "recipe_version": "4",
       "validated_claims": [
         "audio_decode"
       ]

--- a/iosApp/Tests/Fixtures/PlaybackV3/conformance_matrix.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/conformance_matrix.json
@@ -1978,7 +1978,7 @@
         "subtitle_fidelity_preference": "compatible",
         "start_position": 12.5,
         "progress_persistence": "client",
-        "audio_track_id": "file:42:audio:0",
+        "audio_track_id": "file:77:audio:0",
         "audio_track_index": 0,
         "metered": false,
         "client_capabilities": {

--- a/iosApp/Tests/Fixtures/PlaybackV3/conformance_matrix.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/conformance_matrix.json
@@ -175,8 +175,8 @@
         "outcome": "playable",
         "delivery": "server_transcode_hls",
         "decision_reason": "quality_original",
-        "plan_id": "plan:1496ada4f9ff74754e2f14031f86fb21",
-        "plan_attempt_key": "v3:4db9d7afc07c1655",
+        "plan_id": "plan:176744988a004fd5f2230c221961c41a",
+        "plan_attempt_key": "v3:d1ecc0d9511b83b8",
         "selected_tracks": {
           "audio": {
             "id": "file:42:audio:0",
@@ -218,7 +218,7 @@
           {
             "name": "audio_to_aac",
             "executor": "server",
-            "recipe_version": "2",
+            "recipe_version": "4",
             "validated_claims": [
               "audio_decode"
             ]
@@ -767,6 +767,221 @@
             "height": 480,
             "bitrate_kbps": 1500,
             "preserves_source": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "h264_constrained_baseline_direct",
+      "category": "profile_compatibility",
+      "request": {
+        "protocol_version": 3,
+        "client_features": [
+          "playback_plan_v3"
+        ],
+        "file_id": 42,
+        "profile_id": "profile-1",
+        "playback_attempt_id": "attempt-h264-constrained-baseline",
+        "quality_preference": "auto",
+        "subtitle_fidelity_preference": "compatible",
+        "start_position": 12.5,
+        "progress_persistence": "client",
+        "audio_track_id": "file:42:audio:0",
+        "audio_track_index": 0,
+        "metered": false,
+        "client_capabilities": {
+          "video_evidence": "exact",
+          "audio_evidence": "exact",
+          "codecs_video": [
+            "h264"
+          ],
+          "codecs_video_hardware": [
+            "h264"
+          ],
+          "codecs_audio": [
+            "aac"
+          ],
+          "containers": [
+            "mkv"
+          ],
+          "max_resolution": "1080p",
+          "hdr": false,
+          "video_decode": [
+            {
+              "codec": "h264",
+              "profiles": [
+                "baseline"
+              ],
+              "levels": [
+                52
+              ],
+              "bit_depths": [
+                8
+              ],
+              "max_width": 3840,
+              "max_height": 2160,
+              "max_frame_rate": 60,
+              "max_bitrate_kbps": 20000,
+              "hardware": true
+            }
+          ]
+        },
+        "client_playback_context": {
+          "protocol_version": 3,
+          "form_factor": "tv",
+          "app_version": "3.0-test",
+          "device": {
+            "platform": "fixture"
+          },
+          "output": {
+            "output_context_id": "output-a"
+          },
+          "deliveries": {
+            "hls": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "hls"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "original_http": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mkv",
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            },
+            "progressive": {
+              "enabled": true,
+              "supported_on_device": true,
+              "containers": [
+                "mp4"
+              ],
+              "video_codecs": [
+                "hevc",
+                "h264"
+              ],
+              "audio_decode_codecs": [
+                "aac"
+              ],
+              "audio_passthrough_codecs": [],
+              "subtitles": {
+                "embedded_text": false,
+                "sidecar_text": false,
+                "ass_styling": false,
+                "embedded_bitmap": false,
+                "sidecar_bitmap": false,
+                "font_attachments": false
+              },
+              "features": [],
+              "auth_header_refresh": false,
+              "validated_claims": [],
+              "transformations": []
+            }
+          }
+        }
+      },
+      "source": {
+        "media_file_id": 42,
+        "duration_seconds": 7200,
+        "container": "mkv",
+        "video_codec": "h264",
+        "video_profile": "constrained baseline",
+        "video_level": 41,
+        "bit_depth": 8,
+        "width": 1920,
+        "height": 1080,
+        "frame_rate": 23.976023976023978,
+        "bitrate_kbps": 8000,
+        "dynamic_range": "sdr",
+        "hdr10_plus": false,
+        "dv_enhancement_layer": "none",
+        "audio_codec": "aac",
+        "audio_channels": 2,
+        "audio_layout": "stereo"
+      },
+      "expected": {
+        "outcome": "playable",
+        "delivery": "original_http",
+        "decision_reason": "validated_original_playback",
+        "plan_id": "plan:ea7ae9cecded71f3a86ec20a152c8778",
+        "plan_attempt_key": "v3:706f66227a5cae0b",
+        "selected_tracks": {
+          "audio": {
+            "id": "file:42:audio:0",
+            "index": 0
+          }
+        },
+        "subtitle": {
+          "mode": "off",
+          "inventory": []
+        },
+        "claims": {
+          "video": {
+            "hdr10": false,
+            "hdr10_plus": false,
+            "hlg": false,
+            "dolby_vision": false
+          },
+          "audio": {
+            "codec": "aac",
+            "passthrough": false,
+            "atmos_preserved": false,
+            "reason": "client_decode_supported"
+          },
+          "subtitles": {
+            "ass_styling_preserved": false,
+            "bitmap_overlay": false,
+            "bitmap_sidecar": false
+          }
+        },
+        "available_qualities": [
+          {
+            "label": "original",
+            "height": 1080,
+            "bitrate_kbps": 8000,
+            "preserves_source": true
           }
         ]
       }
@@ -1647,8 +1862,8 @@
         "outcome": "playable",
         "delivery": "server_transcode_hls",
         "decision_reason": "quality_fixed_rung",
-        "plan_id": "plan:e8ddb06ffa481d3561b07cef06a91ec5",
-        "plan_attempt_key": "v3:4830f767fa704f38",
+        "plan_id": "plan:f12311eb7ac696c8bbeeab6c135b4225",
+        "plan_attempt_key": "v3:315d40199ceb0333",
         "selected_tracks": {
           "audio": {
             "id": "file:42:audio:0",
@@ -1690,7 +1905,7 @@
           {
             "name": "audio_to_aac",
             "executor": "server",
-            "recipe_version": "2",
+            "recipe_version": "4",
             "validated_claims": [
               "audio_decode"
             ]
@@ -2358,8 +2573,8 @@
         "outcome": "playable",
         "delivery": "server_transcode_hls",
         "decision_reason": "quality_fixed_rung",
-        "plan_id": "plan:23105e95d0363c4627ab0f60ed0bfa96",
-        "plan_attempt_key": "v3:8a4c0deb6795be69",
+        "plan_id": "plan:1aae8ad82720984fbc14c38de3a5485b",
+        "plan_attempt_key": "v3:78825f13a334a7ed",
         "selected_tracks": {
           "audio": {
             "id": "file:42:audio:0",
@@ -2401,7 +2616,7 @@
           {
             "name": "audio_to_aac",
             "executor": "server",
-            "recipe_version": "2",
+            "recipe_version": "4",
             "validated_claims": [
               "audio_decode"
             ]
@@ -3378,6 +3593,7 @@
         "hdr10_plus": false,
         "dolby_vision_profile": 7,
         "dv_bl_compat_id": 6,
+        "dv_base_layer_proven": true,
         "dv_enhancement_layer": "unknown",
         "audio_codec": "aac",
         "audio_channels": 2,
@@ -3387,8 +3603,8 @@
         "outcome": "playable",
         "delivery": "server_transcode_hls",
         "decision_reason": "quality_fixed_rung",
-        "plan_id": "plan:48fee96902632f7f3b70e8e5dd0669f3",
-        "plan_attempt_key": "v3:f7602afa81a3eee0",
+        "plan_id": "plan:e302dcdd4f94f3c3027c7603de66c0a5",
+        "plan_attempt_key": "v3:b1ff9bc2e47e341e",
         "selected_tracks": {
           "audio": {
             "id": "file:42:audio:0",
@@ -3430,7 +3646,7 @@
           {
             "name": "audio_to_aac",
             "executor": "server",
-            "recipe_version": "2",
+            "recipe_version": "4",
             "validated_claims": [
               "audio_decode"
             ]
@@ -3712,8 +3928,8 @@
         "outcome": "playable",
         "delivery": "server_remux_progressive",
         "decision_reason": "audio_adaptation",
-        "plan_id": "plan:7ae72046390c9f41614fc8a0e7465089",
-        "plan_attempt_key": "v3:8e3e32c8e2e5b895",
+        "plan_id": "plan:4f78d95e9fdd6e085ec79506894da894",
+        "plan_attempt_key": "v3:4979cff59d1f3068",
         "selected_tracks": {
           "audio": {
             "id": "file:42:audio:0",
@@ -3747,7 +3963,7 @@
           {
             "name": "audio_to_aac",
             "executor": "server",
-            "recipe_version": "2",
+            "recipe_version": "4",
             "validated_claims": [
               "audio_decode"
             ]
@@ -4357,7 +4573,7 @@
               "audio_passthrough_codecs": [],
               "subtitles": {
                 "embedded_text": true,
-                "sidecar_text": false,
+                "sidecar_text": true,
                 "ass_styling": true,
                 "embedded_bitmap": false,
                 "sidecar_bitmap": false,
@@ -4385,7 +4601,7 @@
               "audio_passthrough_codecs": [],
               "subtitles": {
                 "embedded_text": true,
-                "sidecar_text": false,
+                "sidecar_text": true,
                 "ass_styling": true,
                 "embedded_bitmap": false,
                 "sidecar_bitmap": false,
@@ -4412,7 +4628,7 @@
               "audio_passthrough_codecs": [],
               "subtitles": {
                 "embedded_text": true,
-                "sidecar_text": false,
+                "sidecar_text": true,
                 "ass_styling": true,
                 "embedded_bitmap": false,
                 "sidecar_bitmap": false,
@@ -4686,8 +4902,8 @@
         "outcome": "playable",
         "delivery": "server_transcode_hls",
         "decision_reason": "subtitle_burn_in_required",
-        "plan_id": "plan:3fbb45a597dbfeb7ec62888782109a50",
-        "plan_attempt_key": "v3:09c05142189931a3",
+        "plan_id": "plan:c42d17216c7049e49c5453bc2f21cfe5",
+        "plan_attempt_key": "v3:7ec0846b12cc97a6",
         "selected_tracks": {
           "audio": {
             "id": "file:42:audio:0",
@@ -4748,7 +4964,7 @@
           {
             "name": "audio_to_aac",
             "executor": "server",
-            "recipe_version": "2",
+            "recipe_version": "4",
             "validated_claims": [
               "audio_decode"
             ]
@@ -6537,11 +6753,13 @@
           "server_features": [
             "playback_plan_v3",
             "neutral_playback_v3_contract_v1",
+            "embedded_subtitles_v1",
             "layout_aware_passthrough",
             "playback_route_diagnostics",
             "device_quirks_v1",
             "seek_reanchor_v1",
             "output_change_v1",
+            "output_display_evidence_v1",
             "direct_stream_resume_v1",
             "header_authenticated_media_v1",
             "authorized_media_origins_v1",

--- a/iosApp/Tests/Fixtures/PlaybackV3/decision_response.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/decision_response.json
@@ -3,11 +3,13 @@
   "server_features": [
     "playback_plan_v3",
     "neutral_playback_v3_contract_v1",
+    "embedded_subtitles_v1",
     "layout_aware_passthrough",
     "playback_route_diagnostics",
     "device_quirks_v1",
     "seek_reanchor_v1",
     "output_change_v1",
+    "output_display_evidence_v1",
     "direct_stream_resume_v1",
     "header_authenticated_media_v1",
     "authorized_media_origins_v1",
@@ -90,7 +92,7 @@
           "default": false,
           "hearing_impaired": false,
           "delivery": "sidecar",
-          "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/0.vtt?file_id=42"
+          "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/0.vtt?file_id=42\u0026external_subtitle_key=f903db1c5624c46c4a2c20f2fd8cd247fc0d46e6471c91d4ddb651ae4e039448"
         },
         {
           "track_id": "file:42:subtitle:1",
@@ -103,8 +105,8 @@
           "default": false,
           "hearing_impaired": false,
           "delivery": "sidecar",
-          "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/1.ass?file_id=42",
-          "font_bundle_url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/1/fonts?file_id=42"
+          "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/1.ass?file_id=42\u0026embedded_stream_index=0",
+          "font_bundle_url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/1/fonts?file_id=42\u0026embedded_stream_index=0"
         },
         {
           "track_id": "file:42:subtitle:2",
@@ -117,7 +119,7 @@
           "default": false,
           "hearing_impaired": false,
           "delivery": "sidecar",
-          "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/2.sup?file_id=42"
+          "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/2.sup?file_id=42\u0026embedded_stream_index=1"
         },
         {
           "track_id": "file:42:subtitle:3",

--- a/iosApp/Tests/Fixtures/PlaybackV3/subtitle_inventory.json
+++ b/iosApp/Tests/Fixtures/PlaybackV3/subtitle_inventory.json
@@ -70,7 +70,7 @@
       "default": false,
       "hearing_impaired": false,
       "delivery": "sidecar",
-      "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/0.vtt?file_id=42"
+      "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/0.vtt?file_id=42\u0026external_subtitle_key=f903db1c5624c46c4a2c20f2fd8cd247fc0d46e6471c91d4ddb651ae4e039448"
     },
     {
       "track_id": "file:42:subtitle:1",
@@ -83,8 +83,8 @@
       "default": false,
       "hearing_impaired": false,
       "delivery": "sidecar",
-      "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/1.ass?file_id=42",
-      "font_bundle_url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/1/fonts?file_id=42"
+      "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/1.ass?file_id=42\u0026embedded_stream_index=0",
+      "font_bundle_url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/1/fonts?file_id=42\u0026embedded_stream_index=0"
     },
     {
       "track_id": "file:42:subtitle:2",
@@ -97,7 +97,7 @@
       "default": false,
       "hearing_impaired": false,
       "delivery": "sidecar",
-      "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/2.sup?file_id=42"
+      "url": "/stream/11111111-1111-4111-8111-111111111111/subtitles/2.sup?file_id=42\u0026embedded_stream_index=1"
     },
     {
       "track_id": "file:42:subtitle:3",

--- a/iosApp/Tests/PlaybackProtocolV3ConformanceFixtureTests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3ConformanceFixtureTests.swift
@@ -25,7 +25,7 @@ final class PlaybackProtocolV3ConformanceFixtureTests: XCTestCase {
             bundleClass: Self.self
         )
         XCTAssertEqual(matrix.schemaVersion, 1)
-        XCTAssertEqual(matrix.plannerScenarios.count, 20)
+        XCTAssertEqual(matrix.plannerScenarios.count, 21)
         XCTAssertEqual(matrix.replanScenarios.count, 10)
         XCTAssertEqual(matrix.protocolScenarios.count, 8)
 

--- a/iosApp/Tests/PlaybackProtocolV3Tests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3Tests.swift
@@ -98,6 +98,96 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         XCTAssertNil(intent.embeddedSubtitleIndex)
     }
 
+    func testRenewalKeepsServerSubtitlesOffAfterLocalDisable() {
+        let original = PlayerViewModel.LoadRequest(
+            contentId: "movie", preferredFileId: 42, preferredAudioTrackIndex: nil,
+            preferredSubtitleTrackIndex: 11, preferredSidecarSubtitleTrackId: nil,
+            startFromBeginning: false, preferredProtocolV3SubtitleIndex: 7
+        )
+        // Off and AI-live both disable the server subtitle and carry no sidecar.
+        let recovery = original.copyForRecovery(
+            preferredFileId: 42, preferredAudioTrackIndex: nil,
+            preferredSubtitleTrackIndex: -1, preferredSidecarSubtitleTrackId: nil,
+            offlineDownloadId: nil, serverSubtitlesDisabled: true
+        )
+        XCTAssertNil(recovery.preferredProtocolV3SubtitleIndex)
+        let intent = PlaybackSessionBridge.initialProtocolV3SubtitleIntent(
+            version: makeVersion(container: "mkv", videoCodec: "h264", audioCodec: "aac"),
+            explicitFFmpegIndex: recovery.preferredSubtitleTrackIndex,
+            explicitCombinedIndex: recovery.preferredProtocolV3SubtitleIndex,
+            preferredLanguage: "en", mode: nil, showForced: false,
+            trackSignature: nil, currentAudioLanguage: nil
+        )
+        XCTAssertNil(intent.combinedIndex)
+        XCTAssertNil(intent.ffmpegStreamIndex)
+    }
+
+    func testResumeDistinguishesOffFromPendingStartupSelection() {
+        let sidecar = SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: 8)
+        XCTAssertTrue(PlayerViewModel.serverSubtitlesDisabledForResume(
+            selectedTrackID: SubtitleTrackIdSpace.makeAILiveTrackId(0), hasExplicitChoice: true,
+            pendingEmbeddedIndex: 11, pendingSidecarID: sidecar))
+        XCTAssertFalse(PlayerViewModel.serverSubtitlesDisabledForResume(
+            selectedTrackID: nil, hasExplicitChoice: true,
+            pendingEmbeddedIndex: 11, pendingSidecarID: nil))
+        XCTAssertFalse(PlayerViewModel.serverSubtitlesDisabledForResume(
+            selectedTrackID: nil, hasExplicitChoice: true,
+            pendingEmbeddedIndex: -1, pendingSidecarID: sidecar))
+        XCTAssertTrue(PlayerViewModel.serverSubtitlesDisabledForResume(
+            selectedTrackID: nil, hasExplicitChoice: true,
+            pendingEmbeddedIndex: -1, pendingSidecarID: nil))
+        XCTAssertTrue(PlayerViewModel.serverSubtitlesDisabledForResume(
+            selectedTrackID: nil, hasExplicitChoice: true,
+            pendingEmbeddedIndex: nil, pendingSidecarID: nil))
+        XCTAssertFalse(PlayerViewModel.serverSubtitlesDisabledForResume(
+            selectedTrackID: nil, hasExplicitChoice: false,
+            pendingEmbeddedIndex: nil, pendingSidecarID: nil))
+    }
+
+    func testRenewalPreservesBurnInBeforeItsPickerSelectionPublishes() {
+        let version = makeVersion(container: "mkv", videoCodec: "h264", audioCodec: "aac")
+        let plan = makePlan(selectedSubtitleIndex: 7, subtitleMode: "burn_in",
+            subtitleInventory: [makeInventoryItem(combinedIndex: 7, source: "embedded", delivery: "burn_in_only")])
+        let original = PlayerViewModel.LoadRequest(
+            contentId: "movie", preferredFileId: 42, preferredAudioTrackIndex: nil,
+            preferredSubtitleTrackIndex: nil, preferredSidecarSubtitleTrackId: nil,
+            startFromBeginning: false, preferredProtocolV3SubtitleIndex: 7
+        ).adoptingProtocolV3Intent(plan: plan, selectedVersion: version, activeQualityId: "original")
+        let pending = PlayerViewModel.protocolV3PendingTrackIntent(plan: plan, request: original)
+        XCTAssertEqual(pending.embeddedSubtitleIndex, -1)
+        XCTAssertNil(pending.sidecarSubtitleTrackId)
+        XCTAssertEqual(pending.serverRenderedSubtitleTrackId, SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: 7))
+        let disabled = PlayerViewModel.serverSubtitlesDisabledForResume(
+            selectedTrackID: nil, hasExplicitChoice: true,
+            pendingEmbeddedIndex: pending.embeddedSubtitleIndex,
+            pendingSidecarID: pending.sidecarSubtitleTrackId,
+            pendingServerRenderedID: pending.serverRenderedSubtitleTrackId
+        )
+        XCTAssertFalse(disabled)
+        let recovery = original.copyForRecovery(
+            preferredFileId: 42, preferredAudioTrackIndex: nil,
+            preferredSubtitleTrackIndex: -1, preferredSidecarSubtitleTrackId: nil,
+            offlineDownloadId: nil, serverSubtitlesDisabled: disabled
+        )
+        XCTAssertEqual(recovery.preferredProtocolV3SubtitleIndex, 7)
+        let intent = PlaybackSessionBridge.initialProtocolV3SubtitleIntent(
+            version: version, explicitFFmpegIndex: recovery.preferredSubtitleTrackIndex,
+            explicitCombinedIndex: recovery.preferredProtocolV3SubtitleIndex,
+            preferredLanguage: nil, mode: nil, showForced: false,
+            trackSignature: nil, currentAudioLanguage: nil
+        )
+        XCTAssertEqual(intent.combinedIndex, 7)
+        XCTAssertNil(intent.ffmpegStreamIndex)
+    }
+
+    func testTeardownClearsSubtitleLoadingWithoutAnEngineEvent() async {
+        let model = PlayerViewModel()
+        model.isLoadingSubtitles = true
+        model.cleanup()
+        XCTAssertFalse(model.isLoadingSubtitles)
+        await model.waitForCleanupCompletion()
+    }
+
     func testRenewalReplacesPlanSidecarWithItsNativeEmbeddedIdentity() {
         let plan = makePlan(container: "mkv", selectedSubtitleIndex: 7, subtitleMode: "render",
             subtitleInventory: [makeInventoryItem(combinedIndex: 7, source: "embedded")],

--- a/iosApp/Tests/PlaybackProtocolV3Tests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3Tests.swift
@@ -39,6 +39,52 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         ))
     }
 
+    func testNativePickerIdentityRemainsResolvableForSecondaryAfterPrimaryClears() throws {
+        let nativePlan = makePlan(
+            container: "mkv", selectedSubtitleIndex: 7, subtitleMode: "render",
+            subtitleInventory: [makeInventoryItem(combinedIndex: 7, source: "embedded")],
+            embeddedSubtitle: PlaybackV3EmbeddedSubtitle(streamIndex: 11)
+        )
+        let spec = try AetherLoadSpec(
+            validating: nativePlan, sessionID: "session-v3", matchContentEnabled: false,
+            sourceURLOverride: URL(string: "https://example.test/movie.mkv")
+        )
+        let row = try XCTUnwrap(ApplePlaybackV3PlanAdapter.subtitlePickerTracks(plan: nativePlan).first)
+        let controller = try AetherPlaybackController()
+        defer { controller.stop() }
+        controller.beginLoad(spec)
+        // AI-live primary selection clears only Aether's primary slot. The
+        // native picker identity must remain usable by the secondary slot.
+        controller.selectSubtitleTrack(id: nil)
+        XCTAssertTrue(controller.containsSubtitle(appTrackID: row.trackId))
+        XCTAssertEqual(controller.aetherSubtitleID(forAppID: row.trackId), 11)
+        XCTAssertEqual(controller.appSubtitleID(forAetherID: 11), row.trackId)
+        XCTAssertFalse(controller.subtitleUsesMovieTimeline(appTrackID: row.trackId, slot: .secondary))
+        XCTAssertTrue(spec.options.externalSubtitles.isEmpty)
+        XCTAssertTrue(spec.externalSubtitleAppTrackIDs.isEmpty)
+
+        // The next load replaces native identity, including when the same
+        // combined ordinal now resolves to a different container stream.
+        let replacement = makePlan(
+            container: "mkv", selectedSubtitleIndex: 7, subtitleMode: "render",
+            subtitleInventory: [makeInventoryItem(combinedIndex: 7, source: "embedded")],
+            embeddedSubtitle: PlaybackV3EmbeddedSubtitle(streamIndex: 12)
+        )
+        controller.beginLoad(try AetherLoadSpec(
+            validating: replacement, sessionID: "session-next", matchContentEnabled: false,
+            sourceURLOverride: URL(string: "https://example.test/movie.mkv")
+        ))
+        XCTAssertEqual(controller.aetherSubtitleID(forAppID: row.trackId), 12)
+        XCTAssertEqual(controller.appSubtitleID(forAetherID: 11), 11)
+
+        controller.beginLoad(try AetherLoadSpec(
+            validating: makePlan(), sessionID: "session-off", matchContentEnabled: false,
+            sourceURLOverride: URL(string: "https://example.test/movie.mkv")
+        ))
+        XCTAssertFalse(controller.containsSubtitle(appTrackID: row.trackId))
+        XCTAssertNil(controller.aetherSubtitleID(forAppID: row.trackId))
+    }
+
     func testNativeResumeIdentityDoesNotOverrideLaterLocalSelection() {
         let plan = makePlan(container: "mkv", selectedSubtitleIndex: 7, subtitleMode: "render",
             subtitleInventory: [makeInventoryItem(combinedIndex: 7, source: "embedded")],

--- a/iosApp/Tests/PlaybackProtocolV3Tests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3Tests.swift
@@ -55,6 +55,72 @@ final class PlaybackProtocolV3Tests: XCTestCase {
             selectedTrackID: SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: 7)))
     }
 
+    func testRenewalRequestsNewerDownloadedSidecarInsteadOfPreviousEmbeddedTrack() {
+        let version = makeVersion(container: "mkv", videoCodec: "h264", audioCodec: "aac")
+        let localID = SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: 8)
+        let original = PlayerViewModel.LoadRequest(
+            contentId: "movie", preferredFileId: 42, preferredAudioTrackIndex: nil,
+            preferredSubtitleTrackIndex: 11, preferredSidecarSubtitleTrackId: nil,
+            startFromBeginning: false, preferredProtocolV3SubtitleIndex: 7
+        )
+        // A download completes after the embedded plan was adopted. Recovery
+        // resolves its sidecar id from the current selection, before teardown.
+        let recovery = original.copyForRecovery(
+            preferredFileId: 42, preferredAudioTrackIndex: nil,
+            preferredSubtitleTrackIndex: -1, preferredSidecarSubtitleTrackId: localID,
+            offlineDownloadId: nil
+        )
+        XCTAssertEqual(recovery.preferredProtocolV3SubtitleIndex, 8)
+        let initialIntent = PlaybackSessionBridge.initialProtocolV3SubtitleIntent(
+            version: version, explicitFFmpegIndex: recovery.preferredSubtitleTrackIndex,
+            explicitCombinedIndex: recovery.preferredProtocolV3SubtitleIndex,
+            preferredLanguage: nil, mode: nil, showForced: false,
+            trackSignature: nil, currentAudioLanguage: nil
+        )
+        XCTAssertEqual(initialIntent.combinedIndex, 8)
+        XCTAssertNil(initialIntent.ffmpegStreamIndex)
+        // Session creation rebuilds inventory, including the completed download,
+        // and honors the requested combined ordinal.
+        let refreshedPlan = makePlan(
+            container: "mkv", selectedSubtitleIndex: initialIntent.combinedIndex,
+            subtitleMode: "render", subtitleInventory: [
+                makeInventoryItem(combinedIndex: 7, source: "embedded"),
+                makeInventoryItem(combinedIndex: 8, source: "downloaded")
+            ]
+        )
+        let adopted = recovery.adoptingProtocolV3Intent(
+            plan: refreshedPlan, selectedVersion: version, activeQualityId: "original"
+        )
+        XCTAssertEqual(adopted.preferredSidecarSubtitleTrackId, localID)
+        XCTAssertNil(adopted.preferredSubtitleTrackIndex)
+        let intent = PlayerViewModel.protocolV3PendingTrackIntent(plan: refreshedPlan, request: adopted)
+        XCTAssertEqual(intent.sidecarSubtitleTrackId, localID)
+        XCTAssertNil(intent.embeddedSubtitleIndex)
+    }
+
+    func testRenewalReplacesPlanSidecarWithItsNativeEmbeddedIdentity() {
+        let plan = makePlan(container: "mkv", selectedSubtitleIndex: 7, subtitleMode: "render",
+            subtitleInventory: [makeInventoryItem(combinedIndex: 7, source: "embedded")],
+            embeddedSubtitle: PlaybackV3EmbeddedSubtitle(streamIndex: 11))
+        let request = PlayerViewModel.LoadRequest(
+            contentId: "movie", preferredFileId: 42, preferredAudioTrackIndex: nil,
+            preferredSubtitleTrackIndex: -1,
+            preferredSidecarSubtitleTrackId: SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: 7),
+            startFromBeginning: false
+        )
+        let adopted = request.adoptingProtocolV3Intent(
+            plan: plan,
+            selectedVersion: makeVersion(container: "mkv", videoCodec: "h264", audioCodec: "aac"),
+            activeQualityId: "original"
+        )
+        XCTAssertNil(adopted.preferredSidecarSubtitleTrackId)
+        XCTAssertEqual(adopted.preferredSubtitleTrackIndex, 11)
+        XCTAssertEqual(adopted.preferredProtocolV3SubtitleIndex, 7)
+        let intent = PlayerViewModel.protocolV3PendingTrackIntent(plan: plan, request: adopted)
+        XCTAssertNil(intent.sidecarSubtitleTrackId)
+        XCTAssertEqual(intent.embeddedSubtitleIndex, 11)
+    }
+
     func testNativeEmbeddedDecisionRejectsRepackagedSourceAndInvalidIdentity() {
         for (delivery, index) in [("server_remux_progressive", 11), ("original_http", -1)] {
             let plan = makePlan(

--- a/iosApp/Tests/PlaybackProtocolV3Tests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3Tests.swift
@@ -39,6 +39,22 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         ))
     }
 
+    func testNativeResumeIdentityDoesNotOverrideLaterLocalSelection() {
+        let plan = makePlan(container: "mkv", selectedSubtitleIndex: 7, subtitleMode: "render",
+            subtitleInventory: [makeInventoryItem(combinedIndex: 7, source: "embedded")],
+            embeddedSubtitle: PlaybackV3EmbeddedSubtitle(streamIndex: 11))
+        XCTAssertEqual(PlayerViewModel.selectedEmbeddedSubtitleIndexForResume(plan: plan,
+            selectedTrackID: SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: 7)), 11)
+        XCTAssertNil(PlayerViewModel.selectedEmbeddedSubtitleIndexForResume(plan: plan,
+            selectedTrackID: SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: 8)))
+        XCTAssertNil(PlayerViewModel.selectedEmbeddedSubtitleIndexForResume(plan: plan, selectedTrackID: nil))
+        let off = makePlan(container: "mkv", selectedSubtitleIndex: 7, subtitleMode: "off",
+            subtitleInventory: [makeInventoryItem(combinedIndex: 7, source: "embedded")],
+            embeddedSubtitle: PlaybackV3EmbeddedSubtitle(streamIndex: 11))
+        XCTAssertNil(PlayerViewModel.selectedEmbeddedSubtitleIndexForResume(plan: off,
+            selectedTrackID: SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: 7)))
+    }
+
     func testNativeEmbeddedDecisionRejectsRepackagedSourceAndInvalidIdentity() {
         for (delivery, index) in [("server_remux_progressive", 11), ("original_http", -1)] {
             let plan = makePlan(

--- a/iosApp/Tests/PlaybackProtocolV3Tests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3Tests.swift
@@ -11,6 +11,75 @@ actor PlaybackTestActorBox<Value: Sendable> {
 
 @MainActor
 final class PlaybackProtocolV3Tests: XCTestCase {
+    func testNativeEmbeddedDecisionUsesExactStreamWithoutMountingFallbackURL() throws {
+        let plan = makePlan(
+            container: "mkv", selectedSubtitleIndex: 7, subtitleMode: "render",
+            subtitleInventory: [makeInventoryItem(combinedIndex: 7, source: "embedded")],
+            embeddedSubtitle: PlaybackV3EmbeddedSubtitle(streamIndex: 11)
+        )
+        XCTAssertNoThrow(try ApplePlaybackV3PlanAdapter.validate(plan))
+        let spec = try AetherLoadSpec(
+            validating: plan, sessionID: "session-v3", matchContentEnabled: false,
+            sourceURLOverride: URL(string: "https://example.test/movie.mkv")
+        )
+        XCTAssertTrue(spec.options.externalSubtitles.isEmpty)
+        XCTAssertTrue(spec.externalSubtitleAppTrackIDs.isEmpty)
+        let tracks = ApplePlaybackV3PlanAdapter.subtitlePickerTracks(plan: plan)
+        XCTAssertEqual(tracks.first?.ffIndex, 11)
+        XCTAssertEqual(tracks.first?.srcId, 7)
+        let request = PlayerViewModel.LoadRequest(contentId: "movie", preferredFileId: nil, preferredAudioTrackIndex: nil,
+                                                  preferredSubtitleTrackIndex: nil, preferredSidecarSubtitleTrackId: nil,
+                                                  startFromBeginning: false)
+        let intent = PlayerViewModel.protocolV3PendingTrackIntent(plan: plan, request: request)
+        XCTAssertEqual(intent.embeddedSubtitleIndex, 11)
+        XCTAssertNil(intent.sidecarSubtitleTrackId)
+        XCTAssertNil(PlayerViewModel.protocolV3SidecarRestoreIntent(
+            snapshot: SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: 7),
+            selectedSubtitleIndex: 7, subtitleMode: "render", isEmbedded: true
+        ))
+    }
+
+    func testNativeEmbeddedDecisionRejectsRepackagedSourceAndInvalidIdentity() {
+        for (delivery, index) in [("server_remux_progressive", 11), ("original_http", -1)] {
+            let plan = makePlan(
+                delivery: delivery, container: "mkv", selectedSubtitleIndex: 7, subtitleMode: "render",
+                subtitleInventory: [makeInventoryItem(combinedIndex: 7, source: "embedded")],
+                embeddedSubtitle: PlaybackV3EmbeddedSubtitle(streamIndex: index)
+            )
+            XCTAssertThrowsError(try ApplePlaybackV3PlanAdapter.validate(plan))
+        }
+    }
+
+    func testNativeEmbeddedDecisionRejectsContradictoryTrackIdentities() {
+        let plan = makePlan(container: "mkv", selectedSubtitleIndex: 7,
+            decisionSubtitleTrackId: "file:42:subtitle:8", subtitleMode: "render",
+            subtitleInventory: [makeInventoryItem(combinedIndex: 7, source: "embedded"),
+                                makeInventoryItem(combinedIndex: 8, source: "embedded")],
+            embeddedSubtitle: PlaybackV3EmbeddedSubtitle(streamIndex: 11))
+        XCTAssertThrowsError(try ApplePlaybackV3PlanAdapter.validate(plan)) { error in
+            guard case ApplePlaybackV3PlanError.invalidEmbeddedSubtitle = error else {
+                return XCTFail("Expected invalidEmbeddedSubtitle, got \(error)")
+            }
+        }
+    }
+
+    func testNativeCapabilityUsesCanonicalContainerAndCodecNames() {
+        let native = ApplePlaybackV3Capabilities.nativeEmbeddedSubtitleCapabilities(containers: ["mkv", "matroska"])
+        XCTAssertEqual(native.count, 1)
+        XCTAssertEqual(native.first?.container, "mkv")
+        XCTAssertEqual(native.first?.trackIdentity, "ffmpeg_stream_index")
+        XCTAssertEqual(native.first?.assStyling, false)
+        XCTAssertFalse(native.first?.codecs.contains("xsub") ?? true)
+        XCTAssertEqual(ApplePlaybackV3Capabilities.normalizedSubtitleCodec("srt"), "subrip")
+    }
+
+    func testSubtitleClocksKeepAbsoluteSidecarsAlignedAfterReanchor() {
+        XCTAssertEqual(AetherSubtitleOverlay.renderClock(movieTime: 605, engineTime: 5,
+                                                        usesMovieTimeline: true, delaySeconds: 0.5), 604.5)
+        XCTAssertEqual(AetherSubtitleOverlay.renderClock(movieTime: 605, engineTime: 5,
+                                                        usesMovieTimeline: false, delaySeconds: 0.5), 4.5)
+    }
+
     func testServerGoldenDecisionDecodesAndPublishesCompleteSubtitleInventory() throws {
         let response = try PlaybackV3FixtureTestSupport.decode(
             PlaybackV3DecisionResponse.self,
@@ -54,7 +123,7 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         XCTAssertEqual(authoredASS.hearingImpaired, false)
         XCTAssertEqual(
             authoredASS.fontBundleUrl,
-            "/stream/11111111-1111-4111-8111-111111111111/subtitles/1/fonts?file_id=42"
+            "/stream/11111111-1111-4111-8111-111111111111/subtitles/1/fonts?file_id=42&embedded_stream_index=0"
         )
     }
 
@@ -1861,6 +1930,7 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         decisionSubtitleTrackId: String? = nil,
         subtitleMode: String = "off",
         subtitleInventory: [PlaybackV3SubtitleInventoryItem] = [],
+        embeddedSubtitle: PlaybackV3EmbeddedSubtitle? = nil,
         transformations: [PlaybackV3Transformation] = [],
         appliedQuirks: [PlaybackV3AppliedQuirk] = [],
         runtimeCorrections: [String] = [],
@@ -1944,6 +2014,7 @@ final class PlaybackProtocolV3Tests: XCTestCase {
                 trackId: decisionSubtitleTrackId
                     ?? selectedSubtitleIndex.map { "file:42:subtitle:\($0)" },
                 artifact: nil,
+                embedded: embeddedSubtitle,
                 inventory: subtitleInventory
             ),
             transformations: transformations,

--- a/iosApp/iosApp/Screens/Player/AetherLoadSpec.swift
+++ b/iosApp/iosApp/Screens/Player/AetherLoadSpec.swift
@@ -127,6 +127,9 @@ struct AetherLoadSpec {
     /// picking "English" ends up rendering the first sidecar in the plan. Both
     /// arrays are therefore built at a single append site.
     let externalSubtitleAppTrackIDs: [Int64?]
+    /// The selected native row uses the same picker ID space as sidecars,
+    /// but resolves directly to its container stream, without an external slot.
+    let embeddedSubtitleAlias: (appTrackID: Int64, streamIndex: Int)?
 
     /// The bridge this app assumes for codecs Aether cannot stream-copy, when
     /// a caller does not name one.
@@ -189,6 +192,7 @@ struct AetherLoadSpec {
         timeline = PlaybackTimelineMapper(directStartSeconds: startPosition)
         aetherStartPosition = timeline.aetherStartPosition
         self.audioSourceStreamIndex = audioSourceStreamIndex
+        embeddedSubtitleAlias = nil
         externalSubtitleAppTrackIDs = sidecars.map { sidecar -> Int64? in
             SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: sidecar.index)
         }
@@ -255,6 +259,7 @@ struct AetherLoadSpec {
         timeline = PlaybackTimelineMapper(directStartSeconds: startPosition)
         aetherStartPosition = timeline.aetherStartPosition
         audioSourceStreamIndex = nil
+        embeddedSubtitleAlias = nil
         externalSubtitleAppTrackIDs = sidecars.map { sidecar -> Int64? in
             SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: sidecar.index)
         }
@@ -393,6 +398,16 @@ struct AetherLoadSpec {
         }
         self.audioSourceStreamIndex = audioSourceStreamIndex
         self.externalSubtitleAppTrackIDs = externalSubtitleAppTrackIDs
+        if PlaybackProtocolV3.SubtitleMode.locallyRendered.contains(plan.subtitle.mode),
+           let embedded = plan.subtitle.embedded,
+           let combinedIndex = plan.selectedSubtitleCombinedIndex {
+            embeddedSubtitleAlias = (
+                SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: combinedIndex),
+                embedded.streamIndex
+            )
+        } else {
+            embeddedSubtitleAlias = nil
+        }
         let isServerHLS = [
             PlaybackProtocolV3.PlanDelivery.remuxHLS,
             PlaybackProtocolV3.PlanDelivery.transcodeHLS,

--- a/iosApp/iosApp/Screens/Player/AetherLoadSpec.swift
+++ b/iosApp/iosApp/Screens/Player/AetherLoadSpec.swift
@@ -295,9 +295,7 @@ struct AetherLoadSpec {
         resumeSourcePosition: Double? = nil,
         panelIsInHDRMode: Bool? = nil
     ) throws {
-        guard PlaybackProtocolV3.PlanDelivery.supported.contains(plan.delivery) else {
-            throw ValidationError.unsupportedDelivery(plan.delivery)
-        }
+        try ApplePlaybackV3PlanAdapter.validate(plan)
         let resolvedPlanSourceURL: URL?
         if let resolveURL {
             resolvedPlanSourceURL = resolveURL(plan.stream.url)
@@ -331,9 +329,10 @@ struct AetherLoadSpec {
         // every later Aether external id by one.
         var externalSubtitles: [ExternalSubtitleTrack] = []
         var externalSubtitleAppTrackIDs: [Int64?] = []
-        if let artifact = plan.subtitle.artifact,
+        if plan.subtitle.embedded == nil,
+           let artifact = plan.subtitle.artifact,
            PlaybackProtocolV3.SubtitleMode.locallyRendered.contains(plan.subtitle.mode) {
-            guard abs(artifact.timingOriginSeconds - plan.timeline.timelineOffsetSeconds) < 0.001 else {
+            guard artifact.timingOriginSeconds.isFinite, abs(artifact.timingOriginSeconds) < 0.001 else {
                 throw ValidationError.unsupportedSubtitleTimingOrigin(
                     origin: artifact.timingOriginSeconds,
                     timelineOffset: plan.timeline.timelineOffsetSeconds
@@ -369,7 +368,8 @@ struct AetherLoadSpec {
                     resourceURL: artifactURL,
                     trustedOriginURLs: [sourceURL, apiOriginURL].compactMap { $0 }
                 ),
-                formatHint: artifact.format
+                formatHint: artifact.format,
+                nativeTimelineOffsetSeconds: plan.timeline.timelineOffsetSeconds
             ))
             // A declared artifact the inventory does not name has no stable
             // Silo id; leaving the slot empty keeps the arrays parallel and

--- a/iosApp/iosApp/Screens/Player/AetherPlaybackController.swift
+++ b/iosApp/iosApp/Screens/Player/AetherPlaybackController.swift
@@ -12,6 +12,17 @@ import MediaPlayer
 /// engine observation enter the app through this one generation-fenced owner.
 @MainActor
 final class AetherPlaybackController {
+    struct EmbeddedSubtitleSelectionError: LocalizedError {
+        let streamIndex: Int
+        var errorDescription: String? { "The selected embedded subtitle is unavailable in the opened media." }
+    }
+
+    func validateEmbeddedSubtitleSelection(_ streamIndex: Int) throws {
+        guard engine.subtitleTracks.contains(where: { !$0.isExternal && $0.id == streamIndex }) else {
+            throw EmbeddedSubtitleSelectionError(streamIndex: streamIndex)
+        }
+    }
+
     struct LoadFailure: LocalizedError {
         let failure: PlaybackErrorInfo
         let underlying: Error
@@ -29,6 +40,7 @@ final class AetherPlaybackController {
         case playerTime(Double)
         case duration(Double)
         case buffering(Bool)
+        case subtitleLoading(Bool)
         case firstFrame
         case inventoryChanged
         case telemetryChanged
@@ -511,6 +523,11 @@ final class AetherPlaybackController {
 
         engine.$isBuffering
             .sink { [weak self] buffering in self?.publish(.buffering(buffering)) }
+            .store(in: &subscriptions)
+
+        engine.$isLoadingSubtitles
+            .removeDuplicates()
+            .sink { [weak self] loading in self?.publish(.subtitleLoading(loading)) }
             .store(in: &subscriptions)
 
         engine.$hasFirstFrameReadyForDisplay

--- a/iosApp/iosApp/Screens/Player/AetherPlaybackController.swift
+++ b/iosApp/iosApp/Screens/Player/AetherPlaybackController.swift
@@ -168,6 +168,10 @@ final class AetherPlaybackController {
             spec.externalSubtitleAppTrackIDs,
             declaredTrackCount: spec.options.externalSubtitles.count
         )
+        if let alias = spec.embeddedSubtitleAlias {
+            aetherSubtitleIDByAppID[alias.appTrackID] = alias.streamIndex
+            appSubtitleIDByAetherID[alias.streamIndex] = alias.appTrackID
+        }
         didPublishFirstFrame = false
         didPublishEnd = false
         return epoch

--- a/iosApp/iosApp/Screens/Player/AetherPlaybackController.swift
+++ b/iosApp/iosApp/Screens/Player/AetherPlaybackController.swift
@@ -384,6 +384,17 @@ final class AetherPlaybackController {
         appSubtitleIDByAetherID[id] ?? Int64(id)
     }
 
+    func subtitleUsesMovieTimeline(appTrackID: Int64?, slot: SubtitleSlot) -> Bool {
+        let engineID: Int?
+        if let appTrackID {
+            engineID = aetherSubtitleID(forAppID: appTrackID)
+        } else {
+            // Only the primary slot has an engine-published active identity.
+            engineID = slot == .primary ? engine.activeSubtitleTrackIndex : nil
+        }
+        return engine.subtitleTracks.contains { $0.id == engineID && $0.isExternal }
+    }
+
     func containsSubtitle(appTrackID: Int64) -> Bool {
         aetherSubtitleIDByAppID[appTrackID] != nil
     }

--- a/iosApp/iosApp/Screens/Player/AetherSubtitleOverlay.swift
+++ b/iosApp/iosApp/Screens/Player/AetherSubtitleOverlay.swift
@@ -6,6 +6,8 @@ import SwiftUI
 struct AetherSubtitleOverlay: View {
     let engine: AetherEngine
     let sourceTime: Double
+    let primaryUsesMovieTimeline: Bool
+    let secondaryUsesMovieTimeline: Bool
     let livePrimaryCues: [LiveSubtitleCue]
     let liveSecondaryCues: [LiveSubtitleCue]
     let appearance: SubtitleAppearance
@@ -29,8 +31,8 @@ struct AetherSubtitleOverlay: View {
         GeometryReader { geometry in
             let videoRect = displayedVideoRect(in: geometry.size)
             ZStack {
-                cueLayer(activeCues(in: primary), videoRect: videoRect, secondary: false)
-                cueLayer(activeCues(in: secondary), videoRect: videoRect, secondary: true)
+                cueLayer(activeCues(in: primary, usesMovieTimeline: primaryUsesMovieTimeline), videoRect: videoRect, secondary: false)
+                cueLayer(activeCues(in: secondary, usesMovieTimeline: secondaryUsesMovieTimeline), videoRect: videoRect, secondary: true)
                 liveCueLayer(activeLiveCues(in: livePrimaryCues), videoRect: videoRect, secondary: false)
                 liveCueLayer(activeLiveCues(in: liveSecondaryCues), videoRect: videoRect, secondary: true)
             }
@@ -42,8 +44,15 @@ struct AetherSubtitleOverlay: View {
         .onReceive(engine.clock.$sourceTime) { aetherSourceTime = $0 }
     }
 
-    private func activeCues(in cues: [SubtitleCue]) -> [SubtitleCue] {
-        let renderClock = aetherSourceTime - subtitleDelaySeconds
+    static func renderClock(movieTime: Double, engineTime: Double, usesMovieTimeline: Bool, delaySeconds: Double) -> Double {
+        (usesMovieTimeline ? movieTime : engineTime) - delaySeconds
+    }
+
+    private func activeCues(in cues: [SubtitleCue], usesMovieTimeline: Bool) -> [SubtitleCue] {
+        // Complete sidecars use original movie timestamps; embedded cues use
+        // the served stream's clock, which may be rebased by a server remux.
+        let renderClock = Self.renderClock(movieTime: sourceTime, engineTime: aetherSourceTime,
+                                          usesMovieTimeline: usesMovieTimeline, delaySeconds: subtitleDelaySeconds)
         return cues.filter { $0.startTime <= renderClock && renderClock < $0.endTime }
     }
 

--- a/iosApp/iosApp/Screens/Player/PlayerBufferingCapsule.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerBufferingCapsule.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 /// A single, shell-level buffering indicator shared by every player surface.
 struct PlayerBufferingCapsule: View {
+    var label: LocalizedStringKey = "Loading…"
+
     var body: some View {
         HStack(spacing: spacing) {
             ProgressView()
@@ -9,7 +11,7 @@ struct PlayerBufferingCapsule: View {
                 .progressViewStyle(.circular)
                 .scaleEffect(spinnerScale)
 
-            Text("Loading…")
+            Text(label)
                 .font(.siloSmall.weight(.medium))
                 .foregroundStyle(.white.opacity(0.82))
         }
@@ -23,7 +25,7 @@ struct PlayerBufferingCapsule: View {
         .allowsHitTesting(false)
         .transition(.opacity)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("Loading")
+        .accessibilityLabel(label)
     }
 
     private var spacing: CGFloat {

--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -281,6 +281,8 @@ struct PlayerView: View {
 
                     if viewModel.isLoading || viewModel.isBuffering {
                         PlayerBufferingCapsule()
+                    } else if viewModel.isLoadingSubtitles {
+                        PlayerBufferingCapsule(label: "Loading subtitles…")
                     }
                 }
             }
@@ -581,6 +583,8 @@ struct PlayerView: View {
                 AetherSubtitleOverlay(
                     engine: viewModel.aetherEngine,
                     sourceTime: viewModel.currentTime,
+                    primaryUsesMovieTimeline: viewModel.subtitleUsesMovieTimeline(viewModel.selectedSubtitleId),
+                    secondaryUsesMovieTimeline: viewModel.subtitleUsesMovieTimeline(viewModel.selectedSecondarySubtitleId),
                     livePrimaryCues: viewModel.selectedSubtitleId.map(SubtitleTrackIdSpace.isAILive) == true
                         ? viewModel.livePrimarySubtitleCues
                         : [],

--- a/iosApp/iosApp/Screens/Player/PlayerView.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerView.swift
@@ -584,7 +584,7 @@ struct PlayerView: View {
                     engine: viewModel.aetherEngine,
                     sourceTime: viewModel.currentTime,
                     primaryUsesMovieTimeline: viewModel.subtitleUsesMovieTimeline(viewModel.selectedSubtitleId),
-                    secondaryUsesMovieTimeline: viewModel.subtitleUsesMovieTimeline(viewModel.selectedSecondarySubtitleId),
+                    secondaryUsesMovieTimeline: viewModel.subtitleUsesMovieTimeline(viewModel.selectedSecondarySubtitleId, slot: .secondary),
                     livePrimaryCues: viewModel.selectedSubtitleId.map(SubtitleTrackIdSpace.isAILive) == true
                         ? viewModel.livePrimarySubtitleCues
                         : [],

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -813,7 +813,17 @@ class PlayerViewModel {
                 offlineDownloadId: offlineDownloadId,
                 preferredQualityOverride: preferredQualityOverride
             )
-            request.preferredProtocolV3SubtitleIndex = preferredProtocolV3SubtitleIndex
+            // A completed download can be selected after the last server plan.
+            // Ask the replacement session for that combined ordinal; retaining
+            // the old plan's ordinal would reselect its embedded subtitle.
+            if let preferredSidecarSubtitleTrackId,
+               SubtitleTrackIdSpace.isSidecar(preferredSidecarSubtitleTrackId) {
+                request.preferredProtocolV3SubtitleIndex = SubtitleTrackIdSpace.sidecarIndex(
+                    from: preferredSidecarSubtitleTrackId
+                )
+            } else {
+                request.preferredProtocolV3SubtitleIndex = preferredProtocolV3SubtitleIndex
+            }
             request.prefersLastUsedVersion = prefersLastUsedVersion
             return request
         }

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -3701,9 +3701,8 @@ class PlayerViewModel {
         return selectionIndex
     }
 
-    func subtitleUsesMovieTimeline(_ trackID: Int64?) -> Bool {
-        guard let trackID else { return false }
-        return aetherPlaybackController.containsSubtitle(appTrackID: trackID)
+    func subtitleUsesMovieTimeline(_ trackID: Int64?, slot: SubtitleSlot = .primary) -> Bool {
+        aetherPlaybackController.subtitleUsesMovieTimeline(appTrackID: trackID, slot: slot)
     }
 
     static func selectedEmbeddedSubtitleIndexForResume(plan: PlaybackV3Plan?, selectedTrackID: Int64?) -> Int? {

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -228,6 +228,7 @@ class PlayerViewModel {
     @discardableResult
     private func disposeAetherPlayback(forReplacement: Bool = false) -> Task<Void, Never>? {
         let previewShutdown = scrubPreviewProvider.endSession()
+        isLoadingSubtitles = false
         activeAetherLoadEpoch = nil
         establishedAetherLoadEpoch = nil
         committedProtocolV3LoadEpoch = nil
@@ -801,7 +802,8 @@ class PlayerViewModel {
             preferredAudioTrackIndex: Int?,
             preferredSubtitleTrackIndex: Int?,
             preferredSidecarSubtitleTrackId: Int64?,
-            offlineDownloadId: String?
+            offlineDownloadId: String?,
+            serverSubtitlesDisabled: Bool = false
         ) -> LoadRequest {
             var request = LoadRequest(
                 contentId: contentId,
@@ -816,8 +818,12 @@ class PlayerViewModel {
             // A completed download can be selected after the last server plan.
             // Ask the replacement session for that combined ordinal; retaining
             // the old plan's ordinal would reselect its embedded subtitle.
-            if let preferredSidecarSubtitleTrackId,
-               SubtitleTrackIdSpace.isSidecar(preferredSidecarSubtitleTrackId) {
+            // Local decoder Off also accompanies burn-in. Only an explicit
+            // server disable may erase the server's selected ordinal.
+            if serverSubtitlesDisabled {
+                request.preferredProtocolV3SubtitleIndex = nil
+            } else if let preferredSidecarSubtitleTrackId,
+                      SubtitleTrackIdSpace.isSidecar(preferredSidecarSubtitleTrackId) {
                 request.preferredProtocolV3SubtitleIndex = SubtitleTrackIdSpace.sidecarIndex(
                     from: preferredSidecarSubtitleTrackId
                 )
@@ -2020,7 +2026,7 @@ class PlayerViewModel {
                     self.pendingSidecarSubtitleTrackId = nil
                     self.pendingServerRenderedSubtitleTrackId = trackId
                 case nil:
-                    self.pendingServerRenderedSubtitleTrackId = nil
+                    break
                 }
                 self.pendingExternalSubtitles = prepared.session.subtitleUrls ?? []
                 self.knownExternalSubtitles = self.pendingExternalSubtitles
@@ -3726,7 +3732,28 @@ class PlayerViewModel {
         return embedded.streamIndex
     }
 
+    static func serverSubtitlesDisabledForResume(
+        selectedTrackID: Int64?, hasExplicitChoice: Bool,
+        pendingEmbeddedIndex: Int?, pendingSidecarID: Int64?,
+        pendingServerRenderedID: Int64? = nil
+    ) -> Bool {
+        if selectedTrackID.map(SubtitleTrackIdSpace.isAILive) == true { return true }
+        // Before inventory arrives, nil can mean an unresolved requested track.
+        return hasExplicitChoice && selectedTrackID == nil
+            && pendingSidecarID == nil && pendingServerRenderedID == nil
+            && (pendingEmbeddedIndex ?? -1) < 0
+    }
+
+    private var hasDisabledServerSubtitlesForResume: Bool {
+        Self.serverSubtitlesDisabledForResume(
+            selectedTrackID: selectedSubtitleId, hasExplicitChoice: hasExplicitSubtitleChoice,
+            pendingEmbeddedIndex: pendingSubtitleFfIndex, pendingSidecarID: pendingSidecarSubtitleTrackId,
+            pendingServerRenderedID: pendingServerRenderedSubtitleTrackId
+        )
+    }
+
     private func resolvedSubtitleTrackIndexForResume() -> Int? {
+        if hasDisabledServerSubtitlesForResume { return -1 }
         if let index = Self.selectedEmbeddedSubtitleIndexForResume(
             plan: activePreparedProtocolV3?.plan, selectedTrackID: selectedSubtitleId
         ) {
@@ -3768,6 +3795,7 @@ class PlayerViewModel {
     }
 
     private func resolvedSidecarSubtitleTrackIdForResume() -> Int64? {
+        if hasDisabledServerSubtitlesForResume { return nil }
         if Self.selectedEmbeddedSubtitleIndexForResume(
             plan: activePreparedProtocolV3?.plan, selectedTrackID: selectedSubtitleId
         ) != nil { return nil }
@@ -3816,6 +3844,7 @@ class PlayerViewModel {
         pendingAudioFfIndex = intent.audioIndex
         pendingSubtitleFfIndex = intent.embeddedSubtitleIndex
         pendingSidecarSubtitleTrackId = intent.sidecarSubtitleTrackId
+        pendingServerRenderedSubtitleTrackId = intent.serverRenderedSubtitleTrackId
     }
 
     private func beginFreshLoad(
@@ -4354,7 +4383,8 @@ class PlayerViewModel {
             preferredAudioTrackIndex: resolvedAudioTrackIndexForResume(),
             preferredSubtitleTrackIndex: resolvedSubtitleTrackIndexForResume(),
             preferredSidecarSubtitleTrackId: resolvedSidecarSubtitleTrackIdForResume(),
-            offlineDownloadId: nil
+            offlineDownloadId: nil,
+            serverSubtitlesDisabled: hasDisabledServerSubtitlesForResume
         )
 
         Self.logger.warning(
@@ -4519,7 +4549,8 @@ class PlayerViewModel {
             preferredAudioTrackIndex: resolvedAudioTrackIndexForResume(),
             preferredSubtitleTrackIndex: resolvedSubtitleTrackIndexForResume(),
             preferredSidecarSubtitleTrackId: resolvedSidecarSubtitleTrackIdForResume(),
-            offlineDownloadId: nil
+            offlineDownloadId: nil,
+            serverSubtitlesDisabled: hasDisabledServerSubtitlesForResume
         )
         request.preferredQualityOverride = resolvedQualityId
         beginFreshLoad(
@@ -5290,9 +5321,13 @@ class PlayerViewModel {
         let priorSubtitleId = selectedSubtitleId
         let priorSecondarySubtitleId = selectedSecondarySubtitleId
         let priorPendingSubtitleFfIndex = pendingSubtitleFfIndex
+        let priorPendingSidecarSubtitleTrackId = pendingSidecarSubtitleTrackId
+        let priorPendingServerRenderedSubtitleTrackId = pendingServerRenderedSubtitleTrackId
         let priorHasExplicitSubtitleChoice = hasExplicitSubtitleChoice
         hasExplicitSubtitleChoice = true
         pendingSubtitleFfIndex = nil
+        pendingSidecarSubtitleTrackId = nil
+        pendingServerRenderedSubtitleTrackId = nil
         if selectedSecondarySubtitleId == track.trackId {
             selectedSecondarySubtitleId = nil
             applySecondarySubtitleTrackSelection(nil)
@@ -5323,6 +5358,8 @@ class PlayerViewModel {
             ) else {
                 selectedSubtitleId = priorSubtitleId
                 pendingSubtitleFfIndex = priorPendingSubtitleFfIndex
+                pendingSidecarSubtitleTrackId = priorPendingSidecarSubtitleTrackId
+                pendingServerRenderedSubtitleTrackId = priorPendingServerRenderedSubtitleTrackId
                 hasExplicitSubtitleChoice = priorHasExplicitSubtitleChoice
                 if selectedSecondarySubtitleId != priorSecondarySubtitleId {
                     selectedSecondarySubtitleId = priorSecondarySubtitleId
@@ -5355,9 +5392,13 @@ class PlayerViewModel {
         let priorSubtitleId = selectedSubtitleId
         let priorSecondarySubtitleId = selectedSecondarySubtitleId
         let priorPendingSubtitleFfIndex = pendingSubtitleFfIndex
+        let priorPendingSidecarSubtitleTrackId = pendingSidecarSubtitleTrackId
+        let priorPendingServerRenderedSubtitleTrackId = pendingServerRenderedSubtitleTrackId
         let priorHasExplicitSubtitleChoice = hasExplicitSubtitleChoice
         hasExplicitSubtitleChoice = true
-        pendingSubtitleFfIndex = nil
+        pendingSubtitleFfIndex = -1
+        pendingSidecarSubtitleTrackId = nil
+        pendingServerRenderedSubtitleTrackId = nil
         if selectedSecondarySubtitleId != nil {
             selectedSecondarySubtitleId = nil
             applySecondarySubtitleTrackSelection(nil)
@@ -5376,6 +5417,8 @@ class PlayerViewModel {
             ) else {
                 selectedSubtitleId = priorSubtitleId
                 pendingSubtitleFfIndex = priorPendingSubtitleFfIndex
+                pendingSidecarSubtitleTrackId = priorPendingSidecarSubtitleTrackId
+                pendingServerRenderedSubtitleTrackId = priorPendingServerRenderedSubtitleTrackId
                 hasExplicitSubtitleChoice = priorHasExplicitSubtitleChoice
                 if selectedSecondarySubtitleId != priorSecondarySubtitleId {
                     selectedSecondarySubtitleId = priorSecondarySubtitleId
@@ -5704,6 +5747,7 @@ class PlayerViewModel {
         let audioIndex: Int?
         let embeddedSubtitleIndex: Int?
         let sidecarSubtitleTrackId: Int64?
+        let serverRenderedSubtitleTrackId: Int64?
     }
 
     static func protocolV3PendingTrackIntent(
@@ -5719,6 +5763,9 @@ class PlayerViewModel {
                 : -1,
             sidecarSubtitleTrackId: rendersSubtitleLocally && plan.subtitle.embedded == nil
                 ? request.preferredSidecarSubtitleTrackId
+                : nil,
+            serverRenderedSubtitleTrackId: plan.subtitle.mode == PlaybackProtocolV3.SubtitleMode.burnIn
+                ? plan.selectedSubtitleCombinedIndex.map { SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: $0) }
                 : nil
         )
     }

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -248,6 +248,7 @@ class PlayerViewModel {
     var title: String = ""
     var isLoading = true
     var isBuffering = false
+    var isLoadingSubtitles = false
     /// Fill progress (0–100) toward the buffering-resume threshold; nil
     /// when not buffering or when the active backend doesn't report it.
     var bufferingProgress: Double?
@@ -837,6 +838,7 @@ class PlayerViewModel {
                 // A sidecar is the server-selected artifact even when it was
                 // extracted from an embedded stream. Arming both identities
                 // would publish and select the same subtitle twice.
+                if let embedded = plan.subtitle.embedded { return embedded.streamIndex }
                 guard item.source == "embedded", item.delivery != "sidecar" else { return nil }
                 return ApplePlaybackV3PlanAdapter.ffmpegSubtitleStreamIndex(
                     serverCombinedIndex: item.combinedIndex,
@@ -845,7 +847,7 @@ class PlayerViewModel {
                 )
             }
             let sidecarTrackId: Int64? = selectedSubtitle.flatMap { item in
-                guard item.delivery == "sidecar" else { return nil }
+                guard plan.subtitle.embedded == nil, item.delivery == "sidecar" else { return nil }
                 return SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: item.combinedIndex)
             }
             var request = copyForRecovery(
@@ -1168,6 +1170,8 @@ class PlayerViewModel {
         case .buffering(let buffering):
             isBuffering = buffering
             refreshPlaybackStats(force: true)
+        case .subtitleLoading(let loading):
+            isLoadingSubtitles = loading
         case .firstFrame:
             handleAetherStartupMilestone(epoch: scopedEvent.epoch)
         case .inventoryChanged:
@@ -1257,6 +1261,7 @@ class PlayerViewModel {
             selectedAudioId = aetherPlaybackController.engine.activeAudioTrackIndex
                 .map(Int64.init)
             isBuffering = false
+            isLoadingSubtitles = false
             bufferingProgress = nil
             isQualitySwitching = false
             if freshLoadOwnsFailureHandling || !isAetherLoadEstablished {
@@ -1557,6 +1562,7 @@ class PlayerViewModel {
         progressTask = nil
         isLoading = true
         isBuffering = false
+        isLoadingSubtitles = false
         bufferingProgress = nil
         streamLoadGeneration &+= 1
         let recoveryGeneration = streamLoadGeneration
@@ -1894,6 +1900,7 @@ class PlayerViewModel {
         progressTask?.cancel()
         isLoading = true
         isBuffering = false
+        isLoadingSubtitles = false
         bufferingProgress = nil
         streamLoadGeneration &+= 1
         let currentStreamLoadGeneration = streamLoadGeneration
@@ -1993,7 +2000,8 @@ class PlayerViewModel {
                 switch Self.protocolV3SidecarRestoreIntent(
                     snapshot: selectedSubtitleSnapshot,
                     selectedSubtitleIndex: prepared.protocolV3?.plan.selectedTracks.subtitle?.index,
-                    subtitleMode: prepared.protocolV3?.plan.subtitle.mode
+                    subtitleMode: prepared.protocolV3?.plan.subtitle.mode,
+                    isEmbedded: prepared.protocolV3?.plan.subtitle.embedded != nil
                 ) {
                 case .renderLocally(let trackId):
                     self.pendingSidecarSubtitleTrackId = trackId
@@ -2160,6 +2168,13 @@ class PlayerViewModel {
     private func protocolV3LoadFailureRecovery(
         _ error: Error
     ) -> (shouldAdvanceRoute: Bool, classification: String, message: String) {
+        if let error = error as? ApplePlaybackV3PlanError,
+           case .invalidEmbeddedSubtitle = error {
+            return (true, "subtitle_embedded_failed", error.localizedDescription)
+        }
+        if let failure = error as? AetherPlaybackController.EmbeddedSubtitleSelectionError {
+            return (true, "subtitle_embedded_failed", failure.localizedDescription)
+        }
         if let loadFailure = error as? AetherPlaybackController.LoadFailure {
             let failure = loadFailure.failure
             // Aether defines rate limiting as a retry-later condition at the
@@ -2848,6 +2863,7 @@ class PlayerViewModel {
         try requireCurrentStreamLoad(expectedStreamLoadGeneration)
         isLoading = true
         isBuffering = false
+        isLoadingSubtitles = false
         bufferingProgress = nil
         scrubPreviewProvider.endSession()
         let loadEpoch = aetherPlaybackController.beginLoad(
@@ -2896,6 +2912,9 @@ class PlayerViewModel {
         }
         // Startup ran to completion on this epoch, so the decode route is now
         // settled and deferred track picks may drive the engine.
+        if let embedded = prepared.protocolV3?.plan.subtitle.embedded {
+            try aetherPlaybackController.validateEmbeddedSubtitleSelection(embedded.streamIndex)
+        }
         establishedAetherLoadEpoch = loadEpoch
         scrubPreviewProvider.activate(spec)
         adoptAetherInventory()
@@ -3459,6 +3478,7 @@ class PlayerViewModel {
         }
         isLoading = false
         isBuffering = false
+        isLoadingSubtitles = false
         bufferingProgress = nil
         isPlaying = false
         showControls = true
@@ -3680,7 +3700,15 @@ class PlayerViewModel {
         return selectionIndex
     }
 
+    func subtitleUsesMovieTimeline(_ trackID: Int64?) -> Bool {
+        guard let trackID else { return false }
+        return aetherPlaybackController.containsSubtitle(appTrackID: trackID)
+    }
+
     private func resolvedSubtitleTrackIndexForResume() -> Int? {
+        if let embedded = activePreparedProtocolV3?.plan.subtitle.embedded {
+            return embedded.streamIndex
+        }
         // The id space decides, not the row's metadata: a V3 picker row is
         // published in the sidecar space and carries its FFmpeg index only so
         // an embedded pick can be persisted. Restoring it as an embedded index
@@ -3717,6 +3745,7 @@ class PlayerViewModel {
     }
 
     private func resolvedSidecarSubtitleTrackIdForResume() -> Int64? {
+        if activePreparedProtocolV3?.plan.subtitle.embedded != nil { return nil }
         if let selectedSubtitleId, SubtitleTrackIdSpace.isSidecar(selectedSubtitleId) {
             return selectedSubtitleId
         }
@@ -5614,8 +5643,10 @@ class PlayerViewModel {
     static func protocolV3SidecarRestoreIntent(
         snapshot: Int64?,
         selectedSubtitleIndex: Int?,
-        subtitleMode: String?
+        subtitleMode: String?,
+        isEmbedded: Bool = false
     ) -> ProtocolV3SidecarRestoreIntent? {
+        guard !isEmbedded else { return nil }
         guard let snapshot,
               SubtitleTrackIdSpace.isSidecar(snapshot),
               SubtitleTrackIdSpace.sidecarIndex(from: snapshot) == selectedSubtitleIndex else {
@@ -5659,9 +5690,9 @@ class PlayerViewModel {
         return ProtocolV3PendingTrackIntent(
             audioIndex: request.preferredAudioTrackIndex,
             embeddedSubtitleIndex: rendersSubtitleLocally
-                ? request.preferredSubtitleTrackIndex
+                ? (plan.subtitle.embedded?.streamIndex ?? request.preferredSubtitleTrackIndex)
                 : -1,
-            sidecarSubtitleTrackId: rendersSubtitleLocally
+            sidecarSubtitleTrackId: rendersSubtitleLocally && plan.subtitle.embedded == nil
                 ? request.preferredSidecarSubtitleTrackId
                 : nil
         )
@@ -5718,7 +5749,8 @@ class PlayerViewModel {
                 isHearingImpaired: descriptor.isHearingImpaired ?? false,
                 isDefault: descriptor.isDefault ?? false,
                 httpHeaders: aetherSubtitleRequestHeaders(for: descriptor.url),
-                formatHint: descriptor.codec
+                formatHint: descriptor.codec,
+                nativeTimelineOffsetSeconds: aetherPlaybackController.activeSpec?.timeline.timelineOffsetSeconds ?? 0
             ),
             appTrackID: trackId
         )
@@ -6523,7 +6555,8 @@ class PlayerViewModel {
                     isHearingImpaired: known.hearingImpaired ?? false,
                     isDefault: known.default ?? false,
                     httpHeaders: aetherSubtitleRequestHeaders(for: url),
-                    formatHint: known.codec
+                    formatHint: known.codec,
+                    nativeTimelineOffsetSeconds: aetherPlaybackController.activeSpec?.timeline.timelineOffsetSeconds ?? 0
                 ),
                 appTrackID: local.trackId
             )
@@ -6612,7 +6645,8 @@ class PlayerViewModel {
                     isHearingImpaired: descriptor.isHearingImpaired ?? false,
                     isDefault: descriptor.isDefault ?? false,
                     httpHeaders: aetherSubtitleRequestHeaders(for: descriptor.url),
-                    formatHint: descriptor.codec
+                    formatHint: descriptor.codec,
+                    nativeTimelineOffsetSeconds: aetherPlaybackController.activeSpec?.timeline.timelineOffsetSeconds ?? 0
                 ),
                 appTrackID: appTrackID
             )
@@ -6799,7 +6833,8 @@ class PlayerViewModel {
                 isHearingImpaired: track.isHearingImpaired,
                 isDefault: track.isDefault,
                 httpHeaders: aetherSubtitleRequestHeaders(for: url),
-                formatHint: track.codec
+                formatHint: track.codec,
+                nativeTimelineOffsetSeconds: aetherPlaybackController.activeSpec?.timeline.timelineOffsetSeconds ?? 0
             ),
             appTrackID: track.trackId
         )

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -2904,6 +2904,9 @@ class PlayerViewModel {
                   aetherPlaybackController.activeLoadEpoch == loadEpoch else {
                 throw CancellationError()
             }
+            if let embedded = prepared.protocolV3?.plan.subtitle.embedded {
+                try aetherPlaybackController.validateEmbeddedSubtitleSelection(embedded.streamIndex)
+            }
         } catch {
             if aetherPlaybackController.activeLoadEpoch == loadEpoch {
                 disposeAetherPlayback()
@@ -2912,9 +2915,6 @@ class PlayerViewModel {
         }
         // Startup ran to completion on this epoch, so the decode route is now
         // settled and deferred track picks may drive the engine.
-        if let embedded = prepared.protocolV3?.plan.subtitle.embedded {
-            try aetherPlaybackController.validateEmbeddedSubtitleSelection(embedded.streamIndex)
-        }
         establishedAetherLoadEpoch = loadEpoch
         scrubPreviewProvider.activate(spec)
         adoptAetherInventory()

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -3605,6 +3605,7 @@ class PlayerViewModel {
         preferredSidecarSubtitleTrackId: Int64?,
         preferredProtocolV3SubtitleIndex: Int? = nil
     ) {
+        isLoadingSubtitles = false
         isLoading = true
         error = nil
         noticeDismissTask?.cancel()
@@ -3705,9 +3706,22 @@ class PlayerViewModel {
         return aetherPlaybackController.containsSubtitle(appTrackID: trackID)
     }
 
+    static func selectedEmbeddedSubtitleIndexForResume(plan: PlaybackV3Plan?, selectedTrackID: Int64?) -> Int? {
+        guard let plan,
+              plan.subtitle.mode == PlaybackProtocolV3.SubtitleMode.render,
+              let embedded = plan.subtitle.embedded,
+              let selected = plan.selectedSubtitleInventoryItem,
+              selectedTrackID == SubtitleTrackIdSpace.makeSidecarTrackId(urlIndex: selected.combinedIndex) else {
+            return nil
+        }
+        return embedded.streamIndex
+    }
+
     private func resolvedSubtitleTrackIndexForResume() -> Int? {
-        if let embedded = activePreparedProtocolV3?.plan.subtitle.embedded {
-            return embedded.streamIndex
+        if let index = Self.selectedEmbeddedSubtitleIndexForResume(
+            plan: activePreparedProtocolV3?.plan, selectedTrackID: selectedSubtitleId
+        ) {
+            return index
         }
         // The id space decides, not the row's metadata: a V3 picker row is
         // published in the sidecar space and carries its FFmpeg index only so
@@ -3745,7 +3759,9 @@ class PlayerViewModel {
     }
 
     private func resolvedSidecarSubtitleTrackIdForResume() -> Int64? {
-        if activePreparedProtocolV3?.plan.subtitle.embedded != nil { return nil }
+        if Self.selectedEmbeddedSubtitleIndexForResume(
+            plan: activePreparedProtocolV3?.plan, selectedTrackID: selectedSubtitleId
+        ) != nil { return nil }
         if let selectedSubtitleId, SubtitleTrackIdSpace.isSidecar(selectedSubtitleId) {
             return selectedSubtitleId
         }

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3Capabilities.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3Capabilities.swift
@@ -46,7 +46,8 @@ enum ApplePlaybackV3Capabilities {
         PlaybackProtocolV3.outputChangeFeature,
         PlaybackProtocolV3.directStreamResumeFeature,
         PlaybackProtocolV3.headerAuthenticatedMediaFeature,
-        PlaybackProtocolV3.softwareVideoDecodeFeature
+        PlaybackProtocolV3.softwareVideoDecodeFeature,
+        PlaybackProtocolV3.embeddedSubtitlesFeature
     ]
 
     /// Audiobooks currently restart sessions at part boundaries and do not
@@ -56,6 +57,7 @@ enum ApplePlaybackV3Capabilities {
     static let audiobookFeatures = features.filter {
         $0 != PlaybackProtocolV3.seekReanchorFeature
             && $0 != PlaybackProtocolV3.softwareVideoDecodeFeature
+            && $0 != PlaybackProtocolV3.embeddedSubtitlesFeature
     }
 
     /// `authorized_media_origins_v1` is negotiated per attempt rather than
@@ -106,6 +108,36 @@ enum ApplePlaybackV3Capabilities {
             ]
         )
     ]
+
+    static func normalizedSubtitleCodec(_ codec: String) -> String {
+        switch codec.lowercased() {
+        case "srt": return "subrip"
+        case "vtt": return "webvtt"
+        case "tx3g": return "mov_text"
+        case "pgs", "pgssub": return "hdmv_pgs_subtitle"
+        case "dvdsub", "vobsub": return "dvd_subtitle"
+        case "dvbsub": return "dvb_subtitle"
+        default: return codec.lowercased()
+        }
+    }
+
+    // The pinned Aether demuxer exposes FFmpeg stream ids and drains text and
+    // bitmap packets from the original source. XSUB has no shipped decoder.
+    static func nativeEmbeddedSubtitleCapabilities(containers: [String]) -> [PlaybackV3NativeEmbeddedSubtitleCapability] {
+        var seen = Set<String>()
+        return containers.map { $0.lowercased() == "matroska" ? "mkv" : $0.lowercased() }
+            .filter { ["mkv", "mp4", "mov", "m4v", "webm"].contains($0) && seen.insert($0).inserted }.map {
+            PlaybackV3NativeEmbeddedSubtitleCapability(
+                container: $0,
+                codecs: $0 == "mkv"
+                    ? ["subrip", "ass", "ssa", "webvtt", "hdmv_pgs_subtitle", "dvd_subtitle", "dvb_subtitle"]
+                    : ($0 == "webm" ? ["webvtt"] : ["mov_text"]),
+                trackIdentity: "ffmpeg_stream_index",
+                assStyling: false,
+                fontAttachments: false
+            )
+        }
+    }
 
     static func snapshot(
         videoCapabilityMode requestedMode: AppleDecodeCapabilities.StreamingVideoCapabilityMode? = nil
@@ -167,6 +199,7 @@ enum ApplePlaybackV3Capabilities {
             AppleDecodeCapabilities.isSimulator ? [] : deviceClientTransformations
 
         let aetherSubtitles = PlaybackV3DeliverySubtitleCapabilities(
+            nativeEmbedded: nativeEmbeddedSubtitleCapabilities(containers: containers),
             embeddedText: true,
             sidecarText: true,
             // The Silo overlay preserves normalized text and placement, not

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3PlanAdapter.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/ApplePlaybackV3PlanAdapter.swift
@@ -19,6 +19,7 @@ enum ApplePlaybackV3PlanError: LocalizedError, Equatable {
     case unsupportedClientTransformation(String)
     case invalidClientTransformation(String)
     case unsupportedRuntimeCorrection(String)
+    case invalidEmbeddedSubtitle(String)
 
     var errorDescription: String? {
         switch self {
@@ -30,6 +31,8 @@ enum ApplePlaybackV3PlanError: LocalizedError, Equatable {
             return "The V3 plan requires an unsupported client transformation: \(value)."
         case .invalidClientTransformation(let value):
             return "The V3 client transformation cannot be executed as planned: \(value)."
+        case .invalidEmbeddedSubtitle(let value):
+            return "The embedded subtitle selection is invalid: \(value)."
         case .unsupportedRuntimeCorrection(let value):
             return "The V3 plan requires an unsupported runtime correction: \(value)."
         }
@@ -81,6 +84,25 @@ enum ApplePlaybackV3PlanAdapter {
             throw ApplePlaybackV3PlanError.invalidClientTransformation(
                 "client transformations require the original_http delivery"
             )
+        }
+        if let embedded = plan.subtitle.embedded {
+            guard plan.delivery == PlaybackProtocolV3.PlanDelivery.originalHTTP,
+                  plan.subtitle.mode == PlaybackProtocolV3.SubtitleMode.render,
+                  plan.subtitle.artifact == nil,
+                  embedded.streamIndex >= 0,
+                  embedded.streamIndex <= Int(Int32.max),
+                  let selected = plan.selectedSubtitleInventoryItem,
+                  selected.trackId == plan.subtitle.trackId,
+                  selected.trackId == plan.selectedTracks.subtitle?.id,
+                  plan.selectedTracks.subtitle?.index == nil || plan.selectedTracks.subtitle?.index == selected.combinedIndex,
+                  selected.source == "embedded",
+                  let codec = selected.codec,
+                  let container = plan.stream.container,
+                  ApplePlaybackV3Capabilities.nativeEmbeddedSubtitleCapabilities(
+                    containers: [container]
+                  ).contains(where: { $0.codecs.contains(ApplePlaybackV3Capabilities.normalizedSubtitleCodec(codec)) }) else {
+                throw ApplePlaybackV3PlanError.invalidEmbeddedSubtitle("unsupported source, codec, or stream identity")
+            }
         }
         if let correction = plan.runtimeCorrections.first {
             // Runtime correction tokens belonged to the removed Silo
@@ -197,7 +219,9 @@ enum ApplePlaybackV3PlanAdapter {
             : plan.selectedSubtitleCombinedIndex
         return plan.subtitle.inventory.compactMap { item in
             guard item.combinedIndex >= 0 else { return nil }
-            let ffIndex: Int? = item.source == "embedded"
+            let ffIndex: Int? = item.combinedIndex == selectedIndex && plan.subtitle.embedded != nil
+                ? plan.subtitle.embedded?.streamIndex
+                : item.source == "embedded"
                 ? version.flatMap {
                     ffmpegSubtitleStreamIndex(
                         serverCombinedIndex: item.combinedIndex,

--- a/iosApp/iosApp/Screens/Player/ProtocolV3/PlaybackProtocolV3Models.swift
+++ b/iosApp/iosApp/Screens/Player/ProtocolV3/PlaybackProtocolV3Models.swift
@@ -39,6 +39,7 @@ enum PlaybackProtocolV3 {
     static let clientManagedDynamicRangeClaim = "client_managed_dynamic_range_v1"
     /// Scoped to `original_http`: after probing the complete source, Aether
     /// maps the plan's selected audio ordinal to its concrete stream id.
+    static let embeddedSubtitlesFeature = "embedded_subtitles_v1"
     static let clientSelectedAudioTrackClaim = "client_selected_audio_track_v1"
 
     /// Delivery classes are the unit a client negotiates in
@@ -205,7 +206,16 @@ struct PlaybackV3OutputContext: Codable, Equatable {
     let outputContextId: String?
 }
 
+struct PlaybackV3NativeEmbeddedSubtitleCapability: Codable, Equatable {
+    let container: String
+    let codecs: [String]
+    let trackIdentity: String
+    let assStyling: Bool
+    let fontAttachments: Bool
+}
+
 struct PlaybackV3DeliverySubtitleCapabilities: Codable, Equatable {
+    var nativeEmbedded: [PlaybackV3NativeEmbeddedSubtitleCapability]? = nil
     let embeddedText: Bool
     let sidecarText: Bool
     let assStyling: Bool
@@ -460,10 +470,16 @@ struct PlaybackV3SubtitleInventoryItem: Codable, Equatable {
     let fontBundleUrl: String?
 }
 
+struct PlaybackV3EmbeddedSubtitle: Codable, Equatable {
+    let streamIndex: Int
+    var containerTrackId: String? = nil
+}
+
 struct PlaybackV3SubtitleDecision: Codable, Equatable {
     let mode: String
     let trackId: String?
     let artifact: PlaybackV3SubtitleArtifact?
+    var embedded: PlaybackV3EmbeddedSubtitle? = nil
     /// Authoritative list of every subtitle track for this plan. Select a track
     /// by echoing an entry's `trackId` or `combinedIndex` — never by counting
     /// tracks, summing arrays, or taking max(index) + 1.

--- a/iosApp/iosApp/macOS/PlayerView.swift
+++ b/iosApp/iosApp/macOS/PlayerView.swift
@@ -76,6 +76,8 @@ struct PlayerView: View {
 
                 if viewModel.isLoading || viewModel.isBuffering {
                     PlayerBufferingCapsule()
+                } else if viewModel.isLoadingSubtitles {
+                    PlayerBufferingCapsule(label: "Loading subtitles…")
                 }
 
                 if let notice = viewModel.activeNotice {
@@ -138,6 +140,8 @@ struct PlayerView: View {
             AetherSubtitleOverlay(
                 engine: viewModel.aetherEngine,
                 sourceTime: viewModel.currentTime,
+                primaryUsesMovieTimeline: viewModel.subtitleUsesMovieTimeline(viewModel.selectedSubtitleId),
+                secondaryUsesMovieTimeline: viewModel.subtitleUsesMovieTimeline(viewModel.selectedSecondarySubtitleId),
                 livePrimaryCues: viewModel.selectedSubtitleId.map(SubtitleTrackIdSpace.isAILive) == true
                     ? viewModel.livePrimarySubtitleCues
                     : [],

--- a/iosApp/iosApp/macOS/PlayerView.swift
+++ b/iosApp/iosApp/macOS/PlayerView.swift
@@ -141,7 +141,7 @@ struct PlayerView: View {
                 engine: viewModel.aetherEngine,
                 sourceTime: viewModel.currentTime,
                 primaryUsesMovieTimeline: viewModel.subtitleUsesMovieTimeline(viewModel.selectedSubtitleId),
-                secondaryUsesMovieTimeline: viewModel.subtitleUsesMovieTimeline(viewModel.selectedSecondarySubtitleId),
+                secondaryUsesMovieTimeline: viewModel.subtitleUsesMovieTimeline(viewModel.selectedSecondarySubtitleId, slot: .secondary),
                 livePrimaryCues: viewModel.selectedSubtitleId.map(SubtitleTrackIdSpace.isAILive) == true
                     ? viewModel.livePrimarySubtitleCues
                     : [],

--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -58,7 +58,7 @@ packages:
   # reviewed revision; Package.resolved also freezes its binary dependencies.
   AetherEngine:
     url: https://github.com/Silo-Server/AetherEngine
-    revision: 745de1ccdc4b226adccdf18f03a28071f0e972d5
+    revision: f68ad1309001d879ad69f95dd03b9c57410550b1
   Nuke:
     url: https://github.com/kean/Nuke
     from: "13.2.0"


### PR DESCRIPTION
## Problem

Apple currently waits for server extraction even when Aether can read the selected subtitle directly from the original media. Missing native identities can select the wrong track or fail without typed recovery. External subtitles can use the wrong clock after a server reanchor, and extraction/loading gives the viewer little feedback.

Related issue: #152
Server contract: Silo-Server/silo-server#938
Android companion PR: Silo-Server/silo-android#293 (tracking issue Silo-Server/silo-android#292)

## Changes

- Negotiate `embedded_subtitles_v1` for supported containers and codecs. Validate the selected embedded FFmpeg stream identity, mount that exact track, and report `subtitle_embedded_failed` for server-directed sidecar recovery when it is unavailable. Audiobooks do not advertise this video capability.
- Map the selected native subtitle’s picker ID to its exact container stream, so it remains available as a secondary subtitle after switching the primary to AI-live. Native aliases reset with each load and do not consume external track slots.
- Keep complete sidecar cues on original movie time while embedded cues use the served stream clock. Apply subtitle delay after selecting the correct clock, independently for primary and secondary tracks.
- Dispose a loaded candidate immediately when its native subtitle validation fails, using the existing matching-epoch cleanup path before requesting fallback.
- Preserve the current downloaded subtitle during renewal. Explicit Off and AI-live clear the prior server selection; burn-in retains its combined ordinal even though local embedded rendering is disabled. Pending burn-in choices survive startup before the picker publishes them, and new manual choices clear older pending subtitle identities with rollback on rejection. Resolve overlay clocks from the engine track's external state, including raw IDs without a picker alias and the active primary track; keep the secondary slot independent.
- Wire Aether's subtitle-loading signal into the shared iOS/tvOS/macOS loading indicator, and clear it synchronously during teardown before retiring the engine epoch.
- Pin the existing Silo Aether fork to [`f68ad1309001d879ad69f95dd03b9c57410550b1`](https://github.com/Silo-Server/AetherEngine/commit/f68ad1309001d879ad69f95dd03b9c57410550b1), landed on `silo/host-requested-item-handover`. This preserves the existing item-handover patches and adds complete native subtitle responses and upstream timeline mapping. Both `project.yml` and `Package.resolved` use the published SHA; no local dependency override is needed.
- Pass `nativeTimelineOffsetSeconds` when creating initial, dynamic, re-registered, pending, and secondary external tracks. Update the exact-source notice for the fork changes.
- Vendor the protocol fixtures from committed server revision `5afc5bdd616e4f9c304889c8cadc4c6d31fbc7b7` and cover the native selection, malformed-decision, fallback, and clock boundaries.

## Validation

Final client checks below passed on `142eb1bd1247a31901fab97361c5c3304f2d14f2`.

- `xcodegen generate` and `xcodebuild -resolvePackageDependencies`: passed; resolved Aether from the Silo fork at `f68ad1309001d879ad69f95dd03b9c57410550b1`.
- Complete `xcodebuild test` for the `Silo` scheme on a separate local iOS regression simulator: 1,237 tests, two existing opt-in live-fixture skips, zero failures. Coverage includes downloaded selection recovery, explicit Off/AI-live policy, unresolved burn-in startup, exact native identity, teardown while subtitle loading is active, and native picker identity through primary clearing and replacement loads.
- `xcodebuild build` for `SiloMac` on macOS and `SiloTV` on the tvOS simulator: both passed on the same final source against the published fork dependency.
- Every vendored playback JSON fixture matches the committed server revision byte-for-byte; `git diff --check` passed.

The earlier synthetic iOS playback test selected embedded stream 3 and displayed only its intended cue approximately 0.50 s after selection, with original-media GETs only. That is a bounded native-rendering result, not coverage of every format/device or physical AirPlay/PiP behavior.

Engine validation before landing: 115 focused subtitle/API-documentation tests passed, and documentation links passed. The complete Swift run completed 607 XCTest cases with one skip and no failures; the Swift Testing run had one failure among 2,627 tests. The failure is in the unchanged audio-language test that expects `com` to be unknown; compiling the baseline `AudioLanguageMap.swift` on this host reproduced `com -> com`. No unrelated language behavior was changed to make the suite pass.

Independent correctness review and separate fresh ponytail reviews before commit and push covered the final recovery, teardown, and secondary identity changes. Earlier review covered source, fixtures, and the fork pin/attribution. Screenshots are omitted at the maintainer's request.

## Rollout and remaining limits

Coordinate this client release with server PR #938. Exact native selection is feature-negotiated; do not describe the native route as available on servers without that capability. The fork commit is already published and needs no upstream release or tag before SwiftPM can build this PR.

Physical Cast, AirPlay, and PiP validation remains outside the evidence above. The engine still does not publish a distinct external-subtitle decoding failure event for an Apple-specific error message; this change exposes loading and prevents incomplete native renditions from being accepted as complete.

## AI Disclosure

- Harness: OpenAI Codex desktop app.
- Tool(s): Codex collaboration agents, shell tools, Swift/Xcode/XcodeGen, GitHub CLI (`gh`), and `ponytail-review`.
- Model(s): `gpt-6-astra`.
- Involvement: AI-assisted investigation, implementation, tests, review, and PR preparation; human review is pending.
- Adversarial review: Independent client and server passes checked exact native identities, renderer capability claims, fallback behavior, source/artifact clocks, and extraction state. Findings corrected included duplicate delivery validation, unsafe native-selection heuristics, and native HLS timeline/incomplete-response handling. Fresh ponytail review found no remaining simplification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for selecting and playing embedded subtitles, including ASS and PGS tracks.
  * Added subtitle-loading indicators on iOS and macOS, including accessibility labels.
  * Preserved subtitle timing across playback re-anchoring and recovery.
  * Improved restoration of embedded and external subtitle selections during playback recovery.

* **Bug Fixes**
  * Improved validation and error handling for unavailable or unsupported subtitle streams.
  * Prevented incorrect subtitle fallback behavior when an embedded track is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




