### PR TITLE
fix(tvos): stabilize continuous series episode navigation

### DIFF
--- a/iosApp/Tests/SeriesEpisodeWindowTests.swift
+++ b/iosApp/Tests/SeriesEpisodeWindowTests.swift
@@ -1,0 +1,128 @@
+import XCTest
+@testable import Silo
+
+final class SeriesEpisodeWindowTests: XCTestCase {
+    func testContinuousOrderAndSpecialsLast() throws {
+        let seasons = try [0, 3, 1, 2].map(season)
+        let window = SeriesEpisodeWindow.snapshot(seasons: seasons, selected: 2, pages: [
+            0: [try episode(0, 1)], 1: [try episode(1, 2), try episode(1, 1)],
+            2: [try episode(2, 1)], 3: [try episode(3, 1)],
+        ])
+        XCTAssertEqual(window.episodes.map(\.contentId), ["s1e1", "s1e2", "s2e1", "s3e1", "s0e1"])
+        XCTAssertNil(window.previousSeason)
+        XCTAssertNil(window.nextSeason)
+    }
+
+    func testMissingSeasonDoesNotJoinNonadjacentRuns() throws {
+        let seasons = try (1...4).map(season)
+        let window = SeriesEpisodeWindow.snapshot(seasons: seasons, selected: 3, pages: [
+            1: [try episode(1, 1)], 3: [try episode(3, 1)],
+        ])
+        XCTAssertEqual(window.episodes.map(\.contentId), ["s3e1"])
+        XCTAssertEqual(window.previousSeason, 2)
+        XCTAssertEqual(window.nextSeason, 4)
+    }
+
+    func testLoadedEmptySeasonsAreTraversed() throws {
+        let window = SeriesEpisodeWindow.snapshot(seasons: try (1...4).map(season), selected: 1, pages: [
+            1: [try episode(1, 1)], 2: [], 3: [try episode(3, 1)],
+        ])
+        XCTAssertEqual(window.episodes.map(\.contentId), ["s1e1", "s3e1"])
+        XCTAssertEqual(window.nextSeason, 4)
+    }
+
+    func testUnloadedJumpDoesNotShowThePreviousSeasonsEpisodes() throws {
+        let window = SeriesEpisodeWindow.snapshot(seasons: try (1...3).map(season), selected: 3, pages: [
+            1: [try episode(1, 1)],
+        ])
+        XCTAssertTrue(window.episodes.isEmpty)
+    }
+
+    func testDuplicateSeasonsAndEpisodeIdentitiesDoNotCreateDuplicateCards() throws {
+        let shared = try episode(1, 1)
+        let window = SeriesEpisodeWindow.snapshot(seasons: try [1, 1, 2].map(season), selected: 1, pages: [
+            1: [shared, shared], 2: [shared, try episode(2, 1)],
+        ])
+        XCTAssertEqual(window.episodes.map(\.contentId), ["s1e1", "s2e1"])
+    }
+
+    func testLargeSeriesRetainsFivePagesAndPreservesTheFocusedEpisodeAcrossEviction() throws {
+        let seasons = try (1...30).map(season)
+        let pages = try Dictionary(uniqueKeysWithValues: (1...30).map { number in
+            (number, try (1...100).map { try episode(number, $0) })
+        })
+        let before = SeriesEpisodeWindow.retainedPages(seasons: seasons, selected: 15, pages: pages)
+        XCTAssertEqual(Set(before.keys), Set(13...17))
+        let after = SeriesEpisodeWindow.retainedPages(seasons: seasons, selected: 16, pages: pages)
+        XCTAssertEqual(Set(after.keys), Set(14...18))
+        let oldWindow = SeriesEpisodeWindow.snapshot(seasons: seasons, selected: 15, pages: before)
+        let newWindow = SeriesEpisodeWindow.snapshot(seasons: seasons, selected: 16, pages: after)
+        XCTAssertEqual(oldWindow.episodes.count, 500)
+        XCTAssertEqual(newWindow.episodes.count, 500)
+        XCTAssertEqual(oldWindow.episodes.firstIndex(where: { $0.contentId == "s16e1" }), 300)
+        XCTAssertEqual(newWindow.episodes.firstIndex(where: { $0.contentId == "s16e1" }), 200)
+        XCTAssertEqual(newWindow.previousSeason, 13)
+        XCTAssertEqual(newWindow.nextSeason, 19)
+    }
+
+    func testEmptyPagesSurviveEvictionWithoutDisplacingRealEpisodes() throws {
+        let seasons = try (1...9).map(season)
+        var pages = try Dictionary(uniqueKeysWithValues: (1...9).map { ($0, [try episode($0, 1)]) })
+        pages[2] = []
+        pages[3] = []
+        let retained = SeriesEpisodeWindow.retainedPages(seasons: seasons, selected: 7, pages: pages)
+        XCTAssertEqual(retained.values.filter { !$0.isEmpty }.count, 5)
+        XCTAssertEqual(retained[2], [])
+        XCTAssertEqual(retained[3], [])
+    }
+
+    @MainActor
+    func testEpisodeEntryUsesRequestedSeasonInsteadOfFirstUnplayedSeason() throws {
+        let model = ItemDetailViewModel()
+        let seasons = try (1...38).map(season)
+        model.initialResumeSeasonNumber = 38
+        XCTAssertEqual(model.preferredInitialSeason(seasons: seasons)?.seasonNumber, 38)
+        model.initialResumeSeasonNumber = nil
+        XCTAssertEqual(model.preferredInitialSeason(seasons: seasons)?.seasonNumber, 1)
+    }
+
+    @MainActor
+    func testMissingRequestedSeasonFallsBackToAvailableSeasons() throws {
+        let model = ItemDetailViewModel()
+        model.initialResumeSeasonNumber = 38
+        XCTAssertEqual(model.preferredInitialSeason(seasons: try [2, 3].map(season))?.seasonNumber, 2)
+    }
+
+    func testParentSeriesRouteRetainsExactEpisodeAcrossCopies() throws {
+        let item = try JSONDecoder().decode(SectionItem.self, from: Data(
+            #"{"contentId":"episode-38-1","type":"episode","title":"Episode","seriesId":"series","seriesTitle":"Series","seasonNumber":38,"episodeNumber":1}"#.utf8
+        ))
+        let seed = TVItemDetailRouteSeed.destination(contentId: "series", from: item)
+        let routeCopy = seed
+        XCTAssertEqual(routeCopy.episodeContext?.seriesContentId, "series")
+        XCTAssertEqual(routeCopy.episodeContext?.seasonNumber, 38)
+        XCTAssertEqual(routeCopy.episodeContext?.episodeContentId, "episode-38-1")
+        XCTAssertEqual(seed.episodeContext, routeCopy.episodeContext)
+        XCTAssertEqual(seed.mediaType, "series")
+    }
+
+    func testUnrelatedDestinationDoesNotReceiveEpisodeIntent() throws {
+        let item = try JSONDecoder().decode(SectionItem.self, from: Data(
+            #"{"contentId":"episode","type":"episode","title":"Episode","seriesId":"series","seasonNumber":4,"episodeNumber":1}"#.utf8
+        ))
+        XCTAssertNil(TVItemDetailRouteSeed.destination(contentId: "other", from: item).episodeContext)
+        XCTAssertNil(TVItemDetailRouteSeed.destination(contentId: "episode", from: item).episodeContext)
+    }
+
+    private func season(_ number: Int) throws -> Season {
+        try JSONDecoder().decode(Season.self, from: Data(
+            "{\"contentId\":\"season-\(number)\",\"seasonNumber\":\(number)}".utf8
+        ))
+    }
+
+    private func episode(_ season: Int, _ number: Int) throws -> EpisodeListItem {
+        try JSONDecoder().decode(EpisodeListItem.self, from: Data(
+            "{\"contentId\":\"s\(season)e\(number)\",\"seasonNumber\":\(season),\"episodeNumber\":\(number)}".utf8
+        ))
+    }
+}

--- a/iosApp/Tests/SeriesSeasonSelectionTests.swift
+++ b/iosApp/Tests/SeriesSeasonSelectionTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+@testable import Silo
+
+@MainActor
+final class SeriesSeasonSelectionTests: XCTestCase {
+    func testCompletedChoiceRemainsAuthoritativeBeforeTheSelectorRedraws() async throws {
+        let selection = SeriesSeasonSelection()
+        let load = DeferredLoad()
+        let displayedSeason = try season(1)
+        let newSeason = try season(2)
+        selection.select(newSeason, load: load.load) { _ in }
+        await fulfillment(of: [load.started], timeout: 2)
+        load.finish("s2e1")
+        await fulfillment(of: [load.finished], timeout: 2)
+
+        // A queued focus callback can still hold the previous rendered season.
+        // Returning to S1 must not be mistaken for a no-op after S2 completes.
+        let latestChoice = selection.latestSeasonId ?? displayedSeason.id
+        XCTAssertNotEqual(latestChoice, displayedSeason.id)
+        XCTAssertEqual(latestChoice, newSeason.id)
+    }
+
+    func testRapidReversalOnlyScrollsToLatestChoice() async throws {
+        let selection = SeriesSeasonSelection()
+        var destinations: [String] = []
+        let first = DeferredLoad()
+        let second = DeferredLoad()
+        let returned = DeferredLoad()
+        let season1 = try season(1)
+        let season2 = try season(2)
+
+        selection.select(season1, load: first.load) { destinations.append($0) }
+        await fulfillment(of: [first.started], timeout: 2)
+        selection.select(season2, load: second.load) { destinations.append($0) }
+        await fulfillment(of: [second.started], timeout: 2)
+        selection.select(season1, load: returned.load) { destinations.append($0) }
+        await fulfillment(of: [returned.started], timeout: 2)
+
+        // An old completion cannot clear the newer request, even for the same season.
+        first.finish("old-s1e1")
+        await fulfillment(of: [first.finished], timeout: 2)
+        XCTAssertEqual(selection.latestSeasonId, season1.id)
+        XCTAssertTrue(destinations.isEmpty)
+
+        returned.finish("s1e1")
+        await fulfillment(of: [returned.finished], timeout: 2)
+        second.finish("s2e1")
+        await fulfillment(of: [second.finished], timeout: 2)
+        XCTAssertEqual(destinations, ["s1e1"])
+        XCTAssertEqual(selection.latestSeasonId, season1.id)
+    }
+
+    func testEpisodeFocusCancelsPendingSeasonScroll() async throws {
+        let selection = SeriesSeasonSelection()
+        let load = DeferredLoad()
+        var destinations: [String] = []
+        selection.select(try season(2), load: load.load) { destinations.append($0) }
+        await fulfillment(of: [load.started], timeout: 2)
+        selection.cancel()
+        load.finish("s2e1")
+        await fulfillment(of: [load.finished], timeout: 2)
+        XCTAssertTrue(destinations.isEmpty)
+        XCTAssertNil(selection.latestSeasonId)
+    }
+
+    func testEmptyOrFailedSelectionCanBeRetried() async throws {
+        let selection = SeriesSeasonSelection()
+        let failed = DeferredLoad()
+        let retry = DeferredLoad()
+        var destinations: [String] = []
+        let target = try season(2)
+        selection.select(target, load: failed.load) { destinations.append($0) }
+        await fulfillment(of: [failed.started], timeout: 2)
+        failed.finish(nil)
+        await fulfillment(of: [failed.finished], timeout: 2)
+        XCTAssertNil(selection.latestSeasonId)
+        XCTAssertTrue(destinations.isEmpty)
+        selection.select(target, load: retry.load) { destinations.append($0) }
+        await fulfillment(of: [retry.started], timeout: 2)
+        retry.finish("s2e1")
+        await fulfillment(of: [retry.finished], timeout: 2)
+        XCTAssertEqual(destinations, ["s2e1"])
+    }
+
+    private func season(_ number: Int) throws -> Season {
+        try JSONDecoder().decode(Season.self, from: Data(
+            "{\"contentId\":\"season-\(number)\",\"seasonNumber\":\(number)}".utf8
+        ))
+    }
+
+    /// Deliberately ignores cancellation, like a shared request already in flight.
+    private final class DeferredLoad {
+        let started = XCTestExpectation(description: "load started")
+        let finished = XCTestExpectation(description: "load returned")
+        private var continuation: CheckedContinuation<String?, Never>?
+
+        func load(_ season: Season) async -> String? {
+            let result = await withCheckedContinuation { continuation in
+                self.continuation = continuation
+                started.fulfill()
+            }
+            finished.fulfill()
+            return result
+        }
+
+        func finish(_ contentId: String?) {
+            continuation?.resume(returning: contentId)
+            continuation = nil
+        }
+    }
+}

--- a/iosApp/Tests/SeriesSeasonSelectionTests.swift
+++ b/iosApp/Tests/SeriesSeasonSelectionTests.swift
@@ -82,6 +82,63 @@ final class SeriesSeasonSelectionTests: XCTestCase {
         XCTAssertEqual(destinations, ["s2e1"])
     }
 
