### PR TITLE
fix(tvos): improve top-menu responsiveness

### DIFF
--- a/iosApp/iosApp/Theme/SiloTheme.swift
+++ b/iosApp/iosApp/Theme/SiloTheme.swift
@@ -163,6 +163,8 @@ struct SiloTheme {
         static let cascadeOpenScale: CGFloat = 0.96
         /// Cascade panel scale/fade duration (§4.2, 180 ms).
         static let cascadeOpenDuration: Double = 0.18
+        /// Top-menu panels settle quickly after the focus dwell.
+        static let topMenuPanelOpenDuration: Double = 0.12
         /// Scrim fade duration behind the cascade (§4.2, 150 ms).
         static let cascadeScrimDuration: Double = 0.15
 

--- a/iosApp/iosApp/tvOS/Navigation/TVCascadeSelector.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVCascadeSelector.swift
@@ -193,8 +193,6 @@ struct TVCascadeSelector: View {
             panelHeader(type.librariesHeader)
 
             libraryRows
-
-            panelFooter
         }
         .padding(SiloTheme.Skyline.dropdownPadding)
         .frame(width: SiloTheme.Skyline.dropdownWidth, alignment: .leading)
@@ -272,8 +270,6 @@ struct TVCascadeSelector: View {
                     sectionRow(pill, in: library)
                 }
             }
-
-            panelFooter
         }
         .padding(SiloTheme.Skyline.dropdownPadding)
         .frame(width: SiloTheme.Skyline.dropdownWidth, alignment: .leading)
@@ -370,33 +366,6 @@ struct TVCascadeSelector: View {
             .accessibilityHidden(true)
     }
 
