### PR TITLE
fix(playback): preserve tvOS episode selection and fence realtime frames

### DIFF
--- a/iosApp/Tests/APIv2PlaybackTests.swift
+++ b/iosApp/Tests/APIv2PlaybackTests.swift
@@ -151,8 +151,10 @@ final class APIv2PlaybackTests: XCTestCase {
         let pending = try await store.pendingStarts(authority: authority)
         XCTAssertTrue(pending.isEmpty)
         let replay = V2PlaybackProtocol.requests().filter { $0.0.url?.path.hasSuffix("/start") == true }
-        XCTAssertEqual(replay.count, 2)
-        XCTAssertEqual(replay[0].1, replay[1].1)
+        // Uncertain dispatch, the coordinator's one network retry, then the
+        // explicit replay. Every one of them repeats the original body.
+        XCTAssertEqual(replay.count, 3)
+        XCTAssertEqual(Set(replay.map { $0.1 }).count, 1)
         XCTAssertTrue(V2PlaybackProtocol.requests().allSatisfy { $0.0.httpMethod != "DELETE" && $0.0.url?.path.contains("/timelines/") != true })
         // Only this explicit caller obtains a new snapshot and creates a new attempt.
         _ = try boundContract(attempt: "audio:new-explicit", digest: String(repeating: "b", count: 64))
@@ -271,8 +273,9 @@ final class APIv2PlaybackTests: XCTestCase {
         V2PlaybackProtocol.stopStatus(200)
         await restarted.retryPendingStops()
         let starts = V2PlaybackProtocol.requests().filter { $0.0.url?.path == "/api/v2/playback/start" }
-        XCTAssertEqual(starts.count, 2)
-        XCTAssertEqual(starts[0].1, starts[1].1)
+        // Uncertain dispatch, its one network retry, then the explicit replay.
+        XCTAssertEqual(starts.count, 3)
+        XCTAssertEqual(Set(starts.map { $0.1 }).count, 1)
         let body = try XCTUnwrap(JSONSerialization.jsonObject(with: starts[0].1) as? [String: Any])
         XCTAssertEqual(body["file_id"] as? String, "42")
         XCTAssertEqual(body["audio_track_index"] as? Int, 0)
@@ -355,9 +358,10 @@ final class APIv2PlaybackTests: XCTestCase {
         V2PlaybackProtocol.rejectStart(nil)
         await owner.retryPendingStops()
         let starts = V2PlaybackProtocol.requests().filter { $0.0.url?.path == "/api/v2/playback/start" }
-        XCTAssertEqual(starts.count, 3)
-        XCTAssertEqual(starts[0].1, starts[1].1)
-        XCTAssertEqual(starts[1].1, starts[2].1)
+        // Uncertain dispatch, its one network retry, the 422 validation, then
+        // the explicit replay: four dispatches of the identical attempt body.
+        XCTAssertEqual(starts.count, 4)
+        XCTAssertEqual(Set(starts.map { $0.1 }).count, 1)
         XCTAssertEqual(V2PlaybackProtocol.requests().filter { $0.0.httpMethod == "DELETE" }.count, 1)
         try await owner.requireResolvedStartBeforeLegacy(auth: auth)
     }
@@ -492,8 +496,8 @@ final class APIv2PlaybackTests: XCTestCase {
                 else { _ = await tokens.saveRefreshedTokens("replacement", "replacement-refresh", replacing: capturedRefresh) }
             }
             do {
-                _ = try await PlaybackSessionBridge.startV2WithNetworkRetry(coordinator: owner,
-                    request: request(authorizedOrigins: true), auth: auth, capability: capability())
+                _ = try await owner.startV2(request: request(authorizedOrigins: true),
+                    auth: auth, capability: capability())
                 XCTFail("Lost response retry adopted replacement authority")
             } catch {}
             do {
@@ -534,7 +538,9 @@ final class APIv2PlaybackTests: XCTestCase {
             XCTFail("Restored response-less intent gained media scope")
         } catch {}
         let starts = V2PlaybackProtocol.requests().filter { $0.0.url?.path.hasSuffix("/start") == true }
-        XCTAssertEqual(starts.count, 2)
+        // Uncertain dispatch, its one network retry, then the restored replay.
+        XCTAssertEqual(starts.count, 3)
+        XCTAssertEqual(Set(starts.map { $0.1 }).count, 1)
         XCTAssertEqual(starts.last?.1, original.1)
         XCTAssertTrue(V2PlaybackProtocol.requests().contains { $0.0.httpMethod == "DELETE" }, "Resolved allocation must still retire")
     }
@@ -544,8 +550,8 @@ final class APIv2PlaybackTests: XCTestCase {
         let (decision, id, raw) = try headerMediaDecision()
         V2PlaybackProtocol.configure(capability: try fixtureData("playback_capability_available"), decision: decision)
         V2PlaybackProtocol.loseNextStart {}
-        _ = try await PlaybackSessionBridge.startV2WithNetworkRetry(coordinator: owner,
-            request: request(authorizedOrigins: true), auth: auth, capability: capability())
+        _ = try await owner.startV2(request: request(authorizedOrigins: true),
+            auth: auth, capability: capability())
         let starts = V2PlaybackProtocol.requests().filter { $0.0.url?.path.hasSuffix("/start") == true }
         XCTAssertEqual(starts.count, 2)
         XCTAssertEqual(starts.first?.1, starts.last?.1)
@@ -577,12 +583,13 @@ final class APIv2PlaybackTests: XCTestCase {
         let (_, id, raw) = try headerMediaDecision()
         let pending = try ownerLossWire(start: true, pending: true, session: id)
         V2PlaybackProtocol.rejectStart(pending, status: 202)
-        do { _ = try await PlaybackSessionBridge.startV2WithNetworkRetry(coordinator: owner,
-            request: request(authorizedOrigins: true), auth: auth, capability: capability()); XCTFail() } catch {}
+        do { _ = try await owner.startV2(request: request(authorizedOrigins: true),
+            auth: auth, capability: capability()); XCTFail() } catch {}
         let saved = try JSONDecoder().decode(AuxiliaryJournalSnapshot.self, from: XCTUnwrap(writes.data.last))
         let original = try XCTUnwrap(saved.starts?.values.first)
         XCTAssertNil(original.response)
-        XCTAssertEqual(original.ownerLossResponse, pending)
+        XCTAssertEqual(original.ownerLoss?.state, .draining)
+        XCTAssertEqual(original.ownerLoss?.sessionID, id)
         XCTAssertFalse(original.finished)
         let reloaded = PlaybackMutationCoordinator(api: api, tokens: tokens, store: store, retryDelays: [])
         await reloaded.restorePending()
@@ -594,7 +601,8 @@ final class APIv2PlaybackTests: XCTestCase {
         let settled = try XCTUnwrap(final.starts?[original.id])
         XCTAssertEqual(settled.body, original.body)
         XCTAssertNil(settled.response)
-        XCTAssertEqual(settled.ownerLossResponse, terminal)
+        XCTAssertEqual(settled.ownerLoss?.state, .aborted)
+        XCTAssertEqual(settled.ownerLoss?.recoveryID, original.ownerLoss?.recoveryID)
         XCTAssertTrue(settled.finished)
         XCTAssertNil(settled.ownerLoss?.accepted)
         XCTAssertTrue(final.sessions.isEmpty, "No playable session registration from abandonment")
@@ -640,7 +648,7 @@ final class APIv2PlaybackTests: XCTestCase {
         XCTAssertEqual(settled.stopState, .abandoned)
         XCTAssertEqual(settled.accepted?.position, 12.5)
         XCTAssertNil(settled.historyID)
-        XCTAssertEqual(settled.ownerLossResponse, terminal)
+        XCTAssertEqual(settled.ownerLoss?.state, .aborted)
         let stops = V2PlaybackProtocol.requests().filter { $0.0.httpMethod == "DELETE" }
         XCTAssertEqual(stops.count, 2)
         XCTAssertEqual(stops.first?.1, stops.last?.1)
@@ -684,7 +692,8 @@ final class APIv2PlaybackTests: XCTestCase {
             do { _ = try await owner.startV2(request: request(), auth: auth, capability: capability()); XCTFail("Malformed recovery settled") } catch {}
             let saved = try await store.start(record.id, authority: record.authority)
             XCTAssertFalse(saved.finished)
-            XCTAssertEqual(saved.ownerLossResponse, pending)
+            XCTAssertEqual(saved.ownerLoss, record.ownerLoss)
+            XCTAssertEqual(saved.ownerLoss?.state, .draining)
             XCTAssertEqual(saved.body, record.body)
         }
     }
@@ -730,7 +739,7 @@ final class APIv2PlaybackTests: XCTestCase {
             XCTAssertFalse(done)
             let saved = try await store.session(original.id, authority: original.authority)
             XCTAssertEqual(saved.stop, original.stop)
-            XCTAssertEqual(saved.ownerLossResponse, pending)
+            XCTAssertEqual(saved.ownerLoss, original.ownerLoss)
             XCTAssertEqual(saved.stopState, .draining)
         }
         let stop = try XCTUnwrap(original.stop)
@@ -744,7 +753,7 @@ final class APIv2PlaybackTests: XCTestCase {
         XCTAssertFalse(continued, "Observed AbortID cannot become ordinary StopID success")
         let final = try await store.session(original.id, authority: original.authority)
         XCTAssertEqual(final.stopState, .draining)
-        XCTAssertEqual(final.ownerLossResponse, pending)
+        XCTAssertEqual(final.ownerLoss, original.ownerLoss)
         XCTAssertEqual(final.accepted, original.accepted)
         XCTAssertEqual(final.stop, original.stop)
     }
@@ -801,6 +810,29 @@ final class APIv2PlaybackTests: XCTestCase {
         XCTAssertEqual(afterExplicit.count, 2)
         let fresh = try XCTUnwrap(afterExplicit.last)
         XCTAssertNotEqual((try JSONSerialization.jsonObject(with: fresh.1) as? [String: Any])?["playback_attempt_id"] as? String, originalAttempt)
+    }
+
+    func testFailedSequencedRegistrationBlocksPlainDeleteFallback() async throws {
+        let (owner, tokens, auth, api, _) = try await fixture(failWrites: true)
+        let bridge = PlaybackSessionBridge(mutationCoordinator: owner, api: api, tokens: tokens)
+        do {
+            try await owner.register(sessionID: "orphan", features: [PlaybackSequencedContract.feature], auth: auth)
+            XCTFail("A journal failure must not report a bound session")
+        } catch {}
+        var state = await owner.sequencedState("orphan")
+        XCTAssertEqual(state, .registrationFailed)
+        await bridge.retireAbandonedSession("orphan", reason: "test_registration_failed")
+        XCTAssertTrue(V2PlaybackProtocol.requests().allSatisfy { $0.0.httpMethod != "DELETE" },
+            "A sequenced session with no durable stop intent must never be released by a plain DELETE")
+
+        // Contrast: a session the coordinator never sequenced still takes the
+        // ordinary retirement route.
+        state = await owner.sequencedState("ordinary")
+        XCTAssertEqual(state, .notSequenced)
+        await bridge.retireAbandonedSession("ordinary", reason: "test_not_sequenced")
+        let deletes = V2PlaybackProtocol.requests().filter { $0.0.httpMethod == "DELETE" }
+        XCTAssertEqual(deletes.count, 1)
+        XCTAssertEqual(deletes.first?.0.url?.path, "/api/v1/playback/ordinary")
     }
 
     func testOrdinaryStopBeforeRecoveryStillAllowsActualContinuation() async throws {
@@ -1051,13 +1083,47 @@ final class APIv2PlaybackTests: XCTestCase {
         let response = try await owner.startV2(request: request(), auth: auth, capability: capability())
         let id = try XCTUnwrap(response.sessionId)
         V2PlaybackProtocol.changeInstallation()
+        // The installation captured at START is echoed verbatim. A changed
+        // installation is refused by the server with 409 installation_changed;
+        // the client does not re-probe capabilities to discover it.
         do { try await owner.report(sessionID: id, position: 1, isPaused: false); XCTFail() } catch {}
-        XCTAssertFalse(V2PlaybackProtocol.requests().contains { $0.0.url?.path.hasSuffix("/progress") == true })
+        let progress = V2PlaybackProtocol.requests().filter { $0.0.url?.path.hasSuffix("/progress") == true }
+        XCTAssertEqual(progress.count, 1)
+        let sample = try XCTUnwrap(JSONSerialization.jsonObject(with: progress[0].1) as? [String: Any])
+        XCTAssertEqual(sample["installation_id"] as? String, try capability().requireAvailable())
+        // A changed account epoch is still a local refusal: no request leaves.
         try await tokens.installAccountSession(accessToken: "new", refreshToken: "new-refresh", accountID: "1")
         await tokens.setProfileId("profile")
         let stopped = try await owner.stop(sessionID: id, position: 2, isPaused: true)
         XCTAssertFalse(stopped)
         XCTAssertFalse(V2PlaybackProtocol.requests().contains { $0.0.httpMethod == "DELETE" })
+    }
+
+    func testEachMutationIsOneRequestWithoutACapabilityProbe() async throws {
+        let (owner, _, auth, _, _) = try await fixture()
+        let started = try await owner.startV2(request: request(), auth: auth, capability: capability())
+        let id = try XCTUnwrap(started.sessionId)
+
+        var before = V2PlaybackProtocol.requests().count
+        try await owner.report(sessionID: id, position: 30, isPaused: false)
+        var sent = Array(V2PlaybackProtocol.requests().dropFirst(before))
+        XCTAssertEqual(sent.map { $0.0.url?.path ?? "" }, ["/api/v2/playback/\(id)/progress"])
+        XCTAssertEqual(sent.first?.0.httpMethod, "POST")
+
+        before = V2PlaybackProtocol.requests().count
+        _ = try await owner.replan(sessionID: id, request: replanRequest())
+        sent = Array(V2PlaybackProtocol.requests().dropFirst(before))
+        XCTAssertEqual(sent.map { $0.0.url?.path ?? "" }, ["/api/v2/playback/\(id)/replan"])
+        XCTAssertEqual(sent.first?.0.httpMethod, "POST")
+
+        before = V2PlaybackProtocol.requests().count
+        let stopped = try await owner.stop(sessionID: id, position: 60, isPaused: true)
+        XCTAssertTrue(stopped)
+        sent = Array(V2PlaybackProtocol.requests().dropFirst(before))
+        XCTAssertEqual(sent.map { $0.0.url?.path ?? "" }, ["/api/v2/playback/\(id)"])
+        XCTAssertEqual(sent.first?.0.httpMethod, "DELETE")
+
+        XCTAssertFalse(V2PlaybackProtocol.requests().contains { $0.0.url?.path == "/api/v2/playback/capabilities" })
     }
 }
 
@@ -1107,6 +1173,23 @@ private final class V2PlaybackProtocol: URLProtocol {
             }
         }
         let state = Self.lock.withLock { Self.captured.append((request, body)); return (Self.capability, Self.decision, Self.failStart, Self.stopCode, Self.rejection, Self.progressFailure, Self.rejectionCode) }
+        // The server, not the client, detects a stale installation. Any mutation
+        // that echoes an installation the server no longer knows is refused with
+        // `409 installation_changed`.
+        let known = ((try? JSONSerialization.jsonObject(with: state.0)) as? [String: Any])?["installation_id"] as? String
+        if let known, let echoed = ((try? JSONSerialization.jsonObject(with: body)) as? [String: Any])?["installation_id"] as? String,
+           echoed != known {
+            let problem = try! JSONSerialization.data(withJSONObject: [
+                "type": "https://siloserver.org/docs/api/v2/problems/installation_changed",
+                "title": "Playback installation changed", "status": 409,
+                "detail": "Playback installation changed; refresh capabilities",
+                "instance": "urn:silo:request:0000000000000000000001da"])
+            client?.urlProtocol(self, didReceive: HTTPURLResponse(url: request.url!, statusCode: 409,
+                httpVersion: nil, headerFields: ["Content-Type": "application/problem+json"])!, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: problem)
+            client?.urlProtocolDidFinishLoading(self)
+            return
+        }
         var status = 200
         let output: Data
         if request.url!.path.hasPrefix("/api/v2/watch/") {

--- a/iosApp/Tests/DiagnosticsStorageRootTests.swift
+++ b/iosApp/Tests/DiagnosticsStorageRootTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 @testable import Silo
 
@@ -8,12 +9,56 @@ final class DiagnosticsStorageRootTests: XCTestCase {
         let fileManager = FileManager.default
 #if os(tvOS)
         let platformDirectory = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first
+        XCTAssertEqual(AppleStorageRoot.category, .caches)
+        XCTAssertEqual(AppleStorageRoot.category.rawValue, "caches")
 #else
         let platformDirectory = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+        XCTAssertEqual(AppleStorageRoot.category, .applicationSupport)
+        XCTAssertEqual(AppleStorageRoot.category.rawValue, "applicationSupport")
 #endif
         let expected = platformDirectory
             ?? URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
 
+        XCTAssertEqual(AppleStorageRoot.baseDirectory(fileManager: fileManager), expected)
+        // The diagnostics writers still call the historical name.
         XCTAssertEqual(DiagnosticsStorageRoot.baseDirectory(fileManager: fileManager), expected)
+    }
+
+    /// The defect this helper exists to prevent: `PlaybackMutationStore` wrote to
+    /// a root tvOS rejects, so a playback journal record could not be persisted
+    /// at all. Exercise register, reload from a fresh store, read back, remove —
+    /// under the real selected root, in a unique subdirectory.
+    func testPlaybackMutationRecordPersistsAndReloadsUnderSelectedRoot() async throws {
+        let name = "AppleStorageRootTests.\(UUID().uuidString)"
+        let root = AppleStorageRoot.baseDirectory().appendingPathComponent(name, isDirectory: true)
+        let url = root.appendingPathComponent("playback-mutations.json")
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: root)
+            UserDefaults().removePersistentDomain(forName: name)
+        }
+
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: name))
+        let tokens = TokenStore(keychain: SharedKeychain(service: name, accessGroup: nil),
+                                defaults: SharedDefaults(suite: defaults, standard: defaults))
+        await tokens.switchActiveServer(serverId: "server")
+        await tokens.setServerUrl("https://playback.example")
+        try await tokens.installAccountSession(accessToken: "access", refreshToken: "refresh", accountID: "1")
+        await tokens.setProfileId("profile")
+        let captured = await tokens.captureDurableAccountAuth()
+        let authority = try PlaybackMutationAuthority(auth: XCTUnwrap(captured), installationID: "installation")
+
+        let sessionID = UUID().uuidString.lowercased()
+        let registered = try await PlaybackMutationStore(url: url)
+            .register(sessionID: sessionID, authority: authority, attemptID: "attempt")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+
+        let reloaded = try await PlaybackMutationStore(url: url).session(registered.id, authority: authority)
+        XCTAssertEqual(reloaded.id, registered.id)
+        XCTAssertEqual(reloaded.sessionID, sessionID)
+        XCTAssertEqual(reloaded.attemptID, "attempt")
+        XCTAssertEqual(reloaded.authority, authority)
+
+        try FileManager.default.removeItem(at: url)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: url.path))
     }
 }