+    func testInitialHierarchyFailureClearsEpisodeLoading() async {
+        let model = ItemDetailViewModel()
+        model.isLoadingEpisodes = true
+
+        await model.loadSeasons(seriesId: "hierarchy-failure", fetchSeasons: { _ in
+            throw URLError(.notConnectedToInternet)
+        })
+
+        XCTAssertFalse(model.isLoadingEpisodes)
+        XCTAssertTrue(model.episodes.isEmpty)
+    }
+
+    func testEmptyInitialHierarchyClearsEpisodeLoading() async throws {
+        let model = ItemDetailViewModel()
+        model.isLoadingEpisodes = true
+        let empty = try JSONDecoder().decode(SeasonsResponse.self, from: Data("{\"seasons\":[]}".utf8))
+
+        await model.loadSeasons(seriesId: "empty-hierarchy", fetchSeasons: { _ in empty })
+
+        XCTAssertFalse(model.isLoadingEpisodes)
+        XCTAssertNil(model.selectedSeason)
+    }
+
+    func testBackgroundHierarchyFailureDoesNotClearEpisodeLoading() async {
+        let model = ItemDetailViewModel()
+        model.isLoadingEpisodes = true
+
+        await model.loadSeasons(seriesId: "background-hierarchy", autoSelectInitial: false, fetchSeasons: { _ in
+            throw URLError(.notConnectedToInternet)
+        })
+
+        XCTAssertTrue(model.isLoadingEpisodes)
+    }
+
+    func testOldHierarchyFailureDoesNotClearNewerEpisodeLoading() async throws {
+        let model = ItemDetailViewModel()
+        let detail = try JSONDecoder().decode(ItemDetail.self, from: Data(
+            "{\"contentId\":\"superseded-hierarchy\",\"type\":\"series\",\"title\":\"Synthetic series\"}".utf8
+        ))
+        ResponseCache.shared.set(detail, for: CacheKey.itemDetail(detail.contentId))
+        defer { ResponseCache.shared.removeAll(withPrefix: "item:superseded-hierarchy") }
+        model.hydrateFromCache(contentId: detail.contentId)
+        model.isLoadingEpisodes = true
+        let newerSeason = try season(2)
+        model.episodesBySeason[2] = []
+
+        await model.loadSeasons(seriesId: "superseded-hierarchy", fetchSeasons: { _ in
+            await model.selectSeason(newerSeason)
+            // A newer selection owns the loading indicator from this point.
+            await MainActor.run { model.isLoadingEpisodes = true }
+            throw URLError(.notConnectedToInternet)
+        })
+
+        XCTAssertTrue(model.isLoadingEpisodes)
+        XCTAssertEqual(model.selectedSeason?.seasonNumber, 2)
+    }
+
     private func season(_ number: Int) throws -> Season {
         try JSONDecoder().decode(Season.self, from: Data(
             "{\"contentId\":\"season-\(number)\",\"seasonNumber\":\(number)}".utf8

--- a/iosApp/iosApp/Navigation/Route.swift
+++ b/iosApp/iosApp/Navigation/Route.swift
@@ -91,9 +91,16 @@ enum Route: Hashable {
 }
 
 /// Card metadata that lets tvOS paint a branded detail frame before the
-/// authoritative item response arrives. The seed is deliberately display-only:
-/// playback, personal state, selectors, and actions still wait for `ItemDetail`.
+/// authoritative item response arrives, plus the episode that opened a Series.
+/// Playback, personal state, selectors, and actions still wait for `ItemDetail`.
 struct TVItemDetailRouteSeed: Hashable {
+    struct EpisodeContext: Hashable {
+        let seriesContentId: String
+        let seasonNumber: Int
+        let episodeContentId: String
+    }
+
+    var episodeContext: EpisodeContext? = nil
     let mediaType: String
     let title: String
     let year: Int?
@@ -120,6 +127,22 @@ struct TVItemDetailRouteSeed: Hashable {
         posterThumbhash = item.posterThumbhash
         backdropUrl = item.backdropUrl
         backdropThumbhash = item.backdropThumbhash
+    }
+
+    init(_ detail: ItemDetail, episodeContext: EpisodeContext) {
+        self.episodeContext = episodeContext
+        mediaType = detail.type
+        title = detail.title
+        year = detail.year
+        overview = detail.overview
+        runtime = detail.runtime
+        contentRating = detail.contentRating
+        genre = detail.genres?.first
+        logoUrl = detail.logoUrl
+        posterUrl = detail.posterUrl
+        posterThumbhash = detail.posterThumbhash
+        backdropUrl = detail.backdropUrl
+        backdropThumbhash = detail.backdropThumbhash
     }
 
     init(_ item: BrowseItem) {
@@ -169,7 +192,15 @@ struct TVItemDetailRouteSeed: Hashable {
            seriesId?.isEmpty == false,
            seriesId == contentId,
            contentId != item.contentId {
-            return TVItemDetailRouteSeed(parentSeriesFrom: item)
+            var seed = TVItemDetailRouteSeed(parentSeriesFrom: item)
+            if let seasonNumber = item.seasonNumber {
+                seed.episodeContext = EpisodeContext(
+                    seriesContentId: contentId,
+                    seasonNumber: seasonNumber,
+                    episodeContentId: item.contentId
+                )
+            }
+            return seed
         }
         return TVItemDetailRouteSeed(item)
     }

--- a/iosApp/iosApp/Screens/Detail/ItemDetailView.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailView.swift
@@ -14,6 +14,9 @@ struct ItemDetailView: View {
     var body: some View {
         #if os(tvOS)
         TVItemDetailView(contentId: contentId, seed: tvSeed)
+            // Episode -> Series replaces the route with the same view type.
+            // Its cached model and entry state belong to the new content ID.
+            .id(contentId)
         #else
         ItemDetailPhoneContent(contentId: contentId, onClose: onClose, resumeContext: resumeContext)
         #endif

--- a/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
@@ -898,12 +898,24 @@ class ItemDetailViewModel {
     func loadSeasons(
         seriesId: String,
         autoSelectInitial: Bool = true,
-        coalescesMetadataRequest: Bool = true
+        coalescesMetadataRequest: Bool = true,
+        fetchSeasons: (@Sendable (String) async throws -> SeasonsResponse)? = nil
     ) async {
         let selectionGeneration = episodeLoadGeneration
+        defer {
+            // Cold episode routes start loading before hierarchy resolution.
+            // Failure or an empty hierarchy must end that initial wait, but
+            // must not clear a newer selection or a parallel episode refresh.
+            if autoSelectInitial, selectionGeneration == episodeLoadGeneration,
+               isLoadingEpisodes {
+                isLoadingEpisodes = false
+            }
+        }
         do {
             let response: SeasonsResponse
-            if coalescesMetadataRequest {
+            if let fetchSeasons {
+                response = try await fetchSeasons(seriesId)
+            } else if coalescesMetadataRequest {
                 response = try await MetadataRequestPool.shared.seasons(seriesId: seriesId)
             } else {
                 response = try await SiloAPI.shared.seasons(seriesId: seriesId)

--- a/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
@@ -12,9 +12,21 @@ class ItemDetailViewModel {
     var error: ErrorState?
 
     // Series-specific state
-    var seasons: [Season] = []
-    var selectedSeason: Season?
-    #if os(iOS)
+    var seasons: [Season] = [] {
+        didSet {
+            #if os(tvOS)
+            updateSeriesEpisodeWindow()
+            #endif
+        }
+    }
+    var selectedSeason: Season? {
+        didSet {
+            #if os(tvOS)
+            updateSeriesEpisodeWindow()
+            #endif
+        }
+    }
+    #if os(iOS) || os(tvOS)
     /// One-shot entry intent from Continue Watching; normal poster opens
     /// leave this nil and retain the existing initial-season policy.
     @ObservationIgnored var initialResumeSeasonNumber: Int?
@@ -33,7 +45,13 @@ class ItemDetailViewModel {
     /// Route-scoped pages already loaded while browsing seasons. This keeps
     /// chip taps and iPad page swipes instant when the user comes back to a
     /// season, while `ResponseCache` remains the longer-lived cold-start tier.
-    var episodesBySeason: [Int: [EpisodeListItem]] = [:]
+    var episodesBySeason: [Int: [EpisodeListItem]] = [:] {
+        didSet {
+            #if os(tvOS)
+            updateSeriesEpisodeWindow()
+            #endif
+        }
+    }
     var episodeFavoriteStates: [String: Bool] = [:]
     var isLoadingEpisodes = false
 
@@ -371,12 +389,13 @@ class ItemDetailViewModel {
         if enriched.type == "series" {
             seriesContentId = contentId
             let keepSeason = preserveSeasonSelection ? selectedSeason?.seasonNumber : nil
+            let selectionGeneration = episodeLoadGeneration
             await loadSeasons(
                 seriesId: contentId,
                 autoSelectInitial: keepSeason == nil,
                 coalescesMetadataRequest: coalescesMetadataRequests
             )
-            if let keepSeason {
+            if let keepSeason, selectionGeneration == episodeLoadGeneration, !Task.isCancelled {
                 // Re-point at the freshly-loaded instance of the same
                 // season so its progress counters are current, without
                 // re-fetching the episode rail the user is looking at.
@@ -881,6 +900,7 @@ class ItemDetailViewModel {
         autoSelectInitial: Bool = true,
         coalescesMetadataRequest: Bool = true
     ) async {
+        let selectionGeneration = episodeLoadGeneration
         do {
             let response: SeasonsResponse
             if coalescesMetadataRequest {
@@ -888,10 +908,12 @@ class ItemDetailViewModel {
             } else {
                 response = try await SiloAPI.shared.seasons(seriesId: seriesId)
             }
+            guard !Task.isCancelled else { return }
             ResponseCache.shared.set(response, for: CacheKey.itemSeasons(seriesId))
             seasons = response.seasons.sortedForDisplay()
-            if autoSelectInitial, let target = preferredInitialSeason(seasons: seasons) {
-                #if os(iOS)
+            if autoSelectInitial, selectionGeneration == episodeLoadGeneration,
+               let target = preferredInitialSeason(seasons: seasons) {
+                #if os(iOS) || os(tvOS)
                 initialResumeSeasonNumber = nil
                 #endif
                 #if !os(tvOS)
@@ -1014,7 +1036,7 @@ class ItemDetailViewModel {
     /// then the first partially-watched season, then the first season that
     /// isn't fully played, then fall back to the first season.
     func preferredInitialSeason(seasons: [Season]) -> Season? {
-        #if os(iOS)
+        #if os(iOS) || os(tvOS)
         if let initialResumeSeasonNumber,
            let requested = seasons.first(where: { $0.seasonNumber == initialResumeSeasonNumber }) {
             return requested
@@ -1047,7 +1069,7 @@ class ItemDetailViewModel {
         forceRefresh: Bool = false,
         coalescesMetadataRequest: Bool = true
     ) async {
-        #if os(iOS)
+        #if os(iOS) || os(tvOS)
         // An explicit chip/page selection supersedes the one-shot resume intent.
         // Automatic hierarchy refreshes must retain it until the catalog succeeds.
         if !forceRefresh { initialResumeSeasonNumber = nil }
@@ -1077,6 +1099,55 @@ class ItemDetailViewModel {
             coalescesMetadataRequest: coalescesMetadataRequest
         )
     }
+
+    #if os(tvOS)
+    /// Apply a known episode route before the first Series render or fetch.
+    /// A cold visit then requests this season directly; a warm visit paints it.
+    func prepareInitialSeriesSeason(_ number: Int, seriesId: String) {
+        episodeLoadGeneration += 1
+        cancelDeferredEpisodeFavoriteStateRefresh()
+        initialResumeSeasonNumber = number
+        seriesContentId = seriesId
+        selectedSeason = seasons.first { $0.seasonNumber == number }
+        let cached: EpisodesResponse? = ResponseCache.shared.get(
+            CacheKey.itemEpisodes(seriesId: seriesId, seasonNumber: number)
+        )
+        if let page = episodesBySeason[number] ?? cached?.episodes.sorted(by: { $0.episodeNumber < $1.episodeNumber }) {
+            episodesBySeason[number] = page
+            episodes = page
+            loadedSeasonNumber = number
+            isLoadingEpisodes = false
+        } else {
+            episodes = []
+            isLoadingEpisodes = true
+        }
+    }
+
+    private(set) var seriesEpisodeWindow = SeriesEpisodeWindow(
+        episodes: [], previousSeason: nil, nextSeason: nil
+    )
+
+    private func updateSeriesEpisodeWindow() {
+        seriesEpisodeWindow = SeriesEpisodeWindow.snapshot(
+            seasons: seasons, selected: selectedSeason?.seasonNumber, pages: episodesBySeason
+        )
+    }
+
+    /// Crossing a loaded season boundary is synchronous. Invalidate older
+    /// requests without starting another fetch or discarding the focused card.
+    func activateLoadedSeriesEpisode(_ contentId: String) {
+        guard let episode = seriesEpisodeWindow.episodes.first(where: { $0.contentId == contentId }),
+              selectedSeason?.seasonNumber != episode.seasonNumber,
+              let season = seasons.first(where: { $0.seasonNumber == episode.seasonNumber }),
+              let page = episodesBySeason[episode.seasonNumber] else { return }
+        episodeLoadGeneration += 1
+        cancelDeferredEpisodeFavoriteStateRefresh()
+        selectedSeason = season
+        episodes = page
+        loadedSeasonNumber = season.seasonNumber
+        isLoadingEpisodes = false
+    }
+    #endif
 
     func loadEpisodes(
         seriesId: String,
@@ -1156,10 +1227,12 @@ class ItemDetailViewModel {
            (selectedSeason?.seasonNumber == seasonNumber || selectedSeason == nil) {
             let loadedEpisodes = episodesBySeason[seasonNumber] ?? episodes
             #if os(tvOS)
-            scheduleEpisodeFavoriteStateRefresh(
-                for: loadedEpisodes,
-                episodeLoadGeneration: generation
-            )
+            if detail?.type != "series" {
+                scheduleEpisodeFavoriteStateRefresh(
+                    for: loadedEpisodes,
+                    episodeLoadGeneration: generation
+                )
+            }
             #else
             await refreshEpisodeFavoriteStates(for: loadedEpisodes)
             #endif
@@ -1167,6 +1240,20 @@ class ItemDetailViewModel {
     }
 
     #if os(tvOS)
+    /// Series needs favorite state for the card whose context menu can open.
+    /// Loading a long season must not start one request per episode.
+    func refreshSeriesEpisodeFavorite(contentId: String) async {
+        let mutationVersion = episodeFavoriteMutationVersions[contentId, default: 0]
+        do {
+            let favorite = try await SiloAPI.shared.isFavorite(contentId: contentId)
+            guard !Task.isCancelled,
+                  episodeFavoriteMutationVersions[contentId, default: 0] == mutationVersion else { return }
+            episodeFavoriteStates[contentId] = favorite
+        } catch {
+            // Preserve the last known value on a transient failure.
+        }
+    }
+
     private func scheduleEpisodeFavoriteStateRefresh(
         for episodes: [EpisodeListItem],
         episodeLoadGeneration: Int

--- a/iosApp/iosApp/Screens/Detail/SeriesEpisodeWindow.swift
+++ b/iosApp/iosApp/Screens/Detail/SeriesEpisodeWindow.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// A continuous run of loaded seasons. A missing page is a boundary, while
+/// a successfully loaded empty season can be crossed. Matches Android TV.
+struct SeriesEpisodeWindow {
+    let episodes: [EpisodeListItem]
+    let previousSeason: Int?
+    let nextSeason: Int?
+
+    static func orderedSeasons(_ seasons: [Season]) -> [Season] {
+        var seen = Set<Int>()
+        return seasons.sorted {
+            let lhsSpecial = $0.isSpecials == true || $0.seasonNumber == 0
+            let rhsSpecial = $1.isSpecials == true || $1.seasonNumber == 0
+            if lhsSpecial != rhsSpecial { return !lhsSpecial }
+            return $0.seasonNumber < $1.seasonNumber
+        }.filter { seen.insert($0.seasonNumber).inserted }
+    }
+
+    static func snapshot(
+        seasons: [Season], selected: Int?, pages: [Int: [EpisodeListItem]]
+    ) -> Self {
+        let order = orderedSeasons(seasons).map(\.seasonNumber)
+        guard let selected, let index = order.firstIndex(of: selected),
+              pages[selected] != nil else {
+            return Self(episodes: [], previousSeason: nil, nextSeason: nil)
+        }
+        var first = index
+        var last = index
+        while first > 0, pages[order[first - 1]] != nil { first -= 1 }
+        while last + 1 < order.count, pages[order[last + 1]] != nil { last += 1 }
+        var seen = Set<String>()
+        let episodes = order[first...last].flatMap { number in
+            (pages[number] ?? []).sorted { $0.episodeNumber < $1.episodeNumber }
+        }.filter { seen.insert($0.contentId).inserted }
+        return Self(
+            episodes: episodes,
+            previousSeason: first > 0 ? order[first - 1] : nil,
+            nextSeason: last + 1 < order.count ? order[last + 1] : nil
+        )
+    }
+
+    /// Retain five nonempty season pages around the selected episode. Empty
+    /// results stay as inexpensive markers so they aren't repeatedly fetched.
+    static func retainedPages(
+        seasons: [Season], selected: Int, pages: [Int: [EpisodeListItem]]
+    ) -> [Int: [EpisodeListItem]] {
+        let order = orderedSeasons(seasons).map(\.seasonNumber)
+        guard let index = order.firstIndex(of: selected) else { return pages }
+        let nearest = order.enumerated().filter { !(pages[$0.element]?.isEmpty ?? true) }
+            .sorted {
+                let lhs = abs($0.offset - index)
+                let rhs = abs($1.offset - index)
+                return lhs == rhs ? $0.offset < $1.offset : lhs < rhs
+            }.prefix(5).map(\.element)
+        let keep = Set(nearest)
+        return pages.filter { order.contains($0.key) && ($0.value.isEmpty || keep.contains($0.key)) }
+    }
+}

--- a/iosApp/iosApp/Screens/Detail/SeriesSeasonSelection.swift
+++ b/iosApp/iosApp/Screens/Detail/SeriesSeasonSelection.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Keeps a season choice and its carousel destination in the same operation.
+/// Loads may finish after cancellation; only the latest choice can scroll.
+@Observable
+@MainActor
+final class SeriesSeasonSelection {
+    private(set) var latestSeasonId: String?
+    @ObservationIgnored private var task: Task<Void, Never>?
+
+    func select(
+        _ season: Season,
+        load: @escaping @MainActor (Season) async -> String?,
+        didSelect: @escaping @MainActor (String) -> Void
+    ) {
+        cancel()
+        latestSeasonId = season.id
+        task = Task { @MainActor in
+            guard !Task.isCancelled else { return }
+            let contentId = await load(season)
+            guard !Task.isCancelled else { return }
+            task = nil
+            if let contentId {
+                // Keep the completed choice authoritative while SwiftUI still
+                // has focus callbacks carrying the previous rendered season.
+                didSelect(contentId)
+            } else {
+                latestSeasonId = nil
+            }
+        }
+    }
+
+    func cancel() {
+        task?.cancel()
+        task = nil
+        latestSeasonId = nil
+    }
+}

--- a/iosApp/iosApp/Screens/Home/SectionRow.swift
+++ b/iosApp/iosApp/Screens/Home/SectionRow.swift
@@ -162,68 +162,17 @@ struct SectionRow: View {
         }
 
         #if os(tvOS)
-        if isContinueWatching {
-            let isEpisode = item.type.lowercased() == "episode"
-                || item.episodeNumber != nil
-            if isEpisode,
-               let seriesId = item.seriesId?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !seriesId.isEmpty,
-               let seasonNumber = item.seasonNumber {
-                navigateToSeriesDetail(
-                    to: seriesId,
-                    from: item,
-                    seasonNumber: seasonNumber,
-                    episodeContentId: item.contentId
-                )
-            } else {
-                onItemTap(item.contentId, item)
-            }
-            return
-        }
-
-        if SiloMediaType.isSeries(item.type) {
-            navigateToSeriesDetail(to: item.contentId, from: item)
+        let isEpisode = item.type.lowercased() == "episode" || item.episodeNumber != nil
+        if isEpisode,
+           let seriesId = item.seriesId?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !seriesId.isEmpty,
+           item.seasonNumber != nil {
+            onItemTap(seriesId, item)
             return
         }
         #endif
         onItemTap(contentId, item)
     }
-
-    #if os(tvOS)
-    /// Match Movie navigation: push the branded route seed immediately while
-    /// the existing marquee warm-up and destination request pool finish the
-    /// authoritative Series payload and hierarchy in parallel.
-    private func navigateToSeriesDetail(
-        to seriesContentId: String,
-        from item: SectionItem,
-        seasonNumber: Int? = nil,
-        episodeContentId: String? = nil
-    ) {
-        finishSeriesDetailNavigation(
-            to: seriesContentId,
-            from: item,
-            seasonNumber: seasonNumber,
-            episodeContentId: episodeContentId
-        )
-    }
-
-    private func finishSeriesDetailNavigation(
-        to seriesContentId: String,
-        from item: SectionItem,
-        seasonNumber: Int?,
-        episodeContentId: String?
-    ) {
-        if let seasonNumber, let episodeContentId {
-            TVSeriesDetailNavigationContextStore.stage(
-                seriesContentId: seriesContentId,
-                seasonNumber: seasonNumber,
-                episodeContentId: episodeContentId
-            )
-        }
-        onItemTap(seriesContentId, item)
-    }
-
-    #endif
 
     /// Home injects a model-owned mutation so its membership-driven rows and
     /// cache update immediately. Shared SectionRow callers retain the original

--- a/iosApp/iosApp/tvOS/Caching/CachedAsyncImage.swift
+++ b/iosApp/iosApp/tvOS/Caching/CachedAsyncImage.swift
@@ -55,14 +55,15 @@ struct CachedAsyncImage: View {
                         .clipped()
                         .transition(.opacity)
                         .onAppear(perform: notifyImageLoaded)
-                } else if state.error == nil, let warmedImage {
+                } else if let warmedImage {
                     // The startup/grid prefetchers warm the memory cache under
                     // the shared card-size thumbnail key, while the request
                     // above is keyed by the exact render size — a miss for
                     // Nuke's synchronous first check. Painting the warmed
                     // decode here makes a prefetched card render finished on
                     // its first frame; it is at least as sharp as the card's
-                    // own decode, so the swap-in is invisible.
+                    // own decode, so the swap-in is invisible. Keep this
+                    // usable image even if the display-sized request fails.
                     Image(platformImage: warmedImage)
                         .resizable()
                         .aspectRatio(contentMode: contentMode)

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVDetailCastRail.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVDetailCastRail.swift
@@ -9,6 +9,7 @@ struct TVDetailCastRail: View {
     /// Non-zero changes explicitly hand focus into the first cast card from
     /// the composite Series episode carousel.
     var focusRequest = 0
+    var onFocusChange: ((Bool) -> Void)? = nil
 
     private let photoWidth: CGFloat = 200
     private let photoHeight: CGFloat = 200
@@ -33,6 +34,9 @@ struct TVDetailCastRail: View {
         .focusSection()
         .applyCastRailDefaultFocus(defaultFocusId, binding: $focusedCastId)
         .scrollClipDisabled()
+        .onChange(of: focusedCastId != nil) { _, focused in
+            onFocusChange?(focused)
+        }
         .onChange(of: focusRequest) { _, request in
             guard request > 0, let defaultFocusId else { return }
             focusedCastId = defaultFocusId

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVDetailScrollViewResolver.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVDetailScrollViewResolver.swift
@@ -1,0 +1,61 @@
+#if os(tvOS)
+import SwiftUI
+import UIKit
+
+/// Resolves the nearest scroll-view ancestor of a marker inside its content.
+struct TVDetailScrollViewResolver: UIViewRepresentable {
+    let onResolve: (UIScrollView) -> Void
+
+    func makeUIView(context: Context) -> ResolverView {
+        let view = ResolverView()
+        view.isUserInteractionEnabled = false
+        view.backgroundColor = .clear
+        view.onResolve = onResolve
+        return view
+    }
+
+    func updateUIView(_ uiView: ResolverView, context: Context) {
+        uiView.onResolve = onResolve
+        uiView.resolveIfNeeded()
+    }
+
+    final class ResolverView: UIView {
+        var onResolve: ((UIScrollView) -> Void)?
+        private weak var resolvedScrollView: UIScrollView?
+        private var resolutionScheduled = false
+
+        override func didMoveToSuperview() {
+            super.didMoveToSuperview()
+            resolveIfNeeded()
+        }
+
+        override func didMoveToWindow() {
+            super.didMoveToWindow()
+            resolveIfNeeded()
+        }
+
+        func resolveIfNeeded() {
+            if let resolvedScrollView {
+                onResolve?(resolvedScrollView)
+                return
+            }
+            guard !resolutionScheduled else { return }
+            resolutionScheduled = true
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                self.resolutionScheduled = false
+                var ancestor = self.superview
+                while let view = ancestor {
+                    if let scrollView = view as? UIScrollView {
+                        self.resolvedScrollView = scrollView
+                        self.onResolve?(scrollView)
+                        return
+                    }
+                    ancestor = view.superview
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeHoldRepeat.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeHoldRepeat.swift
@@ -1,0 +1,99 @@
+#if os(tvOS)
+import SwiftUI
+import UIKit
+
+/// Observes held arrows while the carousel owns focus. Discrete presses and
+/// touch swipes continue through SwiftUI's onMoveCommand.
+struct TVEpisodeHoldRepeat: UIViewRepresentable {
+    var isActive: Bool
+    var onMove: (Int) -> Void
+
+    func makeUIView(context: Context) -> RepeatView { RepeatView() }
+
+    func updateUIView(_ uiView: RepeatView, context: Context) {
+        uiView.recognizer.onMove = onMove
+        uiView.recognizer.isEnabled = isActive
+    }
+
+    static func dismantleUIView(_ uiView: RepeatView, coordinator: ()) {
+        uiView.detach()
+    }
+
+    final class RepeatView: UIView {
+        let recognizer = HeldArrowObserver()
+        private weak var attachedWindow: UIWindow?
+
+        override func didMoveToWindow() {
+            super.didMoveToWindow()
+            guard attachedWindow !== window else { return }
+            detach()
+            guard let window else { return }
+            window.addGestureRecognizer(recognizer)
+            attachedWindow = window
+        }
+
+        func detach() {
+            recognizer.stopRepeating()
+            attachedWindow?.removeGestureRecognizer(recognizer)
+            attachedWindow = nil
+        }
+    }
+
+    /// Remains possible until release and never wins gesture recognition. This
+    /// lets the focus engine deliver the initial move and keeps its press/swipe
+    /// recognizers from cancelling our observation before the repeat delay.
+    final class HeldArrowObserver: UIGestureRecognizer {
+        var onMove: (Int) -> Void = { _ in }
+        private var repeatTask: Task<Void, Never>?
+
+        init() {
+            super.init(target: nil, action: nil)
+            allowedPressTypes = [UIPress.PressType.leftArrow, .rightArrow].map { NSNumber(value: $0.rawValue) }
+            allowedTouchTypes = []
+            cancelsTouchesInView = false
+            delaysTouchesBegan = false
+            delaysTouchesEnded = false
+            isEnabled = false
+        }
+
+        override func canPrevent(_ preventedGestureRecognizer: UIGestureRecognizer) -> Bool { false }
+        override func canBePrevented(by preventingGestureRecognizer: UIGestureRecognizer) -> Bool { false }
+
+        override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent) {
+            guard let press = presses.first(where: { $0.type == .leftArrow || $0.type == .rightArrow }) else { return }
+            stopRepeating()
+            let direction = press.type == .leftArrow ? -1 : 1
+            repeatTask = Task { @MainActor [weak self] in
+                do {
+                    try await Task.sleep(for: .milliseconds(350))
+                    while !Task.isCancelled {
+                        guard let self, self.isEnabled else { return }
+                        self.onMove(direction)
+                        try await Task.sleep(for: .milliseconds(120))
+                    }
+                } catch { }
+            }
+        }
+
+        override func pressesEnded(_ presses: Set<UIPress>, with event: UIPressesEvent) {
+            stopRepeating()
+            state = .failed
+        }
+
+        override func pressesCancelled(_ presses: Set<UIPress>, with event: UIPressesEvent) {
+            stopRepeating()
+            state = .failed
+        }
+
+        override func reset() {
+            super.reset()
+            stopRepeating()
+        }
+
+        func stopRepeating() {
+            repeatTask?.cancel()
+            repeatTask = nil
+        }
+    }
+}
+#endif

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
@@ -43,15 +43,43 @@ struct TVEpisodeRail: View {
     var cardSpacing: CGFloat = 54
     var anchorsFocusedCard = false
     /// Anchored Series rails hand vertical exits back to the parent while
-    /// native focus owns movement between episode cards.
+    /// one composite control owns movement between episode cards.
     var onMoveUp: (() -> Void)? = nil
     var onMoveDown: (() -> Void)? = nil
     /// Non-zero changes restore focus to the current Series episode card.
     var focusRequest = 0
+    var focusTargetContentId: String? = nil
+    /// Explicit season-chip jumps scroll the existing carousel without
+    /// taking focus from the chip. Loaded edges extend the same episode row.
+    var scrollRequest = 0
+    var scrollTargetContentId: String? = nil
+    var isSelectingSeason = false
+    var onRequestPrevious: (() -> Void)? = nil
+    var onRequestNext: (() -> Void)? = nil
+
+    private struct PendingEdge: Equatable {
+        let contentId: String
+        let direction: Int
+    }
+    private struct SeasonScrollUpdate: Equatable {
+        let request: Int
+        let episodeIds: [String]
+    }
+    @State private var pendingEdge: PendingEdge?
+    @State private var appliedScrollRequest = 0
+    @State private var scrollGeneration = 0
+    @State private var scrollViewport = ScrollViewport()
+
+    private final class ScrollViewport {
+        weak var scrollView: UIScrollView?
+        var correctionTarget: CGFloat?
+    }
 
     @FocusState private var focusedCardId: String?
+    @FocusState private var railHasFocus: Bool
+    @State private var anchoredFocusedContentId: String?
     @Namespace private var anchoredFocusScope
-    @State private var anchoredIndex = 0
+    @State private var anchoredContentId: String?
     @State private var anchoredScrollPosition = ScrollPosition(x: 0)
     @State private var anchoredPlayedOverrides: [String: Bool] = [:]
     @State private var anchoredFavoriteOverrides: [String: Bool] = [:]
@@ -119,35 +147,48 @@ struct TVEpisodeRail: View {
         }
     }
 
-    /// Episode buttons participate in native focus, including the system's
-    /// navigation sounds. Focus changes only update the existing leading scroll
-    /// position; horizontal input never writes a second focus destination.
+    /// One composite focus owner keeps directional selection and scrolling in
+    /// sync even when the preceding episode is outside the lazy viewport.
     private var anchoredRail: some View {
         GeometryReader { geometry in
             anchoredCards(viewportWidth: geometry.size.width)
                 .onAppear {
-                    seedAnchoredIndex(viewportWidth: geometry.size.width)
+                    seedAnchoredSelection(viewportWidth: geometry.size.width)
                 }
-                .onChange(of: episodeIdentityKey) { _, _ in
-                    seedAnchoredIndex(viewportWidth: geometry.size.width)
+                .task(id: SeasonScrollUpdate(request: scrollRequest, episodeIds: episodeIdentityKey)) {
+                    // Resolve the current target after the new page layout mounts.
+                    await Task.yield()
+                    guard !Task.isCancelled else { return }
+                    if scrollRequest > 0, scrollRequest != appliedScrollRequest,
+                       let scrollTargetContentId,
+                       let index = episodes.firstIndex(where: { $0.contentId == scrollTargetContentId }) {
+                        appliedScrollRequest = scrollRequest
+                        pendingEdge = nil
+                        anchorFocusedSelection(at: index, viewportWidth: geometry.size.width)
+                    } else {
+                        seedAnchoredSelection(
+                            viewportWidth: geometry.size.width,
+                            targetContentId: anchoredFocusedContentId ?? anchoredContentId,
+                            animated: true
+                        )
+                    }
+                    completePendingEdge(viewportWidth: geometry.size.width)
                 }
                 .onChange(of: currentContentId) { _, _ in
-                    guard focusedCardId == nil else { return }
-                    seedAnchoredIndex(viewportWidth: geometry.size.width)
+                    // The season chip owns an explicit animated request.
+                    // Its metadata update must not snap to the same target
+                    // before that request gets a chance to run.
+                    guard anchoredFocusedContentId == nil, !isSelectingSeason else { return }
+                    seedAnchoredSelection(viewportWidth: geometry.size.width)
                 }
                 .onChange(of: focusRequest) { _, request in
                     guard request > 0 else { return }
-                    seedAnchoredIndex(viewportWidth: geometry.size.width)
-                    focusedCardId = anchoredEpisode?.contentId
+                    seedAnchoredSelection(viewportWidth: geometry.size.width, targetContentId: focusTargetContentId)
+                    railHasFocus = true
+                    anchoredFocusedContentId = anchoredEpisode?.contentId
                 }
-                .onChange(of: focusedCardId) { _, contentId in
-                    if let edgeContentId = AnchoredEdgeFocusGuide.edgeEpisode(
-                        for: contentId,
-                        in: episodes
-                    ) {
-                        focusedCardId = edgeContentId
-                        return
-                    }
+                .onChange(of: anchoredFocusedContentId) { _, contentId in
+                    if pendingEdge?.contentId != contentId { pendingEdge = nil }
                     if let contentId,
                        let index = episodes.firstIndex(where: { $0.contentId == contentId }) {
                         anchorFocusedSelection(at: index, viewportWidth: geometry.size.width)
@@ -158,11 +199,56 @@ struct TVEpisodeRail: View {
         .frame(height: anchoredRailHeight)
         .focusScope(anchoredFocusScope)
         .focusSection()
-        .applyCurrentEpisodeDefaultFocus(
-            anchoredEpisode?.contentId,
-            binding: $focusedCardId
-        )
+        .background {
+            TVEpisodeHoldRepeat(isActive: railHasFocus, onMove: moveEpisode)
+                .frame(width: 0, height: 0)
+        }
+        .focusable()
+        .focused($railHasFocus)
+        .focusEffectDisabled()
+        .defaultFocus($railHasFocus, true)
+        .onChange(of: railHasFocus) { _, hasFocus in
+            anchoredFocusedContentId = hasFocus ? anchoredEpisode?.contentId : nil
+        }
+        .onMoveCommand { direction in
+            switch direction {
+            case .up:
+                pendingEdge = nil
+                onMoveUp?()
+            case .down:
+                pendingEdge = nil
+                onMoveDown?()
+            case .left: moveEpisode(by: -1)
+            case .right: moveEpisode(by: 1)
+            default: break
+            }
+        }
+        .onTapGesture {
+            if let episode = anchoredEpisode { onSelect(episode.contentId) }
+        }
+        .contextMenu { anchoredContextActions }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(anchoredAccessibilityLabel)
+        .accessibilityValue("Episode \(anchoredEpisodeIndex + 1) of \(episodes.count)")
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAdjustableAction { direction in
+            switch direction {
+            case .increment: moveEpisode(by: 1)
+            case .decrement: moveEpisode(by: -1)
+            @unknown default: break
+            }
+        }
+        .onChange(of: isSelectingSeason) { _, ownsFocus in
+            if !ownsFocus {
+                scrollGeneration &+= 1
+                cancelNativeScrollCorrection()
+            }
+        }
         .onDisappear {
+            scrollGeneration &+= 1
+            cancelNativeScrollCorrection()
+            scrollViewport.scrollView = nil
+            pendingEdge = nil
             onFocusedEpisodeChange?(nil)
         }
     }
@@ -170,29 +256,17 @@ struct TVEpisodeRail: View {
     private func anchoredCards(viewportWidth: CGFloat) -> some View {
         ScrollView(.horizontal, showsIndicators: false) {
             LazyHStack(alignment: .top, spacing: cardSpacing) {
-                ForEach(Array(episodes.enumerated()), id: \.element.contentId) { index, episode in
-                    anchoredEpisodeButton(episode, index: index)
-                        .zIndex(focusedCardId == episode.contentId ? 1 : 0)
+                ForEach(episodes) { episode in
+                    anchoredEpisodeLabel(episode)
+                        .zIndex(anchoredFocusedContentId == episode.contentId ? 1 : 0)
                 }
             }
-            // Hard horizontal edges live in the native focus graph: a focus
-            // guide hugs each end of the card strip so Left from the first
-            // card and Right from the last resolve to the guide, which hands
-            // focus straight back to that edge card. `onMoveCommand` cannot
-            // do this because the engine resolves the move before it fires.
-            .overlay(alignment: .leading) {
-                anchoredEdgeFocusGuide(AnchoredEdgeFocusGuide.leading)
-                    .alignmentGuide(.leading) { $0[.trailing] }
-            }
-            .overlay(alignment: .trailing) {
-                anchoredEdgeFocusGuide(AnchoredEdgeFocusGuide.trailing)
-                    .alignmentGuide(.trailing) { $0[.leading] }
+            .scrollTargetLayout()
+            .background {
+                TVDetailScrollViewResolver { scrollViewport.scrollView = $0 }
             }
             // Preserve the existing crop, hover clearance and trailing boundary.
-            .padding(
-                .leading,
-                EpisodeHomeHoverMetrics.leadingInset(for: anchoredCardWidth)
-            )
+            .padding(.leading, EpisodeHomeHoverMetrics.leadingInset(for: anchoredCardWidth))
             .padding(
                 .trailing,
                 anchoredTrailingInset(viewportWidth: viewportWidth)
@@ -200,9 +274,13 @@ struct TVEpisodeRail: View {
             .padding(.vertical, 12)
         }
         .scrollPosition($anchoredScrollPosition)
-        // The outer season pager is scroll-disabled. Enable only this inner
-        // rail so native focus can reveal the previous offscreen episode.
-        .environment(\.isScrollEnabled, true)
+        .onScrollGeometryChange(for: CGFloat.self) { geometry in
+            geometry.contentOffset.x
+        } action: { _, offset in
+            if let target = scrollViewport.correctionTarget, abs(offset - target) <= 0.5 {
+                scrollViewport.correctionTarget = nil
+            }
+        }
         .frame(
             width: viewportWidth,
             height: anchoredRailHeight,
@@ -211,67 +289,48 @@ struct TVEpisodeRail: View {
         .clipped()
     }
 
-    @ViewBuilder
-    private func anchoredEpisodeButton(_ episode: EpisodeListItem, index: Int) -> some View {
-        let button = Button {
-            onSelect(episode.contentId)
-        } label: {
-            EpisodeCardLabel(
-                episode: episode,
-                isPlayed: anchoredIsPlayed(episode),
-                isCurrent: currentContentId == episode.contentId,
-                cardWidth: anchoredCardWidth,
-                stillHeight: anchoredStillHeight,
-                stillCornerRadius: 18,
-                captionStyle: uiCustomization.cardPresentation.caption,
-                focusOverride: focusedCardId == episode.contentId,
-                hidesEpisodeTitle: true,
-                usesHomeHoverEffect: true,
-                showsFocusOutline: false,
-                showsCurrentOutline: false
-            )
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(TVAnchoredEpisodeButtonStyle())
-        .focused($focusedCardId, equals: episode.contentId)
-        .onMoveCommand { direction in
-            // Only the vertical boundaries hand off to another focus region.
-            // Left and Right belong entirely to the native episode buttons;
-            // the rail's edge focus guides fence the first and last card.
-            switch direction {
-            case .up: onMoveUp?()
-            case .down: onMoveDown?()
-            default: break
-            }
-        }
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(episodeRailAccessibilityLabel(
+    private func anchoredEpisodeLabel(_ episode: EpisodeListItem) -> some View {
+        EpisodeCardLabel(
+            episode: episode,
+            isPlayed: anchoredIsPlayed(episode),
+            isCurrent: currentContentId == episode.contentId,
+            cardWidth: anchoredCardWidth,
+            stillHeight: anchoredStillHeight,
+            stillCornerRadius: 18,
+            captionStyle: uiCustomization.cardPresentation.caption,
+            focusOverride: railHasFocus && anchoredContentId == episode.contentId,
+            hidesEpisodeTitle: true,
+            usesHomeHoverEffect: true,
+            showsFocusOutline: false,
+            showsCurrentOutline: false
+        )
+    }
+
+    private var anchoredEpisodeIndex: Int {
+        episodes.firstIndex(where: { $0.contentId == (anchoredFocusedContentId ?? anchoredContentId) }) ?? 0
+    }
+
+    private var anchoredAccessibilityLabel: String {
+        guard let episode = anchoredEpisode else { return "Episodes" }
+        return episodeRailAccessibilityLabel(
             seasonNumber: episode.seasonNumber,
             episodeNumber: episode.episodeNumber,
             title: episode.title,
             metadata: anchoredMetadataLine(for: episode),
             isCurrent: currentContentId == episode.contentId,
             isPlayed: anchoredIsPlayed(episode)
-        ))
-        .accessibilityValue("Episode \(index + 1) of \(max(episodes.count, 1))")
-
-        if onPlay != nil || onSetWatched != nil || onSetFavorite != nil {
-            button.contextMenu { anchoredContextActions }
-        } else {
-            button
-        }
+        )
     }
 
-    /// A one-point focusable strip just outside the card strip. It never
-    /// renders and never keeps focus; it only exists so the focus engine has
-    /// an in-rail destination at each hard edge.
-    private func anchoredEdgeFocusGuide(_ id: String) -> some View {
-        Color.clear
-            .frame(width: 1, height: anchoredRailHeight)
-            .focusable(true)
-            .focused($focusedCardId, equals: id)
-            .focusEffectDisabled()
-            .accessibilityHidden(true)
+    private func moveEpisode(by direction: Int) {
+        guard railHasFocus, let episode = anchoredEpisode else { return }
+        let next = anchoredEpisodeIndex + direction
+        if episodes.indices.contains(next) {
+            pendingEdge = nil
+            anchoredFocusedContentId = episodes[next].contentId
+        } else {
+            requestEpisodesAtBoundary(from: episode.contentId, direction: direction)
+        }
     }
 
     private var anchoredCardWidth: CGFloat {
@@ -289,12 +348,11 @@ struct TVEpisodeRail: View {
     }
 
     private var anchoredEpisode: EpisodeListItem? {
-        guard episodes.indices.contains(anchoredIndex) else { return episodes.first }
-        return episodes[anchoredIndex]
+        episodes.first(where: { $0.contentId == (anchoredFocusedContentId ?? anchoredContentId) }) ?? episodes.first
     }
 
-    private var episodeIdentityKey: String {
-        episodes.map(\.contentId).joined(separator: "|")
+    private var episodeIdentityKey: [String] {
+        episodes.map(\.contentId)
     }
 
     private func anchoredContentOffset(
@@ -333,53 +391,81 @@ struct TVEpisodeRail: View {
         return max(0, desiredMaximumOffset - naturalMaximumOffset)
     }
 
-    private func seedAnchoredIndex(viewportWidth: CGFloat) {
-        let seededIndex: Int
-        if let currentContentId,
-           let index = episodes.firstIndex(where: { $0.contentId == currentContentId }) {
-            seededIndex = index
-        } else {
-            seededIndex = min(anchoredIndex, max(episodes.count - 1, 0))
-        }
+    private func seedAnchoredSelection(
+        viewportWidth: CGFloat,
+        targetContentId: String? = nil,
+        animated: Bool = false
+    ) {
+        let target = targetContentId ?? anchoredFocusedContentId ?? currentContentId
+        let episode = episodes.first(where: { $0.contentId == target }) ?? anchoredEpisode
+        guard let episode,
+              let index = episodes.firstIndex(where: { $0.contentId == episode.contentId }) else { return }
+        anchoredContentId = episode.contentId
+        moveAnchoredScroll(to: index, viewportWidth: viewportWidth, animated: animated)
+    }
 
-        // A newly inserted season page inherits the outer pan transaction.
-        // Seeding its internal episode offset inside that same animation made
-        // the cards briefly travel the opposite way while the page itself was
-        // moving correctly. Mount at the resolved index with no animation;
-        // user-driven episode moves retain their normal smooth transition.
-        var transaction = Transaction(animation: nil)
-        transaction.disablesAnimations = true
-        withTransaction(transaction) {
-            anchoredIndex = seededIndex
-            anchoredScrollPosition.scrollTo(
-                x: anchoredContentOffset(
-                    for: seededIndex,
-                    viewportWidth: viewportWidth
-                )
-            )
+    private func requestEpisodesAtBoundary(from contentId: String, direction: Int) {
+        let boundary = direction < 0 ? episodes.first : episodes.last
+        guard boundary?.contentId == contentId,
+              let request = direction < 0 ? onRequestPrevious : onRequestNext else { return }
+        pendingEdge = PendingEdge(contentId: contentId, direction: direction)
+        request()
+    }
+
+    private func completePendingEdge(viewportWidth: CGFloat) {
+        guard let pendingEdge, anchoredFocusedContentId == pendingEdge.contentId,
+              let index = episodes.firstIndex(where: { $0.contentId == pendingEdge.contentId }),
+              episodes.indices.contains(index + pendingEdge.direction) else { return }
+        let target = episodes[index + pendingEdge.direction].contentId
+        seedAnchoredSelection(viewportWidth: viewportWidth, targetContentId: target)
+        // The user's boundary press owns this handoff. Cancel it if another
+        // card or region took focus while the missing season was loading.
+        DispatchQueue.main.async {
+            guard self.pendingEdge == pendingEdge,
+                  anchoredFocusedContentId == pendingEdge.contentId,
+                  episodes.contains(where: { $0.contentId == target }) else { return }
+            self.pendingEdge = nil
+            anchoredFocusedContentId = target
         }
     }
 
-    private func anchorFocusedSelection(
-        at index: Int,
-        viewportWidth: CGFloat
-    ) {
+    private func anchorFocusedSelection(at index: Int, viewportWidth: CGFloat) {
         guard episodes.indices.contains(index) else { return }
+        anchoredContentId = episodes[index].contentId
+        moveAnchoredScroll(to: index, viewportWidth: viewportWidth, animated: true)
+    }
 
-        // Keep focus/selection state out of the scroll animation transaction.
-        // That prevents hero metadata and every card from inheriting the
-        // carousel's animation while the native ScrollView moves its content.
-        anchoredIndex = index
-        let targetOffset = anchoredContentOffset(
-            for: index,
-            viewportWidth: viewportWidth
-        )
-        if reduceMotion {
+    private func cancelNativeScrollCorrection() {
+        guard scrollViewport.correctionTarget != nil else { return }
+        scrollViewport.correctionTarget = nil
+        if let scrollView = scrollViewport.scrollView {
+            scrollView.setContentOffset(scrollView.contentOffset, animated: false)
+        }
+    }
+
+    private func moveAnchoredScroll(to index: Int, viewportWidth: CGFloat, animated: Bool) {
+        scrollGeneration &+= 1
+        let generation = scrollGeneration
+        cancelNativeScrollCorrection()
+        let targetOffset = anchoredContentOffset(for: index, viewportWidth: viewportWidth)
+        let animation: Animation = animated && !reduceMotion
+            ? .easeOut(duration: 0.30)
+            : .linear(duration: 0)
+        withAnimation(animation, completionCriteria: .removed) {
             anchoredScrollPosition.scrollTo(x: targetOffset)
-        } else {
-            withAnimation(.smooth(duration: 0.30, extraBounce: 0)) {
-                anchoredScrollPosition.scrollTo(x: targetOffset)
-            }
+        } completion: {
+            // Dispatching a scroll is not proof it reached the destination.
+            // A replaced animation or lazy layout can leave the viewport at
+            // an intermediate season. Only the latest completed trip may
+            // settle it, after SwiftUI has removed that animation.
+            guard generation == scrollGeneration,
+                  let scrollView = scrollViewport.scrollView,
+                  abs(scrollView.contentOffset.x - targetOffset) > 0.5 else { return }
+            scrollViewport.correctionTarget = reduceMotion ? nil : targetOffset
+            scrollView.setContentOffset(
+                CGPoint(x: targetOffset, y: scrollView.contentOffset.y),
+                animated: !reduceMotion
+            )
         }
     }
 
@@ -456,38 +542,6 @@ struct TVEpisodeRail: View {
                 }
             }
         }
-    }
-}
-
-/// The native button owns focus and sound, while the artwork supplies the
-/// existing Home-style hover without adding a second system lift effect.
-/// Focus identities for the anchored rail's edge guides. They share the
-/// episode `@FocusState` so the rail can bounce them back to a real card.
-private enum AnchoredEdgeFocusGuide {
-    static let leading = "silo.episodeRail.edge.leading"
-    static let trailing = "silo.episodeRail.edge.trailing"
-
-    static func edgeEpisode(
-        for focusedId: String?,
-        in episodes: [EpisodeListItem]
-    ) -> String? {
-        switch focusedId {
-        case leading: return episodes.first?.contentId
-        case trailing: return episodes.last?.contentId
-        default: return nil
-        }
-    }
-}
-
-private struct TVAnchoredEpisodeButtonStyle: ButtonStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .opacity(configuration.isPressed ? 0.96 : 1)
-            .focusEffectDisabled()
-            .animation(
-                .easeOut(duration: SiloTheme.fastDuration),
-                value: configuration.isPressed
-            )
     }
 }
 

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
@@ -14,6 +14,7 @@ struct TVItemDetailView: View {
     let seed: TVItemDetailRouteSeed?
 
     @State private var viewModel: ItemDetailViewModel
+    @State private var hasStartedDetailLoad = false
     /// Set when the user explicitly resets subtitles to "Auto" this visit:
     /// the server override is cleared with a fire-and-forget DELETE, but the
     /// already-fetched detail still carries the old `effectiveSubtitle*`, so
@@ -31,11 +32,11 @@ struct TVItemDetailView: View {
     @State private var failedSeriesRedirectEpisodeContentId: String?
     @State private var isLoadingNextUpPlaybackDetail = false
     @State private var didLoadNextUpPlaybackDetail = false
+    @State private var carouselLoadFailed = false
+    @State private var carouselRetryGeneration = 0
     /// Serializes rapid season-tab intent before it reaches the async view
     /// model. A superseded task must never begin after its replacement and
     /// make an older season the selected one.
-    @State private var seriesSeasonSelectionTask: Task<Void, Never>?
-    @State private var seriesSeasonSelectionGeneration = 0
     /// Whether remote YouTube trailers should be presented, probed once per
     /// page appearance. Real Apple TVs require the YouTube app because tvOS
     /// has no browser fallback. The simulator deliberately presents the
@@ -54,9 +55,7 @@ struct TVItemDetailView: View {
         self.seed = seed
         // Resolve the cached view model eagerly so the first `body`
         // evaluation can render cached content without a blank frame.
-        _viewModel = State(
-            initialValue: ItemDetailCache.shared.viewModel(for: contentId)
-        )
+        _viewModel = State(initialValue: ItemDetailCache.shared.viewModel(for: contentId))
     }
 
     var body: some View {
@@ -64,7 +63,9 @@ struct TVItemDetailView: View {
             // Skip the spinner on cache hits — `detail != nil` means we
             // already have something to paint and the `.task` below is
             // refreshing it in the background.
-            if let detail = viewModel.detail {
+            if !hasStartedDetailLoad, seed?.episodeContext?.seriesContentId == contentId {
+                TVItemDetailLoadingView(seed: seed)
+            } else if let detail = viewModel.detail {
                 content(for: detail)
             } else if let error = viewModel.error {
                 ErrorView(state: error, onRetry: { Task { await viewModel.loadDetail(contentId: contentId) } })
@@ -86,8 +87,6 @@ struct TVItemDetailView: View {
             viewModel.resumeTrailerFetchIfNeeded()
         }
         .onDisappear {
-            seriesSeasonSelectionTask?.cancel()
-            seriesSeasonSelectionTask = nil
             Self.focusLogger.debug("itemDetail.disappear contentId=\(contentId, privacy: .public) pathDepth=\(router.path.count, privacy: .public)")
             viewModel.cancelDeferredEpisodeFavoriteStateRefresh()
             // The coordinator's poll is not owned by `.task`, so it would
@@ -115,12 +114,9 @@ struct TVItemDetailView: View {
             }
         }
         .task(id: contentId) {
-            seriesSeasonSelectionTask?.cancel()
-            seriesSeasonSelectionTask = nil
-            seriesSeasonSelectionGeneration &+= 1
-            let navigationContext = TVSeriesDetailNavigationContextStore.take(
-                for: contentId
-            )
+            let navigationContext = !hasStartedDetailLoad
+                && seed?.episodeContext?.seriesContentId == contentId
+                ? seed?.episodeContext : nil
             didClearSubtitleOverride = false
             didClearNextUpSubtitleOverride = false
             nextUpPlaybackDetail = nil
@@ -129,10 +125,15 @@ struct TVItemDetailView: View {
             failedSeriesRedirectEpisodeContentId = nil
             isLoadingNextUpPlaybackDetail = false
             didLoadNextUpPlaybackDetail = false
-            await viewModel.loadDetail(contentId: contentId)
-            if let navigationContext, !Task.isCancelled {
-                await applySeriesNavigationContext(navigationContext)
+            if let navigationContext {
+                viewModel.prepareInitialSeriesSeason(
+                    navigationContext.seasonNumber, seriesId: contentId
+                )
+            } else {
+                viewModel.initialResumeSeasonNumber = viewModel.selectedSeason?.seasonNumber
             }
+            hasStartedDetailLoad = true
+            await viewModel.loadDetail(contentId: contentId)
             seedSubtitleOverrideIfNeeded()
         }
         .onReceive(NotificationCenter.default.publisher(for: .tvPlaybackStateDidRefresh)) { note in
@@ -147,24 +148,6 @@ struct TVItemDetailView: View {
     private var preferredVersionFileId: Int? {
         get { viewModel.preferredVersionFileId }
         nonmutating set { viewModel.preferredVersionFileId = newValue }
-    }
-
-    /// Continue Watching episodes open the combined Series page at their exact
-    /// season and episode. The marquee has normally warmed this hierarchy, but
-    /// this post-load resolution is authoritative when cached preference state
-    /// points at a different in-progress season.
-    private func applySeriesNavigationContext(
-        _ context: TVSeriesDetailNavigationContextStore.Context
-    ) async {
-        guard viewModel.detail?.type == "series" else { return }
-        if viewModel.selectedSeason?.seasonNumber != context.seasonNumber,
-           let season = viewModel.seasons.first(where: {
-               $0.seasonNumber == context.seasonNumber
-           }) {
-            await viewModel.selectSeason(season)
-        }
-        guard !Task.isCancelled else { return }
-        activeSeriesEpisodeContentId = context.episodeContentId
     }
 
     /// The cache has already reloaded authoritative watched/progress data when
@@ -193,12 +176,13 @@ struct TVItemDetailView: View {
         }
 
         if let activeSeriesEpisodeContentId,
-           let completedIndex = viewModel.episodes.firstIndex(where: {
+           let completedIndex = viewModel.seriesEpisodeWindow.episodes.firstIndex(where: {
                $0.contentId == activeSeriesEpisodeContentId
            }),
-           let next = viewModel.episodes.dropFirst(completedIndex + 1).first(where: {
+           let next = viewModel.seriesEpisodeWindow.episodes.dropFirst(completedIndex + 1).first(where: {
                !($0.userData?.played ?? false)
            }) {
+            viewModel.activateLoadedSeriesEpisode(next.contentId)
             self.activeSeriesEpisodeContentId = next.contentId
             return
         }
@@ -420,7 +404,13 @@ struct TVItemDetailView: View {
                 seasons: viewModel.seasons,
                 selectedSeason: viewModel.selectedSeason,
                 episodes: viewModel.episodes,
-                episodesBySeason: viewModel.episodesBySeason,
+                episodeWindow: viewModel.seriesEpisodeWindow,
+                carouselLoadFailed: carouselLoadFailed,
+                onLoadMoreEpisodes: { _ in
+                    // Neighbors already load as focus approaches. Repeated
+                    // edge presses must not cancel and restart that request.
+                    if carouselLoadFailed { carouselRetryGeneration &+= 1 }
+                },
                 activeEpisodeContentId: activeSeriesEpisodeContentId,
                 episodeFavoriteStates: viewModel.episodeFavoriteStates,
                 isLoadingEpisodes: viewModel.isLoadingEpisodes,
@@ -428,8 +418,6 @@ struct TVItemDetailView: View {
                 selectedNextUpAudioTrackIndex: preferredNextUpAudioTrackIndex,
                 selectedNextUpSubtitleTrackIndex: preferredNextUpSubtitleTrackIndex,
                 nextUpPlaybackDetail: nextUpPlaybackDetail,
-                isLoadingNextUpPlaybackDetail: isLoadingNextUpPlaybackDetail,
-                didLoadNextUpPlaybackDetail: didLoadNextUpPlaybackDetail,
                 nextUpSubtitleOverrideCleared: didClearNextUpSubtitleOverride,
                 trailerEntries: trailerEntries(for: detail),
                 onSelectTrailer: playTrailer,
@@ -446,23 +434,21 @@ struct TVItemDetailView: View {
                 onTrailerStatusShown: { viewModel.trailerFetch.acknowledge() },
                 onSelectSeason: { season in
                     activeSeriesEpisodeContentId = nil
-                    seriesSeasonSelectionTask?.cancel()
-                    seriesSeasonSelectionGeneration &+= 1
-                    let generation = seriesSeasonSelectionGeneration
-                    seriesSeasonSelectionTask = Task { @MainActor in
-                        guard !Task.isCancelled,
-                              generation == seriesSeasonSelectionGeneration else { return }
-                        await viewModel.selectSeason(season)
-                        guard !Task.isCancelled,
-                              generation == seriesSeasonSelectionGeneration else { return }
-                        seriesSeasonSelectionTask = nil
-                    }
+                    await viewModel.selectSeason(season)
+                    guard !Task.isCancelled,
+                          viewModel.selectedSeason?.id == season.id,
+                          let first = viewModel.episodes.first,
+                          first.seasonNumber == season.seasonNumber else { return nil }
+                    return first.contentId
                 },
                 onActivateEpisode: { id in
+                    if let id {
+                        viewModel.activateLoadedSeriesEpisode(id)
+                    }
                     activeSeriesEpisodeContentId = id
                 },
                 onPlayEpisode: { id, fileId, startFromBeginning in
-                    let episode = viewModel.episodes.first(where: { $0.contentId == id })
+                    let episode = viewModel.seriesEpisodeWindow.episodes.first(where: { $0.contentId == id })
                     let resumePosition = startFromBeginning
                         ? nil
                         : playableResumePosition(
@@ -556,11 +542,16 @@ struct TVItemDetailView: View {
                         .id(detail.contentId)
                 }
             )
+            .task(id: activeSeriesEpisodeContentId) {
+                guard let id = activeSeriesEpisodeContentId else { return }
+                do { try await Task.sleep(for: .milliseconds(120)) } catch { return }
+                await viewModel.refreshSeriesEpisodeFavorite(contentId: id)
+            }
             .task(id: seriesNextUpEpisodeContentId(for: detail)) {
                 await loadSeriesNextUpPlaybackDetail(for: detail)
             }
             .task(
-                id: viewModel.selectedSeason?.contentId,
+                id: "\(detail.contentId):\(viewModel.selectedSeason?.seasonNumber ?? -1):\(carouselRetryGeneration)",
                 priority: .background
             ) {
                 await prefetchAdjacentSeriesSeasons(for: detail)
@@ -719,7 +710,7 @@ struct TVItemDetailView: View {
 
     private func episodeSeriesDestination(
         for detail: ItemDetail
-    ) -> TVSeriesDetailNavigationContextStore.Context? {
+    ) -> TVItemDetailRouteSeed.EpisodeContext? {
         guard detail.type == "episode",
               let rawSeriesId = detail.seriesId,
               let seasonNumber = detail.seasonNumber else { return nil }
@@ -727,7 +718,7 @@ struct TVItemDetailView: View {
         let seriesId = rawSeriesId.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !seriesId.isEmpty, seriesId != detail.contentId else { return nil }
 
-        return TVSeriesDetailNavigationContextStore.Context(
+        return TVItemDetailRouteSeed.EpisodeContext(
             seriesContentId: seriesId,
             seasonNumber: seasonNumber,
             episodeContentId: detail.contentId
@@ -735,12 +726,12 @@ struct TVItemDetailView: View {
     }
 
     private func redirectEpisodeToSeries(
-        _ destination: TVSeriesDetailNavigationContextStore.Context
+        _ destination: TVItemDetailRouteSeed.EpisodeContext
     ) async {
         let cacheKey = CacheKey.itemDetail(destination.seriesContentId)
         if let cached: ItemDetail = ResponseCache.shared.get(cacheKey),
            cached.type == "series" {
-            routeToSeries(destination)
+            routeToSeries(destination, series: cached)
             return
         }
 
@@ -755,7 +746,7 @@ struct TVItemDetailView: View {
                 return
             }
             ResponseCache.shared.set(series, for: cacheKey)
-            routeToSeries(destination)
+            routeToSeries(destination, series: series)
         } catch {
             guard !Task.isCancelled,
                   contentId == destination.episodeContentId else { return }
@@ -764,16 +755,15 @@ struct TVItemDetailView: View {
     }
 
     private func routeToSeries(
-        _ destination: TVSeriesDetailNavigationContextStore.Context
+        _ destination: TVItemDetailRouteSeed.EpisodeContext,
+        series: ItemDetail
     ) {
         guard contentId == destination.episodeContentId else { return }
-        TVSeriesDetailNavigationContextStore.stage(
-            seriesContentId: destination.seriesContentId,
-            seasonNumber: destination.seasonNumber,
-            episodeContentId: destination.episodeContentId
-        )
         router.replaceCurrent(
-            with: .itemDetail(contentId: destination.seriesContentId)
+            with: .itemDetail(
+                contentId: destination.seriesContentId,
+                tvSeed: TVItemDetailRouteSeed(series, episodeContext: destination)
+            )
         )
     }
 
@@ -1043,7 +1033,7 @@ struct TVItemDetailView: View {
     private func seriesNextUpEpisode(for detail: ItemDetail) -> EpisodeListItem? {
         guard detail.type == "series" else { return nil }
         if let activeSeriesEpisodeContentId,
-           let active = viewModel.episodes.first(where: {
+           let active = viewModel.seriesEpisodeWindow.episodes.first(where: {
                $0.contentId == activeSeriesEpisodeContentId
            }) {
             return active
@@ -1094,6 +1084,11 @@ struct TVItemDetailView: View {
         }
 
         do {
+            // Paint the episode and any cached selectors immediately. Wait
+            // only on uncached network work while focus sweeps through cards.
+            if activeSeriesEpisodeContentId != nil {
+                try await Task.sleep(for: .milliseconds(120))
+            }
             let item = try await MetadataRequestPool.shared.itemDetail(contentId: nextUp.contentId)
             guard !Task.isCancelled else { return }
             let enriched = await enrichPlaybackMetadata(for: item, contentId: nextUp.contentId)
@@ -1143,16 +1138,17 @@ struct TVItemDetailView: View {
     private func prefetchAdjacentEpisodePlayback(
         around episode: EpisodeListItem
     ) async {
-        guard let index = viewModel.episodes.firstIndex(where: {
+        let episodes = viewModel.seriesEpisodeWindow.episodes
+        guard let index = episodes.firstIndex(where: {
             $0.contentId == episode.contentId
         }) else { return }
 
         let neighborIndices = [index - 1, index + 1]
-            .filter { viewModel.episodes.indices.contains($0) }
+            .filter { episodes.indices.contains($0) }
 
         for neighborIndex in neighborIndices {
             guard !Task.isCancelled else { return }
-            let neighbor = viewModel.episodes[neighborIndex]
+            let neighbor = episodes[neighborIndex]
             let cached: ItemDetail? = ResponseCache.shared.get(
                 CacheKey.itemDetail(neighbor.contentId)
             )
@@ -1173,53 +1169,70 @@ struct TVItemDetailView: View {
         }
     }
 
-    /// Prefetch the episode lists and stills for the seasons beside the
-    /// selected one. `ItemDetailViewModel.selectSeason` already hydrates from
-    /// this same cache key, so first-time season changes avoid the empty/jumpy
-    /// state without duplicating ownership of the published episode array.
+    /// Load only the neighboring pages, walking through known empty seasons.
+    /// Keep artwork warming to the cards beside each boundary, not every still
+    /// in two potentially enormous seasons. The rail loads visible art lazily.
     private func prefetchAdjacentSeriesSeasons(for detail: ItemDetail) async {
-        guard detail.type == "series",
-              let selectedSeason = viewModel.selectedSeason,
-              let index = viewModel.seasons.firstIndex(where: {
-                  $0.contentId == selectedSeason.contentId
-              }) else { return }
+        guard detail.type == "series", let selected = viewModel.selectedSeason?.seasonNumber else { return }
+        let order = SeriesEpisodeWindow.orderedSeasons(viewModel.seasons)
+        guard let selectedIndex = order.firstIndex(where: { $0.seasonNumber == selected }) else { return }
+        carouselLoadFailed = false
+        viewModel.episodesBySeason = SeriesEpisodeWindow.retainedPages(
+            seasons: viewModel.seasons, selected: selected, pages: viewModel.episodesBySeason
+        )
+        async let previous: Void = prefetchSeriesSeasonNeighbor(
+            direction: -1, order: order, selectedIndex: selectedIndex, detail: detail
+        )
+        async let next: Void = prefetchSeriesSeasonNeighbor(
+            direction: 1, order: order, selectedIndex: selectedIndex, detail: detail
+        )
+        _ = await (previous, next)
+    }
 
-        let neighborIndices = [index - 1, index + 1]
-            .filter { viewModel.seasons.indices.contains($0) }
-
-        for neighborIndex in neighborIndices {
-            guard !Task.isCancelled else { return }
-            let season = viewModel.seasons[neighborIndex]
-            let key = CacheKey.itemEpisodes(
-                seriesId: detail.contentId,
-                seasonNumber: season.seasonNumber
-            )
-
-            let response: EpisodesResponse
-            if let cached: EpisodesResponse = ResponseCache.shared.get(key) {
-                response = cached
-            } else {
-                guard let fetched = try? await MetadataRequestPool.shared.episodes(
-                    seriesId: detail.contentId,
-                    seasonNumber: season.seasonNumber
-                ), !Task.isCancelled else { continue }
-                ResponseCache.shared.set(fetched, for: key)
-                response = fetched
+    private func prefetchSeriesSeasonNeighbor(
+        direction: Int, order: [Season], selectedIndex: Int, detail: ItemDetail
+    ) async {
+        let selected = order[selectedIndex].seasonNumber
+        var index = selectedIndex + direction
+        while order.indices.contains(index) {
+            guard !Task.isCancelled, viewModel.selectedSeason?.seasonNumber == selected else { return }
+            let season = order[index]
+            if let page = viewModel.episodesBySeason[season.seasonNumber] {
+                if !page.isEmpty { break }
+                index += direction
+                continue
             }
-
-            let stillURLs = response.episodes.compactMap { episode in
-                episode.stillUrl.flatMap(URL.init(string:))
-            }
-            PosterImageCache.prefetchCardArtwork(stillURLs)
-
-            let sorted = response.episodes.sorted {
-                $0.episodeNumber < $1.episodeNumber
-            }
-            if viewModel.episodesBySeason[season.seasonNumber] == nil {
-                // Feed the route-scoped page cache as well as ResponseCache.
-                // The full season rail can then mount this neighbour before
-                // the first tab movement instead of warming only after it.
-                viewModel.episodesBySeason[season.seasonNumber] = sorted
+            let key = CacheKey.itemEpisodes(seriesId: detail.contentId, seasonNumber: season.seasonNumber)
+            do {
+                let response: EpisodesResponse
+                if let cached: EpisodesResponse = ResponseCache.shared.get(key) {
+                    response = cached
+                } else {
+                    response = try await MetadataRequestPool.shared.episodes(
+                        seriesId: detail.contentId, seasonNumber: season.seasonNumber
+                    )
+                }
+                guard !Task.isCancelled, viewModel.selectedSeason?.seasonNumber == selected,
+                      viewModel.detail?.contentId == detail.contentId else { return }
+                ResponseCache.shared.set(response, for: key)
+                let sorted = response.episodes.sorted { $0.episodeNumber < $1.episodeNumber }
+                // A foreground selection may already have published newer progress.
+                if viewModel.episodesBySeason[season.seasonNumber] == nil {
+                    viewModel.episodesBySeason[season.seasonNumber] = sorted
+                }
+                viewModel.episodesBySeason = SeriesEpisodeWindow.retainedPages(
+                    seasons: viewModel.seasons, selected: selected, pages: viewModel.episodesBySeason
+                )
+                let edgeEpisodes = direction < 0 ? Array(sorted.suffix(3)) : Array(sorted.prefix(3))
+                PosterImageCache.prefetchCardArtwork(edgeEpisodes.compactMap {
+                    $0.stillUrl.flatMap(URL.init(string:))
+                })
+                if !sorted.isEmpty { break }
+                index += direction
+            } catch {
+                guard !Task.isCancelled else { return }
+                carouselLoadFailed = true
+                break
             }
         }
     }
@@ -1296,36 +1309,4 @@ struct TVItemDetailView: View {
     }
 }
 
-/// One-shot route payload for opening an episode in its parent Series overview.
-/// `Route.itemDetail` remains a shared iOS/tvOS destination; this tvOS-only
-/// store supplies the extra browse context without widening every platform's
-/// navigation enum.
-@MainActor
-enum TVSeriesDetailNavigationContextStore {
-    struct Context: Equatable {
-        let seriesContentId: String
-        let seasonNumber: Int
-        let episodeContentId: String
-    }
-
-    private static var pending: Context?
-
-    static func stage(
-        seriesContentId: String,
-        seasonNumber: Int,
-        episodeContentId: String
-    ) {
-        pending = Context(
-            seriesContentId: seriesContentId,
-            seasonNumber: seasonNumber,
-            episodeContentId: episodeContentId
-        )
-    }
-
-    static func take(for contentId: String) -> Context? {
-        guard pending?.seriesContentId == contentId else { return nil }
-        defer { pending = nil }
-        return pending
-    }
-}
 #endif

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -11,23 +11,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         case outside
         case mode
         case episodes
-    }
-
-    /// Stable data for one page in the full linear season rail. Page geometry
-    /// is owned by the season list; only loaded season content is retained.
-    private struct SeasonPageSnapshot {
-        let seasonId: String
-        let episodes: [EpisodeListItem]
-        let currentContentId: String?
-        let isLoading: Bool
-    }
-
-    /// Mutable observation storage that deliberately does not invalidate the
-    /// large detail view every display frame. It records the native scroll
-    /// view's presentation offset so a rapid reversal can stop the old motion
-    /// exactly where it is before issuing the newest destination.
-    private final class SeasonScrollTracker {
-        var liveOffset: CGFloat = 0
+        case supporting
     }
 
     /// Owns only the outer vertical UIScrollView. Locking this concrete scroll
@@ -40,7 +24,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     /// visibly is instead of letting two animations race to the finish.
     private final class PageScrollCoordinator {
         weak var scrollView: UIScrollView?
-        /// Marker view laid out behind the Cast section; its frame converted
+        /// Marker view laid out behind the first supporting section; its frame converted
         /// into the scroll view gives the centering target in content space.
         weak var supportingAnchorView: UIView?
         private var pageAnimator: UIViewPropertyAnimator?
@@ -88,7 +72,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
             }
         }
 
-        /// Centers the Cast section after focus leaves the fixed top viewport.
+        /// Centers the first supporting section after focus leaves the top viewport.
         /// Runs in the same animator slot as the return trip so that an Up
         /// press mid-descent stops this motion where it is and the return
         /// starts from that exact offset.
@@ -201,7 +185,9 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     let seasons: [Season]
     let selectedSeason: Season?
     let episodes: [EpisodeListItem]
-    let episodesBySeason: [Int: [EpisodeListItem]]
+    let episodeWindow: SeriesEpisodeWindow
+    let carouselLoadFailed: Bool
+    let onLoadMoreEpisodes: (Int) -> Void
     let activeEpisodeContentId: String?
     let episodeFavoriteStates: [String: Bool]
     let isLoadingEpisodes: Bool
@@ -209,8 +195,6 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     let selectedNextUpAudioTrackIndex: Int?
     let selectedNextUpSubtitleTrackIndex: Int?
     let nextUpPlaybackDetail: ItemDetail?
-    let isLoadingNextUpPlaybackDetail: Bool
-    let didLoadNextUpPlaybackDetail: Bool
     var nextUpSubtitleOverrideCleared = false
     let trailerEntries: [TrailerRailEntry]
     let onSelectTrailer: (TrailerRailEntry) -> Void
@@ -219,7 +203,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     let trailerFetchStatus: String?
     let isFetchingTrailers: Bool
     let onTrailerStatusShown: () -> Void
-    let onSelectSeason: (Season) -> Void
+    let onSelectSeason: (Season) async -> String?
     /// `nil` restores the show overview and its suggested next episode.
     let onActivateEpisode: (_ contentId: String?) -> Void
     let onPlayEpisode: (_ contentId: String, _ fileId: Int?, _ startFromBeginning: Bool) -> Void
@@ -241,23 +225,18 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     @FocusState private var showActionRowFocused: Bool
     @FocusState private var focusedModeId: String?
     @State private var isShowingSeriesOverview = true
-    @State private var focusedEpisodeContentId: String?
     @State private var primaryFocusRegion: PrimaryFocusRegion = .outside
     @State private var episodeRailFocusRequest = 0
+    @State private var episodeRailFocusTarget: String?
     @State private var supportingRailFocusRequest = 0
     @State private var supportingRailFocusGeneration = 0
     @State private var modeActivationTask: Task<Void, Never>?
     @State private var modeFocusAppearanceTask: Task<Void, Never>?
     @State private var presentedFocusedModeId: String?
-    @State private var seasonTransitionInFlight = false
-    @State private var seasonTransitionTargetId: String?
-    @State private var seasonTransitionGeneration = 0
-    @State private var seasonTransitionTask: Task<Void, Never>?
-    @State private var visibleSeasonId: String?
-    @State private var seasonPageSnapshots: [String: SeasonPageSnapshot] = [:]
-    @State private var seasonPageScrollPosition = ScrollPosition(x: 0)
-    @State private var seasonPageViewportWidth: CGFloat = 0
-    @State private var seasonScrollTracker = SeasonScrollTracker()
+    @State private var hasPositionedModeRow = false
+    @State private var seasonSelection = SeriesSeasonSelection()
+    @State private var episodeScrollTarget: String?
+    @State private var episodeScrollRequest = 0
     @State private var pageScrollCoordinator = PageScrollCoordinator()
     @State private var uiCustomization = UICustomizationPreferences.shared
     @ObservedObject private var profilePrefsStore = ProfilePrefsStore.shared
@@ -293,18 +272,10 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                         .padding(.bottom, TVDetailLayout.pageBottomPadding)
                     }
                     .background {
-                        TVSeriesPageScrollResolver { scrollView in
+                        TVDetailScrollViewResolver { scrollView in
                             pageScrollCoordinator.attach(scrollView)
                         }
                     }
-                }
-                .onChange(of: supportingRailFocusRequest) { _, request in
-                    guard request > 0, hasCast else { return }
-                    // Drive this through the coordinator rather than the
-                    // SwiftUI proxy: a proxy animation cannot be cancelled, so
-                    // a quick Up used to run it against the return trip and
-                    // the page snapped when the loser finished.
-                    pageScrollCoordinator.revealSupporting(reduceMotion: reduceMotion)
                 }
                 .ignoresSafeArea()
                 .focusScope(detailFocusNamespace)
@@ -323,18 +294,10 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
             if activeEpisodeContentId != nil {
                 isShowingSeriesOverview = false
             }
-            synchronizeCurrentSeasonPage()
         }
         .onChange(of: activeEpisodeContentId) { _, contentId in
             if contentId != nil {
                 isShowingSeriesOverview = false
-            }
-        }
-        .onChange(of: seasonPageReadinessKey) { _, _ in
-            if seasonTransitionInFlight {
-                startSeasonScrollIfReady()
-            } else {
-                synchronizeCurrentSeasonPage()
             }
         }
         .onDisappear {
@@ -343,19 +306,8 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
             modeFocusAppearanceTask?.cancel()
             modeFocusAppearanceTask = nil
             presentedFocusedModeId = nil
-            seasonTransitionTask?.cancel()
-            seasonTransitionTask = nil
-            var transaction = Transaction(animation: nil)
-            transaction.disablesAnimations = true
-            withTransaction(transaction) {
-                seasonPageSnapshots.removeAll(keepingCapacity: false)
-                visibleSeasonId = nil
-                seasonPageScrollPosition = ScrollPosition(x: 0)
-                seasonScrollTracker.liveOffset = 0
-            }
+            seasonSelection.cancel()
             pageScrollCoordinator.detach()
-            seasonTransitionInFlight = false
-            seasonTransitionTargetId = nil
         }
     }
 
@@ -528,7 +480,12 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     private var episodeExperience: some View {
         VStack(alignment: .leading, spacing: 14) {
             modeRow
-            smoothlyChangingEpisodeBody
+            episodeBody
+            if carouselLoadFailed {
+                Text("Couldn't load more episodes. Press again to retry.")
+                    .font(.system(size: 18))
+                    .foregroundStyle(Color.siloSecondaryText)
+            }
             if let trailerFetchStatus {
                 TVTrailerStatusPill(
                     message: trailerFetchStatus,
@@ -543,7 +500,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         ScrollViewReader { proxy in
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 12) {
-                    ForEach(seasons) { season in
+                    ForEach(SeriesEpisodeWindow.orderedSeasons(seasons)) { season in
                         TVSeriesModeTab(
                             title: seasonLabel(season),
                             isSelected: selectedModeId == season.id,
@@ -552,6 +509,15 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                         )
                         .id(season.id)
                         .focused($focusedModeId, equals: season.id)
+                        .onMoveCommand { direction in
+                            guard direction == .down else { return }
+                            if !isLoadingEpisodes, let episode = displayedEpisode {
+                                episodeRailFocusTarget = episode.contentId
+                                episodeRailFocusRequest &+= 1
+                            } else {
+                                focusSupportingRail()
+                            }
+                        }
                     }
                 }
                 .padding(.vertical, 4)
@@ -564,6 +530,11 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                 selectedModeId,
                 priority: .userInitiated
             )
+            .onAppear {
+                guard selectedSeason != nil else { return }
+                proxy.scrollTo(selectedModeId, anchor: .center)
+                hasPositionedModeRow = true
+            }
             .onChange(of: selectedModeId) { _, newId in
                 // A click activates immediately, before the focus-paint dwell
                 // finishes. Promote that one focused tab without allowing an
@@ -573,8 +544,14 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                     modeFocusAppearanceTask = nil
                     presentedFocusedModeId = newId
                 }
-                withAnimation(.easeOut(duration: SiloTheme.fastDuration)) {
+                guard selectedSeason != nil else { return }
+                if hasPositionedModeRow {
+                    withAnimation(reduceMotion ? nil : .easeOut(duration: SiloTheme.fastDuration)) {
+                        proxy.scrollTo(newId, anchor: .center)
+                    }
+                } else {
                     proxy.scrollTo(newId, anchor: .center)
+                    hasPositionedModeRow = true
                 }
             }
             .onChange(of: focusedModeId) { _, focusedId in
@@ -582,11 +559,15 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                 guard let focusedId else {
                     modeActivationTask?.cancel()
                     modeActivationTask = nil
+                    if primaryFocusRegion == .mode {
+                        primaryFocusRegion = .outside
+                        pageScrollCoordinator.releasePrimary()
+                    }
                     return
                 }
                 let previousRegion = primaryFocusRegion
                 primaryFocusRegion = .mode
-                if previousRegion == .outside {
+                if previousRegion == .outside || previousRegion == .supporting {
                     pageScrollCoordinator.enterPrimary(
                         animated: true,
                         reduceMotion: reduceMotion
@@ -627,15 +608,13 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     /// The season pill stays selected while the hero shows series info, since
     /// the rail below still lists that season's episodes.
     private var selectedModeId: String {
-        seasonTransitionTargetId
-            ?? visibleSeasonId
-            ?? selectedSeason?.id
-            ?? noSeasonModeId
+        selectedSeason?.id ?? noSeasonModeId
     }
 
     private func showSeriesOverview() {
         modeActivationTask?.cancel()
         modeActivationTask = nil
+        seasonSelection.cancel()
         isShowingSeriesOverview = true
         onActivateEpisode(nil)
     }
@@ -644,173 +623,12 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         modeActivationTask?.cancel()
         modeActivationTask = nil
         isShowingSeriesOverview = false
-        if seasonTransitionInFlight {
-            guard season.id != seasonTransitionTargetId else { return }
-            retargetSeasonTransition(to: season)
-            return
-        }
-        guard visibleSeasonId != season.id else {
-            return
-        }
-        beginSeasonTransition(to: season)
-    }
-
-    private func beginSeasonTransition(to season: Season) {
-        let currentPage = currentSeasonPageSnapshot
-        var transaction = Transaction(animation: nil)
-        transaction.disablesAnimations = true
-        withTransaction(transaction) {
-            seasonPageSnapshots[currentPage.seasonId] = currentPage
-            visibleSeasonId = currentPage.seasonId
-        }
-
-        seasonTransitionTask?.cancel()
-        seasonTransitionTask = nil
-        seasonTransitionGeneration &+= 1
-        seasonTransitionInFlight = true
-        seasonTransitionTargetId = season.id
         onActivateEpisode(nil)
-        onSelectSeason(season)
-        startMountedSeasonScrollIfAvailable(to: season.id)
-    }
-
-    private func retargetSeasonTransition(to season: Season) {
-        // Stop the current native animation at its presentation offset before
-        // giving it a new destination. Without this freeze, several opposing
-        // setContentOffset animations can finish out of order under rapid taps.
-        seasonTransitionTask?.cancel()
-        seasonTransitionTask = nil
-        freezeSeasonScrollAtLiveOffset()
-        seasonTransitionGeneration &+= 1
-        seasonTransitionTargetId = season.id
-        onActivateEpisode(nil)
-        onSelectSeason(season)
-        startMountedSeasonScrollIfAvailable(to: season.id)
-    }
-
-    private func startSeasonScrollIfReady() {
-        guard seasonTransitionInFlight,
-              seasonTransitionTask == nil,
-              let targetId = seasonTransitionTargetId,
-              selectedSeason?.id == targetId,
-              let targetSeason = seasons.first(where: { $0.id == targetId }),
-              !isLoadingEpisodes,
-              seasonPageViewportWidth > 0 else { return }
-
-        // The selected season publishes before its episode request completes.
-        // Do not move the old page toward a loading placeholder or stale rows;
-        // the complete incoming rail must be mounted before native scrolling.
-        guard episodes.isEmpty || episodes.allSatisfy({
-            $0.seasonNumber == targetSeason.seasonNumber
-        }) else { return }
-
-        let incomingPage = currentSeasonPageSnapshot
-        guard incomingPage.seasonId == targetId,
-              let destinationOffset = seasonPageOffset(
-                for: targetId,
-                pageWidth: seasonPageViewportWidth
-              ) else { return }
-
-        var mountTransaction = Transaction(animation: nil)
-        mountTransaction.disablesAnimations = true
-        withTransaction(mountTransaction) {
-            // Populate the target's permanent slot before the rail moves. The
-            // old and new seasons now coexist as literal neighbours in one
-            // HStack, rather than swapping through a temporary side page.
-            seasonPageSnapshots[targetId] = incomingPage
+        seasonSelection.select(season, load: onSelectSeason) { contentId in
+            episodeScrollTarget = contentId
+            onActivateEpisode(contentId)
+            episodeScrollRequest &+= 1
         }
-        startSeasonScroll(
-            to: targetId,
-            destinationOffset: destinationOffset,
-            waitsForPageMount: true
-        )
-    }
-
-    private func startMountedSeasonScrollIfAvailable(to targetId: String) {
-        guard let targetSeason = seasons.first(where: { $0.id == targetId }),
-              let mountedPage = availableSeasonPage(for: targetSeason),
-              let destinationOffset = seasonPageOffset(
-                for: targetId,
-                pageWidth: seasonPageViewportWidth
-              ) else { return }
-        if seasonPageSnapshots[targetId] == nil {
-            var transaction = Transaction(animation: nil)
-            transaction.disablesAnimations = true
-            withTransaction(transaction) {
-                seasonPageSnapshots[targetId] = mountedPage
-            }
-        }
-        startSeasonScroll(
-            to: targetId,
-            destinationOffset: destinationOffset,
-            waitsForPageMount: false
-        )
-    }
-
-    private func startSeasonScroll(
-        to targetId: String,
-        destinationOffset: CGFloat,
-        waitsForPageMount: Bool
-    ) {
-        guard seasonTransitionInFlight,
-              seasonTransitionTargetId == targetId,
-              seasonTransitionTask == nil else { return }
-
-        let generation = seasonTransitionGeneration
-        seasonTransitionTask = Task { @MainActor in
-            await Task.yield()
-            if waitsForPageMount && !reduceMotion {
-                try? await Task.sleep(for: .milliseconds(17))
-            }
-            guard !Task.isCancelled,
-                  generation == seasonTransitionGeneration else { return }
-
-            withAnimation(
-                reduceMotion
-                    ? nil
-                    : .timingCurve(0.4, 0, 0.2, 1, duration: 0.46)
-            ) {
-                seasonPageScrollPosition = ScrollPosition(x: destinationOffset)
-            }
-
-            if !reduceMotion {
-                try? await Task.sleep(for: .milliseconds(480))
-            } else {
-                await Task.yield()
-            }
-            guard !Task.isCancelled,
-                  generation == seasonTransitionGeneration else { return }
-            finishSeasonTransition()
-        }
-    }
-
-    private func finishSeasonTransition() {
-        guard let completedSeasonId = seasonTransitionTargetId else {
-            seasonTransitionInFlight = false
-            seasonTransitionTask = nil
-            return
-        }
-        var transaction = Transaction(animation: nil)
-        transaction.disablesAnimations = true
-        withTransaction(transaction) {
-            // Stay on the real destination page. There is deliberately no
-            // recenter, page deletion, or content replacement after scrolling.
-            visibleSeasonId = completedSeasonId
-            if let offset = seasonPageOffset(
-                for: completedSeasonId,
-                pageWidth: seasonPageViewportWidth
-            ) {
-                // Programmatic native scrolling can still be completing an
-                // older animation when direction reverses. Pin the final
-                // content offset to the latest requested season so the rail
-                // and selected tab can never settle on different pages.
-                seasonPageScrollPosition = ScrollPosition(x: offset)
-                seasonScrollTracker.liveOffset = offset
-            }
-        }
-        seasonTransitionInFlight = false
-        seasonTransitionTargetId = nil
-        seasonTransitionTask = nil
     }
 
     /// Season pills behave like tvOS tabs: resting focus activates one without
@@ -819,13 +637,12 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     private func scheduleModeActivation(for modeId: String) {
         modeActivationTask?.cancel()
         modeActivationTask = nil
-        guard modeId != selectedModeId else { return }
+        guard modeId != (seasonSelection.latestSeasonId ?? selectedModeId) else { return }
 
         modeActivationTask = Task { @MainActor in
             try? await Task.sleep(for: .milliseconds(70))
             guard !Task.isCancelled,
-                  focusedModeId == modeId,
-                  modeId != selectedModeId else { return }
+                  focusedModeId == modeId else { return }
 
             if let season = seasons.first(where: { $0.id == modeId }) {
                 activateSeason(season)
@@ -833,234 +650,51 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         }
     }
 
-    private var seasonPageReadinessKey: String {
-        let seasonId = selectedSeason?.id ?? noSeasonModeId
-        let loadingState = isLoadingEpisodes ? "loading" : "ready"
-        let episodeIds = episodes.map(\.contentId).joined(separator: "|")
-        return "\(seasonId):\(loadingState):\(episodeIds)"
-    }
-
-    private var currentSeasonPageSnapshot: SeasonPageSnapshot {
-        SeasonPageSnapshot(
-            seasonId: selectedSeason?.id ?? noSeasonModeId,
-            episodes: episodes,
-            currentContentId: displayedEpisode?.contentId,
-            isLoading: isLoadingEpisodes
-        )
-    }
-
-    private func synchronizeCurrentSeasonPage() {
-        guard !seasonTransitionInFlight else { return }
-        let page = currentSeasonPageSnapshot
-        var transaction = Transaction(animation: nil)
-        transaction.disablesAnimations = true
-        withTransaction(transaction) {
-            seasonPageSnapshots[page.seasonId] = page
-            visibleSeasonId = page.seasonId
-            if let offset = seasonPageOffset(
-                for: page.seasonId,
-                pageWidth: seasonPageViewportWidth
-            ) {
-                seasonPageScrollPosition = ScrollPosition(x: offset)
-                seasonScrollTracker.liveOffset = offset
-            }
-        }
-    }
-
-    /// The fixed season tabs select between full-width episode pages. The
-    /// inner episode carousel remains unchanged; this native outer ScrollView
-    /// moves the complete old and new season rails together as one page.
-    private var smoothlyChangingEpisodeBody: some View {
-        GeometryReader { geometry in
-            let width = geometry.size.width
-            let viewportWidth = width + TVDetailLayout.horizontalInset
-
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(alignment: .top, spacing: 0) {
-                    ForEach(seasons) { season in
-                        seasonRailPage(
-                            for: season,
-                            contentWidth: width,
-                            pageWidth: viewportWidth
-                        )
-                        .id(season.id)
-                        // Only the page currently inside the viewport may
-                        // participate in tvOS focus. Cached rails elsewhere on
-                        // the giant strip remain visual neighbours, not rival
-                        // focus destinations.
-                        .disabled(
-                            season.id != (visibleSeasonId ?? selectedSeason?.id)
-                        )
-                    }
-                }
-                .scrollTargetLayout()
-            }
-            .scrollPosition($seasonPageScrollPosition)
-            .scrollTargetBehavior(.paging)
-            .scrollDisabled(true)
-            .frame(
-                width: viewportWidth,
-                height: episodeRailReservedHeight,
-                alignment: .topLeading
-            )
-            .clipped()
-            .onScrollGeometryChange(for: CGFloat.self) { geometry in
-                geometry.contentOffset.x
-            } action: { _, liveOffset in
-                seasonScrollTracker.liveOffset = liveOffset
-            }
-            .onAppear {
-                updateSeasonPageViewportWidth(viewportWidth)
-            }
-            .onChange(of: viewportWidth) { _, newWidth in
-                updateSeasonPageViewportWidth(newWidth)
-            }
-        }
-        .frame(height: episodeRailReservedHeight, alignment: .topLeading)
-    }
-
-    /// Every real season owns one permanent, page-width position in a single
-    /// linear rail. Unloaded positions stay lightweight, while the current and
-    /// target episode carousels remain attached to their actual season slots.
+    /// One lazy native focus row spans the loaded season window. Season
+    /// chips scroll this row rather than mounting a second horizontal pager.
     @ViewBuilder
-    private func seasonRailPage(
-        for season: Season,
-        contentWidth: CGFloat,
-        pageWidth: CGFloat
-    ) -> some View {
-        if let page = availableSeasonPage(for: season) {
-            seasonEpisodeBody(page)
-                .frame(
-                    width: contentWidth,
-                    height: episodeRailReservedHeight,
-                    alignment: .topLeading
-                )
-                .frame(
-                    width: pageWidth,
-                    height: episodeRailReservedHeight,
-                    alignment: .topLeading
-                )
-        } else if !seasonTransitionInFlight, selectedSeason?.id == season.id {
-            seasonEpisodeBody(currentSeasonPageSnapshot)
-                .frame(
-                    width: contentWidth,
-                    height: episodeRailReservedHeight,
-                    alignment: .topLeading
-                )
-                .frame(
-                    width: pageWidth,
-                    height: episodeRailReservedHeight,
-                    alignment: .topLeading
-                )
-        } else {
-            Color.clear
-                .frame(
-                    width: pageWidth,
-                    height: episodeRailReservedHeight,
-                    alignment: .topLeading
-                )
-        }
-    }
-
-    private func availableSeasonPage(for season: Season) -> SeasonPageSnapshot? {
-        if let snapshot = seasonPageSnapshots[season.id] {
-            return snapshot
-        }
-        guard let cachedEpisodes = episodesBySeason[season.seasonNumber] else {
-            return nil
-        }
-        let suggestedContentId = cachedEpisodes.first(where: {
-            $0.userData?.isInProgress == true
-        })?.contentId ?? cachedEpisodes.first(where: {
-            !($0.userData?.played ?? false)
-        })?.contentId ?? cachedEpisodes.first?.contentId
-        return SeasonPageSnapshot(
-            seasonId: season.id,
-            episodes: cachedEpisodes,
-            currentContentId: suggestedContentId,
-            isLoading: false
-        )
-    }
-
-    private func updateSeasonPageViewportWidth(_ width: CGFloat) {
-        guard width > 0, width != seasonPageViewportWidth else { return }
-        var transaction = Transaction(animation: nil)
-        transaction.disablesAnimations = true
-        withTransaction(transaction) {
-            seasonPageViewportWidth = width
-            let seasonId = visibleSeasonId ?? selectedSeason?.id
-            let offset = seasonId.flatMap {
-                seasonPageOffset(for: $0, pageWidth: width)
-            } ?? 0
-            seasonPageScrollPosition = ScrollPosition(x: offset)
-            seasonScrollTracker.liveOffset = offset
-        }
-        startSeasonScrollIfReady()
-    }
-
-    private func freezeSeasonScrollAtLiveOffset() {
-        guard seasonPageViewportWidth > 0 else { return }
-        let lastOffset = CGFloat(max(seasons.count - 1, 0))
-            * seasonPageViewportWidth
-        let liveOffset = min(
-            max(seasonScrollTracker.liveOffset, 0),
-            lastOffset
-        )
-        var transaction = Transaction(animation: nil)
-        transaction.disablesAnimations = true
-        withTransaction(transaction) {
-            seasonPageScrollPosition = ScrollPosition(x: liveOffset)
-        }
-    }
-
-    private func seasonPageOffset(
-        for seasonId: String,
-        pageWidth: CGFloat
-    ) -> CGFloat? {
-        guard pageWidth > 0,
-              let index = seasons.firstIndex(where: { $0.id == seasonId }) else {
-            return nil
-        }
-        return CGFloat(index) * pageWidth
-    }
-
-    @ViewBuilder
-    private func seasonEpisodeBody(_ snapshot: SeasonPageSnapshot) -> some View {
-        if snapshot.isLoading {
+    private var episodeBody: some View {
+        let carouselEpisodes = episodeWindow.episodes
+        if isLoadingEpisodes && carouselEpisodes.isEmpty {
             TVEpisodeRailPlaceholder(
                 cardWidth: SiloTheme.thumbnailCardWidth
                     * uiCustomization.cardPresentation.posterSize.scale,
-                cardHeightRatio: SiloTheme.thumbnailCardHeight
-                    / SiloTheme.thumbnailCardWidth,
+                cardHeightRatio: SiloTheme.thumbnailCardHeight / SiloTheme.thumbnailCardWidth,
                 cardSpacing: 40,
                 hidesEpisodeTitle: true
             )
-        } else if snapshot.episodes.isEmpty {
+            .frame(height: episodeRailReservedHeight)
+        } else if carouselEpisodes.isEmpty {
             Text("No episodes available")
-                .font(.system(size: 22, weight: .regular))
-                .foregroundColor(.siloSecondaryText)
-                .frame(maxWidth: .infinity, alignment: .topLeading)
+                .font(.system(size: 22))
+                .foregroundStyle(Color.siloSecondaryText)
+                .frame(maxWidth: .infinity, minHeight: episodeRailReservedHeight, alignment: .topLeading)
         } else {
             TVEpisodeRail(
-                episodes: snapshot.episodes,
+                episodes: carouselEpisodes,
                 onSelect: quickPlayEpisode,
                 onPlay: quickPlayEpisode,
                 onFocusedEpisodeChange: focusEpisode,
                 onSetWatched: onSetEpisodeWatched,
                 onSetFavorite: onSetEpisodeFavorite,
-                currentContentId: snapshot.currentContentId,
-                currentContentIsFavorite: snapshot.currentContentId.map {
-                    episodeFavoriteStates[$0] ?? false
+                currentContentId: displayedEpisode?.contentId,
+                currentContentIsFavorite: displayedEpisode.map {
+                    episodeFavoriteStates[$0.contentId] ?? false
                 } ?? false,
                 favoriteStates: episodeFavoriteStates,
                 baseCardWidth: SiloTheme.thumbnailCardWidth,
-                cardHeightRatio: SiloTheme.thumbnailCardHeight
-                    / SiloTheme.thumbnailCardWidth,
+                cardHeightRatio: SiloTheme.thumbnailCardHeight / SiloTheme.thumbnailCardWidth,
                 cardSpacing: 40,
                 anchorsFocusedCard: true,
                 onMoveUp: focusSelectedMode,
-                onMoveDown: focusPlaybackSelector,
-                focusRequest: episodeRailFocusRequest
+                onMoveDown: focusSupportingRail,
+                focusRequest: episodeRailFocusRequest,
+                focusTargetContentId: episodeRailFocusTarget,
+                scrollRequest: episodeScrollRequest,
+                scrollTargetContentId: episodeScrollTarget,
+                isSelectingSeason: primaryFocusRegion == .mode,
+                onRequestPrevious: episodeWindow.previousSeason == nil ? nil : { onLoadMoreEpisodes(-1) },
+                onRequestNext: episodeWindow.nextSeason == nil ? nil : { onLoadMoreEpisodes(1) }
             )
             .padding(.trailing, -TVDetailLayout.horizontalInset)
         }
@@ -1080,11 +714,8 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         focusedModeId = selectedModeId
     }
 
-    private func focusPlaybackSelector() {
-        focusSupportingRail()
-    }
-
     private func focusSupportingRail() {
+        guard primaryFocusRegion != .supporting else { return }
         // The focus engine snapshots scroll eligibility before delivering the
         // episode rail's move command. Unlock now, then request Cast on the
         // next main-loop turn so its first focus update receives native reveal.
@@ -1100,8 +731,10 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     }
 
     private func focusEpisode(_ contentId: String?) {
-        focusedEpisodeContentId = contentId
+        // Lazy row updates can briefly clear focus during fast lateral input.
+        // Keep the viewport pinned until a real destination claims focus.
         guard let contentId else { return }
+        seasonSelection.cancel()
 
         // Cancel a queued Episodes -> Cast handoff if focus has already moved
         // back into the fixed top viewport before the next focus update.
@@ -1114,7 +747,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                 animated: false,
                 reduceMotion: reduceMotion
             )
-        case .outside:
+        case .outside, .supporting:
             pageScrollCoordinator.enterPrimary(
                 animated: true,
                 reduceMotion: reduceMotion
@@ -1129,9 +762,10 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     }
 
     private func quickPlayEpisode(_ contentId: String) {
+        seasonSelection.cancel()
         isShowingSeriesOverview = false
         onActivateEpisode(contentId)
-        let episode = episodes.first(where: { $0.contentId == contentId })
+        let episode = episodeWindow.episodes.first(where: { $0.contentId == contentId })
         onPlayEpisode(
             contentId,
             episode.flatMap { selectedFileId(for: $0) },
@@ -1204,7 +838,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
 
     private var displayedEpisode: EpisodeListItem? {
         if let activeEpisodeContentId,
-           let active = episodes.first(where: { $0.contentId == activeEpisodeContentId }) {
+           let active = episodeWindow.episodes.first(where: { $0.contentId == activeEpisodeContentId }) {
             return active
         }
         return suggestedEpisode
@@ -1257,15 +891,31 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
 
     // MARK: - Supporting rails
 
+    private func supportingRailDidFocus(centerFirstSection: Bool) {
+        primaryFocusRegion = .supporting
+        if centerFirstSection {
+            pageScrollCoordinator.revealSupporting(reduceMotion: reduceMotion)
+        } else {
+            pageScrollCoordinator.releasePrimary()
+        }
+    }
+
     private var similarSection: some View {
         TVSimilarRail(
             contentId: detail.contentId,
             title: "Recommended Series",
             onSelect: onNavigateToItem,
-            focusRequest: !hasCast && trailerEntries.isEmpty
-                ? supportingRailFocusRequest
-                : 0
+            focusRequest: !hasCast && trailerEntries.isEmpty ? supportingRailFocusRequest : 0,
+            onFocusChange: { focused in
+                guard focused else { return }
+                supportingRailDidFocus(centerFirstSection: !hasCast && trailerEntries.isEmpty)
+            }
         )
+        .background {
+            if !hasCast && trailerEntries.isEmpty {
+                TVSeriesAnchorResolver { pageScrollCoordinator.supportingAnchorView = $0 }
+            }
+        }
     }
 
     private var trailersSection: some View {
@@ -1273,8 +923,17 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
             entries: trailerEntries,
             onSelect: onSelectTrailer,
             focusScale: 1.0,
-            focusRequest: hasCast ? 0 : supportingRailFocusRequest
+            focusRequest: hasCast ? 0 : supportingRailFocusRequest,
+            onFocusChange: { focused in
+                guard focused else { return }
+                supportingRailDidFocus(centerFirstSection: !hasCast)
+            }
         )
+        .background {
+            if !hasCast && !trailerEntries.isEmpty {
+                TVSeriesAnchorResolver { pageScrollCoordinator.supportingAnchorView = $0 }
+            }
+        }
     }
 
     private func castSection(cast: [CastMember]) -> some View {
@@ -1283,14 +942,16 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
             TVDetailCastRail(
                 cast: cast,
                 onTap: onPersonTap,
-                focusRequest: supportingRailFocusRequest
+                focusRequest: supportingRailFocusRequest,
+                onFocusChange: { focused in
+                    guard focused else { return }
+                    supportingRailDidFocus(centerFirstSection: true)
+                }
             )
         }
         .padding(.top, 20)
         .background {
-            TVSeriesAnchorResolver { anchorView in
-                pageScrollCoordinator.supportingAnchorView = anchorView
-            }
+            TVSeriesAnchorResolver { pageScrollCoordinator.supportingAnchorView = $0 }
         }
     }
 
@@ -1302,64 +963,6 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         VStack(alignment: .leading, spacing: TVDetailLayout.sectionHeaderSpacing) {
             TVSectionHeader(title: "Details")
             TVDetailFactsSection(detail: detail)
-        }
-    }
-}
-
-/// Resolves the UIKit scroll view that directly owns the Series page. The
-/// marker sits behind the root vertical content, so its nearest scroll-view
-/// ancestor is never one of the nested horizontal rails.
-private struct TVSeriesPageScrollResolver: UIViewRepresentable {
-    let onResolve: (UIScrollView) -> Void
-
-    func makeUIView(context: Context) -> ResolverView {
-        let view = ResolverView()
-        view.isUserInteractionEnabled = false
-        view.backgroundColor = .clear
-        view.onResolve = onResolve
-        return view
-    }
-
-    func updateUIView(_ uiView: ResolverView, context: Context) {
-        uiView.onResolve = onResolve
-        uiView.resolveIfNeeded()
-    }
-
-    final class ResolverView: UIView {
-        var onResolve: ((UIScrollView) -> Void)?
-        private weak var resolvedScrollView: UIScrollView?
-        private var resolutionScheduled = false
-
-        override func didMoveToSuperview() {
-            super.didMoveToSuperview()
-            resolveIfNeeded()
-        }
-
-        override func didMoveToWindow() {
-            super.didMoveToWindow()
-            resolveIfNeeded()
-        }
-
-        func resolveIfNeeded() {
-            if let resolvedScrollView {
-                onResolve?(resolvedScrollView)
-                return
-            }
-            guard !resolutionScheduled else { return }
-            resolutionScheduled = true
-            DispatchQueue.main.async { [weak self] in
-                guard let self else { return }
-                self.resolutionScheduled = false
-                var ancestor = self.superview
-                while let view = ancestor {
-                    if let scrollView = view as? UIScrollView {
-                        self.resolvedScrollView = scrollView
-                        self.onResolve?(scrollView)
-                        return
-                    }
-                    ancestor = view.superview
-                }
-            }
         }
     }
 }

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSimilarRail.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSimilarRail.swift
@@ -18,6 +18,7 @@ struct TVSimilarRail: View {
     let title: String
     let onSelect: (String) -> Void
     var focusRequest = 0
+    var onFocusChange: ((Bool) -> Void)? = nil
 
     @State private var items: [SimilarPosterItem] = []
     @State private var isLoading = true
@@ -41,6 +42,9 @@ struct TVSimilarRail: View {
             }
         }
         .task(id: contentId, priority: .background) { await load() }
+        .onChange(of: focusedItemId != nil) { _, focused in
+            onFocusChange?(focused)
+        }
         .onChange(of: focusRequest, initial: true) { _, _ in
             applyFocusRequestIfPossible()
         }

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVTrailersRail.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVTrailersRail.swift
@@ -32,6 +32,7 @@ struct TVTrailersRail: View {
     /// Non-zero changes explicitly hand focus into the first trailer when a
     /// Series has no cast rail above it.
     var focusRequest = 0
+    var onFocusChange: ((Bool) -> Void)? = nil
 
     @FocusState private var focusedEntryId: String?
 
@@ -71,6 +72,9 @@ struct TVTrailersRail: View {
         // episode rails, instead of the geometrically-nearest one.
         .applyTrailerRailDefaultFocus(entries.first?.id, binding: $focusedEntryId)
         .scrollClipDisabled()
+        .onChange(of: focusedEntryId != nil) { _, focused in
+            onFocusChange?(focused)
+        }
         .onChange(of: focusRequest) { _, request in
             guard request > 0, let firstId = entries.first?.id else { return }
             focusedEntryId = firstId


### PR DESCRIPTION
Large series could stall during loading, open at the wrong episode, or leave the season selector and visible episodes out of sync after rapid navigation.

Use one continuous carousel backed by a window of up to five populated season pages. Preserve episode context in the route, prefetch adjacent seasons, and load favorite state for the active episode instead of every episode. Keep completed season selections authoritative through delayed callbacks and cancel superseded scroll operations. Clear the initial episode loading state when hierarchy resolution fails or returns no selectable season, without clearing a newer selection or background refresh. A single composite focus owner handles adjacent episode navigation, animated season jumps, held-arrow repeats, and vertical handoffs to supporting sections. Retain usable cached artwork when a differently sized image request fails.

Validation:
- All 53 targeted tests passed: 11 episode-window, 8 season-selection and hierarchy-loading, and 34 detail-navigation tests. The failed and empty hierarchy cases reproduced before the cleanup fix and passed afterward.
- The preceding signed tvOS Release build passed with the session's combined changes and was installed and launched on a physical Apple TV. The hierarchy-failure follow-up was tested locally on the iOS simulator and has not been redeployed to the TV.
- Device checks covered repeated season-boundary crossings, single-step movement, rapid season reversals, held Left/Right and stopping after release, context-menu return, and one-step navigation to Cast.
- `git diff --check` passed. The independent PR branch still requires the Apple regression CI matrix; the full iOS suite and macOS build were not run locally.

Season loading still requests whole seasons. The page-count limit does not bound the number of episodes inside an unusually large individual season. VoiceOver behavior was not tested on-device.

AI disclosure: Developed and reviewed with GPT-6 through the Codex agent harness, including Codex review subagents. The exact backend model identifier is not exposed by this session.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved tvOS series browsing with smoother season selection, episode navigation, boundary loading, and retry handling.
  - Added press-and-hold left/right navigation for episode rails.
  - Preserved episode context when navigating from episodes to series details.
  - Improved focus transitions across episodes, cast, trailers, and similar-content rails.
- **Bug Fixes**
  - Improved view refresh when switching between content items.
  - Warmed images now remain visible when a display-sized image request fails.
- **Tests**
  - Added coverage for season ordering, loading, navigation, cancellation, retries, and episode retention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->