### PR TITLE
fix(tvos): confirm detail menu selections on the first press

### DIFF
--- a/iosApp/iosApp/tvOS/Screens/Detail/TVActionPopoverMenu.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVActionPopoverMenu.swift
@@ -19,7 +19,7 @@ struct TVActionPopoverItem: Identifiable, Equatable {
 /// after confirming a Version/Audio/Subtitle choice.
 ///
 /// The popover is one composite focus item (docs/tvos-focus.md): the panel
-/// itself is the only focusable, rows are passive labels, and d-pad up/down
+/// uses one transparent native Button, rows are passive labels, and d-pad up/down
 /// moves an internal highlight. Select commits the highlighted row; Menu/Back
 /// closes. Both hand focus straight back to the trigger, so the next d-pad
 /// press lands on the row with no system animation to wait out.
@@ -56,12 +56,35 @@ struct TVActionPopoverMenu: View {
         .overlay(Self.shape.strokeBorder(Color.white.opacity(0.10), lineWidth: 1))
         .shadow(color: .black.opacity(0.45), radius: 32, y: 18)
         .contentShape(Self.shape)
-        .focusable(true)
-        .focused($panelFocused)
-        .focusEffectDisabled()
-        .onMoveCommand(perform: handleMove)
-        .onTapGesture(perform: commitHighlighted)
-        .onExitCommand(perform: onClose)
+        .accessibilityHidden(true)
+        .overlay {
+            // The original surface owns layout and appearance. A transparent
+            // native Button owns activation and focus without styling the rows.
+            Button(action: commitHighlighted) {
+                Color.clear.contentShape(Self.shape)
+            }
+            .buttonStyle(TVPopoverActivationButtonStyle())
+            .focused($panelFocused)
+            .focusEffectDisabled()
+            .onMoveCommand(perform: handleMove)
+            .onExitCommand(perform: onClose)
+            // VoiceOver: the composite is one adjustable button. Its value is
+            // the highlighted row (what Select will commit), swipe up/down moves
+            // the highlight, and activate commits it. Rows stay hidden so the
+            // cursor cannot land on a label that does not react to Select.
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(title)
+            .accessibilityValue(highlightedAccessibilityValue)
+            .accessibilityAddTraits([.isButton, .updatesFrequently])
+            .accessibilityAdjustableAction { direction in
+                switch direction {
+                case .increment: moveHighlight(by: 1)
+                case .decrement: moveHighlight(by: -1)
+                @unknown default: break
+                }
+            }
+            .accessibilityAction(.escape, onClose)
+        }
         .background(
             TVActionPopoverMenuPressCatcher(onExit: onClose)
                 .frame(width: 0, height: 0)
@@ -86,23 +109,6 @@ struct TVActionPopoverMenu: View {
             // engine not having moved yet.
             if didClaimFocus { onClose() }
         }
-        // VoiceOver: the composite is one adjustable button. Its value is
-        // the highlighted row (what Select will commit), swipe up/down moves
-        // the highlight, and activate commits it. Rows stay hidden so the
-        // cursor cannot land on a label that does not react to Select.
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(title)
-        .accessibilityValue(highlightedAccessibilityValue)
-        .accessibilityAddTraits([.isButton, .updatesFrequently])
-        .accessibilityAdjustableAction { direction in
-            switch direction {
-            case .increment: moveHighlight(by: 1)
-            case .decrement: moveHighlight(by: -1)
-            @unknown default: break
-            }
-        }
-        .accessibilityAction(.default, commitHighlighted)
-        .accessibilityAction(.escape, onClose)
     }
 
     private var highlightedAccessibilityValue: String {
@@ -208,6 +214,13 @@ struct TVActionPopoverMenu: View {
         guard let item = items.first(where: { $0.id == highlightedId }),
               item.isEnabled else { return }
         onSelect(item)
+    }
+}
+
+/// No system padding, tint, scale, or focus decoration on the invisible host.
+private struct TVPopoverActivationButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
     }
 }
 


### PR DESCRIPTION
## Problem

On tvOS item detail pages, selecting a version, audio track, or subtitle could require multiple Select presses. Physical Apple TV traces showed complete incoming presses and stable menu focus, but the popup's tap-gesture activation handler did not run for the missed presses.

## Changes

Use a transparent native Button as the popup's single focus and activation owner. Keep the existing glass surface, dimensions, passive rows, highlighted selection, and directional navigation outside the Button's styling. Accessibility labels and adjustable actions belong to the activation control.

Remove the temporary input observer and selection tracing used to diagnose and verify the fix. This is an Apple TV UI change; server and Android contracts are unchanged.

## Validation

- Physical Apple TV: after the final appearance adjustment, version, audio, and subtitle selections each activated on the first Select press, with exactly one callback, the expected state update, dismissal, and focus return. The subtitle check included extended navigation through a long list.
- The maintainer confirmed the final popup appearance looks correct.
- The device checks used the same fix with temporary tracing enabled; the submitted source removes that instrumentation.
- Final cleaned source: SiloTV Debug simulator build passed after regenerating the project for current main; existing unrelated warnings remain. SwiftPM locally resolved its transitive package identity during the build; the PR preserves main's checked-in dependency lockfile.
- `git diff --check` passed.

## Remaining limits

VoiceOver and other remote types were not separately exercised. No screenshots or video were captured; the maintainer supplied before-and-after input traces and confirmed the appearance directly. No diagnostic logs or media filenames are included in this PR.

## AI Disclosure

- Harness: OpenAI Codex desktop app.
- Model: `gpt-6-astra`.
- Tools: shell tools, XcodeBuildMCP, XcodeGen, and GitHub CLI (`gh`).
- Involvement: AI-assisted diagnosis, implementation, cleanup, and PR preparation. The maintainer performed physical Apple TV testing and confirmed the appearance. No collaborating agents were used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility and focus behavior for the tvOS action popover.
  * Enhanced remote navigation, activation, escape handling, and adjustable value controls.
  * Removed unintended system button styling from the popover’s activation control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->