### PR TITLE
fix(tvos): smooth season carousel scrolling across paging

### DIFF
--- a/iosApp/Tests/SeriesSeasonScrollTests.swift
+++ b/iosApp/Tests/SeriesSeasonScrollTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import Silo
+
+final class SeriesSeasonScrollTests: XCTestCase {
+    func testForwardAndBackwardTripsAreMonotonicAndFinishAtTheirDestination() {
+        for (start, target): (CGFloat, CGFloat) in [(0, 8000), (8000, 0)] {
+            let motion = SeriesSeasonScroll(startOffset: start, targetOffset: target, startedAt: 10)
+            let samples = (0...60).map { motion.offset(at: 10 + Double($0) / 60) }
+            for (previous, next) in zip(samples, samples.dropFirst()) {
+                XCTAssertGreaterThanOrEqual((next - previous) * (target - start), 0)
+            }
+            XCTAssertEqual(samples.first, start)
+            XCTAssertEqual(samples.last, target)
+            XCTAssertTrue(motion.isComplete(at: 11))
+        }
+    }
+
+    func testPrependingOrEvictingASeasonPreservesVisibleMotionAndCompletionTime() {
+        let original = SeriesSeasonScroll(startOffset: 12000, targetOffset: 18000, startedAt: 10)
+        for shift: CGFloat in [-8000, 8000] {
+            var rebased = original
+            rebased.rebase(by: shift)
+            for frame in 0...60 {
+                let time = 10 + Double(frame) / 60
+                // Subtracting the changed origin gives exactly the same
+                // screen-space position, including halfway through a trip.
+                XCTAssertEqual(rebased.offset(at: time) - shift, original.offset(at: time), accuracy: 0.000001)
+                XCTAssertEqual(rebased.isComplete(at: time), original.isComplete(at: time))
+            }
+        }
+    }
+
+    func testChangingDirectionStartsAtTheVisiblePosition() {
+        let first = SeriesSeasonScroll(startOffset: 0, targetOffset: 8000, startedAt: 10)
+        let visible = first.offset(at: 10.2)
+        let replacement = SeriesSeasonScroll(startOffset: visible, targetOffset: 0, startedAt: 10.2)
+        XCTAssertEqual(replacement.offset(at: 10.2), visible)
+        XCTAssertLessThan(replacement.offset(at: 10.3), visible)
+        XCTAssertEqual(replacement.offset(at: 11), 0)
+    }
+
+    func testFrameBeforeStartCannotOvershoot() {
+        let motion = SeriesSeasonScroll(startOffset: 400, targetOffset: 8000, startedAt: 10)
+        XCTAssertEqual(motion.offset(at: 9.99), 400)
+        XCTAssertFalse(motion.isComplete(at: 9.99))
+    }
+}

