### PR TITLE
fix: preserve series loading state and initial tvOS focus

### DIFF
--- a/iosApp/Tests/DetailDismissalNavigationTests.swift
+++ b/iosApp/Tests/DetailDismissalNavigationTests.swift
@@ -142,8 +142,11 @@ final class DetailDismissalNavigationTests: XCTestCase {
 
         let posterModel = ItemDetailViewModel()
         posterModel.hydrateFromCache(contentId: detail.contentId)
-        XCTAssertNil(posterModel.selectedSeason, "Poster initialization must remain unchanged")
-        XCTAssertTrue(posterModel.episodes.isEmpty)
+        // Ordinary poster entry now hydrates the same cached hierarchy using
+        // its normal initial-season policy, instead of painting an empty rail.
+        XCTAssertEqual(posterModel.selectedSeason?.seasonNumber, 3)
+        XCTAssertEqual(posterModel.episodes.map(\.episodeNumber), [1, 2])
+        XCTAssertFalse(posterModel.isLoadingSeriesHierarchy)
     }
 
     func testContinueWatchingRequestsBothResourcesBeforeEitherResponseReturns() async throws {

--- a/iosApp/Tests/SeriesHierarchyLoadingTests.swift
+++ b/iosApp/Tests/SeriesHierarchyLoadingTests.swift
@@ -1,0 +1,303 @@
+import XCTest
+@testable import Silo
+
+@MainActor
+final class SeriesHierarchyLoadingTests: XCTestCase {
+    private let seriesId = "series-hierarchy-regression"
+
+    func testSeasonsDelayDoesNotLookLikeAnEmptyResult() async throws {
+        let model = ItemDetailViewModel()
+        let gate = ResponseGate<SeasonsResponse>()
+        let started = expectation(description: "seasons requested")
+        let task = Task {
+            await model.loadSeasons(seriesId: seriesId, autoSelectInitial: false, fetchSeasons: { _ in
+                started.fulfill()
+                return await gate.wait()
+            })
+        }
+        await fulfillment(of: [started], timeout: 2)
+        XCTAssertTrue(model.isLoadingSeriesHierarchy)
+        XCTAssertNil(model.seriesLoadErrorMessage)
+        await gate.finish(try seasons([]))
+        await task.value
+        XCTAssertFalse(model.isLoadingSeriesHierarchy)
+        XCTAssertEqual(model.seasonsLoadState, .loaded)
+        XCTAssertNil(model.seriesLoadErrorMessage)
+        clearCache()
+    }
+
+    func testFailedSeasonsAreRetryableAndEmptyRetryIsTerminal() async throws {
+        let model = ItemDetailViewModel()
+        await model.loadSeasons(seriesId: seriesId, fetchSeasons: { _ in throw URLError(.timedOut) })
+        XCTAssertFalse(model.isLoadingSeriesHierarchy)
+        XCTAssertNotNil(model.seriesLoadErrorMessage)
+        await model.loadSeasons(seriesId: seriesId, fetchSeasons: { _ in try self.seasons([]) })
+        XCTAssertFalse(model.isLoadingSeriesHierarchy)
+        XCTAssertNil(model.seriesLoadErrorMessage)
+        clearCache()
+    }
+
+    func testCancelledSeasonResponseCannotPublishOrCache() async throws {
+        let model = ItemDetailViewModel()
+        let gate = ResponseGate<SeasonsResponse>()
+        let started = expectation(description: "seasons requested")
+        let task = Task {
+            await model.loadSeasons(seriesId: seriesId, autoSelectInitial: false, fetchSeasons: { _ in
+                started.fulfill()
+                return await gate.wait()
+            })
+        }
+        await fulfillment(of: [started], timeout: 2)
+        task.cancel()
+        await gate.finish(try seasons([1]))
+        await task.value
+        XCTAssertTrue(model.seasons.isEmpty)
+        XCTAssertEqual(model.seasonsLoadState, .idle)
+        let cached: SeasonsResponse? = ResponseCache.shared.get(CacheKey.itemSeasons(seriesId))
+        XCTAssertNil(cached)
+        // Returning to the page starts a fresh request, including after cancellation.
+        await model.loadSeasons(seriesId: seriesId, autoSelectInitial: false, fetchSeasons: { _ in try self.seasons([2]) })
+        XCTAssertEqual(model.seasons.map(\.seasonNumber), [2])
+        clearCache()
+    }
+
+    func testOlderSeasonsCannotReplaceNewerHierarchy() async throws {
+        let model = ItemDetailViewModel()
+        let gate = ResponseGate<SeasonsResponse>()
+        let started = expectation(description: "old request started")
+        let task = Task {
+            await model.loadSeasons(seriesId: seriesId, autoSelectInitial: false, fetchSeasons: { _ in
+                started.fulfill()
+                return await gate.wait()
+            })
+        }
+        await fulfillment(of: [started], timeout: 2)
+        await model.loadSeasons(seriesId: seriesId, autoSelectInitial: false, fetchSeasons: { _ in try self.seasons([2]) })
+        await gate.finish(try seasons([1]))
+        await task.value
+        XCTAssertEqual(model.seasons.map(\.seasonNumber), [2])
+        let cached: SeasonsResponse? = ResponseCache.shared.get(CacheKey.itemSeasons(seriesId))
+        XCTAssertEqual(cached?.seasons.map(\.seasonNumber), [2])
+        clearCache()
+    }
+
+    func testEpisodeDelayFailureAndRetryHaveDistinctStates() async throws {
+        let model = ItemDetailViewModel()
+        let season = try seasons([1]).seasons[0]
+        model.seasons = [season]
+        model.selectedSeason = season
+        let gate = ResponseGate<EpisodesResponse>()
+        let started = expectation(description: "episode request started")
+        let task = Task {
+            await model.loadEpisodes(seriesId: seriesId, seasonNumber: 1, refreshFavoriteStates: false, fetchEpisodes: { _, _ in
+                started.fulfill()
+                return await gate.wait()
+            })
+        }
+        await fulfillment(of: [started], timeout: 2)
+        XCTAssertTrue(model.isLoadingSeriesHierarchy)
+        await gate.finish(try episodes([]))
+        await task.value
+        XCTAssertFalse(model.isLoadingSeriesHierarchy)
+        XCTAssertNil(model.seriesLoadErrorMessage)
+        await model.loadEpisodes(seriesId: seriesId, seasonNumber: 1, refreshFavoriteStates: false, fetchEpisodes: { _, _ in
+            throw URLError(.timedOut)
+        })
+        XCTAssertFalse(model.isLoadingEpisodes)
+        XCTAssertNotNil(model.seriesLoadErrorMessage)
+        await model.loadEpisodes(seriesId: seriesId, seasonNumber: 1, refreshFavoriteStates: false, fetchEpisodes: { _, _ in try self.episodes([1]) })
+        XCTAssertEqual(model.episodes.map(\.episodeNumber), [1])
+        XCTAssertNil(model.seriesLoadErrorMessage)
+        clearCache()
+    }
+
+    func testCachedPageRemainsVisibleWhileRefreshingAndAfterFailure() async throws {
+        let model = ItemDetailViewModel()
+        model.seasons = try seasons([1]).seasons
+        model.selectedSeason = model.seasons[0]
+        model.episodesBySeason[1] = try episodes([1]).episodes
+        await model.loadEpisodes(seriesId: seriesId, seasonNumber: 1, refreshFavoriteStates: false, fetchEpisodes: { _, _ in
+            await MainActor.run {
+                XCTAssertFalse(model.isLoadingSeriesHierarchy)
+                XCTAssertEqual(model.episodes.map(\.episodeNumber), [1])
+            }
+            throw URLError(.timedOut)
+        })
+        XCTAssertEqual(model.episodes.map(\.episodeNumber), [1])
+        XCTAssertNotNil(model.seriesLoadErrorMessage)
+        clearCache()
+    }
+
+    func testCancelledEpisodeResponseCannotPublishOrCache() async throws {
+        let model = ItemDetailViewModel()
+        let gate = ResponseGate<EpisodesResponse>()
+        let started = expectation(description: "episodes requested")
+        let task = Task {
+            await model.loadEpisodes(seriesId: seriesId, seasonNumber: 1, refreshFavoriteStates: false, fetchEpisodes: { _, _ in
+                started.fulfill()
+                return await gate.wait()
+            })
+        }
+        await fulfillment(of: [started], timeout: 2)
+        task.cancel()
+        await gate.finish(try episodes([1]))
+        await task.value
+        XCTAssertTrue(model.episodes.isEmpty)
+        XCTAssertFalse(model.isLoadingEpisodes)
+        XCTAssertFalse(model.episodesLoadFailed)
+        let cached: EpisodesResponse? = ResponseCache.shared.get(CacheKey.itemEpisodes(seriesId: seriesId, seasonNumber: 1))
+        XCTAssertNil(cached)
+    }
+
+    func testCachedOrdinaryEntryHydratesItsEpisodePageImmediately() throws {
+        let detail = try JSONDecoder().decode(ItemDetail.self, from: Data(
+            "{\"contentId\":\"\(seriesId)\",\"type\":\"series\",\"title\":\"Synthetic series\"}".utf8
+        ))
+        ResponseCache.shared.set(detail, for: CacheKey.itemDetail(seriesId))
+        ResponseCache.shared.set(try seasons([1]), for: CacheKey.itemSeasons(seriesId))
+        ResponseCache.shared.set(try episodes([1]), for: CacheKey.itemEpisodes(seriesId: seriesId, seasonNumber: 1))
+        defer {
+            clearCache()
+            ResponseCache.shared.remove(CacheKey.itemDetail(seriesId))
+        }
+        let model = ItemDetailViewModel()
+        model.hydrateFromCache(contentId: seriesId)
+        XCTAssertEqual(model.selectedSeason?.seasonNumber, 1)
+        XCTAssertEqual(model.episodes.map(\.episodeNumber), [1])
+        XCTAssertFalse(model.isLoadingSeriesHierarchy)
+    }
+
+    func testNavigationAwayInvalidatesAnUnstructuredRetry() async throws {
+        let model = ItemDetailViewModel()
+        let gate = ResponseGate<EpisodesResponse>()
+        let started = expectation(description: "retry started")
+        let task = Task {
+            await model.loadEpisodes(seriesId: seriesId, seasonNumber: 1, refreshFavoriteStates: false, fetchEpisodes: { _, _ in
+                started.fulfill()
+                return await gate.wait()
+            })
+        }
+        await fulfillment(of: [started], timeout: 2)
+        model.cancelDetailLoading()
+        // The task itself is deliberately not cancelled: route invalidation
+        // must also cover a button's unstructured Task.
+        await gate.finish(try episodes([1]))
+        await task.value
+        XCTAssertTrue(model.episodes.isEmpty)
+        XCTAssertFalse(model.isLoadingEpisodes)
+        let cached: EpisodesResponse? = ResponseCache.shared.get(CacheKey.itemEpisodes(seriesId: seriesId, seasonNumber: 1))
+        XCTAssertNil(cached)
+    }
+
+    func testOlderEpisodeResponseCannotReplaceNewerPageOrCache() async throws {
+        let model = ItemDetailViewModel()
+        let gate = ResponseGate<EpisodesResponse>()
+        let started = expectation(description: "old page started")
+        let task = Task {
+            await model.loadEpisodes(seriesId: seriesId, seasonNumber: 1, refreshFavoriteStates: false, fetchEpisodes: { _, _ in
+                started.fulfill()
+                return await gate.wait()
+            })
+        }
+        await fulfillment(of: [started], timeout: 2)
+        await model.loadEpisodes(seriesId: seriesId, seasonNumber: 1, refreshFavoriteStates: false, fetchEpisodes: { _, _ in try self.episodes([2]) })
+        await gate.finish(try episodes([1]))
+        await task.value
+        XCTAssertEqual(model.episodes.map(\.episodeNumber), [2])
+        let cached: EpisodesResponse? = ResponseCache.shared.get(CacheKey.itemEpisodes(seriesId: seriesId, seasonNumber: 1))
+        XCTAssertEqual(cached?.episodes.map(\.episodeNumber), [2])
+        clearCache()
+    }
+
+    func testEmptyHierarchyReplacesPreviouslyLoadedEpisodes() async throws {
+        let model = ItemDetailViewModel()
+        model.seasons = try seasons([1]).seasons
+        model.selectedSeason = model.seasons.first
+        model.episodes = try episodes([1]).episodes
+        model.episodesBySeason[1] = model.episodes
+        await model.loadSeasons(seriesId: seriesId, fetchSeasons: { _ in try self.seasons([]) })
+        XCTAssertNil(model.selectedSeason)
+        XCTAssertTrue(model.episodes.isEmpty)
+        XCTAssertTrue(model.episodesBySeason.isEmpty)
+        XCTAssertFalse(model.isLoadingSeriesHierarchy)
+        clearCache()
+    }
+
+    func testSerializedHierarchyKeepsLoadingUntilTheSelectedPageFinishes() async throws {
+        let model = ItemDetailViewModel()
+        let gate = ResponseGate<EpisodesResponse>()
+        let started = expectation(description: "selected page requested")
+        let task = Task {
+            await model.loadSeasons(seriesId: seriesId,
+                fetchSeasons: { _ in try self.seasons([1]) },
+                fetchEpisodes: { _, number in
+                    XCTAssertEqual(number, 1)
+                    started.fulfill()
+                    return await gate.wait()
+                })
+        }
+        await fulfillment(of: [started], timeout: 2)
+        XCTAssertEqual(model.seasonsLoadState, .loaded)
+        XCTAssertEqual(model.selectedSeason?.seasonNumber, 1)
+        XCTAssertTrue(model.isLoadingSeriesHierarchy)
+        await gate.finish(try episodes([]))
+        await task.value
+        XCTAssertFalse(model.isLoadingSeriesHierarchy)
+        XCTAssertNil(model.seriesLoadErrorMessage)
+        clearCache()
+    }
+
+    func testRequestedSeasonSurvivesEpisodeFailureAndSucceedsOnRetry() async throws {
+        let model = ItemDetailViewModel()
+        model.initialResumeSeasonNumber = 1
+        await model.loadSeasons(seriesId: seriesId,
+            fetchSeasons: { _ in try self.seasons([1]) },
+            fetchEpisodes: { _, _ in throw URLError(.timedOut) })
+        XCTAssertEqual(model.initialResumeSeasonNumber, 1)
+        XCTAssertTrue(model.episodesLoadFailed)
+        await model.loadSeasons(seriesId: seriesId,
+            fetchSeasons: { _ in
+                await MainActor.run { XCTAssertNil(model.seriesLoadErrorMessage) }
+                return try self.seasons([1])
+            },
+            fetchEpisodes: { _, _ in try self.episodes([]) })
+        XCTAssertNil(model.initialResumeSeasonNumber)
+        XCTAssertFalse(model.episodesLoadFailed)
+        XCTAssertEqual(model.selectedSeason?.seasonNumber, 1)
+        clearCache()
+    }
+
+    func testCancelledSelectionCannotChangeTheVisibleSeason() async throws {
+        let model = ItemDetailViewModel()
+        let target = try seasons([1]).seasons[0]
+        let task = Task { await model.selectSeason(target) }
+        task.cancel()
+        await task.value
+        XCTAssertNil(model.selectedSeason)
+        XCTAssertFalse(model.isLoadingEpisodes)
+    }
+
+    private func clearCache() {
+        ResponseCache.shared.remove(CacheKey.itemSeasons(seriesId))
+        ResponseCache.shared.remove(CacheKey.itemEpisodes(seriesId: seriesId, seasonNumber: 1))
+    }
+
+    nonisolated private func seasons(_ numbers: [Int]) throws -> SeasonsResponse {
+        let rows = numbers.map { "{\"contentId\":\"regression-season-\($0)\",\"seasonNumber\":\($0)}" }.joined(separator: ",")
+        return try JSONDecoder().decode(SeasonsResponse.self, from: Data("{\"seasons\":[\(rows)]}".utf8))
+    }
+
+    nonisolated private func episodes(_ numbers: [Int]) throws -> EpisodesResponse {
+        let rows = numbers.map { "{\"contentId\":\"regression-episode-\($0)\",\"seasonNumber\":1,\"episodeNumber\":\($0)}" }.joined(separator: ",")
+        return try JSONDecoder().decode(EpisodesResponse.self, from: Data("{\"episodes\":[\(rows)]}".utf8))
+    }
+}
+
+/// Intentionally ignores cancellation to model a coalesced response already in flight.
+private actor ResponseGate<Value: Sendable> {
+    private var continuation: CheckedContinuation<Value, Never>?
+    func wait() async -> Value {
+        await withCheckedContinuation { continuation = $0 }
+    }
+    func finish(_ value: Value) { continuation?.resume(returning: value) }
+}

--- a/iosApp/Tests/SeriesHierarchyLoadingTests.swift
+++ b/iosApp/Tests/SeriesHierarchyLoadingTests.swift
@@ -325,6 +325,28 @@ final class SeriesHierarchyLoadingTests: XCTestCase {
         XCTAssertEqual(result, 42)
     }
 
+    func testOneRetryRecoversBothContinueWatchingHierarchyFailures() async throws {
+        let model = ItemDetailViewModel()
+        model.seasons = try seasons([1]).seasons
+        model.selectedSeason = model.seasons[0]
+        defer { clearCache() }
+        await model.loadContinueWatchingStructure(
+            contentId: seriesId, seasonNumber: 1,
+            fetchSeasons: { _ in throw URLError(.timedOut) },
+            fetchEpisodes: { _, _ in throw URLError(.timedOut) })
+        XCTAssertEqual(model.seasonsLoadState, .failed)
+        XCTAssertTrue(model.episodesLoadFailed)
+        await model.retrySeriesHierarchy(
+            fetchSeasons: { _ in try self.seasons([1]) },
+            fetchEpisodes: { _, number in
+                XCTAssertEqual(number, 1)
+                return try self.episodes([])
+            })
+        XCTAssertNil(model.seriesLoadErrorMessage)
+        XCTAssertFalse(model.isLoadingSeriesHierarchy)
+        XCTAssertEqual(model.episodesBySeason[1], [])
+    }
+
     private func clearCache() {
         ResponseCache.shared.remove(CacheKey.itemSeasons(seriesId))
         ResponseCache.shared.remove(CacheKey.itemEpisodes(seriesId: seriesId, seasonNumber: 1))

--- a/iosApp/Tests/SeriesHierarchyLoadingTests.swift
+++ b/iosApp/Tests/SeriesHierarchyLoadingTests.swift
@@ -277,6 +277,54 @@ final class SeriesHierarchyLoadingTests: XCTestCase {
         XCTAssertFalse(model.isLoadingEpisodes)
     }
 
+    func testResumeEntryDoesNotPlayAnotherSeasonFromAStaleCache() throws {
+        let detail = try JSONDecoder().decode(ItemDetail.self, from: Data(
+            "{\"contentId\":\"\(seriesId)\",\"type\":\"series\",\"title\":\"Synthetic series\"}".utf8
+        ))
+        ResponseCache.shared.set(detail, for: CacheKey.itemDetail(seriesId))
+        ResponseCache.shared.set(try seasons([1]), for: CacheKey.itemSeasons(seriesId))
+        ResponseCache.shared.set(try episodes([1]), for: CacheKey.itemEpisodes(seriesId: seriesId, seasonNumber: 1))
+        defer {
+            clearCache()
+            ResponseCache.shared.remove(CacheKey.itemDetail(seriesId))
+        }
+        let model = ItemDetailViewModel()
+        model.initialResumeSeasonNumber = 3
+        model.hydrateFromCache(contentId: seriesId)
+        XCTAssertNil(model.selectedSeason)
+        XCTAssertTrue(model.episodes.isEmpty)
+        XCTAssertTrue(model.isLoadingSeriesHierarchy)
+        XCTAssertEqual(model.initialResumeSeasonNumber, 3)
+    }
+
+    func testRetryOfBackgroundHierarchyFailureKeepsTheBrowsedSeason() async throws {
+        let model = ItemDetailViewModel()
+        model.seasons = try seasons([1, 2]).seasons
+        model.selectedSeason = model.seasons[1]
+        // A loaded empty page is still the selected season's authoritative page.
+        model.episodesBySeason[2] = []
+        defer { clearCache() }
+        await model.loadSeasons(seriesId: seriesId, autoSelectInitial: false,
+            fetchSeasons: { _ in throw URLError(.timedOut) })
+        XCTAssertNotNil(model.seriesLoadErrorMessage)
+        await model.retrySeriesHierarchy(
+            fetchSeasons: { _ in try self.seasons([1, 2]) },
+            fetchEpisodes: { _, _ in
+                XCTFail("A hierarchy retry must not replace the browsed episode page")
+                return try self.episodes([])
+            })
+        XCTAssertEqual(model.selectedSeason?.seasonNumber, 2)
+        XCTAssertEqual(model.episodesBySeason[2], [])
+        XCTAssertNil(model.seriesLoadErrorMessage)
+    }
+
+    func testResponseGateRetainsAnEarlyResponse() async {
+        let gate = ResponseGate<Int>()
+        await gate.finish(42)
+        let result = await gate.wait()
+        XCTAssertEqual(result, 42)
+    }
+
     private func clearCache() {
         ResponseCache.shared.remove(CacheKey.itemSeasons(seriesId))
         ResponseCache.shared.remove(CacheKey.itemEpisodes(seriesId: seriesId, seasonNumber: 1))
@@ -296,8 +344,20 @@ final class SeriesHierarchyLoadingTests: XCTestCase {
 /// Intentionally ignores cancellation to model a coalesced response already in flight.
 private actor ResponseGate<Value: Sendable> {
     private var continuation: CheckedContinuation<Value, Never>?
+    private var pending: Value?
     func wait() async -> Value {
-        await withCheckedContinuation { continuation = $0 }
+        if let pending {
+            self.pending = nil
+            return pending
+        }
+        return await withCheckedContinuation { continuation = $0 }
     }
-    func finish(_ value: Value) { continuation?.resume(returning: value) }
+    func finish(_ value: Value) {
+        if let continuation {
+            self.continuation = nil
+            continuation.resume(returning: value)
+        } else {
+            pending = value
+        }
+    }
 }

--- a/iosApp/iosApp/Screens/Detail/ItemDetailView.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailView.swift
@@ -321,6 +321,7 @@ private struct ItemDetailPhoneContent: View {
             seedSubtitleOverrideIfNeeded()
         }
         .onDisappear {
+            viewModel.cancelDetailLoading()
             // The trailer poll isn't owned by `.task`, so it would otherwise
             // keep running (and retaining the view model) after the route
             // pops. Same reasoning as `PersonDetailView.stopMetadataRefresh`.
@@ -644,7 +645,9 @@ private struct ItemDetailPhoneContent: View {
                 selectedSeason: viewModel.selectedSeason,
                 episodes: viewModel.episodes,
                 episodesBySeason: viewModel.episodesBySeason,
-                isLoadingEpisodes: viewModel.isLoadingEpisodes,
+                isLoadingEpisodes: viewModel.isLoadingSeriesHierarchy,
+                hierarchyError: viewModel.seriesLoadErrorMessage,
+                onRetryHierarchy: { await viewModel.retrySeriesHierarchy() },
                 selectedNextUpFileId: preferredNextUpFileId,
                 selectedNextUpAudioTrackIndex: preferredNextUpAudioTrackIndex,
                 selectedNextUpSubtitleTrackIndex: preferredNextUpSubtitleTrackIndex,

--- a/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
@@ -52,13 +52,21 @@ class ItemDetailViewModel {
     ) async {
         guard let seriesId = seriesContentId else { return }
         if seasonsLoadState == .failed || selectedSeason == nil {
+            let hadSelection = selectedSeason != nil
+            let selectionGeneration = episodeLoadGeneration
             await loadSeasons(
                 seriesId: seriesId,
-                autoSelectInitial: selectedSeason == nil,
+                autoSelectInitial: !hadSelection,
                 fetchSeasons: fetchSeasons,
                 fetchEpisodes: fetchEpisodes
             )
-        } else if let target = seasons.first(where: { $0.seasonNumber == failedEpisodeSeasonNumber })
+            // A cold retry already loads its episode page. A warm retry may
+            // need to recover both failures, unless the user selected elsewhere.
+            guard hadSelection, !Task.isCancelled, seasonsLoadState == .loaded,
+                  selectionGeneration == episodeLoadGeneration else { return }
+        }
+        if episodesLoadFailed,
+           let target = seasons.first(where: { $0.seasonNumber == failedEpisodeSeasonNumber })
                     ?? selectedSeason {
             await selectSeason(target, forceRefresh: true, fetchEpisodes: fetchEpisodes)
         }

--- a/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
@@ -11,6 +11,51 @@ class ItemDetailViewModel {
     var isRefreshing = false
     var error: ErrorState?
 
+    // Catalog metadata and the hierarchy finish independently. An empty array
+    // is only an empty result after its request has succeeded.
+    enum HierarchyLoadState { case idle, loading, loaded, failed }
+    var seasonsLoadState: HierarchyLoadState = .idle
+    var episodesLoadFailed = false
+    private var failedEpisodeSeasonNumber: Int?
+    private var seasonsLoadGeneration = 0
+    private var detailLoadGeneration = 0
+
+    /// Also invalidates unstructured retry tasks when the route disappears.
+    func cancelDetailLoading() {
+        detailLoadGeneration += 1
+        _ = beginDetailWrite()
+        seasonsLoadGeneration += 1
+        episodeLoadGeneration += 1
+        if seasonsLoadState == .loading { seasonsLoadState = .idle }
+        isLoadingEpisodes = false
+        isLoading = false
+        isRefreshing = false
+    }
+
+    var isLoadingSeriesHierarchy: Bool {
+        if seasons.isEmpty {
+            return seasonsLoadState == .idle || seasonsLoadState == .loading
+        }
+        return isLoadingEpisodes
+            || (selectedSeason == nil && seasonsLoadState == .loading)
+    }
+
+    var seriesLoadErrorMessage: String? {
+        if seasonsLoadState == .failed { return "Couldn't load seasons." }
+        if episodesLoadFailed { return "Couldn't load episodes." }
+        return nil
+    }
+
+    func retrySeriesHierarchy() async {
+        guard let seriesId = seriesContentId else { return }
+        if seasonsLoadState == .failed || selectedSeason == nil {
+            await loadSeasons(seriesId: seriesId)
+        } else if let target = seasons.first(where: { $0.seasonNumber == failedEpisodeSeasonNumber })
+                    ?? selectedSeason {
+            await selectSeason(target, forceRefresh: true)
+        }
+    }
+
     // Series-specific state
     var seasons: [Season] = [] {
         didSet {
@@ -137,6 +182,23 @@ class ItemDetailViewModel {
         preserveSeasonSelection: Bool = false,
         coalescesMetadataRequests: Bool = true
     ) async {
+        guard !Task.isCancelled else { return }
+        detailLoadGeneration += 1
+        let loadGeneration = detailLoadGeneration
+        if let detail, detail.contentId != contentId {
+            seasonsLoadGeneration += 1
+            episodeLoadGeneration += 1
+            self.detail = nil
+            seriesContentId = nil
+            seasons = []
+            selectedSeason = nil
+            episodes = []
+            episodesBySeason = [:]
+            loadedSeasonNumber = nil
+            seasonsLoadState = .idle
+            episodesLoadFailed = false
+            isLoadingEpisodes = false
+        }
         if detail?.contentId != contentId {
             #if !os(tvOS)
             seasonEpisodePrefetchTask?.cancel()
@@ -195,8 +257,10 @@ class ItemDetailViewModel {
         }
         error = nil
         defer {
-            isLoading = false
-            isRefreshing = false
+            if loadGeneration == detailLoadGeneration {
+                isLoading = false
+                isRefreshing = false
+            }
         }
 
         do {
@@ -281,6 +345,7 @@ class ItemDetailViewModel {
 
             let (favorite, watchlist) = await (favoriteResult, watchlistResult)
             if let favorite, let watchlist,
+               !Task.isCancelled, loadGeneration == detailLoadGeneration,
                detail?.contentId == contentId,
                userStateMutationGeneration == userStateGeneration {
                 isFavorite = favorite
@@ -295,6 +360,7 @@ class ItemDetailViewModel {
                 // it still applies to a superseded load.
             }
         } catch let err {
+            guard !Task.isCancelled, loadGeneration == detailLoadGeneration else { return }
             if detail == nil {
                 self.error = ErrorState(err)
             }
@@ -333,7 +399,7 @@ class ItemDetailViewModel {
         generation: Int,
         coalescesMetadataRequest: Bool = true
     ) async -> ItemDetail? {
-        guard generation == detailGeneration else { return nil }
+        guard !Task.isCancelled, generation == detailGeneration else { return nil }
 
         #if os(tvOS)
         // Non-blocking: the movie cast portraits join the already-installed
@@ -553,52 +619,17 @@ class ItemDetailViewModel {
            seasons.isEmpty,
            let cached: SeasonsResponse = ResponseCache.shared.get(CacheKey.itemSeasons(seriesId)) {
             seasons = cached.seasons.sortedForDisplay()
+            seasonsLoadState = .loaded
         }
         if let detail, let seriesId = seriesContentId, selectedSeason == nil {
-            #if os(tvOS)
             if detail.type == "series" {
-                // The marquee may have completed the whole Series warmup
-                // before this view model exists. Resolve the same initial
-                // season synchronously so the first body sees its chips,
-                // episodes, and Play target together.
                 selectedSeason = preferredInitialSeason(seasons: seasons)
             } else if let seasonNumber = detail.seasonNumber {
-                selectedSeason = seasons.first(where: {
-                    $0.seasonNumber == seasonNumber
-                })
+                selectedSeason = seasons.first { $0.seasonNumber == seasonNumber }
             }
-            #else
-            #if os(iOS)
-            if detail.type == "series", let initialResumeSeasonNumber {
-                selectedSeason = seasons.first { $0.seasonNumber == initialResumeSeasonNumber }
-            }
-            #endif
-            if detail.type != "series", let seasonNumber = detail.seasonNumber {
-                selectedSeason = seasons.first(where: { $0.seasonNumber == seasonNumber })
-            }
-            #endif
-
-            #if os(tvOS)
+            // Both platforms can paint a warmed hierarchy on the first frame,
+            // including a successful empty page. Refresh it silently afterward.
             if let seasonNumber = selectedSeason?.seasonNumber,
-               episodes.isEmpty,
-               let cached: EpisodesResponse = ResponseCache.shared.get(
-                   CacheKey.itemEpisodes(
-                       seriesId: seriesId,
-                       seasonNumber: seasonNumber
-                   )
-               ) {
-                let sorted = cached.episodes.sorted(by: {
-                    $0.episodeNumber < $1.episodeNumber
-                })
-                episodes = sorted
-                episodesBySeason[seasonNumber] = sorted
-                loadedSeasonNumber = seasonNumber
-            }
-            #endif
-
-            #if os(iOS)
-            if detail.type == "series", initialResumeSeasonNumber != nil,
-               let seasonNumber = selectedSeason?.seasonNumber,
                episodes.isEmpty,
                let cached: EpisodesResponse = ResponseCache.shared.get(
                    CacheKey.itemEpisodes(seriesId: seriesId, seasonNumber: seasonNumber)
@@ -608,7 +639,6 @@ class ItemDetailViewModel {
                 episodesBySeason[seasonNumber] = sorted
                 loadedSeasonNumber = seasonNumber
             }
-            #endif
         }
         if let seriesId = seriesContentId,
            let detail,
@@ -843,20 +873,32 @@ class ItemDetailViewModel {
             try await MetadataRequestPool.shared.episodes(seriesId: $0, seasonNumber: $1)
         }
     ) async -> Bool {
-        guard let seasonNumber else { return false }
+        guard let seasonNumber, !Task.isCancelled else { return false }
         seriesContentId = contentId
+        seasonsLoadGeneration += 1
+        let hierarchyGeneration = seasonsLoadGeneration
+        episodeLoadGeneration += 1
+        seasonsLoadState = .loading
+        episodesLoadFailed = false
         let selectionGeneration = episodeLoadGeneration
         defer {
-            if selectionGeneration == episodeLoadGeneration, isLoadingEpisodes {
+            if hierarchyGeneration == seasonsLoadGeneration, seasonsLoadState == .loading {
+                seasonsLoadState = .idle
+            }
+            if hierarchyGeneration == seasonsLoadGeneration,
+               selectionGeneration == episodeLoadGeneration, isLoadingEpisodes {
                 isLoadingEpisodes = false
             }
         }
+        if episodes.isEmpty, !isLoadingEpisodes { isLoadingEpisodes = true }
         async let episodeResponse = try? fetchEpisodes(contentId, seasonNumber)
         let seasonResponse = try? await fetchSeasons(contentId)
         guard !Task.isCancelled,
               expectedDetailGeneration == nil || expectedDetailGeneration == detailGeneration,
+              hierarchyGeneration == seasonsLoadGeneration,
               selectionGeneration == episodeLoadGeneration else { return false }
 
+        seasonsLoadState = seasonResponse == nil ? .failed : .loaded
         if let seasonResponse {
             ResponseCache.shared.set(seasonResponse, for: CacheKey.itemSeasons(contentId))
             let sorted = seasonResponse.seasons.sortedForDisplay()
@@ -864,7 +906,15 @@ class ItemDetailViewModel {
         }
         let target = seasons.first { $0.seasonNumber == seasonNumber }
             ?? preferredInitialSeason(seasons: seasons)
-        guard let target else { return false }
+        guard let target else {
+            if seasonResponse != nil {
+                selectedSeason = nil
+                episodes = []
+                episodesBySeason = [:]
+                loadedSeasonNumber = nil
+            }
+            return false
+        }
         if selectedSeason != target { selectedSeason = target }
 
         if target.seasonNumber != seasonNumber {
@@ -880,6 +930,7 @@ class ItemDetailViewModel {
         let response = await episodeResponse
         guard !Task.isCancelled,
               expectedDetailGeneration == nil || expectedDetailGeneration == detailGeneration,
+              hierarchyGeneration == seasonsLoadGeneration,
               selectionGeneration == episodeLoadGeneration else { return false }
         if let response {
             ResponseCache.shared.set(response, for: CacheKey.itemEpisodes(
@@ -890,6 +941,8 @@ class ItemDetailViewModel {
             if episodes != sorted { episodes = sorted }
             loadedSeasonNumber = seasonNumber
         }
+        episodesLoadFailed = response == nil
+        failedEpisodeSeasonNumber = response == nil ? seasonNumber : nil
         if isLoadingEpisodes { isLoadingEpisodes = false }
         return seasonResponse != nil && response != nil
     }
@@ -899,15 +952,26 @@ class ItemDetailViewModel {
         seriesId: String,
         autoSelectInitial: Bool = true,
         coalescesMetadataRequest: Bool = true,
-        fetchSeasons: (@Sendable (String) async throws -> SeasonsResponse)? = nil
+        fetchSeasons: (@Sendable (String) async throws -> SeasonsResponse)? = nil,
+        fetchEpisodes: (@Sendable (String, Int) async throws -> EpisodesResponse)? = nil
     ) async {
+        guard !Task.isCancelled else { return }
+        seriesContentId = seriesId
+        seasonsLoadGeneration += 1
+        let generation = seasonsLoadGeneration
+        let previousLoadState = seasonsLoadState
+        seasonsLoadState = .loading
+        if autoSelectInitial { episodesLoadFailed = false }
         let selectionGeneration = episodeLoadGeneration
         defer {
+            if generation == seasonsLoadGeneration, seasonsLoadState == .loading {
+                seasonsLoadState = previousLoadState == .loading ? .idle : previousLoadState
+            }
             // Cold episode routes start loading before hierarchy resolution.
             // Failure or an empty hierarchy must end that initial wait, but
             // must not clear a newer selection or a parallel episode refresh.
-            if autoSelectInitial, selectionGeneration == episodeLoadGeneration,
-               isLoadingEpisodes {
+            if generation == seasonsLoadGeneration, autoSelectInitial,
+               selectionGeneration == episodeLoadGeneration, isLoadingEpisodes {
                 isLoadingEpisodes = false
             }
         }
@@ -920,14 +984,22 @@ class ItemDetailViewModel {
             } else {
                 response = try await SiloAPI.shared.seasons(seriesId: seriesId)
             }
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled, generation == seasonsLoadGeneration else { return }
             ResponseCache.shared.set(response, for: CacheKey.itemSeasons(seriesId))
             seasons = response.seasons.sortedForDisplay()
+            seasonsLoadState = .loaded
+            if seasons.isEmpty, selectionGeneration == episodeLoadGeneration,
+               autoSelectInitial || detail?.type == "series" {
+                episodeLoadGeneration += 1
+                selectedSeason = nil
+                episodes = []
+                episodesBySeason = [:]
+                loadedSeasonNumber = nil
+                isLoadingEpisodes = false
+                episodesLoadFailed = false
+            }
             if autoSelectInitial, selectionGeneration == episodeLoadGeneration,
                let target = preferredInitialSeason(seasons: seasons) {
-                #if os(iOS) || os(tvOS)
-                initialResumeSeasonNumber = nil
-                #endif
                 #if !os(tvOS)
                 startEpisodePagePrefetch(
                     seriesId: seriesId,
@@ -938,12 +1010,19 @@ class ItemDetailViewModel {
                 await selectSeason(
                     target,
                     forceRefresh: true,
-                    coalescesMetadataRequest: coalescesMetadataRequest
+                    coalescesMetadataRequest: coalescesMetadataRequest,
+                    fetchEpisodes: fetchEpisodes
                 )
+                #if os(iOS) || os(tvOS)
+                if !Task.isCancelled, generation == seasonsLoadGeneration,
+                   !episodesLoadFailed, loadedSeasonNumber == target.seasonNumber {
+                    initialResumeSeasonNumber = nil
+                }
+                #endif
             }
         } catch {
-            // Seasons loading failure is non-fatal — keep whatever
-            // hydrated from cache.
+            guard !Task.isCancelled, generation == seasonsLoadGeneration else { return }
+            seasonsLoadState = .failed
         }
     }
 
@@ -1079,8 +1158,10 @@ class ItemDetailViewModel {
     func selectSeason(
         _ season: Season,
         forceRefresh: Bool = false,
-        coalescesMetadataRequest: Bool = true
+        coalescesMetadataRequest: Bool = true,
+        fetchEpisodes: (@Sendable (String, Int) async throws -> EpisodesResponse)? = nil
     ) async {
+        guard !Task.isCancelled else { return }
         #if os(iOS) || os(tvOS)
         // An explicit chip/page selection supersedes the one-shot resume intent.
         // Automatic hierarchy refreshes must retain it until the catalog succeeds.
@@ -1101,6 +1182,7 @@ class ItemDetailViewModel {
             episodes = cached
             loadedSeasonNumber = season.seasonNumber
             isLoadingEpisodes = false
+            episodesLoadFailed = false
             return
         }
 
@@ -1108,7 +1190,8 @@ class ItemDetailViewModel {
             seriesId: seriesId,
             seasonNumber: season.seasonNumber,
             fallbackSeasonNumber: fallbackSeasonNumber,
-            coalescesMetadataRequest: coalescesMetadataRequest
+            coalescesMetadataRequest: coalescesMetadataRequest,
+            fetchEpisodes: fetchEpisodes
         )
     }
 
@@ -1166,13 +1249,20 @@ class ItemDetailViewModel {
         seasonNumber: Int,
         refreshFavoriteStates: Bool = true,
         fallbackSeasonNumber: Int? = nil,
-        coalescesMetadataRequest: Bool = true
+        coalescesMetadataRequest: Bool = true,
+        fetchEpisodes: (@Sendable (String, Int) async throws -> EpisodesResponse)? = nil
     ) async {
+        guard !Task.isCancelled else { return }
         #if os(tvOS)
         cancelDeferredEpisodeFavoriteStateRefresh()
         #endif
         episodeLoadGeneration += 1
         let generation = episodeLoadGeneration
+        episodesLoadFailed = false
+        failedEpisodeSeasonNumber = nil
+        defer {
+            if generation == episodeLoadGeneration { isLoadingEpisodes = false }
+        }
         let key = CacheKey.itemEpisodes(seriesId: seriesId, seasonNumber: seasonNumber)
 
         // Hydrate this page from either route memory or ResponseCache, then
@@ -1190,6 +1280,7 @@ class ItemDetailViewModel {
         if shouldPublish, let cachedEpisodes {
             episodes = cachedEpisodes
             loadedSeasonNumber = seasonNumber
+            isLoadingEpisodes = false
         } else if shouldPublish {
             episodes = []
             isLoadingEpisodes = true
@@ -1197,7 +1288,9 @@ class ItemDetailViewModel {
 
         do {
             let response: EpisodesResponse
-            if coalescesMetadataRequest {
+            if let fetchEpisodes {
+                response = try await fetchEpisodes(seriesId, seasonNumber)
+            } else if coalescesMetadataRequest {
                 response = try await MetadataRequestPool.shared.episodes(
                     seriesId: seriesId,
                     seasonNumber: seasonNumber
@@ -1208,9 +1301,9 @@ class ItemDetailViewModel {
                     seasonNumber: seasonNumber
                 )
             }
+            guard !Task.isCancelled, generation == episodeLoadGeneration else { return }
             ResponseCache.shared.set(response, for: key)
             let sorted = response.episodes.sorted(by: { $0.episodeNumber < $1.episodeNumber })
-            guard generation == episodeLoadGeneration else { return }
             episodesBySeason[seasonNumber] = sorted
             if selectedSeason == nil || selectedSeason?.seasonNumber == seasonNumber {
                 episodes = sorted
@@ -1218,7 +1311,9 @@ class ItemDetailViewModel {
                 isLoadingEpisodes = false
             }
         } catch {
-            guard generation == episodeLoadGeneration else { return }
+            guard !Task.isCancelled, generation == episodeLoadGeneration else { return }
+            episodesLoadFailed = true
+            failedEpisodeSeasonNumber = seasonNumber
             if selectedSeason == nil || selectedSeason?.seasonNumber == seasonNumber {
                 if cachedEpisodes == nil,
                    let fallbackSeasonNumber,

--- a/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
+++ b/iosApp/iosApp/Screens/Detail/ItemDetailViewModel.swift
@@ -46,13 +46,21 @@ class ItemDetailViewModel {
         return nil
     }
 
-    func retrySeriesHierarchy() async {
+    func retrySeriesHierarchy(
+        fetchSeasons: (@Sendable (String) async throws -> SeasonsResponse)? = nil,
+        fetchEpisodes: (@Sendable (String, Int) async throws -> EpisodesResponse)? = nil
+    ) async {
         guard let seriesId = seriesContentId else { return }
         if seasonsLoadState == .failed || selectedSeason == nil {
-            await loadSeasons(seriesId: seriesId)
+            await loadSeasons(
+                seriesId: seriesId,
+                autoSelectInitial: selectedSeason == nil,
+                fetchSeasons: fetchSeasons,
+                fetchEpisodes: fetchEpisodes
+            )
         } else if let target = seasons.first(where: { $0.seasonNumber == failedEpisodeSeasonNumber })
                     ?? selectedSeason {
-            await selectSeason(target, forceRefresh: true)
+            await selectSeason(target, forceRefresh: true, fetchEpisodes: fetchEpisodes)
         }
     }
 
@@ -623,7 +631,19 @@ class ItemDetailViewModel {
         }
         if let detail, let seriesId = seriesContentId, selectedSeason == nil {
             if detail.type == "series" {
+                #if os(iOS)
+                if let initialResumeSeasonNumber {
+                    // A stale cache cannot decide that the requested season
+                    // is missing. Wait for the authoritative hierarchy before
+                    // offering playback from a fallback season.
+                    selectedSeason = seasons.first { $0.seasonNumber == initialResumeSeasonNumber }
+                    if selectedSeason == nil { isLoadingEpisodes = true }
+                } else {
+                    selectedSeason = preferredInitialSeason(seasons: seasons)
+                }
+                #else
                 selectedSeason = preferredInitialSeason(seasons: seasons)
+                #endif
             } else if let seasonNumber = detail.seasonNumber {
                 selectedSeason = seasons.first { $0.seasonNumber == seasonNumber }
             }

--- a/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodePage.swift
+++ b/iosApp/iosApp/Screens/Detail/Phone/PhoneEpisodePage.swift
@@ -69,7 +69,7 @@ struct PhoneEpisodePage: View {
 /// Compact season-loading placeholder with the exact artwork/caption rhythm of
 /// the real episode rail. It is intentionally static—no shimmer, blur, or
 /// timer—so it stays cheap while artwork and playback metadata are decoding.
-private struct PhoneEpisodeRailSkeleton: View {
+struct PhoneEpisodeRailSkeleton: View {
     var captionStyleOverride: CardCaptionStyle? = nil
     @State private var uiCustomization = UICustomizationPreferences.shared
 

--- a/iosApp/iosApp/Screens/Detail/SeriesDetailContent.swift
+++ b/iosApp/iosApp/Screens/Detail/SeriesDetailContent.swift
@@ -17,6 +17,8 @@ struct SeriesDetailContent<BelowOverview: View>: View {
     let episodes: [EpisodeListItem]
     let episodesBySeason: [Int: [EpisodeListItem]]
     let isLoadingEpisodes: Bool
+    let hierarchyError: String?
+    let onRetryHierarchy: () async -> Void
     let selectedNextUpFileId: Int?
     let selectedNextUpAudioTrackIndex: Int?
     let selectedNextUpSubtitleTrackIndex: Int?
@@ -56,6 +58,7 @@ struct SeriesDetailContent<BelowOverview: View>: View {
     @ViewBuilder let belowOverview: () -> BelowOverview
 
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @State private var hierarchyRetryTask: Task<Void, Never>?
     @State private var pendingResumeEpisode: EpisodeListItem?
     private struct PendingEpisodePlayRequest: Equatable {
         let seasonNumber: Int?
@@ -101,8 +104,17 @@ struct SeriesDetailContent<BelowOverview: View>: View {
             guard let episode = pendingResumeEpisode else { return }
             onPlayEpisode(episode.contentId, playbackFileId(for: episode), true)
         }
+        .onDisappear {
+            hierarchyRetryTask?.cancel()
+            hierarchyRetryTask = nil
+            pendingEpisodePlayRequest = nil
+        }
+        .onChange(of: hierarchyError) { _, error in
+            if error != nil { pendingEpisodePlayRequest = nil }
+        }
         .onChange(of: nextUpEpisode?.contentId) { _, contentID in
-            guard let request = pendingEpisodePlayRequest, contentID != nil,
+            guard hierarchyError == nil,
+                  let request = pendingEpisodePlayRequest, contentID != nil,
                   let episode = nextUpEpisode else { return }
             if let requestedSeason = request.seasonNumber,
                episode.seasonNumber != requestedSeason {
@@ -149,9 +161,9 @@ struct SeriesDetailContent<BelowOverview: View>: View {
             belowOverview: {
                 VStack(spacing: 14) {
                     belowOverview()
-                    if nextUpEpisode != nil {
-                        playbackSelectorSlot
-                    }
+                    playbackSelectorSlot
+                        .opacity(isLoadingEpisodes || nextUpEpisode != nil ? 1 : 0)
+                        .accessibilityHidden(!isLoadingEpisodes && nextUpEpisode == nil)
                 }
             }
         )
@@ -162,10 +174,12 @@ struct SeriesDetailContent<BelowOverview: View>: View {
         VStack(spacing: 14) {
             PhonePrimaryPillButton(
                 icon: "play.fill",
-                title: nextUpEpisode.map(playButtonLabel) ?? "Play",
+                title: nextUpEpisode.map(playButtonLabel)
+                    ?? (isLoadingEpisodes ? "Loading episodes…" : "Play"),
                 action: handlePrimaryPlayTap,
                 fullWidth: true
             )
+            .disabled(nextUpEpisode == nil && !isLoadingEpisodes)
 
             PhoneLabeledActionRow {
                 PhoneLabeledAction(
@@ -417,7 +431,20 @@ struct SeriesDetailContent<BelowOverview: View>: View {
     @ViewBuilder
     private var episodesSection: some View {
         VStack(alignment: .leading, spacing: 14) {
-            if !seasons.isEmpty {
+            if seasons.isEmpty {
+                HStack(spacing: 10) {
+                    ForEach(0..<3) { _ in
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(.secondary.opacity(0.12))
+                            .frame(width: 100, height: 36)
+                    }
+                }
+                .padding(.vertical, 4)
+                .padding(.horizontal, SiloTheme.safePadding)
+                .opacity(isLoadingEpisodes ? 1 : 0)
+                .accessibilityHidden(!isLoadingEpisodes)
+                .accessibilityLabel("Loading seasons")
+            } else {
                 PhoneSeasonChips(
                     seasons: seasons,
                     selected: selectedSeason,
@@ -431,26 +458,50 @@ struct SeriesDetailContent<BelowOverview: View>: View {
             )
             .padding(.horizontal, SiloTheme.safePadding)
 
-            PhoneSeasonEpisodeBrowser(
-                seasons: seasons,
-                selectedSeason: selectedSeason,
-                episodes: episodes,
-                episodesBySeason: episodesBySeason,
-                isLoadingEpisodes: isLoadingEpisodes,
-                onSelectSeason: handleSeasonSelection,
-                onSelectEpisode: handleEpisodeSelection,
-                onPlayEpisode: { contentId in
-                    guard let episode = episodes.first(where: {
-                        $0.contentId == contentId
-                    }) else { return }
-                    handlePlayTap(for: episode)
-                },
-                currentContentId: nextUpEpisode?.contentId,
-                selectsCenteredEpisode: true,
-                showsSeasonSelector: false,
-                forcesEpisodeCarousel: true,
-                episodeCaptionStyleOverride: .titleMetadata
-            )
+            ZStack(alignment: .topLeading) {
+                PhoneEpisodeRailSkeleton(captionStyleOverride: .titleMetadata)
+                    .hidden()
+                VStack(alignment: .leading, spacing: 14) {
+                    if let hierarchyError {
+                        HStack {
+                            Text(hierarchyError)
+                            Button("Retry") {
+                                pendingEpisodePlayRequest = nil
+                                hierarchyRetryTask?.cancel()
+                                hierarchyRetryTask = Task { await onRetryHierarchy() }
+                            }
+                        }
+                        .padding(.horizontal, SiloTheme.safePadding)
+                    }
+
+                    if hierarchyError == nil && !isLoadingEpisodes && seasons.isEmpty {
+                        Text("No episodes available")
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, SiloTheme.safePadding)
+                    } else if hierarchyError == nil || !episodes.isEmpty {
+                        PhoneSeasonEpisodeBrowser(
+                            seasons: seasons,
+                            selectedSeason: selectedSeason,
+                            episodes: episodes,
+                            episodesBySeason: episodesBySeason,
+                            isLoadingEpisodes: isLoadingEpisodes,
+                            onSelectSeason: handleSeasonSelection,
+                            onSelectEpisode: handleEpisodeSelection,
+                            onPlayEpisode: { contentId in
+                                guard let episode = episodes.first(where: {
+                                    $0.contentId == contentId
+                                }) else { return }
+                                handlePlayTap(for: episode)
+                            },
+                            currentContentId: nextUpEpisode?.contentId,
+                            selectsCenteredEpisode: true,
+                            showsSeasonSelector: false,
+                            forcesEpisodeCarousel: true,
+                            episodeCaptionStyleOverride: .titleMetadata
+                        )
+                    }
+                }
+            }
         }
     }
 

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVDetailActions.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVDetailActions.swift
@@ -484,6 +484,9 @@ struct TVDetailActionRow<PlaybackSelectors: View, MoreMenu: View>: View {
     /// Series reserves one compact width across Play/Resume episode labels.
     /// Movies leave this nil so short labels use their natural pill width.
     var primaryButtonWidth: CGFloat? = nil
+    var isPlaybackLoading = false
+    var allowsInitialPlayFocus = true
+    var tracksInitialFocusNavigation = false
     @ViewBuilder let playbackSelectors: () -> PlaybackSelectors
     @ViewBuilder let moreMenu: () -> MoreMenu
 
@@ -500,7 +503,7 @@ struct TVDetailActionRow<PlaybackSelectors: View, MoreMenu: View>: View {
                 actionSlot {
                     TVPrimaryPillButton(
                         icon: "play.fill",
-                        title: playTitle ?? "Play",
+                        title: playTitle ?? (isPlaybackLoading ? "Loading episodes…" : "Play"),
                         subtitle: playSubtitle,
                         stabilizesFocusMotion: stabilizesFocusMotion,
                         fixedWidth: primaryButtonWidth,
@@ -570,6 +573,12 @@ struct TVDetailActionRow<PlaybackSelectors: View, MoreMenu: View>: View {
                 return
             }
         }
+        .onChange(of: allowsInitialPlayFocus) { _, allowed in
+            if !allowed {
+                didResetInitialPlayFocus = true
+                cancelInitialPlayFocusRetry()
+            }
+        }
         .onChange(of: playbackSelectorsFocused) { _, isFocused in
             if isFocused {
                 focusedAction = .playbackSelectors
@@ -579,7 +588,7 @@ struct TVDetailActionRow<PlaybackSelectors: View, MoreMenu: View>: View {
         }
         .task(id: focusResetKey) {
             cancelInitialPlayFocusRetry()
-            didResetInitialPlayFocus = false
+            didResetInitialPlayFocus = !allowsInitialPlayFocus
             initialFocusSeasonKey = seasonKey
             await Task.yield()
             guard playTitle != nil else { return }
@@ -616,7 +625,7 @@ struct TVDetailActionRow<PlaybackSelectors: View, MoreMenu: View>: View {
     }
 
     private func resetInitialPlayFocus() {
-        guard !didResetInitialPlayFocus else { return }
+        guard allowsInitialPlayFocus, !didResetInitialPlayFocus else { return }
         if case .season = initialFocusScope {
             guard let seasonKey else { return }
             if initialFocusSeasonKey == nil {
@@ -633,21 +642,21 @@ struct TVDetailActionRow<PlaybackSelectors: View, MoreMenu: View>: View {
                 if playFocused.wrappedValue { return }
 
                 if attempt > 0 {
-                    if let focusedNow = actionFocus.wrappedValue,
+                    if !tracksInitialFocusNavigation, let focusedNow = actionFocus.wrappedValue,
                        focusedNow != .play {
                         return
                     }
                     try? await Task.sleep(nanoseconds: 50_000_000)
                     if Task.isCancelled { return }
                     if playFocused.wrappedValue { return }
-                    if let focusedNow = actionFocus.wrappedValue,
+                    if !tracksInitialFocusNavigation, let focusedNow = actionFocus.wrappedValue,
                        focusedNow != .play {
                         return
                     }
                 }
                 resetFocus(in: focusNamespace)
                 await Task.yield()
-                if attempt > 0,
+                if attempt > 0, !tracksInitialFocusNavigation,
                    let focusedNow = actionFocus.wrappedValue,
                    focusedNow != .play {
                     return

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVDetailHero.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVDetailHero.swift
@@ -89,6 +89,7 @@ struct TVDetailHero<Actions: View, BelowSynopsis: View>: View {
     /// reserves a stable slot while an episode's playback detail is loading,
     /// so changing carousel focus never moves the persistent action row.
     let playbackSummary: TVPlaybackSelectionSummary
+    var showsPlaybackSummary = true
     /// A compact editorial header can retain the standard Movie backdrop
     /// geometry independently of its own layout height. Nil keeps both heights
     /// coupled, which is the default behavior for every other detail page.
@@ -242,6 +243,8 @@ struct TVDetailHero<Actions: View, BelowSynopsis: View>: View {
             editorialPrimaryInformationColumn
             creditBlock
             TVPlaybackSelectionSummaryView(summary: playbackSummary)
+                .opacity(showsPlaybackSummary ? 1 : 0)
+                .accessibilityHidden(!showsPlaybackSummary)
         }
         .frame(maxWidth: editorialContentWidth, alignment: .leading)
     }
@@ -264,6 +267,8 @@ struct TVDetailHero<Actions: View, BelowSynopsis: View>: View {
         VStack(alignment: .leading, spacing: creditSummarySpacing) {
             creditBlock
             TVPlaybackSelectionSummaryView(summary: playbackSummary)
+                .opacity(showsPlaybackSummary ? 1 : 0)
+                .accessibilityHidden(!showsPlaybackSummary)
                 .frame(
                     height: playbackSummaryReservedHeight,
                     alignment: .topLeading

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
@@ -87,6 +87,7 @@ struct TVItemDetailView: View {
             viewModel.resumeTrailerFetchIfNeeded()
         }
         .onDisappear {
+            viewModel.cancelDetailLoading()
             Self.focusLogger.debug("itemDetail.disappear contentId=\(contentId, privacy: .public) pathDepth=\(router.path.count, privacy: .public)")
             viewModel.cancelDeferredEpisodeFavoriteStateRefresh()
             // The coordinator's poll is not owned by `.task`, so it would
@@ -413,7 +414,9 @@ struct TVItemDetailView: View {
                 },
                 activeEpisodeContentId: activeSeriesEpisodeContentId,
                 episodeFavoriteStates: viewModel.episodeFavoriteStates,
-                isLoadingEpisodes: viewModel.isLoadingEpisodes,
+                isLoadingEpisodes: viewModel.isLoadingSeriesHierarchy,
+                hierarchyError: viewModel.seriesLoadErrorMessage,
+                onRetryHierarchy: { await viewModel.retrySeriesHierarchy() },
                 selectedNextUpFileId: preferredNextUpFileId,
                 selectedNextUpAudioTrackIndex: preferredNextUpAudioTrackIndex,
                 selectedNextUpSubtitleTrackIndex: preferredNextUpSubtitleTrackIndex,

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -191,6 +191,8 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     let activeEpisodeContentId: String?
     let episodeFavoriteStates: [String: Bool]
     let isLoadingEpisodes: Bool
+    let hierarchyError: String?
+    let onRetryHierarchy: () async -> Void
     let selectedNextUpFileId: Int?
     let selectedNextUpAudioTrackIndex: Int?
     let selectedNextUpSubtitleTrackIndex: Int?
@@ -225,6 +227,8 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     @FocusState private var showActionRowFocused: Bool
     @FocusState private var focusedModeId: String?
     @State private var isShowingSeriesOverview = true
+    @State private var userNavigated = false
+    @State private var hierarchyRetryTask: Task<Void, Never>?
     @State private var primaryFocusRegion: PrimaryFocusRegion = .outside
     @State private var episodeRailFocusRequest = 0
     @State private var episodeRailFocusTarget: String?
@@ -290,6 +294,21 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                 .tvActionPopoverHost()
             }
         }
+        .onReceive(NotificationCenter.default.publisher(for: UIFocusSystem.didUpdateNotification)) { notification in
+            // Automatic fallback has no heading. Observe native movement; do
+            // not intercept remote presses or infer intent from focus alone.
+            guard let context = notification.userInfo?[UIFocusSystem.focusUpdateContextUserInfoKey]
+                    as? UIFocusUpdateContext,
+                  let scrollView = pageScrollCoordinator.scrollView else { return }
+            let previouslyInPage = context.previouslyFocusedView?.isDescendant(of: scrollView) == true
+            let nextInPage = context.nextFocusedView?.isDescendant(of: scrollView) == true
+            let directionalMove = !context.focusHeading.isEmpty && (previouslyInPage || nextInPage)
+            // Selecting the automatically focused synopsis can open a modal
+            // without any directional movement. That interaction also wins.
+            let leftPage = previouslyInPage && context.nextFocusedView != nil && !nextInPage
+            guard directionalMove || leftPage else { return }
+            userNavigated = true
+        }
         .onAppear {
             if activeEpisodeContentId != nil {
                 isShowingSeriesOverview = false
@@ -301,6 +320,9 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
             }
         }
         .onDisappear {
+            userNavigated = true
+            hierarchyRetryTask?.cancel()
+            hierarchyRetryTask = nil
             modeActivationTask?.cancel()
             modeActivationTask = nil
             modeFocusAppearanceTask?.cancel()
@@ -349,6 +371,7 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                 preferredSubtitleLanguage: profilePrefsStore.preferredSubtitleLanguage,
                 showForcedSubtitles: matchingPlaybackDetail?.effectiveShowForcedSubtitles ?? false
             ),
+            showsPlaybackSummary: isLoadingEpisodes || playbackEpisode != nil,
             backdropHeight: TVDetailLayout.heroHeight,
             // The hero shares the standard height and title inset with Movie
             // so the first viewport bottoms out on the episode rail: the season
@@ -443,6 +466,9 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
             rowFocused: $showActionRowFocused,
             stabilizesFocusMotion: true,
             primaryButtonWidth: 340,
+            isPlaybackLoading: isLoadingEpisodes && playbackEpisode == nil,
+            allowsInitialPlayFocus: !userNavigated,
+            tracksInitialFocusNavigation: true,
             playbackSelectors: {
                 // Keep all three triggers mounted while a newly focused
                 // episode's playback detail loads. They disable themselves
@@ -479,8 +505,33 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
 
     private var episodeExperience: some View {
         VStack(alignment: .leading, spacing: 14) {
-            modeRow
+            if seasons.isEmpty {
+                HStack(spacing: 12) {
+                    ForEach(0..<4) { _ in
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(.white.opacity(0.10))
+                            .frame(width: 170, height: 48)
+                    }
+                }
+                .frame(height: 60)
+                .opacity(isLoadingEpisodes ? 1 : 0)
+                .accessibilityHidden(!isLoadingEpisodes)
+                .accessibilityLabel("Loading seasons")
+            } else {
+                modeRow
+            }
             episodeBody
+            if let hierarchyError, !episodeWindow.episodes.isEmpty {
+                HStack {
+                    Text(hierarchyError)
+                    Button("Retry") {
+                        userNavigated = true
+                        hierarchyRetryTask?.cancel()
+                        hierarchyRetryTask = Task { await onRetryHierarchy() }
+                    }
+                }
+                .font(.system(size: 18))
+            }
             if carouselLoadFailed {
                 Text("Couldn't load more episodes. Press again to retry.")
                     .font(.system(size: 18))
@@ -655,7 +706,19 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
     @ViewBuilder
     private var episodeBody: some View {
         let carouselEpisodes = episodeWindow.episodes
-        if isLoadingEpisodes && carouselEpisodes.isEmpty {
+        if let hierarchyError, carouselEpisodes.isEmpty {
+            VStack(alignment: .leading, spacing: 18) {
+                Text(hierarchyError)
+                    .font(.system(size: 22))
+                Button("Retry") {
+                    userNavigated = true
+                    hierarchyRetryTask?.cancel()
+                    hierarchyRetryTask = Task { await onRetryHierarchy() }
+                }
+            }
+            .frame(maxWidth: .infinity, minHeight: episodeRailReservedHeight, alignment: .topLeading)
+            .focusSection()
+        } else if isLoadingEpisodes && carouselEpisodes.isEmpty {
             TVEpisodeRailPlaceholder(
                 cardWidth: SiloTheme.thumbnailCardWidth
                     * uiCustomization.cardPresentation.posterSize.scale,

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVSeriesDetailView.swift
@@ -448,17 +448,22 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
             playTitle: playbackEpisode.map(showPlayTitle(for:)),
             playSubtitle: nil,
             onPlay: {
+                userNavigated = true
                 guard let episode = playbackEpisode else { return }
                 onPlayEpisode(episode.contentId, selectedFileId(for: episode), false)
             },
             onStartOver: playbackEpisode?.userData?.isInProgress == true
                 ? {
+                    userNavigated = true
                     guard let episode = playbackEpisode else { return }
                     onPlayEpisode(episode.contentId, selectedFileId(for: episode), true)
                 }
                 : nil,
             inWatchlist: inWatchlist,
-            onToggleWatchlist: onToggleWatchlist,
+            onToggleWatchlist: {
+                userNavigated = true
+                onToggleWatchlist()
+            },
             focusResetKey: detail.contentId,
             initialFocusScope: .page,
             focusNamespace: detailFocusNamespace,
@@ -556,7 +561,10 @@ struct TVSeriesDetailView<BelowSynopsis: View>: View {
                             title: seasonLabel(season),
                             isSelected: selectedModeId == season.id,
                             rendersFocusedAppearance: presentedFocusedModeId == season.id,
-                            action: { activateSeason(season) }
+                            action: {
+                                userNavigated = true
+                                activateSeason(season)
+                            }
                         )
                         .id(season.id)
                         .focused($focusedModeId, equals: season.id)


### PR DESCRIPTION
Slow seasons requests could leave Series detail looking empty after the title appeared: tvOS reported “No episodes available,” and iOS showed a blank Episodes section without a loading cue on Play.

Track hierarchy loading and failures separately from catalog detail. Keep title/artwork visible, reserve space for missing content, and expose retryable errors. On tvOS, observe native focus movement so delayed Play focus can replace automatic fallback without overriding deliberate navigation. Preserve cached pages, hydrate ordinary cached iOS entries immediately, and reject cancelled or superseded hierarchy results. Continue Watching waits when a stale cache lacks its requested season, and retrying a background hierarchy failure retains the browsed season.

Validation:
- 71 focused tests passed, including 18 new regression tests covering delayed requests, empty results, failures/retries, cancellation, stale responses, and cached entry; existing Continue Watching and season-selection coverage passed.
- A disposable synthetic harness delayed seasons and episodes by 20 seconds each. Five tvOS simulator UI cases passed: delayed entry, navigation and Watchlist activation during loading, cached entry with return from a synthetic playback cover, and failure/retry/empty results. iOS delayed-rendering and failure/retry/empty-result checks passed.
- Normal iOS and tvOS apps built, installed, and launched after removing the diagnostic harness and temporary test targets.

Physical-device behavior, actual media playback, and macOS were not tested. The report of focus remaining on Watchlist remains unconfirmed. Server latency is unchanged; this PR addresses client presentation and request lifecycle only.

AI assistance: OpenAI GPT-6 using the Codex agent harness. The runtime did not expose a more specific model identifier. No other AI tooling was used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer loading states for seasons and episodes, including skeleton views and playback loading feedback.
  * Added error messages and Retry actions when series or episode data fails to load.
  * Play requests can remain queued while episode information loads.
  * Playback summaries and controls now adapt to loading and selection states.

* **Bug Fixes**
  * Improved cached season and episode restoration, including empty hierarchies.
  * Prevented stale or cancelled requests from replacing newer content.
  * Cancelled in-progress detail loading when leaving the screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->