### PR TITLE
Preserve tvOS Settings category focus across pane navigation

### DIFF
--- a/docs/tvos-focus.md
+++ b/docs/tvos-focus.md
@@ -97,6 +97,22 @@ bar.focusedItem -> Calendar
 When this happens, stop adding press interceptors. Decide which focus model the
 control should use, then remove the other one.
 
+## Settings Pane Navigation
+
+Settings uses two native focus sections. Right from a category enters its
+first available detail control. Left from any detail row returns to that
+same category, including after scrolling or dismissing a picker. Up/Down
+continues through the controls in the current pane.
+
+Give both pane entry targets `defaultFocus` with `.userInitiated` priority.
+Do not downgrade the rail's selected-category target while the detail pane
+owns focus: doing so lets Left choose a different category by geometry.
+The outer focus scope still chooses the active pane for entry and modal
+restoration. Remember the rail's current control separately from the selected
+category so cancelling Sign Out restores Sign Out, while Left from the details
+still restores the category. Back returns to the category, then exits Settings
+to Home.
+
 ## Top Menu Ownership
 
 The top menu has three conceptual states:

--- a/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Settings/TVSettingsView.swift
@@ -12,10 +12,10 @@ import SwiftUI
 ///
 /// Focus model: one native graph with one preferred owner. Each pane is a
 /// `.focusSection()`; vertical movement stays in-pane and Left/Right bridges
-/// panes natively. The detail pane gives its preferred row user-initiated
-/// default priority so it wins the initial cross-pane focus resolution before
-/// geometric proximity can select a lower row. The outer scope still chooses
-/// the active pane for page entry and modal restoration (see docs/tvos-focus.md).
+/// panes natively. Both panes give their entry target user-initiated default
+/// priority: Right enters the top detail row and Left returns to the selected
+/// category, regardless of the detail row's vertical position. The outer scope
+/// chooses the active pane for entry and modal restoration (see docs/tvos-focus.md).
 struct TVSettingsView: View {
     @State private var viewModel = SettingsViewModel()
     @State private var diagnosticsModel = DiagnosticsViewModel()
@@ -26,7 +26,9 @@ struct TVSettingsView: View {
     @State private var activePicker: TVSettingsPickerRequest?
     @State private var pendingPickerFocus: TVSettingsDetailFocus?
     @State private var isRestoringDetailFocus = false
+    @State private var isRestoringRailFocus = false
     @State private var preferredFocusOwner: FocusOwner = .rail
+    @State private var preferredRailFocus: RailItem = .category(.general)
     @State private var preferredDetailFocus: TVSettingsDetailFocus = .top
     @FocusState private var railFocus: RailItem?
     @FocusState private var detailFocus: TVSettingsDetailFocus?
@@ -52,6 +54,7 @@ struct TVSettingsView: View {
                     confirm: router.signOutAndReset,
                     additionalDestructiveAction: router.signOutRemoveServerAndReset
                 )
+                .onDisappear(perform: restoreSignOutFocus)
                 .transition(.opacity)
                 .zIndex(1)
             }
@@ -90,13 +93,15 @@ struct TVSettingsView: View {
             await diagnosticsModel.load(profile: viewModel.activeProfile)
         }
         .onChange(of: railFocus) { _, focus in
-            if focus != nil,
+            if let focus,
                activePicker == nil,
                !showSignOutConfirm,
                !showPrivacyPolicy,
                !showOpenSourceAcknowledgements,
-               !isRestoringDetailFocus {
+               !isRestoringDetailFocus,
+               !isRestoringRailFocus {
                 preferredFocusOwner = .rail
+                preferredRailFocus = focus
             }
 
             // The pane previews whatever category the rail focus rests on.
@@ -116,7 +121,8 @@ struct TVSettingsView: View {
                !showSignOutConfirm,
                !showPrivacyPolicy,
                !showOpenSourceAcknowledgements,
-               !isRestoringDetailFocus {
+               !isRestoringDetailFocus,
+               !isRestoringRailFocus {
                 preferredDetailFocus = focus
                 preferredFocusOwner = .detail
             }
@@ -147,6 +153,7 @@ struct TVSettingsView: View {
     private func focusGeneralOnEntry() {
         selectedCategory = .general
         preferredFocusOwner = .rail
+        preferredRailFocus = .category(.general)
         preferredDetailFocus = .generalAppleTVUser
         detailFocus = nil
         railFocus = .category(.general)
@@ -185,8 +192,8 @@ struct TVSettingsView: View {
                 )
                 .defaultFocus(
                     $railFocus,
-                    .category(selectedCategory),
-                    priority: preferredFocusOwner == .rail ? .userInitiated : .automatic
+                    preferredFocusOwner == .detail ? .category(selectedCategory) : preferredRailFocus,
+                    priority: .userInitiated
                 )
                 .prefersDefaultFocus(preferredFocusOwner == .rail, in: settingsFocusScope)
                 .focusSection()
@@ -200,6 +207,7 @@ struct TVSettingsView: View {
                         || showPrivacyPolicy
                         || showOpenSourceAcknowledgements
                         || activePicker != nil
+                        || isRestoringRailFocus
                 )
                 .defaultFocus(
                     $detailFocus,
@@ -374,19 +382,30 @@ struct TVSettingsView: View {
             return
         }
         preferredFocusOwner = .rail
+        preferredRailFocus = .category(selectedCategory)
         detailFocus = nil
         railFocus = .category(selectedCategory)
         resetFocus(in: railFocusScope)
     }
 
     private func dismissSignOutConfirmation() {
-        showSignOutConfirm = false
         preferredFocusOwner = .rail
-        railFocus = .signOut
+        preferredRailFocus = .signOut
+        isRestoringRailFocus = true
+        showSignOutConfirm = false
+        railFocus = nil
+    }
+
+    private func restoreSignOutFocus() {
+        guard isRestoringRailFocus else { return }
+        // Restore after the confirmation's focus subtree has left, ignoring
+        // transient rail focus while the dismissal animation completes.
         Task { @MainActor in
             await Task.yield()
             resetFocus(in: railFocusScope)
             railFocus = .signOut
+            try? await Task.sleep(for: .milliseconds(120))
+            isRestoringRailFocus = false
         }
     }
 


### PR DESCRIPTION
## Summary

- Preserve the selected Settings category as the Left-navigation target from any detail row.
- Track the rail’s current focus separately so cancelling Sign Out restores the Sign Out item.
- Restore Sign Out focus after the confirmation view leaves the focus hierarchy.
- Document the native two-pane focus behavior and restoration rules.

## Testing

- Not run (not requested).

AI disclosure: Generated with OpenAI GPT-5 using Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved focus navigation in the tvOS Settings screen, including more reliable movement between navigation and detail areas.
  - Restored focus more consistently after dismissing sign-out confirmation dialogs.
  - Preserved the most recently selected focus target when returning to settings.
- **Documentation**
  - Added guidance for tvOS Settings focus behavior, including navigation, default focus, picker cancellation, and Back actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->