### PR TITLE
fix(auth): recover stale remembered servers

### DIFF
--- a/iosApp/Tests/DetailDismissalNavigationTests.swift
+++ b/iosApp/Tests/DetailDismissalNavigationTests.swift
@@ -22,6 +22,19 @@ private actor ContinueWatchingResponseGate {
 
 @MainActor
 final class DetailDismissalNavigationTests: XCTestCase {
+    func testServerResolutionClearsPresentationsEvenWhenAuthStateStaysAuthenticated() {
+        let router = AppRouter()
+        router.authState = .authenticated
+        router.presentItemDetail(contentId: "old-server-detail")
+        router.presentPlayer(contentId: "old-server-player")
+
+        router.resetAfterServerResolution(to: .authenticated)
+
+        XCTAssertNil(router.presentedItemDetail)
+        XCTAssertNil(router.presentedPlayer)
+        XCTAssertTrue(router.path.isEmpty)
+    }
+
     func testCloseAndRotationControlsWaitForTapInEveryPhase() async throws {
         let model = PlayerViewModel()
         defer { model.cleanup() }

--- a/iosApp/Tests/RestoredSessionValidatorTests.swift
+++ b/iosApp/Tests/RestoredSessionValidatorTests.swift
@@ -1,0 +1,268 @@
+import XCTest
+@testable import Silo
+
+final class RestoredSessionValidatorTests: XCTestCase {
+    private let expected = RefreshAccountIdentity(
+        serverId: "server-a",
+        serverURL: "https://silo.example",
+        credentialGenerationID: UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")!
+    )
+
+    func testLocalStateRequiresServerThenTokenThenProfile() {
+        XCTAssertEqual(
+            RestoredSessionAuthResolver.localState(
+                hasServer: false,
+                hasAccessToken: false,
+                hasProfile: false
+            ),
+            .needsServerSetup
+        )
+        XCTAssertEqual(
+            RestoredSessionAuthResolver.localState(
+                hasServer: true,
+                hasAccessToken: false,
+                hasProfile: true
+            ),
+            .needsLogin
+        )
+        XCTAssertEqual(
+            RestoredSessionAuthResolver.localState(
+                hasServer: true,
+                hasAccessToken: true,
+                hasProfile: false
+            ),
+            .needsProfile
+        )
+        XCTAssertEqual(
+            RestoredSessionAuthResolver.localState(
+                hasServer: true,
+                hasAccessToken: true,
+                hasProfile: true
+            ),
+            .authenticated
+        )
+    }
+
+    func testConfiguredServerAndSuccessfulAccountProbeAreValid() async {
+        let harness = ValidationHarness(identity: expected)
+        let result = await makeValidator(harness).validate(expected: expected)
+        let accountProbeCount = await harness.accountProbeCount()
+
+        XCTAssertEqual(result, .valid)
+        XCTAssertEqual(accountProbeCount, 1)
+    }
+
+    func testSuccessfulAccountProbeAcceptsRenamedUsernameSession() async {
+        let harness = ValidationHarness(identity: expected)
+        await harness.setObservedUsername("renamed-user")
+
+        let result = await makeValidator(harness).validate(expected: expected)
+        let observedUsername = await harness.observedUsername()
+
+        XCTAssertEqual(result, .valid)
+        XCTAssertEqual(observedUsername, "renamed-user")
+    }
+
+    func testServerThatNeedsSetupEntersRecoveryWithoutAccountProbe() async {
+        let harness = ValidationHarness(
+            identity: expected,
+            setupStatus: SetupStatus(needsSetup: true)
+        )
+
+        let result = await makeValidator(harness).validate(expected: expected)
+        let accountProbeCount = await harness.accountProbeCount()
+        let hasAccessToken = await harness.hasAccessToken(serverID: expected.serverId)
+
+        XCTAssertEqual(result, .serverRecovery(.needsSetup))
+        XCTAssertEqual(accountProbeCount, 0)
+        XCTAssertTrue(hasAccessToken)
+    }
+
+    func testSetupNotFoundEntersNonDestructiveServerRecovery() async {
+        let harness = ValidationHarness(
+            identity: expected,
+            setupFailure: .http(statusCode: 404, body: nil)
+        )
+
+        let result = await makeValidator(harness).validate(expected: expected)
+        let hasAccessToken = await harness.hasAccessToken(serverID: expected.serverId)
+
+        XCTAssertEqual(result, .serverRecovery(.serverNotRecognized))
+        XCTAssertTrue(hasAccessToken)
+    }
+
+    func testMalformedSetupResponseEntersNonDestructiveServerRecovery() async {
+        let harness = ValidationHarness(
+            identity: expected,
+            setupFailure: .decodingFailed(
+                type: "SetupStatus",
+                underlying: NSError(domain: "RestoredSessionValidatorTests", code: 1)
+            )
+        )
+
+        let result = await makeValidator(harness).validate(expected: expected)
+        let hasAccessToken = await harness.hasAccessToken(serverID: expected.serverId)
+
+        XCTAssertEqual(result, .serverRecovery(.serverNotRecognized))
+        XCTAssertTrue(hasAccessToken)
+    }
+
+    func testTransientSetupFailuresRemainIndeterminateAndPreserveToken() async {
+        let failures: [HTTPError] = [
+            .network(underlying: URLError(.cannotFindHost)),
+            .http(statusCode: 408, body: nil),
+            .http(statusCode: 429, body: nil),
+            .http(statusCode: 500, body: nil),
+            .http(statusCode: 503, body: nil),
+        ]
+
+        for failure in failures {
+            let harness = ValidationHarness(identity: expected, setupFailure: failure)
+            let result = await makeValidator(harness).validate(expected: expected)
+            let hasAccessToken = await harness.hasAccessToken(serverID: expected.serverId)
+            XCTAssertEqual(result, .indeterminate, "Expected \(failure) to be retryable")
+            XCTAssertTrue(hasAccessToken)
+        }
+    }
+
+    func testCancelledProbeIsIndeterminateAndPreservesToken() async {
+        let harness = ValidationHarness(identity: expected, setupCancellation: true)
+
+        let result = await makeValidator(harness).validate(expected: expected)
+        let hasAccessToken = await harness.hasAccessToken(serverID: expected.serverId)
+
+        XCTAssertEqual(result, .indeterminate)
+        XCTAssertTrue(hasAccessToken)
+    }
+
+    func testDeletedAccountTerminalRejectionRoutesToLogin() async {
+        let replacementIdentity = RefreshAccountIdentity(
+            serverId: expected.serverId,
+            serverURL: expected.serverURL,
+            credentialGenerationID: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!
+        )
+        let harness = ValidationHarness(
+            identity: expected,
+            accountFailure: .http(statusCode: 401, body: nil),
+            identityAfterAccountFailure: replacementIdentity,
+            hasAccessTokenAfterAccountFailure: false
+        )
+
+        let result = await makeValidator(harness).validate(expected: expected)
+
+        XCTAssertEqual(result, .needsLogin)
+    }
+
+    func testTransientAccountFailureKeepsRestoredSession() async {
+        let harness = ValidationHarness(
+            identity: expected,
+            accountFailure: .http(statusCode: 503, body: nil)
+        )
+
+        let result = await makeValidator(harness).validate(expected: expected)
+        let hasAccessToken = await harness.hasAccessToken(serverID: expected.serverId)
+
+        XCTAssertEqual(result, .indeterminate)
+        XCTAssertTrue(hasAccessToken)
+    }
+
+    func testAccountUnauthorizedWithTokenStillPresentIsIndeterminate() async {
+        let harness = ValidationHarness(
+            identity: expected,
+            accountFailure: .http(statusCode: 401, body: nil)
+        )
+
+        let result = await makeValidator(harness).validate(expected: expected)
+        let hasAccessToken = await harness.hasAccessToken(serverID: expected.serverId)
+
+        XCTAssertEqual(result, .indeterminate)
+        XCTAssertTrue(hasAccessToken)
+    }
+
+    func testLateSetupResultCannotValidateDifferentCredentialGeneration() async {
+        let replacementIdentity = RefreshAccountIdentity(
+            serverId: expected.serverId,
+            serverURL: expected.serverURL,
+            credentialGenerationID: UUID(uuidString: "99999999-8888-7777-6666-555555555555")!
+        )
+        let harness = ValidationHarness(
+            identity: expected,
+            identityAfterSetup: replacementIdentity
+        )
+
+        let result = await makeValidator(harness).validate(expected: expected)
+        let accountProbeCount = await harness.accountProbeCount()
+
+        XCTAssertEqual(result, .identityChanged)
+        XCTAssertEqual(accountProbeCount, 0)
+    }
+
+    private func makeValidator(_ harness: ValidationHarness) -> RestoredSessionValidator {
+        RestoredSessionValidator(
+            setupProbe: { serverURL in try await harness.probeSetup(serverURL: serverURL) },
+            accountProbe: { try await harness.probeAccount() },
+            identityReader: { await harness.currentIdentity() },
+            accessTokenReader: { serverID in await harness.hasAccessToken(serverID: serverID) }
+        )
+    }
+}
+
+private actor ValidationHarness {
+    private var identity: RefreshAccountIdentity?
+    private let setupStatus: SetupStatus
+    private let setupFailure: HTTPError?
+    private let setupCancellation: Bool
+    private let accountFailure: HTTPError?
+    private let identityAfterSetup: RefreshAccountIdentity?
+    private let identityAfterAccountFailure: RefreshAccountIdentity?
+    private let hasAccessTokenAfterAccountFailure: Bool
+    private var accessTokenPresent = true
+    private var accountProbes = 0
+    private var username: String?
+
+    init(
+        identity: RefreshAccountIdentity,
+        setupStatus: SetupStatus = SetupStatus(needsSetup: false),
+        setupFailure: HTTPError? = nil,
+        setupCancellation: Bool = false,
+        accountFailure: HTTPError? = nil,
+        identityAfterSetup: RefreshAccountIdentity? = nil,
+        identityAfterAccountFailure: RefreshAccountIdentity? = nil,
+        hasAccessTokenAfterAccountFailure: Bool = true
+    ) {
+        self.identity = identity
+        self.setupStatus = setupStatus
+        self.setupFailure = setupFailure
+        self.setupCancellation = setupCancellation
+        self.accountFailure = accountFailure
+        self.identityAfterSetup = identityAfterSetup
+        self.identityAfterAccountFailure = identityAfterAccountFailure
+        self.hasAccessTokenAfterAccountFailure = hasAccessTokenAfterAccountFailure
+    }
+
+    func probeSetup(serverURL: String) throws -> SetupStatus {
+        if setupCancellation { throw CancellationError() }
+        if let setupFailure { throw setupFailure }
+        if let identityAfterSetup { identity = identityAfterSetup }
+        return setupStatus
+    }
+
+    func probeAccount() throws {
+        accountProbes += 1
+        if let accountFailure {
+            if let identityAfterAccountFailure { identity = identityAfterAccountFailure }
+            accessTokenPresent = hasAccessTokenAfterAccountFailure
+            throw accountFailure
+        }
+    }
+
+    func currentIdentity() -> RefreshAccountIdentity? { identity }
+
+    func hasAccessToken(serverID: String) -> Bool {
+        identity?.serverId == serverID && accessTokenPresent
+    }
+
+    func accountProbeCount() -> Int { accountProbes }
+    func setObservedUsername(_ value: String) { username = value }
+    func observedUsername() -> String? { username }
+}

--- a/iosApp/Tests/RestoredSessionValidatorTests.swift
+++ b/iosApp/Tests/RestoredSessionValidatorTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Silo
 
+@MainActor
 final class RestoredSessionValidatorTests: XCTestCase {
     private let expected = RefreshAccountIdentity(
         serverId: "server-a",
@@ -53,14 +54,14 @@ final class RestoredSessionValidatorTests: XCTestCase {
     }
 
     func testSuccessfulAccountProbeAcceptsRenamedUsernameSession() async {
-        let harness = ValidationHarness(identity: expected)
-        await harness.setObservedUsername("renamed-user")
+        let harness = ValidationHarness(
+            identity: expected,
+            account: UserInfo(id: "42", username: "renamed-user", isAdmin: false)
+        )
 
         let result = await makeValidator(harness).validate(expected: expected)
-        let observedUsername = await harness.observedUsername()
 
         XCTAssertEqual(result, .valid)
-        XCTAssertEqual(observedUsername, "renamed-user")
     }
 
     func testServerThatNeedsSetupEntersRecoveryWithoutAccountProbe() async {
@@ -197,6 +198,29 @@ final class RestoredSessionValidatorTests: XCTestCase {
         XCTAssertEqual(accountProbeCount, 0)
     }
 
+    func testConfirmedForgetCompletesAndRoutesOutsideTheRecoveryViewLifetime() async throws {
+        let gate = ServerRemovalGate()
+        let router = AppRouter()
+        router.authState = .serverRecovery(.serverNotRecognized)
+        let coordinator = RestoredServerRecoveryCoordinator(
+            removeServer: { serverID in
+                await gate.remove(serverID: serverID)
+            },
+            resolveDestination: { .needsServerSetup }
+        )
+
+        let task = try XCTUnwrap(coordinator.forget(serverID: "server-a", router: router))
+        XCTAssertTrue(coordinator.isForgetting)
+        await gate.allowRemoval()
+        await task.value
+
+        let removedServerID = await gate.removedServerID()
+        XCTAssertEqual(removedServerID, "server-a")
+        XCTAssertFalse(coordinator.isForgetting)
+        XCTAssertNil(coordinator.error)
+        XCTAssertEqual(router.authState, .needsServerSetup)
+    }
+
     private func makeValidator(_ harness: ValidationHarness) -> RestoredSessionValidator {
         RestoredSessionValidator(
             setupProbe: { serverURL in try await harness.probeSetup(serverURL: serverURL) },
@@ -207,18 +231,40 @@ final class RestoredSessionValidatorTests: XCTestCase {
     }
 }
 
+private actor ServerRemovalGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var isRemovalAllowed = false
+    private var serverID: String?
+
+    func remove(serverID: String) async -> Bool {
+        self.serverID = serverID
+        if !isRemovalAllowed {
+            await withCheckedContinuation { continuation = $0 }
+        }
+        return true
+    }
+
+    func allowRemoval() {
+        isRemovalAllowed = true
+        continuation?.resume()
+        continuation = nil
+    }
+
+    func removedServerID() -> String? { serverID }
+}
+
 private actor ValidationHarness {
     private var identity: RefreshAccountIdentity?
     private let setupStatus: SetupStatus
     private let setupFailure: HTTPError?
     private let setupCancellation: Bool
     private let accountFailure: HTTPError?
+    private let account: UserInfo
     private let identityAfterSetup: RefreshAccountIdentity?
     private let identityAfterAccountFailure: RefreshAccountIdentity?
     private let hasAccessTokenAfterAccountFailure: Bool
     private var accessTokenPresent = true
     private var accountProbes = 0
-    private var username: String?
 
     init(
         identity: RefreshAccountIdentity,
@@ -226,6 +272,7 @@ private actor ValidationHarness {
         setupFailure: HTTPError? = nil,
         setupCancellation: Bool = false,
         accountFailure: HTTPError? = nil,
+        account: UserInfo = UserInfo(id: "42", username: "original-user", isAdmin: false),
         identityAfterSetup: RefreshAccountIdentity? = nil,
         identityAfterAccountFailure: RefreshAccountIdentity? = nil,
         hasAccessTokenAfterAccountFailure: Bool = true
@@ -235,6 +282,7 @@ private actor ValidationHarness {
         self.setupFailure = setupFailure
         self.setupCancellation = setupCancellation
         self.accountFailure = accountFailure
+        self.account = account
         self.identityAfterSetup = identityAfterSetup
         self.identityAfterAccountFailure = identityAfterAccountFailure
         self.hasAccessTokenAfterAccountFailure = hasAccessTokenAfterAccountFailure
@@ -247,13 +295,14 @@ private actor ValidationHarness {
         return setupStatus
     }
 
-    func probeAccount() throws {
+    func probeAccount() throws -> UserInfo {
         accountProbes += 1
         if let accountFailure {
             if let identityAfterAccountFailure { identity = identityAfterAccountFailure }
             accessTokenPresent = hasAccessTokenAfterAccountFailure
             throw accountFailure
         }
+        return account
     }
 
     func currentIdentity() -> RefreshAccountIdentity? { identity }
@@ -263,6 +312,4 @@ private actor ValidationHarness {
     }
 
     func accountProbeCount() -> Int { accountProbes }
-    func setObservedUsername(_ value: String) { username = value }
-    func observedUsername() -> String? { username }
 }

--- a/iosApp/iosApp/Components/ErrorView.swift
+++ b/iosApp/iosApp/Components/ErrorView.swift
@@ -37,8 +37,8 @@ struct ErrorView: View {
                         .siloPrimaryButton()
                         .frame(width: 200)
                 }
-                if let secondary = secondaryAction {
-                    Button(secondary.title, action: secondary.run)
+                ForEach(Array(secondaryActions.enumerated()), id: \.offset) { _, action in
+                    Button(action.title, action: action.run)
                         .buttonStyle(.plain)
                         .foregroundColor(.siloSecondaryText)
                         .font(.siloBody)
@@ -88,17 +88,22 @@ struct ErrorView: View {
         return nil
     }
 
-    private var secondaryAction: Action? {
+    private var secondaryActions: [Action] {
+        var actions: [Action] = []
+        if let onManageServers {
+            actions.append(Action(title: "Manage Servers", run: onManageServers))
+        }
         if state.isAuthFailure {
-            return onRetry.map { Action(title: "Try Again", run: $0) }
+            if let onRetry {
+                actions.append(Action(title: "Try Again", run: onRetry))
+            }
+            return actions
         }
         if state.isNotFound, resolvedOnGoBack != nil {
-            if let onRetry { return Action(title: "Try Again", run: onRetry) }
-            return nil
+            if let onRetry {
+                actions.append(Action(title: "Try Again", run: onRetry))
+            }
         }
-        if let onManageServers {
-            return Action(title: "Manage Servers", run: onManageServers)
-        }
-        return nil
+        return actions
     }
 }

--- a/iosApp/iosApp/Components/ErrorView.swift
+++ b/iosApp/iosApp/Components/ErrorView.swift
@@ -10,6 +10,7 @@ struct ErrorView: View {
     var onRetry: (() -> Void)? = nil
     var onGoBack: (() -> Void)? = nil
     var onSignOut: (() -> Void)? = nil
+    var onManageServers: (() -> Void)? = nil
 
     @Environment(AppRouter.self) private var router
 
@@ -94,6 +95,9 @@ struct ErrorView: View {
         if state.isNotFound, resolvedOnGoBack != nil {
             if let onRetry { return Action(title: "Try Again", run: onRetry) }
             return nil
+        }
+        if let onManageServers {
+            return Action(title: "Manage Servers", run: onManageServers)
         }
         return nil
     }

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -598,6 +598,15 @@ struct ContentView: View {
                     }
             }
 
+        case .serverRecovery(let reason):
+            NavigationStack(path: $router.path) {
+                RestoredServerRecoveryView(router: router, reason: reason)
+                    .navigationDestination(for: Route.self) { route in
+                        profileFlowDestination(for: route)
+                    }
+            }
+            .environment(router)
+
         case .needsProfile:
             NavigationStack(path: $router.path) {
                 ProfileSelectionView(
@@ -812,40 +821,31 @@ struct ContentView: View {
         #endif
     }
 
-    /// Determine the initial auth state with the smallest launch-time
-    /// Keychain surface possible. The registry loads synchronously in `init`;
-    /// TokenStore only needs to be retargeted to that active server before the
-    /// first authenticated request lazily loads the full token cache.
+    /// Resolve local credentials first, then opportunistically validate a
+    /// restored account while the brand splash is already visible. Publishing
+    /// the local state before the network probe is intentional: when the
+    /// splash finishes it commits that fallback and removes this task, which
+    /// cancels an unfinished probe instead of extending offline launch time.
     private func checkInitialState() async {
-        let activeServerId = ServerRegistry.shared.activeServerId
-        let hasStoredAccessToken: Bool
-        if let activeServerId, !activeServerId.isEmpty {
-            hasStoredAccessToken = await TokenStore.shared.hasAccessTokenForActiveServer(serverId: activeServerId)
-        } else {
-            hasStoredAccessToken = false
-        }
+        let local = await RestoredSessionAuthResolver.resolveLocal()
+        guard !Task.isCancelled, router.authState == .loading else { return }
+        pendingInitialAuthState = local.state
+        finishInitialStartupIfReady()
 
-        let api = AuthService.shared
-        let targetState: AppRouter.AuthState
-        if !api.hasServer {
-            targetState = .needsServerSetup
-        } else if !hasStoredAccessToken {
-            targetState = .needsLogin
-        } else {
-            targetState = await api.resolveActiveProfileForSession()
-                ? .authenticated
-                : .needsProfile
-        }
+        guard !Task.isCancelled,
+              router.authState == .loading,
+              let expectedAccount = local.restoredAccount else { return }
 
-        #if os(iOS) || os(tvOS)
-        // The single most useful launch line: everything above it is Keychain
-        // and profile resolution, everything below is the routed app. A cold
-        // launch that stalls here (no server reachable, a wedged Keychain read)
-        // shows as a long gap before this phase and nothing after it.
-        LaunchTimeline.recordInitialStateResolved(state: targetState.diagnosticsState)
-        #endif
+        let validation = await AuthService.shared.validateRestoredSession(
+            expected: expectedAccount
+        )
+        guard !Task.isCancelled, router.authState == .loading else { return }
+        let targetState = await RestoredSessionAuthResolver.state(
+            after: validation,
+            fallingBackTo: local.state
+        )
+        guard !Task.isCancelled, router.authState == .loading else { return }
 
-        StartupContentPrefetcher.prefetchForInitialRoute(targetState)
         pendingInitialAuthState = targetState
         finishInitialStartupIfReady()
 
@@ -858,12 +858,16 @@ struct ContentView: View {
         guard didFinishStartupSplash, let targetState = pendingInitialAuthState else { return }
         pendingInitialAuthState = nil
         #if os(iOS) || os(tvOS)
+        // The committed state may be an authoritative validation result or the
+        // offline-safe local fallback when the splash deadline won the race.
+        LaunchTimeline.recordInitialStateResolved(state: targetState.diagnosticsState)
         // Closes the cold-launch chain. Both gates (splash animation and state
         // resolution) have cleared, so this is the moment the user first sees
         // real content. `AppRouter` logs the auth transition itself; this line
         // records that launch reached a terminal, usable state at all.
         LaunchTimeline.recordFirstContent(state: targetState.diagnosticsState)
         #endif
+        StartupContentPrefetcher.prefetchForInitialRoute(targetState)
         router.authState = targetState
     }
 

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -24,6 +24,7 @@ struct ContentView: View {
     @State private var didStartInitialStateCheck = false
     @State private var didFinishStartupSplash = false
     @State private var pendingInitialAuthState: AppRouter.AuthState?
+    @State private var serverRecoveryCoordinator = RestoredServerRecoveryCoordinator()
     #if os(iOS) || os(tvOS)
     @State private var diagnosticsModel = DiagnosticsViewModel()
     #endif
@@ -600,7 +601,11 @@ struct ContentView: View {
 
         case .serverRecovery(let reason):
             NavigationStack(path: $router.path) {
-                RestoredServerRecoveryView(router: router, reason: reason)
+                RestoredServerRecoveryView(
+                    router: router,
+                    reason: reason,
+                    coordinator: serverRecoveryCoordinator
+                )
                     .navigationDestination(for: Route.self) { route in
                         profileFlowDestination(for: route)
                     }

--- a/iosApp/iosApp/Navigation/AppRouter.swift
+++ b/iosApp/iosApp/Navigation/AppRouter.swift
@@ -70,6 +70,10 @@ class AppRouter {
         case needsServerSetup
         /// Server known but user is not signed in.
         case needsLogin
+        /// A remembered server responded authoritatively but cannot safely use
+        /// the restored session. Credentials remain until an explicit removal
+        /// or the existing terminal refresh-rejection path clears them.
+        case serverRecovery(ServerRecoveryReason)
         /// Signed in but no profile has been selected.
         case needsProfile
         /// Fully authenticated with an active profile.
@@ -85,6 +89,7 @@ class AppRouter {
             case .loading: return "loading"
             case .needsServerSetup: return "needsServerSetup"
             case .needsLogin: return "needsLogin"
+            case .serverRecovery(let reason): return "serverRecovery.\(reason.rawValue)"
             case .needsProfile: return "needsProfile"
             case .authenticated: return "authenticated"
             }
@@ -523,6 +528,15 @@ class AppRouter {
         path = NavigationPath()
         profileJourneyLabels = nil
         setAuthState(.needsServerSetup, reason: "resetToServerSetup")
+    }
+
+    /// Commit an auth state produced after validating a server selection.
+    /// Every previous screen belongs to the old server/session boundary.
+    func resetAfterServerResolution(to state: AuthState) {
+        recordScreenBreadcrumb(target: state.diagnosticsState, action: "reset")
+        path = NavigationPath()
+        profileJourneyLabels = nil
+        setAuthState(state, reason: "serverResolution")
     }
 
     /// Sign out of the active server and land at the next sensible step:

--- a/iosApp/iosApp/Navigation/AppRouter.swift
+++ b/iosApp/iosApp/Navigation/AppRouter.swift
@@ -534,6 +534,9 @@ class AppRouter {
     /// Every previous screen belongs to the old server/session boundary.
     func resetAfterServerResolution(to state: AuthState) {
         recordScreenBreadcrumb(target: state.diagnosticsState, action: "reset")
+        PlayerIdentityBoundary.endEngagedVideoPictureInPicture()
+        presentedPlayer = nil
+        dismissItemDetail()
         path = NavigationPath()
         profileJourneyLabels = nil
         setAuthState(state, reason: "serverResolution")

--- a/iosApp/iosApp/Networking/Models.swift
+++ b/iosApp/iosApp/Networking/Models.swift
@@ -1467,7 +1467,7 @@ struct CreateCollectionRequest: Codable {
 
 // MARK: - User Info
 
-struct UserInfo: Codable {
+struct UserInfo: Codable, Sendable {
     let id: String?
     let username: String
     let isAdmin: Bool?

--- a/iosApp/iosApp/Screens/Auth/AuthModels.swift
+++ b/iosApp/iosApp/Screens/Auth/AuthModels.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Server setup status from /api/v1/auth/setup.
-struct SetupStatus: Codable {
+struct SetupStatus: Codable, Equatable, Sendable {
     let needsSetup: Bool
 }
 

--- a/iosApp/iosApp/Screens/Auth/AuthService.swift
+++ b/iosApp/iosApp/Screens/Auth/AuthService.swift
@@ -13,6 +13,7 @@ final class AuthService: @unchecked Sendable {
     private let serverIdentityResolver: ServerIdentityResolver
     private let serverRegistry: ServerRegistry
     private let launchPreferences: ProfileLaunchPreferences
+    private let restoredSessionValidator: RestoredSessionValidator
 
     enum SignOutAuthorization: Equatable, Sendable {
         case allowed(account: RefreshAccountIdentity?)
@@ -22,11 +23,13 @@ final class AuthService: @unchecked Sendable {
     init(
         serverIdentityResolver: ServerIdentityResolver = ServerIdentityResolver(),
         serverRegistry: ServerRegistry = .shared,
-        launchPreferences: ProfileLaunchPreferences = .shared
+        launchPreferences: ProfileLaunchPreferences = .shared,
+        restoredSessionValidator: RestoredSessionValidator = .live
     ) {
         self.serverIdentityResolver = serverIdentityResolver
         self.serverRegistry = serverRegistry
         self.launchPreferences = launchPreferences
+        self.restoredSessionValidator = restoredSessionValidator
     }
 
     // MARK: - Stored State Accessors
@@ -116,6 +119,16 @@ final class AuthService: @unchecked Sendable {
             return
         }
         serverRegistry.updateFetchedName(for: serverId, fetchedName: name)
+    }
+
+    /// Validate a Keychain-restored account without changing the remembered
+    /// server entry. Temporary failures return `indeterminate`; only the
+    /// existing HTTP refresh policy may invalidate a terminally rejected
+    /// credential while the account probe is in flight.
+    func validateRestoredSession(
+        expected: RefreshAccountIdentity
+    ) async -> RestoredSessionValidationResult {
+        await restoredSessionValidator.validate(expected: expected)
     }
 
     // MARK: - Authentication

--- a/iosApp/iosApp/Screens/Auth/RestoredServerRecoveryView.swift
+++ b/iosApp/iosApp/Screens/Auth/RestoredServerRecoveryView.swift
@@ -1,15 +1,67 @@
 import SwiftUI
 
+/// Owns confirmed server removal above the auth subtree. Removing an active
+/// server changes the subtree identity before Keychain cleanup completes, so
+/// this operation must not be tied to the recovery view's lifetime.
+@MainActor
+@Observable
+final class RestoredServerRecoveryCoordinator {
+    typealias RemoveServer = (String) async -> Bool
+    typealias ResolveDestination = () async -> AppRouter.AuthState
+
+    private let removeServer: RemoveServer
+    private let resolveDestination: ResolveDestination
+    @ObservationIgnored private var forgetTask: Task<Void, Never>?
+
+    private(set) var isForgetting = false
+    private(set) var error: String?
+
+    init(
+        removeServer: @escaping RemoveServer = { serverID in
+            await ServerRegistry.shared.remove(serverId: serverID)
+        },
+        resolveDestination: @escaping ResolveDestination = {
+            await RestoredSessionAuthResolver.resolveValidated()
+        }
+    ) {
+        self.removeServer = removeServer
+        self.resolveDestination = resolveDestination
+    }
+
+    /// Removes the confirmed server and commits the fallback route even if
+    /// changing the active server tears down the recovery screen meanwhile.
+    @discardableResult
+    func forget(serverID: String, router: AppRouter) -> Task<Void, Never>? {
+        guard !isForgetting else { return nil }
+        isForgetting = true
+        error = nil
+
+        let task = Task { [self] in
+            let removed = await removeServer(serverID)
+            if removed {
+                let destination = await resolveDestination()
+                router.resetAfterServerResolution(to: destination)
+            } else {
+                error = "Silo couldn't forget this server. Try again."
+            }
+            isForgetting = false
+            forgetTask = nil
+        }
+        forgetTask = task
+        return task
+    }
+}
+
 /// Recovery surface for a remembered server that responded authoritatively but
 /// can no longer accept the restored session. Merely reaching this screen is
 /// non-destructive: the server entry and its Keychain slot stay intact.
 struct RestoredServerRecoveryView: View {
     var router: AppRouter
     let reason: ServerRecoveryReason
+    let coordinator: RestoredServerRecoveryCoordinator
 
     @State private var registry = ServerRegistry.shared
     @State private var isChecking = false
-    @State private var isForgetting = false
     @State private var error: String?
     @State private var retryTask: Task<Void, Never>?
     @State private var showForgetConfirmation = false
@@ -49,8 +101,8 @@ struct RestoredServerRecoveryView: View {
 
                     recoveryCopy
 
-                    if let error {
-                        recoveryError(error)
+                    if let visibleError {
+                        recoveryError(visibleError)
                     }
 
                     HStack(spacing: 24) {
@@ -72,7 +124,7 @@ struct RestoredServerRecoveryView: View {
                             .foregroundStyle(Color.siloError)
                             .focused($focusedAction, equals: .forget)
                     }
-                    .disabled(isChecking || isForgetting)
+                    .disabled(isChecking || coordinator.isForgetting)
                     .focusSection()
                 }
                 .padding(56)
@@ -121,8 +173,8 @@ struct RestoredServerRecoveryView: View {
                 .padding(.bottom, 22)
 
             VStack(spacing: 16) {
-                if let error {
-                    AuroraErrorLabel(error)
+                if let visibleError {
+                    AuroraErrorLabel(visibleError)
                 }
 
                 Button(action: retry) {
@@ -139,7 +191,7 @@ struct RestoredServerRecoveryView: View {
                     .foregroundStyle(Color.siloError)
                     .frame(maxWidth: .infinity)
             }
-            .disabled(isChecking || isForgetting)
+            .disabled(isChecking || coordinator.isForgetting)
             .padding(22)
             .auroraGlass(cornerRadius: 24, emphasized: true)
             .animation(.easeInOut(duration: 0.2), value: error)
@@ -234,7 +286,7 @@ struct RestoredServerRecoveryView: View {
     }
 
     private func retry() {
-        guard !isChecking, !isForgetting else { return }
+        guard !isChecking, !coordinator.isForgetting else { return }
         isChecking = true
         error = nil
         let expectedServerID = registry.activeServerId
@@ -294,34 +346,15 @@ struct RestoredServerRecoveryView: View {
     }
 
     private func requestForget() {
-        guard !isChecking, !isForgetting else { return }
+        guard !isChecking, !coordinator.isForgetting else { return }
         showForgetConfirmation = true
     }
 
     private func confirmForget() {
-        guard !isForgetting, let serverID = registry.activeServerId else { return }
+        guard !coordinator.isForgetting, let serverID = registry.activeServerId else { return }
         showForgetConfirmation = false
-        isForgetting = true
         error = nil
-
-        retryTask = Task {
-            let removed = await registry.remove(serverId: serverID)
-            let destination: AppRouter.AuthState?
-            if removed {
-                destination = await RestoredSessionAuthResolver.resolveValidated()
-            } else {
-                destination = nil
-            }
-            await MainActor.run {
-                isForgetting = false
-                guard !Task.isCancelled else { return }
-                if let destination {
-                    router.resetAfterServerResolution(to: destination)
-                } else {
-                    error = "Silo couldn't forget this server. Try again."
-                }
-            }
-        }
+        coordinator.forget(serverID: serverID, router: router)
     }
 
     #if os(tvOS)
@@ -338,6 +371,9 @@ struct RestoredServerRecoveryView: View {
         retryTask?.cancel()
         retryTask = nil
         isChecking = false
-        isForgetting = false
+    }
+
+    private var visibleError: String? {
+        error ?? coordinator.error
     }
 }

--- a/iosApp/iosApp/Screens/Auth/RestoredServerRecoveryView.swift
+++ b/iosApp/iosApp/Screens/Auth/RestoredServerRecoveryView.swift
@@ -1,0 +1,343 @@
+import SwiftUI
+
+/// Recovery surface for a remembered server that responded authoritatively but
+/// can no longer accept the restored session. Merely reaching this screen is
+/// non-destructive: the server entry and its Keychain slot stay intact.
+struct RestoredServerRecoveryView: View {
+    var router: AppRouter
+    let reason: ServerRecoveryReason
+
+    @State private var registry = ServerRegistry.shared
+    @State private var isChecking = false
+    @State private var isForgetting = false
+    @State private var error: String?
+    @State private var retryTask: Task<Void, Never>?
+    @State private var showForgetConfirmation = false
+    #if os(tvOS)
+    @FocusState private var focusedAction: RecoveryAction?
+
+    private enum RecoveryAction: Hashable {
+        case retry
+        case manageServers
+        case forget
+    }
+    #endif
+
+    var body: some View {
+        #if os(tvOS)
+        tvOSBody
+        #else
+        standardBody
+        #endif
+    }
+
+    #if os(tvOS)
+    private var tvOSBody: some View {
+        ZStack {
+            AuroraBackdrop(variant: .server, scrim: .soft)
+
+            VStack(spacing: 0) {
+                HStack {
+                    SiloWordmarkView(width: 132)
+                    Spacer(minLength: 0)
+                }
+
+                Spacer(minLength: 48)
+
+                VStack(spacing: 28) {
+                    recoveryIcon(size: 58)
+
+                    recoveryCopy
+
+                    if let error {
+                        recoveryError(error)
+                    }
+
+                    HStack(spacing: 24) {
+                        Button(action: retry) {
+                            Label(
+                                isChecking ? "Checking…" : "Try Again",
+                                systemImage: "arrow.clockwise"
+                            )
+                        }
+                        .buttonStyle(AuroraPrimaryButtonStyle(isLoading: isChecking))
+                        .focused($focusedAction, equals: .retry)
+
+                        Button("Manage Servers", action: manageServers)
+                            .buttonStyle(AuroraGhostButtonStyle())
+                            .focused($focusedAction, equals: .manageServers)
+
+                        Button("Forget This Server", action: requestForget)
+                            .buttonStyle(AuroraGhostButtonStyle())
+                            .foregroundStyle(Color.siloError)
+                            .focused($focusedAction, equals: .forget)
+                    }
+                    .disabled(isChecking || isForgetting)
+                    .focusSection()
+                }
+                .padding(56)
+                .frame(width: 980)
+                .auroraGlass(cornerRadius: 30, emphasized: true)
+
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 96)
+            .padding(.vertical, 64)
+            .disabled(showForgetConfirmation)
+
+            if showForgetConfirmation {
+                TVSettingsConfirmationOverlay(
+                    title: "Forget this server?",
+                    message: forgetMessage,
+                    confirmTitle: "Forget Server",
+                    cancel: cancelForget,
+                    confirm: confirmForget
+                )
+                .transition(.opacity.combined(with: .scale(scale: 0.96)))
+                .zIndex(1)
+            }
+        }
+        .ignoresSafeArea()
+        .navigationBarBackButtonHidden()
+        .defaultFocus($focusedAction, .retry, priority: .userInitiated)
+        .animation(.easeInOut(duration: 0.2), value: error)
+        .animation(.easeOut(duration: SiloTheme.fastDuration), value: showForgetConfirmation)
+        .onDisappear(perform: cancelWork)
+    }
+    #endif
+
+    #if !os(tvOS)
+    private var standardBody: some View {
+        AuroraScreen(variant: .server, scrim: .soft) {
+            SiloWordmarkView(width: 112)
+                .frame(maxWidth: .infinity)
+                .padding(.bottom, 24)
+
+            recoveryIcon(size: 36)
+                .frame(maxWidth: .infinity)
+                .padding(.bottom, 18)
+
+            recoveryCopy
+                .padding(.bottom, 22)
+
+            VStack(spacing: 16) {
+                if let error {
+                    AuroraErrorLabel(error)
+                }
+
+                Button(action: retry) {
+                    Text(isChecking ? "Checking…" : "Try Again")
+                }
+                .buttonStyle(AuroraPrimaryButtonStyle(isLoading: isChecking))
+
+                Button("Manage Servers", action: manageServers)
+                    .buttonStyle(AuroraGhostButtonStyle())
+                    .frame(maxWidth: .infinity)
+
+                Button("Forget This Server", role: .destructive, action: requestForget)
+                    .buttonStyle(AuroraGhostButtonStyle())
+                    .foregroundStyle(Color.siloError)
+                    .frame(maxWidth: .infinity)
+            }
+            .disabled(isChecking || isForgetting)
+            .padding(22)
+            .auroraGlass(cornerRadius: 24, emphasized: true)
+            .animation(.easeInOut(duration: 0.2), value: error)
+        }
+        .navigationBarBackButtonHidden()
+        .alert("Forget this server?", isPresented: $showForgetConfirmation) {
+            Button("Forget Server", role: .destructive, action: confirmForget)
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(forgetMessage)
+        }
+        .onDisappear(perform: cancelWork)
+    }
+    #endif
+
+    @ViewBuilder
+    private func recoveryIcon(size: CGFloat) -> some View {
+        let symbol = reason == .needsSetup ? "gearshape.2" : "server.rack"
+        ZStack {
+            Circle().fill(Color.auroraAccent.opacity(0.14))
+            Circle().stroke(Color.auroraAccent.opacity(0.34), lineWidth: 1)
+            Image(systemName: symbol)
+                .font(.system(size: size, weight: .regular))
+                .foregroundStyle(Color.auroraAccent)
+        }
+        #if os(tvOS)
+        .frame(width: 116, height: 116)
+        #else
+        .frame(width: 82, height: 82)
+        #endif
+    }
+
+    private var recoveryCopy: some View {
+        VStack(spacing: 14) {
+            AuroraEyebrow(text: eyebrow, centered: true)
+            Text(title)
+                .font(.siloTitle)
+                .foregroundStyle(Color.auroraInk)
+                .multilineTextAlignment(.center)
+            Text(message)
+                .font(.siloBody)
+                .foregroundStyle(Color.auroraInkSecondary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+            if let serverURL = activeServer?.url {
+                Text(serverURL)
+                    .font(.siloCaption.monospaced())
+                    .foregroundStyle(Color.auroraInkSecondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .accessibilityLabel("Server address: \(serverURL)")
+            }
+        }
+    }
+
+    #if os(tvOS)
+    private func recoveryError(_ message: String) -> some View {
+        Label(message, systemImage: "exclamationmark.circle.fill")
+            .font(.siloCaption)
+            .foregroundStyle(Color.requestRose)
+            .multilineTextAlignment(.center)
+            .fixedSize(horizontal: false, vertical: true)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Error: \(message)")
+    }
+    #endif
+
+    private var activeServer: ServerEntry? {
+        registry.activeServer
+    }
+
+    private var eyebrow: String {
+        reason == .needsSetup ? "SERVER SETUP" : "CONNECTION RECOVERY"
+    }
+
+    private var title: String {
+        reason == .needsSetup ? "This server isn't ready" : "We can't verify this server"
+    }
+
+    private var message: String {
+        switch reason {
+        case .needsSetup:
+            return "Ask the server administrator to finish setup, then try again. Your saved sign-in information has not been removed."
+        case .serverNotRecognized:
+            return "The server may have moved, been reset, or this address may no longer point to Silo. Your saved sign-in information has not been removed."
+        }
+    }
+
+    private var forgetMessage: String {
+        let name = activeServer?.displayName ?? "this server"
+        return "This removes the saved connection and sign-in credentials for \(name) from this device. This can't be undone."
+    }
+
+    private func retry() {
+        guard !isChecking, !isForgetting else { return }
+        isChecking = true
+        error = nil
+        let expectedServerID = registry.activeServerId
+
+        retryTask = Task {
+            let local = await RestoredSessionAuthResolver.resolveLocal()
+            let validation: RestoredSessionValidationResult
+            if let expected = local.restoredAccount {
+                validation = await AuthService.shared.validateRestoredSession(expected: expected)
+            } else {
+                validation = .identityChanged
+            }
+
+            let destination: AppRouter.AuthState?
+            switch validation {
+            case .valid:
+                destination = local.state
+            case .needsLogin:
+                destination = .needsLogin
+            case .serverRecovery(let newReason):
+                destination = newReason == reason ? nil : .serverRecovery(newReason)
+            case .identityChanged:
+                destination = await RestoredSessionAuthResolver.resolveValidated()
+            case .indeterminate:
+                destination = nil
+            }
+
+            await MainActor.run {
+                isChecking = false
+                guard !Task.isCancelled,
+                      registry.activeServerId == expectedServerID else { return }
+                if let destination {
+                    router.resetAfterServerResolution(to: destination)
+                } else {
+                    error = retryMessage(for: validation)
+                }
+            }
+        }
+    }
+
+    private func retryMessage(for validation: RestoredSessionValidationResult) -> String {
+        switch validation {
+        case .serverRecovery(.needsSetup):
+            return "This server still needs administrator setup."
+        case .serverRecovery(.serverNotRecognized):
+            return "This address still doesn't look like a Silo server."
+        case .indeterminate:
+            return "We still can't reach this server. Your saved sign-in information is unchanged."
+        case .valid, .needsLogin, .identityChanged:
+            return "The server changed while it was being checked. Try again."
+        }
+    }
+
+    private func manageServers() {
+        cancelWork()
+        router.navigate(to: .serverList)
+    }
+
+    private func requestForget() {
+        guard !isChecking, !isForgetting else { return }
+        showForgetConfirmation = true
+    }
+
+    private func confirmForget() {
+        guard !isForgetting, let serverID = registry.activeServerId else { return }
+        showForgetConfirmation = false
+        isForgetting = true
+        error = nil
+
+        retryTask = Task {
+            let removed = await registry.remove(serverId: serverID)
+            let destination: AppRouter.AuthState?
+            if removed {
+                destination = await RestoredSessionAuthResolver.resolveValidated()
+            } else {
+                destination = nil
+            }
+            await MainActor.run {
+                isForgetting = false
+                guard !Task.isCancelled else { return }
+                if let destination {
+                    router.resetAfterServerResolution(to: destination)
+                } else {
+                    error = "Silo couldn't forget this server. Try again."
+                }
+            }
+        }
+    }
+
+    #if os(tvOS)
+    private func cancelForget() {
+        showForgetConfirmation = false
+        Task { @MainActor in
+            await Task.yield()
+            focusedAction = .forget
+        }
+    }
+    #endif
+
+    private func cancelWork() {
+        retryTask?.cancel()
+        retryTask = nil
+        isChecking = false
+        isForgetting = false
+    }
+}

--- a/iosApp/iosApp/Screens/Auth/RestoredSessionValidator.swift
+++ b/iosApp/iosApp/Screens/Auth/RestoredSessionValidator.swift
@@ -1,0 +1,227 @@
+import Foundation
+
+/// Why a remembered server cannot safely continue into authenticated content.
+enum ServerRecoveryReason: String, Equatable, Hashable, Sendable {
+    /// The URL still serves Silo, but its database has not been provisioned.
+    case needsSetup
+    /// The URL no longer exposes the native Silo setup/session contract.
+    case serverNotRecognized
+}
+
+/// Result of checking a Keychain-restored account against its remembered URL.
+///
+/// `indeterminate` is deliberately non-destructive. It covers temporary
+/// reachability and server failures, and callers must retain their locally
+/// resolved auth state so cached/offline content remains available.
+enum RestoredSessionValidationResult: Equatable, Sendable {
+    case valid
+    case needsLogin
+    case serverRecovery(ServerRecoveryReason)
+    case indeterminate
+    case identityChanged
+}
+
+/// A small injected boundary around the two requests needed to validate a
+/// restored account. Tests supply deterministic closures; production uses the
+/// existing unauthenticated setup endpoint followed by the authenticated
+/// current-user endpoint.
+struct RestoredSessionValidator: Sendable {
+    typealias SetupProbe = @Sendable (String) async throws -> SetupStatus
+    typealias AccountProbe = @Sendable () async throws -> Void
+    typealias IdentityReader = @Sendable () async -> RefreshAccountIdentity?
+    typealias AccessTokenReader = @Sendable (String) async -> Bool
+
+    private enum Stage: Equatable {
+        case setup
+        case account
+    }
+
+    private let setupProbe: SetupProbe
+    private let accountProbe: AccountProbe
+    private let identityReader: IdentityReader
+    private let accessTokenReader: AccessTokenReader
+
+    init(
+        setupProbe: @escaping SetupProbe,
+        accountProbe: @escaping AccountProbe,
+        identityReader: @escaping IdentityReader,
+        accessTokenReader: @escaping AccessTokenReader
+    ) {
+        self.setupProbe = setupProbe
+        self.accountProbe = accountProbe
+        self.identityReader = identityReader
+        self.accessTokenReader = accessTokenReader
+    }
+
+    static var live: RestoredSessionValidator {
+        RestoredSessionValidator(
+            setupProbe: { serverURL in
+                try await HTTPClient.shared.getUnauthenticated(
+                    serverURL: serverURL,
+                    path: "/api/v1/auth/setup",
+                    quietStatuses: [404]
+                )
+            },
+            accountProbe: {
+                _ = try await SiloAPI.shared.currentUser()
+            },
+            identityReader: {
+                await TokenStore.shared.refreshAccountIdentity()
+            },
+            accessTokenReader: { serverID in
+                await TokenStore.shared.hasAccessTokenForActiveServer(serverId: serverID)
+            }
+        )
+    }
+
+    func validate(expected: RefreshAccountIdentity) async -> RestoredSessionValidationResult {
+        let setup: SetupStatus
+        do {
+            setup = try await setupProbe(expected.serverURL)
+        } catch {
+            return await result(for: error, stage: .setup, expected: expected)
+        }
+
+        guard await identityReader() == expected else {
+            return .identityChanged
+        }
+        guard !setup.needsSetup else {
+            return .serverRecovery(.needsSetup)
+        }
+
+        do {
+            try await accountProbe()
+        } catch {
+            return await result(for: error, stage: .account, expected: expected)
+        }
+
+        guard await identityReader() == expected else {
+            return .identityChanged
+        }
+        return .valid
+    }
+
+    private func result(
+        for error: Error,
+        stage: Stage,
+        expected: RefreshAccountIdentity
+    ) async -> RestoredSessionValidationResult {
+        let current = await identityReader()
+        guard current?.serverId == expected.serverId,
+              current?.serverURL == expected.serverURL else {
+            return .identityChanged
+        }
+
+        // A terminal refresh rejection advances the credential generation and
+        // removes the access token. Check that before the exact-generation
+        // guard so an account deletion resolves to login rather than looking
+        // like an unrelated server switch.
+        let stillHasAccessToken = await accessTokenReader(expected.serverId)
+        if !stillHasAccessToken {
+            return .needsLogin
+        }
+        guard current == expected else {
+            return .identityChanged
+        }
+
+        if error is CancellationError {
+            return .indeterminate
+        }
+        guard let httpError = error as? HTTPError else {
+            return .indeterminate
+        }
+
+        switch httpError {
+        case .requestIdentityChanged:
+            return .identityChanged
+        case .network, .encodingFailed:
+            return .indeterminate
+        case .http(let statusCode, _):
+            if Self.isRetryable(statusCode) {
+                return .indeterminate
+            }
+            if stage == .account, statusCode == 401 || statusCode == 403 {
+                // HTTPClient removes the token before returning only when the
+                // refresh endpoint authoritatively rejects it. If the token is
+                // still present, refresh may instead have failed transiently;
+                // keep the cached session rather than manufacturing a logout.
+                return .indeterminate
+            }
+            return .serverRecovery(.serverNotRecognized)
+        case .invalidResponse, .decodingFailed, .serverUrlNotConfigured, .invalidURL:
+            return .serverRecovery(.serverNotRecognized)
+        }
+    }
+
+    static func isRetryable(_ statusCode: Int) -> Bool {
+        statusCode == 408 || statusCode == 429 || (500...599).contains(statusCode)
+    }
+}
+
+/// Resolves the current registry/token/profile combination into the router's
+/// auth state. Cold launch can use `resolveLocal()` as an immediate fallback
+/// and apply validation only while the splash is still visible; explicit
+/// server switches use `resolveValidated()` and await the same policy.
+enum RestoredSessionAuthResolver {
+    struct LocalResolution: Equatable {
+        let state: AppRouter.AuthState
+        let restoredAccount: RefreshAccountIdentity?
+    }
+
+    static func localState(
+        hasServer: Bool,
+        hasAccessToken: Bool,
+        hasProfile: Bool
+    ) -> AppRouter.AuthState {
+        guard hasServer else { return .needsServerSetup }
+        guard hasAccessToken else { return .needsLogin }
+        return hasProfile ? .authenticated : .needsProfile
+    }
+
+    static func resolveLocal() async -> LocalResolution {
+        let auth = AuthService.shared
+        guard auth.hasServer,
+              let activeServerID = ServerRegistry.shared.activeServerId,
+              !activeServerID.isEmpty else {
+            return LocalResolution(state: .needsServerSetup, restoredAccount: nil)
+        }
+
+        guard await TokenStore.shared.hasAccessTokenForActiveServer(serverId: activeServerID) else {
+            return LocalResolution(state: .needsLogin, restoredAccount: nil)
+        }
+
+        let hasProfile = await auth.resolveActiveProfileForSession()
+        let account = await TokenStore.shared.refreshAccountIdentity()
+        return LocalResolution(
+            state: localState(
+                hasServer: true,
+                hasAccessToken: true,
+                hasProfile: hasProfile
+            ),
+            restoredAccount: account
+        )
+    }
+
+    static func state(
+        after result: RestoredSessionValidationResult,
+        fallingBackTo fallback: AppRouter.AuthState
+    ) async -> AppRouter.AuthState {
+        switch result {
+        case .valid, .indeterminate:
+            return fallback
+        case .needsLogin:
+            return .needsLogin
+        case .serverRecovery(let reason):
+            return .serverRecovery(reason)
+        case .identityChanged:
+            return await resolveLocal().state
+        }
+    }
+
+    static func resolveValidated() async -> AppRouter.AuthState {
+        let local = await resolveLocal()
+        guard let expected = local.restoredAccount else { return local.state }
+        let result = await AuthService.shared.validateRestoredSession(expected: expected)
+        return await state(after: result, fallingBackTo: local.state)
+    }
+}

--- a/iosApp/iosApp/Screens/Auth/RestoredSessionValidator.swift
+++ b/iosApp/iosApp/Screens/Auth/RestoredSessionValidator.swift
@@ -27,7 +27,7 @@ enum RestoredSessionValidationResult: Equatable, Sendable {
 /// current-user endpoint.
 struct RestoredSessionValidator: Sendable {
     typealias SetupProbe = @Sendable (String) async throws -> SetupStatus
-    typealias AccountProbe = @Sendable () async throws -> Void
+    typealias AccountProbe = @Sendable () async throws -> UserInfo
     typealias IdentityReader = @Sendable () async -> RefreshAccountIdentity?
     typealias AccessTokenReader = @Sendable (String) async -> Bool
 
@@ -63,7 +63,7 @@ struct RestoredSessionValidator: Sendable {
                 )
             },
             accountProbe: {
-                _ = try await SiloAPI.shared.currentUser()
+                try await SiloAPI.shared.currentUser()
             },
             identityReader: {
                 await TokenStore.shared.refreshAccountIdentity()
@@ -90,7 +90,7 @@ struct RestoredSessionValidator: Sendable {
         }
 
         do {
-            try await accountProbe()
+            _ = try await accountProbe()
         } catch {
             return await result(for: error, stage: .account, expected: expected)
         }
@@ -140,7 +140,7 @@ struct RestoredSessionValidator: Sendable {
             if Self.isRetryable(statusCode) {
                 return .indeterminate
             }
-            if stage == .account, statusCode == 401 || statusCode == 403 {
+            if stage == .account, (statusCode == 401 || statusCode == 403) {
                 // HTTPClient removes the token before returning only when the
                 // refresh endpoint authoritatively rejects it. If the token is
                 // still present, refresh may instead have failed transiently;

--- a/iosApp/iosApp/Screens/Home/HomeView.swift
+++ b/iosApp/iosApp/Screens/Home/HomeView.swift
@@ -71,7 +71,11 @@ struct HomeView: View {
                 // first-row anchor, and no marquee from a hidden row lingers.
                 .id(homeSectionPreferences.layoutRevision)
             } else if let error = viewModel.error {
-                ErrorView(state: error, onRetry: { Task { await viewModel.loadSections() } })
+                ErrorView(
+                    state: error,
+                    onRetry: { Task { await viewModel.loadSections() } },
+                    onManageServers: { router.navigate(to: .serverList) }
+                )
             } else if viewModel.isLoading {
                 Color.clear
             } else if !viewModel.regularSections.isEmpty {
@@ -110,7 +114,11 @@ struct HomeView: View {
                 if !displayedSections.isEmpty {
                     scrollContent
                 } else if let error = viewModel.error {
-                    ErrorView(state: error, onRetry: { Task { await viewModel.loadSections() } })
+                    ErrorView(
+                        state: error,
+                        onRetry: { Task { await viewModel.loadSections() } },
+                        onManageServers: { router.navigate(to: .serverList) }
+                    )
                 } else if viewModel.isLoading {
                     Color.clear
                 } else if !viewModel.regularSections.isEmpty {

--- a/iosApp/iosApp/Screens/Servers/ServerListView.swift
+++ b/iosApp/iosApp/Screens/Servers/ServerListView.swift
@@ -13,6 +13,7 @@ struct ServerListView: View {
     @Environment(AppRouter.self) private var router
     @State private var registry = ServerRegistry.shared
     @State private var removeTarget: ServerEntry?
+    @State private var isResolvingServer = false
     #if os(tvOS)
     @FocusState private var focusedRow: TVRow?
     #endif
@@ -21,7 +22,7 @@ struct ServerListView: View {
         #if os(tvOS)
         ZStack {
             tvOSContent
-                .disabled(removeTarget != nil)
+                .disabled(removeTarget != nil || isResolvingServer)
 
             if let entry = removeTarget {
                 TVSettingsConfirmationOverlay(
@@ -39,6 +40,7 @@ struct ServerListView: View {
         .animation(.easeOut(duration: SiloTheme.fastDuration), value: removeTarget)
         #else
         contentList
+            .disabled(isResolvingServer)
             .navigationTitle("")
             .siloNavigationTitleDisplayMode(.inline)
             .alert(
@@ -248,12 +250,20 @@ struct ServerListView: View {
             refreshAuthState()
             return
         }
+        isResolvingServer = true
         Task {
             guard await registry.switchTo(
                 serverId: entry.id,
                 resolveDestinationProfile: true
-            ) else { return }
-            await MainActor.run { refreshAuthState() }
+            ) else {
+                await MainActor.run { isResolvingServer = false }
+                return
+            }
+            let state = await RestoredSessionAuthResolver.resolveValidated()
+            await MainActor.run {
+                isResolvingServer = false
+                router.resetAfterServerResolution(to: state)
+            }
         }
     }
 
@@ -275,19 +285,13 @@ struct ServerListView: View {
     /// drop any in-tab navigation that belonged to the previous server.
     private func refreshAuthState() {
         router.popToRoot()
-        // A server switch can land back on `.authenticated`, which the
-        // router's same-value guard drops — so the identity boundary for an
-        // engaged PiP video is enforced here, before the reassignment.
-        PlayerIdentityBoundary.endEngagedVideoPictureInPicture()
-        let auth = AuthService.shared
-        if !auth.hasServer {
-            router.authState = .needsServerSetup
-        } else if !auth.isLoggedIn {
-            router.authState = .needsLogin
-        } else if !auth.hasProfile {
-            router.authState = .needsProfile
-        } else {
-            router.authState = .authenticated
+        isResolvingServer = true
+        Task {
+            let state = await RestoredSessionAuthResolver.resolveValidated()
+            await MainActor.run {
+                isResolvingServer = false
+                router.resetAfterServerResolution(to: state)
+            }
         }
     }
 }

--- a/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
+++ b/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
@@ -657,7 +657,7 @@ enum StartupContentPrefetcher {
             prefetchProfiles()
         case .needsProfile:
             prefetchProfiles()
-        case .loading, .needsServerSetup, .needsLogin:
+        case .loading, .needsServerSetup, .needsLogin, .serverRecovery:
             break
         }
     }


### PR DESCRIPTION
## Problem

Apple clients restore a remembered server and Keychain session without verifying that the URL still serves the same usable Silo installation. On tvOS the registry itself survives reinstall, so a wiped or moved server can send the app directly to a root 404 with no route back to server management.

Fixes #280.

## Solution

- validate restored sessions opportunistically during the existing splash
- preserve the local authenticated state for network failures, timeouts, rate limits, and server faults so offline/cached use still works
- route authoritative setup or server-contract failures to a dedicated recovery screen
- provide Retry, Manage Servers, and confirmed Forget This Server actions
- validate server-list selections with the same policy and add a Home error escape hatch
- keep terminal refresh rejection scoped to the existing active-server credential cleanup

A username rename remains valid because the server resolves the session by user ID. Deleting the user removes its sessions, so validation returns to sign-in rather than producing the stale-server 404.

## Validation

- PASS: staged whitespace check
- PENDING: RestoredSessionValidatorTests and full SiloTests suite
- PENDING: SiloTV and SiloMac builds
- PENDING: rendered tvOS/iOS recovery evidence

Local Xcode execution is unavailable on the current Windows host, so the upstream Apple regression workflow is the compile/test authority for this draft.

## Risk

The validation adds two lightweight requests only while the splash is already visible. If validation is unfinished or receives a retryable failure, startup uses the existing local state and does not clear credentials.

## Follow-up

No server API or installation-identity change is required for this fix.

## AI disclosure

Implemented with OpenAI GPT-5 in the Codex desktop agent harness. Codex filesystem and shell tooling plus the GitHub CLI were used for repository inspection, implementation, testing orchestration, and PR delivery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Restored sessions are now validated against the remembered server before opening authenticated content.
  * Added server recovery options, including **Try Again**, **Manage Servers**, and **Force This Server**.
  * Added **Manage Servers** actions to relevant error screens.
* **Bug Fixes**
  * Improved handling of temporary server or account failures without unnecessarily removing saved credentials.
  * Prevented conflicting actions while switching servers or refreshing authentication.
  * Cleared open player and detail presentations when resolving server authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->