### PR TITLE
feat(auth): add one credential identity comparator and owner fence

### DIFF
--- a/iosApp/Tests/AccountSessionPersistenceTests.swift
+++ b/iosApp/Tests/AccountSessionPersistenceTests.swift
@@ -1,0 +1,278 @@
+import Foundation
+import XCTest
+@testable import Silo
+
+final class AccountSessionPersistenceTests: XCTestCase {
+    private func harness(_ memory: SessionMemory = SessionMemory()) async throws -> (TokenStore, SharedKeychain, SharedDefaults, SessionMemory) {
+        let name = "AccountSessionPersistenceTests.\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: name))
+        addTeardownBlock { UserDefaults().removePersistentDomain(forName: name) }
+        let defaults = SharedDefaults(suite: suite, standard: suite)
+        let keychain = SharedKeychain(service: name, accessGroup: nil)
+        let store = TokenStore(keychain: keychain, defaults: defaults, sessionPersistence: memory.persistence)
+        await store.switchActiveServer(serverId: "server")
+        await store.setServerUrl("https://session.example")
+        return (store, keychain, defaults, memory)
+    }
+    private func restarted(_ keychain: SharedKeychain, _ defaults: SharedDefaults, _ memory: SessionMemory) async -> TokenStore {
+        let store = TokenStore(keychain: keychain, defaults: defaults, sessionPersistence: memory.persistence)
+        await store.switchActiveServer(serverId: "server")
+        return store
+    }
+    func testDelayedLoginInstallRejectsSameAccountReloginInsideActor() async throws {
+        let (store, _, _, _) = try await harness()
+        try await store.installAccountSession(accessToken: "first", refreshToken: "first-refresh", accountID: "12")
+        let captured = await store.refreshAccountIdentity()
+        let expected = try XCTUnwrap(captured)
+        try await store.installAccountSession(accessToken: "new-login", refreshToken: "new-refresh", accountID: "12")
+        do {
+            try await store.installAccountSession(accessToken: "delayed", refreshToken: "delayed-refresh", accountID: "12", expectedAccount: expected)
+            XCTFail("Delayed installer replaced newer login")
+        } catch HTTPError.requestIdentityChanged {}
+        let current = await store.getAccessToken()
+        XCTAssertEqual(current, "new-login")
+    }
+
+    func testReceiverExpectationFencesSwitchAwayAndBackAndConsumesSuccess() async throws {
+        let (store, _, _, memory) = try await harness()
+        let expected = await store.captureAccountInstallationExpectation()
+        await store.switchActiveServer(serverId: "other")
+        await store.switchActiveServer(serverId: "server")
+        do {
+            try await store.installAccountSessionForServer(serverID: "candidate", origin: "https://candidate.example",
+                accessToken: "delayed", refreshToken: "delayed-refresh", accountID: "12", expected: expected)
+            XCTFail("Changed owner accepted")
+        } catch HTTPError.requestIdentityChanged {}
+        let fresh = await store.captureAccountInstallationExpectation()
+        try await store.installAccountSessionForServer(serverID: "candidate", origin: "https://candidate.example",
+            accessToken: "new", refreshToken: "new-refresh", accountID: "12", expected: fresh)
+        let active = await store.getActiveServerId()
+        XCTAssertEqual(active, "server", "Persisting an explicit candidate does not retarget active credentials")
+        do {
+            try await store.installAccountSessionForServer(serverID: "candidate", origin: "https://candidate.example",
+                accessToken: "duplicate", refreshToken: "duplicate-refresh", accountID: "12", expected: fresh)
+            XCTFail("Successful installation must consume its expectation")
+        } catch HTTPError.requestIdentityChanged {}
+        guard case .session(let value) = try memory.persistence.load("candidate") else { return XCTFail() }
+        XCTAssertEqual(value.accessToken, "new")
+    }
+
+    func testTemporaryHandoffCannotReplaceNewerLogin() async throws {
+        let (store, _, _, _) = try await harness()
+        let expected = await store.captureAccountInstallationExpectation()
+        try await store.installAccountSession(accessToken: "new-login", refreshToken: "new-refresh", accountID: "12")
+        let scope = TemporaryAuthScope(serverId: "candidate", serverURL: "https://candidate.example",
+            accessToken: "temporary", refreshToken: "temporary-refresh", profileId: "profile",
+            profileToken: "proof", controllerDeviceId: "controller", expiresAt: Date().addingTimeInterval(600))
+        let installed = await store.beginTemporaryScope(scope, expected: expected)
+        XCTAssertNil(installed)
+        let current = await store.getAccessToken()
+        XCTAssertEqual(current, "new-login")
+    }
+
+    func testReceiverInitialSetupAndExistingProfileProofBoundary() async throws {
+        let (store, keys, defaults, memory) = try await harness()
+        try await store.installAccountSession(accessToken: "old", refreshToken: "old-refresh", accountID: "12")
+        await store.setProfileId("old-profile")
+        _ = await store.setProfileToken("old-proof")
+        let expected = await store.captureAccountInstallationExpectation()
+        try await store.installAccountSessionForServer(serverID: "server", origin: "https://session.example",
+            accessToken: "new", refreshToken: "new-refresh", accountID: "13", expected: expected)
+        let proof = await store.getProfileToken()
+        XCTAssertNil(proof)
+        let fresh = TokenStore(keychain: keys, defaults: defaults, sessionPersistence: memory.persistence)
+        let blankExpected = await fresh.captureAccountInstallationExpectation()
+        XCTAssertNil(blankExpected.account)
+        try await fresh.installAccountSessionForServer(serverID: "candidate", origin: "https://candidate.example",
+            accessToken: "setup", refreshToken: "setup-refresh", accountID: "14", expected: blankExpected)
+        await fresh.setServerUrl("https://candidate.example")
+        await fresh.switchActiveServer(serverId: "candidate")
+        let access = await fresh.getAccessToken()
+        XCTAssertEqual(access, "setup")
+    }
+
+    func testInstallRestartReloginAndOriginBinding() async throws {
+        let (store, keys, defaults, memory) = try await harness()
+        try await store.installAccountSession(accessToken: "one", refreshToken: "refresh-one", accountID: "12")
+        let first = await store.getOrCreateAccountEpoch()
+        let next = await restarted(keys, defaults, memory)
+        let restored = await next.getAccessToken()
+        XCTAssertEqual(restored, "one")
+        let restoredEpoch = await next.getOrCreateAccountEpoch()
+        XCTAssertEqual(restoredEpoch, first)
+        try await next.installAccountSession(accessToken: "two", refreshToken: "refresh-two", accountID: "12")
+        let second = await next.getOrCreateAccountEpoch()
+        XCTAssertNotEqual(first, second)
+        await next.setServerUrl("https://different.example")
+        let foreign = await next.getAccessToken()
+        XCTAssertNil(foreign)
+    }
+    func testFailedInstallNeverPublishesOrFallsBackToLegacyMirrors() async throws {
+        let memory = SessionMemory()
+        let (store, keys, defaults, _) = try await harness(memory)
+        let account = keys.withAudience(.userIndependent)
+        account.set("legacy", for: TokenStore.accessTokenKey(for: "server"))
+        account.set("legacy-refresh", for: TokenStore.refreshTokenKey(for: "server"))
+        memory.failRecordWrites = true
+        do {
+            try await store.installAccountSession(accessToken: "new", refreshToken: "new-refresh", accountID: "12")
+            XCTFail("Install succeeded although the session record could not be written")
+        } catch AccountSessionPersistenceError.unavailable {}
+        let active = await store.getAccessToken()
+        XCTAssertNil(active)
+        let next = await restarted(keys, defaults, memory)
+        let afterRestart = await next.getAccessToken()
+        XCTAssertNil(afterRestart, "Adoption marker blocks stale legacy fallback")
+    }
+    func testVerifiedLegacyMigrationPreservesEpochAndBindsAccount() async throws {
+        let (store, keys, _, memory) = try await harness()
+        let account = keys.withAudience(.userIndependent)
+        let epoch = UUID().uuidString
+        account.set("legacy", for: TokenStore.accessTokenKey(for: "server"))
+        account.set("legacy-refresh", for: TokenStore.refreshTokenKey(for: "server"))
+        account.set(epoch, for: TokenStore.accountEpochKey(for: "server"))
+        await store.setServerUrl("https://session.example/")
+        let capturedValue = await store.captureOrdinaryRequestAuth()
+        let captured = try XCTUnwrap(capturedValue)
+        try await store.bindVerifiedAccount("12", expected: captured)
+        guard case .session(let value) = try memory.persistence.load("server") else { return XCTFail() }
+        XCTAssertEqual(value.accountID, "12")
+        XCTAssertEqual(value.epoch?.uuidString, epoch)
+    }
+    func testRefreshPreservesEpochAndStaleRefreshCannotReplaceRelogin() async throws {
+        let (store, _, _, _) = try await harness()
+        try await store.installAccountSession(accessToken: "one", refreshToken: "refresh-one", accountID: "12")
+        let capturedValue = await store.captureOrdinaryRequestAuth()
+        let auth = try XCTUnwrap(capturedValue)
+        let epoch = await store.getOrCreateAccountEpoch()
+        let captured = CapturedRefreshCredential(account: auth.account, refreshToken: "refresh-one", owner: auth.credentialOwner)
+        let saved = await store.saveRefreshedTokens("two", "refresh-two", replacing: captured)
+        XCTAssertTrue(saved)
+        let after = await store.getOrCreateAccountEpoch()
+        XCTAssertEqual(epoch, after)
+        try await store.installAccountSession(accessToken: "new-login", refreshToken: "new-refresh", accountID: "12")
+        let stale = await store.saveRefreshedTokens("old-response", "old-refresh", replacing: captured)
+        XCTAssertFalse(stale)
+        let current = await store.getAccessToken()
+        XCTAssertEqual(current, "new-login")
+    }
+    func testFailedRefreshPublishesNoMixedCredentials() async throws {
+        let (store, keys, defaults, memory) = try await harness()
+        try await store.installAccountSession(accessToken: "one", refreshToken: "refresh-one", accountID: "12")
+        let capturedValue = await store.captureOrdinaryRequestAuth()
+        let auth = try XCTUnwrap(capturedValue)
+        memory.failRecordWrites = true
+        let saved = await store.saveRefreshedTokens("two", "refresh-two", replacing:
+            CapturedRefreshCredential(account: auth.account, refreshToken: "refresh-one", owner: auth.credentialOwner))
+        XCTAssertFalse(saved)
+        let active = await store.getAccessToken()
+        XCTAssertNil(active)
+        let next = await restarted(keys, defaults, memory)
+        let restored = await next.getAccessToken()
+        XCTAssertEqual(restored, "one", "Only the previously committed pair survives")
+    }
+    func testSignoutTombstoneAndRemovalFallbackPreventMirrorRevival() async throws {
+        for fallback in [false, true] {
+            let (store, keys, defaults, memory) = try await harness()
+            try await store.installAccountSession(accessToken: "one", refreshToken: "refresh-one", accountID: "12")
+            memory.failRecordWrites = fallback
+            let durable = await store.clearTokens()
+            XCTAssertTrue(durable)
+            keys.withAudience(.userIndependent).set("stale-mirror", for: TokenStore.accessTokenKey(for: "server"))
+            let next = await restarted(keys, defaults, memory)
+            let restored = await next.getAccessToken()
+            XCTAssertNil(restored)
+        }
+    }
+    func testSignoutFailureReportsDurabilityLimitAndBlocksRuntime() async throws {
+        let (store, keys, defaults, memory) = try await harness()
+        try await store.installAccountSession(accessToken: "one", refreshToken: "refresh-one", accountID: "12")
+        memory.failRecordWrites = true
+        memory.failRemoval = true
+        let durable = await store.clearTokens()
+        XCTAssertFalse(durable)
+        let active = await store.getAccessToken()
+        XCTAssertNil(active)
+        let next = await restarted(keys, defaults, memory)
+        let restored = await next.getAccessToken()
+        XCTAssertEqual(restored, "one", "Both persistent invalidation mechanisms failed; do not claim durable sign-out")
+    }
+    func testTemporaryCredentialsCannotReplaceDurableBinding() async throws {
+        let (store, _, _, memory) = try await harness()
+        try await store.installAccountSession(accessToken: "owner", refreshToken: "owner-refresh", accountID: "12")
+        guard case .session(let before) = try memory.persistence.load("server") else { return XCTFail() }
+        await store.beginTemporaryScope(TemporaryAuthScope(serverId: "server", serverURL: "https://session.example",
+            accessToken: "temporary", refreshToken: "temporary-refresh", profileId: "guest", profileToken: "proof",
+            controllerDeviceId: "controller", expiresAt: Date().addingTimeInterval(60)))
+        let saved = await store.saveTokens(accessToken: "temporary-two", refreshToken: "temporary-two-refresh")
+        XCTAssertTrue(saved)
+        do {
+            try await store.installAccountSession(accessToken: "wrong", refreshToken: "wrong-refresh", accountID: "99")
+            XCTFail("Persistent install succeeded while a temporary scope owned request authentication")
+        } catch AccountSessionPersistenceError.invalidIdentity {}
+        guard case .session(let after) = try memory.persistence.load("server") else { return XCTFail() }
+        XCTAssertEqual(before, after)
+        let epoch = await store.getOrCreateAccountEpoch()
+        XCTAssertNil(epoch)
+    }
+
+    func testDurableCaptureRequiresVerifiedBindingAndKeepsRuntimeScope() async throws {
+        let (store, _, _, _) = try await harness()
+        let saved = await store.saveTokens(accessToken: "unverified", refreshToken: "refresh")
+        XCTAssertTrue(saved)
+        let unverified = await store.captureDurableAccountAuth()
+        XCTAssertNil(unverified)
+        await store.setProfileId("profile-one")
+        let beforeValue = await store.captureOrdinaryRequestAuth()
+        let before = try XCTUnwrap(beforeValue)
+        try await store.bindVerifiedAccount("12", expected: before)
+        let boundValue = await store.captureDurableAccountAuth()
+        let bound = try XCTUnwrap(boundValue)
+        XCTAssertEqual(bound.accountID, "12")
+        XCTAssertEqual(bound.request.profileId, "profile-one")
+        await store.setProfileId("profile-two")
+        let changedValue = await store.captureDurableAccountAuth()
+        let changed = try XCTUnwrap(changedValue)
+        XCTAssertEqual(changed.accountEpoch, bound.accountEpoch)
+        XCTAssertEqual(changed.request.profileId, "profile-two")
+    }
+
+    func testReadFailureAndCorruptionNeverFallback() async throws {
+        let (_, keys, defaults, memory) = try await harness()
+        keys.withAudience(.userIndependent).set("legacy", for: TokenStore.accessTokenKey(for: "server"))
+        memory.failRead = true
+        let store = await restarted(keys, defaults, memory)
+        let token = await store.getAccessToken()
+        XCTAssertNil(token)
+        memory.failRead = false
+        _ = memory.persistence.write("broken", AccountSessionPersistence.recordKey("server"))
+        let next = await restarted(keys, defaults, memory)
+        let invalid = await next.getAccessToken()
+        XCTAssertNil(invalid)
+    }
+}
+
+private final class SessionMemory: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [String: String] = [:]
+    var failRecordWrites = false
+    var failRemoval = false
+    var failRead = false
+    var persistence: AccountSessionPersistence {
+        AccountSessionPersistence(read: { key in
+            try self.lock.withLock {
+                if self.failRead { throw AccountSessionPersistenceError.unavailable }
+                return self.values[key]
+            }
+        }, write: { value, key in
+            self.lock.withLock {
+                if self.failRecordWrites && key.hasSuffix(".accountSession") { return false }
+                self.values[key] = value; return true
+            }
+        }, remove: { key in
+            self.lock.withLock {
+                if self.failRemoval { return false }; self.values.removeValue(forKey: key); return true
+            }
+        })
+    }
+}

