### PR TITLE
fix(tvos): restore top-row focus after menu selection

### DIFF
--- a/docs/tvos-focus.md
+++ b/docs/tvos-focus.md
@@ -136,6 +136,23 @@ When closing a panel, choose the next owner explicitly:
 - Selecting a panel row closes, updates route/scope state, and then hands focus
   to the destination content.
 
+## Selecting a Page from the Top Menu
+
+Selecting Home, another tab, or a panel destination enters the page at its
+first row or top control, including when reselecting the current page after
+Menu/Back. Reset the vertical scroll position before forwarding the entry
+focus request. A row feed also resets its first row to the first card.
+
+Use `TVMenuEntryScroll` on the page's scroll view to reveal lazy entry controls
+without animation. Forward focus after scroll geometry reports the top and
+the entry row has had a layout pass. Animating a long scroll while claiming
+focus lets intermediate rows take focus and cancel the entry row's
+restoration ownership. Keep page identity and loaded data stable;
+a menu selection only resets scrolling and entry focus.
+
+Returning from a card's detail page still restores the launching card. Ordinary
+Up/Down navigation remains owned by the native focus engine.
+
 ## Debugging Checklist
 
 When tvOS focus feels random, capture logs for the ownership boundary first:

--- a/docs/tvos-focus.md
+++ b/docs/tvos-focus.md
@@ -150,6 +150,11 @@ focus lets intermediate rows take focus and cancel the entry row's
 restoration ownership. Keep page identity and loaded data stable;
 a menu selection only resets scrolling and entry focus.
 
+If Menu/Back returns ownership to the bar or a panel before the entry request
+finishes, cancel that request. Do not replay it when menu focus clears; the
+next deliberate page selection provides a new request. Cancel on disappearance
+as well, so queued layout callbacks cannot focus a page that has been left.
+
 Returning from a card's detail page still restores the launching card. Ordinary
 Up/Down navigation remains owned by the native focus engine.
 

--- a/iosApp/Tests/TVMenuEntryFocusStateTests.swift
+++ b/iosApp/Tests/TVMenuEntryFocusStateTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import Silo
+
+final class TVMenuEntryFocusStateTests: XCTestCase {
+    func testBackCancelsCallbackAlreadyQueuedAfterScrolling() {
+        var state = TVMenuEntryFocusState()
+        XCTAssertTrue(state.receive(1, menuOwnsFocus: false))
+        let queued = state.pendingRequest!
+        state.cancel()
+        XCTAssertFalse(state.consume(queued))
+        XCTAssertFalse(state.receive(1, menuOwnsFocus: false))
+    }
+
+    func testFreshSelectionSurvivesAnOlderQueuedCallback() {
+        var state = TVMenuEntryFocusState()
+        XCTAssertTrue(state.receive(1, menuOwnsFocus: false))
+        state.cancel()
+        XCTAssertTrue(state.receive(2, menuOwnsFocus: false))
+        XCTAssertFalse(state.consume(1))
+        XCTAssertTrue(state.consume(2))
+        XCTAssertFalse(state.consume(2))
+    }
+
+    func testEntryArrivingWhileMenuOwnsFocusDoesNotReplayLater() {
+        var state = TVMenuEntryFocusState()
+        XCTAssertFalse(state.receive(1, menuOwnsFocus: true))
+        XCTAssertFalse(state.receive(1, menuOwnsFocus: false))
+        XCTAssertFalse(state.consume(1))
+        XCTAssertTrue(state.receive(2, menuOwnsFocus: false))
+    }
+
+    func testNewRequestSupersedesUnfinishedScroll() {
+        var state = TVMenuEntryFocusState()
+        XCTAssertTrue(state.receive(1, menuOwnsFocus: false))
+        XCTAssertTrue(state.receive(2, menuOwnsFocus: false))
+        XCTAssertFalse(state.consume(1))
+        XCTAssertTrue(state.consume(2))
+    }
+
+    func testInactiveRequestDoesNotClaimFocus() {
+        var state = TVMenuEntryFocusState()
+        XCTAssertFalse(state.receive(0, menuOwnsFocus: false))
+        XCTAssertFalse(state.consume(0))
+    }
+}

