### PR TITLE
fix(ios): stop keyboard returning after playback from search

### DIFF
--- a/iosApp/iosApp/Screens/Search/SearchView.swift
+++ b/iosApp/iosApp/Screens/Search/SearchView.swift
@@ -65,6 +65,17 @@ struct SearchView: View {
         .task {
             await focusSearchField()
         }
+        // Opening a result presents a sheet, and Play then covers it with the
+        // player. UIKit resigns the search field for the sheet, but SwiftUI
+        // still holds the focus binding as true, so it re-asserts focus and
+        // brings the keyboard back once the cover tears down. Release focus
+        // when a presentation begins so returning lands on the results.
+        .onChange(of: router.presentedItemDetail?.id) { _, presentedID in
+            if presentedID != nil { isSearchFieldFocused = false }
+        }
+        .onChange(of: router.presentedPlayer?.id) { _, presentedID in
+            if presentedID != nil { isSearchFieldFocused = false }
+        }
         #endif
         .onChange(of: viewModel.query) { _, _ in
             viewModel.onQueryChanged()


### PR DESCRIPTION
## Problem

On iOS, play a title from Search results and exit the player. When the detail sheet closes, the keyboard comes back on its own over the results. Reported as "if you play media from search the keyboard is brought up and can't be hidden".

Root cause: opening a result presents the detail sheet, and Play covers it with the player. UIKit resigns the search field for the sheet, but the SwiftUI focus binding on the search field still reads `true`. When the full-screen cover tears down, SwiftUI re-asserts that focus and the keyboard pops back up.

## Solution

`SearchView` now sets its search focus to `false` when a detail sheet or player presentation begins. Returning to Search lands on the results with no keyboard. Tapping the field still focuses it, and the keyboard's search key still dismisses it.

## Validation

Reproduced and verified on an iPhone 17 Pro simulator (iOS 27.0) with the hardware keyboard disconnected. Flow: open Search, type a query, tap a result, tap Play, close the player, close the detail sheet.

Before: keyboard returns over results. After: no keyboard. Field refocus on tap and dismissal via the keyboard's search key confirmed after the fix.

## Risks

Low. Only the iOS search focus binding changes, and only when a presentation begins.

## AI disclosure

Written with Claude Fable 5.1 (`claude-fable-5-1`) in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the search keyboard could reappear after opening and closing item details or the player.
  * Search fields now correctly lose focus when these views are presented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->