--- a/iosApp/iosApp/Screens/Detail/SeriesSeasonScroll.swift
+++ b/iosApp/iosApp/Screens/Detail/SeriesSeasonScroll.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// One continuous season-pill scroll, including changes to the loaded row's origin.
+struct SeriesSeasonScroll {
+    private(set) var startOffset: CGFloat
+    private(set) var targetOffset: CGFloat
+    let startedAt: TimeInterval
+    static let duration: TimeInterval = 0.45
+
+    func offset(at time: TimeInterval) -> CGFloat {
+        let progress = min(1, max(0, (time - startedAt) / Self.duration))
+        let eased = progress * progress * (3 - 2 * progress)
+        return startOffset + (targetOffset - startOffset) * eased
+    }
+
+    func isComplete(at time: TimeInterval) -> Bool {
+        time >= startedAt + Self.duration
+    }
+
+    mutating func rebase(by shift: CGFloat) {
+        startOffset += shift
+        targetOffset += shift
+    }
+}

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
@@ -71,9 +71,56 @@ struct TVEpisodeRail: View {
     @State private var scrollGeneration = 0
     @State private var scrollViewport = ScrollViewport()
 
-    private final class ScrollViewport {
+    private final class ScrollViewport: NSObject {
         weak var scrollView: UIScrollView?
         var correctionTarget: CGFloat?
+        private var seasonMotion: SeriesSeasonScroll?
+        private var displayLink: CADisplayLink?
+        private var onSeasonScrollEnd: ((CGFloat) -> Void)?
+
+        func scrollToSeason(_ offset: CGFloat, onEnd: @escaping (CGFloat) -> Void) {
+            stopSeasonScroll()
+            guard let scrollView else { onEnd(offset); return }
+            seasonMotion = SeriesSeasonScroll(
+                startOffset: scrollView.contentOffset.x,
+                targetOffset: offset,
+                startedAt: CACurrentMediaTime()
+            )
+            onSeasonScrollEnd = onEnd
+            let link = CADisplayLink(target: self, selector: #selector(advanceSeasonScroll))
+            displayLink = link
+            link.add(to: .main, forMode: .common)
+        }
+
+        /// Page eviction changes the coordinate origin, not the animation's
+        /// progress. Shift both endpoints without restarting its clock.
+        func rebaseSeasonScroll(by shift: CGFloat) -> Bool {
+            guard seasonMotion != nil, let scrollView else { return false }
+            seasonMotion?.rebase(by: shift)
+            scrollView.setContentOffset(
+                CGPoint(x: scrollView.contentOffset.x + shift, y: scrollView.contentOffset.y),
+                animated: false
+            )
+            return true
+        }
+
+        @objc private func advanceSeasonScroll(_ link: CADisplayLink) {
+            guard let seasonMotion, let scrollView else { stopSeasonScroll(); return }
+            let offset = seasonMotion.offset(at: link.timestamp)
+            // Advance the actual viewport each frame so the lazy row lays out
+            // intermediate cards. There is no second native settling animation.
+            scrollView.setContentOffset(CGPoint(x: offset, y: scrollView.contentOffset.y), animated: false)
+            if seasonMotion.isComplete(at: link.timestamp) { stopSeasonScroll() }
+        }
+
+        func stopSeasonScroll() {
+            displayLink?.invalidate()
+            displayLink = nil
+            seasonMotion = nil
+            let onEnd = onSeasonScrollEnd
+            onSeasonScrollEnd = nil
+            if let offset = scrollView?.contentOffset.x { onEnd?(offset) }
+        }
     }
 
     @FocusState private var focusedCardId: String?
@@ -165,7 +212,8 @@ struct TVEpisodeRail: View {
                        let index = episodes.firstIndex(where: { $0.contentId == scrollTargetContentId }) {
                         appliedScrollRequest = scrollRequest
                         pendingEdge = nil
-                        anchorFocusedSelection(at: index, viewportWidth: geometry.size.width)
+                        anchoredContentId = episodes[index].contentId
+                        scrollToSelectedSeason(at: index, viewportWidth: geometry.size.width)
                     } else if needsRebasedSelection {
                         // Finish any interrupted one-card movement in the new
                         // coordinates, after the nonanimated rebase has mounted.
@@ -178,15 +226,21 @@ struct TVEpisodeRail: View {
                     // Paging changes coordinates, not the user's selection.
                     // Preserve the visible position when seasons are prepended
                     // or evicted; appends must not restart an ongoing card slide.
-                    guard scrollRequest == appliedScrollRequest,
-                          let id = anchoredFocusedContentId ?? anchoredContentId,
+                    // Do this even when a season-pill jump is pending: its
+                    // destination uses the new coordinates, so its starting
+                    // viewport must be rebased before the task animates it.
+                    guard let id = anchoredFocusedContentId ?? anchoredContentId,
                           let oldIndex = oldIds.firstIndex(of: id),
                           let newIndex = newIds.firstIndex(of: id),
                           oldIndex != newIndex else { return }
                     let shift = CGFloat(newIndex - oldIndex) * (anchoredCardWidth + cardSpacing)
                     let offset = scrollViewport.scrollView?.contentOffset.x ?? 0
-                    moveAnchoredScroll(toOffset: max(0, offset + shift), animated: false)
-                    needsRebasedSelection = true
+                    if scrollViewport.rebaseSeasonScroll(by: shift) {
+                        synchronizeScrollPosition(to: max(0, offset + shift))
+                    } else {
+                        moveAnchoredScroll(toOffset: max(0, offset + shift), animated: false)
+                        needsRebasedSelection = true
+                    }
                 }
                 .onChange(of: currentContentId) { _, _ in
                     // The season chip owns an explicit animated request.
@@ -255,11 +309,13 @@ struct TVEpisodeRail: View {
         .onChange(of: isSelectingSeason) { _, ownsFocus in
             if !ownsFocus {
                 scrollGeneration &+= 1
+                scrollViewport.stopSeasonScroll()
                 cancelNativeScrollCorrection()
             }
         }
         .onDisappear {
             scrollGeneration &+= 1
+            scrollViewport.stopSeasonScroll()
             cancelNativeScrollCorrection()
             scrollViewport.scrollView = nil
             pendingEdge = nil
@@ -456,6 +512,27 @@ struct TVEpisodeRail: View {
         }
     }
 
+    private func synchronizeScrollPosition(to offset: CGFloat) {
+        var transaction = Transaction(animation: nil)
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            anchoredScrollPosition.scrollTo(x: offset)
+        }
+    }
+
+    private func scrollToSelectedSeason(at index: Int, viewportWidth: CGFloat) {
+        guard !reduceMotion, scrollViewport.scrollView != nil else {
+            moveAnchoredScroll(to: index, viewportWidth: viewportWidth, animated: false)
+            return
+        }
+        scrollGeneration &+= 1
+        cancelNativeScrollCorrection()
+        scrollViewport.scrollToSeason(
+            anchoredContentOffset(for: index, viewportWidth: viewportWidth),
+            onEnd: { synchronizeScrollPosition(to: $0) }
+        )
+    }
+
     private func moveAnchoredScroll(to index: Int, viewportWidth: CGFloat, animated: Bool) {
         moveAnchoredScroll(
             toOffset: anchoredContentOffset(for: index, viewportWidth: viewportWidth),
@@ -464,6 +541,7 @@ struct TVEpisodeRail: View {
     }
 
     private func moveAnchoredScroll(toOffset targetOffset: CGFloat, animated: Bool) {
+        scrollViewport.stopSeasonScroll()
         scrollGeneration &+= 1
         let generation = scrollGeneration
         cancelNativeScrollCorrection()

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
@@ -67,6 +67,7 @@ struct TVEpisodeRail: View {
     }
     @State private var pendingEdge: PendingEdge?
     @State private var appliedScrollRequest = 0
+    @State private var needsRebasedSelection = false
     @State private var scrollGeneration = 0
     @State private var scrollViewport = ScrollViewport()
 
@@ -165,14 +166,27 @@ struct TVEpisodeRail: View {
                         appliedScrollRequest = scrollRequest
                         pendingEdge = nil
                         anchorFocusedSelection(at: index, viewportWidth: geometry.size.width)
-                    } else {
-                        seedAnchoredSelection(
-                            viewportWidth: geometry.size.width,
-                            targetContentId: anchoredFocusedContentId ?? anchoredContentId,
-                            animated: true
-                        )
+                    } else if needsRebasedSelection {
+                        // Finish any interrupted one-card movement in the new
+                        // coordinates, after the nonanimated rebase has mounted.
+                        seedAnchoredSelection(viewportWidth: geometry.size.width, animated: true)
                     }
-                    completePendingEdge(viewportWidth: geometry.size.width)
+                    needsRebasedSelection = false
+                    completePendingEdge()
+                }
+                .onChange(of: episodeIdentityKey) { oldIds, newIds in
+                    // Paging changes coordinates, not the user's selection.
+                    // Preserve the visible position when seasons are prepended
+                    // or evicted; appends must not restart an ongoing card slide.
+                    guard scrollRequest == appliedScrollRequest,
+                          let id = anchoredFocusedContentId ?? anchoredContentId,
+                          let oldIndex = oldIds.firstIndex(of: id),
+                          let newIndex = newIds.firstIndex(of: id),
+                          oldIndex != newIndex else { return }
+                    let shift = CGFloat(newIndex - oldIndex) * (anchoredCardWidth + cardSpacing)
+                    let offset = scrollViewport.scrollView?.contentOffset.x ?? 0
+                    moveAnchoredScroll(toOffset: max(0, offset + shift), animated: false)
+                    needsRebasedSelection = true
                 }
                 .onChange(of: currentContentId) { _, _ in
                     // The season chip owns an explicit animated request.
@@ -412,12 +426,11 @@ struct TVEpisodeRail: View {
         request()
     }
 
-    private func completePendingEdge(viewportWidth: CGFloat) {
+    private func completePendingEdge() {
         guard let pendingEdge, anchoredFocusedContentId == pendingEdge.contentId,
               let index = episodes.firstIndex(where: { $0.contentId == pendingEdge.contentId }),
               episodes.indices.contains(index + pendingEdge.direction) else { return }
         let target = episodes[index + pendingEdge.direction].contentId
-        seedAnchoredSelection(viewportWidth: viewportWidth, targetContentId: target)
         // The user's boundary press owns this handoff. Cancel it if another
         // card or region took focus while the missing season was loading.
         DispatchQueue.main.async {
@@ -444,10 +457,16 @@ struct TVEpisodeRail: View {
     }
 
     private func moveAnchoredScroll(to index: Int, viewportWidth: CGFloat, animated: Bool) {
+        moveAnchoredScroll(
+            toOffset: anchoredContentOffset(for: index, viewportWidth: viewportWidth),
+            animated: animated
+        )
+    }
+
+    private func moveAnchoredScroll(toOffset targetOffset: CGFloat, animated: Bool) {
         scrollGeneration &+= 1
         let generation = scrollGeneration
         cancelNativeScrollCorrection()
-        let targetOffset = anchoredContentOffset(for: index, viewportWidth: viewportWidth)
         let animation: Animation = animated && !reduceMotion
             ? .easeOut(duration: 0.30)
             : .linear(duration: 0)
@@ -461,10 +480,10 @@ struct TVEpisodeRail: View {
             guard generation == scrollGeneration,
                   let scrollView = scrollViewport.scrollView,
                   abs(scrollView.contentOffset.x - targetOffset) > 0.5 else { return }
-            scrollViewport.correctionTarget = reduceMotion ? nil : targetOffset
+            scrollViewport.correctionTarget = animated && !reduceMotion ? targetOffset : nil
             scrollView.setContentOffset(
                 CGPoint(x: targetOffset, y: scrollView.contentOffset.y),
-                animated: !reduceMotion
+                animated: animated && !reduceMotion
             )
         }
     }


### PR DESCRIPTION
## Summary

- Preserve the visible episode-rail position when seasons are prepended or evicted during paging.
- Drive season-carousel transitions with a display-link animation so lazy-loaded cards follow the intermediate scroll position.
- Rebase active scroll endpoints when the content origin changes without restarting animation progress.
- Add regression coverage for monotonic scrolling, rebasing, direction changes, completion timing, and pre-start frames.

## Testing

- Not run locally.
- Added `SeriesSeasonScrollTests` covering forward and backward motion, paging rebases, direction changes, and completion behavior.

AI disclosure: Generated with GPT-5 using Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added smooth animated scrolling between seasons on the episode rail.
  - Season selection now remains synchronized with the visible scroll position after animations complete.
  - Scrolling adapts when seasons are added or removed, preserving the current viewing position where possible.

- **Bug Fixes**
  - Improved behavior when changing scroll direction or selecting seasons near the beginning of the list.
  - Prevented premature completion and unnecessary animation during reduced-motion scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->