--- a/iosApp/iosApp/Components/MediaRow.swift
+++ b/iosApp/iosApp/Components/MediaRow.swift
@@ -141,12 +141,17 @@ struct MediaRow: View {
         lastAppliedFocusRequest = request
         focusRestorationGeneration += 1
         let generation = focusRestorationGeneration
+        // A recycled row can retain this value after UIKit drops its focus.
+        // Clear it so reselecting the same entry card produces a fresh claim.
+        focusedItemId = nil
         // Scroll to the requested card first, claim a turn later: a row parked
         // deep in its strip can keep that card unmounted (LazyHStack) or clipped, and
         // the focus engine silently drops @FocusState writes to views it
         // can't focus. The instant scroll mounts/unclips the card; the
         // deferred write then lands on a focusable target.
-        withAnimation(reduceMotion ? nil : .easeInOut(duration: SiloTheme.slowDuration)) {
+        var transaction = Transaction(animation: nil)
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
             proxy.scrollTo(targetItem.id, anchor: .center)
         }
         DispatchQueue.main.async {
@@ -158,10 +163,9 @@ struct MediaRow: View {
     /// Write the claim, then verify it actually stuck and re-assert if not.
     /// A single write races two things that both win by coming later: the
     /// engine's remembered-focus repair after the top bar resigns, and the
-    /// geometric re-repairs it makes while the feed's scroll-to-top slides
-    /// rows (and their cards) under whatever it had focused. @FocusState
-    /// reflects *actual* focus, so a rejected/overridden write reads back as
-    /// a different value — retry until the scroll settles and ours is last.
+    /// layout that mounts the requested card after scrolling. @FocusState
+    /// reflects actual focus, so a rejected write reads back as a different
+    /// value. Restoration ownership cancels retries when focus leaves the row.
     private func claimRequestedItemFocus(
         _ targetItem: SectionItem,
         generation: Int,
@@ -173,8 +177,7 @@ struct MediaRow: View {
         focusedItemId = targetItem.contentId
         lastFocusedItemId = targetItem.contentId
         onItemFocus?(targetItem)
-        // Window must outlast the ~300ms animated ride home plus the engine's
-        // settling repairs, or the last mid-flight repair wins after all.
+        // Allow a bounded window for lazy layout and the engine's entry repair.
         guard attempt < 8 else { return }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
             guard generation == focusRestorationGeneration,

--- a/iosApp/iosApp/Screens/Calendar/CalendarView.swift
+++ b/iosApp/iosApp/Screens/Calendar/CalendarView.swift
@@ -13,6 +13,7 @@ struct CalendarView: View {
     @State private var viewModel = CalendarViewModel()
     @Environment(AppRouter.self) private var router
     #if os(tvOS)
+    @State private var entryFocusRequest = 0
     /// Focus hand-off for day selection: picking a day in the week strip
     /// scrolls to that day's shelf and kicks focus onto its first card.
     @State private var shelfFocusRequest = 0
@@ -199,7 +200,7 @@ struct CalendarView: View {
                         CalendarFilterBar(
                             selected: viewModel.filter,
                             onSelect: { viewModel.select(filter: $0) },
-                            focusRequest: focusRequest,
+                            focusRequest: entryFocusRequest,
                             onMoveUp: onTopMenuFocusRequest
                         )
 
@@ -227,6 +228,7 @@ struct CalendarView: View {
                 .padding(.top, TVTopMenuLayout.contentTopInset)
                 .padding(.bottom, SiloTheme.largePadding)
             }
+            .modifier(TVMenuEntryScroll(request: focusRequest) { entryFocusRequest = $0 })
         }
     }
     #endif

--- a/iosApp/iosApp/Screens/Calendar/CalendarView.swift
+++ b/iosApp/iosApp/Screens/Calendar/CalendarView.swift
@@ -8,6 +8,7 @@ struct CalendarView: View {
     /// changes (the Calendar root was selected), focus is pushed onto
     /// the filter bar so the screen never opens with a dead remote.
     var focusRequest: Int = 0
+    var isTopMenuFocused: Bool = false
     var onTopMenuFocusRequest: (() -> Void)? = nil
 
     @State private var viewModel = CalendarViewModel()
@@ -228,7 +229,7 @@ struct CalendarView: View {
                 .padding(.top, TVTopMenuLayout.contentTopInset)
                 .padding(.bottom, SiloTheme.largePadding)
             }
-            .modifier(TVMenuEntryScroll(request: focusRequest) { entryFocusRequest = $0 })
+            .modifier(TVMenuEntryScroll(request: focusRequest, isTopMenuFocused: isTopMenuFocused) { entryFocusRequest = $0 })
         }
     }
     #endif

--- a/iosApp/iosApp/Screens/Personal/FavoritesView.swift
+++ b/iosApp/iosApp/Screens/Personal/FavoritesView.swift
@@ -307,8 +307,6 @@ struct FavoritesView: View {
             await loadFavorites()
         }
         #if os(tvOS)
-        .onAppear { applyFocusRequest(focusRequest) }
-        .onChange(of: focusRequest) { _, request in applyFocusRequest(request) }
         .onChange(of: items.map(\.contentId)) { _, _ in applyFocusRequest(focusRequest) }
         #endif
     }
@@ -385,6 +383,7 @@ struct FavoritesView: View {
             .padding(.top, usesTVTopMenu ? TVTopMenuLayout.contentTopInset : 20)
             .padding(.bottom, SiloTheme.safePadding)
         }
+        .modifier(TVMenuEntryScroll(request: focusRequest, onReady: applyFocusRequest))
     }
 
     private var sectionSelector: some View {

--- a/iosApp/iosApp/Screens/Personal/FavoritesView.swift
+++ b/iosApp/iosApp/Screens/Personal/FavoritesView.swift
@@ -383,7 +383,7 @@ struct FavoritesView: View {
             .padding(.top, usesTVTopMenu ? TVTopMenuLayout.contentTopInset : 20)
             .padding(.bottom, SiloTheme.safePadding)
         }
-        .modifier(TVMenuEntryScroll(request: focusRequest, onReady: applyFocusRequest))
+        .modifier(TVMenuEntryScroll(request: focusRequest, isTopMenuFocused: isTopMenuFocused, onReady: applyFocusRequest))
     }
 
     private var sectionSelector: some View {

--- a/iosApp/iosApp/Screens/Personal/WatchlistView.swift
+++ b/iosApp/iosApp/Screens/Personal/WatchlistView.swift
@@ -82,8 +82,6 @@ struct WatchlistView: View {
             await loadWatchlist()
         }
         #if os(tvOS)
-        .onAppear { applyFocusRequest(focusRequest) }
-        .onChange(of: focusRequest) { _, request in applyFocusRequest(request) }
         .onChange(of: items.map(\.contentId)) { _, _ in applyFocusRequest(focusRequest) }
         #endif
     }
@@ -190,6 +188,7 @@ struct WatchlistView: View {
             .padding(.top, usesTVTopMenu ? TVTopMenuLayout.contentTopInset : SiloTheme.smallPadding)
             .padding(.bottom, SiloTheme.safePadding)
         }
+        .modifier(TVMenuEntryScroll(request: focusRequest, onReady: applyFocusRequest))
     }
 
     /// Keep the final poster width stable even when the global poster-size

--- a/iosApp/iosApp/Screens/Personal/WatchlistView.swift
+++ b/iosApp/iosApp/Screens/Personal/WatchlistView.swift
@@ -188,7 +188,7 @@ struct WatchlistView: View {
             .padding(.top, usesTVTopMenu ? TVTopMenuLayout.contentTopInset : SiloTheme.smallPadding)
             .padding(.bottom, SiloTheme.safePadding)
         }
-        .modifier(TVMenuEntryScroll(request: focusRequest, onReady: applyFocusRequest))
+        .modifier(TVMenuEntryScroll(request: focusRequest, isTopMenuFocused: isTopMenuFocused, onReady: applyFocusRequest))
     }
 
     /// Keep the final poster width stable even when the global poster-size

