### PR TITLE
fix(tvos): keep browsing responsive with device-tested warming and rolling gates

### DIFF
--- a/.github/workflows/player-regression.yml
+++ b/.github/workflows/player-regression.yml
@@ -5,11 +5,13 @@ on:
     paths:
       - 'iosApp/**'
       - '.github/workflows/player-regression.yml'
+      - 'scripts/ci/test-tvos-browsing.py'
   push:
     branches: [main]
     paths:
       - 'iosApp/**'
       - '.github/workflows/player-regression.yml'
+      - 'scripts/ci/test-tvos-browsing.py'
   workflow_dispatch:
     inputs:
       baseline_ref:
@@ -53,6 +55,10 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '26.3'
+      - name: Check tvOS rolling gate and startup timing
+        if: matrix.scheme == 'SiloTV'
+        timeout-minutes: 2
+        run: python3 scripts/ci/test-tvos-browsing.py
       - name: Prepare iOS simulator
         if: matrix.action == 'test'
         timeout-minutes: 10

--- a/iosApp/iosApp/Components/EpisodeThumbCard.swift
+++ b/iosApp/iosApp/Components/EpisodeThumbCard.swift
@@ -17,6 +17,10 @@ struct EpisodeThumbCard: View {
     /// card must start that episode. Ordinary Home and browse thumbnails keep
     /// the source-aware detail-card presentation.
     var usesProvidedTapAction: Bool = false
+    /// Use one episode caption beneath the artwork on Series pages.
+    var usesEpisodeCaption = false
+    var defersOffscreenArtwork = false
+    var onArtworkVisibilityChange: ((Bool) -> Void)? = nil
     /// tvOS-only shortcut invoked by the remote's Play/Pause button while
     /// this card owns focus. Select continues to invoke `action`.
     var playAction: (() -> Void)? = nil
@@ -28,13 +32,17 @@ struct EpisodeThumbCard: View {
     var onOpenContextDetail: (() -> Void)? = nil
     var onRemoveFromContinueWatching: (() -> Void)? = nil
     var onSetWatched: ((Bool) async -> Bool)? = nil
+    var initialIsFavorite = false
+    var onSetFavorite: ((Bool) async -> Bool)? = nil
 
     @State private var playedOverride: Bool?
+    @State private var favoriteOverride: Bool?
     @State private var uiCustomization = UICustomizationPreferences.shared
     @EnvironmentObject private var overlayStore: OverlayPrefsStore
     #if os(tvOS)
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var continueWatchingMetadata = TVContinueWatchingPlaybackMetadataStore.shared
+    @State private var artworkIsVisible = false
     #endif
     /// iOS 26 zoom transition namespace, shared from `MainTabView`. Lets the
     /// tapped thumbnail act as the `.matchedTransitionSource` for the zoom into
@@ -101,8 +109,16 @@ struct EpisodeThumbCard: View {
         }
         .frame(width: cardWidth)
         .focusSection()
+        .onScrollVisibilityChange(threshold: 0.01) { isVisible in
+            guard defersOffscreenArtwork else { return }
+            artworkIsVisible = isVisible
+            onArtworkVisibilityChange?(isVisible)
+        }
         .onChange(of: item.userState?.played) { _, _ in
             playedOverride = nil
+        }
+        .onChange(of: initialIsFavorite) { _, _ in
+            favoriteOverride = nil
         }
         .task(id: continueWatchingMetadataTaskId) {
             guard onRemoveFromContinueWatching != nil else { return }
@@ -164,14 +180,36 @@ struct EpisodeThumbCard: View {
 
     // MARK: - Thumbnail
 
-    private var thumbnail: some View {
-        ZStack(alignment: .bottomLeading) {
-            AsyncImageView(
+    @ViewBuilder
+    private var thumbnailArtwork: some View {
+        #if os(tvOS)
+        if defersOffscreenArtwork {
+            TVEpisodeArtwork(
                 url: imageUrl,
                 thumbhash: item.backdropThumbhash ?? item.posterThumbhash,
-                targetSize: CGSize(width: cardWidth, height: cardHeight),
-                contentMode: .fill
+                size: CGSize(width: cardWidth, height: cardHeight),
+                isVisible: artworkIsVisible || isFocused
             )
+        } else {
+            standardThumbnailArtwork
+        }
+        #else
+        standardThumbnailArtwork
+        #endif
+    }
+
+    private var standardThumbnailArtwork: some View {
+        AsyncImageView(
+            url: imageUrl,
+            thumbhash: item.backdropThumbhash ?? item.posterThumbhash,
+            targetSize: CGSize(width: cardWidth, height: cardHeight),
+            contentMode: .fill
+        )
+    }
+
+    private var thumbnail: some View {
+        ZStack(alignment: .bottomLeading) {
+            thumbnailArtwork
             .frame(width: cardWidth, height: cardHeight)
             .clipped()
             .clipShape(RoundedRectangle(cornerRadius: SiloTheme.cornerRadius))
@@ -238,6 +276,10 @@ struct EpisodeThumbCard: View {
         playedOverride ?? (item.userState?.played == true)
     }
 
+    private var isFavorite: Bool {
+        favoriteOverride ?? initialIsFavorite
+    }
+
     private var resolvedOverlayData: OverlayData {
         #if os(tvOS)
         if onRemoveFromContinueWatching != nil,
@@ -262,13 +304,25 @@ struct EpisodeThumbCard: View {
         return item.posterUrl ?? ""
     }
 
-    /// Series title for episodes, otherwise the item title.
+    /// Series pages already show the series name in their hero, so their
+    /// primary caption identifies the individual episode instead.
     private var displayTitle: String {
-        item.seriesTitle ?? item.title
+        if usesEpisodeCaption, EpisodeCardCaption.isEpisode(item) {
+            let code: String?
+            if let season = item.seasonNumber, let episode = item.episodeNumber {
+                code = String(format: "S%02d E%02d", season, episode)
+            } else {
+                code = nil
+            }
+            let parts = [code, EpisodeCardCaption.episodeTitle(for: item)].compactMap { $0 }
+            return parts.isEmpty ? item.title : parts.joined(separator: " · ")
+        }
+        return item.seriesTitle ?? item.title
     }
 
     /// Secondary line — "S01E02 · Pilot" for episodes, otherwise year.
     private var subtitleLine: String? {
+        if usesEpisodeCaption, EpisodeCardCaption.isEpisode(item) { return nil }
         if let episodeLine = EpisodeCardCaption.line(for: item) {
             return episodeLine
         }
@@ -282,7 +336,7 @@ struct EpisodeThumbCard: View {
     }
 
     private var accessibilityDescription: String {
-        var components = [displayTitle]
+        var components = [usesEpisodeCaption ? (item.seriesTitle ?? item.title) : displayTitle]
         if let episodeAccessibilityLabel {
             components.append(episodeAccessibilityLabel)
         } else if let subtitleLine {
@@ -376,6 +430,7 @@ struct EpisodeThumbCard: View {
         (contextPlayTitle != nil && playAction != nil)
             || onOpenContextDetail != nil
             || onSetWatched != nil
+            || onSetFavorite != nil
             || onRemoveFromContinueWatching != nil
     }
 
@@ -407,6 +462,24 @@ struct EpisodeThumbCard: View {
                 Label(
                     isPlayed ? "Mark as Unwatched" : "Mark as Watched",
                     systemImage: isPlayed ? "circle" : "checkmark.circle"
+                )
+            }
+        }
+
+        if let onSetFavorite {
+            Button {
+                let newFavoriteValue = !isFavorite
+                Task { @MainActor in
+                    favoriteOverride = newFavoriteValue
+                    let succeeded = await onSetFavorite(newFavoriteValue)
+                    if !succeeded {
+                        favoriteOverride = nil
+                    }
+                }
+            } label: {
+                Label(
+                    isFavorite ? "Remove from Favorites" : "Add to Favorites",
+                    systemImage: isFavorite ? "heart.slash" : "heart"
                 )
             }
         }

--- a/iosApp/iosApp/Components/MediaRow.swift
+++ b/iosApp/iosApp/Components/MediaRow.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 #if os(tvOS)
 import os
+import Nuke
 #endif
 
 /// Layout mode for a horizontal media row.
@@ -20,6 +21,13 @@ struct MediaRow: View {
     let title: String
     let items: [SectionItem]
     let onItemTap: (String) -> Void
+    /// Detail surfaces can reuse the exact Home rail without drawing a second
+    /// section heading above it. Home keeps the default.
+    var showsHeader = true
+    /// Nested season pages keep every episode mounted so the native focus
+    /// engine sees a finite set of card targets at both ends of the strip.
+    /// Home retains its lazy working set.
+    var usesLazyCardLayout = true
     /// tvOS-only direct-play action for focused leaf items. Container items
     /// intentionally receive no Play/Pause command and retain normal focus.
     var onItemPlay: ((SectionItem) -> Void)? = nil
@@ -30,6 +38,11 @@ struct MediaRow: View {
     /// Preserve a caller's immediate thumbnail action instead of presenting
     /// item detail. Used by Player "On Deck"; normal media rows leave this off.
     var usesProvidedThumbnailTapAction: Bool = false
+    /// Series pages identify each thumbnail by episode code and title.
+    /// Home keeps its series title and optional metadata line.
+    var usesEpisodeCaption = false
+    /// Keep focus targets mounted while deferring offscreen thumbnail work.
+    var defersOffscreenArtwork = false
     /// When true (and there are items), the row's first card becomes the
     /// default focus target — on initial appearance AND on user-driven
     /// d-pad entry into the row's focus section. Implemented via
@@ -48,6 +61,9 @@ struct MediaRow: View {
     /// where `.userInitiated` defaultFocus alone doesn't fire because the
     /// focus engine isn't doing the moving.
     var focusRequest: Int = 0
+    /// Optional item used by native default-focus resolution when entering the
+    /// row. Home normally leaves this nil and uses the first card.
+    var defaultFocusItemId: String? = nil
     /// Optional item to claim for a programmatic row handoff. When absent the
     /// request retains its existing first-item behavior. Skyline uses this to
     /// restore the exact card last focused in the preceding row.
@@ -65,6 +81,7 @@ struct MediaRow: View {
     /// only, avoiding a redundant menu entry on ordinary discovery cards.
     var showsPlayInContextMenu = false
     var onSetWatched: ((SectionItem, Bool) async -> Bool)? = nil
+    var onSetFavorite: ((SectionItem, Bool) async -> Bool)? = nil
     var onMoveUp: (() -> Void)? = nil
     /// tvOS-only: reports which of the row's items holds card focus —
     /// the Skyline focus marquee mirrors it. Fires on focus gain only;
@@ -77,6 +94,9 @@ struct MediaRow: View {
     /// Optional tvOS-only vertical padding override for the card strip.
     /// Standard rows keep the default breathing room for focus lift.
     var cardVerticalPadding: CGFloat? = nil
+    /// Home uses the standard safe-area gutter. Embedded detail rails can
+    /// supply the gutter already established by their parent layout.
+    var horizontalContentMargin: CGFloat = SiloTheme.safePadding
     /// Down at the row's boundary — used by the Skyline section pager to
     /// page to the next section (there is no row geometrically below).
     var onMoveDown: (() -> Void)? = nil
@@ -100,6 +120,76 @@ struct MediaRow: View {
     @State private var focusRestorationGeneration = 0
     @State private var lastAppliedDetailReturnFocusRequest = 0
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.tvArtworkLoadingEnabled) private var parentArtworkLoadingEnabled
+    @State private var artworkScrollIsActive = false
+    @State private var artworkScrollIsInteractive = false
+    @State private var lastArtworkFocusTime: TimeInterval?
+    @State private var artworkScrollHasSettled = true
+    @State private var visibleArtworkIds = Set<String>()
+    @State private var episodeArtworkWarmer = EpisodeArtworkWarmer()
+    @State private var artworkCustomization = UICustomizationPreferences.shared
+    @Environment(\.displayScale) private var artworkDisplayScale
+
+    private struct ArtworkActivity: Hashable {
+        let scrolling: Bool
+        let focusTime: TimeInterval?
+    }
+
+    private final class EpisodeArtworkWarmer {
+        private let prefetcher = ImagePrefetcher(
+            pipeline: ImagePipeline.shared, destination: .memoryCache,
+            maxConcurrentRequestCount: 1
+        )
+        private var urls = Set<URL>()
+        private var size = CGSize.zero
+
+        func update(_ candidates: [URL], pixelSize: CGSize, enabled: Bool) {
+            prefetcher.isPaused = true
+            guard enabled else { return }
+            if size != pixelSize { cancel(); size = pixelSize }
+            let next = Set(candidates)
+            prefetcher.stopPrefetching(with: urls.subtracting(next).map {
+                PosterImageCache.displayRequest(url: $0, pixelSize: size, priority: .low)
+            })
+            var added = Set<URL>()
+            prefetcher.startPrefetching(with: candidates.filter {
+                !urls.contains($0) && added.insert($0).inserted
+            }.map {
+                PosterImageCache.displayRequest(url: $0, pixelSize: size, priority: .low)
+            })
+            urls = next
+            prefetcher.isPaused = false
+        }
+
+        func cancel() {
+            prefetcher.stopPrefetching()
+            urls.removeAll()
+        }
+    }
+
+    private var episodeArtworkPixelSize: CGSize {
+        let scale = artworkCustomization.cardPresentation.posterSize.scale * artworkDisplayScale
+        return CGSize(width: SiloTheme.thumbnailCardWidth * scale,
+                      height: SiloTheme.thumbnailCardHeight * scale)
+    }
+
+    private var episodeArtworkWarmURLs: [URL] {
+        guard defersOffscreenArtwork else { return [] }
+        let indices = items.indices.filter { visibleArtworkIds.contains(items[$0].contentId) }
+        guard let first = indices.first, let last = indices.last else { return [] }
+        return [last + 1, first - 1, last + 2, first - 2].compactMap { index in
+            guard items.indices.contains(index) else { return nil }
+            let item = items[index]
+            let url = item.backdropUrl.flatMap { $0.isEmpty ? nil : $0 } ?? item.posterUrl
+            return url.flatMap(URL.init(string:))
+        }
+    }
+
+    private var episodeArtworkWarmKey: String {
+        "\(parentArtworkLoadingEnabled && artworkScrollHasSettled):\(episodeArtworkPixelSize):"
+            + episodeArtworkWarmURLs.map(\.absoluteString).joined(separator: "|")
+    }
+
     private static let focusLogger = Logger(
         subsystem: Bundle.main.bundleIdentifier ?? "org.siloserver.silo",
         category: "TVFocus"
@@ -108,7 +198,9 @@ struct MediaRow: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: rowVerticalSpacing) {
-            header
+            if showsHeader {
+                header
+            }
             scrollContent
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -117,6 +209,14 @@ struct MediaRow: View {
         .modifier(TVRowMoveHandler(onMoveUp: onMoveUp, onMoveDown: onMoveDown))
         .modifier(TVRowFocusObserver(focusedItemId: $focusedItemId) { newValue in
             guard let item = items.first(where: { $0.contentId == newValue }) else { return }
+            if defersOffscreenArtwork, newValue != lastFocusedItemId {
+                let now = ProcessInfo.processInfo.systemUptime
+                let rapid = lastArtworkFocusTime.map { now - $0 < 0.13 } == true
+                lastArtworkFocusTime = now
+                // Moderate clicks can keep loading the next cards throughout
+                // their native scroll animation. Only a burst pauses new work.
+                artworkScrollHasSettled = !rapid && !artworkScrollIsInteractive
+            }
             lastFocusedItemId = newValue
             Self.focusLogger.debug("mediaRow.focus changed")
             onItemFocus?(item)
@@ -346,11 +446,14 @@ struct MediaRow: View {
 
     private func scrollStrip(_ rowProxy: ScrollViewProxy) -> some View {
         ScrollView(.horizontal, showsIndicators: false) {
-            LazyHStack(alignment: HorizontalMediaRailLayout.cardAlignment, spacing: cardSpacing) {
-                ForEach(items) { item in
-                    mediaCard(for: item)
-                }
-            }
+            cardStack
+            #if os(tvOS)
+            .environment(
+                \.tvArtworkLoadingEnabled,
+                parentArtworkLoadingEnabled
+                    && (!defersOffscreenArtwork || artworkScrollHasSettled)
+            )
+            #endif
             #if !os(tvOS)
             .padding(.horizontal, SiloTheme.safePadding)
             #endif
@@ -364,14 +467,54 @@ struct MediaRow: View {
         // the engine's scroll-to-focused both align to the margin-inset
         // viewport, so with inner padding they overshoot left by the gutter
         // width and then visibly drift back to the rest position.
-        .contentMargins(.horizontal, SiloTheme.safePadding, for: .scrollContent)
+        .contentMargins(.horizontal, horizontalContentMargin, for: .scrollContent)
         // tvOS focus lift expands cards on focus — give them breathing room
         // so they don't clip against the row above/below.
         .scrollClipDisabled()
+        .onScrollPhaseChange { _, phase in
+            guard defersOffscreenArtwork else { return }
+            artworkScrollIsActive = phase != .idle
+            artworkScrollIsInteractive = phase == .tracking
+                || phase == .interacting || phase == .decelerating
+            if artworkScrollIsInteractive {
+                artworkScrollHasSettled = false
+            }
+        }
+        .task(id: ArtworkActivity(scrolling: artworkScrollIsActive, focusTime: lastArtworkFocusTime)) {
+            guard defersOffscreenArtwork, !artworkScrollIsActive else { return }
+            // Native focus keeps moving immediately. Only new image work waits
+            // for a quiet interval, avoiding decode churn between rapid clicks.
+            do {
+                try await Task.sleep(for: .milliseconds(160))
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
+            artworkScrollHasSettled = true
+        }
+        .onChange(of: episodeArtworkWarmKey, initial: true) { _, _ in
+            guard defersOffscreenArtwork else { return }
+            episodeArtworkWarmer.update(
+                episodeArtworkWarmURLs, pixelSize: episodeArtworkPixelSize,
+                enabled: parentArtworkLoadingEnabled && artworkScrollHasSettled
+            )
+        }
+        .onDisappear {
+            artworkScrollIsActive = false
+            artworkScrollIsInteractive = false
+            lastArtworkFocusTime = nil
+            artworkScrollHasSettled = true
+            visibleArtworkIds.removeAll()
+            episodeArtworkWarmer.cancel()
+        }
         .applyDefaultFirstItemFocus(
             enabled: prefersDefaultFocusOnFirstItem,
             binding: $focusedItemId,
-            firstItemId: items.first?.contentId,
+            firstItemId: defaultFocusItemId.flatMap { requestedId in
+                items.contains(where: { $0.contentId == requestedId })
+                    ? requestedId
+                    : nil
+            } ?? items.first?.contentId,
             priority: defaultFocusPriority
         )
         // The programmatic focus kick needs the scroll proxy (it scrolls the
@@ -386,6 +529,25 @@ struct MediaRow: View {
             restoreFocusAfterDetailReturn(request, proxy: rowProxy)
         }
         #endif
+    }
+
+    @ViewBuilder
+    private var cardStack: some View {
+        if usesLazyCardLayout {
+            LazyHStack(alignment: HorizontalMediaRailLayout.cardAlignment, spacing: cardSpacing) {
+                cards
+            }
+        } else {
+            HStack(alignment: HorizontalMediaRailLayout.cardAlignment, spacing: cardSpacing) {
+                cards
+            }
+        }
+    }
+
+    private var cards: some View {
+        ForEach(items) { item in
+            mediaCard(for: item)
+        }
     }
 
     @ViewBuilder
@@ -420,13 +582,23 @@ struct MediaRow: View {
                 showProgress: showProgress,
                 action: { onItemTap(item.contentId) },
                 usesProvidedTapAction: usesProvidedThumbnailTapAction,
+                usesEpisodeCaption: usesEpisodeCaption,
+                defersOffscreenArtwork: defersOffscreenArtwork,
+                onArtworkVisibilityChange: { visible in
+                    #if os(tvOS)
+                    if visible { visibleArtworkIds.insert(item.contentId) }
+                    else { visibleArtworkIds.remove(item.contentId) }
+                    #endif
+                },
                 playAction: playAction(for: item),
                 focusedItemId: rowFocusBinding,
                 contextPlayTitle: contextPlayTitle(for: item),
                 contextDetailTitle: contextDetailTitle(for: item),
                 onOpenContextDetail: contextDetailAction(for: item),
                 onRemoveFromContinueWatching: continueWatchingRemovalAction(for: item),
-                onSetWatched: watchedToggleAction(for: item)
+                onSetWatched: watchedToggleAction(for: item),
+                initialIsFavorite: item.userState?.isFavorite == true,
+                onSetFavorite: favoriteToggleAction(for: item)
             )
         }
     }
@@ -506,6 +678,13 @@ struct MediaRow: View {
             }
             #endif
             return await onSetWatched(item, played)
+        }
+    }
+
+    private func favoriteToggleAction(for item: SectionItem) -> ((Bool) async -> Bool)? {
+        guard let onSetFavorite else { return nil }
+        return { isFavorite in
+            await onSetFavorite(item, isFavorite)
         }
     }
 

--- a/iosApp/iosApp/Components/MediaRow.swift
+++ b/iosApp/iosApp/Components/MediaRow.swift
@@ -684,7 +684,12 @@ struct MediaRow: View {
     private func favoriteToggleAction(for item: SectionItem) -> ((Bool) async -> Bool)? {
         guard let onSetFavorite else { return nil }
         return { isFavorite in
-            await onSetFavorite(item, isFavorite)
+            #if os(tvOS)
+            await MainActor.run {
+                preserveFocusForContextMutation(on: item)
+            }
+            #endif
+            return await onSetFavorite(item, isFavorite)
         }
     }
 

--- a/iosApp/iosApp/Components/StartupSplashView.swift
+++ b/iosApp/iosApp/Components/StartupSplashView.swift
@@ -6,14 +6,26 @@ import SwiftUI
 /// keyframes in `StartupSplashAnimation`. No AVPlayer is involved: AetherEngine
 /// remains the only production media engine constructed by Silo.
 struct StartupSplashView: View {
-    private static let maximumDisplayDuration: Duration = .seconds(4)
+    #if os(tvOS)
+    // The wordmark lands at frame 160; the remaining source frames are a
+    // static hold. Continue into the loading cycle as soon as it lands.
+    private static let introDuration = 160 / StartupSplashAnimation.framesPerSecond
+    private let repeatsTowerWhileWaiting = true
+    #else
+    private static let introDuration: Double = 4
+    private let repeatsTowerWhileWaiting = false
+    #endif
 
+    var isContentReady = true
     let onFinished: () -> Void
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var completionTask: Task<Void, Never>?
     @State private var didFinish = false
+    @State private var didFinishIntro = false
     @State private var startDate: Date?
+    @State private var waitingStartDate: Date?
+    @State private var completionCycle: Int?
 
     var body: some View {
         ZStack {
@@ -21,8 +33,14 @@ struct StartupSplashView: View {
 
             GeometryReader { proxy in
                 let size = surfaceSize(in: proxy.size)
-                TimelineView(.animation(paused: reduceMotion)) { context in
-                    StartupSplashCanvas(frame: frame(at: context.date))
+                TimelineView(.animation(paused: reduceMotion || (didFinishIntro && !repeatsTowerWhileWaiting))) { context in
+                    StartupSplashCanvas(
+                        frame: frame(at: context.date),
+                        towerFrame: waitingTowerFrame(at: context.date)
+                    )
+                    .onChange(of: towerIsComplete(at: context.date)) { _, complete in
+                        if complete { finishIfReady() }
+                    }
                 }
                 .frame(width: size.width, height: size.height)
                 .position(x: proxy.size.width / 2, y: proxy.size.height / 2)
@@ -33,6 +51,25 @@ struct StartupSplashView: View {
         .onAppear {
             startDate = Date()
             scheduleCompletion()
+        }
+        .onChange(of: isContentReady) { _, ready in
+            if ready, let waitingStartDate {
+                // Finish the cycle currently on screen, without interrupting
+                // its unstack or restack and without starting another one.
+                let elapsed = max(Date().timeIntervalSince(waitingStartDate), 0)
+                completionCycle = Int(elapsed / StartupSplashCanvas.cycleDuration) + 1
+            } else {
+                completionCycle = nil
+            }
+            finishIfReady()
+        }
+        .onChange(of: didFinishIntro) { _, _ in
+            // Reveal immediately if Home was prepared during the opening.
+            // Otherwise begin reversing from the completed stack right now.
+            finishIfReady()
+            if !didFinish, repeatsTowerWhileWaiting, !reduceMotion {
+                waitingStartDate = Date()
+            }
         }
         .onDisappear {
             completionTask?.cancel()
@@ -63,18 +100,39 @@ struct StartupSplashView: View {
         return min(max(elapsed * StartupSplashAnimation.framesPerSecond, 0), last)
     }
 
+    private func waitingTowerFrame(at date: Date) -> Double? {
+        guard repeatsTowerWhileWaiting, !reduceMotion, let waitingStartDate else { return nil }
+        let elapsed = date.timeIntervalSince(waitingStartDate)
+        if let completionCycle,
+           elapsed >= Double(completionCycle) * StartupSplashCanvas.cycleDuration {
+            return StartupSplashCanvas.stackEnd
+        }
+        return StartupSplashCanvas.waitingTowerFrame(elapsed: elapsed)
+    }
+
+    private func towerIsComplete(at date: Date) -> Bool {
+        guard repeatsTowerWhileWaiting, !reduceMotion, let waitingStartDate else { return true }
+        guard let completionCycle else { return false }
+        return date.timeIntervalSince(waitingStartDate)
+            >= Double(completionCycle) * StartupSplashCanvas.cycleDuration
+    }
+
     private func scheduleCompletion() {
         guard completionTask == nil else { return }
-        let duration: Duration = reduceMotion ? .seconds(1) : Self.maximumDisplayDuration
+        let duration: Duration = reduceMotion ? .seconds(1) : .seconds(Self.introDuration)
         completionTask = Task {
             try? await Task.sleep(for: duration)
             guard !Task.isCancelled else { return }
-            finish()
+            didFinishIntro = true
+            #if !os(tvOS)
+            finishIfReady()
+            #endif
         }
     }
 
-    private func finish() {
-        guard !didFinish else { return }
+    private func finishIfReady() {
+        guard !didFinish, didFinishIntro, isContentReady,
+              towerIsComplete(at: Date()) else { return }
         didFinish = true
         completionTask?.cancel()
         completionTask = nil
@@ -86,6 +144,22 @@ struct StartupSplashView: View {
 /// so the mark occludes the wordmark while it slides out from behind it.
 private struct StartupSplashCanvas: View {
     let frame: Double
+    var towerFrame: Double? = nil
+
+    private static let stackStart: Double = 2
+    static let stackEnd: Double = 92
+    private static let stackDuration = (stackEnd - stackStart) / StartupSplashAnimation.framesPerSecond
+    static let cycleDuration = 2 * stackDuration
+
+    /// The source already contains its easing. Advance through its frames at
+    /// the original 60 fps in each direction; do not apply a second easing curve.
+    static func waitingTowerFrame(elapsed: TimeInterval) -> Double {
+        let phase = max(elapsed, 0).truncatingRemainder(dividingBy: cycleDuration)
+        if phase < stackDuration {
+            return stackEnd - phase * StartupSplashAnimation.framesPerSecond
+        }
+        return stackStart + (phase - stackDuration) * StartupSplashAnimation.framesPerSecond
+    }
 
     var body: some View {
         Canvas(rendersAsynchronously: false) { context, size in
@@ -93,9 +167,17 @@ private struct StartupSplashCanvas: View {
             let scale = size.width / composition.width
             context.scaleBy(x: scale, y: scale)
 
-            for layer in StartupSplashAnimation.layers where frame >= layer.inPoint {
-                let position = Self.interpolate(layer.position, at: frame)
-                let layerScale = Self.interpolate(layer.scale, at: frame)
+            for layer in StartupSplashAnimation.layers {
+                let isWaitingTower = towerFrame != nil && layer.name != "wordmark"
+                let layerFrame = layer.name == "wordmark" ? frame : (towerFrame ?? frame)
+                guard layerFrame >= layer.inPoint else { continue }
+                var position = Self.interpolate(layer.position, at: layerFrame)
+                let layerScale = Self.interpolate(layer.scale, at: layerFrame)
+                if isWaitingTower, let finalPosition = layer.position.last {
+                    // Keep the completed wordmark and tower's final horizontal
+                    // placement. Only the block assembly motion is replayed.
+                    position[0] = finalPosition.v[0]
+                }
 
                 var transform = CGAffineTransform.identity
                 transform = transform.translatedBy(x: position[0], y: position[1])

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -24,6 +24,9 @@ struct ContentView: View {
     @State private var didStartInitialStateCheck = false
     @State private var didFinishStartupSplash = false
     @State private var pendingInitialAuthState: AppRouter.AuthState?
+    #if os(tvOS)
+    @State private var didPrepareInitialHome = false
+    #endif
     #if os(iOS) || os(tvOS)
     @State private var diagnosticsModel = DiagnosticsViewModel()
     #endif
@@ -563,11 +566,20 @@ struct ContentView: View {
     }
     #endif
 
+    private var initialSplashContentReady: Bool {
+        #if os(tvOS)
+        guard let target = pendingInitialAuthState else { return false }
+        return target != .authenticated || didPrepareInitialHome
+        #else
+        return true
+        #endif
+    }
+
     @ViewBuilder
     private var authContent: some View {
         switch router.authState {
         case .loading:
-            StartupSplashView {
+            StartupSplashView(isContentReady: initialSplashContentReady) {
                 #if os(iOS) || os(tvOS)
                 LaunchTimeline.recordSplashFinished()
                 #endif
@@ -582,6 +594,12 @@ struct ContentView: View {
                 #endif
                 await checkInitialState()
             }
+            #if os(tvOS)
+            .task(id: pendingInitialAuthState == .authenticated) {
+                guard pendingInitialAuthState == .authenticated else { return }
+                await prepareInitialTVHome()
+            }
+            #endif
 
         case .needsServerSetup:
             #if os(tvOS)
@@ -854,12 +872,47 @@ struct ContentView: View {
         #endif
     }
 
+    #if os(tvOS)
+    @MainActor
+    private func prepareInitialTVHome() async {
+        let serverID = ServerRegistry.shared.activeServerId
+        let profileID = AuthService.shared.profileId
+        func finishPreparation() {
+            guard !Task.isCancelled,
+                  router.authState == .loading,
+                  pendingInitialAuthState == .authenticated,
+                  ServerRegistry.shared.activeServerId == serverID,
+                  AuthService.shared.profileId == profileID else { return }
+            didPrepareInitialHome = true
+            finishInitialStartupIfReady()
+        }
+
+        // Start alongside the splash, not after its animation. A slow/offline
+        // server still gets the ordinary Home retry UI after a bounded wait.
+        let timeout = Task { @MainActor in
+            do {
+                try await Task.sleep(for: .seconds(8))
+            } catch { return }
+            finishPreparation()
+        }
+        defer { timeout.cancel() }
+        await StartupContentPrefetcher.prepareTVHomeForLaunch()
+        finishPreparation()
+    }
+    #endif
+
     private func finishInitialStartupIfReady() {
+        #if os(tvOS)
+        guard router.authState == .loading else { return }
+        #endif
         guard didFinishStartupSplash, let targetState = pendingInitialAuthState else { return }
+        #if os(tvOS)
+        guard targetState != .authenticated || didPrepareInitialHome else { return }
+        #endif
         pendingInitialAuthState = nil
         #if os(iOS) || os(tvOS)
-        // Closes the cold-launch chain. Both gates (splash animation and state
-        // resolution) have cleared, so this is the moment the user first sees
+        // The splash, route resolution and tvOS Home preparation gates have
+        // cleared, so this is the moment the user first sees
         // real content. `AppRouter` logs the auth transition itself; this line
         // records that launch reached a terminal, usable state at all.
         LaunchTimeline.recordFirstContent(state: targetState.diagnosticsState)

--- a/iosApp/iosApp/Screens/Home/HomeView.swift
+++ b/iosApp/iosApp/Screens/Home/HomeView.swift
@@ -64,7 +64,8 @@ struct HomeView: View {
                     onTopMenuFocusRequest: onTopMenuFocusRequest,
                     onItemTap: navigateToDetail,
                     onRemoveFromContinueWatching: dismissContinueWatching,
-                    onSetWatched: setWatched
+                    onSetWatched: setWatched,
+                    warmsFocusedRowArtwork: true
                 )
                 // Preference edits replace the row band as one stable unit:
                 // the next visible row takes the vacated slot at the fixed

--- a/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
+++ b/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
@@ -621,6 +621,28 @@ enum StartupContentPrefetcher {
         }
     }
 
+    #if os(tvOS)
+    /// Join the launch requests before revealing Home. Completed responses
+    /// are already in the cache used by HomeViewModel and TVMainTabView's
+    /// initializers; an empty library is a completed response too.
+    static func prepareTVHomeForLaunch() async {
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask { @MainActor in
+                guard ResponseCache.shared.get(
+                    CacheKey.homeSections, as: SectionsResponse.self
+                ) == nil else { return }
+                _ = try? await fetchHomeSections()
+            }
+            group.addTask { @MainActor in
+                guard ResponseCache.shared.get(
+                    CacheKey.userLibraries, as: LibrariesResponse.self
+                ) == nil else { return }
+                _ = try? await fetchUserLibraries()
+            }
+        }
+    }
+    #endif
+
     static func prefetchAuthenticatedContent() {
         prefetchHomeSections()
         prefetchRecommendations()
@@ -745,6 +767,62 @@ enum StartupContentPrefetcher {
             #endif
         }
 
+        #if os(tvOS)
+        // No client renders a featured hero anymore — featured sections show
+        // as ordinary rows. Entry still earns the first logo and hero backdrop,
+        // but card slots are dealt round-robin across the first four rows. A
+        // row-major fill spent the whole budget on row one and left every row
+        // below it cold just as its LazyHStack began mounting new cards.
+        let contentSections = response.sections.filter { !$0.items.isEmpty }
+        if let firstRow = contentSections.first {
+            append(firstRow.items.first?.logoUrl, into: &logoURLs, seen: &seenLogos)
+            // Only the marquee's initial selection earns a hero-size decode.
+            // A w1920 backdrop is ~8 MB decoded, so warming the whole first
+            // row would spend the entire 96 MB tvOS budget on artwork the
+            // user may never rest on and evict the very cards this warm-up
+            // exists to paint. The neighbours the user is most likely to
+            // reach are pulled into the disk cache (bytes only) by
+            // `PosterImageCache.warmNeighborBackdrops` once the marquee
+            // rests, which removes the network round trip without a decode.
+            appendBackdrop(firstRow.items.first?.backdropUrl)
+        }
+
+        func appendCardArtwork(_ item: SectionItem, in section: ResolvedSection) {
+            if episodeSectionTypes.contains(section.sectionType.lowercased()) {
+                // Episode stills render the backdrop as the card art and the
+                // marquee may show the same source at a separate hero size.
+                append(item.backdropUrl ?? item.posterUrl, into: &cardURLs, seen: &seenCards)
+            } else {
+                append(item.posterUrl, into: &cardURLs, seen: &seenCards)
+            }
+        }
+
+        let startupRows = Array(contentSections.prefix(4))
+        var itemOffset = 0
+        while count < maxHomeArtworkURLs {
+            var foundItemAtOffset = false
+            for section in startupRows where itemOffset < section.items.count {
+                foundItemAtOffset = true
+                appendCardArtwork(section.items[itemOffset], in: section)
+                if count >= maxHomeArtworkURLs { break }
+            }
+            guard foundItemAtOffset else { break }
+            itemOffset += 1
+        }
+
+        // Very short leading rows can leave budget unused. Preserve the old
+        // fallback by spending any remainder on later Home rows.
+        if count < maxHomeArtworkURLs {
+            for section in contentSections.dropFirst(startupRows.count) {
+                for item in section.items {
+                    appendCardArtwork(item, in: section)
+                    if count >= maxHomeArtworkURLs { break }
+                }
+                if count >= maxHomeArtworkURLs { break }
+            }
+        }
+
+        #else
         // No client renders a featured hero anymore — featured sections show
         // as ordinary rows. Entry lands on the first card of the first content
         // row. Warm that row's logo + art first (so a cold start paints a
@@ -787,6 +865,8 @@ enum StartupContentPrefetcher {
             }
             if count >= maxHomeArtworkURLs { break }
         }
+
+        #endif
 
         PosterImageCache.prefetchOriginalArtwork(logoURLs)
         PosterImageCache.prefetchCardArtwork(cardURLs)

--- a/iosApp/iosApp/Theme/SiloTheme.swift
+++ b/iosApp/iosApp/Theme/SiloTheme.swift
@@ -232,17 +232,14 @@ struct SiloTheme {
         /// thrashing large backdrops. Matches Android's
         /// `TvMarqueeFocusRestMillis`.
         static let marqueeRestDebounceMilliseconds = 150
+        /// An isolated move gets its backdrop promptly. A second move before
+        /// this expires establishes a roll and switches to the longer gate.
+        static let marqueeBackdropIsolatedRestMilliseconds = 400
+        /// Once focus is rolling, keep hero decoding and compositing out of
+        /// navigation until the final selection has been quiet this long.
+        static let marqueeBackdropRollRestMilliseconds = 800
         /// Backdrop + tint crossfade between rested selections (§4.2).
         static let marqueeCrossfadeDuration: Double = 0.24
-        /// Longest a row-change scroll may hold the backdrop swap. The hold
-        /// keeps the crossfade out of the row animation, but the band's
-        /// scroll phase stays non-idle for over a second after a single
-        /// move, so the swap releases once the visible motion has finished.
-        static let marqueeBackdropHoldCapMilliseconds = 320
-        /// Neighbouring cards on either side of a rested selection whose
-        /// backdrop bytes are pulled into the disk cache at low priority,
-        /// so the next rest skips the network round trip.
-        static let marqueeNeighborBackdropPrefetchRadius = 2
 
         // MARK: Row band under the marquee (§5.7, revised)
 

--- a/iosApp/iosApp/tvOS/Caching/CachedAsyncImage.swift
+++ b/iosApp/iosApp/tvOS/Caching/CachedAsyncImage.swift
@@ -35,12 +35,19 @@ struct CachedAsyncImage: View {
     var body: some View {
         GeometryReader { geometry in
             let resolvedSize = targetSize ?? geometry.size
-            let warmedImage = prefetchedImage()
+            let imageRequest = request(for: resolvedSize)
+            // A gated rail must not discard artwork that has already been
+            // decoded at its display size when LazyImage's request becomes nil.
+            // This is a memory-cache lookup only; it starts no image work.
+            let retainedImage = artworkLoadingEnabled ? nil : imageRequest.flatMap {
+                ImagePipeline.shared.cache[$0]?.image
+            }
+            let warmedImage = retainedImage ?? prefetchedImage()
             let loadAnimation: Animation? = reduceMotion || warmedImage != nil
                 ? nil
                 : .easeOut(duration: SiloTheme.slowDuration)
             LazyImage(
-                request: artworkLoadingEnabled ? request(for: resolvedSize) : nil,
+                request: artworkLoadingEnabled ? imageRequest : nil,
                 transaction: Transaction(animation: loadAnimation)
             ) { state in
                 if let image = state.image {
@@ -126,6 +133,93 @@ struct CachedAsyncImage: View {
         .frame(width: size.width, height: size.height)
     }
 }
+
+#if os(tvOS)
+/// Episode strips retain the painted image independently of the request gate.
+/// Pausing new work must never replace every visible card's image subtree.
+struct TVEpisodeArtwork: View {
+    let url: String
+    let thumbhash: String?
+    let size: CGSize
+    let isVisible: Bool
+
+    @Environment(\.displayScale) private var displayScale
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.tvArtworkLoadingEnabled) private var loadingEnabled
+    @State private var retainedImage: PlatformImage?
+    @State private var retainedKey: ImageKey?
+
+    private struct ImageKey: Hashable {
+        let url: String
+        let width: CGFloat
+        let height: CGFloat
+    }
+
+    private struct LoadKey: Hashable {
+        let image: ImageKey
+        let visible: Bool
+        let enabled: Bool
+    }
+
+    var body: some View {
+        let key = ImageKey(url: url, width: size.width * displayScale, height: size.height * displayScale)
+        let request = URL(string: url).map {
+            PosterImageCache.displayRequest(url: $0, pixelSize: CGSize(width: key.width, height: key.height))
+        }
+        let cached = isVisible ? request.flatMap { ImagePipeline.shared.cache[$0]?.image } : nil
+        let image = isVisible ? (retainedKey == key ? retainedImage : nil) ?? cached : nil
+        Group {
+            if let image {
+                Image(platformImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .transition(.opacity)
+            } else if isVisible {
+                ThumbhashImage(thumbhash: thumbhash)
+            } else {
+                Color.siloSurface
+            }
+        }
+        .frame(width: size.width, height: size.height)
+        .clipped()
+        .task(id: LoadKey(image: key, visible: isVisible, enabled: loadingEnabled)) {
+            guard isVisible else {
+                retainedImage = nil
+                retainedKey = nil
+                return
+            }
+            guard retainedKey != key || retainedImage == nil else { return }
+            // Cached artwork paints even during a fast scroll. No request or
+            // decode is needed, and the image branch keeps the same identity.
+            if let cached {
+                var transaction = Transaction(animation: nil)
+                transaction.disablesAnimations = true
+                withTransaction(transaction) {
+                    retainedKey = key
+                    retainedImage = cached
+                }
+                return
+            }
+            guard loadingEnabled, let request else { return }
+            do {
+                let loaded = try await ImagePipeline.shared.image(for: request)
+                guard !Task.isCancelled else { return }
+                withAnimation(reduceMotion ? nil : .easeOut(duration: 0.2)) {
+                    retainedKey = key
+                    retainedImage = loaded
+                }
+            } catch {
+                // Keep the placeholder; the next visibility/settle change can
+                // retry. Cancelled work must never repaint a departed card.
+            }
+        }
+        .onDisappear {
+            retainedImage = nil
+            retainedKey = nil
+        }
+    }
+}
+#endif
 
 #if os(tvOS)
 private struct TVArtworkLoadingEnabledKey: EnvironmentKey {

--- a/iosApp/iosApp/tvOS/Caching/PosterImageCache.swift
+++ b/iosApp/iosApp/tvOS/Caching/PosterImageCache.swift
@@ -94,6 +94,67 @@ enum PosterImageCache {
         prefetcher.stopPrefetching(with: urls.map(cardWarmRequest(for:)))
     }
 
+    #if os(tvOS)
+    /// Low-priority exact-size working set for the focused Home row. Home rows
+    /// contain 20 cards, so warming the complete row removes the cold boundary
+    /// that otherwise appears after card 16. Cached results remain under
+    /// Nuke's normal memory LRU; only unfinished work from the prior row is
+    /// cancelled.
+    private static let homeRowCardPrefetchLimit = 20
+    private static let homeRowCardPrefetcher: ImagePrefetcher = {
+        let prefetcher = ImagePrefetcher(
+            pipeline: ImagePipeline.shared,
+            destination: .memoryCache,
+            maxConcurrentRequestCount: 2
+        )
+        prefetcher.priority = .low
+        return prefetcher
+    }()
+    private struct HomeRowCardWarmKey: Equatable {
+        let url: URL
+        let pixelSize: CGSize
+    }
+    @MainActor private static var homeRowCardWarmKeys: [HomeRowCardWarmKey] = []
+
+    @MainActor
+    static func warmHomeRowCardArtwork(_ candidates: [URL], pointSize: CGSize) {
+        let pixelSize = CGSize(
+            width: pointSize.width * displayScale,
+            height: pointSize.height * displayScale
+        )
+        var seen = Set<URL>()
+        let keys = candidates
+            .filter { seen.insert($0).inserted }
+            .prefix(homeRowCardPrefetchLimit)
+            .map { HomeRowCardWarmKey(url: $0, pixelSize: pixelSize) }
+        guard keys != homeRowCardWarmKeys else { return }
+
+        let stale = homeRowCardWarmKeys.filter { !keys.contains($0) }
+        let fresh = keys.filter { !homeRowCardWarmKeys.contains($0) }
+        homeRowCardWarmKeys = keys
+
+        if !stale.isEmpty {
+            homeRowCardPrefetcher.stopPrefetching(with: stale.map(homeRowCardRequest(for:)))
+        }
+        if !fresh.isEmpty {
+            homeRowCardPrefetcher.startPrefetching(with: fresh.map(homeRowCardRequest(for:)))
+        }
+    }
+
+    @MainActor
+    static func cancelHomeRowCardWarmup() {
+        guard !homeRowCardWarmKeys.isEmpty else { return }
+        homeRowCardPrefetcher.stopPrefetching(
+            with: homeRowCardWarmKeys.map(homeRowCardRequest(for:))
+        )
+        homeRowCardWarmKeys.removeAll()
+    }
+
+    private static func homeRowCardRequest(for key: HomeRowCardWarmKey) -> ImageRequest {
+        displayRequest(url: key.url, pixelSize: key.pixelSize, priority: .low)
+    }
+    #endif
+
     /// Warm full-size artwork under its bare-URL key. Only for art whose
     /// consumers read the unprocessed decode synchronously (marquee logos).
     static func prefetchOriginalArtwork(_ urls: [URL]) {

--- a/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
+++ b/iosApp/iosApp/tvOS/Components/TVFocusMarquee.swift
@@ -69,9 +69,9 @@ struct TVMarqueeContent: Equatable {
     /// The previewed item's content id — keys the low-priority detail
     /// enrichment (§9 backfill). `nil` for collections.
     let contentId: String?
-    /// Stable identity of the source row (`ResolvedSection.id`). Row
-    /// changes are detected on this, never on the display title, which
-    /// adjacent sections may share. `nil` for previews without a section.
+    /// Stable identity of the source row (`ResolvedSection.id`). This keeps
+    /// otherwise identical content in same-named sections distinguishable.
+    /// `nil` for previews without a section.
     let rowId: String?
     /// The source row's title (`Continue Watching`). Not rendered — the
     /// row's own header names the source — but kept for the VoiceOver
@@ -602,12 +602,12 @@ struct TVMarqueeEnrichment: Equatable {
 // MARK: - Debounce model
 
 /// Focused-card → marquee state shared by the tvOS Home and library
-/// Browse landings. Rows report card focus immediately; the marquee text
-/// and cached metadata follow on the same frame, while the backdrop swaps
-/// only after focus has rested 150 ms (§4.2), so scrubbing across a row
-/// never flashes intermediate backdrops. While focus is in chrome the last
-/// previewed item is retained — rows never report focus loss, only focus
-/// gain.
+/// Browse landings. Rows report card focus immediately; foreground text and
+/// cached metadata follow on the same frame. Uncached enrichment waits for
+/// the short rest debounce, while the large backdrop uses the longer stop
+/// gate so rolling never composites intermediate hero artwork. While focus
+/// is in chrome the last previewed item is retained — rows report focus gain,
+/// never focus loss.
 @Observable
 @MainActor
 final class TVFocusMarqueeModel {
@@ -655,31 +655,16 @@ final class TVFocusMarqueeModel {
     private var backdropTask: Task<Void, Never>?
     private var tintTask: Task<Void, Never>?
     private var enrichTask: Task<Void, Never>?
-    /// Decodes a held backdrop (and samples its tint) while the row band is
-    /// still scrolling, so releasing the hold is a memory-cache hit.
-    private var backdropWarmTask: Task<Void, Never>?
-    private var warmedDeferredBackdropURL: String?
-    /// Neighbour backdrops queued by `preview`, warmed once focus rests.
-    private var pendingNeighborBackdropURLs: [String] = []
+    /// A second preview before the isolated gate expires establishes a roll.
+    /// The state remains sticky until the final long gate completes, so slower
+    /// focus delivery while a rail scrolls cannot be mistaken for a stop.
+    private var isBackdropRoll = false
     /// The content whose backdrop may be shown. `nil` while a previewed
-    /// selection has not rested yet, so enrichment landing early cannot
-    /// swap the backdrop ahead of the 150 ms gate.
+    /// selection has not rested yet, so enrichment landing early cannot swap
+    /// the backdrop ahead of the stop gate.
     private var backdropContentID: String?
     /// False while the feed is offscreen; every entry point is a no-op then.
     private var isActive = true
-    /// True while the host's row band is mid-scroll. Swapping the large
-    /// composited backdrop during the row-change animation competes with it
-    /// for GPU time, so the swap waits for the scroll to settle.
-    private var isBackdropDeferred = false
-    private var hasDeferredBackdropUpdate = false
-    /// Releases a held swap once the visible row animation has had time to
-    /// finish. The band's scroll phase can stay non-idle for over a second
-    /// after a single row move, long after the motion the hold protects.
-    private var backdropHoldCapTask: Task<Void, Never>?
-    /// True once the cap has elapsed for the current row move, so a swap
-    /// that becomes ready afterwards (episode backdrop from detail) applies
-    /// at once instead of waiting for the scroll phase to report idle.
-    private var backdropHoldCapElapsed = false
     private var enrichmentState: TVHeroEnrichmentState = .notStarted
     private var lastSampledTintURL: String?
     /// Per-item enrichment cache so scrubbing back over a row never
@@ -694,172 +679,63 @@ final class TVFocusMarqueeModel {
     func seed(_ candidate: TVMarqueeContent) {
         guard isActive, content == nil else { return }
         content = candidate
-        restImmediately(on: candidate)
-    }
-
-    /// Keep foreground information responsive while rapid focus movement
-    /// leaves the existing backdrop still. Only a rested selection (150 ms,
-    /// §4.2) replaces the large composited image and starts its palette
-    /// work — the same gate Android uses, so a roll across a row never
-    /// flashes intermediate backdrops while a single click still lands the
-    /// new art well under half a second.
-    ///
-    /// `neighborBackdropURLs` are the backdrops of the cards on either side
-    /// of the candidate in its row. Once the candidate rests their bytes are
-    /// pulled into the disk cache at low priority so the user's most likely
-    /// next stop skips the network round trip and only pays one decode.
-    func preview(_ candidate: TVMarqueeContent, neighborBackdropURLs: [String] = []) {
-        guard isActive, candidate != content else { return }
-        // A row change is one discrete move whose scroll already holds the
-        // visible swap, so the rest gate would only delay the warm-up. The
-        // band's scroll phase lingers non-idle after the move, so a Left/
-        // Right roll inside the new row must still see the rest gate: only
-        // a change of row identity counts, never the display title, which
-        // adjacent sections may share.
-        let isRowChange = isBackdropDeferred
-            && candidate.rowId != nil
-            && candidate.rowId != content?.rowId
-        cancelBackdropWork()
-        content = candidate
-        pendingNeighborBackdropURLs = neighborBackdropURLs
-        if isRowChange {
-            restForRowChange(on: candidate)
-            return
-        }
-        loadEnrichment(for: candidate, deferNetwork: true)
-        backdropTask = Task { [weak self] in
-            try? await Task.sleep(for: .milliseconds(SiloTheme.Skyline.marqueeRestDebounceMilliseconds))
-            guard !Task.isCancelled, let self,
-                  self.isActive, self.content == candidate else { return }
-            self.rest(on: candidate)
-        }
-    }
-
-    /// The row band's scroll is the gate for `candidate`: restart the hold
-    /// cap for this move, start enrichment without the network debounce
-    /// (episode backdrops resolve from detail, so until it starts there is
-    /// nothing to warm), and rest immediately.
-    private func restForRowChange(on candidate: TVMarqueeContent) {
-        armBackdropHoldCap()
-        loadEnrichment(for: candidate, deferNetwork: false)
-        rest(on: candidate)
-    }
-
-    /// Focus has settled on `candidate`: allow its backdrop through and
-    /// warm the cards beside it.
-    private func rest(on candidate: TVMarqueeContent) {
-        backdropTask?.cancel()
-        backdropTask = nil
-        backdropContentID = candidate.id
-        updateBackdropIfReady()
-        PosterImageCache.warmNeighborBackdrops(pendingNeighborBackdropURLs)
-        pendingNeighborBackdropURLs = []
-    }
-
-    /// Feed left the screen: stop every in-flight task and warmup. `content`
-    /// is kept so `resume` can restore the same selection.
-    func suspend() {
-        isActive = false
-        // Drop any hold left over from an in-flight scroll. The feed can
-        // disappear mid-scroll without ever reporting `.idle`, and a feed
-        // that comes back already at rest has no phase change to release the
-        // hold — `resume` would then pin the restored selection behind the
-        // previous artwork until the user scrolled the band again.
-        isBackdropDeferred = false
-        hasDeferredBackdropUpdate = false
-        backdropHoldCapTask?.cancel()
-        backdropHoldCapTask = nil
-        backdropHoldCapElapsed = false
-        PosterImageCache.cancelNeighborBackdropWarmup()
-        cancelBackdropWork()
-        enrichTask?.cancel()
-        enrichTask = nil
-    }
-
-    /// Feed is back on screen: show the retained selection without waiting
-    /// for a fresh focus report or the rest debounce.
-    func resume() {
-        guard !isActive else { return }
-        isActive = true
-        guard let content else { return }
-        restImmediately(on: content)
-    }
-
-    /// Treat `candidate` as already rested: point the backdrop at it, then
-    /// load enrichment (which may itself complete the backdrop synchronously
-    /// from cache) and apply whatever artwork is resolvable now.
-    private func restImmediately(on candidate: TVMarqueeContent) {
         backdropContentID = candidate.id
         loadEnrichment(for: candidate)
         updateBackdropIfReady()
     }
 
-    /// Cancel the pending rest and palette work and forget which content
-    /// the backdrop belongs to. The displayed artwork itself stays put.
-    private func cancelBackdropWork() {
+    /// Keep foreground information responsive while rapid focus movement
+    /// leaves the existing backdrop still. Only a genuinely rested selection
+    /// replaces the large composited image and starts its palette work.
+    func preview(_ candidate: TVMarqueeContent) {
+        guard isActive, candidate != content else { return }
+        if backdropTask != nil {
+            isBackdropRoll = true
+        }
+        let backdropRestMilliseconds = isBackdropRoll
+            ? SiloTheme.Skyline.marqueeBackdropRollRestMilliseconds
+            : SiloTheme.Skyline.marqueeBackdropIsolatedRestMilliseconds
         backdropTask?.cancel()
         tintTask?.cancel()
-        backdropWarmTask?.cancel()
+        lastSampledTintURL = nil
+        backdropContentID = nil
+        content = candidate
+        loadEnrichment(for: candidate, deferNetwork: true)
+        backdropTask = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(backdropRestMilliseconds))
+            guard !Task.isCancelled, let self,
+                  self.isActive, self.content == candidate else { return }
+            self.backdropTask = nil
+            self.isBackdropRoll = false
+            self.backdropContentID = candidate.id
+            self.updateBackdropIfReady()
+        }
+    }
+
+    func suspend() {
+        isActive = false
+        backdropTask?.cancel()
+        enrichTask?.cancel()
+        tintTask?.cancel()
         backdropTask = nil
+        enrichTask = nil
         tintTask = nil
-        backdropWarmTask = nil
-        warmedDeferredBackdropURL = nil
+        isBackdropRoll = false
         backdropContentID = nil
         lastSampledTintURL = nil
     }
 
-    /// Hold backdrop swaps while `deferred` is true; the latest pending swap
-    /// applies as soon as the hold is released.
-    func setBackdropDeferred(_ deferred: Bool) {
-        guard isBackdropDeferred != deferred else { return }
-        isBackdropDeferred = deferred
-        if deferred {
-            armBackdropHoldCap()
-            // The scroll started after the focus report: the row band is
-            // now the gate, so stop waiting out the rest debounce and the
-            // enrichment debounce, and begin warming the new backdrop
-            // while the band animates.
-            if backdropTask != nil, let content { restForRowChange(on: content) }
-        } else {
-            backdropHoldCapTask?.cancel()
-            backdropHoldCapTask = nil
-            backdropHoldCapElapsed = false
-            releaseDeferredBackdrop()
-        }
+    func resume() {
+        guard !isActive else { return }
+        isActive = true
+        guard let content else { return }
+        backdropContentID = content.id
+        loadEnrichment(for: content)
+        updateBackdropIfReady()
     }
 
-    /// Restart the hold cap for a new row move. The scroll phase can stay
-    /// non-idle across several quick moves, so the cap is per move rather
-    /// than per scroll.
-    private func armBackdropHoldCap() {
-        backdropHoldCapTask?.cancel()
-        backdropHoldCapElapsed = false
-        backdropHoldCapTask = Task { [weak self] in
-            try? await Task.sleep(
-                for: .milliseconds(SiloTheme.Skyline.marqueeBackdropHoldCapMilliseconds)
-            )
-            guard !Task.isCancelled, let self, self.isBackdropDeferred else { return }
-            self.backdropHoldCapElapsed = true
-            self.releaseDeferredBackdrop()
-        }
-    }
-
-    /// Apply the latest held swap, if any. Safe while the hold is still set:
-    /// a later update during the same scroll is held again until the phase
-    /// change or the next cap.
-    private func releaseDeferredBackdrop() {
-        guard hasDeferredBackdropUpdate else { return }
-        hasDeferredBackdropUpdate = false
-        updateBackdropIfReady(ignoringHold: true)
-    }
-
-    private func updateBackdropIfReady(ignoringHold: Bool = false) {
+    private func updateBackdropIfReady() {
         guard isActive, let content, backdropContentID == content.id else { return }
-        if isBackdropDeferred, !ignoringHold, !backdropHoldCapElapsed {
-            hasDeferredBackdropUpdate = true
-            warmDeferredBackdrop()
-            return
-        }
         if let artwork = resolvedArtwork {
             displayedArtwork = artwork
             sampleTintIfNeeded(for: artwork.url)
@@ -868,25 +744,6 @@ final class TVFocusMarqueeModel {
             tintColor = .siloBackground
             tintTask?.cancel()
             lastSampledTintURL = nil
-        }
-    }
-
-    /// The hold only exists to keep the crossfade's compositing out of the
-    /// row-change animation. The expensive half of a swap — the fetch, the
-    /// hero-size decode, and the palette sample — runs on the pipeline's
-    /// background queues, so start it now instead of after the scroll
-    /// settles. When the hold lifts the swap reads both from memory and the
-    /// crossfade begins on the same frame. Row changes are single moves, so
-    /// this is at most one warm per rested row change.
-    private func warmDeferredBackdrop() {
-        guard let artwork = resolvedArtwork,
-              artwork.url != displayedArtwork?.url,
-              artwork.url != warmedDeferredBackdropURL,
-              let url = URL(string: artwork.url) else { return }
-        warmedDeferredBackdropURL = artwork.url
-        backdropWarmTask?.cancel()
-        backdropWarmTask = Task {
-            await PosterImageCache.warmHeroBackdrop(url)
         }
     }
 

--- a/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
+++ b/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
@@ -33,9 +33,13 @@ struct TVSkylineSectionFeed: View {
     var onRemoveFromContinueWatching: ((SectionItem) -> Void)? = nil
     /// Optional Home-only watched-state mutation. Library feeds leave this nil.
     var onSetWatched: ((SectionItem, Bool) async -> Bool)? = nil
+    /// Home opts into a bounded decoded working set for whichever horizontal
+    /// rail owns focus. Library landings keep their existing prefetch policy.
+    var warmsFocusedRowArtwork = false
 
     /// Immediate foreground content with a separately delayed backdrop.
     @State private var marqueeModel = TVFocusMarqueeModel()
+    @State private var uiCustomization = UICustomizationPreferences.shared
     /// Token handed only to row 1 when the shell explicitly enters content.
     /// It is never changed during ordinary row-to-row navigation.
     @State private var contentFocusToken = 0
@@ -76,7 +80,12 @@ struct TVSkylineSectionFeed: View {
             seedMarqueeFromFirstItem()
             requestEntryFocus(focusRequest)
         }
-        .onDisappear { marqueeModel.suspend() }
+        .onDisappear {
+            marqueeModel.suspend()
+            if warmsFocusedRowArtwork {
+                PosterImageCache.cancelHomeRowCardWarmup()
+            }
+        }
         .onChange(of: focusRequest) { _, request in requestEntryFocus(request) }
         .onChange(of: isTopMenuFocused) { _, isFocused in
             if isFocused {
@@ -99,6 +108,7 @@ struct TVSkylineSectionFeed: View {
     private var scrollingRows: some View {
         GeometryReader { proxy in
             let bandHeight = proxy.size.height * SiloTheme.Skyline.rowBandHeightFraction
+            let focusBandTop = max(0, proxy.size.height - bandHeight)
             // Position the focusable viewport with layout, not a render
             // offset. Its bottom must match the screen's bottom: otherwise
             // tvOS can resolve directional clicks against offscreen space
@@ -108,6 +118,13 @@ struct TVSkylineSectionFeed: View {
                 max(0, proxy.size.height - bandHeight + SiloTheme.Skyline.landingContentVerticalOffset)
             )
             let visibleBandHeight = max(0, proxy.size.height - bandTop)
+            // Keep the layout-only strip above the visual band inside the
+            // physical screen. When a short first row (for example Continue
+            // Watching) scrolls just above the band, this runway keeps its
+            // native focus section materialized so Up can discover it. A
+            // render mask below still hides every departing row at `bandTop`.
+            let focusRetentionInset = max(0, bandTop - focusBandTop)
+            let focusBandHeight = max(0, proxy.size.height - focusBandTop)
             let trailingPreviewPadding = max(
                 0,
                 visibleBandHeight - SiloTheme.Skyline.rowBandBottomInset
@@ -132,13 +149,10 @@ struct TVSkylineSectionFeed: View {
                     // with a blank preview area underneath instead of clamping.
                     .padding(.bottom, trailingPreviewPadding)
                 }
+                // The inset preserves the exact on-screen row position while
+                // the scroll view itself retains focus geometry above it.
+                .contentMargins(.top, focusRetentionInset, for: .scrollContent)
                 .scrollTargetBehavior(.viewAligned)
-                // Row changes animate the band; the marquee holds its backdrop
-                // swap until the scroll settles so the two never composite in
-                // the same frames.
-                .onScrollPhaseChange { _, phase in
-                    marqueeModel.setBackdropDeferred(phase != .idle)
-                }
                 // Animated ride home; the first card's focus claim is
                 // re-asserted by MediaRow until the scroll settles, so the
                 // animation can't lose the claim to mid-flight focus repairs.
@@ -150,9 +164,15 @@ struct TVSkylineSectionFeed: View {
                     }
                 }
             }
-            .frame(width: proxy.size.width, height: visibleBandHeight, alignment: .topLeading)
+            .frame(width: proxy.size.width, height: focusBandHeight, alignment: .topLeading)
             .clipped()
-            .padding(.top, bandTop)
+            // Focus uses the full layout frame; painting still begins at the
+            // original visual band edge, so the marquee remains unobstructed.
+            .mask(alignment: .top) {
+                Rectangle()
+                    .padding(.top, focusRetentionInset)
+            }
+            .padding(.top, focusBandTop)
             .frame(width: proxy.size.width, height: proxy.size.height, alignment: .topLeading)
         }
     }
@@ -239,36 +259,15 @@ struct TVSkylineSectionFeed: View {
     }
 
     private func previewFocusedItem(_ item: SectionItem, in section: ResolvedSection) {
+        warmFocusedRowArtworkIfNeeded(section, focusedItemId: item.contentId)
         marqueeModel.preview(
             TVMarqueeContent(
                 item: item,
                 rowId: section.id,
                 rowTitle: section.title,
                 isContinueWatching: section.isContinueWatchingSection
-            ),
-            neighborBackdropURLs: neighborBackdropURLs(around: item, in: section)
+            )
         )
-    }
-
-    /// Section-level backdrops of the cards on either side of `item` in its
-    /// row. Only direct backdrops qualify: episodes and items without one
-    /// resolve their hero art from detail enrichment, which is a metadata
-    /// request the marquee already rate-limits and must not be duplicated
-    /// here for cards the user may never rest on.
-    private func neighborBackdropURLs(
-        around item: SectionItem,
-        in section: ResolvedSection
-    ) -> [String] {
-        guard let index = section.items.firstIndex(where: { $0.id == item.id }) else { return [] }
-        let radius = SiloTheme.Skyline.marqueeNeighborBackdropPrefetchRadius
-        let window = section.items.indices.clamped(to: (index - radius)..<(index + radius + 1))
-        return window.compactMap { neighborIndex -> String? in
-            guard neighborIndex != index else { return nil }
-            let neighbor = section.items[neighborIndex]
-            guard neighbor.type.lowercased() != "episode",
-                  let url = neighbor.backdropUrl, !url.isEmpty else { return nil }
-            return url
-        }
     }
 
     /// Seed the first card as soon as sections exist, so cold entry does not
@@ -278,6 +277,7 @@ struct TVSkylineSectionFeed: View {
         guard marqueeModel.content == nil,
               let section = sections.first,
               let item = section.items.first else { return }
+        warmFocusedRowArtworkIfNeeded(section, focusedItemId: item.contentId)
         marqueeModel.seed(
             TVMarqueeContent(
                 item: item,
@@ -285,6 +285,57 @@ struct TVSkylineSectionFeed: View {
                 rowTitle: section.title,
                 isContinueWatching: section.isContinueWatchingSection
             )
+        )
+    }
+
+    private func warmFocusedRowArtworkIfNeeded(
+        _ section: ResolvedSection,
+        focusedItemId: String
+    ) {
+        guard warmsFocusedRowArtwork,
+              section.items.contains(where: { $0.contentId == focusedItemId }) else { return }
+        let sectionType = section.sectionType.lowercased()
+        let usesEpisodeStills = sectionType.contains("next")
+            || section.isContinueWatchingSection
+            || section.items.contains { $0.type.lowercased() == "episode" }
+        // Home supplies a fixed 20-card row. Queue it once in stable order
+        // instead of sliding a 16-card window on every Left/Right press; the
+        // latter left a repeatable cold edge at the end of the rail.
+        let rowItems = section.items.prefix(20)
+        let urls = rowItems.compactMap { item -> URL? in
+            let value = usesEpisodeStills
+                ? (item.backdropUrl ?? item.posterUrl)
+                : item.posterUrl
+            guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !trimmed.isEmpty else { return nil }
+            return URL(string: trimmed)
+        }
+        PosterImageCache.warmHomeRowCardArtwork(
+            urls,
+            pointSize: cardArtworkPointSize(for: section, usesEpisodeStills: usesEpisodeStills)
+        )
+    }
+
+    private func cardArtworkPointSize(
+        for section: ResolvedSection,
+        usesEpisodeStills: Bool
+    ) -> CGSize {
+        let scale = uiCustomization.cardPresentation.posterSize.scale
+        if usesEpisodeStills {
+            let width = SiloTheme.thumbnailCardWidth * scale
+            return CGSize(
+                width: width,
+                height: width * (SiloTheme.thumbnailCardHeight / SiloTheme.thumbnailCardWidth)
+            )
+        }
+
+        let width = SiloTheme.Skyline.densePosterCardWidth * scale
+        let isSquare = !section.items.isEmpty && section.items.allSatisfy(\.isAudiobook)
+        return CGSize(
+            width: width,
+            height: isSquare
+                ? width
+                : width * (SiloTheme.posterCardHeight / SiloTheme.posterCardWidth)
         )
     }
 

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVDetailCastRail.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVDetailCastRail.swift
@@ -9,6 +9,9 @@ struct TVDetailCastRail: View {
     /// Non-zero changes explicitly hand focus into the first cast card from
     /// the composite Series episode carousel.
     var focusRequest = 0
+    var focusRequestIsActive = true
+    var onFocusRequestFailed: (() -> Void)? = nil
+    var onFocus: (() -> Void)? = nil
 
     private let photoWidth: CGFloat = 200
     private let photoHeight: CGFloat = 200
@@ -17,25 +20,46 @@ struct TVDetailCastRail: View {
     @FocusState private var focusedCastId: String?
 
     var body: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            LazyHStack(spacing: cardSpacing) {
-                ForEach(cast.prefix(maxEntries)) { member in
-                    TVCastCard(
-                        member: member,
-                        photoSize: CGSize(width: photoWidth, height: photoHeight),
-                        onTap: onTap
-                    )
-                    .focused($focusedCastId, equals: member.id)
+        ScrollViewReader { proxy in
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHStack(spacing: cardSpacing) {
+                    ForEach(cast.prefix(maxEntries)) { member in
+                        TVCastCard(
+                            member: member,
+                            photoSize: CGSize(width: photoWidth, height: photoHeight),
+                            onTap: onTap
+                        )
+                        .focused($focusedCastId, equals: member.id)
+                        .id(member.id)
+                    }
                 }
+                .padding(.vertical, 12)
             }
-            .padding(.vertical, 12)
-        }
-        .focusSection()
-        .applyCastRailDefaultFocus(defaultFocusId, binding: $focusedCastId)
-        .scrollClipDisabled()
-        .onChange(of: focusRequest) { _, request in
-            guard request > 0, let defaultFocusId else { return }
-            focusedCastId = defaultFocusId
+            .focusSection()
+            .applyCastRailDefaultFocus(defaultFocusId, binding: $focusedCastId)
+            .scrollClipDisabled()
+            .task(id: "\(focusRequest):\(focusRequestIsActive)") {
+                guard focusRequest > 0, focusRequestIsActive, let defaultFocusId else { return }
+                // A previously scrolled cast strip may not have its first lazy
+                // card mounted. Reveal it before handing focus across the boundary.
+                proxy.scrollTo(defaultFocusId, anchor: .leading)
+                for _ in 0..<12 {
+                    do {
+                        try await Task.sleep(for: .milliseconds(50))
+                    } catch { return }
+                    guard !Task.isCancelled else { return }
+                    if focusedCastId == defaultFocusId { return }
+                    focusedCastId = defaultFocusId
+                }
+                do {
+                    try await Task.sleep(for: .milliseconds(50))
+                } catch { return }
+                guard !Task.isCancelled, focusedCastId != defaultFocusId else { return }
+                onFocusRequestFailed?()
+            }
+            .onChange(of: focusedCastId) { _, id in
+                if id != nil { onFocus?() }
+            }
         }
     }
 

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVDetailCastRail.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVDetailCastRail.swift
@@ -40,6 +40,12 @@ struct TVDetailCastRail: View {
             .scrollClipDisabled()
             .task(id: "\(focusRequest):\(focusRequestIsActive)") {
                 guard focusRequest > 0, focusRequestIsActive, let defaultFocusId else { return }
+                // Disappearing or replacing this task must release its pending
+                // handoff. The parent checks the captured generation and request
+                // so an old cancellation cannot clear its replacement.
+                defer {
+                    if Task.isCancelled { onFocusRequestFailed?() }
+                }
                 // A previously scrolled cast strip may not have its first lazy
                 // card mounted. Reveal it before handing focus across the boundary.
                 proxy.scrollTo(defaultFocusId, anchor: .leading)

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
@@ -16,8 +16,8 @@ private enum EpisodeHomeHoverMetrics {
 ///
 /// Pass `currentContentId` to highlight the episode currently represented
 /// by the surrounding detail experience. Legacy rails center that card on
-/// first appearance. Series can instead pin focused cards to the leading
-/// carousel slot until the content reaches its trailing scroll boundary.
+/// first appearance. Series uses Home's native thumbnail controls inside
+/// the season pager.
 struct TVEpisodeRail: View {
     let episodes: [EpisodeListItem]
     let onSelect: (String) -> Void
@@ -33,6 +33,8 @@ struct TVEpisodeRail: View {
     var currentContentId: String? = nil
     var currentContentIsFavorite = false
     var favoriteStates: [String: Bool] = [:]
+    var seriesId: String? = nil
+    var seriesTitle: String? = nil
     var prefersCurrentContentFocus = false
     /// Series opts into a larger carousel card. The default keeps the
     /// approved 480-point geometry on existing season/episode pages.
@@ -50,20 +52,88 @@ struct TVEpisodeRail: View {
     var focusRequest = 0
 
     @FocusState private var focusedCardId: String?
-    @Namespace private var anchoredFocusScope
-    @State private var anchoredIndex = 0
-    @State private var anchoredScrollPosition = ScrollPosition(x: 0)
-    @State private var anchoredPlayedOverrides: [String: Bool] = [:]
-    @State private var anchoredFavoriteOverrides: [String: Bool] = [:]
     @State private var uiCustomization = UICustomizationPreferences.shared
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @ViewBuilder
     var body: some View {
         if anchorsFocusedCard {
-            anchoredRail
+            homeStyleRail
         } else {
             legacyRail
+        }
+    }
+
+    /// Series uses the same component and card path as Home's Continue
+    /// Watching row. The season tabs and their page transition stay outside
+    /// this view and are unchanged.
+    private var homeStyleRail: some View {
+        MediaRow(
+            title: "Episodes",
+            items: homeStyleItems,
+            onItemTap: onSelect,
+            showsHeader: false,
+            usesLazyCardLayout: false,
+            onItemPlay: homeStylePlayAction,
+            showProgress: true,
+            layout: .thumbnail,
+            usesProvidedThumbnailTapAction: true,
+            usesEpisodeCaption: true,
+            defersOffscreenArtwork: true,
+            prefersDefaultFocusOnFirstItem: true,
+            focusRequest: focusRequest,
+            defaultFocusItemId: currentContentId,
+            focusRequestItemId: currentContentId,
+            showsPlayInContextMenu: onPlay != nil,
+            onSetWatched: homeStyleWatchedAction,
+            onSetFavorite: homeStyleFavoriteAction,
+            onMoveUp: onMoveUp,
+            onItemFocus: { item in
+                onFocusedEpisodeChange?(item.contentId)
+            },
+            cardVerticalPadding: 12,
+            horizontalContentMargin: EpisodeHomeHoverMetrics.leadingInset(
+                for: baseCardWidth * uiCustomization.cardPresentation.posterSize.scale
+            ),
+            onMoveDown: onMoveDown
+        )
+        // The enclosing season pager is deliberately scroll-disabled so its
+        // tabs can change pages without the remote dragging that outer rail.
+        // Re-enable scrolling for the nested Home carousel itself.
+        .environment(\.isScrollEnabled, true)
+        .frame(height: anchoredRailHeight, alignment: .topLeading)
+        .onDisappear {
+            onFocusedEpisodeChange?(nil)
+        }
+    }
+
+    private var homeStyleItems: [SectionItem] {
+        episodes.map { episode in
+            SectionItem(
+                episode: episode,
+                seriesId: seriesId,
+                seriesTitle: seriesTitle,
+                isFavorite: favoriteStates[episode.contentId]
+                    ?? (currentContentId == episode.contentId && currentContentIsFavorite)
+            )
+        }
+    }
+
+    private var homeStylePlayAction: ((SectionItem) -> Void)? {
+        guard let onPlay else { return nil }
+        return { item in onPlay(item.contentId) }
+    }
+
+    private var homeStyleWatchedAction: ((SectionItem, Bool) async -> Bool)? {
+        guard let onSetWatched else { return nil }
+        return { item, played in
+            await onSetWatched(item.contentId, played)
+        }
+    }
+
+    private var homeStyleFavoriteAction: ((SectionItem, Bool) async -> Bool)? {
+        guard let onSetFavorite else { return nil }
+        return { item, isFavorite in
+            await onSetFavorite(item.contentId, isFavorite)
         }
     }
 
@@ -119,375 +189,59 @@ struct TVEpisodeRail: View {
         }
     }
 
-    /// Episode buttons participate in native focus, including the system's
-    /// navigation sounds. Focus changes only update the existing leading scroll
-    /// position; horizontal input never writes a second focus destination.
-    private var anchoredRail: some View {
-        GeometryReader { geometry in
-            anchoredCards(viewportWidth: geometry.size.width)
-                .onAppear {
-                    seedAnchoredIndex(viewportWidth: geometry.size.width)
-                }
-                .onChange(of: episodeIdentityKey) { _, _ in
-                    seedAnchoredIndex(viewportWidth: geometry.size.width)
-                }
-                .onChange(of: currentContentId) { _, _ in
-                    guard focusedCardId == nil else { return }
-                    seedAnchoredIndex(viewportWidth: geometry.size.width)
-                }
-                .onChange(of: focusRequest) { _, request in
-                    guard request > 0 else { return }
-                    seedAnchoredIndex(viewportWidth: geometry.size.width)
-                    focusedCardId = anchoredEpisode?.contentId
-                }
-                .onChange(of: focusedCardId) { _, contentId in
-                    if let edgeContentId = AnchoredEdgeFocusGuide.edgeEpisode(
-                        for: contentId,
-                        in: episodes
-                    ) {
-                        focusedCardId = edgeContentId
-                        return
-                    }
-                    if let contentId,
-                       let index = episodes.firstIndex(where: { $0.contentId == contentId }) {
-                        anchorFocusedSelection(at: index, viewportWidth: geometry.size.width)
-                    }
-                    onFocusedEpisodeChange?(contentId)
-                }
-        }
-        .frame(height: anchoredRailHeight)
-        .focusScope(anchoredFocusScope)
-        .focusSection()
-        .applyCurrentEpisodeDefaultFocus(
-            anchoredEpisode?.contentId,
-            binding: $focusedCardId
-        )
-        .onDisappear {
-            onFocusedEpisodeChange?(nil)
-        }
-    }
-
-    private func anchoredCards(viewportWidth: CGFloat) -> some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            LazyHStack(alignment: .top, spacing: cardSpacing) {
-                ForEach(Array(episodes.enumerated()), id: \.element.contentId) { index, episode in
-                    anchoredEpisodeButton(episode, index: index)
-                        .zIndex(focusedCardId == episode.contentId ? 1 : 0)
-                }
-            }
-            // Hard horizontal edges live in the native focus graph: a focus
-            // guide hugs each end of the card strip so Left from the first
-            // card and Right from the last resolve to the guide, which hands
-            // focus straight back to that edge card. `onMoveCommand` cannot
-            // do this because the engine resolves the move before it fires.
-            .overlay(alignment: .leading) {
-                anchoredEdgeFocusGuide(AnchoredEdgeFocusGuide.leading)
-                    .alignmentGuide(.leading) { $0[.trailing] }
-            }
-            .overlay(alignment: .trailing) {
-                anchoredEdgeFocusGuide(AnchoredEdgeFocusGuide.trailing)
-                    .alignmentGuide(.trailing) { $0[.leading] }
-            }
-            // Preserve the existing crop, hover clearance and trailing boundary.
-            .padding(
-                .leading,
-                EpisodeHomeHoverMetrics.leadingInset(for: anchoredCardWidth)
-            )
-            .padding(
-                .trailing,
-                anchoredTrailingInset(viewportWidth: viewportWidth)
-            )
-            .padding(.vertical, 12)
-        }
-        .scrollPosition($anchoredScrollPosition)
-        // The outer season pager is scroll-disabled. Enable only this inner
-        // rail so native focus can reveal the previous offscreen episode.
-        .environment(\.isScrollEnabled, true)
-        .frame(
-            width: viewportWidth,
-            height: anchoredRailHeight,
-            alignment: .topLeading
-        )
-        .clipped()
-    }
-
-    @ViewBuilder
-    private func anchoredEpisodeButton(_ episode: EpisodeListItem, index: Int) -> some View {
-        let button = Button {
-            onSelect(episode.contentId)
-        } label: {
-            EpisodeCardLabel(
-                episode: episode,
-                isPlayed: anchoredIsPlayed(episode),
-                isCurrent: currentContentId == episode.contentId,
-                cardWidth: anchoredCardWidth,
-                stillHeight: anchoredStillHeight,
-                stillCornerRadius: 18,
-                captionStyle: uiCustomization.cardPresentation.caption,
-                focusOverride: focusedCardId == episode.contentId,
-                hidesEpisodeTitle: true,
-                usesHomeHoverEffect: true,
-                showsFocusOutline: false,
-                showsCurrentOutline: false
-            )
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(TVAnchoredEpisodeButtonStyle())
-        .focused($focusedCardId, equals: episode.contentId)
-        .onMoveCommand { direction in
-            // Only the vertical boundaries hand off to another focus region.
-            // Left and Right belong entirely to the native episode buttons;
-            // the rail's edge focus guides fence the first and last card.
-            switch direction {
-            case .up: onMoveUp?()
-            case .down: onMoveDown?()
-            default: break
-            }
-        }
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(episodeRailAccessibilityLabel(
-            seasonNumber: episode.seasonNumber,
-            episodeNumber: episode.episodeNumber,
-            title: episode.title,
-            metadata: anchoredMetadataLine(for: episode),
-            isCurrent: currentContentId == episode.contentId,
-            isPlayed: anchoredIsPlayed(episode)
-        ))
-        .accessibilityValue("Episode \(index + 1) of \(max(episodes.count, 1))")
-
-        if onPlay != nil || onSetWatched != nil || onSetFavorite != nil {
-            button.contextMenu { anchoredContextActions }
-        } else {
-            button
-        }
-    }
-
-    /// A one-point focusable strip just outside the card strip. It never
-    /// renders and never keeps focus; it only exists so the focus engine has
-    /// an in-rail destination at each hard edge.
-    private func anchoredEdgeFocusGuide(_ id: String) -> some View {
-        Color.clear
-            .frame(width: 1, height: anchoredRailHeight)
-            .focusable(true)
-            .focused($focusedCardId, equals: id)
-            .focusEffectDisabled()
-            .accessibilityHidden(true)
-    }
-
-    private var anchoredCardWidth: CGFloat {
-        baseCardWidth * uiCustomization.cardPresentation.posterSize.scale
-    }
-
-    private var anchoredStillHeight: CGFloat {
-        anchoredCardWidth * cardHeightRatio
-    }
-
     private var anchoredRailHeight: CGFloat {
-        anchoredStillHeight
+        let width = baseCardWidth * uiCustomization.cardPresentation.posterSize.scale
+        return width * cardHeightRatio
             + (uiCustomization.cardPresentation.caption.showsTitle ? 46 : 0)
             + 24
     }
+}
 
-    private var anchoredEpisode: EpisodeListItem? {
-        guard episodes.indices.contains(anchoredIndex) else { return episodes.first }
-        return episodes[anchoredIndex]
-    }
-
-    private var episodeIdentityKey: String {
-        episodes.map(\.contentId).joined(separator: "|")
-    }
-
-    private func anchoredContentOffset(
-        for index: Int,
-        viewportWidth: CGFloat
-    ) -> CGFloat {
-        guard !episodes.isEmpty else { return 0 }
-        let step = anchoredCardWidth + cardSpacing
-        let contentWidth = CGFloat(episodes.count) * anchoredCardWidth
-            + CGFloat(max(episodes.count - 1, 0)) * cardSpacing
-        let minimumTrailingOffset = max(0, contentWidth - viewportWidth)
-        // Keep the hard rail crop, but stop its terminal position on the next
-        // complete card step. The final group can then show a full card at
-        // both edges while the last episode remains entirely visible; any
-        // remainder becomes harmless trailing breathing room.
-        let maximumOffset = ceil(minimumTrailingOffset / step) * step
-        return min(CGFloat(index) * step, maximumOffset)
-    }
-
-    /// Adds only the extra scrollable width needed to preserve the rail's
-    /// existing stepped trailing boundary. SwiftUI can then clamp concrete
-    /// scroll positions natively without changing the final card grouping.
-    private func anchoredTrailingInset(viewportWidth: CGFloat) -> CGFloat {
-        guard !episodes.isEmpty else { return 0 }
-        let leadingInset = EpisodeHomeHoverMetrics.leadingInset(for: anchoredCardWidth)
-        let contentWidth = CGFloat(episodes.count) * anchoredCardWidth
-            + CGFloat(max(episodes.count - 1, 0)) * cardSpacing
-        let naturalMaximumOffset = max(
-            0,
-            leadingInset + contentWidth - viewportWidth
-        )
-        let desiredMaximumOffset = anchoredContentOffset(
-            for: episodes.count - 1,
-            viewportWidth: viewportWidth
-        )
-        return max(0, desiredMaximumOffset - naturalMaximumOffset)
-    }
-
-    private func seedAnchoredIndex(viewportWidth: CGFloat) {
-        let seededIndex: Int
-        if let currentContentId,
-           let index = episodes.firstIndex(where: { $0.contentId == currentContentId }) {
-            seededIndex = index
-        } else {
-            seededIndex = min(anchoredIndex, max(episodes.count - 1, 0))
-        }
-
-        // A newly inserted season page inherits the outer pan transaction.
-        // Seeding its internal episode offset inside that same animation made
-        // the cards briefly travel the opposite way while the page itself was
-        // moving correctly. Mount at the resolved index with no animation;
-        // user-driven episode moves retain their normal smooth transition.
-        var transaction = Transaction(animation: nil)
-        transaction.disablesAnimations = true
-        withTransaction(transaction) {
-            anchoredIndex = seededIndex
-            anchoredScrollPosition.scrollTo(
-                x: anchoredContentOffset(
-                    for: seededIndex,
-                    viewportWidth: viewportWidth
-                )
-            )
-        }
-    }
-
-    private func anchorFocusedSelection(
-        at index: Int,
-        viewportWidth: CGFloat
+private extension SectionItem {
+    /// Adapts a season episode to the same model consumed by Home's
+    /// Continue Watching carousel. This is data mapping only; the Home row
+    /// remains the sole owner of horizontal scrolling and focus behavior.
+    init(
+        episode: EpisodeListItem,
+        seriesId: String?,
+        seriesTitle: String?,
+        isFavorite: Bool
     ) {
-        guard episodes.indices.contains(index) else { return }
-
-        // Keep focus/selection state out of the scroll animation transaction.
-        // That prevents hero metadata and every card from inheriting the
-        // carousel's animation while the native ScrollView moves its content.
-        anchoredIndex = index
-        let targetOffset = anchoredContentOffset(
-            for: index,
-            viewportWidth: viewportWidth
+        contentId = episode.contentId
+        type = "episode"
+        title = episode.title ?? "Episode \(episode.episodeNumber)"
+        self.seriesId = seriesId
+        self.seriesTitle = seriesTitle
+        seasonNumber = episode.seasonNumber
+        episodeNumber = episode.episodeNumber
+        year = nil
+        genres = nil
+        status = nil
+        ratingImdb = nil
+        ratingTmdb = nil
+        ratingRtCritic = nil
+        ratingRtAudience = nil
+        contentRating = nil
+        runtime = episode.runtime
+        originalLanguage = nil
+        studios = nil
+        networks = nil
+        showStatus = nil
+        overview = episode.overview
+        itemSource = nil
+        positionSeconds = episode.userData?.positionSeconds
+        durationSeconds = episode.userData?.durationSeconds
+        progressUpdatedAt = nil
+        posterUrl = episode.stillUrl
+        posterThumbhash = episode.stillThumbhash
+        backdropUrl = episode.stillUrl
+        backdropThumbhash = episode.stillThumbhash
+        logoUrl = nil
+        userState = MediaItemUserState(
+            played: episode.userData?.played ?? false,
+            isFavorite: isFavorite
         )
-        if reduceMotion {
-            anchoredScrollPosition.scrollTo(x: targetOffset)
-        } else {
-            withAnimation(.smooth(duration: 0.30, extraBounce: 0)) {
-                anchoredScrollPosition.scrollTo(x: targetOffset)
-            }
-        }
-    }
-
-    private func anchoredIsPlayed(_ episode: EpisodeListItem) -> Bool {
-        anchoredPlayedOverrides[episode.contentId]
-            ?? episode.userData?.played
-            ?? false
-    }
-
-    private func anchoredIsFavorite(_ episode: EpisodeListItem) -> Bool {
-        anchoredFavoriteOverrides[episode.contentId]
-            ?? favoriteStates[episode.contentId]
-            ?? (currentContentId == episode.contentId && currentContentIsFavorite)
-    }
-
-    private func anchoredMetadataLine(for episode: EpisodeListItem) -> String? {
-        var parts: [String] = []
-        if let airDate = DetailDateFormatting.abbreviatedDate(episode.airDate) {
-            parts.append(airDate)
-        }
-        if let runtime = episode.runtime, runtime > 0 {
-            parts.append(runtime >= 60
-                ? "\(runtime / 60)h \(runtime % 60)m"
-                : "\(runtime)m")
-        }
-        return parts.isEmpty ? nil : parts.joined(separator: "  ·  ")
-    }
-
-    @ViewBuilder
-    private var anchoredContextActions: some View {
-        if let episode = anchoredEpisode {
-            if let onPlay {
-                Button {
-                    onPlay(episode.contentId)
-                } label: {
-                    Label(
-                        "Play S\(episode.seasonNumber):E\(episode.episodeNumber)",
-                        systemImage: "play.fill"
-                    )
-                }
-            }
-
-            if let onSetWatched {
-                Button {
-                    let played = !anchoredIsPlayed(episode)
-                    anchoredPlayedOverrides[episode.contentId] = played
-                    Task {
-                        if await onSetWatched(episode.contentId, played) == false {
-                            anchoredPlayedOverrides[episode.contentId] = nil
-                        }
-                    }
-                } label: {
-                    Label(
-                        anchoredIsPlayed(episode) ? "Mark as Unwatched" : "Mark as Watched",
-                        systemImage: anchoredIsPlayed(episode) ? "circle" : "checkmark.circle"
-                    )
-                }
-            }
-
-            if let onSetFavorite {
-                Button {
-                    let isFavorite = !anchoredIsFavorite(episode)
-                    anchoredFavoriteOverrides[episode.contentId] = isFavorite
-                    Task {
-                        if await onSetFavorite(episode.contentId, isFavorite) == false {
-                            anchoredFavoriteOverrides[episode.contentId] = nil
-                        }
-                    }
-                } label: {
-                    Label(
-                        anchoredIsFavorite(episode) ? "Remove from Favorites" : "Add to Favorites",
-                        systemImage: anchoredIsFavorite(episode) ? "heart.slash" : "heart"
-                    )
-                }
-            }
-        }
-    }
-}
-
-/// The native button owns focus and sound, while the artwork supplies the
-/// existing Home-style hover without adding a second system lift effect.
-/// Focus identities for the anchored rail's edge guides. They share the
-/// episode `@FocusState` so the rail can bounce them back to a real card.
-private enum AnchoredEdgeFocusGuide {
-    static let leading = "silo.episodeRail.edge.leading"
-    static let trailing = "silo.episodeRail.edge.trailing"
-
-    static func edgeEpisode(
-        for focusedId: String?,
-        in episodes: [EpisodeListItem]
-    ) -> String? {
-        switch focusedId {
-        case leading: return episodes.first?.contentId
-        case trailing: return episodes.last?.contentId
-        default: return nil
-        }
-    }
-}
-
-private struct TVAnchoredEpisodeButtonStyle: ButtonStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .opacity(configuration.isPressed ? 0.96 : 1)
-            .focusEffectDisabled()
-            .animation(
-                .easeOut(duration: SiloTheme.fastDuration),
-                value: configuration.isPressed
-            )
+        overlaySummary = nil
     }
 }
 

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -1255,6 +1255,13 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         }
     }
 
+    private func failSupportingHandoff(_ generation: Int, request: Int) {
+        guard supportingHandoffPending,
+              supportingRailFocusGeneration == generation,
+              supportingRailFocusRequest == request else { return }
+        cancelSupportingHandoff()
+    }
+
     private func cancelSupportingHandoff() {
         supportingHandoffPending = false
         supportingRailFocusGeneration &+= 1
@@ -1447,7 +1454,10 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                 onTap: onPersonTap,
                 focusRequest: supportingRailFocusRequest,
                 focusRequestIsActive: supportingHandoffPending,
-                onFocusRequestFailed: cancelSupportingHandoff,
+                onFocusRequestFailed: { [generation = supportingRailFocusGeneration,
+                                         request = supportingRailFocusRequest] in
+                    failSupportingHandoff(generation, request: request)
+                },
                 onFocus: {
                     cancelSupportingHandoff()
                     primaryFocusRegion = .outside

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -1,6 +1,7 @@
 #if os(tvOS)
 import SwiftUI
 import UIKit
+import Nuke
 
 /// Single-page Series experience for tvOS. `Show` and every season are
 /// in-place modes: the series backdrop never changes, episode focus updates
@@ -9,6 +10,7 @@ import UIKit
 struct TVSeriesDetailView<BelowSynopsis: View>: View {
     private enum PrimaryFocusRegion {
         case outside
+        case actions
         case mode
         case episodes
     }
@@ -28,6 +30,48 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     /// exactly where it is before issuing the newest destination.
     private final class SeasonScrollTracker {
         var liveOffset: CGFloat = 0
+    }
+
+    /// One low-priority worker warms only the first visible cards of three
+    /// nearby seasons. It owns its requests independently of Home prefetching.
+    private final class SeasonArtworkWarmer {
+        private let prefetcher: ImagePrefetcher = {
+            let value = ImagePrefetcher(
+                pipeline: ImagePipeline.shared,
+                destination: .memoryCache,
+                maxConcurrentRequestCount: 1
+            )
+            value.priority = .low
+            return value
+        }()
+        private var urls: Set<URL> = []
+        private var pixelSize: CGSize = .zero
+
+        func update(urls requestedURLs: [URL], pixelSize requestedSize: CGSize) {
+            if pixelSize != requestedSize {
+                cancel()
+                pixelSize = requestedSize
+            }
+            let next = Set(requestedURLs)
+            let removed = urls.subtracting(next)
+            prefetcher.stopPrefetching(with: removed.map {
+                PosterImageCache.displayRequest(url: $0, pixelSize: pixelSize, priority: .low)
+            })
+            // Preserve destination-first ordering while deduplicating URLs.
+            var added = Set<URL>()
+            let requests = requestedURLs.filter {
+                !urls.contains($0) && added.insert($0).inserted
+            }.map {
+                PosterImageCache.displayRequest(url: $0, pixelSize: pixelSize, priority: .low)
+            }
+            prefetcher.startPrefetching(with: requests)
+            urls = next
+        }
+
+        func cancel() {
+            prefetcher.stopPrefetching()
+            urls.removeAll()
+        }
     }
 
     /// Owns only the outer vertical UIScrollView. Locking this concrete scroll
@@ -57,20 +101,16 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         }
 
         func enterPrimary(animated: Bool, reduceMotion: Bool) {
+            // Row-to-row focus changes share the same destination. Keep an
+            // existing return trip running instead of restarting it on Up.
+            guard !primaryOwnsViewport else { return }
             primaryOwnsViewport = true
-            // Moves between rows inside the fixed viewport (Season row <->
-            // Episodes) ask for `animated: false` because the page should
-            // already be resting at the top. On a double Up from Cast the
-            // first press's return trip is still mid-flight; jumping now is
-            // the snap. Finish that trip as an animation from wherever the
-            // page visibly is instead.
-            let continuesInFlightTrip = pageAnimator?.state == .active
             stopPageAnimation()
             guard let scrollView else { return }
-
-            scrollView.isScrollEnabled = true
+            // Programmatic offsets still animate while native reveal is held.
+            scrollView.isScrollEnabled = false
             let target = topOffset(in: scrollView)
-            guard animated || continuesInFlightTrip,
+            guard animated,
                   !reduceMotion,
                   abs(scrollView.contentOffset.y - target.y) > 0.5 else {
                 scrollView.setContentOffset(target, animated: false)
@@ -95,9 +135,9 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         func revealSupporting(reduceMotion: Bool) {
             primaryOwnsViewport = false
             stopPageAnimation()
-            guard let scrollView, let supportingAnchorView else { return }
-
+            guard let scrollView else { return }
             scrollView.isScrollEnabled = true
+            guard let supportingAnchorView else { return }
             let target = centeredOffset(for: supportingAnchorView, in: scrollView)
             guard !reduceMotion,
                   abs(scrollView.contentOffset.y - target.y) > 0.5 else {
@@ -160,8 +200,14 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
             guard let pageAnimator else { return }
             self.pageAnimator = nil
             if pageAnimator.state == .active {
+                let visibleOffset = scrollView?.layer.presentation()?.bounds.origin
                 pageAnimator.stopAnimation(false)
                 pageAnimator.finishAnimation(at: .current)
+                if let visibleOffset, let scrollView {
+                    UIView.performWithoutAnimation {
+                        scrollView.setContentOffset(visibleOffset, animated: false)
+                    }
+                }
             } else {
                 pageAnimator.stopAnimation(true)
             }
@@ -246,9 +292,17 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     @State private var episodeRailFocusRequest = 0
     @State private var supportingRailFocusRequest = 0
     @State private var supportingRailFocusGeneration = 0
+    @State private var supportingHandoffPending = false
     @State private var modeActivationTask: Task<Void, Never>?
     @State private var modeFocusAppearanceTask: Task<Void, Never>?
     @State private var presentedFocusedModeId: String?
+    @State private var queuedSeasonId: String?
+    @State private var queuedSeasonTask: Task<Void, Never>?
+    @State private var lastSeasonActivationTime: TimeInterval?
+    @State private var lastSeasonFocusTime: TimeInterval?
+    @State private var seasonTransitionDuration = 0.46
+    @State private var seasonArtworkWarmer = SeasonArtworkWarmer()
+    @Environment(\.displayScale) private var displayScale
     @State private var seasonTransitionInFlight = false
     @State private var seasonTransitionTargetId: String?
     @State private var seasonTransitionGeneration = 0
@@ -298,24 +352,15 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                         }
                     }
                 }
-                .onChange(of: supportingRailFocusRequest) { _, request in
-                    guard request > 0, hasCast else { return }
-                    // Drive this through the coordinator rather than the
-                    // SwiftUI proxy: a proxy animation cannot be cancelled, so
-                    // a quick Up used to run it against the return trip and
-                    // the page snapped when the loser finished.
-                    pageScrollCoordinator.revealSupporting(reduceMotion: reduceMotion)
-                }
                 .ignoresSafeArea()
                 .focusScope(detailFocusNamespace)
                 .defaultFocus($playFocused, true, priority: .userInitiated)
-                .detailFocusScroll(
-                    proxy: scrollProxy,
-                    seasonRowFocused: false,
-                    actionRowFocused: showActionRowFocused,
-                    episodeSectionId: episodeSectionScrollId,
-                    heroId: heroScrollId
-                )
+                .onChange(of: showActionRowFocused) { _, focused in
+                    guard focused else { return }
+                    cancelSupportingHandoff()
+                    primaryFocusRegion = .actions
+                    pageScrollCoordinator.enterPrimary(animated: true, reduceMotion: reduceMotion)
+                }
                 .tvActionPopoverHost()
             }
         }
@@ -337,7 +382,19 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                 synchronizeCurrentSeasonPage()
             }
         }
+        .onChange(of: seasonArtworkWarmKey, initial: true) { _, _ in
+            seasonArtworkWarmer.update(
+                urls: seasonArtworkWarmURLs,
+                pixelSize: seasonArtworkPixelSize
+            )
+        }
         .onDisappear {
+            queuedSeasonTask?.cancel()
+            queuedSeasonTask = nil
+            queuedSeasonId = nil
+            lastSeasonActivationTime = nil
+            lastSeasonFocusTime = nil
+            seasonArtworkWarmer.cancel()
             modeActivationTask?.cancel()
             modeActivationTask = nil
             modeFocusAppearanceTask?.cancel()
@@ -353,6 +410,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                 seasonPageScrollPosition = ScrollPosition(x: 0)
                 seasonScrollTracker.liveOffset = 0
             }
+            cancelSupportingHandoff()
             pageScrollCoordinator.detach()
             seasonTransitionInFlight = false
             seasonTransitionTargetId = nil
@@ -573,6 +631,10 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                     modeFocusAppearanceTask = nil
                     presentedFocusedModeId = newId
                 }
+                // Native focus already scrolls the tab row during remote
+                // navigation. Recentring on every activation competes with
+                // that motion, particularly across a long season list.
+                guard focusedModeId == nil else { return }
                 withAnimation(.easeOut(duration: SiloTheme.fastDuration)) {
                     proxy.scrollTo(newId, anchor: .center)
                 }
@@ -584,6 +646,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                     modeActivationTask = nil
                     return
                 }
+                cancelSupportingHandoff()
                 let previousRegion = primaryFocusRegion
                 primaryFocusRegion = .mode
                 if previousRegion == .outside {
@@ -627,7 +690,8 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     /// The season pill stays selected while the hero shows series info, since
     /// the rail below still lists that season's episodes.
     private var selectedModeId: String {
-        seasonTransitionTargetId
+        queuedSeasonId
+            ?? seasonTransitionTargetId
             ?? visibleSeasonId
             ?? selectedSeason?.id
             ?? noSeasonModeId
@@ -640,10 +704,38 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         onActivateEpisode(nil)
     }
 
-    private func activateSeason(_ season: Season) {
+    private func activateSeason(_ season: Season, followsRapidFocus: Bool = false) {
         modeActivationTask?.cancel()
         modeActivationTask = nil
+        guard season.id != selectedModeId else { return }
         isShowingSeriesOverview = false
+        let now = ProcessInfo.processInfo.systemUptime
+        let isBurst = followsRapidFocus || queuedSeasonTask != nil
+            || lastSeasonActivationTime.map { now - $0 < 0.18 } == true
+        lastSeasonActivationTime = now
+        queuedSeasonTask?.cancel()
+        queuedSeasonTask = nil
+
+        if isBurst {
+            // Rolling quiet window: each new click replaces the pending
+            // destination. The current slide can finish; obsolete seasons
+            // never create their own animation or artwork warm-up.
+            queuedSeasonId = season.id
+            queuedSeasonTask = Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(120))
+                guard !Task.isCancelled, queuedSeasonId == season.id else { return }
+                queuedSeasonTask = nil
+                queuedSeasonId = nil
+                performSeasonActivation(season, isBurst: true)
+            }
+        } else {
+            queuedSeasonId = nil
+            performSeasonActivation(season, isBurst: false)
+        }
+    }
+
+    private func performSeasonActivation(_ season: Season, isBurst: Bool) {
+        seasonTransitionDuration = isBurst ? 0.30 : 0.46
         if seasonTransitionInFlight {
             guard season.id != seasonTransitionTargetId else { return }
             retargetSeasonTransition(to: season)
@@ -757,6 +849,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
               seasonTransitionTask == nil else { return }
 
         let generation = seasonTransitionGeneration
+        let duration = seasonTransitionDuration
         seasonTransitionTask = Task { @MainActor in
             await Task.yield()
             if waitsForPageMount && !reduceMotion {
@@ -768,13 +861,13 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
             withAnimation(
                 reduceMotion
                     ? nil
-                    : .timingCurve(0.4, 0, 0.2, 1, duration: 0.46)
+                    : .timingCurve(0.4, 0, 0.2, 1, duration: duration)
             ) {
                 seasonPageScrollPosition = ScrollPosition(x: destinationOffset)
             }
 
             if !reduceMotion {
-                try? await Task.sleep(for: .milliseconds(480))
+                try? await Task.sleep(for: .seconds(duration + 0.02))
             } else {
                 await Task.yield()
             }
@@ -819,7 +912,16 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     private func scheduleModeActivation(for modeId: String) {
         modeActivationTask?.cancel()
         modeActivationTask = nil
+        let now = ProcessInfo.processInfo.systemUptime
+        let followsRapidFocus = lastSeasonFocusTime.map { now - $0 < 0.18 } == true
+        lastSeasonFocusTime = now
         guard modeId != selectedModeId else { return }
+        if queuedSeasonId != nil, let season = seasons.first(where: { $0.id == modeId }) {
+            // Extend an already-open gate on the actual focus event, before
+            // the ordinary focus dwell can let an obsolete target escape.
+            activateSeason(season, followsRapidFocus: true)
+            return
+        }
 
         modeActivationTask = Task { @MainActor in
             try? await Task.sleep(for: .milliseconds(70))
@@ -828,9 +930,39 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                   modeId != selectedModeId else { return }
 
             if let season = seasons.first(where: { $0.id == modeId }) {
-                activateSeason(season)
+                activateSeason(season, followsRapidFocus: followsRapidFocus)
             }
         }
+    }
+
+    private var seasonArtworkPixelSize: CGSize {
+        let scale = uiCustomization.cardPresentation.posterSize.scale * displayScale
+        return CGSize(
+            width: SiloTheme.thumbnailCardWidth * scale,
+            height: SiloTheme.thumbnailCardHeight * scale
+        )
+    }
+
+    private var seasonArtworkWarmURLs: [URL] {
+        guard !seasons.isEmpty,
+              let center = seasons.firstIndex(where: {
+                  $0.id == (seasonTransitionTargetId ?? visibleSeasonId ?? selectedSeason?.id)
+              }) else { return [] }
+        let lower = min(max(center - 1, 0), max(seasons.count - 3, 0))
+        let upper = min(lower + 3, seasons.count)
+        let indices = [center] + (lower..<upper).filter { $0 != center }
+        return indices.flatMap { index -> [URL] in
+            let season = seasons[index]
+            let pageEpisodes = availableSeasonPage(for: season)?.episodes ?? []
+            return pageEpisodes.prefix(4).compactMap { episode in
+                episode.stillUrl.flatMap(URL.init(string:))
+            }
+        }
+    }
+
+    private var seasonArtworkWarmKey: String {
+        "\(seasonArtworkPixelSize.width)x\(seasonArtworkPixelSize.height):"
+            + seasonArtworkWarmURLs.map(\.absoluteString).joined(separator: "|")
     }
 
     private var seasonPageReadinessKey: String {
@@ -876,14 +1008,28 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
             let viewportWidth = width + TVDetailLayout.horizontalInset
 
             ScrollView(.horizontal, showsIndicators: false) {
-                HStack(alignment: .top, spacing: 0) {
+                // Mount season pages as they approach the viewport instead
+                // of building every cached season's complete episode strip.
+                // Each mounted episode row keeps its eager, finite focus graph.
+                LazyHStack(alignment: .top, spacing: 0) {
                     ForEach(seasons) { season in
                         seasonRailPage(
                             for: season,
                             contentWidth: width,
                             pageWidth: viewportWidth
                         )
+                        // Each eager episode strip may draw beyond its own
+                        // scroll viewport. Keep that overflow inside this
+                        // season's page while the outer pager slides it.
+                        .clipped()
                         .id(season.id)
+                        // Keep cached artwork visible during a slide, but
+                        // admit new image work only for the settled season.
+                        .environment(
+                            \.tvArtworkLoadingEnabled,
+                            !seasonTransitionInFlight && queuedSeasonId == nil
+                                && season.id == (visibleSeasonId ?? selectedSeason?.id)
+                        )
                         // Only the page currently inside the viewport may
                         // participate in tvOS focus. Cached rails elsewhere on
                         // the giant strip remain visual neighbours, not rival
@@ -1053,6 +1199,8 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                     episodeFavoriteStates[$0] ?? false
                 } ?? false,
                 favoriteStates: episodeFavoriteStates,
+                seriesId: detail.contentId,
+                seriesTitle: detail.title,
                 baseCardWidth: SiloTheme.thumbnailCardWidth,
                 cardHeightRatio: SiloTheme.thumbnailCardHeight
                     / SiloTheme.thumbnailCardWidth,
@@ -1077,6 +1225,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     }
 
     private func focusSelectedMode() {
+        cancelSupportingHandoff()
         focusedModeId = selectedModeId
     }
 
@@ -1088,8 +1237,15 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         // The focus engine snapshots scroll eligibility before delivering the
         // episode rail's move command. Unlock now, then request Cast on the
         // next main-loop turn so its first focus update receives native reveal.
+        guard !supportingHandoffPending else { return }
+        supportingHandoffPending = hasCast
         pageScrollCoordinator.releasePrimary()
         primaryFocusRegion = .outside
+        // Reveal before asking the child to claim focus, so the focus engine
+        // sees the incoming row in the page's destination geometry.
+        if hasCast {
+            pageScrollCoordinator.revealSupporting(reduceMotion: reduceMotion)
+        }
         supportingRailFocusGeneration &+= 1
         let generation = supportingRailFocusGeneration
         DispatchQueue.main.async {
@@ -1099,17 +1255,23 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         }
     }
 
+    private func cancelSupportingHandoff() {
+        supportingHandoffPending = false
+        supportingRailFocusGeneration &+= 1
+    }
+
     private func focusEpisode(_ contentId: String?) {
+        let previousContentId = focusedEpisodeContentId
         focusedEpisodeContentId = contentId
         guard let contentId else { return }
+        // A repeated report from the departing card is not a reversal.
+        guard !supportingHandoffPending || contentId != previousContentId else { return }
+        cancelSupportingHandoff()
 
-        // Cancel a queued Episodes -> Cast handoff if focus has already moved
-        // back into the fixed top viewport before the next focus update.
-        supportingRailFocusGeneration &+= 1
         let previousRegion = primaryFocusRegion
         primaryFocusRegion = .episodes
         switch previousRegion {
-        case .mode:
+        case .mode, .actions:
             pageScrollCoordinator.enterPrimary(
                 animated: false,
                 reduceMotion: reduceMotion
@@ -1283,7 +1445,16 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
             TVDetailCastRail(
                 cast: cast,
                 onTap: onPersonTap,
-                focusRequest: supportingRailFocusRequest
+                focusRequest: supportingRailFocusRequest,
+                focusRequestIsActive: supportingHandoffPending,
+                onFocusRequestFailed: cancelSupportingHandoff,
+                onFocus: {
+                    cancelSupportingHandoff()
+                    primaryFocusRegion = .outside
+                    if pageScrollCoordinator.primaryOwnsViewport {
+                        pageScrollCoordinator.releasePrimary()
+                    }
+                }
             )
         }
         .padding(.top, 20)

--- a/scripts/ci/test-tvos-browsing.py
+++ b/scripts/ci/test-tvos-browsing.py
@@ -1,16 +1,25 @@
 #!/usr/bin/env python3
-"""Run actual tvOS gate/timeline function bodies with a virtual clock.
+"""Run actual tvOS gate, timeline and focus-lifecycle bodies with a virtual clock.
 
 SwiftUI, Nuke, networking and the native focus engine are not simulated here.
-These checks cover cancellation and frame math; physical TV checks cover UX.
+These checks cover cancellation, callback ownership and frame math; TV checks cover UX.
 """
 from pathlib import Path
+import os
 import re
 import subprocess
 import tempfile
 
 ROOT = Path(__file__).resolve().parents[2]
 APP = ROOT / "iosApp/iosApp"
+
+
+def app_source(path):
+    # Run these same regressions against a specified baseline without a checkout.
+    if ref := os.environ.get("SILO_TV_TEST_SOURCE_REF"):
+        return subprocess.check_output(
+            ["git", "show", f"{ref}:iosApp/iosApp/{path}"], cwd=ROOT, text=True)
+    return (APP / path).read_text()
 
 
 def function(source, signature):
@@ -24,10 +33,28 @@ def function(source, signature):
     return source[start:end]
 
 
-marquee = (APP / "tvOS/Components/TVFocusMarquee.swift").read_text()
-splash = (APP / "Components/StartupSplashView.swift").read_text()
-theme = (APP / "Theme/SiloTheme.swift").read_text()
-frames = (APP / "Components/StartupSplashAnimation.swift").read_text()
+marquee = app_source("tvOS/Components/TVFocusMarquee.swift")
+splash = app_source("Components/StartupSplashView.swift")
+theme = app_source("Theme/SiloTheme.swift")
+frames = app_source("Components/StartupSplashAnimation.swift")
+row = app_source("Components/MediaRow.swift")
+cast = app_source("tvOS/Screens/Detail/TVDetailCastRail.swift")
+series = app_source("tvOS/Screens/Detail/TVSeriesDetailView.swift")
+favorite = function(row, "private func favoriteToggleAction(").replace("private func", "func")
+favorite = favorite.replace("#if os(tvOS)", "").replace("#endif", "")
+cast_task = function(cast, '.task(id: "\\(focusRequest):')
+cast_body = cast_task[cast_task.index("{") + 1:-1].replace("Task.sleep(for:", "VirtualClock.sleep(for:")
+cancel = function(series, "private func cancelSupportingHandoff()").replace("private func", "func")
+# The baseline passed cancelSupportingHandoff directly; preserve that wiring.
+failure_callback = "{ parent.cancelSupportingHandoff() }"
+failure_method = ""
+if "private func failSupportingHandoff(" in series:
+    failure_method = function(series, "private func failSupportingHandoff(").replace("private func", "func")
+    callback_start = series.index("onFocusRequestFailed: {")
+    callback = function(series[callback_start:], "onFocusRequestFailed:").split(": ", 1)[1]
+    failure_callback = callback.replace("supportingRailFocusGeneration", "parent.supportingRailFocusGeneration").replace(
+        "supportingRailFocusRequest", "parent.supportingRailFocusRequest").replace(
+        "failSupportingHandoff(", "parent.failSupportingHandoff(")
 isolated = re.search(r"marqueeBackdropIsolatedRestMilliseconds = (\d+)", theme)[1]
 rolling = re.search(r"marqueeBackdropRollRestMilliseconds = (\d+)", theme)[1]
 fps = re.search(r"framesPerSecond: Double = (\d+)", frames)[1]
@@ -54,6 +81,7 @@ enum StartupSplashAnimation { static let framesPerSecond: Double = FPS }
         let parts = duration.components
         let ms = Int(parts.seconds * 1000 + parts.attoseconds / 1_000_000_000_000_000)
         await withCheckedContinuation { waiters.append((now + ms, $0)) }
+        try Task.checkCancellation()
     }
     static func advance(_ ms: Int) async {
         now += ms
@@ -94,7 +122,53 @@ enum StartupSplashCanvas { TIMELINE }
     COMPLETE
     FINISH
 }
+struct SectionItem { let id: String }
+@MainActor final class FavoriteState {
+    var onSetFavorite: ((SectionItem, Bool) async -> Bool)?
+    var events: [String] = []
+}
+@MainActor struct FavoriteHarness {
+    let state = FavoriteState()
+    var onSetFavorite: ((SectionItem, Bool) async -> Bool)? {
+        get { state.onSetFavorite }
+        nonmutating set { state.onSetFavorite = newValue }
+    }
+    var events: [String] {
+        get { state.events }
+        nonmutating set { state.events = newValue }
+    }
+    func preserveFocusForContextMutation(on item: SectionItem) { events.append("preserve:" + item.id) }
+    FAVORITE
+}
+@MainActor final class HandoffHarness {
+    var supportingHandoffPending = true
+    var supportingRailFocusGeneration = 1
+    var supportingRailFocusRequest = 1
+    CANCEL
+    FAILURE_METHOD
+}
+@MainActor final class CastHarness {
+    struct Proxy {
+        enum Anchor { case leading }
+        func scrollTo(_ id: String, anchor: Anchor) {}
+    }
+    let proxy = Proxy()
+    var focusRequest = 1
+    var focusRequestIsActive = true
+    var defaultFocusId: String? = "first"
+    var acceptsFocus = false
+    private var storedFocus: String?
+    var focusedCastId: String? {
+        get { storedFocus }
+        set { if acceptsFocus { storedFocus = newValue } }
+    }
+    var onFocusRequestFailed: (() -> Void)?
+    func runRequest() async { CAST_BODY }
+}
 @main struct Checks {
+    @MainActor static func failureCallback(_ parent: HandoffHarness) -> () -> Void {
+        FAILURE_CALLBACK
+    }
     @MainActor static func main() async {
         let a = TVMarqueeContent(id: "a"), b = TVMarqueeContent(id: "b"), c = TVMarqueeContent(id: "c")
         let m = MarqueeHarness()
@@ -158,11 +232,77 @@ enum StartupSplashCanvas { TIMELINE }
         reduced.finishIfReady()
         precondition(reduced.finishes == 1, "Reduce Motion cannot wait for an animated cycle")
         print("PASS: actual rolling-gate cancellation, suspension/reset, source-frame timing and ready-Home completion bodies")
+        var failures = 0
+        func expect(_ condition: Bool, _ label: String) {
+            print("\(condition ? "PASS" : "FAIL"): \(label)")
+            if !condition { failures += 1 }
+        }
+        let favorite = FavoriteHarness()
+        let item = SectionItem(id: "card")
+        expect(favorite.favoriteToggleAction(for: item) == nil, "missing favourite handler stays unavailable")
+        for result in [false, true] {
+            favorite.events = []
+            favorite.onSetFavorite = { item, value in
+                favorite.events.append("mutation:" + item.id)
+                return result
+            }
+            let returned = await favorite.favoriteToggleAction(for: item)!(result)
+            expect(favorite.events == ["preserve:card", "mutation:card"] && returned == result,
+                   "favourite preserves focus before mutation and returns \(result)")
+        }
+        for cancelAtEnd in [false, true] {
+            let rail = CastHarness(), parent = HandoffHarness()
+            rail.onFocusRequestFailed = failureCallback(parent)
+            let task = Task { await rail.runRequest() }
+            await VirtualClock.drain()
+            if cancelAtEnd { for _ in 0..<12 { await VirtualClock.advance(50) } }
+            task.cancel()
+            await VirtualClock.advance(50)
+            await task.value
+            expect(!parent.supportingHandoffPending && parent.supportingRailFocusGeneration == 2,
+                   "cancellation releases pending handoff during \(cancelAtEnd ? "final" : "first") wait")
+        }
+        for replacement in ["generation", "request"] {
+            let rail = CastHarness(), parent = HandoffHarness()
+            rail.onFocusRequestFailed = failureCallback(parent)
+            let staleFailure = rail.onFocusRequestFailed!
+            let task = Task { await rail.runRequest() }
+            await VirtualClock.drain()
+            if replacement == "generation" { parent.supportingRailFocusGeneration += 1 }
+            else { parent.supportingRailFocusRequest += 1 }
+            task.cancel()
+            await VirtualClock.advance(50)
+            await task.value
+            expect(parent.supportingHandoffPending, "old cancellation preserves replacement \(replacement)")
+            staleFailure()
+            expect(parent.supportingHandoffPending, "old timeout preserves replacement \(replacement)")
+            failureCallback(parent)()
+            expect(!parent.supportingHandoffPending, "replacement \(replacement) can still release its own handoff")
+        }
+        for outcome in ["success", "timeout", "inactive"] {
+            let rail = CastHarness()
+            var callbacks = 0
+            rail.onFocusRequestFailed = { callbacks += 1 }
+            rail.acceptsFocus = outcome == "success"
+            rail.focusRequestIsActive = outcome != "inactive"
+            let task = Task { await rail.runRequest() }
+            await VirtualClock.drain()
+            for _ in 0..<13 { await VirtualClock.advance(50) }
+            await task.value
+            expect(callbacks == (outcome == "timeout" ? 1 : 0), "cast \(outcome) preserves callback behaviour")
+        }
+        let completed = HandoffHarness()
+        completed.supportingHandoffPending = false
+        failureCallback(completed)()
+        expect(completed.supportingRailFocusGeneration == 1, "completed handoff ignores late failure")
+        if failures > 0 { exit(1) }
     }
 }
 '''
 for key, value in {"ISOLATED": isolated, "ROLLING": rolling, "FPS": fps,
-                   "METHODS": methods, "TIMELINE": timeline, "COMPLETE": complete, "FINISH": finish}.items():
+                   "METHODS": methods, "TIMELINE": timeline, "COMPLETE": complete, "FINISH": finish,
+                   "FAVORITE": favorite, "CAST_BODY": cast_body, "CANCEL": cancel,
+                   "FAILURE_METHOD": failure_method, "FAILURE_CALLBACK": failure_callback}.items():
     source = source.replace(key, value)
 with tempfile.TemporaryDirectory(prefix="silo-tvos-gates-") as folder:
     path = Path(folder)

--- a/scripts/ci/test-tvos-browsing.py
+++ b/scripts/ci/test-tvos-browsing.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Run actual tvOS gate/timeline function bodies with a virtual clock.
+
+SwiftUI, Nuke, networking and the native focus engine are not simulated here.
+These checks cover cancellation and frame math; physical TV checks cover UX.
+"""
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[2]
+APP = ROOT / "iosApp/iosApp"
+
+
+def function(source, signature):
+    start = source.index(signature)
+    brace = source.index("{", start)
+    depth = 1
+    end = brace + 1
+    while depth:
+        depth += (source[end] == "{") - (source[end] == "}")
+        end += 1
+    return source[start:end]
+
+
+marquee = (APP / "tvOS/Components/TVFocusMarquee.swift").read_text()
+splash = (APP / "Components/StartupSplashView.swift").read_text()
+theme = (APP / "Theme/SiloTheme.swift").read_text()
+frames = (APP / "Components/StartupSplashAnimation.swift").read_text()
+isolated = re.search(r"marqueeBackdropIsolatedRestMilliseconds = (\d+)", theme)[1]
+rolling = re.search(r"marqueeBackdropRollRestMilliseconds = (\d+)", theme)[1]
+fps = re.search(r"framesPerSecond: Double = (\d+)", frames)[1]
+methods = "\n".join(function(marquee, s) for s in [
+    "func seed(_ candidate:", "func preview(_ candidate:", "func suspend()", "func resume()",
+]).replace("Task.sleep(for:", "VirtualClock.sleep(for:")
+start = splash.index("    private static let stackStart")
+end = splash.index("    var body:", start)
+timeline = splash[start:end]
+complete = function(splash, "private func towerIsComplete(at date:") .replace("private func", "func")
+finish = function(splash, "private func finishIfReady()") .replace("private func", "func").replace("Date()", "now")
+source = r'''
+import Foundation
+struct TVMarqueeContent: Equatable { let id: String }
+enum SiloTheme { enum Skyline {
+    static let marqueeBackdropIsolatedRestMilliseconds = ISOLATED
+    static let marqueeBackdropRollRestMilliseconds = ROLLING
+} }
+enum StartupSplashAnimation { static let framesPerSecond: Double = FPS }
+@MainActor enum VirtualClock {
+    static var now = 0
+    static var waiters: [(Int, CheckedContinuation<Void, Never>)] = []
+    static func sleep(for duration: Duration) async throws {
+        let parts = duration.components
+        let ms = Int(parts.seconds * 1000 + parts.attoseconds / 1_000_000_000_000_000)
+        await withCheckedContinuation { waiters.append((now + ms, $0)) }
+    }
+    static func advance(_ ms: Int) async {
+        now += ms
+        let due = waiters.filter { $0.0 <= now }
+        waiters.removeAll { $0.0 <= now }
+        due.forEach { $0.1.resume() }
+        await drain()
+    }
+    static func drain() async { for _ in 0..<20 { await Task.yield() } }
+}
+@MainActor final class MarqueeHarness {
+    var content: TVMarqueeContent?
+    var backdropTask: Task<Void, Never>?
+    var enrichTask: Task<Void, Never>?
+    var tintTask: Task<Void, Never>?
+    var isBackdropRoll = false
+    var backdropContentID: String?
+    var isActive = true
+    var lastSampledTintURL: String?
+    var displayed: [String] = []
+    func loadEnrichment(for candidate: TVMarqueeContent, deferNetwork: Bool = false) {}
+    func updateBackdropIfReady() { if let backdropContentID { displayed.append(backdropContentID) } }
+    METHODS
+}
+enum StartupSplashCanvas { TIMELINE }
+@MainActor final class CompletionHarness {
+    var repeatsTowerWhileWaiting = true
+    var reduceMotion = false
+    var waitingStartDate: Date? = Date(timeIntervalSince1970: 0)
+    var completionCycle: Int?
+    var now = Date(timeIntervalSince1970: 0)
+    var didFinish = false
+    var didFinishIntro = false
+    var isContentReady = false
+    var completionTask: Task<Void, Never>?
+    var finishes = 0
+    func onFinished() { finishes += 1 }
+    COMPLETE
+    FINISH
+}
+@main struct Checks {
+    @MainActor static func main() async {
+        let a = TVMarqueeContent(id: "a"), b = TVMarqueeContent(id: "b"), c = TVMarqueeContent(id: "c")
+        let m = MarqueeHarness()
+        m.seed(a)
+        precondition(m.displayed == ["a"], "cold seed must paint immediately")
+        m.preview(b)
+        precondition(m.content == b && m.displayed == ["a"], "focus must move before backdrop")
+        await VirtualClock.drain()
+        await VirtualClock.advance(ISOLATED - 1)
+        precondition(m.displayed == ["a"], "isolated gate must hold")
+        await VirtualClock.advance(1)
+        precondition(m.displayed == ["a", "b"] && !m.isBackdropRoll, "isolated gate must release")
+        m.preview(a)
+        await VirtualClock.drain()
+        await VirtualClock.advance(100)
+        m.preview(c)
+        await VirtualClock.drain()
+        await VirtualClock.advance(ROLLING - 1)
+        precondition(m.displayed == ["a", "b"] && m.isBackdropRoll, "obsolete selection must not paint")
+        await VirtualClock.advance(1)
+        precondition(m.displayed == ["a", "b", "c"] && !m.isBackdropRoll, "only final roll selection may paint")
+        m.preview(b)
+        await VirtualClock.drain()
+        m.suspend()
+        await VirtualClock.advance(ROLLING)
+        precondition(m.displayed == ["a", "b", "c"], "offscreen work must not publish")
+        m.resume()
+        precondition(m.displayed.last == "b", "return must restore current selection")
+        m.preview(a)
+        await VirtualClock.drain()
+        await VirtualClock.advance(ISOLATED)
+        precondition(m.displayed.last == "a", "new isolated click must not inherit roll delay")
+        let duration = StartupSplashCanvas.cycleDuration
+        for i in 0...180 {
+            let t = Double(i) / StartupSplashAnimation.framesPerSecond
+            let frame = StartupSplashCanvas.waitingTowerFrame(elapsed: t)
+            precondition(frame >= 2 && frame <= 92, "tower frame escaped source bounds")
+            let reverse = StartupSplashCanvas.waitingTowerFrame(elapsed: duration - t)
+            precondition(abs(frame - reverse) < 0.000001, "unstack/restack pace must match")
+        }
+        precondition(StartupSplashCanvas.waitingTowerFrame(elapsed: 0) == 92)
+        precondition(StartupSplashCanvas.waitingTowerFrame(elapsed: duration / 2) == 2)
+        precondition(StartupSplashCanvas.waitingTowerFrame(elapsed: duration) == 92)
+        let gate = CompletionHarness()
+        gate.didFinishIntro = true
+        gate.completionCycle = 1
+        gate.now = Date(timeIntervalSince1970: duration)
+        gate.finishIfReady()
+        precondition(gate.finishes == 0, "stack alone cannot reveal unready Home")
+        gate.isContentReady = true
+        gate.now = Date(timeIntervalSince1970: duration - 0.001)
+        gate.finishIfReady()
+        precondition(gate.finishes == 0, "ready Home cannot interrupt unfinished stack")
+        gate.now = Date(timeIntervalSince1970: duration)
+        gate.finishIfReady(); gate.finishIfReady()
+        precondition(gate.finishes == 1, "ready Home reveals once on completed stack")
+        let reduced = CompletionHarness()
+        reduced.reduceMotion = true
+        reduced.didFinishIntro = true
+        reduced.isContentReady = true
+        reduced.finishIfReady()
+        precondition(reduced.finishes == 1, "Reduce Motion cannot wait for an animated cycle")
+        print("PASS: actual rolling-gate cancellation, suspension/reset, source-frame timing and ready-Home completion bodies")
+    }
+}
+'''
+for key, value in {"ISOLATED": isolated, "ROLLING": rolling, "FPS": fps,
+                   "METHODS": methods, "TIMELINE": timeline, "COMPLETE": complete, "FINISH": finish}.items():
+    source = source.replace(key, value)
+with tempfile.TemporaryDirectory(prefix="silo-tvos-gates-") as folder:
+    path = Path(folder)
+    (path / "Checks.swift").write_text(source)
+    subprocess.run(["xcrun", "swiftc", "-parse-as-library", str(path / "Checks.swift"),
+                    "-o", str(path / "checks")], check=True, timeout=60)
+    subprocess.run([str(path / "checks")], check=True, timeout=20)


### PR DESCRIPTION
## What I changed and why

I built this around repeated testing on my **physical Apple TV 4K (3rd generation), running tvOS 26.6 (23L773), with the real Siri Remote**. These were Xcode-built, signed Silo test apps installed on the TV. I kept revisiting Home, Continue Watching, the main tab pages and long series until individual clicks felt immediate and fast scrolling stopped leaving the page struggling to catch up.

The main goal is responsiveness: warm the artwork people are about to reach, keep useful decoded images in the existing cache, and use a rolling gate to avoid spending work on intermediate selections during rapid navigation. The same pass fixes Series season/episode rails and makes the animated startup finish on a prepared Home page.

This PR is **Apple TV only**. Shared files contain the TV integration, with the new Home-preparation and warmup behaviour restricted to tvOS. It is based on current upstream `main`; engine upgrades, iOS features, dependency changes and unrelated cleanup are not part of its diff.

## Home, Continue Watching and the main tabs

### Keep individual clicks responsive; coalesce rapid browsing

Focus and cached foreground information follow the selected card immediately. Cold entry still seeds its first backdrop immediately. The expensive backdrop/tint change is scheduled separately:

- One isolated move uses a **400 ms** rest gate.
- A second move before that gate finishes establishes a roll. The gate stays in that state until the final selection has rested for **800 ms**.
- Every further move cancels the older task. An intermediate card cannot later publish its backdrop after focus has moved away.
- Finishing the roll resets the gate, so the next isolated click gets the short path again. Leaving the page cancels pending work.
- Missing detail enrichment retains its separate 150 ms rest gate. Cached information can be used synchronously.

**On my physical Apple TV, the 400 ms backdrop gate felt effectively immediate during individual Up/Down/Left/Right clicks. Focus and cached foreground information responded immediately, and I did not perceive the backdrop change as a loading pause.** The 400 ms value is the actual scheduling policy; “immediate” here describes the experience I checked with my eyes and the remote, rather than a claim of zero elapsed time.

Home, Movies, Series and For You share this marquee behaviour. Fast movement keeps the existing backdrop stable while the remote remains responsive, then paints the final selection. This replaces the competing row-scroll/backdrop hold behaviour that I had been testing against.

### Warm a useful, bounded working set

- Home warms its focused row at the exact card display size, including the current poster-size preference and display scale. The working set covers up to 20 cards, fixing the cold boundary near the end of a row that a sliding 16-card window left behind.
- The row prefetcher uses the existing Nuke pipeline and memory cache, low priority, and at most two concurrent requests. A row change cancels obsolete unfinished requests; completed images remain subject to the normal cache eviction policy.
- Startup distributes its finite card-artwork budget round-robin across the first four Home rows, so moving Down does not immediately enter rows left cold by spending the entire budget on the first row.
- The new full-row warmup is Home-specific. Library landings keep their existing prefetch ownership. Normal navigation does not start a whole-library warmup.

### Fix the Continue Watching return path

A short first row such as Continue Watching could move just above the visible row band and lose the native focus geometry that an Up click needed. I preserve a small layout area above the painted band so tvOS can still discover that row, while a mask keeps it out of the marquee visually.

Returning from detail also restores the exact launch card and its owning row. The restoration is bounded and yields when the user moves elsewhere. This fixes the Home/Continue Watching case where a return could leave focus missing and Up unable to get back to the top menu. Artwork warming covers the thumbnail row as well as poster rows.

## Series seasons and episodes

This was repeatedly checked on the physical TV with long season lists, including a series with around 20 seasons, fast movement, reversals and individual clicks.

- Season pages keep permanent positions in one connected rail. New requests cancel and retarget the current movement instead of queuing a succession of animations or leaving one season painted behind another.
- An isolated season move starts promptly. Rapid activations are coalesced through a 120 ms gate and use a 0.30-second pan to the final requested season; ordinary transitions retain the 0.46-second timing. The season tabs use native focus scrolling rather than repeatedly fighting it with recentering.
- The episode rail reuses the Home `MediaRow` navigation instead of maintaining a second competing horizontal implementation. Each episode remains a native focus target with the normal Apple navigation sound and finite strip boundaries.
- Episode focus targets stay mounted, while image work is bounded separately. Nearby season warmup covers the first visible episode cards, and visible-episode warmup follows the strip as it moves.
- Already-painted visible images remain attached when the request gate changes. Moving one or a few clicks to an offscreen episode no longer makes every visible episode repaint. Cached images can paint during a fast scroll; cold work resumes after settling. Departed cards release their retained image reference.
- Series-page captions identify the actual episode, for example **S01 E02 · Episode name**, while Home retains its existing series caption treatment. Play/Resume, watched and favourite actions remain available.
- Down from the primary Series area hands focus to Cast & Crew and unlocks the outer scroll together. Returning Up uses the coordinated primary-region transition, fixing the missed Down handoff and the bounce from quick repeated Up presses.

## Animated startup into a ready Home

The original tower entrance and wordmark swoop remain. Once the wordmark lands, the text stays fixed while the tower can unstack and restack using the original source frames and pace. The loop is about three seconds, with matching 1.5-second unstack and restack movements.

Home sections and library data are prepared into the caches while the startup animation is running. When readiness arrives during a cycle, the app completes that stack before revealing Home. It does not cut the stack in half or begin another unnecessary loop. If Home was ready during the opening, it can reveal at the completed opening.

On the TV, this removed the second page-loading pause after the splash that I had been seeing. There is still a bounded eight-second data-preparation fallback to the ordinary retry/error UI for an unavailable server; the current stack finishes before handoff. Reduce Motion does not wait for an animated loop. This changes the startup transition, not the sign-in form or authentication rules.

## Physical-device evidence and benchmarks

### Recorded Instruments comparison from my earlier TV work

The following measurements are the **physical Apple TV build 37 → build 38 comparison recorded in [PR #230](https://github.com/Silo-Server/silo-apple/pull/230)**. They establish the measured device baseline behind this continuing browsing work. They are not relabelled as a new benchmark of this PR revision.

| Metric in the selected 30-second active-scrolling window | Build 37 | Build 38 |
| --- | ---: | ---: |
| Hitches | 393 | 179 |
| Hitch p95 | 60 ms | 40 ms |
| Longest hitch | 120 ms | 80 ms |
| Union of hitch intervals | 12.240 s | 4.160 s |
| Main-thread sampled CPU time | 20.890 s | 11.401 s |

That is about **54% fewer hitches**, **66% less time covered by hitch intervals**, and **45% less sampled main-thread CPU time** in those recorded windows.

- **Before:** `cb73f725e0f8a6521cf143ff75ebefeff1445ad9`, [build 37](https://github.com/blurbery/silo-apple/actions/runs/33739898872).
- **After:** `a1e20b1fb6cf565e2b5d781eb87c2f13547d7afd`, [build 38](https://github.com/blurbery/silo-apple/actions/runs/33746397660).
- **Device and workload:** the same physical Apple TV 4K (3rd generation), tvOS 26.6, personally signed Release apps. Instruments used the Animation Hitches template in all-processes mode, followed by process-filtered analysis. I moved across Home posters, rapidly down several rows, then back up with individual clicks.
- **Sample:** one selected 30-second window per build: 31.907–61.907 seconds for build 37 and 29.832–59.832 for build 38. Gesture counts, content and cache warmth were not identical; these are single manual samples, not repeated controlled trials.
- **Analysis:** `xcrun xctrace export`; the recorded build-38 helper command was `python3 -u work/summarize_trace.py work/tvos-current.trace 17241 29.832 59.832 SiloTV 1 --cpu`. The temporary helper and raw traces were deleted after that analysis, as already disclosed in #230. The recorded aggregates remain in that PR.
- **Interpretation:** the build-37 trace contained substantial main-thread view-graph, layout and focus work. Those categories overlap. Main-thread sampled CPU is not total process CPU or FPS, and the aggregate improvement does not isolate a single change's contribution.

### Testing and diagnostics for this pass

I continued the work through repeated physical-TV installs and real remote input. **Device-tested build 81 is saved at [`390038d`](https://github.com/blurbery/silo-apple/commit/390038d)**. The combined build 82 at [`541d6e5`](https://github.com/blurbery/silo-apple/commit/541d6e5) was built with Xcode 26.6, signed, installed and launched on the same physical TV after adding the requested current engine/upstream features. Those engine changes are outside this PR because upstream already contains them.

Tool-captured app/runtime diagnostic output was also used during investigation, including focus/scroll activity and image/decode-related work. It informed where warming, cancellation and image retention needed attention. Those diagnostics are supporting investigation evidence; I am not presenting log-line counts as unique image decodes or as a new frame-time benchmark.

The hands-on regression work covered:

1. Home and the main tabs: individual Up/Down/Left/Right clicks, rapid scrolling and reversals, then returning to single clicks without lingering lag.
2. Home Continue Watching: returning Up to the short first row, opening an item and returning to its card, and reaching the top menu again.
3. Long Series lists: rapid season selection, final-season alignment, reversals, and moving through episodes in both directions.
4. Episode artwork: slow and moderately paced clicks across the visible boundary, followed by fast scrolling, checking that visible cards do not all repaint together.
5. Series vertical focus: Down to Cast & Crew, Up back to the primary area, and quick repeated Up presses without the earlier bounce.
6. Startup: the wordmark entrance, fixed text during the tower loop, matched unstack/restack pacing, and reveal on a completed stack with Home data prepared.

My acceptance was based on that physical-device experience. The historical Instruments figures support the measured improvement from the earlier pass; this later pass has repeated device observations and diagnostic-guided refinement, without a fresh before/after Instruments capture. No new motion recording is attached.

## Automated validation

- **Passed locally:** changed Swift files parsed with `xcrun swiftc -frontend -parse <path>`; `git diff --check`; workflow YAML parsing.
- **Passed locally:** `python3 scripts/ci/test-tvos-browsing.py`. It compiles the actual marquee gate and startup completion/timeline function bodies with a virtual clock. It checks immediate cold seeding, immediate foreground selection, isolated/rolling deadlines, stale-task cancellation, suspension and reset, matching stack pace, ready-Home/complete-stack ordering, single completion and Reduce Motion. The harness substitutes the clock and external dependencies; it does not test SwiftUI focus, Nuke scheduling or physical rendering.
- **Passed for the combined installed source `541d6e5`:** [run 33942250489](https://github.com/blurbery/silo-apple/actions/runs/33942250489), iOS suite **1,248 tests, 2 skipped, 0 failures**, plus tvOS and macOS builds. The skipped cases require opt-in playback fixtures. This is separate from validation of the upstream-based PR revision.
- **Original PR revision `36557ffbae81ccef86f83c565018eda10f4edfd3`:** [Apple regression run 33943504159](https://github.com/Silo-Server/silo-apple/actions/runs/33943504159) passed the iOS test job and tvOS/macOS builds, including the focused tvOS harness. The CI scripts check passed too.

The PR carries the TV work onto current upstream naming and APIs, keeps its current popover host and top-menu integration, and restricts the new shared startup behaviour to tvOS. Physical observations above identify their tested development builds rather than implying that every later integration revision has been rebenchmarked.

## Review follow-up: context-menu and cast focus

In [e042c86](https://github.com/blurbery/silo-apple/commit/e042c8691df8832d3d5d018fc82849ce8794044a), I fixed both verified CodeRabbit findings. Favourite actions now preserve their card's focus before the asynchronous mutation, matching watched-state actions. Cancelling the Cast & Crew focus task releases its pending handoff, with captured generation and request checks so old cancellation/timeout callbacks cannot clear a newer request. Completed handoffs ignore late failure callbacks. These changes add no navigation delay or new artwork work.

- **Passed on `e042c8691df8832d3d5d018fc82849ce8794044a`:** `python3 scripts/ci/test-tvos-browsing.py`, Swift frontend parsing of the three changed app files, and `git diff --check`.
- **Baseline comparison:** with the updated harness, `SILO_TV_TEST_SOURCE_REF=36557ffbae81ccef86f83c565018eda10f4edfd3 python3 scripts/ci/test-tvos-browsing.py` fails the new favourite-ordering and cast cleanup/ownership assertions as expected. The existing gate/startup assertions still pass. All assertions pass against the fixed source.
- The focus checks execute the production function/task bodies and callback wiring, with a virtual clock and stubbed focus/scroll dependencies. They cover mutation success/failure, cancellation during the first and final waits, replaced generations/request IDs, stale timeouts, success, timeout, inactive requests and already-completed handoffs. They do not reproduce the native focus engine or rendering.
- **Pending:** CI for this follow-up commit. **Not rerun:** physical Apple TV verification or performance benchmarks for these two fixes; the physical observations and historical measurements above remain attributed to their stated builds.

## Review considerations

The main areas to exercise are native focus at clipped row boundaries, interruption of a season pan, returning from detail, and cache-pressure behaviour with a cold or slow server. Warmups are bounded, but there is no new memory-pressure soak or quantitative bandwidth benchmark. The physical checks used one Apple TV/tvOS combination. Cold artwork can still depend on the server/network even though navigation and already-cached artwork remain responsive.

No server or Android contract change is required. Production app identities, signing, dependencies and playback-engine selection are unchanged by this PR.

## AI disclosure

**AI-assisted with Astra. I directed the task and designed the work.**

- Model: `gpt-6-astra` (Astra, confirmed as this task's model label).
- Harness: OpenAI Codex desktop; shell/GitHub CLI and Apple development tools.
- I supplied the design direction, performed the physical Apple TV navigation/visual checks and used those observations to direct the refinements. Astra assisted with implementation, source review, diagnostic interpretation, targeted checks, builds and this write-up.
- The source review was performed by the same coding agent; no independent subagent review is claimed. Earlier #230 assistance is disclosed in that PR and is not reattributed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved tvOS startup flow with smoother animation and content-ready launch transitions.
  * Added episode season/number captions and improved accessibility labels.
  * Added optimistic favorite updates with automatic recovery if saving fails.
  * Improved focus handling across Home, series details, episodes, and cast rails.
* **Performance Improvements**
  * Faster, smoother artwork loading through intelligent preloading and offscreen loading controls.
  * Improved focused-row artwork readiness and marquee backdrop transitions.
* **Bug Fixes**
  * Improved season switching and rapid navigation behavior on series detail pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