-    private var panelFooter: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Rectangle()
-                .fill(Color.siloDivider)
-                .frame(height: 1)
-                .padding(.horizontal, 12)
-                .padding(.top, 6)
-
-            Text(footerCaption)
-                .font(.system(size: SiloTheme.Skyline.dropdownHeaderSize, design: .monospaced))
-                .tracking(1.2)
-                .foregroundStyle(Color.white.opacity(0.34))
-                .lineLimit(2)
-                .fixedSize(horizontal: false, vertical: true)
-                .padding(.horizontal, 16)
-                .padding(.top, 10)
-                .padding(.bottom, 4)
-        }
-        .accessibilityHidden(true)
-    }
-
-    private var footerCaption: String {
-        isSingleLibrary
-            ? "Press opens the section · Menu closes"
-            : "Press opens the library · → jumps to a section · Menu closes"
-    }
-
     // MARK: - Focus plumbing
 
     private func applyEntryGeneration(_ generation: Int) {
@@ -421,9 +390,6 @@ struct TVCascadeSelector: View {
     }
 
     private func handleFocusChange(_ newValue: Focus?) {
-        if newValue != nil, entersPanel {
-            onPanelFocusChanged(true)
-        }
         guard let newValue else { return }
         switch newValue {
         case .library(let id):
@@ -532,18 +498,15 @@ struct TVCascadeSelector: View {
 
     private func moveToLibrary(_ libraryId: Int) {
         flyoutFollowTask?.cancel()
-        flyoutAnchorId = libraryId
-        onPanelFocusChanged(true)
+        // Highlight immediately; handleFocusChange moves the flyout only
+        // after the user rests on this row.
         focus = .library(libraryId)
-        claimPanelFocus()
     }
 
     private func moveToSection(libraryId: Int, pill: TVLibraryPill) {
         flyoutFollowTask?.cancel()
         flyoutAnchorId = libraryId
-        onPanelFocusChanged(true)
         focus = .section(libraryId, pill)
-        claimPanelFocus()
     }
 
     private func commitFocusedSelection() {
@@ -581,8 +544,6 @@ private struct TVCascadeLibraryRowLabel: View {
     let trailingGlyph: String
     let isFocused: Bool
 
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-
     var body: some View {
         HStack(spacing: 14) {
             Image(systemName: systemImage)
@@ -607,8 +568,8 @@ private struct TVCascadeLibraryRowLabel: View {
                 .fill(isFocused ? Color.white : Color.clear)
         )
         .focusEffectDisabled()
-        // Reduce Motion snaps the cascade row inversion (§4.2 acceptance).
-        .animation(reduceMotion ? nil : SiloTheme.springAnimation, value: isFocused)
+        // Row selection should read immediately as the remote moves.
+        .animation(nil, value: isFocused)
     }
 
     private var foreground: Color {
@@ -622,8 +583,6 @@ private struct TVCascadeSectionRowLabel: View {
     let title: String
     let systemImage: String
     let isFocused: Bool
-
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         HStack(spacing: 12) {
@@ -645,8 +604,8 @@ private struct TVCascadeSectionRowLabel: View {
                 .fill(isFocused ? Color.white : Color.clear)
         )
         .focusEffectDisabled()
-        // Reduce Motion snaps the flyout row inversion (§4.2 acceptance).
-        .animation(reduceMotion ? nil : SiloTheme.springAnimation, value: isFocused)
+        // Row selection should read immediately as the remote moves.
+        .animation(nil, value: isFocused)
     }
 }
 

--- a/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
@@ -556,7 +556,7 @@ struct TVMainTabView: View {
             .allowsHitTesting(isActive)
             .accessibilityHidden(!isActive)
             .animation(
-                reduceMotion ? nil : .easeOut(duration: SiloTheme.Skyline.cascadeOpenDuration),
+                reduceMotion ? nil : .easeOut(duration: SiloTheme.Skyline.topMenuPanelOpenDuration),
                 value: isActive
             )
             .onExitCommand { closePanel() }

--- a/iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVTopMenuBar.swift
@@ -1030,8 +1030,6 @@ struct TVForYouDropdown: View {
             actionButton("Favorites", systemImage: "heart.fill", id: .favorites, action: onFavorites)
             actionButton("Recommendations", systemImage: "sparkles", id: .recommendations, action: onRecommendations)
                 .modifier(TVDropdownBoundaryMoveHandler(onMoveUp: nil, onMoveDown: onExitToContent))
-
-            panelFooter
         }
         .padding(SiloTheme.Skyline.dropdownPadding)
         .frame(width: SiloTheme.Skyline.dropdownWidth, alignment: .leading)
@@ -1051,27 +1049,6 @@ struct TVForYouDropdown: View {
             .padding(.top, 8)
             .padding(.bottom, 2)
             .accessibilityHidden(true)
-    }
-
-    private var panelFooter: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Rectangle()
-                .fill(Color.siloDivider)
-                .frame(height: 1)
-                .padding(.horizontal, 12)
-                .padding(.top, 6)
-
-            Text("Press opens the section · Menu closes")
-                .font(.system(size: SiloTheme.Skyline.dropdownHeaderSize, design: .monospaced))
-                .tracking(1.2)
-                .foregroundStyle(Color.white.opacity(0.34))
-                .lineLimit(2)
-                .fixedSize(horizontal: false, vertical: true)
-                .padding(.horizontal, 16)
-                .padding(.top, 10)
-                .padding(.bottom, 4)
-        }
-        .accessibilityHidden(true)
     }
 
     @ViewBuilder
@@ -1228,16 +1205,6 @@ struct TVProfileDropdown: View {
             // regress existing users.
             actionButton("Switch Server", systemImage: "server.rack", id: .switchServer, action: onSwitchServer)
             actionButton("Sign Out", systemImage: "rectangle.portrait.and.arrow.right", id: .signOut, isDestructive: true, action: onSignOut)
-
-            divider
-
-            Text("Press Menu to close")
-                .font(.system(size: SiloTheme.Skyline.dropdownHeaderSize, design: .monospaced))
-                .tracking(1.4)
-                .foregroundStyle(Color.white.opacity(0.38))
-                .padding(.horizontal, 16)
-                .padding(.bottom, 4)
-                .accessibilityHidden(true)
         }
         .padding(SiloTheme.Skyline.dropdownPadding)
         .frame(width: SiloTheme.Skyline.dropdownWidth, alignment: .leading)
@@ -1348,8 +1315,8 @@ private struct TVProfileMenuButtonBody: View {
             )
             .opacity(configuration.isPressed ? 0.75 : 1.0)
             .focusEffectDisabled()
-            // Reduce Motion snaps the profile-menu row inversion (§4.2).
-            .animation(reduceMotion ? nil : SiloTheme.springAnimation, value: isFocused)
+            // Match the cascade: focus feedback follows each press immediately.
+            .animation(nil, value: isFocused)
             .animation(reduceMotion ? nil : .easeOut(duration: SiloTheme.fastDuration), value: configuration.isPressed)
     }
 


### PR DESCRIPTION
Top-menu navigation felt delayed because directional moves repeatedly reclaimed panel focus and animated the row highlight. Highlight rows immediately, defer flyout movement until focus rests, and shorten the panel-opening animation. Remove the instructional footer text from the dropdowns.

Validation: signed tvOS Release build passed with the session's combined changes, and navigation was checked on a physical Apple TV with user confirmation. `git diff --check` passed. The independent PR branch still requires the Apple regression CI matrix.

AI disclosure: Developed and reviewed with GPT-6 through the Codex agent harness, including Codex review subagents. The exact backend model identifier is not exposed by this session.