--- a/iosApp/iosApp/tvOS/Components/TVMenuEntryScroll.swift
+++ b/iosApp/iosApp/tvOS/Components/TVMenuEntryScroll.swift
@@ -1,0 +1,48 @@
+#if os(tvOS)
+import SwiftUI
+
+/// Reveal a page's entry controls before forwarding a top-menu focus request.
+/// Keep the same scroll view and content state when the user reselects a page.
+struct TVMenuEntryScroll: ViewModifier {
+    let request: Int
+    let onReady: (Int) -> Void
+
+    @State private var position = ScrollPosition(edge: .top)
+    @State private var lastRequest = 0
+    @State private var pendingRequest: Int?
+    @State private var isAtTop = false
+
+    func body(content: Content) -> some View {
+        content
+            .scrollPosition($position)
+            .onScrollGeometryChange(for: Bool.self) { geometry in
+                geometry.contentOffset.y + geometry.contentInsets.top <= 1
+            } action: { _, atTop in
+                isAtTop = atTop
+                if atTop { forwardPendingRequest() }
+            }
+            .onChange(of: request, initial: true) { _, request in
+                guard request > 0, request != lastRequest else { return }
+                lastRequest = request
+                pendingRequest = request
+                var transaction = Transaction(animation: nil)
+                transaction.disablesAnimations = true
+                withTransaction(transaction) {
+                    position.scrollTo(edge: .top)
+                }
+                // Already at the top produces no geometry change.
+                if isAtTop { forwardPendingRequest() }
+            }
+    }
+
+    private func forwardPendingRequest() {
+        guard let pending = pendingRequest else { return }
+        // Wait for the layout that revealed the lazy entry row to commit.
+        DispatchQueue.main.async {
+            guard isAtTop, pendingRequest == pending else { return }
+            pendingRequest = nil
+            onReady(pending)
+        }
+    }
+}
+#endif