--- a/iosApp/Tests/PlaybackMutationStoreTests.swift
+++ b/iosApp/Tests/PlaybackMutationStoreTests.swift
@@ -26,15 +26,15 @@ final class PlaybackMutationStoreTests: XCTestCase {
             fileId: "42", partOffsetSeconds: 60, partDurationSeconds: 30, durationSeconds: 90)
         let session = try await store.register(sessionID: sessionID, authority: authority, progressTimeline: binding, attemptID: "original")
         let pendingProgress = try await store.prepareProgress(session.id, authority: authority, position: 20, isPaused: false)
-        let stop = try await store.prepareStop(session.id, authority: authority, position: 29, isPaused: true)
+        let stopProposal = try await store.proposedStop(session.id, authority: authority, position: 29, isPaused: true)
+        let stop = try await store.persistStop(session.id, authority: authority, stop: stopProposal)
         let recoveryID = UUID().uuidString.lowercased()
         func recovery(_ accepted: PlaybackSequencedSample?, state: PlaybackOwnerLossRecovery.State = .aborted) -> PlaybackOwnerLossRecovery {
             PlaybackOwnerLossRecovery(recoveryID: recoveryID, attemptID: "original", sessionID: sessionID,
                 state: state, reason: "owner_lost", accepted: accepted)
         }
         let draining = recovery(nil, state: .draining)
-        try await store.observeStopOwnerLoss(session.id, authority: authority, sent: stop, recovery: draining,
-            response: JSONEncoder().encode(draining))
+        try await store.observeStopOwnerLoss(session.id, authority: authority, sent: stop, recovery: draining)
         let restored = PlaybackMutationStore(url: url)
         let before = try Data(contentsOf: url)
         for sample in [
@@ -44,13 +44,12 @@ final class PlaybackMutationStoreTests: XCTestCase {
             try PlaybackSequencedSample(sequence: 1, position: 5, isPaused: false, timelineId: String(repeating: "b", count: 64), itemPosition: 65)
         ] {
             do { try await restored.observeStopOwnerLoss(session.id, authority: authority, sent: stop,
-                recovery: recovery(sample), response: Data()); XCTFail() } catch {}
+                recovery: recovery(sample)); XCTFail() } catch {}
             XCTAssertEqual(try Data(contentsOf: url), before)
         }
         let last = try PlaybackSequencedSample(sequence: 1, position: 5, isPaused: false, timelineId: binding.timelineId, itemPosition: 65)
         let terminal = recovery(last)
