### PR TITLE
fix(tvos): prevent repeated episode carousel animations

### DIFF
--- a/iosApp/Tests/SeriesSeasonScrollTests.swift
+++ b/iosApp/Tests/SeriesSeasonScrollTests.swift
@@ -62,11 +62,14 @@ final class SeriesSeasonScrollTests: XCTestCase {
     }
 
     func testBothScrollTimingsStayWithinBoundsInEitherDirection() {
-        for timing in [SeriesSeasonScroll.Timing.season, .episode] {
+        for (timing, deadline) in [(SeriesSeasonScroll.Timing.season, 0.45), (.episode, 0.30)] {
             for (start, target): (CGFloat, CGFloat) in [(0, 8800), (8800, 0)] {
                 let motion = SeriesSeasonScroll(
                     startOffset: start, targetOffset: target, startedAt: 10, timing: timing
                 )
+                XCTAssertFalse(motion.isComplete(at: 10 + deadline - 0.001))
+                XCTAssertTrue(motion.isComplete(at: 10 + deadline))
+                XCTAssertEqual(motion.offset(at: 10 + deadline), target, accuracy: 0.000001)
                 let samples = (0...60).map { motion.offset(at: 10 + Double($0) / 60) }
                 for (previous, next) in zip(samples, samples.dropFirst()) {
                     XCTAssertGreaterThanOrEqual((next - previous) * (target - start), 0)
@@ -76,6 +79,49 @@ final class SeriesSeasonScrollTests: XCTestCase {
                 XCTAssertEqual(samples.last, target)
             }
         }
+    }
+    func testPagingCannotOverscrollARailThatFitsInTheViewport() {
+        for shift: CGFloat in [-280, 280] {
+            XCTAssertEqual(SeriesSeasonScroll.clampedOffset(shift, maximumOffset: 0), 0)
+            var motion = SeriesSeasonScroll(startOffset: 0, targetOffset: 280, startedAt: 10)
+            motion.rebase(by: shift)
+            for frame in 0...60 {
+                let offset = motion.offset(at: 10 + Double(frame) / 60)
+                XCTAssertEqual(SeriesSeasonScroll.clampedOffset(offset, maximumOffset: 0), 0)
+            }
+            XCTAssertTrue(motion.isComplete(at: 10.45))
+        }
+    }
+
+    func testShrinkingRangeClampsIdleOffsetWithoutAnOriginShift() {
+        XCTAssertEqual(SeriesSeasonScroll.clampedOffset(1120, maximumOffset: 560), 560)
+        XCTAssertEqual(SeriesSeasonScroll.clampedOffset(-280, maximumOffset: 560), 0)
+    }
+
+    func testClippingRebasedFramesPreservesLegalIntermediatePositionsAndDeadline() {
+        var motion = SeriesSeasonScroll(startOffset: 0, targetOffset: 1200, startedAt: 10)
+        motion.rebase(by: -400)
+        // At the midpoint, translating the curve gives 200. Clamping the
+        // endpoints first would instead produce 400 and visibly jump ahead.
+        XCTAssertEqual(
+            SeriesSeasonScroll.clampedOffset(motion.offset(at: 10.225), maximumOffset: 800),
+            200, accuracy: 0.000001
+        )
+        for maximum: CGFloat in [560, 800] {
+            for frame in 0...60 {
+                let offset = SeriesSeasonScroll.clampedOffset(
+                    motion.offset(at: 10 + Double(frame) / 60), maximumOffset: maximum
+                )
+                XCTAssertGreaterThanOrEqual(offset, 0)
+                XCTAssertLessThanOrEqual(offset, maximum)
+            }
+            XCTAssertEqual(
+                SeriesSeasonScroll.clampedOffset(motion.offset(at: 10.45), maximumOffset: maximum),
+                maximum, accuracy: 0.000001
+            )
+        }
+        XCTAssertFalse(motion.isComplete(at: 10.449))
+        XCTAssertTrue(motion.isComplete(at: 10.45))
     }
 
 }

--- a/iosApp/Tests/SeriesSeasonScrollTests.swift
+++ b/iosApp/Tests/SeriesSeasonScrollTests.swift
@@ -44,4 +44,38 @@ final class SeriesSeasonScrollTests: XCTestCase {
         XCTAssertEqual(motion.offset(at: 9.99), 400)
         XCTAssertFalse(motion.isComplete(at: 9.99))
     }
+
+    func testEpisodeMoveKeepsItsDeadlineWhenAPageArrivesMidAnimation() {
+        let original = SeriesSeasonScroll(
+            startOffset: 400, targetOffset: 800, startedAt: 10, timing: .episode
+        )
+        var rebased = original
+        rebased.rebase(by: 8800)
+
+        for frame in 0...30 {
+            let time = 10 + Double(frame) / 100
+            XCTAssertEqual(rebased.offset(at: time) - 8800, original.offset(at: time), accuracy: 0.000001)
+        }
+        XCTAssertFalse(rebased.isComplete(at: 10.29))
+        XCTAssertTrue(rebased.isComplete(at: 10.30))
+        XCTAssertEqual(rebased.offset(at: 10.30), 9600, accuracy: 0.000001)
+    }
+
+    func testBothScrollTimingsStayWithinBoundsInEitherDirection() {
+        for timing in [SeriesSeasonScroll.Timing.season, .episode] {
+            for (start, target): (CGFloat, CGFloat) in [(0, 8800), (8800, 0)] {
+                let motion = SeriesSeasonScroll(
+                    startOffset: start, targetOffset: target, startedAt: 10, timing: timing
+                )
+                let samples = (0...60).map { motion.offset(at: 10 + Double($0) / 60) }
+                for (previous, next) in zip(samples, samples.dropFirst()) {
+                    XCTAssertGreaterThanOrEqual((next - previous) * (target - start), 0)
+                    XCTAssertGreaterThanOrEqual(next, min(start, target))
+                    XCTAssertLessThanOrEqual(next, max(start, target))
+                }
+                XCTAssertEqual(samples.last, target)
+            }
+        }
+    }
+
 }

--- a/iosApp/iosApp/Screens/Detail/SeriesSeasonScroll.swift
+++ b/iosApp/iosApp/Screens/Detail/SeriesSeasonScroll.swift
@@ -1,20 +1,29 @@
 import Foundation
 
-/// One continuous season-pill scroll, including changes to the loaded row's origin.
+/// One continuous episode-rail scroll, including changes to the loaded row's origin.
 struct SeriesSeasonScroll {
     private(set) var startOffset: CGFloat
     private(set) var targetOffset: CGFloat
     let startedAt: TimeInterval
-    static let duration: TimeInterval = 0.45
+    enum Timing {
+        case season
+        case episode
+
+        var duration: TimeInterval { self == .season ? 0.45 : 0.30 }
+    }
+
+    var timing: Timing = .season
 
     func offset(at time: TimeInterval) -> CGFloat {
-        let progress = min(1, max(0, (time - startedAt) / Self.duration))
-        let eased = progress * progress * (3 - 2 * progress)
+        let progress = min(1, max(0, (time - startedAt) / timing.duration))
+        let eased = timing == .season
+            ? progress * progress * (3 - 2 * progress)
+            : 1 - pow(1 - progress, 3)
         return startOffset + (targetOffset - startOffset) * eased
     }
 
     func isComplete(at time: TimeInterval) -> Bool {
-        time >= startedAt + Self.duration
+        time >= startedAt + timing.duration
     }
 
     mutating func rebase(by shift: CGFloat) {

--- a/iosApp/iosApp/Screens/Detail/SeriesSeasonScroll.swift
+++ b/iosApp/iosApp/Screens/Detail/SeriesSeasonScroll.swift
@@ -26,6 +26,12 @@ struct SeriesSeasonScroll {
         time >= startedAt + timing.duration
     }
 
+    /// Clamp rendered frames, not the animation endpoints, so paging keeps
+    /// the same easing and deadline even when a boundary clips the motion.
+    static func clampedOffset(_ offset: CGFloat, maximumOffset: CGFloat) -> CGFloat {
+        min(max(0, offset), max(0, maximumOffset))
+    }
+
     mutating func rebase(by shift: CGFloat) {
         startOffset += shift
         targetOffset += shift

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
@@ -74,6 +74,7 @@ struct TVEpisodeRail: View {
     private final class ScrollViewport: NSObject {
         weak var scrollView: UIScrollView?
         private var intendedOffset: CGFloat?
+        private var maximumOffset: CGFloat = 0
         private var motion: SeriesSeasonScroll?
         private var displayLink: CADisplayLink?
 
@@ -83,9 +84,10 @@ struct TVEpisodeRail: View {
             if let intendedOffset { setOffset(intendedOffset) }
         }
 
-        func move(to offset: CGFloat, timing: SeriesSeasonScroll.Timing?) {
+        func move(to offset: CGFloat, maximumOffset: CGFloat, timing: SeriesSeasonScroll.Timing?) {
+            self.maximumOffset = maximumOffset
             stopScroll()
-            guard let scrollView else { intendedOffset = offset; return }
+            guard let scrollView else { setOffset(offset); return }
             guard let timing else { setOffset(offset); return }
             motion = SeriesSeasonScroll(
                 startOffset: scrollView.contentOffset.x,
@@ -100,7 +102,8 @@ struct TVEpisodeRail: View {
 
         /// Page changes shift coordinates, including any in-flight card move,
         /// without starting another animation or changing its completion time.
-        func rebase(by shift: CGFloat) {
+        func rebase(by shift: CGFloat, maximumOffset: CGFloat) {
+            self.maximumOffset = maximumOffset
             motion?.rebase(by: shift)
             if let offset = intendedOffset ?? scrollView?.contentOffset.x {
                 setOffset(offset + shift)
@@ -108,6 +111,9 @@ struct TVEpisodeRail: View {
         }
 
         private func setOffset(_ offset: CGFloat) {
+            // Use the new model geometry; UIScrollView.contentSize can still
+            // describe the old lazy page during insertion or eviction.
+            let offset = SeriesSeasonScroll.clampedOffset(offset, maximumOffset: maximumOffset)
             intendedOffset = offset
             guard let scrollView else { return }
             scrollView.setContentOffset(
@@ -237,12 +243,22 @@ struct TVEpisodeRail: View {
                     // Do this even when a season-pill jump is pending: its
                     // destination uses the new coordinates, so its starting
                     // viewport must be rebased before the task animates it.
-                    guard let id = anchoredFocusedContentId ?? anchoredContentId,
-                          let oldIndex = oldIds.firstIndex(of: id),
-                          let newIndex = newIds.firstIndex(of: id),
-                          oldIndex != newIndex else { return }
-                    let shift = CGFloat(newIndex - oldIndex) * (anchoredCardWidth + cardSpacing)
-                    scrollViewport.rebase(by: shift)
+                    let id = anchoredFocusedContentId ?? anchoredContentId
+                    let oldIndex = id.flatMap { oldIds.firstIndex(of: $0) }
+                    let newIndex = id.flatMap { newIds.firstIndex(of: $0) }
+                    let shift: CGFloat
+                    if let oldIndex, let newIndex {
+                        shift = CGFloat(newIndex - oldIndex) * (anchoredCardWidth + cardSpacing)
+                    } else {
+                        shift = 0
+                    }
+                    // Even a tail-only eviction can shrink the valid range.
+                    scrollViewport.rebase(
+                        by: shift,
+                        maximumOffset: anchoredContentOffset(
+                            for: episodes.count - 1, viewportWidth: geometry.size.width
+                        )
+                    )
                 }
                 .onChange(of: currentContentId) { _, _ in
                     // The season chip owns an explicit animated request.
@@ -502,6 +518,7 @@ struct TVEpisodeRail: View {
     private func scrollToSelectedSeason(at index: Int, viewportWidth: CGFloat) {
         scrollViewport.move(
             to: anchoredContentOffset(for: index, viewportWidth: viewportWidth),
+            maximumOffset: anchoredContentOffset(for: episodes.count - 1, viewportWidth: viewportWidth),
             timing: reduceMotion ? nil : .season
         )
     }
@@ -509,6 +526,7 @@ struct TVEpisodeRail: View {
     private func moveAnchoredScroll(to index: Int, viewportWidth: CGFloat, animated: Bool) {
         scrollViewport.move(
             to: anchoredContentOffset(for: index, viewportWidth: viewportWidth),
+            maximumOffset: anchoredContentOffset(for: episodes.count - 1, viewportWidth: viewportWidth),
             timing: animated && !reduceMotion ? .episode : nil
         )
     }

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVEpisodeRail.swift
@@ -67,59 +67,73 @@ struct TVEpisodeRail: View {
     }
     @State private var pendingEdge: PendingEdge?
     @State private var appliedScrollRequest = 0
-    @State private var needsRebasedSelection = false
-    @State private var scrollGeneration = 0
     @State private var scrollViewport = ScrollViewport()
 
+    /// Own the actual viewport for both card moves and season jumps. Binding a
+    /// second SwiftUI ScrollPosition replays its stale point when pages change.
     private final class ScrollViewport: NSObject {
         weak var scrollView: UIScrollView?
-        var correctionTarget: CGFloat?
-        private var seasonMotion: SeriesSeasonScroll?
+        private var intendedOffset: CGFloat?
+        private var motion: SeriesSeasonScroll?
         private var displayLink: CADisplayLink?
-        private var onSeasonScrollEnd: ((CGFloat) -> Void)?
 
-        func scrollToSeason(_ offset: CGFloat, onEnd: @escaping (CGFloat) -> Void) {
-            stopSeasonScroll()
-            guard let scrollView else { onEnd(offset); return }
-            seasonMotion = SeriesSeasonScroll(
+        func attach(_ scrollView: UIScrollView) {
+            guard self.scrollView !== scrollView else { return }
+            self.scrollView = scrollView
+            if let intendedOffset { setOffset(intendedOffset) }
+        }
+
+        func move(to offset: CGFloat, timing: SeriesSeasonScroll.Timing?) {
+            stopScroll()
+            guard let scrollView else { intendedOffset = offset; return }
+            guard let timing else { setOffset(offset); return }
+            motion = SeriesSeasonScroll(
                 startOffset: scrollView.contentOffset.x,
                 targetOffset: offset,
-                startedAt: CACurrentMediaTime()
+                startedAt: CACurrentMediaTime(),
+                timing: timing
             )
-            onSeasonScrollEnd = onEnd
-            let link = CADisplayLink(target: self, selector: #selector(advanceSeasonScroll))
+            let link = CADisplayLink(target: self, selector: #selector(advanceScroll))
             displayLink = link
             link.add(to: .main, forMode: .common)
         }
 
-        /// Page eviction changes the coordinate origin, not the animation's
-        /// progress. Shift both endpoints without restarting its clock.
-        func rebaseSeasonScroll(by shift: CGFloat) -> Bool {
-            guard seasonMotion != nil, let scrollView else { return false }
-            seasonMotion?.rebase(by: shift)
+        /// Page changes shift coordinates, including any in-flight card move,
+        /// without starting another animation or changing its completion time.
+        func rebase(by shift: CGFloat) {
+            motion?.rebase(by: shift)
+            if let offset = intendedOffset ?? scrollView?.contentOffset.x {
+                setOffset(offset + shift)
+            }
+        }
+
+        private func setOffset(_ offset: CGFloat) {
+            intendedOffset = offset
+            guard let scrollView else { return }
             scrollView.setContentOffset(
-                CGPoint(x: scrollView.contentOffset.x + shift, y: scrollView.contentOffset.y),
-                animated: false
+                CGPoint(x: offset, y: scrollView.contentOffset.y), animated: false
             )
-            return true
         }
 
-        @objc private func advanceSeasonScroll(_ link: CADisplayLink) {
-            guard let seasonMotion, let scrollView else { stopSeasonScroll(); return }
-            let offset = seasonMotion.offset(at: link.timestamp)
-            // Advance the actual viewport each frame so the lazy row lays out
-            // intermediate cards. There is no second native settling animation.
-            scrollView.setContentOffset(CGPoint(x: offset, y: scrollView.contentOffset.y), animated: false)
-            if seasonMotion.isComplete(at: link.timestamp) { stopSeasonScroll() }
+        /// Lazy layout can restore its previous content offset after a page
+        /// insertion. This composite owns scrolling, so reconcile that layout
+        /// write with the latest frame instead of starting a settling animation.
+        func reconcileOffset() {
+            guard let intendedOffset, let scrollView,
+                  abs(scrollView.contentOffset.x - intendedOffset) > 0.5 else { return }
+            setOffset(intendedOffset)
         }
 
-        func stopSeasonScroll() {
+        @objc private func advanceScroll(_ link: CADisplayLink) {
+            guard let motion, scrollView != nil else { stopScroll(); return }
+            setOffset(motion.offset(at: link.timestamp))
+            if motion.isComplete(at: link.timestamp) { stopScroll() }
+        }
+
+        func stopScroll() {
             displayLink?.invalidate()
             displayLink = nil
-            seasonMotion = nil
-            let onEnd = onSeasonScrollEnd
-            onSeasonScrollEnd = nil
-            if let offset = scrollView?.contentOffset.x { onEnd?(offset) }
+            motion = nil
         }
     }
 
@@ -128,7 +142,6 @@ struct TVEpisodeRail: View {
     @State private var anchoredFocusedContentId: String?
     @Namespace private var anchoredFocusScope
     @State private var anchoredContentId: String?
-    @State private var anchoredScrollPosition = ScrollPosition(x: 0)
     @State private var anchoredPlayedOverrides: [String: Bool] = [:]
     @State private var anchoredFavoriteOverrides: [String: Bool] = [:]
     @State private var uiCustomization = UICustomizationPreferences.shared
@@ -214,12 +227,7 @@ struct TVEpisodeRail: View {
                         pendingEdge = nil
                         anchoredContentId = episodes[index].contentId
                         scrollToSelectedSeason(at: index, viewportWidth: geometry.size.width)
-                    } else if needsRebasedSelection {
-                        // Finish any interrupted one-card movement in the new
-                        // coordinates, after the nonanimated rebase has mounted.
-                        seedAnchoredSelection(viewportWidth: geometry.size.width, animated: true)
                     }
-                    needsRebasedSelection = false
                     completePendingEdge()
                 }
                 .onChange(of: episodeIdentityKey) { oldIds, newIds in
@@ -234,13 +242,7 @@ struct TVEpisodeRail: View {
                           let newIndex = newIds.firstIndex(of: id),
                           oldIndex != newIndex else { return }
                     let shift = CGFloat(newIndex - oldIndex) * (anchoredCardWidth + cardSpacing)
-                    let offset = scrollViewport.scrollView?.contentOffset.x ?? 0
-                    if scrollViewport.rebaseSeasonScroll(by: shift) {
-                        synchronizeScrollPosition(to: max(0, offset + shift))
-                    } else {
-                        moveAnchoredScroll(toOffset: max(0, offset + shift), animated: false)
-                        needsRebasedSelection = true
-                    }
+                    scrollViewport.rebase(by: shift)
                 }
                 .onChange(of: currentContentId) { _, _ in
                     // The season chip owns an explicit animated request.
@@ -308,15 +310,11 @@ struct TVEpisodeRail: View {
         }
         .onChange(of: isSelectingSeason) { _, ownsFocus in
             if !ownsFocus {
-                scrollGeneration &+= 1
-                scrollViewport.stopSeasonScroll()
-                cancelNativeScrollCorrection()
+                scrollViewport.stopScroll()
             }
         }
         .onDisappear {
-            scrollGeneration &+= 1
-            scrollViewport.stopSeasonScroll()
-            cancelNativeScrollCorrection()
+            scrollViewport.stopScroll()
             scrollViewport.scrollView = nil
             pendingEdge = nil
             onFocusedEpisodeChange?(nil)
@@ -333,7 +331,7 @@ struct TVEpisodeRail: View {
             }
             .scrollTargetLayout()
             .background {
-                TVDetailScrollViewResolver { scrollViewport.scrollView = $0 }
+                TVDetailScrollViewResolver { scrollViewport.attach($0) }
             }
             // Preserve the existing crop, hover clearance and trailing boundary.
             .padding(.leading, EpisodeHomeHoverMetrics.leadingInset(for: anchoredCardWidth))
@@ -343,13 +341,10 @@ struct TVEpisodeRail: View {
             )
             .padding(.vertical, 12)
         }
-        .scrollPosition($anchoredScrollPosition)
         .onScrollGeometryChange(for: CGFloat.self) { geometry in
             geometry.contentOffset.x
-        } action: { _, offset in
-            if let target = scrollViewport.correctionTarget, abs(offset - target) <= 0.5 {
-                scrollViewport.correctionTarget = nil
-            }
+        } action: { _, _ in
+            scrollViewport.reconcileOffset()
         }
         .frame(
             width: viewportWidth,
@@ -504,66 +499,18 @@ struct TVEpisodeRail: View {
         moveAnchoredScroll(to: index, viewportWidth: viewportWidth, animated: true)
     }
 
-    private func cancelNativeScrollCorrection() {
-        guard scrollViewport.correctionTarget != nil else { return }
-        scrollViewport.correctionTarget = nil
-        if let scrollView = scrollViewport.scrollView {
-            scrollView.setContentOffset(scrollView.contentOffset, animated: false)
-        }
-    }
-
-    private func synchronizeScrollPosition(to offset: CGFloat) {
-        var transaction = Transaction(animation: nil)
-        transaction.disablesAnimations = true
-        withTransaction(transaction) {
-            anchoredScrollPosition.scrollTo(x: offset)
-        }
-    }
-
     private func scrollToSelectedSeason(at index: Int, viewportWidth: CGFloat) {
-        guard !reduceMotion, scrollViewport.scrollView != nil else {
-            moveAnchoredScroll(to: index, viewportWidth: viewportWidth, animated: false)
-            return
-        }
-        scrollGeneration &+= 1
-        cancelNativeScrollCorrection()
-        scrollViewport.scrollToSeason(
-            anchoredContentOffset(for: index, viewportWidth: viewportWidth),
-            onEnd: { synchronizeScrollPosition(to: $0) }
+        scrollViewport.move(
+            to: anchoredContentOffset(for: index, viewportWidth: viewportWidth),
+            timing: reduceMotion ? nil : .season
         )
     }
 
     private func moveAnchoredScroll(to index: Int, viewportWidth: CGFloat, animated: Bool) {
-        moveAnchoredScroll(
-            toOffset: anchoredContentOffset(for: index, viewportWidth: viewportWidth),
-            animated: animated
+        scrollViewport.move(
+            to: anchoredContentOffset(for: index, viewportWidth: viewportWidth),
+            timing: animated && !reduceMotion ? .episode : nil
         )
-    }
-
-    private func moveAnchoredScroll(toOffset targetOffset: CGFloat, animated: Bool) {
-        scrollViewport.stopSeasonScroll()
-        scrollGeneration &+= 1
-        let generation = scrollGeneration
-        cancelNativeScrollCorrection()
-        let animation: Animation = animated && !reduceMotion
-            ? .easeOut(duration: 0.30)
-            : .linear(duration: 0)
-        withAnimation(animation, completionCriteria: .removed) {
-            anchoredScrollPosition.scrollTo(x: targetOffset)
-        } completion: {
-            // Dispatching a scroll is not proof it reached the destination.
-            // A replaced animation or lazy layout can leave the viewport at
-            // an intermediate season. Only the latest completed trip may
-            // settle it, after SwiftUI has removed that animation.
-            guard generation == scrollGeneration,
-                  let scrollView = scrollViewport.scrollView,
-                  abs(scrollView.contentOffset.x - targetOffset) > 0.5 else { return }
-            scrollViewport.correctionTarget = animated && !reduceMotion ? targetOffset : nil
-            scrollView.setContentOffset(
-                CGPoint(x: targetOffset, y: scrollView.contentOffset.y),
-                animated: animated && !reduceMotion
-            )
-        }
     }
 
     private func anchoredIsPlayed(_ episode: EpisodeListItem) -> Bool {


### PR DESCRIPTION
Changing seasons in a long tvOS episode carousel could reach episode 1, jump away, then animate back. The issue remained reproducible after #273 because SwiftUI scroll-position updates and lazy layout could overwrite the animated viewport.

Use one scroll controller for season jumps and episode moves, preserve animation progress when pages change, and reconcile layout offsets without starting another animation. Clamp rendered offsets to the current scrollable range after insertion or eviction, including when the entire row fits on screen. Preserve the 450 ms season and 300 ms episode durations.

Validation:
- Complete iOS test suite, tvOS simulator build, and macOS build passed in CI.
- Nine focused XCTest cases passed using the production motion helper, covering rebasing, bounds, easing, and explicit completion deadlines.
- Signed physical tvOS build and profile validation passed.
- The main animation fix was verified on a physical Apple TV across long-season transitions, page changes, direction reversals, and eight focus assertions. The bounds follow-up awaits final device validation.

A separate Reduce Motion device check was not run. Codex reviewed the latest commit without new findings; CodeRabbit recognized its resolved test comment but rate-limited a further full review. Macroscope was skipped.

AI disclosure: Assisted by OpenAI `gpt-6-astra` using the Codex agent harness through T3 Code, with automated Codex and CodeRabbit PR reviews.