--- a/iosApp/iosApp/tvOS/Components/TVMenuEntryScroll.swift
+++ b/iosApp/iosApp/tvOS/Components/TVMenuEntryScroll.swift
@@ -1,3 +1,27 @@
+/// Tracks a single entry request across delayed scroll and layout callbacks.
+/// Returning to the menu cancels the request; only a new selection can rearm it.
+struct TVMenuEntryFocusState {
+    private var lastRequest = 0
+    private(set) var pendingRequest: Int?
+
+    mutating func receive(_ request: Int, menuOwnsFocus: Bool) -> Bool {
+        guard request > 0, request != lastRequest else { return false }
+        lastRequest = request
+        pendingRequest = menuOwnsFocus ? nil : request
+        return pendingRequest != nil
+    }
+
+    mutating func cancel() {
+        pendingRequest = nil
+    }
+
+    mutating func consume(_ request: Int) -> Bool {
+        guard pendingRequest == request else { return false }
+        pendingRequest = nil
+        return true
+    }
+}
+
 #if os(tvOS)
 import SwiftUI
 
@@ -5,11 +29,11 @@ import SwiftUI
 /// Keep the same scroll view and content state when the user reselects a page.
 struct TVMenuEntryScroll: ViewModifier {
     let request: Int
+    let isTopMenuFocused: Bool
     let onReady: (Int) -> Void
 
     @State private var position = ScrollPosition(edge: .top)
-    @State private var lastRequest = 0
-    @State private var pendingRequest: Int?
+    @State private var focusState = TVMenuEntryFocusState()
     @State private var isAtTop = false
 
     func body(content: Content) -> some View {
@@ -21,10 +45,12 @@ struct TVMenuEntryScroll: ViewModifier {
                 isAtTop = atTop
                 if atTop { forwardPendingRequest() }
             }
+            .onChange(of: isTopMenuFocused) { _, menuOwnsFocus in
+                if menuOwnsFocus { focusState.cancel() }
+            }
+            .onDisappear { focusState.cancel() }
             .onChange(of: request, initial: true) { _, request in
-                guard request > 0, request != lastRequest else { return }
-                lastRequest = request
-                pendingRequest = request
+                guard focusState.receive(request, menuOwnsFocus: isTopMenuFocused) else { return }
                 var transaction = Transaction(animation: nil)
                 transaction.disablesAnimations = true
                 withTransaction(transaction) {
@@ -36,11 +62,10 @@ struct TVMenuEntryScroll: ViewModifier {
     }
 
     private func forwardPendingRequest() {
-        guard let pending = pendingRequest else { return }
+        guard let pending = focusState.pendingRequest else { return }
         // Wait for the layout that revealed the lazy entry row to commit.
         DispatchQueue.main.async {
-            guard isAtTop, pendingRequest == pending else { return }
-            pendingRequest = nil
+            guard isAtTop, focusState.consume(pending) else { return }
             onReady(pending)
         }
     }

--- a/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
+++ b/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
@@ -130,7 +130,7 @@ struct TVSkylineSectionFeed: View {
             .onScrollPhaseChange { _, phase in
                 marqueeModel.setBackdropDeferred(phase != .idle)
             }
-            .modifier(TVMenuEntryScroll(request: lastAppliedRequest, onReady: claimEntryFocus))
+            .modifier(TVMenuEntryScroll(request: lastAppliedRequest, isTopMenuFocused: isTopMenuFocused, onReady: claimEntryFocus))
             .frame(width: proxy.size.width, height: visibleBandHeight, alignment: .topLeading)
             .clipped()
             .padding(.top, bandTop)

--- a/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
+++ b/iosApp/iosApp/tvOS/Components/TVSkylineSectionFeed.swift
@@ -39,12 +39,6 @@ struct TVSkylineSectionFeed: View {
     /// Token handed only to row 1 when the shell explicitly enters content.
     /// It is never changed during ordinary row-to-row navigation.
     @State private var contentFocusToken = 0
-    /// Snaps the row band back to the first section before a focus claim.
-    /// The band clips rows outside the viewport, and tvOS refuses to focus a
-    /// clipped view — so when entry focus fires while the user is parked on a
-    /// lower row (e.g. re-clicking the current tab in the top menu), the first
-    /// card's claim silently no-ops unless the band is scrolled home first.
-    @State private var entryScrollToken = 0
     /// Entry tokens that arrived before any row mounted — sections load
     /// async, so the initial hand-down would land on nothing.
     @State private var pendingFocusRequest: Int?
@@ -52,8 +46,6 @@ struct TVSkylineSectionFeed: View {
     /// The row that owns card focus or its context-menu dismissal flow. Unlike
     /// the marquee preview, this is cleared when focus moves into chrome.
     @State private var focusRestorationOwnerSectionId: String?
-
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         ZStack(alignment: .top) {
@@ -113,43 +105,32 @@ struct TVSkylineSectionFeed: View {
                 visibleBandHeight - SiloTheme.Skyline.rowBandBottomInset
             )
 
-            ScrollViewReader { scrollProxy in
-                ScrollView(.vertical, showsIndicators: false) {
-                    // Bound the live view graph to nearby rows. Keeping the
-                    // entire feed mounted makes focus and scroll transactions
-                    // traverse offscreen card, image, and button subgraphs.
-                    // The native scroll container loads directional targets;
-                    // its viewport uses the corrected layout frames above.
-                    LazyVStack(alignment: .leading, spacing: SiloTheme.Skyline.rowBandPreviewSpacing) {
-                        ForEach(Array(sections.enumerated()), id: \.element.id) { index, section in
-                            featuredRow(section, isFirstRow: index == 0)
-                                .fixedSize(horizontal: false, vertical: true)
-                                .id(section.id)
-                        }
-                    }
-                    .scrollTargetLayout()
-                    // Allows the final row to top-align like every prior row,
-                    // with a blank preview area underneath instead of clamping.
-                    .padding(.bottom, trailingPreviewPadding)
-                }
-                .scrollTargetBehavior(.viewAligned)
-                // Row changes animate the band; the marquee holds its backdrop
-                // swap until the scroll settles so the two never composite in
-                // the same frames.
-                .onScrollPhaseChange { _, phase in
-                    marqueeModel.setBackdropDeferred(phase != .idle)
-                }
-                // Animated ride home; the first card's focus claim is
-                // re-asserted by MediaRow until the scroll settles, so the
-                // animation can't lose the claim to mid-flight focus repairs.
-                .onChange(of: entryScrollToken) { _, _ in
-                    if let firstId = sections.first?.id {
-                        withAnimation(reduceMotion ? nil : .easeInOut(duration: SiloTheme.slowDuration)) {
-                            scrollProxy.scrollTo(firstId, anchor: .top)
-                        }
+            ScrollView(.vertical, showsIndicators: false) {
+                // Bound the live view graph to nearby rows. Keeping the
+                // entire feed mounted makes focus and scroll transactions
+                // traverse offscreen card, image, and button subgraphs.
+                // The native scroll container loads directional targets;
+                // its viewport uses the corrected layout frames above.
+                LazyVStack(alignment: .leading, spacing: SiloTheme.Skyline.rowBandPreviewSpacing) {
+                    ForEach(Array(sections.enumerated()), id: \.element.id) { index, section in
+                        featuredRow(section, isFirstRow: index == 0)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .id(section.id)
                     }
                 }
+                .scrollTargetLayout()
+                // Allows the final row to top-align like every prior row,
+                // with a blank preview area underneath instead of clamping.
+                .padding(.bottom, trailingPreviewPadding)
             }
+            .scrollTargetBehavior(.viewAligned)
+            // Row changes animate the band; the marquee holds its backdrop
+            // swap until the scroll settles so the two never composite in
+            // the same frames.
+            .onScrollPhaseChange { _, phase in
+                marqueeModel.setBackdropDeferred(phase != .idle)
+            }
+            .modifier(TVMenuEntryScroll(request: lastAppliedRequest, onReady: claimEntryFocus))
             .frame(width: proxy.size.width, height: visibleBandHeight, alignment: .topLeading)
             .clipped()
             .padding(.top, bandTop)
@@ -225,17 +206,14 @@ struct TVSkylineSectionFeed: View {
         if isTopMenuFocused { return }
         guard request != lastAppliedRequest else { return }
         lastAppliedRequest = request
-        guard let firstSectionId = sections.first?.id else { return }
+    }
+
+    private func claimEntryFocus(_ request: Int) {
+        guard !isTopMenuFocused,
+              lastAppliedRequest == request,
+              let firstSectionId = sections.first?.id else { return }
         focusRestorationOwnerSectionId = firstSectionId
-        // Scroll the band home first, then claim on the next turn: the claim
-        // is a @FocusState write on the first row's first card, which the
-        // engine drops while that card is still clipped out of the viewport.
-        entryScrollToken += 1
-        DispatchQueue.main.async {
-            guard !isTopMenuFocused,
-                  sections.first?.id == firstSectionId else { return }
-            contentFocusToken += 1
-        }
+        contentFocusToken += 1
     }
 
     private func previewFocusedItem(_ item: SectionItem, in section: ResolvedSection) {

--- a/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
+++ b/iosApp/iosApp/tvOS/Navigation/TVMainTabView.swift
@@ -385,6 +385,12 @@ struct TVMainTabView: View {
         }
     }
 
+    /// The bar and an entered panel both own chrome focus. Native bar-focus
+    /// telemetry can be false during those handoffs, so use shell ownership.
+    private var menuOwnsFocus: Bool {
+        !isTopMenuFocusSuppressed || panelEntersFocus
+    }
+
     @ViewBuilder
     private var selectedRootContent: some View {
         switch selectedRoot {
@@ -392,13 +398,13 @@ struct TVMainTabView: View {
             HomeView(
                 homeFocusRequest: contentFocusRequest,
                 detailReturnFocusRequest: detailReturnFocusRequest,
-                isTopMenuFocused: isTopMenuFocused,
+                isTopMenuFocused: menuOwnsFocus,
                 onTopMenuFocusRequest: { focusTopMenuIfVisible() }
             )
         case .recommendations:
             RecommendationsView(
                 focusRequest: contentFocusRequest,
-                isTopMenuFocused: isTopMenuFocused,
+                isTopMenuFocused: menuOwnsFocus,
                 onTopMenuFocusRequest: { focusTopMenuIfVisible() }
             )
         case .libraryType(let type):
@@ -409,7 +415,7 @@ struct TVMainTabView: View {
                 activeLibrary: active,
                 selectedPill: pillSelection(for: type),
                 focusRequest: contentFocusRequest,
-                isTopMenuFocused: isTopMenuFocused,
+                isTopMenuFocused: menuOwnsFocus,
                 onTopMenuFocusRequest: { focusTopMenuIfVisible() }
             )
             // Re-create the tab body when the type changes so per-type
@@ -425,7 +431,7 @@ struct TVMainTabView: View {
                     activeLibrary: library,
                     selectedPill: shortcutPillSelection(for: libraryId, categoryType: type),
                     focusRequest: contentFocusRequest,
-                    isTopMenuFocused: isTopMenuFocused,
+                    isTopMenuFocused: menuOwnsFocus,
                     onTopMenuFocusRequest: { focusTopMenuIfVisible() }
                 )
                 .id(library.id)
@@ -440,6 +446,7 @@ struct TVMainTabView: View {
         case .calendar:
             CalendarView(
                 focusRequest: contentFocusRequest,
+                isTopMenuFocused: menuOwnsFocus,
                 onTopMenuFocusRequest: { focusTopMenuIfVisible() }
             )
         }
@@ -453,7 +460,7 @@ struct TVMainTabView: View {
                 showsNavigationTitle: false,
                 usesTVTopMenu: true,
                 focusRequest: contentFocusRequest,
-                isTopMenuFocused: isTopMenuFocused,
+                isTopMenuFocused: menuOwnsFocus,
                 onTopMenuFocusRequest: { focusTopMenuIfVisible() }
             )
         case .favorites:
@@ -461,7 +468,7 @@ struct TVMainTabView: View {
                 showsNavigationTitle: false,
                 usesTVTopMenu: true,
                 focusRequest: contentFocusRequest,
-                isTopMenuFocused: isTopMenuFocused,
+                isTopMenuFocused: menuOwnsFocus,
                 onTopMenuFocusRequest: { focusTopMenuIfVisible() }
             )
         }

--- a/iosApp/iosApp/tvOS/Screens/Libraries/TVLibraryCollectionsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Libraries/TVLibraryCollectionsView.swift
@@ -37,13 +37,12 @@ struct TVLibraryCollectionsView: View {
             }
             .padding(.bottom, SiloTheme.largePadding)
         }
+        .modifier(TVMenuEntryScroll(request: focusRequest, onReady: noteShellFocusRequest))
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .task {
             guard collectionSections.isEmpty else { return }
             await loadCollections()
         }
-        .onAppear { noteShellFocusRequest(focusRequest) }
-        .onChange(of: focusRequest) { _, request in noteShellFocusRequest(request) }
         .onChange(of: collectionSections.isEmpty) { _, isEmpty in
             if !isEmpty, hasPendingFocusClaim {
                 claimContentFocusIfReady()

--- a/iosApp/iosApp/tvOS/Screens/Libraries/TVLibraryCollectionsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Libraries/TVLibraryCollectionsView.swift
@@ -48,6 +48,10 @@ struct TVLibraryCollectionsView: View {
                 claimContentFocusIfReady()
             }
         }
+        .onChange(of: isTopMenuFocused) { _, menuOwnsFocus in
+            if menuOwnsFocus { hasPendingFocusClaim = false }
+        }
+        .onDisappear { hasPendingFocusClaim = false }
     }
 
     @ViewBuilder
@@ -170,12 +174,12 @@ struct TVLibraryCollectionsView: View {
     }
 
     private func claimContentFocusIfReady() {
-        guard collectionSections.contains(where: { !$0.collections.isEmpty }) else {
-            hasPendingFocusClaim = true
+        guard !isTopMenuFocused else {
+            hasPendingFocusClaim = false
             return
         }
-        if isTopMenuFocused {
-            hasPendingFocusClaim = false
+        guard collectionSections.contains(where: { !$0.collections.isEmpty }) else {
+            hasPendingFocusClaim = true
             return
         }
         hasPendingFocusClaim = false

--- a/iosApp/iosApp/tvOS/Screens/Libraries/TVLibraryCollectionsView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Libraries/TVLibraryCollectionsView.swift
@@ -37,7 +37,7 @@ struct TVLibraryCollectionsView: View {
             }
             .padding(.bottom, SiloTheme.largePadding)
         }
-        .modifier(TVMenuEntryScroll(request: focusRequest, onReady: noteShellFocusRequest))
+        .modifier(TVMenuEntryScroll(request: focusRequest, isTopMenuFocused: isTopMenuFocused, onReady: noteShellFocusRequest))
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .task {
             guard collectionSections.isEmpty else { return }
@@ -174,7 +174,7 @@ struct TVLibraryCollectionsView: View {
             hasPendingFocusClaim = true
             return
         }
-        if hasPendingFocusClaim, isTopMenuFocused {
+        if isTopMenuFocused {
             hasPendingFocusClaim = false
             return
         }

--- a/iosApp/iosApp/tvOS/Screens/Libraries/TVLibraryGridView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Libraries/TVLibraryGridView.swift
@@ -106,9 +106,7 @@ struct TVLibraryGridView: View {
             }
             await viewModel.loadFacetsIfNeeded()
         }
-        .onAppear { noteShellFocusRequest(focusRequest) }
         .onDisappear { viewModel.cancelPosterPrefetch() }
-        .onChange(of: focusRequest) { _, request in noteShellFocusRequest(request) }
     }
 
     @ViewBuilder
@@ -197,6 +195,7 @@ struct TVLibraryGridView: View {
             }
             .padding(.bottom, 48)
         }
+        .modifier(TVMenuEntryScroll(request: focusRequest, onReady: noteShellFocusRequest))
     }
 
     // MARK: - Focus routing

--- a/iosApp/iosApp/tvOS/Screens/Libraries/TVLibraryGridView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Libraries/TVLibraryGridView.swift
@@ -195,7 +195,7 @@ struct TVLibraryGridView: View {
             }
             .padding(.bottom, 48)
         }
-        .modifier(TVMenuEntryScroll(request: focusRequest, onReady: noteShellFocusRequest))
+        .modifier(TVMenuEntryScroll(request: focusRequest, isTopMenuFocused: isTopMenuFocused, onReady: noteShellFocusRequest))
     }
 
     // MARK: - Focus routing


### PR DESCRIPTION
Selecting Home or another tvOS menu destination should return to its first row or top control, including when reselecting the current page. Previously, deep scroll positions and lazy layout could prevent focus from reaching the entry row.

The shared page-entry modifier resets vertical scrolling without animation, waits for entry content to be laid out, then forwards focus. Feed entry also resets the first card while preserving loaded page state and detail-return focus. Pending requests now cancel when Menu/Back returns ownership to the bar or a menu panel, or when the page disappears. Stale callbacks cannot replay an abandoned request; a fresh selection creates a new one. Collections also checks menu ownership before every content-focus claim and clears claims waiting for data when the menu takes ownership or the page disappears.

Validation:
- Five focused state-model XCTest tests passed in an isolated SwiftPM harness compiling the production state source.
- tvOS simulator build, install, and launch passed for the follow-up fix.
- Independent code review found no further correctness defects. CodeRabbit confirmed the fixes in thread replies; its full review of the final push was rate limited. Macroscope skipped its check.
- The original change passed simulator focus checks and a physical Apple TV Release check of deep Home scrolling, Back, Home re-entry, and subsequent Right navigation. The cancellation follow-up has not been redeployed to hardware.
- The additional rapid Select/Back simulator check was blocked by WebDriverAgent startup failure; that interaction remains a rendered verification gap. Full XCTest suite was not run locally. CI passed the complete iOS suite and the tvOS/macOS builds on 004e4bee.

AI disclosure: Implemented with GPT-6 using the Codex agent harness, with a Codex review subagent and GitHub Codex/CodeRabbit feedback. Earlier PR work was disclosed as GPT-5 using Codex.