-        let bytes = try JSONEncoder().encode(terminal)
-        try await restored.observeStopOwnerLoss(session.id, authority: authority, sent: stop, recovery: terminal, response: bytes)
+        try await restored.observeStopOwnerLoss(session.id, authority: authority, sent: stop, recovery: terminal)
         try await restored.acknowledgeProgress(session.id, authority: authority, sent: pendingProgress,
             receipt: PlaybackSequencedProgressReceipt(outcome: .applied,
                 accepted: try PlaybackSequencedSample(sequence: 3, position: 29, isPaused: true,
@@ -61,7 +60,7 @@ final class PlaybackMutationStoreTests: XCTestCase {
         XCTAssertEqual(saved.stop, stop)
         XCTAssertEqual(saved.pendingProgress, pendingProgress)
         XCTAssertEqual(saved.accepted, last)
-        XCTAssertEqual(saved.ownerLossResponse, bytes)
+        XCTAssertEqual(saved.ownerLoss, terminal)
         XCTAssertNil(saved.historyID)
         try await reloaded.requireTerminalBoundSessions(authority: authority)
         let pending = try await reloaded.pendingStops(authority: authority, afterRestart: true)
@@ -75,10 +74,11 @@ final class PlaybackMutationStoreTests: XCTestCase {
         let sample = try await store.prepareProgress(session.id, authority: authority, position: 9, isPaused: false)
         try await store.acknowledgeProgress(session.id, authority: authority, sent: sample,
             receipt: PlaybackSequencedProgressReceipt(outcome: .applied, accepted: sample))
-        let stop = try await store.prepareStop(session.id, authority: authority, position: 99, isPaused: true)
+        let stopProposal = try await store.proposedStop(session.id, authority: authority, position: 99, isPaused: true)
+        let stop = try await store.persistStop(session.id, authority: authority, stop: stopProposal)
         let recovery = PlaybackOwnerLossRecovery(recoveryID: UUID().uuidString, attemptID: "original", sessionID: sessionID,
             state: .aborted, reason: "owner_lost", accepted: nil)
-        try await store.observeStopOwnerLoss(session.id, authority: authority, sent: stop, recovery: recovery, response: Data())
+        try await store.observeStopOwnerLoss(session.id, authority: authority, sent: stop, recovery: recovery)
         let saved = try await PlaybackMutationStore(url: url).session(session.id, authority: authority)
         XCTAssertNil(saved.accepted)
         XCTAssertEqual(saved.stop, stop)
@@ -92,11 +92,16 @@ final class PlaybackMutationStoreTests: XCTestCase {
         XCTAssertEqual(stillAbandoned.stopState, .abandoned)
         let legacyID = UUID().uuidString.lowercased()
         let legacy = try await store.register(sessionID: legacyID, authority: authority)
-        let legacyStop = try await store.prepareStop(legacy.id, authority: authority, position: nil, isPaused: true)
+        let legacyStopProposal = try await store.proposedStop(legacy.id, authority: authority, position: nil, isPaused: true)
+        let legacyStop = try await store.persistStop(legacy.id, authority: authority, stop: legacyStopProposal)
         let before = try Data(contentsOf: url)
-        do { try await store.observeStopOwnerLoss(legacy.id, authority: authority, sent: legacyStop,
-            recovery: PlaybackOwnerLossRecovery(recoveryID: UUID().uuidString, attemptID: "guessed", sessionID: legacyID,
-                state: .aborted, reason: "owner_lost", accepted: nil), response: Data()); XCTFail() } catch {}
+        do {
+            try await store.observeStopOwnerLoss(legacy.id, authority: authority, sent: legacyStop,
+                recovery: PlaybackOwnerLossRecovery(recoveryID: UUID().uuidString, attemptID: "guessed", sessionID: legacyID,
+                    state: .aborted, reason: "owner_lost", accepted: nil))
+            XCTFail("A record without a journaled attempt cannot bind a recovery")
+        } catch PlaybackSequencedError.authorityChanged {
+        } catch { XCTFail("Unexpected error: \(error)") }
         XCTAssertEqual(try Data(contentsOf: url), before)
         try await store.acknowledgeStop(legacy.id, authority: authority, sent: legacyStop,
             receipt: PlaybackSequencedStopReceipt(outcome: .stopped, stopId: legacyStop.stopID, accepted: nil, historyId: nil))
@@ -106,14 +111,14 @@ final class PlaybackMutationStoreTests: XCTestCase {
         let (store, authority, url, _) = try await fixture(installation: "installation")
         let id = UUID().uuidString.lowercased()
         let session = try await store.register(sessionID: id, authority: authority, attemptID: "original")
-        let stop = try await store.prepareStop(session.id, authority: authority, position: 99, isPaused: true)
+        let stopProposal = try await store.proposedStop(session.id, authority: authority, position: 99, isPaused: true)
+        let stop = try await store.persistStop(session.id, authority: authority, stop: stopProposal)
         let recoveryID = UUID().uuidString.lowercased()
         for state in [PlaybackOwnerLossRecovery.State.draining, .aborted] {
             let last = state == .aborted ? try PlaybackSequencedSample(sequence: 1, position: 12, isPaused: false) : nil
             let recovery = PlaybackOwnerLossRecovery(recoveryID: recoveryID, attemptID: "original", sessionID: id,
                 state: state, reason: "owner_lost", accepted: last)
-            try await store.observeStopOwnerLoss(session.id, authority: authority, sent: stop,
-                recovery: recovery, response: JSONEncoder().encode(recovery))
+            try await store.observeStopOwnerLoss(session.id, authority: authority, sent: stop, recovery: recovery)
             let before = try Data(contentsOf: url)
             let reloaded = PlaybackMutationStore(url: url)
             for outcome in [PlaybackSequencedStopReceipt.Outcome.draining, .stopped, .replayed] {
@@ -162,13 +167,15 @@ final class PlaybackMutationStoreTests: XCTestCase {
         let binding = APIv2ProgressTimeline(timelineId: String(repeating: "a", count: 64),
             mediaItemId: "book", fileId: "42", partOffsetSeconds: 0, partDurationSeconds: 30, durationSeconds: 90)
         let session = try await store.register(sessionID: "bound", authority: authority, progressTimeline: binding)
-        let stop = try await store.prepareStop(session.id, authority: authority, position: nil, isPaused: true)
+        let stopProposal = try await store.proposedStop(session.id, authority: authority, position: nil, isPaused: true)
+        let stop = try await store.persistStop(session.id, authority: authority, stop: stopProposal)
         let body = try XCTUnwrap(JSONSerialization.jsonObject(with: SiloAPI.playbackMutationBody(stop)) as? [String: Any])
         XCTAssertEqual(body["timeline_id"] as? String, binding.timelineId)
         XCTAssertNil(body["position"])
         let restarted = PlaybackMutationStore(url: url)
         do { try await restarted.requireTerminalBoundSessions(authority: authority); XCTFail() } catch {}
-        let retry = try await restarted.prepareStop(session.id, authority: authority, position: 29, isPaused: false)
+        let retryProposal = try await restarted.proposedStop(session.id, authority: authority, position: 29, isPaused: false)
+        let retry = try await restarted.persistStop(session.id, authority: authority, stop: retryProposal)
         XCTAssertEqual(try SiloAPI.playbackMutationBody(stop), try SiloAPI.playbackMutationBody(retry))
         try await restarted.acknowledgeStop(session.id, authority: authority, sent: stop,
             receipt: PlaybackSequencedStopReceipt(outcome: .draining, stopId: stop.stopID, accepted: nil, historyId: nil))
@@ -208,9 +215,11 @@ final class PlaybackMutationStoreTests: XCTestCase {
     func testStopSurvivesRestartAndLateDrainingCannotReopenTerminal() async throws {
         let (store, authority, url, _) = try await fixture(installation: "verified-installation")
         let session = try await store.register(sessionID: "session", authority: authority)
-        let stop = try await store.prepareStop(session.id, authority: authority, position: 3, isPaused: true)
+        let stopProposal = try await store.proposedStop(session.id, authority: authority, position: 3, isPaused: true)
+        let stop = try await store.persistStop(session.id, authority: authority, stop: stopProposal)
         let restarted = PlaybackMutationStore(url: url)
-        let retried = try await restarted.prepareStop(session.id, authority: authority, position: 99, isPaused: false)
+        let retriedProposal = try await restarted.proposedStop(session.id, authority: authority, position: 99, isPaused: false)
+        let retried = try await restarted.persistStop(session.id, authority: authority, stop: retriedProposal)
         XCTAssertEqual(stop, retried)
         let pending = try await restarted.pendingStops(authority: authority, afterRestart: true)
         XCTAssertEqual(pending.first?.stop, stop)
@@ -230,7 +239,8 @@ final class PlaybackMutationStoreTests: XCTestCase {
     func testUnknownInstallationAndReloginNeverPromotePendingIntent() async throws {
         let (store, authority, _, tokens) = try await fixture()
         let session = try await store.register(sessionID: "session", authority: authority)
-        _ = try await store.prepareStop(session.id, authority: authority, position: nil, isPaused: true)
+        let pendingProposal = try await store.proposedStop(session.id, authority: authority, position: nil, isPaused: true)
+        _ = try await store.persistStop(session.id, authority: authority, stop: pendingProposal)
         let restarted = try await store.pendingStops(authority: authority, afterRestart: true)
         XCTAssertTrue(restarted.isEmpty)
         try await tokens.installAccountSession(accessToken: "new", refreshToken: "new-refresh", accountID: "1")
@@ -258,7 +268,8 @@ final class PlaybackMutationStoreTests: XCTestCase {
         let session = try await store.register(sessionID: "session", authority: authority)
         let failed = PlaybackMutationStore(url: url) { _, _ in throw CocoaError(.fileWriteOutOfSpace) }
         do { _ = try await failed.prepareProgress(session.id, authority: authority, position: 1, isPaused: false); XCTFail() } catch {}
-        do { _ = try await failed.prepareStop(session.id, authority: authority, position: 2, isPaused: true); XCTFail() } catch {}
+        let proposed = try await failed.proposedStop(session.id, authority: authority, position: 2, isPaused: true)
+        do { _ = try await failed.persistStop(session.id, authority: authority, stop: proposed); XCTFail() } catch {}
         let unchanged = try await store.session(session.id, authority: authority)
         XCTAssertEqual(unchanged.allocatedSequence, 0)
         XCTAssertNil(unchanged.pendingProgress)

--- a/iosApp/Tests/PlaybackSequencedTransportTests.swift
+++ b/iosApp/Tests/PlaybackSequencedTransportTests.swift
@@ -122,8 +122,41 @@ final class PlaybackSequencedTransportTests: XCTestCase {
     func testFeatureAbsentNeverRegistersSequencedOwner() async throws {
         let (owner, _, auth) = try await fixture()
         try await owner.register(sessionID: "legacy", features: [], auth: auth)
-        let handles = await owner.handles("legacy")
-        XCTAssertFalse(handles)
+        let state = await owner.sequencedState("legacy")
+        // Absent contract feature is not a failure: it stays eligible for the
+        // ordinary stop route rather than being fenced off from it.
+        XCTAssertEqual(state, .notSequenced)
+        XCTAssertTrue(SequencedPlaybackProtocol.requests().isEmpty)
+    }
+
+    func testSequencedStateSeparatesNeverRegisteredFailedAndBoundSessions() async throws {
+        let writer = PlaybackTestWriter()
+        let (owner, _, auth) = try await fixture(writer: writer)
+        var state = await owner.sequencedState("session")
+        XCTAssertEqual(state, .notSequenced)
+
+        // A durable record that cannot be written leaves the server-allocated
+        // session sequenced but unbound.
+        writer.fail(true)
+        do {
+            try await owner.register(sessionID: "session", features: [PlaybackSequencedContract.feature], auth: auth)
+            XCTFail("A journal failure must not report a bound session")
+        } catch {}
+        state = await owner.sequencedState("session")
+        XCTAssertEqual(state, .registrationFailed)
+
+        // A missing durable owner is the same fenced state, not an ordinary session.
+        do {
+            try await owner.register(sessionID: "unowned", features: [PlaybackSequencedContract.feature], auth: nil)
+            XCTFail("A registration without a durable owner must fail")
+        } catch {}
+        state = await owner.sequencedState("unowned")
+        XCTAssertEqual(state, .registrationFailed)
+
+        writer.fail(false)
+        try await owner.register(sessionID: "session", features: [PlaybackSequencedContract.feature], auth: auth)
+        state = await owner.sequencedState("session")
+        XCTAssertEqual(state, .bound)
         XCTAssertTrue(SequencedPlaybackProtocol.requests().isEmpty)
     }
 }

--- a/iosApp/iosApp/Downloads/DownloadFilePaths.swift
+++ b/iosApp/iosApp/Downloads/DownloadFilePaths.swift
@@ -2,14 +2,16 @@ import Foundation
 import CryptoKit
 import OSLog
 
-/// On-disk layout for offline downloads. Everything lives under
-/// Application Support (NOT Caches — the OS purges Caches under storage
-/// pressure and downloaded media must survive that). Paths are scoped by
+/// On-disk layout for offline downloads. Everything lives under the root
+/// `AppleStorageRoot` selects: Application Support everywhere it is writable,
+/// because the OS purges Caches under storage pressure and downloaded media
+/// should survive that. tvOS is the exception — it rejects Application Support
+/// writes outright, so there Caches is the only option. Paths are scoped by
 /// `(serverId, profileId)` so a profile or server switch is just a
 /// different directory tree with no migration.
 ///
 /// ```
-/// <AppSupport>/SiloDownloads/<serverId>/<profileId>/
+/// <StorageRoot>/SiloDownloads/<serverId>/<profileId>/
 ///   store.json
 ///   <downloadId>/
 ///     media.<ext>
@@ -30,11 +32,10 @@ enum DownloadFilePaths {
     private static let rootFolderName = "SiloDownloads"
     static let storeFileName = "store.json"
 
-    /// `<AppSupport>/SiloDownloads`, created on first use and excluded from
+    /// `<StorageRoot>/SiloDownloads`, created on first use and excluded from
     /// iCloud/iTunes backup (downloads are large and not re-uploadable).
     static func rootDirectory() -> URL {
-        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-        let root = base.appendingPathComponent(rootFolderName, isDirectory: true)
+        let root = AppleStorageRoot.baseDirectory().appendingPathComponent(rootFolderName, isDirectory: true)
         ensureDirectory(root, excludeFromBackup: true)
         return root
     }
@@ -45,7 +46,7 @@ enum DownloadFilePaths {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
         let key = SHA256.hash(data: try encoder.encode(authority)).map { String(format: "%02x", $0) }.joined()
-        let base = rootOverride ?? FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        let base = rootOverride ?? AppleStorageRoot.baseDirectory()
             .appendingPathComponent("SiloDownloadsV2", isDirectory: true)
         return base.appendingPathComponent(key, isDirectory: true)
     }

--- a/iosApp/iosApp/Networking/PlaybackSequencedMutations.swift
+++ b/iosApp/iosApp/Networking/PlaybackSequencedMutations.swift
@@ -164,7 +164,7 @@ struct PlaybackOwnerLossRecovery: Codable, Equatable, Sendable {
 
 enum PlaybackStopResolution: Sendable {
     case ordinary(PlaybackSequencedStopReceipt)
-    case ownerLost(PlaybackOwnerLossRecovery, Data)
+    case ownerLost(PlaybackOwnerLossRecovery)
 }
 
 enum PlaybackSequencedError: LocalizedError {
@@ -189,14 +189,6 @@ extension SiloAPI {
         return try JSONDecoder().decode(PlaybackSequencedProgressReceipt.self, from: response.data)
     }
 
-    func stopSequencedPlayback(sessionID: String, stop: PlaybackSequencedStop,
-                              auth: CapturedOrdinaryRequestAuth, installationID: String? = nil) async throws -> PlaybackSequencedStopReceipt {
-        let resolution = try await resolveSequencedPlaybackStop(sessionID: sessionID, stop: stop,
-            auth: auth, installationID: installationID)
-        guard case .ordinary(let receipt) = resolution else { throw PlaybackSequencedError.invalidResponse }
-        return receipt
-    }
-
     func resolveSequencedPlaybackStop(sessionID: String, stop: PlaybackSequencedStop,
         auth: CapturedOrdinaryRequestAuth, installationID: String?) async throws -> PlaybackStopResolution {
         let response = try await playbackMutation(method: "DELETE", sessionID: sessionID, suffix: "",
@@ -205,7 +197,7 @@ extension SiloAPI {
         if object?.keys.contains("stop_id") != true,
            let recovery = try PlaybackOwnerLossRecovery.decode(response.data, status: response.statusCode, start: false) {
             guard installationID != nil else { throw PlaybackSequencedError.authorityChanged }
-            return .ownerLost(recovery, response.data)
+            return .ownerLost(recovery)
         }
         let receipt = try JSONDecoder().decode(PlaybackSequencedStopReceipt.self, from: response.data)
         guard receipt.stopId == stop.stopID,

--- a/iosApp/iosApp/Networking/SettingsMutationJournal.swift
+++ b/iosApp/iosApp/Networking/SettingsMutationJournal.swift
@@ -144,11 +144,10 @@ enum SettingsMutationHold: LocalizedError {
 final class SettingsMutationJournal: @unchecked Sendable {
     /// Canonical callers that overlap the player's targets share its existing
     /// file and lock. Existing records retain their original bytes and owner.
-    static let sharedCanonical = SettingsMutationJournal(url: FileManager.default.urls(
-        for: .applicationSupportDirectory, in: .userDomainMask)[0]
-        .appendingPathComponent("SettingsV2/player-commands.json"),
-        retainedProfileJournalURL: FileManager.default.urls(
-            for: .applicationSupportDirectory, in: .userDomainMask)[0]
+    static let sharedCanonical = SettingsMutationJournal(
+        url: AppleStorageRoot.baseDirectory()
+            .appendingPathComponent("SettingsV2/player-commands.json"),
+        retainedProfileJournalURL: AppleStorageRoot.baseDirectory()
             .appendingPathComponent("SettingsV2/onboarding-profile-commands.json"))
     private let lock = NSLock()
     private let url: URL

--- a/iosApp/iosApp/Networking/UICustomizationV2Transport.swift
+++ b/iosApp/iosApp/Networking/UICustomizationV2Transport.swift
@@ -15,8 +15,7 @@ final class SiloUICustomizationTransport: UICustomizationTransport, @unchecked S
     init(api: SiloAPI = .shared, tokens: TokenStore = .shared, defaults: SharedDefaults = .shared,
          journal: SettingsMutationJournal? = nil) {
         self.api = api; self.tokens = tokens; self.defaults = defaults
-        let journal = journal ?? SettingsMutationJournal(url: FileManager.default.urls(
-            for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        let journal = journal ?? SettingsMutationJournal(url: AppleStorageRoot.baseDirectory()
             .appendingPathComponent("SettingsV2/interface-commands.json"))
         self.journal = journal
         dispatcher = SettingsMutationDispatcher(journal: journal, tokens: tokens, api: api)

--- a/iosApp/iosApp/Screens/Audio/AudioPlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Audio/AudioPlayerViewModel.swift
@@ -13,7 +13,6 @@ final class AudioPlayerViewModel {
     }
 
     private let mutationCoordinator = PlaybackMutationCoordinator.shared
-    private var sequencedSessionIDs: Set<String> = []
     private var manifest: APIv2PlaybackManifest?
     private var manifestAuth: CapturedDurableAccountAuth?
     private var manifestCapability: APIv2PlaybackCapabilities?
@@ -317,7 +316,9 @@ final class AudioPlayerViewModel {
             let priorSession = activeSession
             var finalPosition: Double?
             if let priorSession {
-                guard sequencedSessionIDs.contains(priorSession.sessionId) else { throw PlaybackSequencedError.invalidSession }
+                guard await mutationCoordinator.sequencedState(priorSession.sessionId) == .bound else {
+                    throw PlaybackSequencedError.invalidSession
+                }
                 engine.pause()
                 let priorTrack = context.tracks.first { $0.index == activeTrackIndex }
                 finalPosition = priorTrack.map { AudioPlaybackTimeline.localTime(for: currentTime, in: $0) }
@@ -447,9 +448,6 @@ final class AudioPlayerViewModel {
         let response = try await mutationCoordinator.startV2(request: request,
             auth: capturedPlaybackAuth, capability: initialCapability, progressTimeline: binding)
 
-        if let id = PlaybackSessionBridge.allocatedSessionId(in: response) {
-            sequencedSessionIDs.insert(id)
-        }
         switch response.validatedForApple() {
         case .terminal(let terminal):
             throw PlaybackV3TerminalFailure(
@@ -540,7 +538,7 @@ final class AudioPlayerViewModel {
     }
 
     private func stopAllocatedSession(id: String, position: Double? = nil) async throws {
-        guard sequencedSessionIDs.contains(id),
+        guard await mutationCoordinator.sequencedState(id) == .bound,
               try await mutationCoordinator.stop(sessionID: id, position: position, isPaused: true) else {
             throw PlaybackV3TerminalFailure(reason: "audiobook_stop_unresolved",
                 message: "The previous audiobook part has not confirmed its stop. Resolve pending playback before starting another part.",

--- a/iosApp/iosApp/Screens/Player/PlaybackCancellationShield.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackCancellationShield.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+/// Single-owner handoff for one cancellation-shielded request outcome.
+///
+/// Exactly one of the caller and the shielded request itself takes the result,
+/// never both — otherwise a cancelled start could return a session *and* delete
+/// it. A lock rather than an actor because `withTaskCancellationHandler`'s
+/// cancellation handler is synchronous and cannot `await`.
+final class PlaybackCancellationShieldGate<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Value, Error>?
+    private var bufferedOutcome: Result<Value, Error>?
+    private var callerSettled = false
+
+    /// Suspends the caller until the outcome arrives, or resumes it immediately
+    /// when the outcome (or a cancellation) already landed.
+    func attachCaller(_ continuation: CheckedContinuation<Value, Error>) {
+        lock.lock()
+        if let bufferedOutcome {
+            self.bufferedOutcome = nil
+            lock.unlock()
+            continuation.resume(with: bufferedOutcome)
+            return
+        }
+        if callerSettled {
+            lock.unlock()
+            continuation.resume(throwing: CancellationError())
+            return
+        }
+        self.continuation = continuation
+        lock.unlock()
+    }
+
+    /// Returns `true` when the caller took the outcome, `false` when it gave up
+    /// first and the shielded request now owns the cleanup.
+    func deliver(_ outcome: Result<Value, Error>) -> Bool {
+        lock.lock()
+        guard !callerSettled else {
+            lock.unlock()
+            return false
+        }
+        callerSettled = true
+        guard let waiting = continuation else {
+            // The caller has not suspended yet; `attachCaller` collects this.
+            bufferedOutcome = outcome
+            lock.unlock()
+            return true
+        }
+        continuation = nil
+        lock.unlock()
+        waiting.resume(with: outcome)
+        return true
+    }
+
+    /// The caller was cancelled. It stops waiting now; the request keeps going.
+    func abandon() {
+        lock.lock()
+        guard !callerSettled else {
+            lock.unlock()
+            return
+        }
+        callerSettled = true
+        let waiting = continuation
+        continuation = nil
+        lock.unlock()
+        waiting?.resume(throwing: CancellationError())
+    }
+}
+
+enum PlaybackCancellationShield {
+    /// Runs a server-allocating request so caller-side cancellation cannot
+    /// orphan what it allocated.
+    ///
+    /// `URLSession` aborts on task cancellation, and `POST /playback/start` has
+    /// no idempotent retract: a request cancelled after it reached the server
+    /// leaves a session nothing on the client will ever stop. So the request
+    /// runs in an unstructured child that does not inherit cancellation — an
+    /// `async let` or task-group child would inherit it and reintroduce exactly
+    /// that abort. The caller still observes its own cancellation and throws
+    /// promptly, because the autoplay start timeout has to fire on time; the
+    /// child then reclaims the result the caller never saw.
+    static func run<Value>(
+        operation: @escaping @Sendable () async throws -> Value,
+        reclaim: @escaping @Sendable (Value) async -> Void
+    ) async throws -> Value {
+        let gate = PlaybackCancellationShieldGate<Value>()
+        Task {
+            let outcome: Result<Value, Error>
+            do {
+                outcome = .success(try await operation())
+            } catch {
+                outcome = .failure(error)
+            }
+            // Only the abandoned path reclaims, so there is one owner and no
+            // duplicate retirement.
+            guard !gate.deliver(outcome), case .success(let value) = outcome else { return }
+            await reclaim(value)
+        }
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                gate.attachCaller(continuation)
+            }
+        } onCancel: {
+            gate.abandon()
+        }
+    }
+}

--- a/iosApp/iosApp/Screens/Player/PlaybackMutationCoordinator.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackMutationCoordinator.swift
@@ -1,14 +1,27 @@
 import Foundation
 import Observation
 
+/// Observable projection of `PlaybackMutationCoordinator`'s pending stop
+/// notices. The coordinator owns the set; this type only mirrors it for SwiftUI
+/// and has no writer of its own.
 @Observable
 @MainActor
 final class PlaybackStopNotices {
     static let shared = PlaybackStopNotices()
     private(set) var pending: Set<UUID> = []
-    func setPending(_ id: UUID, _ value: Bool) {
-        if value { pending.insert(id) } else { pending.remove(id) }
+    fileprivate func apply(_ id: UUID, pending isPending: Bool) {
+        if isPending { pending.insert(id) } else { pending.remove(id) }
     }
+}
+
+/// The one answer to "does this session belong to the v2 sequenced contract".
+/// `registrationFailed` is not `notSequenced`: the server allocated the session
+/// under the sequenced contract but this process never bound a durable mutation
+/// record for it, so it must never fall back to a plain DELETE.
+enum PlaybackSequencedSessionState: Sendable, Equatable {
+    case notSequenced
+    case registrationFailed
+    case bound
 }
 
 /// Retains sequenced mutation intent independently of the player/bridge lifetime.
@@ -50,6 +63,12 @@ actor PlaybackMutationCoordinator {
     private var stopIntents: [UUID: StopIntent] = [:]
     private var draining: Set<UUID> = []
     private var restoredBoundSessions: Set<UUID> = []
+    /// Sessions the server allocated under the sequenced contract that this
+    /// process could not bind. Retained so `sequencedState` alone can keep them
+    /// out of the ordinary DELETE fallback.
+    private var failedRegistrations: Set<String> = []
+    /// Authoritative pending-stop notices. `PlaybackStopNotices` mirrors this.
+    private var pendingStopNotices: Set<UUID> = []
 
     init(api: SiloAPI = .shared, tokens: TokenStore = .shared, store: PlaybackMutationStore = .shared,
          retryDelays: [Duration] = [.seconds(1), .seconds(2), .seconds(4), .seconds(5), .seconds(5), .seconds(5), .seconds(5)],
@@ -61,20 +80,46 @@ actor PlaybackMutationCoordinator {
         self.pendingStarts = pendingStarts ?? { try await store.pendingStarts(authority: $0) }
     }
 
-    func register(sessionID: String, features: [String], auth: CapturedDurableAccountAuth,
+    /// A session advertised under the sequenced contract is bound here or
+    /// recorded as a registration failure. Both outcomes are readable through
+    /// `sequencedState`; callers keep no parallel bookkeeping.
+    func register(sessionID: String, features: [String], auth: CapturedDurableAccountAuth?,
                   installationID: String? = nil, attemptID: String? = nil, progressTimeline: APIv2ProgressTimeline? = nil) async throws {
         guard features.contains(PlaybackSequencedContract.feature) else { return }
-        let authority = try PlaybackMutationAuthority(auth: auth, installationID: installationID)
-        _ = try await currentAuth(authority)
-        let saved = try await store.register(sessionID: sessionID, authority: authority, progressTimeline: progressTimeline, attemptID: attemptID)
-        _ = try await currentAuth(authority)
-        // A bare server session ID must never retarget an older bridge's
-        // delayed callback to another account/profile/origin in this process.
-        if let existing = contexts[sessionID], existing.authority != authority {
-            throw PlaybackSequencedError.authorityChanged
+        do {
+            guard let auth else { throw PlaybackSequencedError.authorityChanged }
+            let authority = try PlaybackMutationAuthority(auth: auth, installationID: installationID)
+            _ = try await currentAuth(authority)
+            let saved = try await store.register(sessionID: sessionID, authority: authority, progressTimeline: progressTimeline, attemptID: attemptID)
+            _ = try await currentAuth(authority)
+            // A bare server session ID must never retarget an older bridge's
+            // delayed callback to another account/profile/origin in this process.
+            if let existing = contexts[sessionID], existing.authority != authority {
+                throw PlaybackSequencedError.authorityChanged
+            }
+            contexts[sessionID] = Context(recordID: saved.id, sessionID: sessionID, authority: authority,
+                attemptID: saved.attemptID ?? contexts[sessionID]?.attemptID)
+            failedRegistrations.remove(sessionID)
+        } catch {
+            failedRegistrations.insert(sessionID)
+            throw error
         }
-        contexts[sessionID] = Context(recordID: saved.id, sessionID: sessionID, authority: authority,
-            attemptID: try await store.originalAttemptID(saved) ?? contexts[sessionID]?.attemptID)
+    }
+
+    /// Single source of truth for "is this a v2 sequenced session".
+    func sequencedState(_ sessionID: String) -> PlaybackSequencedSessionState {
+        // A recorded failure outranks a live context: an authority that changed
+        // under an already-bound session id is still unsafe to release plainly.
+        if failedRegistrations.contains(sessionID) { return .registrationFailed }
+        return contexts[sessionID] != nil ? .bound : .notSequenced
+    }
+
+    /// Mirrors one pending-stop notice onto the observable projection. The
+    /// coordinator's own set is authoritative and deduplicates the hop.
+    private func publishStopNotice(_ id: UUID, pending: Bool) async {
+        let changed = pending ? pendingStopNotices.insert(id).inserted : pendingStopNotices.remove(id) != nil
+        guard changed else { return }
+        await PlaybackStopNotices.shared.apply(id, pending: pending)
     }
 
     func requireResolvedStartBeforeLegacy(auth: CapturedDurableAccountAuth) async throws {
@@ -139,8 +184,22 @@ actor PlaybackMutationCoordinator {
         if prepared.created { originalStartAuth[start.id] = auth.request }
         guard !completedStarts.contains(start.id) else { throw PlaybackSequencedError.invalidSession }
         unresolvedStarts[start.id] = start
-        await PlaybackStopNotices.shared.setPending(start.id, true)
-        return try await resolveStart(start, retire: false)
+        await publishStopNotice(start.id, pending: true)
+        return try await resolveStartWithNetworkRetry(start)
+    }
+
+    /// One retry for a start whose response never arrived. Only a transport
+    /// failure is retried: the journal holds the byte-exact body and
+    /// `resolveStart` revalidates authority before it dispatches again, so the
+    /// retry either repeats the identical attempt or fails closed. Any other
+    /// error is an answer from the server and is not repeated.
+    private func resolveStartWithNetworkRetry(_ start: StoredPlaybackStart) async throws -> PlaybackV3DecisionResponse {
+        do {
+            return try await resolveStart(start, retire: false)
+        } catch let error as HTTPError {
+            guard case .network = error else { throw error }
+            return try await resolveStart(start, retire: false)
+        }
     }
 
     private func resolveStart(_ start: StoredPlaybackStart, retire: Bool) async throws -> PlaybackV3DecisionResponse {
@@ -158,7 +217,7 @@ actor PlaybackMutationCoordinator {
         guard !start.finished else {
             completedStarts.insert(start.id)
             unresolvedStarts.removeValue(forKey: start.id)
-            await PlaybackStopNotices.shared.setPending(start.id, false)
+            await publishStopNotice(start.id, pending: false)
             throw PlaybackSequencedError.invalidSession
         }
         let auth = try await currentAuth(start.authority)
@@ -177,11 +236,11 @@ actor PlaybackMutationCoordinator {
             let response = try await api.v2.playbackRequest(method: "POST", suffix: "/start", body: start.body, auth: auth)
             _ = try await currentAuth(start.authority)
             if let recovery = try PlaybackOwnerLossRecovery.decode(response.data, status: response.statusCode, start: true) {
-                try await store.observeStartOwnerLoss(start.id, authority: start.authority, recovery: recovery, response: response.data)
+                try await store.observeStartOwnerLoss(start.id, authority: start.authority, recovery: recovery)
                 if recovery.state == .draining { throw PlaybackSequencedError.pendingStart }
                 completedStarts.insert(start.id)
                 unresolvedStarts.removeValue(forKey: start.id)
-                await PlaybackStopNotices.shared.setPending(start.id, false)
+                await publishStopNotice(start.id, pending: false)
                 // A terminal decision has no renderer/session adoption. Original
                 // body and any historical response remain unchanged in the journal.
                 return try HTTPClient.makeJSONDecoder().decode(APIv2PlaybackDecision.self, from: response.data).legacy()
@@ -225,7 +284,7 @@ actor PlaybackMutationCoordinator {
         try await store.acknowledgeStart(start.id, authority: start.authority, response: data, finished: true)
         completedStarts.insert(start.id)
         unresolvedStarts.removeValue(forKey: start.id)
-        await PlaybackStopNotices.shared.setPending(start.id, false)
+        await publishStopNotice(start.id, pending: false)
         do {
             let response = try wire.legacy()
             if let sessionID, !retire {
@@ -252,10 +311,10 @@ actor PlaybackMutationCoordinator {
             for start in try await pendingStarts(authority) {
                 guard !completedStarts.contains(start.id) else { continue }
                 unresolvedStarts[start.id] = start
-                await PlaybackStopNotices.shared.setPending(start.id, true)
+                await publishStopNotice(start.id, pending: true)
                 if completedStarts.contains(start.id) {
                     unresolvedStarts.removeValue(forKey: start.id)
-                    await PlaybackStopNotices.shared.setPending(start.id, false)
+                    await publishStopNotice(start.id, pending: false)
                 }
             }
             for session in try await store.pendingStops(authority: authority, afterRestart: true) {
@@ -266,15 +325,12 @@ actor PlaybackMutationCoordinator {
                     restoredBoundSessions.insert(session.id)
                 }
                 try await register(sessionID: session.sessionID, features: [PlaybackSequencedContract.feature], auth: auth,
-                    installationID: authority.installationID, progressTimeline: session.progressTimeline)
-                await PlaybackStopNotices.shared.setPending(session.id, true)
+                    installationID: authority.installationID, attemptID: session.attemptID,
+                    progressTimeline: session.progressTimeline)
+                await publishStopNotice(session.id, pending: true)
             }
         } catch { /* Unknown or changed authority remains quarantined. */ }
     }
-
-    func usesV2(_ sessionID: String) -> Bool { contexts[sessionID]?.authority.installationID != nil }
-
-    func handles(_ sessionID: String) -> Bool { contexts[sessionID] != nil }
 
     func replan(sessionID: String, request: PlaybackV3ReplanRequest) async throws -> PlaybackV3DecisionResponse {
         guard let context = contexts[sessionID], let installation = context.authority.installationID,
@@ -424,7 +480,12 @@ actor PlaybackMutationCoordinator {
         guard plan.stream.headers.allSatisfy({ key, value in
             key.caseInsensitiveCompare("X-Profile-Id") != .orderedSame || value == auth.profileId
         }) else { throw PlaybackSequencedError.authorityChanged }
-        guard let context = contexts[sessionID], stopIntents[context.recordID] == nil,
+        // The session and stop-intent re-reads below are each placed after one
+        // of the two suspension points in this guard: the durable-owner capture
+        // and the request-auth identity check. A stop intent is never cleared,
+        // so a repeat between non-suspending reads could not observe anything
+        // the next re-read misses.
+        guard let context = contexts[sessionID],
               auth.profileId == context.authority.profileID,
               auth.account.serverId == context.authority.serverID,
               auth.account.serverURL == context.authority.origin,
@@ -460,18 +521,16 @@ actor PlaybackMutationCoordinator {
         return request
     }
 
+    /// Local comparison only. The installation ID is captured once from
+    /// `GET /api/v2/playback/capabilities` in `captureStartAuth` (or in
+    /// `restorePending` after a process restart) and is echoed on every
+    /// mutation. A stale installation is answered by the server with
+    /// `409 installation_changed`, so re-probing capabilities per call adds a
+    /// no-store round trip per mutation without adding a guarantee.
     private func currentAuth(_ authority: PlaybackMutationAuthority) async throws -> CapturedOrdinaryRequestAuth {
         guard let current = await tokens.captureDurableAccountAuth(),
               try PlaybackMutationAuthority(auth: current, installationID: authority.installationID) == authority else {
             throw PlaybackSequencedError.authorityChanged
-        }
-        if let installation = authority.installationID {
-            let capability = try await api.v2.playbackCapabilities(auth: current.request)
-            guard try capability.requireAvailable() == installation else { throw PlaybackSequencedError.authorityChanged }
-            guard let after = await tokens.captureDurableAccountAuth(),
-                  try PlaybackMutationAuthority(auth: after, installationID: installation) == authority else {
-                throw PlaybackSequencedError.authorityChanged
-            }
         }
         return current.request
     }
@@ -498,7 +557,7 @@ actor PlaybackMutationCoordinator {
         }
         guard draining.insert(context.recordID).inserted else { return false }
         defer { draining.remove(context.recordID) }
-        await PlaybackStopNotices.shared.setPending(context.recordID, true)
+        await publishStopNotice(context.recordID, pending: true)
         var intent = stopIntents[context.recordID]!
         if intent.proposed == nil {
             intent.proposed = try await store.proposedStop(context.recordID, authority: context.authority,
@@ -510,7 +569,7 @@ actor PlaybackMutationCoordinator {
         let stop = try await store.persistStop(context.recordID, authority: context.authority, stop: intent.proposed!)
         let saved = try await store.session(context.recordID, authority: context.authority)
         if saved.stopState.isTerminal {
-            await PlaybackStopNotices.shared.setPending(context.recordID, false)
+            await publishStopNotice(context.recordID, pending: false)
             if saved.stopState == .abandoned { throw PlaybackOwnerLossRecovery.terminalFailure }
             return true
         }
@@ -526,14 +585,14 @@ actor PlaybackMutationCoordinator {
                 case .ordinary(let receipt):
                     try await store.acknowledgeStop(context.recordID, authority: context.authority, sent: stop, receipt: receipt)
                     if receipt.outcome != .draining {
-                        await PlaybackStopNotices.shared.setPending(context.recordID, false)
+                        await publishStopNotice(context.recordID, pending: false)
                         return true
                     }
-                case .ownerLost(let recovery, let response):
+                case .ownerLost(let recovery):
                     try await store.observeStopOwnerLoss(context.recordID, authority: context.authority, sent: stop,
-                        recovery: recovery, response: response)
+                        recovery: recovery)
                     if recovery.state == .aborted {
-                        await PlaybackStopNotices.shared.setPending(context.recordID, false)
+                        await publishStopNotice(context.recordID, pending: false)
                         // Do not let a pending final sample or an automatic bound
                         // part transition interpret abandonment as its STOP success.
                         throw PlaybackOwnerLossRecovery.terminalFailure

--- a/iosApp/iosApp/Screens/Player/PlaybackMutationStore.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackMutationStore.swift
@@ -30,9 +30,10 @@ struct StoredPlaybackMutationSession: Codable, Sendable {
     let sessionID: String
     let authority: PlaybackMutationAuthority
     var progressTimeline: APIv2ProgressTimeline? = nil
+    /// The attempt that allocated this session. Nil only for a record written by
+    /// an older build; owner-loss recovery for such a record stays fail-closed.
     var attemptID: String? = nil
     var ownerLoss: PlaybackOwnerLossRecovery? = nil
-    var ownerLossResponse: Data? = nil
     var allocatedSequence: Int64 = 0
     var pendingProgress: PlaybackSequencedSample?
     var accepted: PlaybackSequencedSample?
@@ -51,7 +52,6 @@ struct StoredPlaybackStart: Codable, Sendable {
     var response: Data?
     var progressTimeline: APIv2ProgressTimeline? = nil
     var ownerLoss: PlaybackOwnerLossRecovery? = nil
-    var ownerLossResponse: Data? = nil
     var finished = false
 }
 
@@ -74,8 +74,13 @@ private struct PlaybackMutationStoreFile: Codable {
 /// Durable idempotency data, not authority. Callers must obtain current canonical
 /// credentials before each request. This actor never dispatches or replays traffic.
 actor PlaybackMutationStore {
-    static let shared = PlaybackMutationStore(url: FileManager.default.urls(for: .applicationSupportDirectory,
-        in: .userDomainMask)[0].appendingPathComponent("playback-mutations.json"))
+    /// tvOS rejects Application Support writes, which failed this journal before
+    /// `/api/v2/playback/start` was ever sent. `AppleStorageRoot` owns that rule.
+    static let shared: PlaybackMutationStore = {
+        AppleStorageRoot.logSelectedCategory(subsystemCategory: "PlaybackMutations")
+        return PlaybackMutationStore(
+            url: AppleStorageRoot.baseDirectory().appendingPathComponent("playback-mutations.json"))
+    }()
 
     private let url: URL
     private let write: @Sendable (Data, URL) throws -> Void
@@ -177,12 +182,6 @@ actor PlaybackMutationStore {
         return stop
     }
 
-    func prepareStop(_ id: UUID, authority: PlaybackMutationAuthority, position: Double?,
-                     isPaused: Bool) throws -> PlaybackSequencedStop {
-        let stop = try proposedStop(id, authority: authority, position: position, isPaused: isPaused)
-        return try persistStop(id, authority: authority, stop: stop)
-    }
-
     func acknowledgeStop(_ id: UUID, authority: PlaybackMutationAuthority, sent: PlaybackSequencedStop,
                          receipt: PlaybackSequencedStopReceipt) throws {
         var file = try read()
@@ -206,23 +205,16 @@ actor PlaybackMutationStore {
         try persist(file)
     }
 
-    /// Old sessions may obtain the attempt only from their exact durable START
-    /// record. No ambient plan, login or first-observation binding is permitted.
-    func originalAttemptID(_ session: StoredPlaybackMutationSession) throws -> String? {
-        if let attempt = session.attemptID { return attempt }
-        return try read().starts?.values.first(where: { start in
-            guard start.authority == session.authority, let data = start.response,
-                  let decision = try? HTTPClient.makeJSONDecoder().decode(APIv2PlaybackDecision.self, from: data) else { return false }
-            return (decision.sessionId ?? decision.playbackPlan?.sessionId) == session.sessionID
-        })?.attemptID
-    }
-
     func observeStopOwnerLoss(_ id: UUID, authority: PlaybackMutationAuthority, sent: PlaybackSequencedStop,
-        recovery: PlaybackOwnerLossRecovery, response: Data) throws {
+        recovery: PlaybackOwnerLossRecovery) throws {
         var file = try read()
         guard var session = file.sessions[id], session.authority == authority, authority.installationID != nil,
               session.stop == sent else { throw PlaybackSequencedError.authorityChanged }
-        try recovery.validate(attemptID: originalAttemptID(session), sessionID: session.sessionID,
+        // A session may obtain the attempt only from its own durable record. No
+        // ambient plan, login or first-observation binding is permitted, so a
+        // record written before the attempt was journaled can never recover.
+        guard let attemptID = session.attemptID else { throw PlaybackSequencedError.authorityChanged }
+        try recovery.validate(attemptID: attemptID, sessionID: session.sessionID,
             previous: session.ownerLoss, timeline: session.progressTimeline)
         // A real matching StopID receipt already stored remains authoritative.
         guard session.stopState != .terminal,
@@ -230,7 +222,6 @@ actor PlaybackMutationStore {
             throw PlaybackSequencedError.invalidResponse
         }
         session.ownerLoss = recovery
-        session.ownerLossResponse = response
         session.stopState = recovery.state == .aborted ? .abandoned : .draining
         if recovery.state == .aborted {
             session.accepted = recovery.accepted
@@ -241,7 +232,7 @@ actor PlaybackMutationStore {
     }
 
     func observeStartOwnerLoss(_ id: UUID, authority: PlaybackMutationAuthority,
-        recovery: PlaybackOwnerLossRecovery, response: Data) throws {
+        recovery: PlaybackOwnerLossRecovery) throws {
         var file = try read()
         guard var start = file.starts?[id], start.authority == authority, authority.installationID != nil else {
             throw PlaybackSequencedError.authorityChanged
@@ -254,7 +245,6 @@ actor PlaybackMutationStore {
         try recovery.validate(attemptID: start.attemptID, sessionID: decision?.sessionId ?? decision?.playbackPlan?.sessionId,
             previous: start.ownerLoss, timeline: start.progressTimeline)
         start.ownerLoss = recovery
-        start.ownerLossResponse = response
         start.finished = recovery.state == .aborted
         file.starts?[id] = start
         try persist(file)
@@ -291,11 +281,6 @@ actor PlaybackMutationStore {
         guard !((try read()).sessions.values.contains {
             $0.authority == authority && $0.progressTimeline != nil && $0.stopState.isTerminal == false
         }) else { throw PlaybackSequencedError.invalidSession }
-    }
-
-    func prepareStart(authority: PlaybackMutationAuthority, attemptID: String, body: Data, progressTimeline: APIv2ProgressTimeline? = nil) throws -> StoredPlaybackStart {
-        try prepareStartWithDisposition(authority: authority, attemptID: attemptID, body: body,
-            progressTimeline: progressTimeline).start
     }
 
     /// Creation is reported atomically with persistence; callers must never

--- a/iosApp/iosApp/Screens/Player/PlaybackRealtimeClient.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackRealtimeClient.swift
@@ -230,8 +230,10 @@ actor PlaybackRealtimeClient {
         binding: PlaybackMutationCoordinator.ControlBinding
     ) async throws {
         while isCurrentBinding(sessionId: sessionId, generation: generation) {
+            // The socket carries a binding this client already validated, and
+            // every command re-validates it around execution. An inbound frame
+            // by itself mutates no playback state, so it is not fenced again.
             let message = try await socket.receive()
-            try await mutationCoordinator.validateControlBinding(binding)
             guard isCurrentBinding(sessionId: sessionId, generation: generation) else { return }
             guard let data = decodeInboundMessageData(message) else { continue }
             guard let inbound = parsePlaybackRealtimeInboundMessage(data) else { continue }

--- a/iosApp/iosApp/Screens/Player/PlaybackRealtimeClient.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackRealtimeClient.swift
@@ -230,10 +230,9 @@ actor PlaybackRealtimeClient {
         binding: PlaybackMutationCoordinator.ControlBinding
     ) async throws {
         while isCurrentBinding(sessionId: sessionId, generation: generation) {
-            // The socket carries a binding this client already validated, and
-            // every command re-validates it around execution. An inbound frame
-            // by itself mutates no playback state, so it is not fenced again.
             let message = try await socket.receive()
+            try await mutationCoordinator.validateControlBinding(binding)
+            try Task.checkCancellation()
             guard isCurrentBinding(sessionId: sessionId, generation: generation) else { return }
             guard let data = decodeInboundMessageData(message) else { continue }
             guard let inbound = parsePlaybackRealtimeInboundMessage(data) else { continue }

--- a/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
+++ b/iosApp/iosApp/Screens/Player/PlaybackSessionBridge.swift
@@ -4,82 +4,6 @@ import OSLog
 import TVServices
 #endif
 
-struct PreparedPlayback {
-    let watchDetail: WatchDetail
-    let selectedVersion: FileVersion
-    let session: PlaybackSessionResponse
-    let activeQualityId: String
-    let protocolV3: PreparedPlaybackV3?
-
-    init(
-        watchDetail: WatchDetail,
-        selectedVersion: FileVersion,
-        session: PlaybackSessionResponse,
-        activeQualityId: String = ApplePlaybackQuality.autoId,
-        protocolV3: PreparedPlaybackV3? = nil
-    ) {
-        self.watchDetail = watchDetail
-        self.selectedVersion = selectedVersion
-        self.session = session
-        self.activeQualityId = activeQualityId
-        self.protocolV3 = protocolV3
-    }
-
-    var displayTitle: String {
-        if watchDetail.type == "episode" {
-            let season = watchDetail.seasonNumber.map { "S\($0)" } ?? nil
-            let episode = watchDetail.episodeNumber.map { "E\($0)" } ?? nil
-            let episodeTag = [season, episode].compactMap { $0 }.joined()
-
-            if let seriesTitle = watchDetail.seriesTitle, !seriesTitle.isEmpty, !episodeTag.isEmpty {
-                return "\(seriesTitle) • \(episodeTag) • \(watchDetail.title)"
-            }
-        }
-
-        return watchDetail.title
-    }
-
-    /// Build the hero-strip metadata bundle for the tvOS overlay. Reads
-    /// everything off the already-fetched `WatchDetail` + `FileVersion` so
-    /// the overlay doesn't need a second API call — we only transform the
-    /// shapes the server already gave us into display strings.
-    func playerMetadata(primaryAudioLayout: String? = nil) -> PlayerMetadata {
-        let isEpisode = watchDetail.type == "episode"
-        let episodeTag: String? = {
-            guard isEpisode else { return nil }
-            let s = watchDetail.seasonNumber.map { "S\($0)" }
-            let e = watchDetail.episodeNumber.map { "E\($0)" }
-            let joined = [s, e].compactMap { $0 }.joined(separator: " · ")
-            return joined.isEmpty ? nil : joined
-        }()
-
-        var badges: [String] = []
-        if let resolution = selectedVersion.resolution, !resolution.isEmpty {
-            badges.append(PlayerMetadata.badgeLabel(forResolution: resolution))
-        }
-        if selectedVersion.hdr == true {
-            badges.append("HDR")
-        }
-        if let codec = selectedVersion.codecVideo?.uppercased(), !codec.isEmpty {
-            badges.append(codec)
-        }
-        if let layout = primaryAudioLayout?.uppercased(), !layout.isEmpty {
-            badges.append(layout)
-        } else if let audioCodec = selectedVersion.codecAudio?.uppercased(), !audioCodec.isEmpty {
-            badges.append(audioCodec)
-        }
-
-        return PlayerMetadata(
-            seriesTitle: isEpisode ? watchDetail.seriesTitle : nil,
-            episodeTag: episodeTag,
-            primaryTitle: watchDetail.title,
-            year: isEpisode ? nil : watchDetail.year,
-            overview: watchDetail.overview,
-            badges: badges
-        )
-    }
-}
-
 enum PlaybackSessionStopResolution: Equatable, Sendable {
     case noSession, closed, pending, ownerLost
 }
@@ -96,86 +20,6 @@ struct PlaybackV3TerminalFailure: LocalizedError, Equatable {
     let retryable: Bool
 
     var errorDescription: String? { message }
-}
-
-/// Secondary metadata shown in the tvOS player overlay's hero strip.
-/// Populated from the playback session at load time via
-/// `PreparedPlayback.playerMetadata(primaryAudioLayout:)` — everything here
-/// is already fetched as part of `/api/v1/watch/{id}`, so no extra API
-/// calls are needed.
-struct PlayerMetadata: Equatable {
-    /// For episodes: series title, e.g. "Foundation".
-    var seriesTitle: String?
-    /// For episodes: "S2 · E3" or similar compact tag.
-    var episodeTag: String?
-    /// Episode display title when the container is a series episode.
-    /// For movies, this is the only title and is shown as the hero title.
-    var primaryTitle: String
-    /// Release year for movies; nil for episodes.
-    var year: Int?
-    /// Short plot description. Surfaced as secondary text below the title.
-    var overview: String?
-    /// Tagged media attributes rendered as pills in the hero strip:
-    /// "4K" / "HDR" / "DV" / "HEVC" / "5.1" etc.
-    var badges: [String]
-
-    static let empty = PlayerMetadata(
-        seriesTitle: nil,
-        episodeTag: nil,
-        primaryTitle: "",
-        year: nil,
-        overview: nil,
-        badges: []
-    )
-
-    /// Map raw resolution strings ("1920x1080", "1080p", "2160p") to the
-    /// short marketing label shown in the overlay ("4K" / "FHD" / "HD" / "SD").
-    static func badgeLabel(forResolution raw: String) -> String {
-        let lower = raw.lowercased()
-        if lower.contains("2160") || lower.contains("4k") { return "4K" }
-        if lower.contains("1440") { return "QHD" }
-        if lower.contains("1080") { return "FHD" }
-        if lower.contains("720") { return "HD" }
-        if lower.contains("480") { return "SD" }
-        return raw.uppercased()
-    }
-}
-
-enum PlaybackDeliveryStrategy {
-    case direct
-    case remux
-    case transcode
-
-    init(playMethod: String) {
-        switch playMethod.lowercased() {
-        case "remux":
-            self = .remux
-        case "transcode":
-            self = .transcode
-        default:
-            self = .direct
-        }
-    }
-
-    var name: String {
-        switch self {
-        case .direct:
-            return "direct"
-        case .remux:
-            return "remux"
-        case .transcode:
-            return "transcode"
-        }
-    }
-
-    var preservesSourceVideoMetadata: Bool {
-        switch self {
-        case .direct, .remux:
-            return true
-        case .transcode:
-            return false
-        }
-    }
 }
 
 /// One capability probe per active server, shared by video and audiobook
@@ -259,118 +103,9 @@ actor PlaybackV3CapabilityGate {
     }
 }
 
-/// Manages the lifecycle of a playback session with the Silo API.
-/// Handles session creation, periodic progress reporting, and cleanup.
-///
 /// Owns the server playback-session lifecycle and Protocol V3 contract state.
 /// Capability reporting must stay aligned with what the active AetherEngine
 /// boundary can actually execute.
-/// Single-owner handoff for one cancellation-shielded request outcome.
-///
-/// Exactly one of the caller and the shielded request itself takes the result,
-/// never both — otherwise a cancelled start could return a session *and* delete
-/// it. A lock rather than an actor because `withTaskCancellationHandler`'s
-/// cancellation handler is synchronous and cannot `await`.
-final class PlaybackCancellationShieldGate<Value>: @unchecked Sendable {
-    private let lock = NSLock()
-    private var continuation: CheckedContinuation<Value, Error>?
-    private var bufferedOutcome: Result<Value, Error>?
-    private var callerSettled = false
-
-    /// Suspends the caller until the outcome arrives, or resumes it immediately
-    /// when the outcome (or a cancellation) already landed.
-    func attachCaller(_ continuation: CheckedContinuation<Value, Error>) {
-        lock.lock()
-        if let bufferedOutcome {
-            self.bufferedOutcome = nil
-            lock.unlock()
-            continuation.resume(with: bufferedOutcome)
-            return
-        }
-        if callerSettled {
-            lock.unlock()
-            continuation.resume(throwing: CancellationError())
-            return
-        }
-        self.continuation = continuation
-        lock.unlock()
-    }
-
-    /// Returns `true` when the caller took the outcome, `false` when it gave up
-    /// first and the shielded request now owns the cleanup.
-    func deliver(_ outcome: Result<Value, Error>) -> Bool {
-        lock.lock()
-        guard !callerSettled else {
-            lock.unlock()
-            return false
-        }
-        callerSettled = true
-        guard let waiting = continuation else {
-            // The caller has not suspended yet; `attachCaller` collects this.
-            bufferedOutcome = outcome
-            lock.unlock()
-            return true
-        }
-        continuation = nil
-        lock.unlock()
-        waiting.resume(with: outcome)
-        return true
-    }
-
-    /// The caller was cancelled. It stops waiting now; the request keeps going.
-    func abandon() {
-        lock.lock()
-        guard !callerSettled else {
-            lock.unlock()
-            return
-        }
-        callerSettled = true
-        let waiting = continuation
-        continuation = nil
-        lock.unlock()
-        waiting?.resume(throwing: CancellationError())
-    }
-}
-
-enum PlaybackCancellationShield {
-    /// Runs a server-allocating request so caller-side cancellation cannot
-    /// orphan what it allocated.
-    ///
-    /// `URLSession` aborts on task cancellation, and `POST /playback/start` has
-    /// no idempotent retract: a request cancelled after it reached the server
-    /// leaves a session nothing on the client will ever stop. So the request
-    /// runs in an unstructured child that does not inherit cancellation — an
-    /// `async let` or task-group child would inherit it and reintroduce exactly
-    /// that abort. The caller still observes its own cancellation and throws
-    /// promptly, because the autoplay start timeout has to fire on time; the
-    /// child then reclaims the result the caller never saw.
-    static func run<Value>(
-        operation: @escaping @Sendable () async throws -> Value,
-        reclaim: @escaping @Sendable (Value) async -> Void
-    ) async throws -> Value {
-        let gate = PlaybackCancellationShieldGate<Value>()
-        Task {
-            let outcome: Result<Value, Error>
-            do {
-                outcome = .success(try await operation())
-            } catch {
-                outcome = .failure(error)
-            }
-            // Only the abandoned path reclaims, so there is one owner and no
-            // duplicate retirement.
-            guard !gate.deliver(outcome), case .success(let value) = outcome else { return }
-            await reclaim(value)
-        }
-        return try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation { continuation in
-                gate.attachCaller(continuation)
-            }
-        } onCancel: {
-            gate.abandon()
-        }
-    }
-}
-
 actor PlaybackSessionBridge {
     private static let nearEndResumeSuppressionSeconds: Double = 5
     private static let pastEndResumeClampSeconds: Double = 0.25
@@ -380,6 +115,9 @@ actor PlaybackSessionBridge {
         category: "Playback"
     )
 
+    /// Dedups the whole retirement — final progress report, DELETE, and the
+    /// shared resolution a second caller awaits — for ordinary non-v2 sessions
+    /// too; the coordinator's `draining` set only dedups the v2 stop request.
     private var retiringSession: Task<PlaybackSessionStopResolution, Never>?
     private let mutationCoordinator: PlaybackMutationCoordinator
     private let api: SiloAPI
@@ -390,8 +128,6 @@ actor PlaybackSessionBridge {
         self.api = api
         self.tokens = tokens
     }
-    private var sequencedSessionIDs: Set<String> = []
-    private var failedSequencedRegistrations: Set<String> = []
     private var sessionId: String?
     private var currentSession: PlaybackSessionResponse?
 
@@ -479,6 +215,22 @@ actor PlaybackSessionBridge {
 
     private var pendingProtocolV3Transition: PendingProtocolV3Transition?
 
+    /// The staged transition this prepared playback came from, if it is still
+    /// the staged one. Identity is the candidate session and plan the server
+    /// issued. Whether the bridge already points at that candidate is a
+    /// separate question: commit and recovery require it, while a rollback has
+    /// to recognise a candidate the bridge never adopted.
+    private func stagedTransition(
+        matching prepared: PreparedPlayback
+    ) -> PendingProtocolV3Transition? {
+        guard let pending = pendingProtocolV3Transition,
+              pending.candidateSessionId == prepared.session.sessionId,
+              pending.candidatePlanId == prepared.protocolV3?.plan.planId else {
+            return nil
+        }
+        return pending
+    }
+
     private func isCurrentProtocolV3Attempt(
         _ expected: ProtocolV3AttemptIdentity,
         sessionId expectedSessionId: String
@@ -518,19 +270,13 @@ actor PlaybackSessionBridge {
         }
     }
 
+    /// The coordinator records the binding — or the registration failure — so
+    /// the bridge keeps no parallel view of which sessions are sequenced.
     private func registerSequencedAllocation(_ response: PlaybackV3DecisionResponse,
                                              auth: CapturedDurableAccountAuth?) async throws {
         guard let id = Self.allocatedSessionId(in: response) else { return }
-        if await mutationCoordinator.usesV2(id) { sequencedSessionIDs.insert(id); return }
-        guard response.serverFeatures.contains(PlaybackSequencedContract.feature) else { return }
-        sequencedSessionIDs.insert(id)
-        do {
-            guard let auth else { throw PlaybackSequencedError.authorityChanged }
-            try await mutationCoordinator.register(sessionID: id, features: response.serverFeatures, auth: auth)
-        } catch {
-            failedSequencedRegistrations.insert(id)
-            throw error
-        }
+        guard await mutationCoordinator.sequencedState(id) != .bound else { return }
+        try await mutationCoordinator.register(sessionID: id, features: response.serverFeatures, auth: auth)
     }
 
     /// Retires a server session this client allocated but will never execute.
@@ -539,22 +285,68 @@ actor PlaybackSessionBridge {
     /// own — but a failure still costs the user a lingering session slot, so it
     /// is logged rather than swallowed. The DELETE in `stopSession` has always
     /// logged; these paths used a bare `try?` and were silent.
-    private func retireAbandonedSession(
+    func retireAbandonedSession(
         _ abandonedSessionId: String,
         reason: String
     ) async {
         do {
-            if sequencedSessionIDs.contains(abandonedSessionId) {
-                guard !failedSequencedRegistrations.contains(abandonedSessionId) else { throw PlaybackSequencedError.authorityChanged }
+            switch await mutationCoordinator.sequencedState(abandonedSessionId) {
+            case .bound:
                 _ = try await mutationCoordinator.stop(sessionID: abandonedSessionId, position: nil, isPaused: true)
                 return
+            case .registrationFailed:
+                // A sequenced allocation this process never bound has no durable
+                // stop intent, and a plain DELETE would discard the server's stop
+                // contract for it. Fail closed and let the idle timeout reclaim it.
+                throw PlaybackSequencedError.authorityChanged
+            case .notSequenced:
+                try await api.stopPlayback(sessionId: abandonedSessionId)
             }
-            try await SiloAPI.shared.stopPlayback(sessionId: abandonedSessionId)
         } catch {
             logger.error(
                 "abandoned-session stop failed for \(abandonedSessionId, privacy: .public) (\(reason, privacy: .public)); server-side session may linger until idle timeout: \(MediaLogRedactor.sanitize(error), privacy: .public)"
             )
         }
+    }
+
+    /// The attempt a terminal route event names. There is none before a start
+    /// succeeds, so a failed start reports no event.
+    private struct ProtocolV3TerminalReport {
+        let active: ActiveProtocolV3
+        let sessionId: String
+    }
+
+    /// The dead end shared by start and replan: retire the session this client
+    /// will never execute, report the terminal route event, then hand the
+    /// caller the failure to throw. The order is load-bearing — the abandoned
+    /// session is released before the event that explains why, and the throw
+    /// happens last, in the caller.
+    ///
+    /// `retiring` is nil when the response allocated nothing or when the
+    /// allocation is the session still in use. `retireReason` defaults to
+    /// `reason`; the two differ wherever the server-facing stop reason names
+    /// the response that was rejected rather than the failure it produced.
+    @discardableResult
+    private func failProtocolV3Attempt(
+        reason: String,
+        message: String,
+        retryable: Bool = false,
+        retiring retiredSessionId: String?,
+        retireReason: String? = nil,
+        reporting report: ProtocolV3TerminalReport? = nil
+    ) async -> PlaybackV3TerminalFailure {
+        if let retiredSessionId {
+            await retireAbandonedSession(retiredSessionId, reason: retireReason ?? reason)
+        }
+        if let report {
+            await emitProtocolV3Terminal(
+                active: report.active,
+                sessionId: report.sessionId,
+                reason: reason,
+                message: message
+            )
+        }
+        return PlaybackV3TerminalFailure(reason: reason, message: message, retryable: retryable)
     }
 
     /// Records a server-issued candidate plan as pending until Aether commits
@@ -586,9 +378,7 @@ actor PlaybackSessionBridge {
     /// Commits the server decision only after Aether's load epoch commits.
     /// Returns false when a newer transition or teardown already won.
     func commitPendingProtocolV3Transition(_ prepared: PreparedPlayback) -> Bool {
-        guard let pending = pendingProtocolV3Transition,
-              pending.candidateSessionId == prepared.session.sessionId,
-              pending.candidatePlanId == prepared.protocolV3?.plan.planId,
+        guard let pending = stagedTransition(matching: prepared),
               sessionId == pending.candidateSessionId,
               activeProtocolV3?.plan.planId == pending.candidatePlanId else {
             return false
@@ -646,9 +436,7 @@ actor PlaybackSessionBridge {
     func promotePendingProtocolV3TransitionForRecovery(
         _ prepared: PreparedPlayback
     ) -> Bool {
-        guard let pending = pendingProtocolV3Transition,
-              pending.candidateSessionId == prepared.session.sessionId,
-              pending.candidatePlanId == prepared.protocolV3?.plan.planId,
+        guard let pending = stagedTransition(matching: prepared),
               sessionId == pending.candidateSessionId,
               activeProtocolV3?.plan.planId == pending.candidatePlanId else {
             return false
@@ -666,11 +454,7 @@ actor PlaybackSessionBridge {
     /// session. Same-session replans restore client state; the server keeps its
     /// own immutable attempt history for the next bounded replan.
     func rollbackPendingProtocolV3Transition(_ prepared: PreparedPlayback) {
-        guard let pending = pendingProtocolV3Transition,
-              pending.candidateSessionId == prepared.session.sessionId,
-              pending.candidatePlanId == prepared.protocolV3?.plan.planId else {
-            return
-        }
+        guard stagedTransition(matching: prepared) != nil else { return }
         rollbackAnyPendingProtocolV3Transition()
     }
 
@@ -1011,19 +795,6 @@ actor PlaybackSessionBridge {
         }
     }
 
-    /// Retry only the exact attempt inside the cancellation shield. The
-    /// coordinator retains its original ephemeral authority across uncertainty.
-    static func startV2WithNetworkRetry(coordinator: PlaybackMutationCoordinator,
-        request: PlaybackV3StartRequest, auth: CapturedDurableAccountAuth?,
-        capability: APIv2PlaybackCapabilities) async throws -> PlaybackV3DecisionResponse {
-        do {
-            return try await coordinator.startV2(request: request, auth: auth, capability: capability)
-        } catch let error as HTTPError {
-            guard case .network = error else { throw error }
-            return try await coordinator.startV2(request: request, auth: auth, capability: capability)
-        }
-    }
-
     private func stageProtocolV3Start(
         watchDetail: WatchDetail,
         selectedVersion: FileVersion,
@@ -1079,8 +850,8 @@ actor PlaybackSessionBridge {
         // timeout. Shield the request from cancellation and retire whatever it
         // allocated if the caller has already walked away.
         let response = try await PlaybackCancellationShield.run {
-            try await Self.startV2WithNetworkRetry(coordinator: self.mutationCoordinator,
-                request: request, auth: capturedPlaybackAuth, capability: initialCapability)
+            try await self.mutationCoordinator.startV2(request: request,
+                auth: capturedPlaybackAuth, capability: initialCapability)
         } reclaim: { [self] abandoned in
             guard let orphaned = Self.allocatedSessionId(in: abandoned) else { return }
             try? await registerSequencedAllocation(abandoned, auth: capturedPlaybackAuth)
@@ -1097,29 +868,21 @@ actor PlaybackSessionBridge {
                 retryable: terminal.retryable
             )
         case .incompatible(let allocatedSessionId):
-            if let allocatedSessionId {
-                await retireAbandonedSession(
-                    allocatedSessionId,
-                    reason: "incompatible_start_response"
-                )
-            }
-            throw PlaybackV3TerminalFailure(
+            throw await failProtocolV3Attempt(
                 reason: "invalid_playback_plan",
                 message: "The server returned an incompatible protocol V3 playback plan.",
-                retryable: false
+                retiring: allocatedSessionId,
+                retireReason: "incompatible_start_response"
             )
         case .playable(let plan, let resolvedSessionId):
             guard response.serverFeatures.contains(
                 PlaybackProtocolV3.headerAuthenticatedMediaFeature
             ) else {
-                await retireAbandonedSession(
-                    resolvedSessionId,
-                    reason: "start_without_header_authenticated_media"
-                )
-                throw PlaybackV3TerminalFailure(
+                throw await failProtocolV3Attempt(
                     reason: "server_upgrade_required",
                     message: "This server did not honor authenticated media transport for the playback plan.",
-                    retryable: false
+                    retiring: resolvedSessionId,
+                    retireReason: "start_without_header_authenticated_media"
                 )
             }
             do {
@@ -1134,14 +897,11 @@ actor PlaybackSessionBridge {
             guard let effectiveVersion = watchDetail.versions.first(where: {
                 $0.fileId == plan.effectiveMediaFileId
             }) else {
-                await retireAbandonedSession(
-                    resolvedSessionId,
-                    reason: "start_effective_file_unavailable"
-                )
-                throw PlaybackV3TerminalFailure(
+                throw await failProtocolV3Attempt(
                     reason: "effective_file_unavailable",
                     message: "The server selected a media version that is not present in the item response.",
-                    retryable: false
+                    retiring: resolvedSessionId,
+                    retireReason: "start_effective_file_unavailable"
                 )
             }
             let session = ApplePlaybackV3PlanAdapter.playbackSession(
@@ -1226,38 +986,31 @@ actor PlaybackSessionBridge {
     /// operation. A user-initiated track or quality change is an intent, not a
     /// failure, and carries no `failure` block.
     ///
-    /// This overload predates `output_change_v1` and keeps an output-route
-    /// change on `failure_recovery`. Prefer the `serverFeatures` overload:
-    /// only that one can tell whether the server offers the intent operation.
-    static func replanOperation(forClassification classification: String) -> String {
+    /// An output-route change is an intent too: the device never rejected the
+    /// plan, the display it was chosen for did. §6 gives `output_change`
+    /// exactly that meaning — it keeps the previous route eligible, where
+    /// `failure_recovery` excludes the current plan key and so forces a
+    /// different route even when the new sink can still play it.
+    ///
+    /// That operation only exists on a server advertising `output_change_v1`;
+    /// an older one rejects it as an invalid operation, so the historical
+    /// failure-recovery spelling remains the fallback there. Omitting
+    /// `serverFeatures` means exactly that older server.
+    static func replanOperation(
+        forClassification classification: String,
+        serverFeatures: [String] = []
+    ) -> String {
         switch classification {
         case "audio_track_changed", "subtitle_track_changed":
             return PlaybackProtocolV3.ReplanOperation.trackChange
         case "quality_changed":
             return PlaybackProtocolV3.ReplanOperation.qualityChange
+        case "output_route_changed"
+            where serverFeatures.contains(PlaybackProtocolV3.outputChangeFeature):
+            return PlaybackProtocolV3.ReplanOperation.outputChange
         default:
             return PlaybackProtocolV3.ReplanOperation.failureRecovery
         }
-    }
-
-    /// An output-route change is an intent, not a failed recipe: the device
-    /// never rejected the plan, the display it was chosen for did. §6 gives
-    /// `output_change` exactly that meaning — it keeps the previous route
-    /// eligible, where `failure_recovery` excludes the current plan key and so
-    /// forces a different route even when the new sink can still play it.
-    ///
-    /// The operation only exists on a server advertising `output_change_v1`;
-    /// an older one rejects it as an invalid operation, so the historical
-    /// failure-recovery spelling remains the fallback there.
-    static func replanOperation(
-        forClassification classification: String,
-        serverFeatures: [String]
-    ) -> String {
-        if classification == "output_route_changed",
-           serverFeatures.contains(PlaybackProtocolV3.outputChangeFeature) {
-            return PlaybackProtocolV3.ReplanOperation.outputChange
-        }
-        return replanOperation(forClassification: classification)
     }
 
     /// AVAudioSession emits route-change notifications for configuration
@@ -1359,7 +1112,6 @@ actor PlaybackSessionBridge {
                    PlaybackProtocolV3.ReplanOperation.seekReanchor].contains(operation)
     }
 
-    /// Returns whether a validated replan retains the current route attempt.
     static func replanPreservesAttempt(operation: String, usesV2: Bool,
         currentSessionID: String, nextSessionID: String,
         current: PlaybackV3Plan, next: PlaybackV3Plan,
@@ -1417,16 +1169,11 @@ actor PlaybackSessionBridge {
         )
         let expectedAttempt = ProtocolV3AttemptIdentity(active)
         guard active.attemptCount < 8 else {
-            await emitProtocolV3Terminal(
-                active: active,
-                sessionId: currentSessionId,
-                reason: "attempt_limit_reached",
-                message: "Playback recovery exhausted the protocol V3 route ladder."
-            )
-            throw PlaybackV3TerminalFailure(
+            throw await failProtocolV3Attempt(
                 reason: "attempt_limit_reached",
                 message: "Playback recovery exhausted the protocol V3 route ladder.",
-                retryable: false
+                retiring: nil,
+                reporting: .init(active: active, sessionId: currentSessionId)
             )
         }
 
@@ -1440,7 +1187,7 @@ actor PlaybackSessionBridge {
             || operation == PlaybackProtocolV3.ReplanOperation.outputChange
         let invalidatesIntent = isIntent || classification == "output_route_changed"
         let isSeekReanchor = operation == PlaybackProtocolV3.ReplanOperation.seekReanchor
-        let usesV2 = await mutationCoordinator.usesV2(currentSessionId)
+        let usesV2 = await mutationCoordinator.sequencedState(currentSessionId) == .bound
         let preservesRoute = isSeekReanchor || Self.isV2SameRouteRecovery(operation: operation, usesV2: usesV2)
         if isSeekReanchor,
            !active.serverFeatures.contains(PlaybackProtocolV3.seekReanchorFeature) {
@@ -1576,71 +1323,44 @@ actor PlaybackSessionBridge {
         }
         switch validatedResponse {
         case .terminal(let terminal):
-            await emitProtocolV3Terminal(
-                active: active,
-                sessionId: currentSessionId,
-                reason: terminal.reason,
-                message: terminal.message
-            )
-            throw PlaybackV3TerminalFailure(
+            throw await failProtocolV3Attempt(
                 reason: terminal.reason,
                 message: terminal.message,
-                retryable: terminal.retryable
+                retryable: terminal.retryable,
+                retiring: nil,
+                reporting: .init(active: active, sessionId: currentSessionId)
             )
         case .incompatible(let allocatedSessionId):
-            if let allocatedSessionId, allocatedSessionId != currentSessionId {
-                await retireAbandonedSession(
-                    allocatedSessionId,
-                    reason: "incompatible_replan_response"
-                )
-            }
-            await emitProtocolV3Terminal(
-                active: active,
-                sessionId: currentSessionId,
-                reason: "invalid_replan",
-                message: "The server returned an incompatible protocol V3 replacement plan."
-            )
-            throw PlaybackV3TerminalFailure(
+            throw await failProtocolV3Attempt(
                 reason: "invalid_replan",
                 message: "The server returned an incompatible protocol V3 replacement plan.",
-                retryable: false
+                retiring: allocatedSessionId == currentSessionId ? nil : allocatedSessionId,
+                retireReason: "incompatible_replan_response",
+                reporting: .init(active: active, sessionId: currentSessionId)
             )
         case .playable(let nextPlan, let nextSessionId):
             guard response.serverFeatures.contains(
                 PlaybackProtocolV3.headerAuthenticatedMediaFeature
             ) else {
-                if nextSessionId != currentSessionId {
-                    await retireAbandonedSession(
-                        nextSessionId,
-                        reason: "replan_without_header_authenticated_media"
-                    )
-                }
-                await emitProtocolV3Terminal(
-                    active: active,
-                    sessionId: currentSessionId,
-                    reason: "server_upgrade_required",
-                    message: "The server did not preserve authenticated media transport during replanning."
-                )
-                throw PlaybackV3TerminalFailure(
+                throw await failProtocolV3Attempt(
                     reason: "server_upgrade_required",
                     message: "The server did not preserve authenticated media transport during replanning.",
-                    retryable: false
+                    retiring: nextSessionId == currentSessionId ? nil : nextSessionId,
+                    retireReason: "replan_without_header_authenticated_media",
+                    reporting: .init(active: active, sessionId: currentSessionId)
                 )
             }
             do {
                 try ApplePlaybackV3PlanAdapter.validate(nextPlan)
             } catch {
-                if nextSessionId != currentSessionId {
-                    await retireAbandonedSession(
-                        nextSessionId,
-                        reason: "unexecutable_replan_plan"
-                    )
-                }
-                await emitProtocolV3Terminal(
-                    active: active,
-                    sessionId: currentSessionId,
+                // The adapter's own error stays the thrown one; the helper's
+                // failure only describes what the terminal event reports.
+                await failProtocolV3Attempt(
                     reason: "invalid_replan",
-                    message: error.localizedDescription
+                    message: error.localizedDescription,
+                    retiring: nextSessionId == currentSessionId ? nil : nextSessionId,
+                    retireReason: "unexecutable_replan_plan",
+                    reporting: .init(active: active, sessionId: currentSessionId)
                 )
                 throw error
             }
@@ -1653,32 +1373,23 @@ actor PlaybackSessionBridge {
                     current: active.plan, next: nextPlan, attemptedKeys: attemptedKeys,
                     responseFeatures: response.serverFeatures)
             } catch let failure as PlaybackV3TerminalFailure {
-                if nextSessionId != currentSessionId {
-                    await retireAbandonedSession(nextSessionId, reason: failure.reason)
-                }
-                await emitProtocolV3Terminal(active: active, sessionId: currentSessionId,
-                    reason: failure.reason, message: failure.message)
-                throw failure
+                throw await failProtocolV3Attempt(
+                    reason: failure.reason,
+                    message: failure.message,
+                    retryable: failure.retryable,
+                    retiring: nextSessionId == currentSessionId ? nil : nextSessionId,
+                    reporting: .init(active: active, sessionId: currentSessionId)
+                )
             }
             guard let selectedVersion = watchDetail.versions.first(where: {
                 $0.fileId == nextPlan.effectiveMediaFileId
             }) else {
-                if nextSessionId != currentSessionId {
-                    await retireAbandonedSession(
-                        nextSessionId,
-                        reason: "replan_effective_file_unavailable"
-                    )
-                }
-                await emitProtocolV3Terminal(
-                    active: active,
-                    sessionId: currentSessionId,
-                    reason: "effective_file_unavailable",
-                    message: "The replacement plan selected an unavailable media version."
-                )
-                throw PlaybackV3TerminalFailure(
+                throw await failProtocolV3Attempt(
                     reason: "effective_file_unavailable",
                     message: "The replacement plan selected an unavailable media version.",
-                    retryable: false
+                    retiring: nextSessionId == currentSessionId ? nil : nextSessionId,
+                    retireReason: "replan_effective_file_unavailable",
+                    reporting: .init(active: active, sessionId: currentSessionId)
                 )
             }
             let nextSession = ApplePlaybackV3PlanAdapter.playbackSession(
@@ -1918,7 +1629,7 @@ actor PlaybackSessionBridge {
         guard let sid = sessionId else { return .transientFailure }
         guard position.isFinite, position >= 0 else { return .transientFailure }
 
-        if sequencedSessionIDs.contains(sid) {
+        if await mutationCoordinator.sequencedState(sid) != .notSequenced {
             do {
                 try await mutationCoordinator.report(sessionID: sid, position: position, isPaused: isPaused)
                 return .success
@@ -1930,7 +1641,7 @@ actor PlaybackSessionBridge {
         }
         let report = ProgressReport(position: position, isPaused: isPaused)
         do {
-            try await SiloAPI.shared.reportPlaybackProgress(
+            try await api.reportPlaybackProgress(
                 sessionId: sid,
                 report: report
             )
@@ -1960,6 +1671,27 @@ actor PlaybackSessionBridge {
         }
     }
 
+    /// Resolves the media request for a session the bridge allocated. Media
+    /// authority stays with the coordinator; the player consumes the outcome.
+    /// A local download carries its own `file://` source and never has one.
+    func streamRequest(
+        session: PlaybackSessionResponse,
+        additionalHeaders: [String: String] = [:],
+        requiresHeaderAuthenticatedMedia: Bool = false,
+        allowsAuthorizedMediaOrigins: Bool = false
+    ) async -> StreamRequest? {
+        if session.streamUrl.hasPrefix("file://") {
+            return StreamRequest.resolve(rawURL: session.streamUrl, serverURL: "",
+                additionalHeaders: [:], accessToken: nil,
+                requiresHeaderAuthenticatedMedia: requiresHeaderAuthenticatedMedia)
+        }
+        return try? await mutationCoordinator.streamRequest(
+            sessionID: session.sessionId, rawURL: session.streamUrl,
+            additionalHeaders: additionalHeaders,
+            requiresHeaderAuthenticatedMedia: requiresHeaderAuthenticatedMedia,
+            allowsAuthorizedMediaOrigins: allowsAuthorizedMediaOrigins)
+    }
+
     func syncProgress(
         contentId: String,
         position: Double,
@@ -1973,7 +1705,7 @@ actor PlaybackSessionBridge {
         }
 
         do {
-            try await SiloAPI.shared.syncProgress(
+            try await api.syncProgress(
                 mediaItemId: contentId,
                 position: position,
                 duration: duration.isFinite && duration > 0 ? duration : 0,
@@ -2041,11 +1773,15 @@ actor PlaybackSessionBridge {
         if let supersededSessionId, supersededSessionId != sid {
             stopStaleSession(supersededSessionId)
         }
+        // One read decides both the breadcrumb wording and the stop route; a
+        // failed registration stays on the sequenced route so it can never fall
+        // through to the plain DELETE below.
+        let isSequenced = await mutationCoordinator.sequencedState(sid) != .notSequenced
         #if os(iOS) || os(tvOS)
         DiagnosticsCoordinator.recordBreadcrumb(
             category: .playback,
             tag: "PlaybackSession",
-            message: sequencedSessionIDs.contains(sid) ? "local playback closed; server stop pending" : "playback session stopped",
+            message: isSequenced ? "local playback closed; server stop pending" : "playback session stopped",
             attrs: [
                 "session_id": .string(sid),
                 // The attribute registry has no float type, so playback
@@ -2069,7 +1805,7 @@ actor PlaybackSessionBridge {
             )
         }
 
-        if sequencedSessionIDs.contains(sid) {
+        if isSequenced {
             do {
                 return try await mutationCoordinator.stop(sessionID: sid, position: position, isPaused: isPaused) ? .closed : .pending
             }
@@ -2084,7 +1820,7 @@ actor PlaybackSessionBridge {
         if position.isFinite, position >= 0 {
             let report = ProgressReport(position: position, isPaused: isPaused)
             do {
-                try await SiloAPI.shared.reportPlaybackProgress(
+                try await api.reportPlaybackProgress(
                     sessionId: sid,
                     report: report
                 )
@@ -2096,7 +1832,7 @@ actor PlaybackSessionBridge {
         }
 
         do {
-            try await SiloAPI.shared.stopPlayback(sessionId: sid)
+            try await api.stopPlayback(sessionId: sid)
         } catch {
             // Best-effort delete; the server times out idle sessions on its
             // own, but a missed delete extends the grace period. Log so
@@ -2107,7 +1843,6 @@ actor PlaybackSessionBridge {
         }
 
         #if os(tvOS)
-        // Nudge the Top Shelf to re-fetch now that progress has advanced.
         TVTopShelfContentProvider.topShelfContentDidChange()
         #endif
         return .closed

--- a/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
+++ b/iosApp/iosApp/Screens/Player/PlayerViewModel.swift
@@ -6579,13 +6579,8 @@ class PlayerViewModel {
         requiresHeaderAuthenticatedMedia: Bool = false,
         allowsAuthorizedMediaOrigins: Bool = false
     ) async -> StreamRequest? {
-        if session.streamUrl.hasPrefix("file://") {
-            return StreamRequest.resolve(rawURL: session.streamUrl, serverURL: "",
-                additionalHeaders: [:], accessToken: nil,
-                requiresHeaderAuthenticatedMedia: requiresHeaderAuthenticatedMedia)
-        }
-        return try? await PlaybackMutationCoordinator.shared.streamRequest(
-            sessionID: session.sessionId, rawURL: session.streamUrl,
+        await sessionBridge.streamRequest(
+            session: session,
             additionalHeaders: additionalHeaders,
             requiresHeaderAuthenticatedMedia: requiresHeaderAuthenticatedMedia,
             allowsAuthorizedMediaOrigins: allowsAuthorizedMediaOrigins)

--- a/iosApp/iosApp/Screens/Player/PreparedPlayback.swift
+++ b/iosApp/iosApp/Screens/Player/PreparedPlayback.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+struct PreparedPlayback {
+    let watchDetail: WatchDetail
+    let selectedVersion: FileVersion
+    let session: PlaybackSessionResponse
+    let activeQualityId: String
+    let protocolV3: PreparedPlaybackV3?
+
+    init(
+        watchDetail: WatchDetail,
+        selectedVersion: FileVersion,
+        session: PlaybackSessionResponse,
+        activeQualityId: String = ApplePlaybackQuality.autoId,
+        protocolV3: PreparedPlaybackV3? = nil
+    ) {
+        self.watchDetail = watchDetail
+        self.selectedVersion = selectedVersion
+        self.session = session
+        self.activeQualityId = activeQualityId
+        self.protocolV3 = protocolV3
+    }
+
+    var displayTitle: String {
+        if watchDetail.type == "episode" {
+            let season = watchDetail.seasonNumber.map { "S\($0)" } ?? nil
+            let episode = watchDetail.episodeNumber.map { "E\($0)" } ?? nil
+            let episodeTag = [season, episode].compactMap { $0 }.joined()
+
+            if let seriesTitle = watchDetail.seriesTitle, !seriesTitle.isEmpty, !episodeTag.isEmpty {
+                return "\(seriesTitle) • \(episodeTag) • \(watchDetail.title)"
+            }
+        }
+
+        return watchDetail.title
+    }
+
+    /// Build the hero-strip metadata bundle for the tvOS overlay. Reads
+    /// everything off the already-fetched `WatchDetail` + `FileVersion` so
+    /// the overlay doesn't need a second API call — we only transform the
+    /// shapes the server already gave us into display strings.
+    func playerMetadata(primaryAudioLayout: String? = nil) -> PlayerMetadata {
+        let isEpisode = watchDetail.type == "episode"
+        let episodeTag: String? = {
+            guard isEpisode else { return nil }
+            let s = watchDetail.seasonNumber.map { "S\($0)" }
+            let e = watchDetail.episodeNumber.map { "E\($0)" }
+            let joined = [s, e].compactMap { $0 }.joined(separator: " · ")
+            return joined.isEmpty ? nil : joined
+        }()
+
+        var badges: [String] = []
+        if let resolution = selectedVersion.resolution, !resolution.isEmpty {
+            badges.append(PlayerMetadata.badgeLabel(forResolution: resolution))
+        }
+        if selectedVersion.hdr == true {
+            badges.append("HDR")
+        }
+        if let codec = selectedVersion.codecVideo?.uppercased(), !codec.isEmpty {
+            badges.append(codec)
+        }
+        if let layout = primaryAudioLayout?.uppercased(), !layout.isEmpty {
+            badges.append(layout)
+        } else if let audioCodec = selectedVersion.codecAudio?.uppercased(), !audioCodec.isEmpty {
+            badges.append(audioCodec)
+        }
+
+        return PlayerMetadata(
+            seriesTitle: isEpisode ? watchDetail.seriesTitle : nil,
+            episodeTag: episodeTag,
+            primaryTitle: watchDetail.title,
+            year: isEpisode ? nil : watchDetail.year,
+            overview: watchDetail.overview,
+            badges: badges
+        )
+    }
+}
+
+/// Secondary metadata shown in the tvOS player overlay's hero strip.
+/// Populated from the playback session at load time via
+/// `PreparedPlayback.playerMetadata(primaryAudioLayout:)` — everything here
+/// is already fetched as part of `/api/v1/watch/{id}`, so no extra API
+/// calls are needed.
+struct PlayerMetadata: Equatable {
+    /// For episodes: series title, e.g. "Foundation".
+    var seriesTitle: String?
+    /// For episodes: "S2 · E3" or similar compact tag.
+    var episodeTag: String?
+    /// Episode display title when the container is a series episode.
+    /// For movies, this is the only title and is shown as the hero title.
+    var primaryTitle: String
+    /// Release year for movies; nil for episodes.
+    var year: Int?
+    /// Short plot description. Surfaced as secondary text below the title.
+    var overview: String?
+    /// Tagged media attributes rendered as pills in the hero strip:
+    /// "4K" / "HDR" / "DV" / "HEVC" / "5.1" etc.
+    var badges: [String]
+
+    static let empty = PlayerMetadata(
+        seriesTitle: nil,
+        episodeTag: nil,
+        primaryTitle: "",
+        year: nil,
+        overview: nil,
+        badges: []
+    )
+
+    /// Map raw resolution strings ("1920x1080", "1080p", "2160p") to the
+    /// short marketing label shown in the overlay ("4K" / "FHD" / "HD" / "SD").
+    static func badgeLabel(forResolution raw: String) -> String {
+        let lower = raw.lowercased()
+        if lower.contains("2160") || lower.contains("4k") { return "4K" }
+        if lower.contains("1440") { return "QHD" }
+        if lower.contains("1080") { return "FHD" }
+        if lower.contains("720") { return "HD" }
+        if lower.contains("480") { return "SD" }
+        return raw.uppercased()
+    }
+}
+
+enum PlaybackDeliveryStrategy {
+    case direct
+    case remux
+    case transcode
+
+    init(playMethod: String) {
+        switch playMethod.lowercased() {
+        case "remux":
+            self = .remux
+        case "transcode":
+            self = .transcode
+        default:
+            self = .direct
+        }
+    }
+
+    var name: String {
+        switch self {
+        case .direct:
+            return "direct"
+        case .remux:
+            return "remux"
+        case .transcode:
+            return "transcode"
+        }
+    }
+
+    var preservesSourceVideoMetadata: Bool {
+        switch self {
+        case .direct, .remux:
+            return true
+        case .transcode:
+            return false
+        }
+    }
+}

--- a/iosApp/iosApp/Shared/AppleStorageRoot.swift
+++ b/iosApp/iosApp/Shared/AppleStorageRoot.swift
@@ -1,0 +1,50 @@
+import Foundation
+import OSLog
+
+/// One platform rule for every app-private durable file this client writes.
+///
+/// tvOS devices only permit writes under Caches. Application Support writes
+/// fail there with `NSCocoaErrorDomain` 513, and the tvOS simulator does not
+/// enforce the constraint, so simulator testing cannot catch a regression.
+/// Every other platform uses Application Support, which the OS does not purge
+/// under storage pressure.
+///
+/// This type is deliberately unguarded by `#if os(...)`: the iOS, tvOS, and
+/// macOS targets all compile callers of it.
+enum AppleStorageRoot {
+    /// Storage category selected by the platform rule. Only the category name is
+    /// safe to log; a container path identifies the installation and is not.
+    enum Category: String {
+        case caches
+        case applicationSupport
+
+        var searchPathDirectory: FileManager.SearchPathDirectory {
+            switch self {
+            case .caches: return .cachesDirectory
+            case .applicationSupport: return .applicationSupportDirectory
+            }
+        }
+    }
+
+    static var category: Category {
+#if os(tvOS)
+        .caches
+#else
+        .applicationSupport
+#endif
+    }
+
+    static func baseDirectory(fileManager: FileManager = .default) -> URL {
+        fileManager.urls(for: category.searchPathDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+    }
+
+    /// Records which category the platform rule chose, by name only. Diagnosing
+    /// a storage-root regression needs the category, never the private path.
+    static func logSelectedCategory(subsystemCategory: String) {
+        Logger(
+            subsystem: Bundle.main.bundleIdentifier ?? "org.siloserver.silo",
+            category: subsystemCategory
+        ).log("storage root category=\(category.rawValue, privacy: .public)")
+    }
+}

--- a/iosApp/iosApp/Shared/Diagnostics/DiagnosticsStorageRoot.swift
+++ b/iosApp/iosApp/Shared/Diagnostics/DiagnosticsStorageRoot.swift
@@ -1,17 +1,4 @@
-#if os(iOS) || os(tvOS)
-import Foundation
-
-/// tvOS devices only permit writes under Caches; the simulator does not enforce
-/// this constraint, so simulator testing cannot catch storage-root regressions.
-enum DiagnosticsStorageRoot {
-    static func baseDirectory(fileManager: FileManager) -> URL {
-#if os(tvOS)
-        let searchPathDirectory: FileManager.SearchPathDirectory = .cachesDirectory
-#else
-        let searchPathDirectory: FileManager.SearchPathDirectory = .applicationSupportDirectory
-#endif
-        return fileManager.urls(for: searchPathDirectory, in: .userDomainMask).first
-            ?? URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
-    }
-}
-#endif
+/// Historical name for the shared platform storage rule, kept because the
+/// diagnostics writers are documented and discussed under it. The rule itself
+/// now lives in `AppleStorageRoot` so every durable writer shares one copy.
+typealias DiagnosticsStorageRoot = AppleStorageRoot

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
@@ -162,12 +162,8 @@ struct TVItemDetailView: View {
         let activeWasCompleted = activeSeriesEpisodeContentId.map {
             event.completedContentIds.contains($0)
         } ?? false
-        let completedEpisodeIsVisible = viewModel.episodes.contains {
-            event.completedContentIds.contains($0.contentId)
-        }
         guard activeSeriesEpisodeContentId == nil
-                || activeWasCompleted
-                || completedEpisodeIsVisible else { return }
+                || activeWasCompleted else { return }
 
         if activeSeriesEpisodeContentId == nil,
            let inProgress = viewModel.episodes.first(where: {

--- a/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
+++ b/iosApp/iosApp/tvOS/Screens/Detail/TVItemDetailView.swift
@@ -169,9 +169,10 @@ struct TVItemDetailView: View {
                 || activeWasCompleted
                 || completedEpisodeIsVisible else { return }
 
-        if let inProgress = viewModel.episodes.first(where: {
-            $0.userData?.isInProgress == true && !($0.userData?.played ?? false)
-        }) {
+        if activeSeriesEpisodeContentId == nil,
+           let inProgress = viewModel.episodes.first(where: {
+               $0.userData?.isInProgress == true && !($0.userData?.played ?? false)
+           }) {
             activeSeriesEpisodeContentId = inProgress.contentId
             return
         }


### PR DESCRIPTION
After tvOS playback refreshes, completing a different visible episode could replace an unfinished Continue Watching selection. Realtime frames could also reach event handlers or command acknowledgments after the server or profile authority changed.

Preserve a selected episode unless that episode completed, then use the existing next-unwatched logic. Validate the captured playback authority immediately after each WebSocket receive, before dispatching events or acknowledging commands, and retain cancellation and connection-generation checks.

Validation:
- iOS and tvOS simulator builds, installs, and launches passed locally with Xcode 27.
- Eight selection scenarios and five realtime scenarios passed in isolated Swift harnesses using the actual methods with stubbed dependencies. Both reported regressions reproduced against the reviewed commit. These checks do not establish live-server playback behavior.
- All 71 existing tests in APIv2PlaybackTests and DetailVersionSelectionTests passed on the iOS simulator (zero failures or skips).
- Fresh GitHub CI is pending. The previous CI run failed in TVMediaCard type checking and several unrelated iOS tests.

AI assistance: GPT-6 through the Codex agent harness. The exact runtime model identifier was not exposed to the agent. No other AI tooling was used for this update.
