### PR TITLE
feat(detail): mark a season watched from its chip on iOS and tvOS

### DIFF
--- a/iosApp/iosApp/Screens/Detail/ItemDetailView.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailView.swift
@@ -734,6 +734,12 @@ private struct ItemDetailPhoneContent: View {
                 onToggleFavorite: { Task { await viewModel.toggleFavorite() } },
                 onToggleWatchlist: { Task { await viewModel.toggleWatchlist() } },
                 onToggleWatched: { Task { await viewModel.toggleWatched() } },
+                onSetSeasonWatched: { season, played in
+                    await viewModel.setSeasonWatched(season, played: played)
+                },
+                onSetEpisodeWatched: { id, played in
+                    await viewModel.setEpisodeWatched(contentId: id, played: played)
+                },
                 onPersonTap: { personId in
                     if let pid = Int(personId) {
                         router.navigate(to: .personDetail(personId: pid))

--- a/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
@@ -1307,6 +1307,9 @@ class ItemDetailViewModel {
     /// change so callers can roll back an optimistic UI state.
     func setSeasonWatched(_ season: Season, played: Bool) async -> Bool {
         guard let seriesId = seriesContentId else { return false }
+        // The route can change while the request is in flight. Nothing below
+        // may publish into a detail that replaced this one.
+        let routeGeneration = detailGeneration
         do {
             try await SiloAPI.shared.setWatched(
                 contentId: season.contentId,
@@ -1321,12 +1324,10 @@ class ItemDetailViewModel {
             seriesId: seriesId,
             seasonNumber: season.seasonNumber
         )
+        guard routeGeneration == detailGeneration else { return true }
 
-        await loadSeasons(
-            seriesId: seriesId,
-            autoSelectInitial: false,
-            coalescesMetadataRequest: false
-        )
+        await refreshSeasonList(seriesId: seriesId, routeGeneration: routeGeneration)
+        guard routeGeneration == detailGeneration else { return true }
         let refreshed = seasons.first(where: {
             $0.contentId == season.contentId
                 || $0.seasonNumber == season.seasonNumber
@@ -1339,58 +1340,85 @@ class ItemDetailViewModel {
             )
         } else {
             // Refresh the route-scoped page for a non-selected season so a
-            // later chip tap or page swipe paints the new checkmarks.
-            await loadEpisodes(
+            // later chip tap or page swipe paints the new checkmarks. This
+            // must not touch the selected page's load generation or its
+            // loading flag.
+            await refreshCachedEpisodePage(
                 seriesId: seriesId,
                 seasonNumber: refreshed.seasonNumber,
-                refreshFavoriteStates: false,
-                coalescesMetadataRequest: false
+                routeGeneration: routeGeneration
             )
         }
         return true
     }
 
     func setEpisodeWatched(contentId: String, played: Bool) async -> Bool {
+        let routeGeneration = detailGeneration
         do {
             try await SiloAPI.shared.setWatched(contentId: contentId, played: played)
-            if contentId == detail?.contentId {
-                isWatched = played
-            }
-            invalidateRelatedCaches(
-                contentId: contentId,
-                seriesId: seriesContentId,
-                seasonNumber: selectedSeason?.seasonNumber
-            )
-            if let seriesId = seriesContentId, let seasonNumber = selectedSeason?.seasonNumber {
-                await loadEpisodes(
-                    seriesId: seriesId,
-                    seasonNumber: seasonNumber,
-                    refreshFavoriteStates: false,
-                    coalescesMetadataRequest: false
-                )
-                // A single episode can complete or reopen its season, so the
-                // season-level watched state must follow.
-                await refreshSelectedSeasonUserData(seriesId: seriesId)
-            }
-            return true
         } catch {
             return false
         }
+        guard routeGeneration == detailGeneration else { return true }
+        if contentId == detail?.contentId {
+            isWatched = played
+        }
+        invalidateRelatedCaches(
+            contentId: contentId,
+            seriesId: seriesContentId,
+            seasonNumber: selectedSeason?.seasonNumber
+        )
+        if let seriesId = seriesContentId, let seasonNumber = selectedSeason?.seasonNumber {
+            await loadEpisodes(
+                seriesId: seriesId,
+                seasonNumber: seasonNumber,
+                refreshFavoriteStates: false,
+                coalescesMetadataRequest: false
+            )
+            // A single episode can complete or reopen its season, so the
+            // season-level watched state must follow.
+            await refreshSelectedSeasonUserData(seriesId: seriesId, routeGeneration: routeGeneration)
+        }
+        return true
     }
 
     /// Reload the season list and re-point `selectedSeason` at its refreshed
     /// payload without changing the selection or reloading its episodes.
-    private func refreshSelectedSeasonUserData(seriesId: String) async {
+    private func refreshSelectedSeasonUserData(seriesId: String, routeGeneration: Int) async {
         let selectedId = selectedSeason?.contentId
-        await loadSeasons(
-            seriesId: seriesId,
-            autoSelectInitial: false,
-            coalescesMetadataRequest: false
-        )
-        guard let selectedId,
+        await refreshSeasonList(seriesId: seriesId, routeGeneration: routeGeneration)
+        guard routeGeneration == detailGeneration,
+              let selectedId,
               let refreshed = seasons.first(where: { $0.contentId == selectedId }),
               refreshed != selectedSeason else { return }
         selectedSeason = refreshed
+    }
+
+    /// Fresh season list for a watched mutation. Publishes only while the
+    /// route that started the mutation is still on screen.
+    private func refreshSeasonList(seriesId: String, routeGeneration: Int) async {
+        guard let response = try? await SiloAPI.shared.seasons(seriesId: seriesId) else { return }
+        ResponseCache.shared.set(response, for: CacheKey.itemSeasons(seriesId))
+        guard routeGeneration == detailGeneration, seriesContentId == seriesId else { return }
+        seasons = response.seasons.sortedForDisplay()
+    }
+
+    /// Refresh one non-selected season's cached page in the background. It
+    /// deliberately stays outside `loadEpisodes`, whose shared generation and
+    /// loading flag belong to the selected page.
+    private func refreshCachedEpisodePage(seriesId: String, seasonNumber: Int, routeGeneration: Int) async {
+        guard let response = try? await SiloAPI.shared.episodes(
+            seriesId: seriesId,
+            seasonNumber: seasonNumber
+        ) else { return }
+        ResponseCache.shared.set(response, for: CacheKey.itemEpisodes(seriesId: seriesId, seasonNumber: seasonNumber))
+        guard routeGeneration == detailGeneration, seriesContentId == seriesId else { return }
+        let sorted = response.episodes.sorted(by: { $0.episodeNumber < $1.episodeNumber })
+        episodesBySeason[seasonNumber] = sorted
+        if selectedSeason?.seasonNumber == seasonNumber {
+            // The user moved onto this season while it refreshed.
+            episodes = sorted
+        }
     }
 
     func setEpisodeFavorite(contentId: String, isFavorite: Bool) async -> Bool {

--- a/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
@@ -1307,9 +1307,9 @@ class ItemDetailViewModel {
     /// change so callers can roll back an optimistic UI state.
     func setSeasonWatched(_ season: Season, played: Bool) async -> Bool {
         guard let seriesId = seriesContentId else { return false }
-        // The route can change while the request is in flight. Nothing below
-        // may publish into a detail that replaced this one.
-        let routeGeneration = detailGeneration
+        // The route can change while the request is in flight. Caches are
+        // invalidated regardless; only route-scoped UI publication is skipped.
+        let route = watchedMutationRoute()
         do {
             try await SiloAPI.shared.setWatched(
                 contentId: season.contentId,
@@ -1324,10 +1324,10 @@ class ItemDetailViewModel {
             seriesId: seriesId,
             seasonNumber: season.seasonNumber
         )
-        guard routeGeneration == detailGeneration else { return true }
+        guard route == watchedMutationRoute() else { return true }
 
-        await refreshSeasonList(seriesId: seriesId, routeGeneration: routeGeneration)
-        guard routeGeneration == detailGeneration else { return true }
+        await refreshSeasonList(seriesId: seriesId, route: route)
+        guard route == watchedMutationRoute() else { return true }
         let refreshed = seasons.first(where: {
             $0.contentId == season.contentId
                 || $0.seasonNumber == season.seasonNumber
@@ -1346,29 +1346,34 @@ class ItemDetailViewModel {
             await refreshCachedEpisodePage(
                 seriesId: seriesId,
                 seasonNumber: refreshed.seasonNumber,
-                routeGeneration: routeGeneration
+                route: route
             )
         }
         return true
     }
 
     func setEpisodeWatched(contentId: String, played: Bool) async -> Bool {
-        let routeGeneration = detailGeneration
+        let route = watchedMutationRoute()
+        // Captured up front: the caches to invalidate belong to the route that
+        // issued the mutation, even if the user has left it by the time the
+        // server answers.
+        let seriesId = seriesContentId
+        let seasonNumber = selectedSeason?.seasonNumber
         do {
             try await SiloAPI.shared.setWatched(contentId: contentId, played: played)
         } catch {
             return false
         }
-        guard routeGeneration == detailGeneration else { return true }
+        invalidateRelatedCaches(
+            contentId: contentId,
+            seriesId: seriesId,
+            seasonNumber: seasonNumber
+        )
+        guard route == watchedMutationRoute() else { return true }
         if contentId == detail?.contentId {
             isWatched = played
         }
-        invalidateRelatedCaches(
-            contentId: contentId,
-            seriesId: seriesContentId,
-            seasonNumber: selectedSeason?.seasonNumber
-        )
-        if let seriesId = seriesContentId, let seasonNumber = selectedSeason?.seasonNumber {
+        if let seriesId, let seasonNumber = selectedSeason?.seasonNumber {
             await loadEpisodes(
                 seriesId: seriesId,
                 seasonNumber: seasonNumber,
@@ -1377,17 +1382,29 @@ class ItemDetailViewModel {
             )
             // A single episode can complete or reopen its season, so the
             // season-level watched state must follow.
-            await refreshSelectedSeasonUserData(seriesId: seriesId, routeGeneration: routeGeneration)
+            await refreshSelectedSeasonUserData(seriesId: seriesId, route: route)
         }
         return true
     }
 
+    /// Identity of the detail route a watched mutation started on. Unlike
+    /// `detailGeneration`, which advances on every metadata write to the
+    /// same page, this changes only when the page shows a different item.
+    private struct WatchedMutationRoute: Equatable {
+        let contentId: String?
+        let seriesId: String?
+    }
+
+    private func watchedMutationRoute() -> WatchedMutationRoute {
+        WatchedMutationRoute(contentId: detail?.contentId, seriesId: seriesContentId)
+    }
+
     /// Reload the season list and re-point `selectedSeason` at its refreshed
     /// payload without changing the selection or reloading its episodes.
-    private func refreshSelectedSeasonUserData(seriesId: String, routeGeneration: Int) async {
+    private func refreshSelectedSeasonUserData(seriesId: String, route: WatchedMutationRoute) async {
         let selectedId = selectedSeason?.contentId
-        await refreshSeasonList(seriesId: seriesId, routeGeneration: routeGeneration)
-        guard routeGeneration == detailGeneration,
+        await refreshSeasonList(seriesId: seriesId, route: route)
+        guard route == watchedMutationRoute(),
               let selectedId,
               let refreshed = seasons.first(where: { $0.contentId == selectedId }),
               refreshed != selectedSeason else { return }
@@ -1396,23 +1413,23 @@ class ItemDetailViewModel {
 
     /// Fresh season list for a watched mutation. Publishes only while the
     /// route that started the mutation is still on screen.
-    private func refreshSeasonList(seriesId: String, routeGeneration: Int) async {
+    private func refreshSeasonList(seriesId: String, route: WatchedMutationRoute) async {
         guard let response = try? await SiloAPI.shared.seasons(seriesId: seriesId) else { return }
         ResponseCache.shared.set(response, for: CacheKey.itemSeasons(seriesId))
-        guard routeGeneration == detailGeneration, seriesContentId == seriesId else { return }
+        guard route == watchedMutationRoute() else { return }
         seasons = response.seasons.sortedForDisplay()
     }
 
     /// Refresh one non-selected season's cached page in the background. It
     /// deliberately stays outside `loadEpisodes`, whose shared generation and
     /// loading flag belong to the selected page.
-    private func refreshCachedEpisodePage(seriesId: String, seasonNumber: Int, routeGeneration: Int) async {
+    private func refreshCachedEpisodePage(seriesId: String, seasonNumber: Int, route: WatchedMutationRoute) async {
         guard let response = try? await SiloAPI.shared.episodes(
             seriesId: seriesId,
             seasonNumber: seasonNumber
         ) else { return }
         ResponseCache.shared.set(response, for: CacheKey.itemEpisodes(seriesId: seriesId, seasonNumber: seasonNumber))
-        guard routeGeneration == detailGeneration, seriesContentId == seriesId else { return }
+        guard route == watchedMutationRoute() else { return }
         let sorted = response.episodes.sorted(by: { $0.episodeNumber < $1.episodeNumber })
         episodesBySeason[seasonNumber] = sorted
         if selectedSeason?.seasonNumber == seasonNumber {

--- a/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
@@ -1290,43 +1290,64 @@ class ItemDetailViewModel {
     }
 
     /// Series overview action: mutate the season currently selected in the
-    /// pill row, not the whole series. The server already fans a season
+    /// pill row, not the whole series.
+    func toggleSelectedSeasonWatched() async {
+        guard let selectedSeason else { return }
+        _ = await setSeasonWatched(
+            selectedSeason,
+            played: !(selectedSeason.userData?.played ?? false)
+        )
+    }
+
+    /// Mark one season watched or unwatched. The server already fans a season
     /// mutation out to its episodes; refreshing the season + episode payloads
     /// keeps every checkmark and next-up calculation consistent afterward.
-    func toggleSelectedSeasonWatched() async {
-        guard let selectedSeason,
-              let seriesId = seriesContentId else { return }
-
-        let played = !(selectedSeason.userData?.played ?? false)
+    /// Works for any season, so chip context menus can target a season that
+    /// is not the selected page. Returns false when the server rejected the
+    /// change so callers can roll back an optimistic UI state.
+    func setSeasonWatched(_ season: Season, played: Bool) async -> Bool {
+        guard let seriesId = seriesContentId else { return false }
         do {
             try await SiloAPI.shared.setWatched(
-                contentId: selectedSeason.contentId,
+                contentId: season.contentId,
                 played: played
             )
-            invalidateRelatedCaches(
-                contentId: selectedSeason.contentId,
-                seriesId: seriesId,
-                seasonNumber: selectedSeason.seasonNumber
-            )
-
-            await loadSeasons(
-                seriesId: seriesId,
-                autoSelectInitial: false,
-                coalescesMetadataRequest: false
-            )
-            if let refreshed = seasons.first(where: {
-                $0.contentId == selectedSeason.contentId
-                    || $0.seasonNumber == selectedSeason.seasonNumber
-            }) {
-                await selectSeason(
-                    refreshed,
-                    forceRefresh: true,
-                    coalescesMetadataRequest: false
-                )
-            }
         } catch {
             // Leave the server-provided state untouched on failure.
+            return false
         }
+        invalidateRelatedCaches(
+            contentId: season.contentId,
+            seriesId: seriesId,
+            seasonNumber: season.seasonNumber
+        )
+
+        await loadSeasons(
+            seriesId: seriesId,
+            autoSelectInitial: false,
+            coalescesMetadataRequest: false
+        )
+        let refreshed = seasons.first(where: {
+            $0.contentId == season.contentId
+                || $0.seasonNumber == season.seasonNumber
+        }) ?? season
+        if selectedSeason?.seasonNumber == refreshed.seasonNumber {
+            await selectSeason(
+                refreshed,
+                forceRefresh: true,
+                coalescesMetadataRequest: false
+            )
+        } else {
+            // Refresh the route-scoped page for a non-selected season so a
+            // later chip tap or page swipe paints the new checkmarks.
+            await loadEpisodes(
+                seriesId: seriesId,
+                seasonNumber: refreshed.seasonNumber,
+                refreshFavoriteStates: false,
+                coalescesMetadataRequest: false
+            )
+        }
+        return true
     }
 
     func setEpisodeWatched(contentId: String, played: Bool) async -> Bool {
@@ -1347,11 +1368,29 @@ class ItemDetailViewModel {
                     refreshFavoriteStates: false,
                     coalescesMetadataRequest: false
                 )
+                // A single episode can complete or reopen its season, so the
+                // season-level watched state must follow.
+                await refreshSelectedSeasonUserData(seriesId: seriesId)
             }
             return true
         } catch {
             return false
         }
+    }
+
+    /// Reload the season list and re-point `selectedSeason` at its refreshed
+    /// payload without changing the selection or reloading its episodes.
+    private func refreshSelectedSeasonUserData(seriesId: String) async {
+        let selectedId = selectedSeason?.contentId
+        await loadSeasons(
+            seriesId: seriesId,
+            autoSelectInitial: false,
+            coalescesMetadataRequest: false
+        )
+        guard let selectedId,
+              let refreshed = seasons.first(where: { $0.contentId == selectedId }),
+              refreshed != selectedSeason else { return }
+        selectedSeason = refreshed
     }
 
     func setEpisodeFavorite(contentId: String, isFavorite: Bool) async -> Bool {

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeFormatting.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeFormatting.swift
@@ -1,5 +1,5 @@
 #if !os(tvOS)
-import Foundation
+import SwiftUI
 
 /// Shared display formatting for the compact episode rail and expanded iPad
 /// rows. Keeping these labels in one seam prevents the two adaptive layouts
@@ -50,6 +50,45 @@ enum PhoneEpisodeFormatting {
             return "\(minutes / 60)h \(minutes % 60)m"
         }
         return "\(minutes)m"
+    }
+}
+
+/// Long-press menu shared by the compact episode card and the expanded iPad
+/// row: Play, then the watched toggle. Mirrors the tvOS episode rail. The
+/// caller flips its optimistic state first and rolls back only on failure.
+struct PhoneEpisodeContextActions: View {
+    let episode: EpisodeListItem
+    let isPlayed: Bool
+    let onPlay: (() -> Void)?
+    let onSetWatched: ((Bool) async -> Bool)?
+    @Binding var playedOverride: Bool?
+
+    var body: some View {
+        if let onPlay {
+            Button(action: onPlay) {
+                Label(
+                    "Play S\(episode.seasonNumber):E\(episode.episodeNumber)",
+                    systemImage: "play.fill"
+                )
+            }
+        }
+
+        if let onSetWatched {
+            Button {
+                let played = !isPlayed
+                Task { @MainActor in
+                    playedOverride = played
+                    if await onSetWatched(played) == false {
+                        playedOverride = nil
+                    }
+                }
+            } label: {
+                Label(
+                    isPlayed ? "Mark as Unwatched" : "Mark as Watched",
+                    systemImage: isPlayed ? "circle" : "checkmark.circle"
+                )
+            }
+        }
     }
 }
 #endif

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeFormatting.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeFormatting.swift
@@ -62,6 +62,9 @@ struct PhoneEpisodeContextActions: View {
     let onPlay: (() -> Void)?
     let onSetWatched: ((Bool) async -> Bool)?
     @Binding var playedOverride: Bool?
+    /// One request at a time per card. A second toggle while the first is in
+    /// flight could reach the server in either order.
+    @Binding var isMutatingWatched: Bool
 
     var body: some View {
         if let onPlay {
@@ -75,12 +78,15 @@ struct PhoneEpisodeContextActions: View {
 
         if let onSetWatched {
             Button {
+                guard !isMutatingWatched else { return }
                 let played = !isPlayed
+                isMutatingWatched = true
                 Task { @MainActor in
                     playedOverride = played
                     if await onSetWatched(played) == false {
                         playedOverride = nil
                     }
+                    isMutatingWatched = false
                 }
             } label: {
                 Label(
@@ -88,6 +94,7 @@ struct PhoneEpisodeContextActions: View {
                     systemImage: isPlayed ? "circle" : "checkmark.circle"
                 )
             }
+            .disabled(isMutatingWatched)
         }
     }
 }

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeList.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeList.swift
@@ -31,6 +31,7 @@ struct PhoneEpisodeList: View {
     let episodes: [EpisodeListItem]
     let onSelect: (String) -> Void
     var onPlay: ((String) -> Void)? = nil
+    var onSetWatched: ((_ contentId: String, _ played: Bool) async -> Bool)? = nil
     var currentContentId: String? = nil
 
     @State private var availableWidth: CGFloat = 0
@@ -77,6 +78,9 @@ struct PhoneEpisodeList: View {
             onSelect: { onSelect(episode.contentId) },
             onPlay: onPlay.map { play in
                 { play(episode.contentId) }
+            },
+            onSetWatched: onSetWatched.map { setWatched in
+                { played in await setWatched(episode.contentId, played) }
             }
         )
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeListRow.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeListRow.swift
@@ -9,28 +9,31 @@ struct PhoneEpisodeListRow: View {
     let isCurrent: Bool
     let onSelect: () -> Void
     let onPlay: (() -> Void)?
+    var onSetWatched: ((Bool) async -> Bool)? = nil
+
+    @State private var playedOverride: Bool?
 
     private let thumbnailWidth: CGFloat = 168
     private var thumbnailHeight: CGFloat { thumbnailWidth * 9 / 16 }
 
+    private var isPlayed: Bool {
+        playedOverride ?? (episode.userData?.played == true)
+    }
+
     var body: some View {
         ZStack(alignment: .topLeading) {
-            Button(action: onSelect) {
-                HStack(alignment: .top, spacing: 14) {
-                    thumbnail
-                    metadata
+            Group {
+                if onPlay != nil || onSetWatched != nil {
+                    rowButton.contextMenu { contextActions }
+                } else {
+                    rowButton
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel(
-                PhoneEpisodeFormatting.accessibilityDescription(
-                    for: episode,
-                    isCurrent: isCurrent
-                )
-            )
+            // Refreshed payloads carry the server's answer; drop the
+            // optimistic state so a rejected change cannot linger.
+            .onChange(of: episode.userData) { _, _ in
+                playedOverride = nil
+            }
 
             if let onPlay {
                 Button(action: onPlay) {
@@ -52,6 +55,35 @@ struct PhoneEpisodeListRow: View {
         }
     }
 
+    private var rowButton: some View {
+        Button(action: onSelect) {
+            HStack(alignment: .top, spacing: 14) {
+                thumbnail
+                metadata
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(
+            PhoneEpisodeFormatting.accessibilityDescription(
+                for: episode,
+                isCurrent: isCurrent
+            )
+        )
+    }
+
+    private var contextActions: some View {
+        PhoneEpisodeContextActions(
+            episode: episode,
+            isPlayed: isPlayed,
+            onPlay: onPlay,
+            onSetWatched: onSetWatched,
+            playedOverride: $playedOverride
+        )
+    }
+
     private var thumbnail: some View {
         ZStack(alignment: .bottom) {
             AsyncImageView(
@@ -64,7 +96,7 @@ struct PhoneEpisodeListRow: View {
             .clipped()
             .accessibilityHidden(true)
 
-            if episode.userData?.played == true {
+            if isPlayed {
                 Color.black.opacity(0.3)
             }
 
@@ -80,7 +112,7 @@ struct PhoneEpisodeListRow: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             }
 
-            if episode.userData?.played == true {
+            if isPlayed {
                 Image(systemName: "checkmark")
                     .font(.system(size: 10, weight: .bold))
                     .foregroundStyle(.black)

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeListRow.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeListRow.swift
@@ -12,6 +12,7 @@ struct PhoneEpisodeListRow: View {
     var onSetWatched: ((Bool) async -> Bool)? = nil
 
     @State private var playedOverride: Bool?
+    @State private var isMutatingWatched = false
 
     private let thumbnailWidth: CGFloat = 168
     private var thumbnailHeight: CGFloat { thumbnailWidth * 9 / 16 }
@@ -80,7 +81,8 @@ struct PhoneEpisodeListRow: View {
             isPlayed: isPlayed,
             onPlay: onPlay,
             onSetWatched: onSetWatched,
-            playedOverride: $playedOverride
+            playedOverride: $playedOverride,
+            isMutatingWatched: $isMutatingWatched
         )
     }
 

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodePage.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodePage.swift
@@ -8,6 +8,7 @@ struct PhoneEpisodePage: View {
     let usesExpandedList: Bool
     let onSelect: (String) -> Void
     var onPlay: ((String) -> Void)? = nil
+    var onSetWatched: ((_ contentId: String, _ played: Bool) async -> Bool)? = nil
     var currentContentId: String? = nil
     var selectsCenteredEpisode = false
     var captionStyleOverride: CardCaptionStyle? = nil
@@ -37,6 +38,7 @@ struct PhoneEpisodePage: View {
                     episodes: episodes,
                     onSelect: onSelect,
                     onPlay: onPlay,
+                    onSetWatched: onSetWatched,
                     currentContentId: currentContentId
                 )
             } else {
@@ -44,6 +46,7 @@ struct PhoneEpisodePage: View {
                     episodes: episodes,
                     onSelect: onSelect,
                     onPlay: onPlay,
+                    onSetWatched: onSetWatched,
                     currentContentId: currentContentId,
                     selectsCenteredEpisode: selectsCenteredEpisode,
                     captionStyleOverride: captionStyleOverride

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeRail.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeRail.swift
@@ -9,6 +9,9 @@ struct PhoneEpisodeRail: View {
     let episodes: [EpisodeListItem]
     let onSelect: (String) -> Void
     var onPlay: ((String) -> Void)? = nil
+    /// Optional long-press action. Returns false when the server rejected the
+    /// change so the card can drop its optimistic watched state.
+    var onSetWatched: ((_ contentId: String, _ played: Bool) async -> Bool)? = nil
     var currentContentId: String? = nil
     var selectsCenteredEpisode = false
     var captionStyleOverride: CardCaptionStyle? = nil
@@ -38,6 +41,9 @@ struct PhoneEpisodeRail: View {
                         onSelect: { onSelect(episode.contentId) },
                         onPlay: onPlay.map { play in
                             { play(episode.contentId) }
+                        },
+                        onSetWatched: onSetWatched.map { setWatched in
+                            { played in await setWatched(episode.contentId, played) }
                         }
                     )
                     .id(episode.contentId)
@@ -97,15 +103,28 @@ private struct PhoneEpisodeCard: View {
     let captionStyle: CardCaptionStyle
     let onSelect: () -> Void
     let onPlay: (() -> Void)?
+    var onSetWatched: ((Bool) async -> Bool)? = nil
+
+    @State private var playedOverride: Bool?
+
+    private var isPlayed: Bool {
+        playedOverride ?? (episode.userData?.played == true)
+    }
 
     var body: some View {
         ZStack(alignment: .top) {
-            Button(action: onSelect) {
-                cardContent
+            Group {
+                if onPlay != nil || onSetWatched != nil {
+                    cardButton.contextMenu { contextActions }
+                } else {
+                    cardButton
+                }
             }
-            .buttonStyle(.plain)
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel(accessibilityDescription)
+            // Refreshed payloads carry the server's answer; drop the
+            // optimistic state so a rejected change cannot linger.
+            .onChange(of: episode.userData) { _, _ in
+                playedOverride = nil
+            }
 
             if let onPlay {
                 Button(action: onPlay) {
@@ -122,6 +141,25 @@ private struct PhoneEpisodeCard: View {
                 )
             }
         }
+    }
+
+    private var cardButton: some View {
+        Button(action: onSelect) {
+            cardContent
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityDescription)
+    }
+
+    private var contextActions: some View {
+        PhoneEpisodeContextActions(
+            episode: episode,
+            isPlayed: isPlayed,
+            onPlay: onPlay,
+            onSetWatched: onSetWatched,
+            playedOverride: $playedOverride
+        )
     }
 
     private var cardContent: some View {
@@ -194,12 +232,12 @@ private struct PhoneEpisodeCard: View {
             .frame(width: cardWidth, height: stillHeight)
             .clipped()
 
-            if episode.userData?.played == true {
+            if isPlayed {
                 Color.black.opacity(0.32)
                     .frame(width: cardWidth, height: stillHeight)
             }
 
-            if episode.userData?.played == true {
+            if isPlayed {
                 VStack {
                     HStack {
                         Spacer()

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeRail.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodeRail.swift
@@ -106,6 +106,7 @@ private struct PhoneEpisodeCard: View {
     var onSetWatched: ((Bool) async -> Bool)? = nil
 
     @State private var playedOverride: Bool?
+    @State private var isMutatingWatched = false
 
     private var isPlayed: Bool {
         playedOverride ?? (episode.userData?.played == true)
@@ -158,7 +159,8 @@ private struct PhoneEpisodeCard: View {
             isPlayed: isPlayed,
             onPlay: onPlay,
             onSetWatched: onSetWatched,
-            playedOverride: $playedOverride
+            playedOverride: $playedOverride,
+            isMutatingWatched: $isMutatingWatched
         )
     }
 

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneSeasonChips.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneSeasonChips.swift
@@ -17,6 +17,8 @@ struct PhoneSeasonChips: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var playedOverrides: [String: SeasonWatchedOverride] = [:]
+    /// Seasons with a watched mutation in flight; the menu ignores repeats.
+    @State private var mutatingSeasonIds: Set<String> = []
 
     var body: some View {
         ScrollViewReader { proxy in
@@ -55,14 +57,19 @@ struct PhoneSeasonChips: View {
     private func contextActions(for season: Season) -> some View {
         if let onSetWatched {
             Button {
+                // One request per season at a time: a second toggle while the
+                // first is in flight could reach the server in either order.
+                guard !mutatingSeasonIds.contains(season.id) else { return }
                 let played = !isPlayed(season)
                 let request = UUID()
                 playedOverrides[season.id] = SeasonWatchedOverride(played: played, request: request)
+                mutatingSeasonIds.insert(season.id)
                 Task { @MainActor in
                     if await onSetWatched(season, played) == false,
                        playedOverrides[season.id]?.request == request {
                         playedOverrides[season.id] = nil
                     }
+                    mutatingSeasonIds.remove(season.id)
                 }
             } label: {
                 // Always say "Season N" here even when the chip shows a custom
@@ -74,6 +81,7 @@ struct PhoneSeasonChips: View {
                     systemImage: isPlayed(season) ? "circle" : "checkmark.circle"
                 )
             }
+            .disabled(mutatingSeasonIds.contains(season.id))
         }
     }
 

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneSeasonChips.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneSeasonChips.swift
@@ -16,7 +16,7 @@ struct PhoneSeasonChips: View {
     var onSetWatched: ((Season, Bool) async -> Bool)? = nil
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var playedOverrides: [String: Bool] = [:]
+    @State private var playedOverrides: [String: SeasonWatchedOverride] = [:]
 
     var body: some View {
         ScrollViewReader { proxy in
@@ -36,16 +36,19 @@ struct PhoneSeasonChips: View {
             .onChange(of: selected?.id) { _, newId in
                 scrollToSelection(newId, using: proxy, animated: !reduceMotion)
             }
-            .onChange(of: seasons) { _, _ in
-                // Refreshed payloads carry the server's answer; drop any
-                // optimistic chip state so a rejected change cannot linger.
-                playedOverrides = [:]
+            .onChange(of: seasons) { _, refreshed in
+                // A refreshed season carries the server's answer for itself
+                // only; a pending mutation on another season keeps its
+                // optimistic state.
+                for season in refreshed where playedOverrides[season.id]?.played == season.userData?.played {
+                    playedOverrides[season.id] = nil
+                }
             }
         }
     }
 
     private func isPlayed(_ season: Season) -> Bool {
-        playedOverrides[season.id] ?? (season.userData?.played ?? false)
+        playedOverrides[season.id]?.played ?? (season.userData?.played ?? false)
     }
 
     @ViewBuilder
@@ -53,9 +56,11 @@ struct PhoneSeasonChips: View {
         if let onSetWatched {
             Button {
                 let played = !isPlayed(season)
-                playedOverrides[season.id] = played
+                let request = UUID()
+                playedOverrides[season.id] = SeasonWatchedOverride(played: played, request: request)
                 Task { @MainActor in
-                    if await onSetWatched(season, played) == false {
+                    if await onSetWatched(season, played) == false,
+                       playedOverrides[season.id]?.request == request {
                         playedOverrides[season.id] = nil
                     }
                 }

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneSeasonChips.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneSeasonChips.swift
@@ -9,8 +9,14 @@ struct PhoneSeasonChips: View {
     let seasons: [Season]
     let selected: Season?
     let onSelect: (Season) -> Void
+    /// Optional long-press action. When set, every chip offers
+    /// "Mark <Season> Watched/Unwatched" for its own season. Returns false
+    /// when the server rejected the change so the chip drops its optimistic
+    /// state.
+    var onSetWatched: ((Season, Bool) async -> Bool)? = nil
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var playedOverrides: [String: Bool] = [:]
 
     var body: some View {
         ScrollViewReader { proxy in
@@ -30,6 +36,39 @@ struct PhoneSeasonChips: View {
             .onChange(of: selected?.id) { _, newId in
                 scrollToSelection(newId, using: proxy, animated: !reduceMotion)
             }
+            .onChange(of: seasons) { _, _ in
+                // Refreshed payloads carry the server's answer; drop any
+                // optimistic chip state so a rejected change cannot linger.
+                playedOverrides = [:]
+            }
+        }
+    }
+
+    private func isPlayed(_ season: Season) -> Bool {
+        playedOverrides[season.id] ?? (season.userData?.played ?? false)
+    }
+
+    @ViewBuilder
+    private func contextActions(for season: Season) -> some View {
+        if let onSetWatched {
+            Button {
+                let played = !isPlayed(season)
+                playedOverrides[season.id] = played
+                Task { @MainActor in
+                    if await onSetWatched(season, played) == false {
+                        playedOverrides[season.id] = nil
+                    }
+                }
+            } label: {
+                // Always say "Season N" here even when the chip shows a custom
+                // title such as "Series 2"; the action names the watched target.
+                Label(
+                    isPlayed(season)
+                        ? "Mark \(season.downloadDisplayName) as Unwatched"
+                        : "Mark \(season.downloadDisplayName) as Watched",
+                    systemImage: isPlayed(season) ? "circle" : "checkmark.circle"
+                )
+            }
         }
     }
 
@@ -48,7 +87,17 @@ struct PhoneSeasonChips: View {
         }
     }
 
+    @ViewBuilder
     private func chip(for season: Season) -> some View {
+        if onSetWatched != nil {
+            chipButton(for: season)
+                .contextMenu { contextActions(for: season) }
+        } else {
+            chipButton(for: season)
+        }
+    }
+
+    private func chipButton(for season: Season) -> some View {
         let isSelected = selected?.id == season.id
         return Button {
             onSelect(season)

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneSeasonEpisodeBrowser.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneSeasonEpisodeBrowser.swift
@@ -13,6 +13,8 @@ struct PhoneSeasonEpisodeBrowser: View {
     let onSelectSeason: (Season) -> Void
     let onSelectEpisode: (String) -> Void
     var onPlayEpisode: ((String) -> Void)? = nil
+    /// Optional long-press watched toggle for episode cards and rows.
+    var onSetEpisodeWatched: ((_ contentId: String, _ played: Bool) async -> Bool)? = nil
     var currentContentId: String? = nil
     var selectsCenteredEpisode = false
     /// Some detail layouts place the selector before their Episodes heading
@@ -54,6 +56,7 @@ struct PhoneSeasonEpisodeBrowser: View {
                     onSelectSeason: onSelectSeason,
                     onSelectEpisode: onSelectEpisode,
                     onPlayEpisode: onPlayEpisode,
+                    onSetEpisodeWatched: onSetEpisodeWatched,
                     currentContentId: currentContentId,
                     selectsCenteredEpisode: selectsCenteredEpisode,
                     showsSeasonSelector: showsSeasonSelector,
@@ -75,6 +78,7 @@ struct PhoneSeasonEpisodeBrowser: View {
                         usesExpandedList: usesExpandedList,
                         onSelect: onSelectEpisode,
                         onPlay: onPlayEpisode,
+                        onSetWatched: onSetEpisodeWatched,
                         currentContentId: currentContentId,
                         selectsCenteredEpisode: selectsCenteredEpisode,
                         captionStyleOverride: episodeCaptionStyleOverride

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneSeasonEpisodePager.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneSeasonEpisodePager.swift
@@ -12,6 +12,7 @@ struct PhoneSeasonEpisodePager: View {
     let onSelectSeason: (Season) -> Void
     let onSelectEpisode: (String) -> Void
     var onPlayEpisode: ((String) -> Void)? = nil
+    var onSetEpisodeWatched: ((_ contentId: String, _ played: Bool) async -> Bool)? = nil
     var currentContentId: String? = nil
     var selectsCenteredEpisode = false
     var showsSeasonSelector = true
@@ -40,6 +41,7 @@ struct PhoneSeasonEpisodePager: View {
                             usesExpandedList: true,
                             onSelect: onSelectEpisode,
                             onPlay: onPlayEpisode,
+                            onSetWatched: onSetEpisodeWatched,
                             currentContentId: currentContentId,
                             selectsCenteredEpisode: selectsCenteredEpisode
                         )

--- a/iosApp/iosApp/Screens/Detail/SeasonWatchedOverride.swift
+++ b/iosApp/iosApp/Screens/Detail/SeasonWatchedOverride.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// An optimistic season watched value plus the request that produced it.
+/// Season chips and tabs keep one per season while a context-menu mutation
+/// is in flight, so an older completion cannot clear a newer value and a
+/// refreshed payload only reconciles the season it describes.
+struct SeasonWatchedOverride: Equatable {
+    let played: Bool
+    let request: UUID
+}

--- a/iosApp/iosApp/Screens/Detail/SeriesDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/SeriesDetailContent.swift
@@ -32,6 +32,11 @@ struct SeriesDetailContent<BelowOverview: View>: View {
     let onToggleFavorite: () -> Void
     let onToggleWatchlist: () -> Void
     let onToggleWatched: () -> Void
+    /// Long-press actions on a season chip and on an episode card. Both
+    /// return false when the server rejected the change so the control can
+    /// drop its optimistic state.
+    let onSetSeasonWatched: (_ season: Season, _ played: Bool) async -> Bool
+    let onSetEpisodeWatched: (_ contentId: String, _ played: Bool) async -> Bool
     let onPersonTap: (String) -> Void
     let onNavigateToItem: (String) -> Void
     /// Play a local extra from the trailers rail. Routed separately from
@@ -421,7 +426,8 @@ struct SeriesDetailContent<BelowOverview: View>: View {
                 PhoneSeasonChips(
                     seasons: seasons,
                     selected: selectedSeason,
-                    onSelect: handleSeasonSelection
+                    onSelect: handleSeasonSelection,
+                    onSetWatched: onSetSeasonWatched
                 )
             }
 
@@ -445,6 +451,7 @@ struct SeriesDetailContent<BelowOverview: View>: View {
                     }) else { return }
                     handlePlayTap(for: episode)
                 },
+                onSetEpisodeWatched: onSetEpisodeWatched,
                 currentContentId: nextUpEpisode?.contentId,
                 selectsCenteredEpisode: true,
                 showsSeasonSelector: false,

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
@@ -496,6 +496,9 @@ struct TVItemDetailView: View {
                 onSetEpisodeWatched: { id, played in
                     await viewModel.setEpisodeWatched(contentId: id, played: played)
                 },
+                onSetSeasonWatched: { season, played in
+                    await viewModel.setSeasonWatched(season, played: played)
+                },
                 onSetEpisodeFavorite: { id, isFavorite in
                     await viewModel.setEpisodeFavorite(contentId: id, isFavorite: isFavorite)
                 },

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -254,8 +254,9 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     @State private var modeFocusAppearanceTask: Task<Void, Never>?
     @State private var presentedFocusedModeId: String?
     /// Optimistic watched state per season id while a tab's context-menu
-    /// mutation is in flight. Cleared when refreshed season payloads arrive.
-    @State private var seasonPlayedOverrides: [String: Bool] = [:]
+    /// mutation is in flight, keyed to the request that set it so an older
+    /// completion cannot clear a newer value.
+    @State private var seasonPlayedOverrides: [String: SeasonWatchedOverride] = [:]
     @State private var seasonTransitionInFlight = false
     @State private var seasonTransitionTargetId: String?
     @State private var seasonTransitionGeneration = 0
@@ -572,10 +573,13 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                 selectedModeId,
                 priority: .userInitiated
             )
-            .onChange(of: seasons) { _, _ in
-                // Refreshed payloads carry the server's answer; drop any
-                // optimistic tab state so a rejected change cannot linger.
-                seasonPlayedOverrides = [:]
+            .onChange(of: seasons) { _, refreshed in
+                // A refreshed season carries the server's answer for itself
+                // only; a pending mutation on another season keeps its
+                // optimistic state.
+                for season in refreshed where seasonPlayedOverrides[season.id]?.played == season.userData?.played {
+                    seasonPlayedOverrides[season.id] = nil
+                }
             }
             .onChange(of: selectedModeId) { _, newId in
                 // A click activates immediately, before the focus-paint dwell
@@ -1265,18 +1269,21 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     }
 
     private func isSeasonPlayed(_ season: Season) -> Bool {
-        seasonPlayedOverrides[season.id] ?? (season.userData?.played ?? false)
+        seasonPlayedOverrides[season.id]?.played ?? (season.userData?.played ?? false)
     }
 
     /// Long-press menu on a season tab. Mirrors the episode rail: flip the
-    /// local state immediately, then roll back only if the server refuses.
+    /// local state immediately, then roll back only if the server refuses
+    /// and no newer request for this season has started since.
     @ViewBuilder
     private func seasonContextActions(for season: Season) -> some View {
         Button {
             let played = !isSeasonPlayed(season)
-            seasonPlayedOverrides[season.id] = played
+            let request = UUID()
+            seasonPlayedOverrides[season.id] = SeasonWatchedOverride(played: played, request: request)
             Task {
-                if await onSetSeasonWatched(season, played) == false {
+                if await onSetSeasonWatched(season, played) == false,
+                   seasonPlayedOverrides[season.id]?.request == request {
                     seasonPlayedOverrides[season.id] = nil
                 }
             }

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -257,6 +257,8 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     /// mutation is in flight, keyed to the request that set it so an older
     /// completion cannot clear a newer value.
     @State private var seasonPlayedOverrides: [String: SeasonWatchedOverride] = [:]
+    /// Seasons with a watched mutation in flight; the menu ignores repeats.
+    @State private var mutatingSeasonIds: Set<String> = []
     @State private var seasonTransitionInFlight = false
     @State private var seasonTransitionTargetId: String?
     @State private var seasonTransitionGeneration = 0
@@ -1278,14 +1280,19 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     @ViewBuilder
     private func seasonContextActions(for season: Season) -> some View {
         Button {
+            // One request per season at a time: a second toggle while the
+            // first is in flight could reach the server in either order.
+            guard !mutatingSeasonIds.contains(season.id) else { return }
             let played = !isSeasonPlayed(season)
             let request = UUID()
             seasonPlayedOverrides[season.id] = SeasonWatchedOverride(played: played, request: request)
+            mutatingSeasonIds.insert(season.id)
             Task {
                 if await onSetSeasonWatched(season, played) == false,
                    seasonPlayedOverrides[season.id]?.request == request {
                     seasonPlayedOverrides[season.id] = nil
                 }
+                mutatingSeasonIds.remove(season.id)
             }
         } label: {
             // Always say "Season N" here even when the tab shows a custom
@@ -1297,6 +1304,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                 systemImage: isSeasonPlayed(season) ? "circle" : "checkmark.circle"
             )
         }
+        .disabled(mutatingSeasonIds.contains(season.id))
     }
 
     private func runtimeLabel(_ minutes: Int) -> String {

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -224,6 +224,10 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     let onActivateEpisode: (_ contentId: String?) -> Void
     let onPlayEpisode: (_ contentId: String, _ fileId: Int?, _ startFromBeginning: Bool) -> Void
     let onSetEpisodeWatched: (_ contentId: String, _ played: Bool) async -> Bool
+    /// Long-press action on a season tab. Targets that tab's season, which
+    /// need not be the selected page. Returns false when the server rejected
+    /// the change so the tab can drop its optimistic state.
+    let onSetSeasonWatched: (_ season: Season, _ played: Bool) async -> Bool
     let onSetEpisodeFavorite: (_ contentId: String, _ isFavorite: Bool) async -> Bool
     let onSelectNextUpVersion: (Int?) -> Void
     let onSelectNextUpAudioTrack: (Int?) -> Void
@@ -249,6 +253,9 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     @State private var modeActivationTask: Task<Void, Never>?
     @State private var modeFocusAppearanceTask: Task<Void, Never>?
     @State private var presentedFocusedModeId: String?
+    /// Optimistic watched state per season id while a tab's context-menu
+    /// mutation is in flight. Cleared when refreshed season payloads arrive.
+    @State private var seasonPlayedOverrides: [String: Bool] = [:]
     @State private var seasonTransitionInFlight = false
     @State private var seasonTransitionTargetId: String?
     @State private var seasonTransitionGeneration = 0
@@ -552,6 +559,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                         )
                         .id(season.id)
                         .focused($focusedModeId, equals: season.id)
+                        .contextMenu { seasonContextActions(for: season) }
                     }
                 }
                 .padding(.vertical, 4)
@@ -564,6 +572,11 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                 selectedModeId,
                 priority: .userInitiated
             )
+            .onChange(of: seasons) { _, _ in
+                // Refreshed payloads carry the server's answer; drop any
+                // optimistic tab state so a rejected change cannot linger.
+                seasonPlayedOverrides = [:]
+            }
             .onChange(of: selectedModeId) { _, newId in
                 // A click activates immediately, before the focus-paint dwell
                 // finishes. Promote that one focused tab without allowing an
@@ -1249,6 +1262,34 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
         if let title = season.title, !title.isEmpty { return title }
         if season.seasonNumber == 0 { return "Specials" }
         return "Season \(season.seasonNumber)"
+    }
+
+    private func isSeasonPlayed(_ season: Season) -> Bool {
+        seasonPlayedOverrides[season.id] ?? (season.userData?.played ?? false)
+    }
+
+    /// Long-press menu on a season tab. Mirrors the episode rail: flip the
+    /// local state immediately, then roll back only if the server refuses.
+    @ViewBuilder
+    private func seasonContextActions(for season: Season) -> some View {
+        Button {
+            let played = !isSeasonPlayed(season)
+            seasonPlayedOverrides[season.id] = played
+            Task {
+                if await onSetSeasonWatched(season, played) == false {
+                    seasonPlayedOverrides[season.id] = nil
+                }
+            }
+        } label: {
+            // Always say "Season N" here even when the tab shows a custom
+            // title such as "Series 2"; the action names the watched target.
+            Label(
+                isSeasonPlayed(season)
+                    ? "Mark \(season.downloadDisplayName) as Unwatched"
+                    : "Mark \(season.downloadDisplayName) as Watched",
+                systemImage: isSeasonPlayed(season) ? "circle" : "checkmark.circle"
+            )
+        }
     }
 
     private func runtimeLabel(_ minutes: Int) -> String {


### PR DESCRIPTION
## Problem

The Series page had no way to mark a whole season watched from the season selector. tvOS only offered "Mark Season Watched" for the selected season through the More menu, and iOS had no season-level action at all. Episode cards in the iOS carousel and the iPad episode list also lacked the long-press menu the tvOS episode rail already had.

## Solution

Long-press a season chip on iOS, or hold Select on a season tab on tvOS, to get "Mark Season N as Watched" or "Mark Season N as Unwatched" for that chip's season. It works for any season, not only the selected page. The label names the season by number even when the server supplies a custom title such as "Series 2". Specials stay "Specials".

- **View model**: new `setSeasonWatched(_:played:)` works on any season and returns success so callers can roll back an optimistic state. `toggleSelectedSeasonWatched` delegates to it. Marking a single episode now also refreshes the season payloads so the season's watched flag follows.
- **tvOS**: every season tab in `TVSeriesDetailView` gets a context menu with the action. Optimistic per-season state clears when refreshed season data arrives. The existing More-menu entry for the selected season is unchanged.
- **iOS**: `PhoneSeasonChips` gets the same context menu. Episode carousel cards and iPad episode list rows get a long-press menu with "Play S2:E1" and the watched toggle, sharing one `PhoneEpisodeContextActions` view. The checkmark and dim overlay flip immediately and roll back on failure.

Wiring follows the existing optimistic pattern used by `MediaCard` and `EpisodeThumbCard`: local override, `async -> Bool` handler, rollback on `false`.

## Validation

- tvOS (`SiloTV`) and iOS (`Silo`) compile.
- iOS XCTest suites for detail behaviour pass: `DetailDismissalNavigationTests`, `DetailVersionSelectionTests`, `HorizontalMediaRailTests` (38 tests, 0 failures).
- iOS simulator against a live server: long-press on the "Series 2" chip showed "Mark Season 2 as Watched"; selecting it wrote 4 completed rows for that season on the server. Long-press again showed "as Unwatched" and selecting it removed them. Long-press on an episode card showed Play plus "Mark as Unwatched"; selecting it cleared that episode's row and its checkmark.
- tvOS: signed device build installed and launched on a physical Apple TV 4K. The tvOS long-press was not exercised interactively, because the tvOS simulator refused synthesized remote input in this environment.
- Test data was restored afterward.

No screenshots or video are attached by request.

## Risks

- No unit test covers `setSeasonWatched`, because `ItemDetailViewModel` calls `SiloAPI.shared` directly and cannot be stubbed in the existing test setup.
- tvOS context menus on `TVSeriesModeTab` use SwiftUI `.contextMenu`, the same mechanism the episode rail already relies on for long-press.

## Related

- Android counterpart: Silo-Server/silo-android#299 (same behaviour and wording on phone and Android TV).

## AI disclosure

AI-assisted. Model: `claude-fable-5-1[1m]` (Claude Fable 5.1). Harness: Claude Code running inside T3 Code. No other AI tooling. The author directed the change, reviewed the diff, and ran the simulator and device validation described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added long-press menus for marking seasons and episodes as watched or unwatched on iOS and tvOS.
  - Added Play actions where available alongside watched-state controls.
  - Watched status updates immediately in the interface while changes are processed.

- **Bug Fixes**
  - Season and episode watched states now refresh consistently after updates.
  - Rejected watched-status changes are rolled back instead of leaving stale visual indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->