### PR TITLE
Fix tvOS continue watching episode return

### DIFF
--- a/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
@@ -169,9 +169,10 @@ struct TVItemDetailView: View {
                 || activeWasCompleted
                 || completedEpisodeIsVisible else { return }
 
-        if let inProgress = viewModel.episodes.first(where: {
-            $0.userData?.isInProgress == true && !($0.userData?.played ?? false)
-        }) {
+        if activeSeriesEpisodeContentId == nil,
+           let inProgress = viewModel.episodes.first(where: {
+               $0.userData?.isInProgress == true && !($0.userData?.played ?? false)
+           }) {
             activeSeriesEpisodeContentId = inProgress.contentId
             return
         }


### PR DESCRIPTION
When playback refreshes after dismissing the player, tvOS could replace the selected continue-watching episode with the first in-progress episode in series order.

Guard the fallback lookup so an existing active episode is preserved; completed active episodes still advance through the existing next-unwatched logic.

Validation: source-level fix applied to the shared tvOS detail path; simulator test run remains pending.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the currently selected episode after playback refreshes.
  * Prevented an in-progress episode from replacing an already active series episode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->