--- a/iosApp/Tests/CredentialIdentityTests.swift
+++ b/iosApp/Tests/CredentialIdentityTests.swift
@@ -226,6 +226,53 @@ final class CredentialIdentityTests: XCTestCase {
         XCTAssertFalse(bodyRan.value, "A stale owner must be refused before the request is sent")
     }
 
+    // MARK: - withCurrentDurableAuthority
+
+    /// A durable authority is bound to the verified account and its epoch, so
+    /// it must outlive the one credential change a request owner ignores too:
+    /// access-token rotation.
+    func testDurableAuthoritySurvivesAccessTokenRotation() async throws {
+        let (store, _) = try await makeStore()
+        let ownerValue = await store.captureOrdinaryRequestAuth()
+        let owner = try XCTUnwrap(ownerValue)
+        // A durable authority only exists for a verified account binding.
+        try await store.bindVerifiedAccount("12", expected: owner)
+        let durableValue = await store.captureDurableAccountAuth()
+        let durable = try XCTUnwrap(durableValue)
+        let rotated = await store.saveRefreshedTokens(
+            "access-2",
+            "refresh-2",
+            replacing: CapturedRefreshCredential(
+                account: owner.account,
+                refreshToken: "refresh",
+                owner: owner.credentialOwner
+            )
+        )
+        XCTAssertTrue(rotated)
+        let ran = BodyFlag()
+        try await store.withCurrentDurableAuthority(durable) { ran.set() }
+        XCTAssertTrue(ran.value, "queued work must still run for the same account after a token refresh")
+    }
+
+    /// A profile switch does change the owner the queued work was prepared
+    /// for, so the durable fence must refuse it.
+    func testDurableAuthorityRejectsProfileSwitch() async throws {
+        let (store, _) = try await makeStore()
+        let ownerValue = await store.captureOrdinaryRequestAuth()
+        let owner = try XCTUnwrap(ownerValue)
+        try await store.bindVerifiedAccount("12", expected: owner)
+        let durableValue = await store.captureDurableAccountAuth()
+        let durable = try XCTUnwrap(durableValue)
+        await store.setProfileId("profile-b")
+        _ = await store.setProfileToken("proof-b")
+        let ran = BodyFlag()
+        do {
+            try await store.withCurrentDurableAuthority(durable) { ran.set() }
+            XCTFail("Durable fence accepted work prepared for another profile")
+        } catch HTTPError.authorityChanged {}
+        XCTAssertFalse(ran.value)
+    }
+
     func testFencePropagatesBodyErrorsUnchanged() async throws {
         let (store, _) = try await makeStore()
         let ownerValue = await store.captureOrdinaryRequestAuth()

--- a/iosApp/Tests/CredentialIdentityTests.swift
+++ b/iosApp/Tests/CredentialIdentityTests.swift
@@ -1,0 +1,249 @@
+import Foundation
+import XCTest
+@testable import Silo
+
+/// Pins the one ownership comparator and the fence built on it.
+///
+/// `sameCredentialIdentity(as:)` is the field set every fence in the client
+/// relies on. The table below changes exactly one field at a time so a future
+/// edit that drops a field (the leak the audit found in hand-written copies)
+/// or adds `accessToken` (which would break shared-refresh detection) fails
+/// here rather than in production.
+final class CredentialIdentityTests: XCTestCase {
+    private static let generation = UUID()
+
+    private static func auth(
+        serverId: String = "server-a",
+        serverURL: String = "https://silo.example",
+        generation: UUID = CredentialIdentityTests.generation,
+        credentialOwner: CapturedHTTPRequestCredentialOwner = .persistentServer(serverId: "server-a"),
+        accessToken: String? = "access",
+        profileId: String? = "profile-a",
+        profileToken: String? = "proof-a"
+    ) -> CapturedOrdinaryRequestAuth {
+        CapturedOrdinaryRequestAuth(
+            account: RefreshAccountIdentity(
+                serverId: serverId,
+                serverURL: serverURL,
+                credentialGenerationID: generation
+            ),
+            credentialOwner: credentialOwner,
+            accessToken: accessToken,
+            profileId: profileId,
+            profileToken: profileToken
+        )
+    }
+
+    func testIdenticalCapturesMatch() {
+        XCTAssertTrue(Self.auth().sameCredentialIdentity(as: Self.auth()))
+    }
+
+    /// Each stored identity field, changed alone, breaks the match.
+    func testEachIdentityFieldDifferingAloneBreaksTheMatch() {
+        let base = Self.auth()
+        let variants: [(String, CapturedOrdinaryRequestAuth)] = [
+            ("account.serverId", Self.auth(serverId: "server-b")),
+            ("account.serverURL", Self.auth(serverURL: "https://other.example")),
+            ("account.credentialGenerationID", Self.auth(generation: UUID())),
+            ("credentialOwner", Self.auth(credentialOwner: .temporary)),
+            ("profileId", Self.auth(profileId: "profile-b")),
+            ("profileId nil", Self.auth(profileId: nil)),
+            ("profileToken", Self.auth(profileToken: "proof-b")),
+            ("profileToken nil", Self.auth(profileToken: nil)),
+        ]
+        for (field, variant) in variants {
+            XCTAssertFalse(
+                base.sameCredentialIdentity(as: variant),
+                "\(field) differing alone must break the identity match"
+            )
+            XCTAssertFalse(
+                variant.sameCredentialIdentity(as: base),
+                "\(field) comparison must be symmetric"
+            )
+        }
+    }
+
+    /// Access-token rotation is the one change that keeps the owner: a shared
+    /// refresh must let its caller detect the new token through this match.
+    func testAccessTokenDifferingAloneStillMatches() {
+        let base = Self.auth()
+        XCTAssertTrue(base.sameCredentialIdentity(as: Self.auth(accessToken: "rotated")))
+        XCTAssertTrue(base.sameCredentialIdentity(as: Self.auth(accessToken: nil)))
+        XCTAssertNotEqual(base, Self.auth(accessToken: "rotated"), "Equatable still sees the token")
+    }
+
+    // MARK: - withOwnerFence
+
+    private func makeStore() async throws -> (TokenStore, SharedKeychain) {
+        let name = "CredentialIdentityTests.\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: name))
+        let keychain = SharedKeychain(service: name, accessGroup: nil)
+        addTeardownBlock {
+            for key in [
+                TokenStore.accessTokenKey(for: "server-a"),
+                TokenStore.refreshTokenKey(for: "server-a"),
+                TokenStore.profileTokenKey(for: "server-a"),
+                TokenStore.accountEpochKey(for: "server-a"),
+                AccountSessionPersistence.recordKey("server-a"),
+                AccountSessionPersistence.markerKey("server-a"),
+                SharedStorage.mirroredAccessTokenAccount,
+                SharedStorage.mirroredProfileTokenAccount,
+            ] {
+                keychain.withAudience(.userIndependent).delete(key)
+                keychain.withAudience(.currentUser).delete(key)
+            }
+            UserDefaults().removePersistentDomain(forName: name)
+        }
+        let store = TokenStore(
+            keychain: keychain,
+            defaults: SharedDefaults(suite: suite, standard: suite)
+        )
+        await store.switchActiveServer(serverId: "server-a")
+        await store.setServerUrl("https://silo.example")
+        let saved = await store.saveTokens(accessToken: "access", refreshToken: "refresh")
+        XCTAssertTrue(saved)
+        await store.setProfileId("profile-a")
+        let proofStored = await store.setProfileToken("proof-a")
+        XCTAssertTrue(proofStored)
+        return (store, keychain)
+    }
+
+    func testFencePassesWhenOwnerIsUnchanged() async throws {
+        let (store, _) = try await makeStore()
+        let ownerValue = await store.captureOrdinaryRequestAuth()
+        let owner = try XCTUnwrap(ownerValue)
+        let result = try await store.withOwnerFence(owner) { "applied" }
+        XCTAssertEqual(result, "applied")
+    }
+
+    func testFencePassesAcrossAccessTokenRotation() async throws {
+        let (store, _) = try await makeStore()
+        let ownerValue = await store.captureOrdinaryRequestAuth()
+        let owner = try XCTUnwrap(ownerValue)
+        let result = try await store.withOwnerFence(owner) {
+            let rotated = await store.saveRefreshedTokens(
+                "access-2",
+                "refresh-2",
+                replacing: CapturedRefreshCredential(
+                    account: owner.account,
+                    refreshToken: "refresh",
+                    owner: owner.credentialOwner
+                )
+            )
+            XCTAssertTrue(rotated)
+            return "applied"
+        }
+        XCTAssertEqual(result, "applied")
+        let current = await store.getAccessToken()
+        XCTAssertEqual(current, "access-2")
+    }
+
+    func testFenceRejectsProfileSwitchDuringBody() async throws {
+        let (store, _) = try await makeStore()
+        let ownerValue = await store.captureOrdinaryRequestAuth()
+        let owner = try XCTUnwrap(ownerValue)
+        do {
+            _ = try await store.withOwnerFence(owner) {
+                let activated = await store.activateProfile(
+                    profileID: "profile-b",
+                    profileToken: "proof-b",
+                    expectedAccount: owner.account
+                )
+                XCTAssertTrue(activated)
+                return "must not be applied"
+            }
+            XCTFail("Fence accepted a response after the profile changed")
+        } catch HTTPError.authorityChanged {}
+    }
+
+    func testFenceRejectsProfileProofClearDuringBody() async throws {
+        let (store, _) = try await makeStore()
+        let ownerValue = await store.captureOrdinaryRequestAuth()
+        let owner = try XCTUnwrap(ownerValue)
+        do {
+            _ = try await store.withOwnerFence(owner) {
+                let cleared = await store.setProfileToken(nil)
+                XCTAssertTrue(cleared)
+                return "must not be applied"
+            }
+            XCTFail("Fence accepted a response after the profile proof was cleared")
+        } catch HTTPError.authorityChanged {}
+    }
+
+    func testFenceRejectsSignOutAndReloginDuringBody() async throws {
+        let (store, _) = try await makeStore()
+        let ownerValue = await store.captureOrdinaryRequestAuth()
+        let owner = try XCTUnwrap(ownerValue)
+        do {
+            _ = try await store.withOwnerFence(owner) {
+                let cleared = await store.clearTokens()
+                XCTAssertTrue(cleared)
+                let saved = await store.saveTokens(accessToken: "access-again", refreshToken: "refresh-again")
+                XCTAssertTrue(saved)
+                await store.setProfileId("profile-a")
+                _ = await store.setProfileToken("proof-a")
+                return "must not be applied"
+            }
+            XCTFail("Fence accepted a response across a sign-out and re-login on the same server")
+        } catch HTTPError.authorityChanged {}
+    }
+
+    func testFenceRejectsTemporaryScopeInstalledDuringBody() async throws {
+        let (store, _) = try await makeStore()
+        let ownerValue = await store.captureOrdinaryRequestAuth()
+        let owner = try XCTUnwrap(ownerValue)
+        do {
+            _ = try await store.withOwnerFence(owner) {
+                await store.beginTemporaryScope(TemporaryAuthScope(
+                    serverId: "server-a",
+                    serverURL: "https://silo.example",
+                    accessToken: "temporary",
+                    refreshToken: "temporary-refresh",
+                    profileId: "profile-a",
+                    profileToken: "proof-a",
+                    controllerDeviceId: "controller",
+                    expiresAt: Date().addingTimeInterval(60)
+                ))
+                return "must not be applied"
+            }
+            XCTFail("Fence accepted a response after a temporary owner replaced the persistent one")
+        } catch HTTPError.authorityChanged {}
+    }
+
+    func testFenceRejectsStaleOwnerBeforeBodyRuns() async throws {
+        let (store, _) = try await makeStore()
+        let ownerValue = await store.captureOrdinaryRequestAuth()
+        let owner = try XCTUnwrap(ownerValue)
+        await store.setProfileId("profile-b")
+        let bodyRan = BodyFlag()
+        do {
+            _ = try await store.withOwnerFence(owner) {
+                bodyRan.set()
+                return "must not run"
+            }
+            XCTFail("Fence dispatched under an owner that had already changed")
+        } catch HTTPError.authorityChanged {}
+        XCTAssertFalse(bodyRan.value, "A stale owner must be refused before the request is sent")
+    }
+
+    func testFencePropagatesBodyErrorsUnchanged() async throws {
+        let (store, _) = try await makeStore()
+        let ownerValue = await store.captureOrdinaryRequestAuth()
+        let owner = try XCTUnwrap(ownerValue)
+        do {
+            _ = try await store.withOwnerFence(owner) { () async throws -> String in
+                throw HTTPError.http(statusCode: 503, body: nil)
+            }
+            XCTFail("Body error was swallowed")
+        } catch HTTPError.http(let status, _) {
+            XCTAssertEqual(status, 503)
+        }
+    }
+}
+
+private final class BodyFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var flag = false
+    var value: Bool { lock.withLock { flag } }
+    func set() { lock.withLock { flag = true } }
+}

