### PR TITLE
perf(tvos): omit unused season artwork

### DIFF
--- a/iosApp/iosApp/Networking/SiloAPI.swift
+++ b/iosApp/iosApp/Networking/SiloAPI.swift
@@ -254,9 +254,14 @@ actor SiloAPI {
     }
 
     func seasons(seriesId: String) async throws -> SeasonsResponse {
-        try await http.get(
+        var query = await imageSizeQuery
+        #if os(tvOS)
+        // tvOS season selectors display labels and do not use season posters.
+        query["include_artwork"] = "false"
+        #endif
+        return try await http.get(
             "/api/v1/catalog/series/\(seriesId)/seasons",
-            query: await imageSizeQuery
+            query: query
         )
     }
 


### PR DESCRIPTION
tvOS requests poster URLs for every season even though its season selectors display labels. Send `include_artwork=false` on tvOS season-list requests so the server can skip that work. iOS and macOS retain artwork for their existing detail views.

Related issue: Silo-Server/silo-server#825
Companion server PR: https://github.com/Silo-Server/silo-server/pull/992

Validation: the standard tvOS simulator helper passed build, install, and launch. The server's 38-season HTTP regression verifies that omitting artwork preserves all non-image metadata and performs no poster signing. Independent static review checked the tvOS consumers and found no client contract regression. iOS/macOS builds and live deployment timing were not rerun.

The server defaults to including artwork, so this optimization takes effect when the companion server change is deployed.

## AI Disclosure

- Harness: OpenAI Codex desktop.
- Tools: Codex multi-agent collaboration, shell tooling, GitHub CLI, and the Silo simulator build helper.
- Model: `gpt-6-astra`.
- Involvement: AI-assisted at the maintainer's request; pending maintainer review.
- Adversarial review: an independent static pass checked season consumers, request behavior, and the companion API contract; no client findings were reported.