--- a/iosApp/Tests/SettingValuesAPITests.swift
+++ b/iosApp/Tests/SettingValuesAPITests.swift
@@ -2234,13 +2234,26 @@ final class SettingValuesAPITests: XCTestCase {
         )
         let refreshAfterWrongURL = await tokenStore.getRefreshToken()
         XCTAssertFalse(wrongURLStored)
-        XCTAssertEqual(refreshAfterWrongURL, "dummy")
+        XCTAssertNil(refreshAfterWrongURL, "Canonical credentials cannot authorize a retargeted origin")
 
         await tokenStore.setServerUrl(identity.serverURL)
-        let rotated = await tokenStore.saveRefreshedTokens(
+        // Returning to the origin restores the stored session, but under a new
+        // credential generation: the refresh captured before the retarget must
+        // not rotate it.
+        let staleGenerationRotated = await tokenStore.saveRefreshedTokens(
             "placeholder",
             "redacted",
             replacing: originalRefresh
+        )
+        XCTAssertFalse(staleGenerationRotated)
+        let afterReturnValue = await tokenStore.refreshAccountIdentity()
+        let afterReturn = try XCTUnwrap(afterReturnValue)
+        let afterReturnCredentialValue = await tokenStore.captureRefreshCredential(expected: afterReturn)
+        let afterReturnCredential = try XCTUnwrap(afterReturnCredentialValue)
+        let rotated = await tokenStore.saveRefreshedTokens(
+            "placeholder",
+            "redacted",
+            replacing: afterReturnCredential
         )
         XCTAssertTrue(rotated)
         let staleStored = await tokenStore.saveRefreshedTokens(

--- a/iosApp/iosApp/Components/ErrorState.swift
+++ b/iosApp/iosApp/Components/ErrorState.swift
@@ -48,7 +48,7 @@ struct ErrorState: Equatable {
         switch httpError {
         case .serverUrlNotConfigured:
             return "No server is configured."
-        case .requestIdentityChanged:
+        case .requestIdentityChanged, .authorityChanged:
             return "The active server or profile changed. Try again."
         case .invalidURL:
             return "The request URL was invalid."

--- a/iosApp/iosApp/Networking/HTTPClient.swift
+++ b/iosApp/iosApp/Networking/HTTPClient.swift
@@ -970,7 +970,10 @@ actor HTTPClient {
                ) == refreshedAuth {
                 // Rebuild from one account-owner/profile snapshot. If any of
                 // those identities changed during the shared flight, keep the
-                // original 401 instead of sending mixed credentials.
+                // original 401 instead of sending mixed credentials. This is
+                // deliberately not `withOwnerFence`: the retry must attach
+                // exactly the credential set that is current now, including
+                // the rotated access token, so the whole snapshot is compared.
                 var retry = try makeRequest(serverUrl)
                 attachOrdinaryAuthHeaders(&retry, auth: refreshedAuth)
                 Self.apply(additionalHeaders, to: &retry)
@@ -2075,6 +2078,11 @@ struct HTTPRawResponse: Sendable {
 enum HTTPError: LocalizedError, CustomStringConvertible {
     case serverUrlNotConfigured
     case requestIdentityChanged
+    /// Thrown by `TokenStore.withOwnerFence` when the account, credential
+    /// owner, profile, or profile proof that issued an operation is no longer
+    /// current when the operation is about to start or when it returns. The
+    /// response was discarded; nothing was applied to the replacement owner.
+    case authorityChanged
     case invalidURL(String)
     case invalidResponse
     case network(underlying: Error)
@@ -2088,6 +2096,8 @@ enum HTTPError: LocalizedError, CustomStringConvertible {
             return "Server URL is not configured."
         case .requestIdentityChanged:
             return "The active server or profile changed before the request could start."
+        case .authorityChanged:
+            return "The account or profile changed while the request was in flight."
         case .invalidURL(let url):
             return "Invalid URL: \(url)"
         case .invalidResponse:
@@ -2114,6 +2124,8 @@ enum HTTPError: LocalizedError, CustomStringConvertible {
             return "server_url_not_configured"
         case .requestIdentityChanged:
             return "request_identity_changed"
+        case .authorityChanged:
+            return "authority_changed"
         case .invalidURL:
             return "invalid_url"
         case .invalidResponse:

--- a/iosApp/iosApp/Networking/TokenStore.swift
+++ b/iosApp/iosApp/Networking/TokenStore.swift
@@ -349,11 +349,18 @@ actor TokenStore {
     /// the effect. Throws `HTTPError.authorityChanged` when the verified
     /// account, its epoch, or the request owner moved since `expected` was
     /// captured.
+    ///
+    /// The request owner is compared with `sameCredentialIdentity(as:)`, not
+    /// `==`: a durable authority is meant to outlive access-token rotation, so
+    /// the rotated token must not make queued work look foreign. Profile and
+    /// credential-owner changes still break it, because the queued work was
+    /// prepared for that profile's view of the account.
     func withCurrentDurableAuthority(_ expected: CapturedDurableAccountAuth,
                                      operation: @Sendable () throws -> Void) throws {
         try Task.checkCancellation()
         guard let current = captureDurableAccountAuth(), current.accountID == expected.accountID,
-              current.accountEpoch == expected.accountEpoch, current.request == expected.request else {
+              current.accountEpoch == expected.accountEpoch,
+              current.request.sameCredentialIdentity(as: expected.request) else {
             throw HTTPError.authorityChanged
         }
         try operation()
@@ -1081,8 +1088,8 @@ actor TokenStore {
         }
         recordSessionEvent(
             phase: "clearTokens",
-            outcome: "cleared",
-            reason: "persistentSession"
+            outcome: durable ? "cleared" : "failed",
+            reason: durable ? "persistentSession" : "persistenceUnavailable"
         )
         accountKeychain.delete(accessTokenKey)
         accountKeychain.delete(refreshTokenKey)
@@ -1099,6 +1106,9 @@ actor TokenStore {
     func deleteTokens(for serverId: String) -> Bool {
         guard !serverId.isEmpty else { return true }
         let durable = sessions.invalidate(serverId)
+        if !durable {
+            recordSessionEvent(phase: "deleteTokens", outcome: "failed", reason: "persistenceUnavailable")
+        }
         runtimeBlockedServers.insert(serverId)
         accountKeychain.delete(Self.accessTokenKey(for: serverId))
         accountKeychain.delete(Self.refreshTokenKey(for: serverId))

--- a/iosApp/iosApp/Networking/TokenStore.swift
+++ b/iosApp/iosApp/Networking/TokenStore.swift
@@ -264,6 +264,20 @@ actor TokenStore {
         #endif
     }
 
+    /// Fixed classification of a session-persistence failure for
+    /// `recordSessionEvent`. The error itself never reaches the breadcrumb;
+    /// only one of these literals does.
+    private static func persistenceFailureReason(_ error: Error) -> String {
+        switch error {
+        case AccountSessionPersistenceError.unavailable: return "persistenceUnavailable"
+        case AccountSessionPersistenceError.invalidRecord: return "invalidSessionRecord"
+        case AccountSessionPersistenceError.invalidIdentity: return "invalidSessionIdentity"
+        case is DecodingError: return "invalidSessionRecord"
+        case is SharedKeychain.ReadError: return "keychainReadFailed"
+        default: return "persistenceUnavailable"
+        }
+    }
+
     // MARK: - Active server
 
     /// Point the Keychain reads at a different server. Flushes the
@@ -681,7 +695,24 @@ actor TokenStore {
             }
 
             if let original = canonicalSession {
-                guard case .session(let current) = try? sessions.load(serverId), current == original else { return false }
+                let stored: AccountSessionPersistence.State
+                do { stored = try sessions.load(serverId) }
+                catch {
+                    recordSessionEvent(
+                        phase: "tokenRefresh",
+                        outcome: "discarded",
+                        reason: Self.persistenceFailureReason(error)
+                    )
+                    return false
+                }
+                guard case .session(let current) = stored, current == original else {
+                    recordSessionEvent(
+                        phase: "tokenRefresh",
+                        outcome: "discarded",
+                        reason: "canonicalSessionMismatch"
+                    )
+                    return false
+                }
             }
             let rotated = CanonicalAccountSession(version: 1, signedOut: false,
                 origin: canonicalSession?.origin ?? captured.account.serverURL,
@@ -689,7 +720,15 @@ actor TokenStore {
                 epoch: canonicalSession?.epoch ?? accountKeychain.get(accountEpochKey).flatMap(UUID.init(uuidString:)) ?? UUID(),
                 accessToken: accessValue, refreshToken: value)
             do { try sessions.save(rotated, serverID: serverId) }
-            catch { blockRuntimeSession(); return false }
+            catch {
+                recordSessionEvent(
+                    phase: "tokenRefresh",
+                    outcome: "failed",
+                    reason: Self.persistenceFailureReason(error)
+                )
+                blockRuntimeSession()
+                return false
+            }
             canonicalSession = rotated
             mirrorCanonicalSession(rotated)
             cachedAccessToken = accessValue
@@ -848,7 +887,14 @@ actor TokenStore {
             case .signedOut: return nil
             case .legacy: return accountKeychain.get(Self.accessTokenKey(for: serverId))
             }
-        } catch { return nil }
+        } catch {
+            recordSessionEvent(
+                phase: "sessionLoad",
+                outcome: "failed",
+                reason: Self.persistenceFailureReason(error)
+            )
+            return nil
+        }
     }
 
     /// Minimal launch-time check for whether the active server has a stored
@@ -872,7 +918,17 @@ actor TokenStore {
             temporaryScope?.refreshToken = refreshToken
             return true
         }
-        return (try? installAccountSession(accessToken: accessToken, refreshToken: refreshToken, accountID: nil, clearProfile: false)) != nil
+        do {
+            try installAccountSession(accessToken: accessToken, refreshToken: refreshToken, accountID: nil, clearProfile: false)
+            return true
+        } catch {
+            recordSessionEvent(
+                phase: "sessionInstall",
+                outcome: "failed",
+                reason: Self.persistenceFailureReason(error)
+            )
+            return false
+        }
     }
 
     struct AccountInstallationExpectation: Equatable, Sendable {
@@ -1114,7 +1170,14 @@ actor TokenStore {
             case .signedOut: return nil
             case .legacy: break
             }
-        } catch { return nil }
+        } catch {
+            recordSessionEvent(
+                phase: "sessionLoad",
+                outcome: "failed",
+                reason: Self.persistenceFailureReason(error)
+            )
+            return nil
+        }
         let epochKey = Self.accountEpochKey(for: serverID)
         let accessKey = Self.accessTokenKey(for: serverID)
         if let existing = accountKeychain.get(epochKey), !existing.isEmpty {
@@ -1288,7 +1351,16 @@ actor TokenStore {
                         cachedRefreshToken = accountKeychain.get(refreshTokenKey)
                         cachedProfileToken = profileKeychain.get(profileTokenKey)
                     }
-                } catch { runtimeBlockedServers.insert(activeServerId) }
+                } catch {
+                    // Fail closed: a record that cannot be read or decoded
+                    // blocks the runtime session until the next install.
+                    recordSessionEvent(
+                        phase: "sessionLoad",
+                        outcome: "blocked",
+                        reason: Self.persistenceFailureReason(error)
+                    )
+                    runtimeBlockedServers.insert(activeServerId)
+                }
             }
         }
         loadedForServerId = activeServerId

--- a/iosApp/iosApp/Networking/TokenStore.swift
+++ b/iosApp/iosApp/Networking/TokenStore.swift
@@ -37,6 +37,37 @@ struct CapturedOrdinaryRequestAuth: Equatable, Sendable {
     let profileToken: String?
 }
 
+extension CapturedOrdinaryRequestAuth {
+    /// The one ownership comparator. Two captures describe the same owner when
+    /// every stored identity field matches: the account (server, URL, and
+    /// process-local credential generation), the credential owner (persistent
+    /// slot or temporary handoff), the selected profile, and the profile
+    /// verification proof (`profileToken`). Only `accessToken` is excluded:
+    /// a shared refresh rotates it without changing who owns the request, and
+    /// `currentOrdinaryRequestAuth(matchingIdentityOf:)` relies on that to
+    /// detect a completed rotation.
+    ///
+    /// Every fence in the client must go through this method or through
+    /// `TokenStore.withOwnerFence`. A hand-written subset of these fields is a
+    /// leak: a response could be applied under a profile or owner that
+    /// replaced the one that issued the request.
+    func sameCredentialIdentity(as other: CapturedOrdinaryRequestAuth) -> Bool {
+        account == other.account
+            && credentialOwner == other.credentialOwner
+            && profileId == other.profileId
+            && profileToken == other.profileToken
+    }
+}
+
+/// Durable account owner for queued or persisted work. Unlike the request
+/// owner it survives access-token rotation and profile switches: it is bound
+/// to the verified account id and the account epoch installed by a login.
+struct CapturedDurableAccountAuth: Sendable {
+    let accountID: String
+    let accountEpoch: UUID
+    let request: CapturedOrdinaryRequestAuth
+}
+
 enum RejectedRefreshDisposition: Equatable, Sendable {
     case persistentSessionCleared
     case temporarySessionExpired
@@ -139,6 +170,9 @@ actor TokenStore {
 
     private let keychain: SharedKeychain
     private let defaults: SharedDefaults
+    private let sessions: AccountSessionPersistence
+    private var canonicalSession: CanonicalAccountSession?
+    private var runtimeBlockedServers: Set<String> = []
 
     private let serverUrlDefaultsKey = SharedStorage.serverUrlKey
     private let profileIdDefaultsKey = SharedStorage.profileIdKey
@@ -193,9 +227,11 @@ actor TokenStore {
     private var lastMirroredProfileToken: String?
 
     init(keychain: SharedKeychain = SharedKeychain(),
-         defaults: SharedDefaults = .shared) {
+         defaults: SharedDefaults = .shared,
+         sessionPersistence: AccountSessionPersistence? = nil) {
         self.keychain = keychain
         self.defaults = defaults
+        self.sessions = sessionPersistence ?? AccountSessionPersistence(keychain: keychain)
     }
 
     // MARK: - Diagnostics
@@ -284,6 +320,31 @@ actor TokenStore {
         )
     }
 
+    /// One shared binding for future queued authenticated operations. Unverified
+    /// legacy sessions and temporary playback credentials cannot acquire it.
+    func captureDurableAccountAuth() -> CapturedDurableAccountAuth? {
+        guard temporaryScope == nil, let request = captureOrdinaryRequestAuth(),
+              !runtimeBlockedServers.contains(activeServerId), let session = canonicalSession,
+              let accountID = session.accountID, let epoch = session.epoch,
+              session.origin == request.account.serverURL, session.accessToken == request.accessToken else { return nil }
+        return CapturedDurableAccountAuth(accountID: accountID, accountEpoch: epoch, request: request)
+    }
+
+    /// Execute a synchronous effect in the same actor turn as its durable
+    /// authority check. No credential/profile mutation can interleave before
+    /// the effect. Throws `HTTPError.authorityChanged` when the verified
+    /// account, its epoch, or the request owner moved since `expected` was
+    /// captured.
+    func withCurrentDurableAuthority(_ expected: CapturedDurableAccountAuth,
+                                     operation: @Sendable () throws -> Void) throws {
+        try Task.checkCancellation()
+        guard let current = captureDurableAccountAuth(), current.accountID == expected.accountID,
+              current.accountEpoch == expected.accountEpoch, current.request == expected.request else {
+            throw HTTPError.authorityChanged
+        }
+        try operation()
+    }
+
     /// Capture the account, credential owner, and complete request auth header
     /// set in one actor turn. The request carries this immutable identity
     /// through its 401 path so a later server, temporary-owner, or profile
@@ -344,13 +405,42 @@ actor TokenStore {
         matchingIdentityOf expected: CapturedOrdinaryRequestAuth
     ) -> CapturedOrdinaryRequestAuth? {
         guard let current = captureOrdinaryRequestAuth(),
-              current.account == expected.account,
-              current.credentialOwner == expected.credentialOwner,
-              current.profileId == expected.profileId,
-              current.profileToken == expected.profileToken else {
+              current.sameCredentialIdentity(as: expected) else {
             return nil
         }
         return current
+    }
+
+    /// Ownership fence for one awaited operation.
+    ///
+    /// `auth` is the owner captured with `captureOrdinaryRequestAuth()` before
+    /// the caller left the actor. The fence checks that owner is still current
+    /// immediately before `body` runs and again after it returns, and throws
+    /// `HTTPError.authorityChanged` on either mismatch so a response can never
+    /// be applied to a profile, server, or temporary scope that replaced the one
+    /// that issued the request. The comparison is `sameCredentialIdentity(as:)`:
+    /// a shared refresh that only rotated the access token passes.
+    ///
+    /// The actor is not held while `body` is suspended, so `body` may call back
+    /// into the store or into other actors freely.
+    func withOwnerFence<T: Sendable>(
+        _ auth: CapturedOrdinaryRequestAuth,
+        _ body: @Sendable () async throws -> T
+    ) async throws -> T {
+        guard currentOrdinaryRequestAuth(matchingIdentityOf: auth) != nil else {
+            throw HTTPError.authorityChanged
+        }
+        let value = try await body()
+        guard currentOrdinaryRequestAuth(matchingIdentityOf: auth) != nil else {
+            throw HTTPError.authorityChanged
+        }
+        return value
+    }
+
+    /// An approved handoff must still belong to the owner captured before polling.
+    func beginTemporaryScope(_ scope: TemporaryAuthScope, expected: AccountInstallationExpectation) -> TemporaryAuthScopeSnapshot? {
+        guard captureAccountInstallationExpectation() == expected else { return nil }
+        return beginTemporaryScope(scope)
     }
 
     @discardableResult
@@ -590,6 +680,18 @@ actor TokenStore {
                 return false
             }
 
+            if let original = canonicalSession {
+                guard case .session(let current) = try? sessions.load(serverId), current == original else { return false }
+            }
+            let rotated = CanonicalAccountSession(version: 1, signedOut: false,
+                origin: canonicalSession?.origin ?? captured.account.serverURL,
+                accountID: canonicalSession?.accountID,
+                epoch: canonicalSession?.epoch ?? accountKeychain.get(accountEpochKey).flatMap(UUID.init(uuidString:)) ?? UUID(),
+                accessToken: accessValue, refreshToken: value)
+            do { try sessions.save(rotated, serverID: serverId) }
+            catch { blockRuntimeSession(); return false }
+            canonicalSession = rotated
+            mirrorCanonicalSession(rotated)
             cachedAccessToken = accessValue
             cachedRefreshToken = value
             recordSessionEvent(
@@ -672,6 +774,10 @@ actor TokenStore {
                 outcome: "cleared",
                 reason: "refreshRejected"
             )
+            let durable = sessions.invalidate(serverId)
+            runtimeBlockedServers.insert(serverId)
+            canonicalSession = nil
+            if !durable { recordSessionEvent(phase: "sessionInvalidation", outcome: "failed", reason: "persistenceUnavailable") }
             cachedAccessToken = nil
             cachedRefreshToken = nil
             cachedProfileToken = nil
@@ -735,7 +841,14 @@ actor TokenStore {
             ensureLoaded()
             return cachedAccessToken
         }
-        return accountKeychain.get(Self.accessTokenKey(for: serverId))
+        guard !runtimeBlockedServers.contains(serverId) else { return nil }
+        do {
+            switch try sessions.load(serverId) {
+            case .session(let value): return value.accessToken
+            case .signedOut: return nil
+            case .legacy: return accountKeychain.get(Self.accessTokenKey(for: serverId))
+            }
+        } catch { return nil }
     }
 
     /// Minimal launch-time check for whether the active server has a stored
@@ -746,31 +859,137 @@ actor TokenStore {
         if loadedForServerId == activeServerId {
             return cachedAccessToken != nil
         }
-        cachedAccessToken = accountKeychain.get(Self.accessTokenKey(for: serverId))
+        ensureLoaded()
         return cachedAccessToken != nil
     }
 
-    func saveTokens(accessToken: String, refreshToken: String) {
+    /// Compatibility entry point for unverified sessions; it creates no verified
+    /// durable account binding. Actual login/pairing installers supply accountID.
+    @discardableResult
+    func saveTokens(accessToken: String, refreshToken: String) -> Bool {
         if temporaryScope != nil {
             temporaryScope?.accessToken = accessToken
             temporaryScope?.refreshToken = refreshToken
-            return
+            return true
         }
-        guard !activeServerId.isEmpty else { return }
-        ensureLoaded()
+        return (try? installAccountSession(accessToken: accessToken, refreshToken: refreshToken, accountID: nil, clearProfile: false)) != nil
+    }
+
+    struct AccountInstallationExpectation: Equatable, Sendable {
+        let account: RefreshAccountIdentity?
+        let generation: UUID
+    }
+
+    func captureAccountInstallationExpectation() -> AccountInstallationExpectation {
+        AccountInstallationExpectation(account: refreshAccountIdentity(), generation: persistentCredentialGenerationID)
+    }
+
+    /// Explicit receiver targets are persisted without changing the active owner.
+    /// Comparison and checked keychain publication occur in one actor turn.
+    func installAccountSessionForServer(serverID: String, origin: String, accessToken: String,
+        refreshToken: String, accountID: String, expected: AccountInstallationExpectation) throws {
+        guard captureAccountInstallationExpectation() == expected, temporaryScope == nil else {
+            throw HTTPError.requestIdentityChanged
+        }
+        let origin = ServerRegistry.normalize(url: origin)
+        guard !serverID.isEmpty, !origin.isEmpty, !accountID.isEmpty,
+              !accessToken.isEmpty, !refreshToken.isEmpty else { throw AccountSessionPersistenceError.invalidIdentity }
+        let value = CanonicalAccountSession(version: 1, signedOut: false, origin: origin,
+            accountID: accountID, epoch: UUID(), accessToken: accessToken, refreshToken: refreshToken)
+        do { try sessions.save(value, serverID: serverID) }
+        catch {
+            runtimeBlockedServers.insert(serverID)
+            if serverID == activeServerId { blockRuntimeSession() }
+            throw error
+        }
+        runtimeBlockedServers.remove(serverID)
+        profileKeychain.delete(Self.profileTokenKey(for: serverID))
+        if serverID == activeServerId { defaults.removeObject(forKey: profileIdDefaultsKey) }
+        // A successful install consumes this expectation even for an inactive target.
         persistentCredentialGenerationID = UUID()
+        if serverID == activeServerId {
+            canonicalSession = nil
+            cachedAccessToken = nil
+            cachedRefreshToken = nil
+            cachedProfileToken = nil
+            loadedForServerId = nil
+        }
+    }
+
+    func installAccountSession(accessToken: String, refreshToken: String, accountID: String?, clearProfile: Bool = true, expectedAccount: RefreshAccountIdentity? = nil) throws {
+        if let expectedAccount, refreshAccountIdentity() != expectedAccount { throw HTTPError.requestIdentityChanged }
+        guard temporaryScope == nil, !activeServerId.isEmpty, !accessToken.isEmpty, !refreshToken.isEmpty,
+              accountID == nil || accountID?.isEmpty == false else { throw AccountSessionPersistenceError.invalidIdentity }
+        let origin = ServerRegistry.normalize(url: defaults.string(forKey: serverUrlDefaultsKey) ?? "")
+        guard !origin.isEmpty else { throw AccountSessionPersistenceError.invalidIdentity }
+        let value = CanonicalAccountSession(version: 1, signedOut: false, origin: origin, accountID: accountID,
+            epoch: UUID(), accessToken: accessToken, refreshToken: refreshToken)
+        do { try sessions.save(value, serverID: activeServerId) }
+        catch { blockRuntimeSession(); throw error }
+        runtimeBlockedServers.remove(activeServerId)
+        if clearProfile {
+            defaults.removeObject(forKey: profileIdDefaultsKey)
+            profileKeychain.delete(profileTokenKey)
+            cachedProfileToken = nil
+        } else {
+            // The install marks the cache loaded below, so the profile proof
+            // must reflect the Keychain now: a blocked or never-loaded slot
+            // would otherwise hide a stored proof until the next switch.
+            cachedProfileToken = profileKeychain.get(profileTokenKey)
+        }
+        persistentCredentialGenerationID = UUID()
+        canonicalSession = value
         cachedAccessToken = accessToken
         cachedRefreshToken = refreshToken
-        accountKeychain.set(accessToken, for: accessTokenKey)
-        accountKeychain.set(refreshToken, for: refreshTokenKey)
-        accountKeychain.set(UUID().uuidString, for: accountEpochKey)
+        loadedForServerId = activeServerId
+        mirrorCanonicalSession(value)
         mirrorActiveTokensForExtension()
+    }
+
+    /// Bind a legacy/unverified session only after an authenticated account response
+    /// under this exact token and process identity. Existing queues are not relabelled.
+    func bindVerifiedAccount(_ accountID: String, expected: CapturedOrdinaryRequestAuth) throws {
+        guard temporaryScope == nil else { return }
+        ensureLoaded()
+        guard !accountID.isEmpty, refreshAccountIdentity() == expected.account,
+              cachedAccessToken == expected.accessToken else { throw HTTPError.requestIdentityChanged }
+        // Access-only legacy credentials can still read account metadata, but cannot
+        // establish a refreshable durable login envelope or queue authority.
+        guard let access = cachedAccessToken, let refresh = cachedRefreshToken else { return }
+        if let canonicalSession {
+            guard canonicalSession.accountID == nil || canonicalSession.accountID == accountID else {
+                throw AccountSessionPersistenceError.invalidIdentity
+            }
+            if canonicalSession.accountID == accountID { return }
+        }
+        let legacyEpoch = accountKeychain.get(accountEpochKey).flatMap(UUID.init(uuidString:))
+        let value = CanonicalAccountSession(version: 1, signedOut: false, origin: expected.account.serverURL,
+            accountID: accountID, epoch: canonicalSession?.epoch ?? legacyEpoch ?? UUID(), accessToken: access, refreshToken: refresh)
+        do { try sessions.save(value, serverID: activeServerId) }
+        catch { blockRuntimeSession(); throw error }
+        canonicalSession = value
+        mirrorCanonicalSession(value)
+    }
+
+    private func mirrorCanonicalSession(_ value: CanonicalAccountSession) {
+        if let access = value.accessToken { accountKeychain.set(access, for: accessTokenKey) }
+        if let refresh = value.refreshToken { accountKeychain.set(refresh, for: refreshTokenKey) }
+        if let epoch = value.epoch { accountKeychain.set(epoch.uuidString, for: accountEpochKey) }
+    }
+
+    private func blockRuntimeSession() {
+        runtimeBlockedServers.insert(activeServerId)
+        persistentCredentialGenerationID = UUID()
+        cachedAccessToken = nil; cachedRefreshToken = nil; cachedProfileToken = nil; canonicalSession = nil
+        loadedForServerId = activeServerId
+        clearMirroredTokensForExtension()
     }
 
     /// Clear tokens for the active server only. Leaves other servers'
     /// stored tokens intact and leaves the active-server registry entry
     /// in place (sign-out keeps the URL / name).
-    func clearTokens() {
+    @discardableResult
+    func clearTokens() -> Bool {
         // The deliberate counterpart to `invalidateRejectedRefresh`: reaching
         // login through this path means the app dropped the session on
         // purpose (sign-out), not because the server rejected it. Reports that
@@ -784,8 +1003,11 @@ actor TokenStore {
                 outcome: "cleared",
                 reason: "temporaryScope"
             )
-            return
+            return true
         }
+        let durable = activeServerId.isEmpty || sessions.invalidate(activeServerId)
+        runtimeBlockedServers.insert(activeServerId)
+        canonicalSession = nil
         ensureLoaded()
         persistentCredentialGenerationID = UUID()
         cachedAccessToken = nil
@@ -799,7 +1021,7 @@ actor TokenStore {
                 outcome: "cleared",
                 reason: "noActiveServer"
             )
-            return
+            return true
         }
         recordSessionEvent(
             phase: "clearTokens",
@@ -812,17 +1034,22 @@ actor TokenStore {
         profileKeychain.delete(profileTokenKey)
         defaults.removeObject(forKey: profileIdDefaultsKey)
         clearMirroredTokensForExtension()
+        return durable
     }
 
     /// Delete tokens for an arbitrary server. Used by the registry when
     /// removing a server or signing out from a non-active server.
-    func deleteTokens(for serverId: String) {
-        guard !serverId.isEmpty else { return }
+    @discardableResult
+    func deleteTokens(for serverId: String) -> Bool {
+        guard !serverId.isEmpty else { return true }
+        let durable = sessions.invalidate(serverId)
+        runtimeBlockedServers.insert(serverId)
         accountKeychain.delete(Self.accessTokenKey(for: serverId))
         accountKeychain.delete(Self.refreshTokenKey(for: serverId))
         accountKeychain.delete(Self.accountEpochKey(for: serverId))
         profileKeychain.delete(Self.profileTokenKey(for: serverId))
         if serverId == activeServerId {
+            canonicalSession = nil
             persistentCredentialGenerationID = UUID()
             cachedAccessToken = nil
             cachedRefreshToken = nil
@@ -830,6 +1057,7 @@ actor TokenStore {
             loadedForServerId = nil
             clearMirroredTokensForExtension()
         }
+        return durable
     }
 
     // MARK: - Profile
@@ -879,7 +1107,14 @@ actor TokenStore {
     }
 
     func getOrCreateAccountEpoch(for serverID: String) -> String? {
-        guard !serverID.isEmpty else { return nil }
+        guard !serverID.isEmpty, !runtimeBlockedServers.contains(serverID) else { return nil }
+        do {
+            switch try sessions.load(serverID) {
+            case .session(let value): return value.epoch?.uuidString
+            case .signedOut: return nil
+            case .legacy: break
+            }
+        } catch { return nil }
         let epochKey = Self.accountEpochKey(for: serverID)
         let accessKey = Self.accessTokenKey(for: serverID)
         if let existing = accountKeychain.get(epochKey), !existing.isEmpty {
@@ -970,7 +1205,12 @@ actor TokenStore {
     }
 
     func setServerUrl(_ url: String) {
-        defaults.set(ServerRegistry.normalize(url: url), forKey: serverUrlDefaultsKey)
+        let normalized = ServerRegistry.normalize(url: url)
+        if normalized != defaults.string(forKey: serverUrlDefaultsKey) {
+            loadedForServerId = nil
+            persistentCredentialGenerationID = UUID()
+        }
+        defaults.set(normalized, forKey: serverUrlDefaultsKey)
     }
 
     // MARK: - Private
@@ -1029,9 +1269,27 @@ actor TokenStore {
             cachedRefreshToken = nil
             cachedProfileToken = nil
         } else {
-            cachedAccessToken = accountKeychain.get(accessTokenKey)
-            cachedRefreshToken = accountKeychain.get(refreshTokenKey)
-            cachedProfileToken = profileKeychain.get(profileTokenKey)
+            canonicalSession = nil
+            cachedAccessToken = nil; cachedRefreshToken = nil; cachedProfileToken = nil
+            if !runtimeBlockedServers.contains(activeServerId) {
+                do {
+                    switch try sessions.load(activeServerId) {
+                    case .session(let value):
+                        let origin = ServerRegistry.normalize(url: defaults.string(forKey: serverUrlDefaultsKey) ?? "")
+                        if value.origin == origin {
+                            canonicalSession = value
+                            cachedAccessToken = value.accessToken
+                            cachedRefreshToken = value.refreshToken
+                            cachedProfileToken = profileKeychain.get(profileTokenKey)
+                        }
+                    case .signedOut: break
+                    case .legacy:
+                        cachedAccessToken = accountKeychain.get(accessTokenKey)
+                        cachedRefreshToken = accountKeychain.get(refreshTokenKey)
+                        cachedProfileToken = profileKeychain.get(profileTokenKey)
+                    }
+                } catch { runtimeBlockedServers.insert(activeServerId) }
+            }
         }
         loadedForServerId = activeServerId
     }

--- a/iosApp/iosApp/Notifications/ApplePushRegistration.swift
+++ b/iosApp/iosApp/Notifications/ApplePushRegistration.swift
@@ -4,7 +4,7 @@ import OSLog
 import UIKit
 import UserNotifications
 
-struct ApplePushRegistrationRequest: Encodable, Equatable {
+struct ApplePushRegistrationRequest: Encodable, Equatable, Sendable {
     let deviceId: String
     let apnsToken: String
     let apnsEnvironment: String
@@ -12,7 +12,7 @@ struct ApplePushRegistrationRequest: Encodable, Equatable {
     let pushMode: String
 }
 
-struct ApplePushRegistrationResponse: Decodable {
+struct ApplePushRegistrationResponse: Decodable, Sendable {
     let id: String
     let serverDeviceId: String
     let enabled: Bool
@@ -151,11 +151,6 @@ enum ApplePushRegistrationWire {
     }
 }
 
-struct ApplePushRegistrationIdentity: Equatable {
-    let account: RefreshAccountIdentity
-    let profileID: String
-}
-
 @MainActor
 final class ApplePushRegistrationCoordinator {
     static let shared = ApplePushRegistrationCoordinator()
@@ -258,20 +253,27 @@ final class ApplePushRegistrationCoordinator {
         inFlightFingerprint = fingerprint
         defer { inFlightFingerprint = nil }
 
-        // Snapshot the identity the registration is for. The response may
-        // land after a sign-out, server switch, or profile change has already
-        // cleared the display-token slot for the new context; writing the
-        // old context's token into it would resurrect a revoked credential.
-        let identityBefore = await Self.currentIdentity()
+        // Snapshot the owner the registration is for. The response may land
+        // after a sign-out, server switch, profile change, or PIN
+        // re-verification has already cleared the display-token slot for the
+        // new context; writing the old context's token into it would
+        // resurrect a revoked credential. `withOwnerFence` rejects the
+        // response unless the account, credential owner, profile, and profile
+        // proof are all still the ones that issued the request.
+        let tokenStore = TokenStore.shared
+        guard let owner = await tokenStore.captureOrdinaryRequestAuth() else {
+            // No resolvable account: the request could only have gone out
+            // unauthenticated and been refused.
+            Self.logger.info("Skipping Apple push registration: no account identity to register under")
+            return
+        }
 
         do {
-            let response: ApplePushRegistrationResponse = try await HTTPClient.shared.post(
-                ApplePushRegistrationWire.endpoint,
-                body: request
-            )
-            guard await Self.currentIdentity() == identityBefore else {
-                Self.logger.info("Discarding Apple push registration response: identity changed while in flight")
-                return
+            let response: ApplePushRegistrationResponse = try await tokenStore.withOwnerFence(owner) {
+                try await HTTPClient.shared.post(
+                    ApplePushRegistrationWire.endpoint,
+                    body: request
+                )
             }
             lastSuccessfulFingerprint = fingerprint
             endpointUnsupportedForContext = nil
@@ -281,28 +283,19 @@ final class ApplePushRegistrationCoordinator {
             let storedDisplayToken = displayTokenStore.store(
                 response.displayToken,
                 expiresAt: response.displayTokenExpiresAt,
-                serverId: identityBefore?.account.serverId ?? ""
+                serverId: owner.account.serverId
             )
             // Older servers return none; back off for this context for a while.
             displayTokenUnavailable = response.displayToken == nil ? (fingerprint, Date()) : nil
             Self.logger.info("Registered APNs token with Silo server_device_id=\(response.serverDeviceId, privacy: .private) enabled=\(response.enabled, privacy: .public) displayToken=\(response.displayToken != nil, privacy: .public) stored=\(storedDisplayToken, privacy: .public)")
+        } catch HTTPError.authorityChanged {
+            Self.logger.info("Discarding Apple push registration response: identity changed while in flight")
         } catch HTTPError.http(let statusCode, _) where statusCode == 404 || statusCode == 405 {
             endpointUnsupportedForContext = fingerprint
             Self.logger.info("Apple push device endpoint is not available on this Silo server yet")
         } catch {
             Self.logger.error("Apple push device registration failed: \(String(describing: error), privacy: .public)")
         }
-    }
-
-    /// The account (server + credential generation) and profile a
-    /// registration belongs to. Any change, including a sign-out and
-    /// sign-in to the same server, produces a different value.
-    private static func currentIdentity() async -> ApplePushRegistrationIdentity? {
-        guard let account = await TokenStore.shared.refreshAccountIdentity() else { return nil }
-        return ApplePushRegistrationIdentity(
-            account: account,
-            profileID: await TokenStore.shared.getProfileId() ?? ""
-        )
     }
 
     private func makeRegistrationRequest(deviceToken: Data) -> ApplePushRegistrationRequest {

--- a/iosApp/iosApp/Pairing/Receiver/ReceiverPairingCoordinator.swift
+++ b/iosApp/iosApp/Pairing/Receiver/ReceiverPairingCoordinator.swift
@@ -354,6 +354,9 @@ final class ReceiverPairingCoordinator {
             return false
         }
         let previousTokenServerID = await TokenStore.shared.getActiveServerId()
+        let previousServerURL = await TokenStore.shared.getServerUrl()
+        let previousProfileID = await TokenStore.shared.getProfileId()
+        let previousProfileToken = await TokenStore.shared.getProfileToken()
         // From this first persistent mutation onward the transaction must
         // finish even if the pairing task is cancelled. Publishing failure
         // after committed credentials would make the phone and TV disagree.
@@ -366,7 +369,18 @@ final class ReceiverPairingCoordinator {
         await TokenStore.shared.setProfileId(nil)
         await TokenStore.shared.setProfileToken(nil)
         guard await TokenStore.shared.saveTokens(accessToken: access, refreshToken: refresh) else {
+            // The session record could not be written, so nothing durable was
+            // committed for the candidate. Put every TokenStore mutation above
+            // back the way it was: the active server, its URL, and the profile
+            // selection. Otherwise the registry still names the previous server
+            // while the token store already points at the candidate URL, and a
+            // canonical session bound to the previous origin reads as logged
+            // out. The registry entry stays: it carries no credential, and the
+            // user can retry pairing against it.
+            await TokenStore.shared.setServerUrl(previousServerURL)
             await TokenStore.shared.switchActiveServer(serverId: previousTokenServerID)
+            await TokenStore.shared.setProfileId(previousProfileID)
+            _ = await TokenStore.shared.setProfileToken(previousProfileToken)
             await HTTPClient.shared.endIdentityTransition(transitionLease)
             return false
         }

--- a/iosApp/iosApp/Pairing/Receiver/ReceiverPairingCoordinator.swift
+++ b/iosApp/iosApp/Pairing/Receiver/ReceiverPairingCoordinator.swift
@@ -388,7 +388,15 @@ final class ReceiverPairingCoordinator {
             serverId: id,
             holding: transitionLease
         ) else {
+            // Same rollback as the failed save above. The candidate's tokens
+            // are already persisted under its own server id, which is harmless
+            // and lets a retry succeed, but the previous server must get its
+            // URL and profile back or its canonical session no longer matches
+            // its origin and it reads as logged out.
+            await TokenStore.shared.setServerUrl(previousServerURL)
             await TokenStore.shared.switchActiveServer(serverId: previousTokenServerID)
+            await TokenStore.shared.setProfileId(previousProfileID)
+            _ = await TokenStore.shared.setProfileToken(previousProfileToken)
             await HTTPClient.shared.endIdentityTransition(transitionLease)
             return false
         }

--- a/iosApp/iosApp/Pairing/Receiver/ReceiverPairingCoordinator.swift
+++ b/iosApp/iosApp/Pairing/Receiver/ReceiverPairingCoordinator.swift
@@ -365,7 +365,11 @@ final class ReceiverPairingCoordinator {
         await TokenStore.shared.switchActiveServer(serverId: id)
         await TokenStore.shared.setProfileId(nil)
         await TokenStore.shared.setProfileToken(nil)
-        await TokenStore.shared.saveTokens(accessToken: access, refreshToken: refresh)
+        guard await TokenStore.shared.saveTokens(accessToken: access, refreshToken: refresh) else {
+            await TokenStore.shared.switchActiveServer(serverId: previousTokenServerID)
+            await HTTPClient.shared.endIdentityTransition(transitionLease)
+            return false
+        }
         guard await ServerRegistry.shared.commitSwitchTo(
             serverId: id,
             holding: transitionLease

--- a/iosApp/iosApp/Screens/Auth/AuthService.swift
+++ b/iosApp/iosApp/Screens/Auth/AuthService.swift
@@ -175,10 +175,20 @@ final class AuthService: @unchecked Sendable {
             launchPreferences.clearRememberedProfile(for: serverID)
         }
         await TokenStore.shared.clearTokens()
-        await TokenStore.shared.saveTokens(
-            accessToken: accessToken,
-            refreshToken: refreshToken
-        )
+        do {
+            // v1 login responses carry no verified account id for the durable
+            // binding; the session installs unverified, exactly as
+            // `saveTokens` did, but a failed persist is reported instead of
+            // returning a "logged in" that does not survive the next launch.
+            try await TokenStore.shared.installAccountSession(
+                accessToken: accessToken,
+                refreshToken: refreshToken,
+                accountID: nil
+            )
+        } catch {
+            await HTTPClient.shared.endIdentityTransition(transitionLease)
+            throw error
+        }
         await clearAllCaches()
         await HTTPClient.shared.endIdentityTransition(transitionLease)
     }

--- a/iosApp/iosApp/Screens/Auth/RestoredSessionValidator.swift
+++ b/iosApp/iosApp/Screens/Auth/RestoredSessionValidator.swift
@@ -132,7 +132,7 @@ struct RestoredSessionValidator: Sendable {
         }
 
         switch httpError {
-        case .requestIdentityChanged:
+        case .requestIdentityChanged, .authorityChanged:
             return .identityChanged
         case .network, .encodingFailed:
             return .indeterminate

--- a/iosApp/iosApp/Shared/AccountSessionPersistence.swift
+++ b/iosApp/iosApp/Shared/AccountSessionPersistence.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+struct CanonicalAccountSession: Codable, Equatable, Sendable {
+    let version: Int
+    let signedOut: Bool
+    let origin: String?
+    let accountID: String?
+    let epoch: UUID?
+    let accessToken: String?
+    let refreshToken: String?
+
+    static let tombstone = CanonicalAccountSession(version: 1, signedOut: true, origin: nil,
+        accountID: nil, epoch: nil, accessToken: nil, refreshToken: nil)
+}
+
+enum AccountSessionPersistenceError: Error {
+    case unavailable, invalidRecord, invalidIdentity
+}
+
+/// The adoption marker is written first. Once present, missing/corrupt/inaccessible
+/// canonical state fails closed; legacy mirrors can never become authoritative again.
+struct AccountSessionPersistence: Sendable {
+    enum State { case legacy, signedOut, session(CanonicalAccountSession) }
+    let read: @Sendable (String) throws -> String?
+    let write: @Sendable (String, String) -> Bool
+    let remove: @Sendable (String) -> Bool
+
+    init(keychain: SharedKeychain) {
+        let account = keychain.withAudience(.userIndependent)
+        read = { try account.getChecked($0) }
+        write = { account.set($0, for: $1) }
+        remove = { account.delete($0) }
+    }
+
+    init(read: @escaping @Sendable (String) throws -> String?,
+         write: @escaping @Sendable (String, String) -> Bool,
+         remove: @escaping @Sendable (String) -> Bool) {
+        self.read = read; self.write = write; self.remove = remove
+    }
+
+    static func recordKey(_ serverID: String) -> String { "com.continuum.\(serverID).accountSession" }
+    static func markerKey(_ serverID: String) -> String { "com.continuum.\(serverID).accountSessionAdopted" }
+
+    func load(_ serverID: String) throws -> State {
+        let adopted = try read(Self.markerKey(serverID))
+        guard let raw = try read(Self.recordKey(serverID)) else {
+            return adopted == nil ? .legacy : .signedOut
+        }
+        let value = try JSONDecoder().decode(CanonicalAccountSession.self, from: Data(raw.utf8))
+        guard value.version == 1 else { throw AccountSessionPersistenceError.invalidRecord }
+        if value.signedOut { return .signedOut }
+        guard let origin = value.origin, !origin.isEmpty, value.epoch != nil,
+              value.accessToken?.isEmpty == false, value.refreshToken?.isEmpty == false,
+              value.accountID == nil || value.accountID?.isEmpty == false else {
+            throw AccountSessionPersistenceError.invalidRecord
+        }
+        return .session(value)
+    }
+
+    func save(_ value: CanonicalAccountSession, serverID: String) throws {
+        guard !serverID.isEmpty else { throw AccountSessionPersistenceError.invalidIdentity }
+        let raw = String(decoding: try JSONEncoder().encode(value), as: UTF8.self)
+        guard write("1", Self.markerKey(serverID)), write(raw, Self.recordKey(serverID)) else {
+            throw AccountSessionPersistenceError.unavailable
+        }
+    }
+
+    /// A durable marker plus absent record is also a signed-out state. If neither
+    /// tombstone nor removal can persist, callers must report durable sign-out failure.
+    func invalidate(_ serverID: String) -> Bool {
+        guard !serverID.isEmpty, write("1", Self.markerKey(serverID)) else { return false }
+        if let raw = try? JSONEncoder().encode(CanonicalAccountSession.tombstone),
+           write(String(decoding: raw, as: UTF8.self), Self.recordKey(serverID)) { return true }
+        return remove(Self.recordKey(serverID))
+    }
+}
+
+extension AccountSessionPersistenceError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .unavailable:
+            return "Sign-in could not be saved on this device. Try again."
+        case .invalidRecord:
+            return "The sign-in saved on this device is unreadable. Sign in again."
+        case .invalidIdentity:
+            return "The active server changed before sign-in could be saved."
+        }
+    }
+}

--- a/iosApp/iosApp/Shared/Diagnostics/DiagnosticsCoordinator.swift
+++ b/iosApp/iosApp/Shared/Diagnostics/DiagnosticsCoordinator.swift
@@ -2349,7 +2349,8 @@ actor DiagnosticsCoordinator {
             case .http(let statusCode, _):
                 return (500...599).contains(statusCode)
             case .serverUrlNotConfigured, .invalidURL, .invalidResponse,
-                 .requestIdentityChanged, .encodingFailed, .decodingFailed:
+                 .requestIdentityChanged, .authorityChanged, .encodingFailed,
+                 .decodingFailed:
                 return false
             }
         }

--- a/iosApp/iosApp/Shared/SharedStorage.swift
+++ b/iosApp/iosApp/Shared/SharedStorage.swift
@@ -309,6 +309,13 @@ struct SharedKeychain {
         return false
     }
 
+    /// A strict read that failed with a Keychain status other than success or
+    /// item-not-found. Carries the `OSStatus` so the cause survives the throw.
+    struct ReadError: Error, CustomStringConvertible {
+        let status: OSStatus
+        var description: String { "keychain_read_failed(status=\(status))" }
+    }
+
     /// Strict reads for canonical authority. A locked/inaccessible keychain is
     /// not an absent record and must never authorize a legacy fallback.
     func getChecked(_ account: String) throws -> String? {
@@ -317,11 +324,15 @@ struct SharedKeychain {
         if shouldUseAppLocalFallback(for: configured.status) {
             let fallback = readResult(account: account, accessGroup: nil)
             guard fallback.status == errSecSuccess || fallback.status == errSecItemNotFound else {
-                throw CocoaError(.fileReadNoPermission)
+                Self.logger.error("App-local Keychain fallback checked read failed: status=\(fallback.status, privacy: .public)")
+                throw ReadError(status: fallback.status)
             }
             return fallback.value
         }
-        guard configured.status == errSecItemNotFound else { throw CocoaError(.fileReadNoPermission) }
+        guard configured.status == errSecItemNotFound else {
+            Self.logger.error("Keychain checked read failed: status=\(configured.status, privacy: .public)")
+            throw ReadError(status: configured.status)
+        }
         return nil
     }
 

--- a/iosApp/iosApp/Shared/SharedStorage.swift
+++ b/iosApp/iosApp/Shared/SharedStorage.swift
@@ -309,6 +309,22 @@ struct SharedKeychain {
         return false
     }
 
+    /// Strict reads for canonical authority. A locked/inaccessible keychain is
+    /// not an absent record and must never authorize a legacy fallback.
+    func getChecked(_ account: String) throws -> String? {
+        let configured = readResult(account: account, accessGroup: accessGroup)
+        if configured.status == errSecSuccess { return configured.value }
+        if shouldUseAppLocalFallback(for: configured.status) {
+            let fallback = readResult(account: account, accessGroup: nil)
+            guard fallback.status == errSecSuccess || fallback.status == errSecItemNotFound else {
+                throw CocoaError(.fileReadNoPermission)
+            }
+            return fallback.value
+        }
+        guard configured.status == errSecItemNotFound else { throw CocoaError(.fileReadNoPermission) }
+        return nil
+    }
+
     func get(_ account: String) -> String? {
         let configuredRead = readResult(account: account, accessGroup: accessGroup)
         if let found = configuredRead.value {

--- a/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
+++ b/iosApp/iosApp/Startup/StartupContentPrefetcher.swift
@@ -250,7 +250,7 @@ enum StartupContentPrefetcher {
         switch httpError {
         case .serverUrlNotConfigured:
             return "no_server"
-        case .requestIdentityChanged:
+        case .requestIdentityChanged, .authorityChanged:
             return "identity_changed"
         case .network(let underlying):
             // A cancellation reaches here wrapped: `HTTPClient.perform` catches


### PR DESCRIPTION

## Problem

Main has one ownership fence spelling: capture `captureOrdinaryRequestAuth()` before an await, re-check `currentOrdinaryRequestAuth(matchingIdentityOf:)` after it. The apiv2 branch reproduced that comparison by hand 24 times with divergent field sets (`HTTPClient.swift` omits `credentialOwner`, `ReadOwnedMembershipModel.swift` includes it), and `ApplePushRegistration.swift` on main fences with its own `ApplePushRegistrationIdentity` that compares only account and profile id, not the credential owner or the profile proof. Gate 2 needs one comparator, one fence helper, and the durable account owner (`CapturedDurableAccountAuth`) that the write surfaces build on, so PR 2c and the gate 3 PRs can replace the two-line ceremony with a single call.

## Solution

Branch `apiv2-replay/identity`, based on `origin/main` @ `f31ca261`, head `73890946` (two commits: the port at `652d9c05` and one fix-up). Not stacked; merges first in gate 2.

- `CapturedOrdinaryRequestAuth.sameCredentialIdentity(as:)` (`Networking/TokenStore.swift`) compares `account`, `credentialOwner`, `profileId`, and `profileToken`. `accessToken` is the only stored field excluded so a completed shared refresh still matches. `currentOrdinaryRequestAuth(matchingIdentityOf:)` now calls it, so there is exactly one comparator.
- `TokenStore.withOwnerFence<T: Sendable>(_ auth: CapturedOrdinaryRequestAuth, _ body: @Sendable () async throws -> T) async throws -> T` checks the captured owner immediately before `body` runs and again after it returns, and throws **`HTTPError.authorityChanged`** on either mismatch. PR 2c should match on that exact spelling. Its log-safe `description` is `authority_changed`; `ErrorState`, `StartupContentPrefetcher.prefetchFailureReason` (`identity_changed`), and `DiagnosticsCoordinator` treat it the same as `requestIdentityChanged`.
- `ApplePushRegistration.swift` moves from its hand-rolled account+profileID snapshot onto `withOwnerFence`, which also covers `credentialOwner` and `profileToken`. `ApplePushRegistrationIdentity` and `currentIdentity()` are deleted; the fence sits at exactly the same point (capture before `post`, re-check before the display-token write).
- Ported from apiv2 `1a546711`: `CapturedDurableAccountAuth`, `Shared/AccountSessionPersistence.swift` (`CanonicalAccountSession`, `AccountSessionPersistenceError`, `AccountSessionPersistence`), `SharedKeychain.getChecked(_:)`, and the `TokenStore` plumbing they need (`sessions` / `canonicalSession` / `runtimeBlockedServers`, `init(sessionPersistence:)`, `captureDurableAccountAuth`, `withCurrentDurableAuthority`, `AccountInstallationExpectation`, `captureAccountInstallationExpectation`, `installAccountSession`, `installAccountSessionForServer`, `bindVerifiedAccount`, `beginTemporaryScope(_:expected:)`, session-aware `ensureLoaded` / `getAccessToken(for:)` / `getOrCreateAccountEpoch(for:)` / `saveRefreshedTokens` / `invalidateRejectedRefresh`, and `saveTokens` / `clearTokens` / `deleteTokens` returning `Bool`). `withCurrentDurableAuthority` throws `HTTPError.authorityChanged` (apiv2 threw `requestIdentityChanged`) so the two fence helpers share one error. Nothing from settings, playback, downloads, or push sync came along.
- Two additions beyond a straight port: `installAccountSession(clearProfile: false)` reloads `cachedProfileToken` from the Keychain because the install marks the cache loaded (apiv2 left a stale nil there); and `AccountSessionPersistenceError` gains `LocalizedError` copy because it now reaches the login screen.
- `AuthService.installSession` calls `installAccountSession(accountID: nil)` directly and rethrows a failed persist (apiv2's `saveTokens` returned `false` and main ignored the result). `ReceiverPairingCoordinator.persistServer` returns `false` and restores the previous token server when the persist fails. Both paths previously reported a login that would not survive relaunch.

### Fix-up after verification

Verification blocked `652d9c05` on one §1 finding: the ported session-persistence paths in `Networking/TokenStore.swift` swallowed their errors with no breadcrumb, and `SharedKeychain.getChecked` dropped the `OSStatus` when it threw. Commit `73890946` adds a breadcrumb at each site with the file's existing literal-only `recordSessionEvent(phase:outcome:reason:)` pattern. No control flow, return value, thrown error type, or fence moved.

| Site (`652d9c05` line) | Breadcrumb now recorded |
|---|---|
| `saveRefreshedTokens` canonical-session guard (`:683/:684`) | `tokenRefresh/discarded/canonicalSessionMismatch` when the stored record differs; `tokenRefresh/discarded/<load reason>` when the load throws |
| `saveRefreshedTokens` rotated-record save (`:692`) | `tokenRefresh/failed/<reason>` before `blockRuntimeSession()` |
| `getAccessToken(for:)` (`:851`) | `sessionLoad/failed/<reason>` |
| `saveTokens` (`:875`) | `sessionInstall/failed/<reason>` (the `try?` became `do/catch`; still returns `false`) |
| `getOrCreateAccountEpoch(for:)` (`:1117`) | `sessionLoad/failed/<reason>` |
| `ensureLoaded` fail-closed catch (`:1291`) | `sessionLoad/blocked/<reason>` |
| `SharedStorage.swift` `getChecked` | Throws a new `SharedKeychain.ReadError(status:)` carrying the `OSStatus` and logs it with the existing `Logger`, matching `get` |

`<reason>` is one of five compile-time literals chosen by a private `persistenceFailureReason(_:)` switch: `persistenceUnavailable`, `invalidSessionRecord` (also for `DecodingError`), `invalidSessionIdentity`, `keychainReadFailed` (`SharedKeychain.ReadError`), with `persistenceUnavailable` as the default. No token, URL, server id, or error description reaches a breadcrumb. `:692` and `:875` got the breadcrumb too, even though `SharedKeychain.set` already logs the write `OSStatus` one frame down; the breadcrumb distinguishes `.invalidIdentity` from `.unavailable`, which the unified-log line cannot.

No test was added for the `:1291` breadcrumb: `DiagTrace.breadcrumb` writes into `DiagnosticsCoordinator`'s private static journal behind the consent gate, and there is no test-visible read hook, so asserting it would need a bespoke stub. The existing `testReadFailureAndCorruptionNeverFallback` still exercises both fail-closed causes (read failure and corrupt record) and passed.

### Converting main's 5 `matchingIdentityOf` sites

| Site on main | What happened |
|---|---|
| `TokenStore.swift:344` declaration | Kept. Now delegates to `sameCredentialIdentity(as:)`; it is the primitive `withOwnerFence` calls. |
| `HTTPClient.swift:969` (401 retry, `== refreshedAuth`) | Kept as is, with a comment. It compares the whole refreshed snapshot (including the rotated `accessToken`) so the retry attaches exactly the credentials current now; `withOwnerFence` returns the body value, not the current auth. |
| `HTTPClient.swift:1877`, `:1893`, `:1917` (`refreshTokens` pre-check, after joining a flight, after own flight) | Kept as is. Each needs the returned `current` value to compare `accessToken` against `expected`; the check already goes through the single comparator. Wrapping them would add a second fence around a non-suspending call without changing behavior. |
| `ApplePushRegistration.swift:265/272` (hand-rolled, not `matchingIdentityOf`) | Converted to `withOwnerFence`. This is the production-bug site the brief cites. |

No fence was deleted. The refresh path sites are not the capture/await/re-check ceremony; they are the credential-rotation detector the ceremony depends on, and the brief's escape clause ("keep the existing spelling there, make it call `sameCredentialIdentity(as:)`") applies.

## Validation evidence

Head `73890946`. All commands ran from the worktree on dedicated simulators (`gate2-2af-ios` 0BAAA60D-62BA-473B-905E-236A29B5F034, iPhone 17 / iOS 27.0; `gate2-2af-tvos` 74F6D58F-8981-4A5A-A77D-378E73C28D42, Apple TV 4K 3rd gen / tvOS 27.0) and DerivedData `$HOME/silo-build-gate2-2af`. Logs under `$HOME/silo-build-gate2-2af/logs/`. Unsigned builds are compile evidence only.

| Command | Result line | Log |
|---|---|---|
| `cd iosApp && /opt/homebrew/bin/xcodegen generate` | `Created project at .../iosApp/Silo.xcodeproj` | (stdout) |
| `xcodebuild build -project Silo.xcodeproj -scheme Silo -destination "id=0BAAA60D-…" -derivedDataPath "$HOME/silo-build-gate2-2af" CODE_SIGNING_ALLOWED=NO` | `** BUILD SUCCEEDED **` (exit 0, 0 `error:` lines) | `logs/build-ios.log` |
| `xcodebuild build -project Silo.xcodeproj -scheme SiloTV -destination "id=74F6D58F-…" -derivedDataPath "$HOME/silo-build-gate2-2af" CODE_SIGNING_ALLOWED=NO` | `** BUILD SUCCEEDED **` (exit 0, 0 `error:` lines) | `logs/build-tvos.log` |
| `xcodebuild build -project Silo.xcodeproj -scheme SiloMac -destination "platform=macOS" -derivedDataPath "$HOME/silo-build-gate2-2af" CODE_SIGNING_ALLOWED=NO` | `** BUILD SUCCEEDED **` (exit 0, 0 `error:` lines) | `logs/build-macos.log` |
| `xcodebuild test -project Silo.xcodeproj -scheme Silo -destination "id=0BAAA60D-…" -derivedDataPath "$HOME/silo-build-gate2-2af" -only-testing:SiloTests` | `** TEST SUCCEEDED **` (exit 0); `Executed 1326 tests, with 2 tests skipped and 0 failures (0 unexpected) in 34.265 (35.168) seconds`; `Test Suite 'AccountSessionPersistenceTests' passed`, `Test Suite 'CredentialIdentityTests' passed`; 0 `error:` lines | `logs/test-ios.log` |
| `SiloTVTests` | Not run: the target does not exist on this branch (`grep -c SiloTVTests iosApp/project.yml` = 0; PR 2b adds it). | — |

The earlier `652d9c05` run (`$HOME/silo-build-gate2-2a/logs/`) reported `Executed 1326 tests, with 2 tests skipped and 0 failures (0 unexpected)`; the verifier reproduced that on the pinned simulators. New suites: `AccountSessionPersistenceTests` (14 tests), `CredentialIdentityTests` (11 tests). The first pre-`SettingValuesAPITests`-port run failed 1 test in `testScopedRefreshRejectsChangedServerAccountAndTemporaryScope`; see Risks. That earlier log is kept as `$HOME/silo-build-gate2-2a/logs/test-ios-mixed-runs-1-and-2.log`.

## Fence counts

Counts are `withOwnerFence` + `matchingIdentityOf` tokens in code lines (comments excluded); `captureOrdinaryRequestAuth` for reference.

| File | apiv2 `1a546711` | PR `73890946` | Notes |
|---|---|---|---|
| `Networking/TokenStore.swift` | 2 (declaration; `withCurrentOrdinaryAuthority`) | 4 (declaration; `withOwnerFence` declaration; its two `matchingIdentityOf` checks) | `withCurrentOrdinaryAuthority` was not ported; its only apiv2 callers are in files later PRs own, and `withOwnerFence` covers the same check with an async body. `captureOrdinaryRequestAuth`: apiv2 2, PR 3. |
| `Networking/HTTPClient.swift` | 4 | 4 | Same four sites. apiv2's four extra hand-written `expectedAuth` compares (`427-428`, `464-466`, `975-977`, `1008-1010`) belong to the `expectedAuth:` parameter PR 2c introduces; not in scope here. |
| `Notifications/ApplePushRegistration.swift` | 1 | 1 | apiv2 rewrote this file around a journal; the PR fences main's existing site with `withOwnerFence`. main had 0 tokens here (hand-rolled compare). |
| `Shared/AccountSessionPersistence.swift` | 0 | 0 | New file; no fences by design. |
| **Total** | **7** | **9** | main: 5. |

## Risks

- `saveTokens` now routes through `installAccountSession`, which refuses an empty access or refresh token or an empty server URL and returns `false` instead of writing. Main's callers (`AuthService.installSession`, `ReceiverPairingCoordinator.persistServer`) now surface that; tests that call `saveTokens` before `setServerUrl` would silently store nothing (none do on this branch: all 30 test call sites set the URL first and still pass).
- `TokenStore.setServerUrl` now bumps the credential generation and invalidates the cache when the URL changes, and `ensureLoaded` binds a canonical session to its origin. This is apiv2's origin-binding behavior; `SettingValuesAPITests.testScopedRefreshRejectsChangedServerAccountAndTemporaryScope` was updated to apiv2's expectation (a retargeted origin exposes no refresh token, and a refresh credential captured before the retarget cannot rotate the restored session). Production only writes `serverUrl` through `ServerRegistry`, which sets it before `switchActiveServer`, so the runtime path is unchanged.
- `hasAccessTokenForActiveServer` now performs the full `ensureLoaded` (session record decode plus profile token read) instead of one Keychain read. It runs once at cold launch; the cost is two extra Keychain reads.
- A failed session-record write blocks the runtime session for that server (`runtimeBlockedServers`) until the next successful install. That is apiv2's fail-closed policy; it means a Keychain outage during login produces the login screen rather than a half-installed session. Since `73890946` each such block leaves a `tokenRefresh/failed`, `sessionInstall/failed`, or `sessionLoad/blocked` breadcrumb with a fixed reason literal.
- "Production only writes `serverUrl` through `ServerRegistry`" above is imprecise: `ReceiverPairingCoordinator.persistServer` also calls `TokenStore.setServerUrl` directly. The conclusion holds because `switchActiveServer` follows and resets the generation and cache anyway.
- Sign-out (`clearTokens`, `deleteTokens`) writes an adoption marker and a tombstone. On a future launch a legacy slot can no longer revive a session for that server. This is intended (tested by `testSignoutTombstoneAndRemovalFallbackPreventMirrorRevival`), and legacy slots are still mirrored on every install so the Top Shelf extension and `AuthService.isLoggedIn`, which read them directly, keep working.

## Follow-ups

- `AuthService.isLoggedIn` and `TopShelfHTTPClient` still read the legacy access-token Keychain slot directly. They agree with `TokenStore` today because every install mirrors into the legacy slots and every sign-out deletes them, but they will disagree if a server becomes runtime-blocked after a failed persist. apiv2 taught Top Shelf to read `AccountSessionPersistence` (`TopShelfHTTPClient.swift:37-51` on apiv2); that belongs to whichever PR touches Top Shelf, or PR 3j.
- Login and device-login responses on main carry `AuthUser.id: Int`; the durable binding needs a verified string account id. Until PR 3f moves login to v2 and calls `bindVerifiedAccount` / `installAccountSession(accountID:)`, `captureDurableAccountAuth()` returns `nil` for every session installed on main. Nothing on main calls it yet.
- `withCurrentOrdinaryAuthority` (apiv2 `TokenStore.swift:390`) was not ported. PR 3h/3i and the push-sync work that use it should call `withOwnerFence` instead, or ask for a sync same-turn variant if a non-async body is required.
- Second independent problem noted, not fixed: `HTTPClient.swift` on apiv2 adds an `expectedAuth:` pre-dispatch guard that omits `credentialOwner` (the audit's leak). When PR 2c introduces that parameter it should compare with `sameCredentialIdentity(as:)`.
- Surface or retry a failed durable sign-out: when both the tombstone write and record removal fail, `clearTokens` / `deleteTokens(for:)` return `false` and leave a `failed/persistenceUnavailable` breadcrumb, but callers still discard the result (raised in review; UX change out of scope for gate 2).

## Decisions needed from the developer

- **"Profile proof" field.** `CapturedOrdinaryRequestAuth` has no separate proof field on main or apiv2. The profile verification proof is `profileToken`; the comparator compares `profileId` and `profileToken` together. No field was added to the struct.
- **Error spelling.** `authorityChanged` is a new case on the existing `HTTPError` enum (`HTTPError.authorityChanged`), not a dedicated error type, so callers that already match `HTTPError` need no second catch chain and the existing exhaustive switches were extended. If you prefer a dedicated type, say so before PR 2c lands its 46 call sites.
- **`saveTokens` fail-closed behavior.** Keeping apiv2's semantics means a login whose session record cannot be written now fails visibly (throws `AccountSessionPersistenceError.unavailable` from `AuthService.installSession`, returns `false` from pairing). Main previously reported success and wrote nothing durable. Confirm this is the intended user-facing behavior.

## AI disclosure

Implemented and verified by Claude Fable 5.1 (model identifier `claude-fable-5-1`, 1M-context variant) running as subagents of the Claude Code desktop app (Code tab) via its Workflow multi-agent orchestration tool, orchestrated by the same model. No other AI tooling was used.

## Rebase onto current main

Rebased onto `main` at `71299aa3` (after #284, stale server recovery) before opening. `git merge-tree` reported no textual conflicts. Rebuilt and retested on the rebased stack (branch `apiv2-replay/wire` at `dbda477f`, which contains all three gate 2 branches):

| Check | Result |
|---|---|
| Silo (iOS simulator, signed, install + launch) | PASS |
| SiloTV (tvOS simulator, signed, install + launch) | PASS |
| SiloMac (compile-only, `CODE_SIGNING_ALLOWED=NO`) | BUILD SUCCEEDED |
| SiloTests | 1459 executed, 2 skipped, 0 failures |
| SiloTVTests | 1336 executed, 2 skipped, 0 failures |

One semantic conflict surfaced that git did not flag: #284's `RestoredSessionValidator` switches exhaustively over `HTTPError`, and this branch adds `HTTPError.authorityChanged`. Commit `d28f8e8b` maps `authorityChanged` to `.identityChanged`, the same treatment as `requestIdentityChanged`, matching the three other exhaustive switches this branch already updated.

## Verification (independent verifier, pre-rebase head)

A verifier agent that did not write the branch built all three platforms with the mac-builder helper, ran both test suites, counted fence sites against apiv2 `1a546711`, and checked the 13 audit invariants. Summary below; the pre-rebase evidence refers to the pre-rebase commit SHAs.


**Ready.** Both refuters reviewed the verifier's findings; no violation was raised, so none stands and none was overturned.

- Standing violations: none. (Refuter votes: none to record, since the verifier reported no violation and neither refuter raised one.)
- Violations overturned by both refuters: none.
- Builds and tests: Silo (iOS sim `1EDC379C-E54F-47CB-B32C-443EB049B728`) PASS, signed "Sign to Run Locally", install and launch, `** BUILD SUCCEEDED **`, log `/Users/macdev/silo-build-ios/gate2r-apiv2-replay-identity-ios.log` and `/tmp/silo-ios-simulator-build-73890946.log`; SiloTV (tvOS sim `69ED27D0-C293-40CA-956B-35CB341569F6`) PASS, signed, install and launch, `** BUILD SUCCEEDED **`, log `/Users/macdev/silo-build-tvos/gate2r-apiv2-replay-identity-tvos.log` and `/tmp/silo-tvos-simulator-build-73890946.log`; SiloMac `** BUILD SUCCEEDED **` compile-only with `CODE_SIGNING_ALLOWED=NO`, log `/Users/macdev/silo-build-macos/gate2r-apiv2-replay-identity-mac.log`; SiloTests executed 1326, failed 0 (2 skipped), log `/Users/macdev/silo-build-ios/gate2r-apiv2-replay-identity-tests.log`; SiloTVTests not run on this branch by the verifier (target absent; PR 2b adds it), evidence agent's scratch merge of 2a+2b executed 1204, failed 0, log `/Users/macdev/silo-build-tvos/gate2r-apiv2-replay-identity-tvtests.log`.
- Fence counts (`withOwnerFence` + `matchingIdentityOf`, equivalent code paths): apiv2 `1a546711` 7, PR `73890946` 9, main `f31ca261` 5. Verifier, evidence agent, and implementer agree on 9 for the PR.
- Decisions needed from the developer (implementer's list, verbatim):
  1. "Profile proof" field. CapturedOrdinaryRequestAuth has no separate proof field on main or apiv2. The profile verification proof is profileToken; the comparator compares profileId and profileToken together. No field was added to the struct.
  2. Error spelling. authorityChanged is a new case on the existing HTTPError enum (HTTPError.authorityChanged), not a dedicated error type, so callers that already match HTTPError need no second catch chain and the existing exhaustive switches were extended. If you prefer a dedicated type, say so before PR 2c lands its 46 call sites.
  3. saveTokens fail-closed behavior. Keeping apiv2's semantics means a login whose session record cannot be written now fails visibly (throws AccountSessionPersistenceError.unavailable from AuthService.installSession, returns false from pairing). Main previously reported success and wrote nothing durable. Confirm this is the intended user-facing behavior.
- Deferred by the implementer: no regression test for the `ensureLoaded` (`:1291`) breadcrumb, because `DiagTrace.breadcrumb` writes into `DiagnosticsCoordinator`'s private static `BreadcrumbJournal` behind the consent gate with no test-visible read hook; the existing `testReadFailureAndCorruptionNeverFallback` still covers both fail-closed causes and passed.

Rebased commits: 8dcc7c32, 36c2bf59, d28f8e8b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

