### PR TITLE
build(tests): add SiloTVTests target, shared URLProtocol stub, and tvOS CI

### DIFF
--- a/.github/workflows/player-regression.yml
+++ b/.github/workflows/player-regression.yml
@@ -41,9 +41,9 @@ jobs:
       matrix:
         include: >-
           ${{ fromJSON(inputs.ios_only &&
-            '[{"scheme":"Silo","destination":"platform=iOS Simulator,name=iPhone 17 Pro","action":"test"}]' ||
-            '[{"scheme":"Silo","destination":"platform=iOS Simulator,name=iPhone 17 Pro","action":"test"},
-              {"scheme":"SiloTV","destination":"generic/platform=tvOS Simulator","action":"build"},
+            '[{"scheme":"Silo","destination":"platform=iOS Simulator,name=iPhone 17 Pro","action":"test","platform":"iOS","test_target":"SiloTests"}]' ||
+            '[{"scheme":"Silo","destination":"platform=iOS Simulator,name=iPhone 17 Pro","action":"test","platform":"iOS","test_target":"SiloTests"},
+              {"scheme":"SiloTV","destination":"platform=tvOS Simulator,name=Apple TV 4K (3rd generation)","action":"test","platform":"tvOS","test_target":"SiloTVTests"},
               {"scheme":"SiloMac","destination":"generic/platform=macOS","action":"build"}]') }}
     steps:
       - uses: actions/checkout@v4
@@ -53,33 +53,54 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '26.3'
-      - name: Prepare iOS simulator
+      - name: Prepare simulator
         if: matrix.action == 'test'
         timeout-minutes: 10
         shell: bash
+        env:
+          PLATFORM: ${{ matrix.platform }}
         run: |
           set -euo pipefail
           # Hosted images do not always have a usable pre-created device.
           # Match the selected Xcode SDK and reuse one explicit destination.
-          runtime_version=$(xcrun --sdk iphonesimulator --show-sdk-version)
+          # iOS and tvOS differ only in SDK name, runtime prefix, and device.
+          case "$PLATFORM" in
+            iOS)
+              sdk=iphonesimulator
+              runtime_prefix=com.apple.CoreSimulator.SimRuntime.iOS-
+              device_type=com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro
+              destination_platform="iOS Simulator"
+              ;;
+            tvOS)
+              sdk=appletvsimulator
+              runtime_prefix=com.apple.CoreSimulator.SimRuntime.tvOS-
+              device_type=com.apple.CoreSimulator.SimDeviceType.Apple-TV-4K-3rd-generation-4K
+              destination_platform="tvOS Simulator"
+              ;;
+            *)
+              echo "::error::Unknown simulator platform $PLATFORM"
+              exit 1
+              ;;
+          esac
+          runtime_version=$(xcrun --sdk "$sdk" --show-sdk-version)
           find_runtime() {
-            xcrun simctl list runtimes --json | jq -r --arg version "$runtime_version" \
+            xcrun simctl list runtimes --json | jq -r --arg version "$runtime_version" --arg prefix "$runtime_prefix" \
               '[.runtimes[] | select(.isAvailable and .version == $version and
-                (.identifier | startswith("com.apple.CoreSimulator.SimRuntime.iOS-")))][0].identifier // empty'
+                (.identifier | startswith($prefix)))][0].identifier // empty'
           }
           runtime_id=$(find_runtime)
           if [ -z "$runtime_id" ]; then
-            xcodebuild -downloadPlatform iOS -buildVersion "$runtime_version"
+            xcodebuild -downloadPlatform "$PLATFORM" -buildVersion "$runtime_version"
             runtime_id=$(find_runtime)
           fi
           if [ -z "$runtime_id" ]; then
-            echo "::error::No available iOS $runtime_version simulator runtime"
+            echo "::error::No available $PLATFORM $runtime_version simulator runtime"
             exit 1
           fi
-          simulator_id=$(xcrun simctl create Silo-Player-Regression \
-            com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro "$runtime_id")
+          simulator_id=$(xcrun simctl create "Silo-Player-Regression-$PLATFORM" \
+            "$device_type" "$runtime_id")
           echo "SILO_SIMULATOR_ID=$simulator_id" >> "$GITHUB_ENV"
-          echo "SILO_TEST_DESTINATION=platform=iOS Simulator,id=$simulator_id" >> "$GITHUB_ENV"
+          echo "SILO_TEST_DESTINATION=platform=$destination_platform,id=$simulator_id" >> "$GITHUB_ENV"
           xcrun simctl boot "$simulator_id"
           xcrun simctl bootstatus "$simulator_id" -b
       - name: Generate Xcode project
@@ -111,28 +132,32 @@ jobs:
               CODE_SIGNING_ALLOWED=NO | tee /tmp/player-validation.log
           fi
       - name: Package simulator tests for focused visual verification
-        if: matrix.action == 'test' && !inputs.baseline_ref
+        if: matrix.action == 'test' && matrix.platform == 'iOS' && !inputs.baseline_ref
         run: ditto -c -k --keepParent /tmp/silo-derived/Build/Products /tmp/Silo-simulator-tests.zip
       - name: Upload compiled simulator tests
-        if: matrix.action == 'test' && !inputs.baseline_ref
+        if: matrix.action == 'test' && matrix.platform == 'iOS' && !inputs.baseline_ref
         uses: actions/upload-artifact@v4
         with:
           name: Silo-simulator-tests
           path: /tmp/Silo-simulator-tests.zip
           retention-days: 3
-      - name: Run complete iOS suite
+      - name: Run complete simulator suite
         if: matrix.action == 'test'
         timeout-minutes: 12
+        env:
+          SCHEME: ${{ matrix.scheme }}
+          TEST_TARGET: ${{ matrix.test_target }}
         run: |
           set -o pipefail
-          xcodebuild test-without-building -project iosApp/Silo.xcodeproj -scheme Silo \
+          xcodebuild test-without-building -project iosApp/Silo.xcodeproj -scheme "$SCHEME" \
             -destination "$SILO_TEST_DESTINATION" -derivedDataPath /tmp/silo-derived \
+            -only-testing:"$TEST_TARGET" \
             -parallel-testing-enabled NO \
             -test-timeouts-enabled YES -maximum-test-execution-time-allowance 60 \
             -resultBundlePath /tmp/player-validation.xcresult \
             CODE_SIGNING_ALLOWED=YES CODE_SIGN_IDENTITY=- | tee /tmp/player-validation.log
       - name: Record synthetic preview expansion and successor playback
-        if: matrix.action == 'test' && !inputs.baseline_ref && steps.build.outcome == 'success' && !cancelled() && github.event_name == 'workflow_dispatch' && inputs.record_preview
+        if: matrix.action == 'test' && matrix.platform == 'iOS' && !inputs.baseline_ref && steps.build.outcome == 'success' && !cancelled() && github.event_name == 'workflow_dispatch' && inputs.record_preview
         timeout-minutes: 10
         shell: bash
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ docs/tvos-player/*
 !docs/tvos-player/aetherengine-replacement-spec.md
 !docs/tvos-player/ass-subtitles.md
 !docs/release/*
+!docs/release/
+!docs/*-api-v2.md

--- a/iosApp/Tests/DiagnosticsChunkedUploadTests.swift
+++ b/iosApp/Tests/DiagnosticsChunkedUploadTests.swift
@@ -2,6 +2,8 @@ import XCTest
 @testable import Silo
 
 final class DiagnosticsChunkedUploadTests: XCTestCase {
+    private let stub = ChunkedUploadStub()
+
     // MARK: - Bare-413 classification (the proxy body-cap bug)
 
     func testBare413MapsToRequestBlockedByProxy() {
@@ -115,14 +117,12 @@ final class DiagnosticsChunkedUploadTests: XCTestCase {
         )
         await tokenStore.setServerUrl("http://chunk-test.invalid")
 
-        let config = URLSessionConfiguration.ephemeral
-        config.protocolClasses = [ChunkedUploadStubProtocol.self]
-        let http = HTTPClient(session: URLSession(configuration: config), tokenStore: tokenStore)
+        let http = HTTPClient(session: stub.handler.makeSession(), tokenStore: tokenStore)
         return DiagnosticsAPI(http: http)
     }
 
     func testUploadChunkedSplitsSequentiallyAndCompletes() async throws {
-        ChunkedUploadStubProtocol.reset(chunkBytes: 4, failChunkIndex: nil)
+        stub.reset(chunkBytes: 4, failChunkIndex: nil)
         let api = await makeStubbedAPI()
 
         let bundle = Data("0123456789".utf8) // 10 bytes → chunks of 4/4/2
@@ -130,7 +130,7 @@ final class DiagnosticsChunkedUploadTests: XCTestCase {
         let response = try await api.uploadChunked(manifestData: manifest, bundleData: bundle)
 
         XCTAssertEqual(response.shortID, "SILO-TEST12345678")
-        let state = ChunkedUploadStubProtocol.state()
+        let state = stub.state()
         XCTAssertEqual(state.chunkBodies.count, 3)
         XCTAssertEqual(state.chunkBodies.map(\.count), [4, 4, 2])
         XCTAssertEqual(Data(state.chunkBodies.joined()), bundle, "reassembled chunks must equal the bundle")
@@ -145,7 +145,7 @@ final class DiagnosticsChunkedUploadTests: XCTestCase {
     }
 
     func testUploadChunkedAbortsSessionWhenAChunkFails() async throws {
-        ChunkedUploadStubProtocol.reset(chunkBytes: 4, failChunkIndex: 1)
+        stub.reset(chunkBytes: 4, failChunkIndex: 1)
         let api = await makeStubbedAPI()
 
         do {
@@ -160,7 +160,7 @@ final class DiagnosticsChunkedUploadTests: XCTestCase {
             }
         }
 
-        let state = ChunkedUploadStubProtocol.state()
+        let state = stub.state()
         XCTAssertFalse(state.completed)
         XCTAssertTrue(state.aborted, "a failed upload must best-effort abort its session")
     }
@@ -168,7 +168,7 @@ final class DiagnosticsChunkedUploadTests: XCTestCase {
     func testUploadChunkedFailsFastOnNonPositiveChunkBytes() async throws {
         // A zero/negative advertised chunk size must fail fast, not degrade
         // to 1-byte chunks (millions of PUTs for a real bundle).
-        ChunkedUploadStubProtocol.reset(chunkBytes: 0, failChunkIndex: nil)
+        stub.reset(chunkBytes: 0, failChunkIndex: nil)
         let api = await makeStubbedAPI()
 
         do {
@@ -183,7 +183,7 @@ final class DiagnosticsChunkedUploadTests: XCTestCase {
             }
         }
 
-        let state = ChunkedUploadStubProtocol.state()
+        let state = stub.state()
         XCTAssertTrue(state.chunkIndexes.isEmpty, "no chunk PUTs may be issued")
         XCTAssertFalse(state.completed)
         XCTAssertTrue(state.aborted, "the opened session should still be reclaimed")
@@ -194,7 +194,7 @@ final class DiagnosticsChunkedUploadTests: XCTestCase {
         // fires before every post-init request, the remaining bundle bytes
         // must not be sent, and no abort may be issued (it would target the
         // newly active destination).
-        ChunkedUploadStubProtocol.reset(chunkBytes: 4, failChunkIndex: nil)
+        stub.reset(chunkBytes: 4, failChunkIndex: nil)
         let api = await makeStubbedAPI()
 
         let checkCount = ChunkCheckCounter()
@@ -209,7 +209,7 @@ final class DiagnosticsChunkedUploadTests: XCTestCase {
             XCTAssertEqual(error, .retryable("destination_changed"))
         }
 
-        let state = ChunkedUploadStubProtocol.state()
+        let state = stub.state()
         XCTAssertEqual(state.chunkIndexes, [0], "upload must stop after the destination changed")
         XCTAssertFalse(state.completed)
         XCTAssertFalse(state.aborted, "abort would target the new destination and must be skipped")
@@ -225,9 +225,9 @@ private actor ChunkCheckCounter {
     }
 }
 
-/// In-process stub for the chunked upload endpoints. State is static because
-/// URLSession instantiates the protocol itself; `reset` scopes it per test.
-final class ChunkedUploadStubProtocol: URLProtocol {
+/// The chunked upload endpoints as routes on the shared stub. `State` is what
+/// the tests assert on; `reset` scopes it per test.
+private final class ChunkedUploadStub: @unchecked Sendable {
     struct State {
         var chunkBytes = 4
         var failChunkIndex: Int?
@@ -238,103 +238,47 @@ final class ChunkedUploadStubProtocol: URLProtocol {
         var aborted = false
     }
 
-    private static let lock = NSLock()
-    private static var current = State()
+    let handler = StubURLProtocol.Handler()
+    private let lock = NSLock()
+    private var current = State()
 
-    static func reset(chunkBytes: Int, failChunkIndex: Int?) {
-        lock.lock()
-        current = State(chunkBytes: chunkBytes, failChunkIndex: failChunkIndex)
-        lock.unlock()
-    }
-
-    static func state() -> State {
-        lock.lock()
-        defer { lock.unlock() }
-        return current
-    }
-
-    private static func mutate(_ apply: (inout State) -> Void) {
-        lock.lock()
-        apply(&current)
-        lock.unlock()
-    }
-
-    override static func canInit(with request: URLRequest) -> Bool {
-        request.url?.host == "chunk-test.invalid"
-    }
-
-    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
-        request
-    }
-
-    override func startLoading() {
-        let path = request.url?.path ?? ""
-        let method = request.httpMethod ?? ""
-        let body = Self.requestBody(of: request)
-
-        switch (method, path) {
-        case ("POST", "/api/v1/diagnostics/reports/uploads"):
-            Self.mutate { $0.initBody = body }
-            let chunkBytes = Self.state().chunkBytes
-            respond(status: 201, json: #"{"upload_id":"stub-session","chunk_bytes":\#(chunkBytes),"total_chunks":3,"expires_at":"2026-01-01T00:00:00Z"}"#)
-        case ("PUT", let chunkPath) where chunkPath.contains("/uploads/stub-session/chunks/"):
-            let index = Int(chunkPath.split(separator: "/").last ?? "") ?? -1
-            if Self.state().failChunkIndex == index {
-                respond(status: 500, json: #"{"error":"internal_error","message":"stub chunk failure"}"#)
-                return
+    func reset(chunkBytes: Int, failChunkIndex: Int?) {
+        lock.withLock { current = State(chunkBytes: chunkBytes, failChunkIndex: failChunkIndex) }
+        handler.reset()
+        handler.route(StubURLProtocol.method("POST", path: "/api/v1/diagnostics/reports/uploads")) { [self] request in
+            mutate { $0.initBody = request.body }
+            let chunkBytes = state().chunkBytes
+            return .json(#"{"upload_id":"stub-session","chunk_bytes":\#(chunkBytes),"total_chunks":3,"expires_at":"2026-01-01T00:00:00Z"}"#, status: 201)
+        }
+        handler.route({ $0.method == "PUT" && $0.path.contains("/uploads/stub-session/chunks/") }) { [self] request in
+            let index = Int(request.path.split(separator: "/").last ?? "") ?? -1
+            if state().failChunkIndex == index {
+                return .json(#"{"error":"internal_error","message":"stub chunk failure"}"#, status: 500)
             }
-            Self.mutate {
+            mutate {
                 $0.chunkIndexes.append(index)
-                $0.chunkBodies.append(body ?? Data())
+                $0.chunkBodies.append(request.body ?? Data())
             }
-            respond(status: 200, json: #"{"received_chunks":\#(index + 1),"total_chunks":3}"#)
-        case ("POST", "/api/v1/diagnostics/reports/uploads/stub-session/complete"):
-            Self.mutate { $0.completed = true }
-            respond(status: 201, json: #"{"report_id":"11111111-1111-1111-1111-111111111111","short_id":"SILO-TEST12345678"}"#)
-        case ("DELETE", "/api/v1/diagnostics/reports/uploads/stub-session"):
-            Self.mutate { $0.aborted = true }
-            respond(status: 204, json: "")
-        default:
-            respond(status: 404, json: #"{"error":"not_found"}"#)
+            return .json(#"{"received_chunks":\#(index + 1),"total_chunks":3}"#)
+        }
+        handler.route(StubURLProtocol.method("POST", path: "/api/v1/diagnostics/reports/uploads/stub-session/complete")) { [self] _ in
+            mutate { $0.completed = true }
+            return .json(#"{"report_id":"11111111-1111-1111-1111-111111111111","short_id":"SILO-TEST12345678"}"#, status: 201)
+        }
+        handler.route(StubURLProtocol.method("DELETE", path: "/api/v1/diagnostics/reports/uploads/stub-session")) { [self] _ in
+            mutate { $0.aborted = true }
+            return .json("", status: 204)
+        }
+        handler.route(StubURLProtocol.any) { _ in
+            .json(#"{"error":"not_found"}"#, status: 404)
         }
     }
 
-    override func stopLoading() {}
-
-    /// URLSession surfaces outgoing bodies to URLProtocol as a stream, not
-    /// `httpBody`; drain it.
-    private static func requestBody(of request: URLRequest) -> Data? {
-        if let body = request.httpBody {
-            return body
-        }
-        guard let stream = request.httpBodyStream else {
-            return nil
-        }
-        stream.open()
-        defer { stream.close() }
-        var data = Data()
-        let bufferSize = 64 * 1024
-        var buffer = [UInt8](repeating: 0, count: bufferSize)
-        while stream.hasBytesAvailable {
-            let read = stream.read(&buffer, maxLength: bufferSize)
-            guard read > 0 else { break }
-            data.append(buffer, count: read)
-        }
-        return data
+    func state() -> State {
+        lock.withLock { current }
     }
 
-    private func respond(status: Int, json: String) {
-        guard let url = request.url, let client else { return }
-        let response = HTTPURLResponse(
-            url: url,
-            statusCode: status,
-            httpVersion: "HTTP/1.1",
-            headerFields: ["Content-Type": "application/json"]
-        )!
-        client.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-        if !json.isEmpty {
-            client.urlProtocol(self, didLoad: Data(json.utf8))
-        }
-        client.urlProtocolDidFinishLoading(self)
+    private func mutate(_ apply: (inout State) -> Void) {
+        lock.withLock { apply(&current) }
     }
 }

--- a/iosApp/Tests/DiagnosticsReviewFixesTests.swift
+++ b/iosApp/Tests/DiagnosticsReviewFixesTests.swift
@@ -119,6 +119,8 @@ final class DiagnosticsReviewFixesTests: XCTestCase {
 
     // MARK: - Byte-safe stack truncation (#11)
 
+#if os(iOS)
+    // MetricKitDiagnosticParser is iOS-only.
     func testStackExcerptTruncatesToUTF8ByteLimit() throws {
         // 12 frames of multibyte symbols exceed 8192 UTF-8 bytes when joined.
         let frame: [String: Any] = ["symbolName": String(repeating: "é", count: 1000), "offset": 1]
@@ -137,6 +139,7 @@ final class DiagnosticsReviewFixesTests: XCTestCase {
         // Passes the same validation the server enforces.
         XCTAssertNoThrow(try crash.validate())
     }
+#endif
 
     // MARK: - Declined-prompt suppression (round 2 #6)
 
@@ -434,6 +437,8 @@ final class DiagnosticsReviewFixesTests: XCTestCase {
         XCTAssertNotEqual(store.currentURL, store.leftoverURL)
     }
 
+#if os(iOS)
+    // MetricKitCapture is iOS-only; the rest of this file runs on tvOS too.
     // MARK: - MetricKit evidence isolation (PR #98)
 
     func testMetricKitCaptureOmitsUncorrelatedProcessEvidence() throws {
@@ -474,6 +479,7 @@ final class DiagnosticsReviewFixesTests: XCTestCase {
         ))
         XCTAssertTrue(report.manifest.playbackSessionIds.isEmpty)
     }
+#endif
 
     func testEmptyFailedRunLogSnapshotStillFreezesLogsArtifact() async {
         DiagLog.ring.clear()

--- a/iosApp/Tests/HostedDiagnosticsAPITests.swift
+++ b/iosApp/Tests/HostedDiagnosticsAPITests.swift
@@ -3,11 +3,8 @@ import XCTest
 import zlib
 
 final class HostedDiagnosticsAPITests: XCTestCase {
-    override func tearDown() {
-        HostedDiagnosticsStubProtocol.reset()
-        SelfHostedDiagnosticsStubProtocol.reset()
-        super.tearDown()
-    }
+    private let hostedStub = HostedDiagnosticsStub()
+    private let selfHostedStub = SelfHostedDiagnosticsStub()
 
     func testDefaultCollectorSessionHasNoSharedCookiesOrCredentials() throws {
         XCTAssertEqual(
@@ -57,7 +54,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
                 installationToken: "hosted-installation-token"
             )
         )
-        HostedDiagnosticsStubProtocol.configure(reportID: reportID, bundle: bundle)
+        hostedStub.configure(reportID: reportID, bundle: bundle)
         let api = HostedDiagnosticsAPI(
             baseURL: try XCTUnwrap(URL(string: "https://collector.example")),
             session: makeSession(),
@@ -75,7 +72,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
         XCTAssertEqual(response.state, .processing)
         XCTAssertEqual(credentialStore.saveCount, 0, "an existing installation must be reused")
 
-        let requests = HostedDiagnosticsStubProtocol.requests()
+        let requests = hostedStub.requests()
         XCTAssertEqual(requests.map(\.path), [
             "/v1/reports",
             "/v1/reports/\(reportID.uuidString.lowercased())/bundle",
@@ -124,9 +121,9 @@ final class HostedDiagnosticsAPITests: XCTestCase {
             credentialStore: HostedTestCredentialStore(credential: credential)
         )
 
-        HostedDiagnosticsStubProtocol.configureDelete(reportID: reportID, statusCode: 204)
+        hostedStub.configureDelete(reportID: reportID, statusCode: 204)
         try await api.deleteReport(reportID: reportID)
-        var request = try XCTUnwrap(HostedDiagnosticsStubProtocol.requests().last)
+        var request = try XCTUnwrap(hostedStub.requests().last)
         XCTAssertEqual(request.method, "DELETE")
         XCTAssertEqual(request.path, "/v1/reports/\(reportID.uuidString.lowercased())")
         XCTAssertEqual(request.authorization, "Bearer hosted-delete-token")
@@ -134,14 +131,14 @@ final class HostedDiagnosticsAPITests: XCTestCase {
         XCTAssertNil(request.profileTokenHeader)
         XCTAssertNil(request.siloDeviceIDHeader)
 
-        HostedDiagnosticsStubProtocol.configureDelete(reportID: reportID, statusCode: 404)
+        hostedStub.configureDelete(reportID: reportID, statusCode: 404)
         do {
             try await api.deleteReport(reportID: reportID)
             XCTFail("A foreign/unowned report must keep the erasure intent retryable")
         } catch let error as HostedDiagnosticsAPIError {
             XCTAssertEqual(error, .http(statusCode: 404, code: "report_not_found"))
         }
-        request = try XCTUnwrap(HostedDiagnosticsStubProtocol.requests().last)
+        request = try XCTUnwrap(hostedStub.requests().last)
         XCTAssertEqual(request.method, "DELETE")
         XCTAssertEqual(request.path, "/v1/reports/\(reportID.uuidString.lowercased())")
     }
@@ -149,7 +146,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
     func testValidatedPutAcceptanceSurvivesInformationalStatusFailure() async throws {
         let reportID = try XCTUnwrap(UUID(uuidString: "99999999-8888-7777-6666-555555555555"))
         let bundle = Data("accepted-before-status-failure".utf8)
-        HostedDiagnosticsStubProtocol.configureStatusFailureAfterAccepted(
+        hostedStub.configureStatusFailureAfterAccepted(
             reportID: reportID,
             bundle: bundle
         )
@@ -174,7 +171,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
         XCTAssertEqual(response.shortID, "SILO-APPLE1234")
         XCTAssertEqual(response.state, .processing)
         XCTAssertEqual(
-            HostedDiagnosticsStubProtocol.requests().last?.path,
+            hostedStub.requests().last?.path,
             "/v1/reports/\(reportID.uuidString.lowercased())"
         )
     }
@@ -183,7 +180,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
         let fixture = try makePendingHostedReport(label: "wrong-short-id")
         let bundle = Data("wrong-short-id-bundle".utf8)
         let reportID = fixture.report.id
-        HostedDiagnosticsStubProtocol.configurePutAcceptance(
+        hostedStub.configurePutAcceptance(
             reportID: reportID,
             bundle: bundle,
             body: #"{"report_id":"\#(reportID.uuidString.lowercased())","short_id":"SILO-WRONG9999","state":"processing"}"#
@@ -193,7 +190,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
 
         XCTAssertEqual(error, .remoteReportIdentityMismatch)
         await assertRetryRetains(error, fixture: fixture)
-        XCTAssertFalse(HostedDiagnosticsStubProtocol.requests().contains { $0.method == "GET" })
+        XCTAssertFalse(hostedStub.requests().contains { $0.method == "GET" })
     }
 
     func testPutAcceptanceNonDurableStatesRetainPendingEvidence() async throws {
@@ -201,7 +198,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
             let fixture = try makePendingHostedReport(label: "non-durable-\(state)")
             let bundle = Data("non-durable-\(state)-bundle".utf8)
             let reportID = fixture.report.id
-            HostedDiagnosticsStubProtocol.configurePutAcceptance(
+            hostedStub.configurePutAcceptance(
                 reportID: reportID,
                 bundle: bundle,
                 body: #"{"report_id":"\#(reportID.uuidString.lowercased())","short_id":"SILO-APPLE1234","state":"\#(state)"}"#
@@ -212,7 +209,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
             XCTAssertEqual(error, .invalidResponse, state)
             await assertRetryRetains(error, fixture: fixture, message: state)
             XCTAssertFalse(
-                HostedDiagnosticsStubProtocol.requests().contains { $0.method == "GET" },
+                hostedStub.requests().contains { $0.method == "GET" },
                 state
             )
         }
@@ -221,7 +218,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
     func testMalformedPutAcceptanceRetainsPendingEvidence() async throws {
         let fixture = try makePendingHostedReport(label: "malformed-put")
         let bundle = Data("malformed-put-bundle".utf8)
-        HostedDiagnosticsStubProtocol.configurePutAcceptance(
+        hostedStub.configurePutAcceptance(
             reportID: fixture.report.id,
             bundle: bundle,
             body: #"{"report_id":broken-json"#
@@ -236,13 +233,13 @@ final class HostedDiagnosticsAPITests: XCTestCase {
             return XCTFail("Expected malformed 202 to produce a retryable decode failure, got \(error)")
         }
         await assertRetryRetains(error, fixture: fixture)
-        XCTAssertFalse(HostedDiagnosticsStubProtocol.requests().contains { $0.method == "GET" })
+        XCTAssertFalse(hostedStub.requests().contains { $0.method == "GET" })
     }
 
     func testReadyPutAcceptanceIsDurable() async throws {
         let reportID = try XCTUnwrap(UUID(uuidString: "eeeeeeee-dddd-cccc-bbbb-aaaaaaaaaaaa"))
         let bundle = Data("ready-put-bundle".utf8)
-        HostedDiagnosticsStubProtocol.configurePutAcceptance(
+        hostedStub.configurePutAcceptance(
             reportID: reportID,
             bundle: bundle,
             body: #"{"report_id":"\#(reportID.uuidString.lowercased())","short_id":"SILO-APPLE1234","state":"ready"}"#
@@ -314,7 +311,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
         let reportID = try XCTUnwrap(UUID(uuidString: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
         let bundle = Data("new-installation-bundle".utf8)
         let credentialStore = HostedTestCredentialStore(credential: nil)
-        HostedDiagnosticsStubProtocol.configure(reportID: reportID, bundle: bundle)
+        hostedStub.configure(reportID: reportID, bundle: bundle)
         let api = HostedDiagnosticsAPI(
             baseURL: try XCTUnwrap(URL(string: "https://collector.example")),
             session: makeSession(),
@@ -335,7 +332,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
                 installationToken: "generated-installation-token"
             )
         )
-        let requests = HostedDiagnosticsStubProtocol.requests()
+        let requests = hostedStub.requests()
         XCTAssertEqual(requests.map(\.path).first, "/v1/installations")
         let installation = try XCTUnwrap(requests.first)
         XCTAssertEqual(installation.timeoutInterval, 10)
@@ -367,7 +364,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
             session: makeSession(),
             credentialStore: credentialStore
         )
-        HostedDiagnosticsStubProtocol.configure(
+        hostedStub.configure(
             reportID: unusedReportID,
             bundle: Data()
         )
@@ -379,7 +376,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
         XCTAssertEqual(credentials[0], credentials[1])
         XCTAssertEqual(credentialStore.saveCount, 1)
         XCTAssertEqual(
-            HostedDiagnosticsStubProtocol.requests().count {
+            hostedStub.requests().count {
                 $0.method == "POST" && $0.path == "/v1/installations"
             },
             1
@@ -395,7 +392,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
                 installationToken: "revoked-installation-token"
             )
         )
-        HostedDiagnosticsStubProtocol.configureInvalidTokenRecovery(
+        hostedStub.configureInvalidTokenRecovery(
             reportID: reportID,
             bundle: bundle
         )
@@ -421,7 +418,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
                 installationToken: "generated-installation-token"
             )
         )
-        let requests = HostedDiagnosticsStubProtocol.requests()
+        let requests = hostedStub.requests()
         XCTAssertEqual(requests.map(\.path), [
             "/v1/reports",
             "/v1/installations",
@@ -510,7 +507,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
         XCTAssertEqual(embedded.playbackSessionIds, bundle.manifest.playbackSessionIds)
         XCTAssertEqual(embedded.logSummary, bundle.manifest.logSummary)
 
-        HostedDiagnosticsStubProtocol.configure(reportID: report.id, bundle: bundle.bundleData)
+        hostedStub.configure(reportID: report.id, bundle: bundle.bundleData)
         let api = HostedDiagnosticsAPI(
             baseURL: try XCTUnwrap(URL(string: "https://collector.example")),
             session: makeSession(),
@@ -528,7 +525,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
         )
 
         let create = try XCTUnwrap(
-            HostedDiagnosticsStubProtocol.requests().first(where: { $0.path == "/v1/reports" })
+            hostedStub.requests().first(where: { $0.path == "/v1/reports" })
         )
         XCTAssertFalse(String(decoding: create.body, as: UTF8.self).contains(token))
         let envelope = try XCTUnwrap(
@@ -1319,7 +1316,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
         )
         let coordinator = DiagnosticsCoordinator(hostedAPI: api, pendingStore: fixture.store)
 
-        HostedDiagnosticsStubProtocol.configureDelete(
+        hostedStub.configureDelete(
             reportID: fixture.report.id,
             statusCode: 503
         )
@@ -1344,7 +1341,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
         XCTAssertFalse(renderedIntent.contains(fixture.report.binding.serverInstanceID))
         XCTAssertFalse(renderedIntent.contains(fixture.report.binding.accountUserID))
 
-        HostedDiagnosticsStubProtocol.configureDelete(
+        hostedStub.configureDelete(
             reportID: fixture.report.id,
             statusCode: 204
         )
@@ -1376,7 +1373,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
                 forceRemoteIntent: true
             )
         }
-        HostedDiagnosticsStubProtocol.configureDelete(
+        hostedStub.configureDelete(
             reportID: reports[0].id,
             statusCode: 204
         )
@@ -1399,7 +1396,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
 
         XCTAssertFalse(completedAll)
         XCTAssertEqual(
-            HostedDiagnosticsStubProtocol.requests().count { $0.method == "DELETE" },
+            hostedStub.requests().count { $0.method == "DELETE" },
             2
         )
         XCTAssertFalse(try fixture.store.hostedDeletionIntents().isEmpty)
@@ -1417,7 +1414,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
             fixture.report,
             forceRemoteIntent: true
         )
-        HostedDiagnosticsStubProtocol.configureDelete(
+        hostedStub.configureDelete(
             reportID: selected.id,
             statusCode: 204
         )
@@ -1437,7 +1434,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
         XCTAssertTrue(erased)
 
         let firstDelete = try XCTUnwrap(
-            HostedDiagnosticsStubProtocol.requests().first(where: { $0.method == "DELETE" })
+            hostedStub.requests().first(where: { $0.method == "DELETE" })
         )
         XCTAssertEqual(
             firstDelete.path,
@@ -1453,7 +1450,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
             droppedLogLines: 0
         )
         try fixture.store.saveHostedEnvelope(bundle, for: fixture.report)
-        HostedDiagnosticsStubProtocol.configureDelete(
+        hostedStub.configureDelete(
             reportID: fixture.report.id,
             statusCode: 503
         )
@@ -1477,7 +1474,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
 
     func testHostedUploadFenceDefersExplicitDeleteUntilNetworkHandoffSettles() async throws {
         let fixture = try makePendingHostedReport(label: "delete-during-create")
-        HostedDiagnosticsStubProtocol.configureDelete(
+        hostedStub.configureDelete(
             reportID: fixture.report.id,
             statusCode: 204
         )
@@ -1503,12 +1500,12 @@ final class HostedDiagnosticsAPITests: XCTestCase {
         XCTAssertFalse(erasedWhileUploading)
         XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.report.directoryURL.path))
         XCTAssertEqual(try fixture.store.hostedDeletionIntents(), [fixture.report.id])
-        XCTAssertTrue(HostedDiagnosticsStubProtocol.requests().isEmpty)
+        XCTAssertTrue(hostedStub.requests().isEmpty)
 
         let erasedAfterUpload = await coordinator.endHostedUploadFence(reportID: fixture.report.id)
         XCTAssertTrue(erasedAfterUpload)
         XCTAssertTrue(try fixture.store.hostedDeletionIntents().isEmpty)
-        XCTAssertEqual(HostedDiagnosticsStubProtocol.requests().map(\.method), ["DELETE"])
+        XCTAssertEqual(hostedStub.requests().map(\.method), ["DELETE"])
     }
 
     func testTurnOffErasesReadyHandoffAfterPendingDirectoryIsAlreadyGone() async throws {
@@ -1531,7 +1528,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
         try fixture.store.recordHostedReadyAndDelete(fixture.report)
         _ = await coordinator.endHostedUploadFence(reportID: fixture.report.id)
 
-        HostedDiagnosticsStubProtocol.configureDelete(
+        hostedStub.configureDelete(
             reportID: fixture.report.id,
             statusCode: 204
         )
@@ -1539,9 +1536,9 @@ final class HostedDiagnosticsAPITests: XCTestCase {
 
         XCTAssertTrue(erased)
         XCTAssertTrue(try fixture.store.hostedDeletionIntents().isEmpty)
-        XCTAssertEqual(HostedDiagnosticsStubProtocol.requests().map(\.method), ["DELETE"])
+        XCTAssertEqual(hostedStub.requests().map(\.method), ["DELETE"])
         XCTAssertEqual(
-            HostedDiagnosticsStubProtocol.requests().map(\.path),
+            hostedStub.requests().map(\.path),
             ["/v1/reports/\(fixture.report.id.uuidString.lowercased())"]
         )
     }
@@ -1565,7 +1562,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
             try restoredStore.hostedReadyReceiptIDs(for: fixture.report.binding.binding),
             [fixture.report.id]
         )
-        HostedDiagnosticsStubProtocol.configureDelete(
+        hostedStub.configureDelete(
             reportID: fixture.report.id,
             statusCode: 204
         )
@@ -1586,7 +1583,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
         XCTAssertTrue(erased)
         XCTAssertTrue(try restoredStore.hostedDeletionIntents().isEmpty)
         XCTAssertTrue(try restoredStore.hostedReadyReceiptIDs().isEmpty)
-        XCTAssertEqual(HostedDiagnosticsStubProtocol.requests().map(\.method), ["DELETE"])
+        XCTAssertEqual(hostedStub.requests().map(\.method), ["DELETE"])
     }
 
     func testReadyReceiptHidesEvidenceAcrossInterruptedLocalRemoval() async throws {
@@ -1639,7 +1636,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
         XCTAssertEqual(try fixture.store.hostedDeletionIntents(), [fixture.report.id])
         XCTAssertTrue(FileManager.default.fileExists(atPath: fixture.report.directoryURL.path))
 
-        HostedDiagnosticsStubProtocol.configureDelete(
+        hostedStub.configureDelete(
             reportID: fixture.report.id,
             statusCode: 204
         )
@@ -1658,7 +1655,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
         XCTAssertTrue(visible.isEmpty)
         let uploadDecision = await coordinator.upload(report: fixture.report)
         XCTAssertEqual(uploadDecision, .keptRetryable)
-        XCTAssertTrue(HostedDiagnosticsStubProtocol.requests().isEmpty)
+        XCTAssertTrue(hostedStub.requests().isEmpty)
     }
 
     func testMalformedDeletionIntentLedgerQuarantinesSurvivingEvidence() async throws {
@@ -1837,7 +1834,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
             XCTAssertEqual(uploadDecision, .keptRetryable)
             XCTAssertFalse(drained)
             XCTAssertFalse(turnedOff)
-            XCTAssertTrue(HostedDiagnosticsStubProtocol.requests().isEmpty)
+            XCTAssertTrue(hostedStub.requests().isEmpty)
             XCTAssertEqual(try Data(contentsOf: ledgerURL), noncanonicalData)
             XCTAssertTrue(FileManager.default.fileExists(atPath: fixture.report.directoryURL.path))
         }
@@ -1862,7 +1859,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
                 let listed = await coordinator.pendingReports(for: fixture.binding)
                 XCTAssertEqual(listed.map(\.id), fixture.reports.map(\.id))
 
-                SelfHostedDiagnosticsStubProtocol.configure(
+                selfHostedStub.configure(
                     serverInstanceID: fixture.binding.serverInstanceID,
                     reportID: fixture.reports[0].id
                 )
@@ -1878,7 +1875,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
                 XCTAssertFalse(FileManager.default.fileExists(
                     atPath: fixture.reports[0].directoryURL.path
                 ))
-                XCTAssertEqual(SelfHostedDiagnosticsStubProtocol.requestedPaths(), [
+                XCTAssertEqual(selfHostedStub.requestedPaths(), [
                     "/api/v1/diagnostics/status",
                     "/api/v1/auth/me",
                     "/api/v1/diagnostics/reports",
@@ -1898,7 +1895,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
                 let remaining = await coordinator.pendingReports(for: fixture.binding)
                 XCTAssertTrue(remaining.isEmpty)
                 XCTAssertEqual(try Data(contentsOf: ledgerURL), corruptBytes)
-                XCTAssertTrue(HostedDiagnosticsStubProtocol.requests().isEmpty)
+                XCTAssertTrue(hostedStub.requests().isEmpty)
             }
         }
     }
@@ -1941,7 +1938,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
         let fixture = try makePendingHostedReport(label: "ready-history")
         let shortID = "SILO-HISTORY"
         fixture.store.markHostedProcessing(fixture.report, shortID: shortID)
-        HostedDiagnosticsStubProtocol.configureReportStatus(
+        hostedStub.configureReportStatus(
             reportID: fixture.report.id,
             shortID: shortID,
             state: .ready,
@@ -1990,7 +1987,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
         )
         let shortID = "SILO-READY-LOCAL-FAILURE"
         fixture.store.markHostedProcessing(fixture.report, shortID: shortID)
-        HostedDiagnosticsStubProtocol.configureReportStatus(
+        hostedStub.configureReportStatus(
             reportID: fixture.report.id,
             shortID: shortID,
             state: .ready,
@@ -2047,7 +2044,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
             let fixture = try makePendingHostedReport(label: "remote-\(state.rawValue)")
             let shortID = "SILO-\(state.rawValue.uppercased())"
             fixture.store.markHostedProcessing(fixture.report, shortID: shortID)
-            HostedDiagnosticsStubProtocol.configureReportStatus(
+            hostedStub.configureReportStatus(
                 reportID: fixture.report.id,
                 shortID: shortID,
                 state: state,
@@ -2103,7 +2100,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
     }
 
     func testCapabilitiesArePublicAndMapCollectorIdentity() async throws {
-        HostedDiagnosticsStubProtocol.configureCapabilities()
+        hostedStub.configureCapabilities()
         let api = HostedDiagnosticsAPI(
             baseURL: try XCTUnwrap(URL(string: "https://collector.example")),
             session: makeSession(),
@@ -2118,7 +2115,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
             HostedDiagnosticsCapabilities.pinnedCollectorID
         )
         XCTAssertEqual(capabilities.acceptedSchemaVersions, [1])
-        let request = try XCTUnwrap(HostedDiagnosticsStubProtocol.requests().first)
+        let request = try XCTUnwrap(hostedStub.requests().first)
         XCTAssertNil(request.authorization, "capability discovery must be anonymous")
         XCTAssertNil(request.cookieHeader)
         XCTAssertNil(request.profileHeader)
@@ -2127,7 +2124,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
     }
 
     func testCapabilitiesRejectUnexpectedCollectorIdentityBeforeSend() async throws {
-        HostedDiagnosticsStubProtocol.configureCapabilities(
+        hostedStub.configureCapabilities(
             collectorID: "unexpected-collector"
         )
         let api = HostedDiagnosticsAPI(
@@ -2145,7 +2142,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
     }
 
     func testCapabilitiesRejectCollectorWithoutSchemaV1BeforeSend() async throws {
-        HostedDiagnosticsStubProtocol.configureCapabilities(acceptedSchemaVersions: [2])
+        hostedStub.configureCapabilities(acceptedSchemaVersions: [2])
         let api = HostedDiagnosticsAPI(
             baseURL: try XCTUnwrap(URL(string: "https://collector.example")),
             session: makeSession(),
@@ -2162,7 +2159,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
 
     func testCapabilitiesPreserveValidDisabledAndStorageUnavailableStatuses() async throws {
         for status in [DiagnosticsAvailabilityStatus.disabled, .storageUnavailable] {
-            HostedDiagnosticsStubProtocol.configureCapabilities(status: status)
+            hostedStub.configureCapabilities(status: status)
             let api = HostedDiagnosticsAPI(
                 baseURL: try XCTUnwrap(URL(string: "https://collector.example")),
                 session: makeSession(),
@@ -2446,7 +2443,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
         XCTAssertNil(restoredStore.report(id: fixture.report.id))
         XCTAssertTrue(FileManager.default.fileExists(atPath: fixture.report.directoryURL.path))
 
-        HostedDiagnosticsStubProtocol.configureReportStatus(
+        hostedStub.configureReportStatus(
             reportID: fixture.report.id,
             shortID: "SILO-QUARANTINED",
             state: .ready,
@@ -2466,7 +2463,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
 
         let uploadDecision = await coordinator.upload(report: processingReport)
         XCTAssertEqual(uploadDecision, .keptRetryable)
-        XCTAssertTrue(HostedDiagnosticsStubProtocol.requests().isEmpty)
+        XCTAssertTrue(hostedStub.requests().isEmpty)
 
         let retryBatch = restoredStore.prepareHostedDeletionRetries()
         XCTAssertTrue(retryBatch.reportIDs.isEmpty)
@@ -2474,7 +2471,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
         XCTAssertTrue(retryBatch.hasCorruptLedger)
         let drained = await coordinator.retryHostedDeletions()
         XCTAssertFalse(drained)
-        XCTAssertTrue(HostedDiagnosticsStubProtocol.requests().isEmpty)
+        XCTAssertTrue(hostedStub.requests().isEmpty)
 
         let turnedOff = await coordinator.turnOffAndDelete(
             binding: fixture.report.binding.binding
@@ -2483,7 +2480,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
         XCTAssertEqual(try Data(contentsOf: ledgerURL), corruptBytes)
         XCTAssertTrue(FileManager.default.fileExists(atPath: fixture.report.directoryURL.path))
         XCTAssertTrue(restoredStore.listReports(now: Date()).isEmpty)
-        XCTAssertTrue(HostedDiagnosticsStubProtocol.requests().isEmpty)
+        XCTAssertTrue(hostedStub.requests().isEmpty)
     }
 
     private func assertHostedErasureLedgerLoadFails(
@@ -2705,10 +2702,8 @@ final class HostedDiagnosticsAPITests: XCTestCase {
             accessToken: "self-hosted-access-token",
             refreshToken: "self-hosted-refresh-token"
         )
-        let configuration = URLSessionConfiguration.ephemeral
-        configuration.protocolClasses = [SelfHostedDiagnosticsStubProtocol.self]
         let http = HTTPClient(
-            session: URLSession(configuration: configuration),
+            session: selfHostedStub.handler.makeSession(),
             tokenStore: tokenStore
         )
         let destinationStore = DiagnosticsDestinationStore(defaults: defaults)
@@ -2928,7 +2923,7 @@ final class HostedDiagnosticsAPITests: XCTestCase {
 
     private func makeSession() -> URLSession {
         let configuration = URLSessionConfiguration.ephemeral
-        configuration.protocolClasses = [HostedDiagnosticsStubProtocol.self]
+        hostedStub.handler.install(into: configuration)
         configuration.httpCookieStorage = nil
         configuration.httpShouldSetCookies = false
         configuration.urlCredentialStorage = nil
@@ -3014,7 +3009,11 @@ private final class HostedTestCredentialStore: HostedDiagnosticsCredentialStorin
     }
 }
 
-private final class HostedDiagnosticsStubProtocol: URLProtocol {
+/// The hosted collector as a mode-driven route on the shared stub. The
+/// `configure*` calls pick the scenario and start a fresh recording;
+/// `requests()` returns what the collector saw, decoded into the fields the
+/// tests assert on.
+private final class HostedDiagnosticsStub: @unchecked Sendable {
     struct CapturedRequest {
         let method: String
         let path: String
@@ -3029,6 +3028,22 @@ private final class HostedDiagnosticsStubProtocol: URLProtocol {
         let contentLength: String?
         let timeoutInterval: TimeInterval
         let body: Data
+
+        init(_ request: StubURLProtocol.Request) {
+            method = request.method
+            path = request.path
+            host = request.url?.host
+            authorization = request.header("Authorization")
+            profileHeader = request.header("X-Profile-Id")
+            profileTokenHeader = request.header("X-Profile-Token")
+            siloDeviceIDHeader = request.header("X-Silo-Device-Id")
+            cookieHeader = request.header("Cookie")
+            uploadToken = request.header("X-Upload-Token")
+            contentType = request.header("Content-Type")
+            contentLength = request.header("Content-Length")
+            timeoutInterval = request.underlying.timeoutInterval
+            body = request.body ?? Data()
+        }
     }
 
     private enum Mode {
@@ -3050,131 +3065,84 @@ private final class HostedDiagnosticsStubProtocol: URLProtocol {
         )
     }
 
-    private static let lock = NSLock()
-    nonisolated(unsafe) private static var mode: Mode = .capabilities(
+    let handler = StubURLProtocol.Handler()
+    private let lock = NSLock()
+    private var mode: Mode = .capabilities(
         status: .available,
         collectorID: HostedDiagnosticsCapabilities.pinnedCollectorID,
         acceptedSchemaVersions: [1]
     )
-    nonisolated(unsafe) private static var captured: [CapturedRequest] = []
-    nonisolated(unsafe) private static var rejectedRevokedToken = false
+    private var rejectedRevokedToken = false
 
-    static func configure(reportID: UUID, bundle: Data) {
+    init() {
+        installRoute()
+    }
+
+    private func set(_ newMode: Mode) {
         lock.withLock {
-            mode = .upload(reportID: reportID, bundle: bundle)
-            captured = []
+            mode = newMode
             rejectedRevokedToken = false
+        }
+        handler.reset()
+        installRoute()
+    }
+
+    private func installRoute() {
+        handler.route(StubURLProtocol.any) { [self] request in
+            let (status, body) = respond(to: request)
+            return .json(body, status: status)
         }
     }
 
-    static func configureInvalidTokenRecovery(reportID: UUID, bundle: Data) {
-        lock.withLock {
-            mode = .invalidTokenRecovery(reportID: reportID, bundle: bundle)
-            captured = []
-            rejectedRevokedToken = false
-        }
+    func configure(reportID: UUID, bundle: Data) {
+        set(.upload(reportID: reportID, bundle: bundle))
     }
 
-    static func configureStatusFailureAfterAccepted(reportID: UUID, bundle: Data) {
-        lock.withLock {
-            mode = .statusFailureAfterAccepted(reportID: reportID, bundle: bundle)
-            captured = []
-            rejectedRevokedToken = false
-        }
+    func configureInvalidTokenRecovery(reportID: UUID, bundle: Data) {
+        set(.invalidTokenRecovery(reportID: reportID, bundle: bundle))
     }
 
-    static func configurePutAcceptance(reportID: UUID, bundle: Data, body: String) {
-        lock.withLock {
-            mode = .putAcceptance(reportID: reportID, bundle: bundle, body: body)
-            captured = []
-            rejectedRevokedToken = false
-        }
+    func configureStatusFailureAfterAccepted(reportID: UUID, bundle: Data) {
+        set(.statusFailureAfterAccepted(reportID: reportID, bundle: bundle))
     }
 
-    static func configureReportStatus(
+    func configurePutAcceptance(reportID: UUID, bundle: Data, body: String) {
+        set(.putAcceptance(reportID: reportID, bundle: bundle, body: body))
+    }
+
+    func configureReportStatus(
         reportID: UUID,
         shortID: String,
         state: DiagnosticsRemoteReportState,
         errorCode: String?
     ) {
-        lock.withLock {
-            mode = .reportStatus(
-                reportID: reportID,
-                shortID: shortID,
-                state: state,
-                errorCode: errorCode
-            )
-            captured = []
-            rejectedRevokedToken = false
-        }
+        set(.reportStatus(reportID: reportID, shortID: shortID, state: state, errorCode: errorCode))
     }
 
-    static func configureDelete(reportID: UUID, statusCode: Int) {
-        lock.withLock {
-            mode = .delete(reportID: reportID, statusCode: statusCode)
-            captured = []
-            rejectedRevokedToken = false
-        }
+    func configureDelete(reportID: UUID, statusCode: Int) {
+        set(.delete(reportID: reportID, statusCode: statusCode))
     }
 
-    static func configureCapabilities(
+    func configureCapabilities(
         status: DiagnosticsAvailabilityStatus = .available,
         collectorID: String = HostedDiagnosticsCapabilities.pinnedCollectorID,
         acceptedSchemaVersions: [Int] = [1]
     ) {
-        lock.withLock {
-            mode = .capabilities(
-                status: status,
-                collectorID: collectorID,
-                acceptedSchemaVersions: acceptedSchemaVersions
-            )
-            captured = []
-            rejectedRevokedToken = false
-        }
+        set(.capabilities(
+            status: status,
+            collectorID: collectorID,
+            acceptedSchemaVersions: acceptedSchemaVersions
+        ))
     }
 
-    static func requests() -> [CapturedRequest] {
-        lock.withLock { captured }
+    func requests() -> [CapturedRequest] {
+        handler.requests.map(CapturedRequest.init)
     }
 
-    static func reset() {
-        configureCapabilities()
-    }
-
-    override class func canInit(with request: URLRequest) -> Bool {
-        request.url?.host == "collector.example"
-    }
-
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
-        request
-    }
-
-    override func startLoading() {
-        guard let url = request.url else {
-            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
-            return
-        }
-        let body = Self.requestBody(of: request)
-        Self.lock.withLock {
-            Self.captured.append(CapturedRequest(
-                method: request.httpMethod ?? "",
-                path: url.path,
-                host: url.host,
-                authorization: request.value(forHTTPHeaderField: "Authorization"),
-                profileHeader: request.value(forHTTPHeaderField: "X-Profile-Id"),
-                profileTokenHeader: request.value(forHTTPHeaderField: "X-Profile-Token"),
-                siloDeviceIDHeader: request.value(forHTTPHeaderField: "X-Silo-Device-Id"),
-                cookieHeader: request.value(forHTTPHeaderField: "Cookie"),
-                uploadToken: request.value(forHTTPHeaderField: "X-Upload-Token"),
-                contentType: request.value(forHTTPHeaderField: "Content-Type"),
-                contentLength: request.value(forHTTPHeaderField: "Content-Length"),
-                timeoutInterval: request.timeoutInterval,
-                body: body
-            ))
-        }
-
-        let response = Self.lock.withLock { () -> (Int, String) in
-            switch Self.mode {
+    private func respond(to request: StubURLProtocol.Request) -> (Int, String) {
+        let body = request.body ?? Data()
+        return lock.withLock { () -> (Int, String) in
+            switch mode {
             case .capabilities(let status, let collectorID, let acceptedSchemaVersions):
                 let versions = acceptedSchemaVersions.map(String.init).joined(separator: ",")
                 return (200, #"{"status":"\#(status.rawValue)","collector_id":"\#(collectorID)","accepted_schema_versions":[\#(versions)],"max_bundle_bytes":10485760,"max_manifest_bytes":65536,"retention_days":30,"consent_notice_version":1}"#)
@@ -3187,34 +3155,31 @@ private final class HostedDiagnosticsStubProtocol: URLProtocol {
             case .upload(let reportID, let expectedBundle):
                 return Self.uploadResponse(
                     request: request,
-                    url: url,
                     body: body,
                     reportID: reportID,
                     expectedBundle: expectedBundle
                 )
             case .invalidTokenRecovery(let reportID, let expectedBundle):
-                if request.httpMethod == "POST",
-                   url.path == "/v1/reports",
-                   request.value(forHTTPHeaderField: "Authorization") == "Bearer revoked-installation-token",
-                   !Self.rejectedRevokedToken {
-                    Self.rejectedRevokedToken = true
+                if request.method == "POST",
+                   request.path == "/v1/reports",
+                   request.header("Authorization") == "Bearer revoked-installation-token",
+                   !rejectedRevokedToken {
+                    rejectedRevokedToken = true
                     return (401, #"{"error":"invalid_installation_token","message":"Installation token is invalid"}"#)
                 }
                 return Self.uploadResponse(
                     request: request,
-                    url: url,
                     body: body,
                     reportID: reportID,
                     expectedBundle: expectedBundle
                 )
             case .statusFailureAfterAccepted(let reportID, let expectedBundle):
-                if request.httpMethod == "GET",
-                   url.path == "/v1/reports/\(reportID.uuidString.lowercased())" {
+                if request.method == "GET",
+                   request.path == "/v1/reports/\(reportID.uuidString.lowercased())" {
                     return (503, #"{"error":"unavailable","message":"Try again"}"#)
                 }
                 return Self.uploadResponse(
                     request: request,
-                    url: url,
                     body: body,
                     reportID: reportID,
                     expectedBundle: expectedBundle
@@ -3222,15 +3187,14 @@ private final class HostedDiagnosticsStubProtocol: URLProtocol {
             case .putAcceptance(let reportID, let expectedBundle, let responseBody):
                 return Self.uploadResponse(
                     request: request,
-                    url: url,
                     body: body,
                     reportID: reportID,
                     expectedBundle: expectedBundle,
                     putResponseBody: responseBody
                 )
             case .delete(let reportID, let statusCode):
-                guard request.httpMethod == "DELETE",
-                      url.path == "/v1/reports/\(reportID.uuidString.lowercased())" else {
+                guard request.method == "DELETE",
+                      request.path == "/v1/reports/\(reportID.uuidString.lowercased())" else {
                     return (404, #"{"error":"report_not_found"}"#)
                 }
                 if statusCode == 204 {
@@ -3242,21 +3206,17 @@ private final class HostedDiagnosticsStubProtocol: URLProtocol {
                 return (statusCode, #"{"error":"unavailable"}"#)
             }
         }
-        respond(statusCode: response.0, body: response.1)
     }
 
-    override func stopLoading() {}
-
     private static func uploadResponse(
-        request: URLRequest,
-        url: URL,
+        request: StubURLProtocol.Request,
         body: Data,
         reportID: UUID,
         expectedBundle: Data,
         putResponseBody: String? = nil
     ) -> (Int, String) {
         let id = reportID.uuidString.lowercased()
-        switch (request.httpMethod, url.path) {
+        switch (request.method, request.path) {
         case ("POST", "/v1/installations"):
             return (201, #"{"installation_id":"install_apple_generated","installation_token":"generated-installation-token"}"#)
         case ("POST", "/v1/reports"):
@@ -3276,124 +3236,46 @@ private final class HostedDiagnosticsStubProtocol: URLProtocol {
             return (404, #"{"error":"not_found"}"#)
         }
     }
-
-    private static func requestBody(of request: URLRequest) -> Data {
-        if let body = request.httpBody {
-            return body
-        }
-        guard let stream = request.httpBodyStream else {
-            return Data()
-        }
-        stream.open()
-        defer { stream.close() }
-        var data = Data()
-        var buffer = [UInt8](repeating: 0, count: 64 * 1024)
-        while stream.hasBytesAvailable {
-            let read = stream.read(&buffer, maxLength: buffer.count)
-            guard read > 0 else { break }
-            data.append(buffer, count: read)
-        }
-        return data
-    }
-
-    private func respond(statusCode: Int, body: String) {
-        guard let url = request.url,
-              let response = HTTPURLResponse(
-                url: url,
-                statusCode: statusCode,
-                httpVersion: "HTTP/1.1",
-                headerFields: ["Content-Type": "application/json"]
-              ) else {
-            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
-            return
-        }
-        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-        if !body.isEmpty {
-            client?.urlProtocol(self, didLoad: Data(body.utf8))
-        }
-        client?.urlProtocolDidFinishLoading(self)
-    }
 }
 
-private final class SelfHostedDiagnosticsStubProtocol: URLProtocol {
-    private static let lock = NSLock()
-    nonisolated(unsafe) private static var serverInstanceID = "self-hosted-diagnostics-instance"
-    nonisolated(unsafe) private static var reportID = UUID()
-    nonisolated(unsafe) private static var paths: [String] = []
+/// A self-hosted Silo's diagnostics routes on the shared stub.
+private final class SelfHostedDiagnosticsStub: @unchecked Sendable {
+    let handler = StubURLProtocol.Handler()
+    private let lock = NSLock()
+    private var serverInstanceID = "self-hosted-diagnostics-instance"
+    private var reportID = UUID()
 
-    static func configure(serverInstanceID: String, reportID: UUID) {
+    init() {
+        installRoutes()
+    }
+
+    func configure(serverInstanceID: String, reportID: UUID) {
         lock.withLock {
             self.serverInstanceID = serverInstanceID
             self.reportID = reportID
-            paths = []
         }
+        handler.reset()
+        installRoutes()
     }
 
-    static func requestedPaths() -> [String] {
-        lock.withLock { paths }
+    func requestedPaths() -> [String] {
+        handler.requests.map(\.path)
     }
 
-    static func reset() {
-        lock.withLock {
-            serverInstanceID = "self-hosted-diagnostics-instance"
-            reportID = UUID()
-            paths = []
+    private func installRoutes() {
+        handler.route(StubURLProtocol.method("GET", path: "/api/v1/diagnostics/status")) { [self] _ in
+            let serverInstanceID = lock.withLock { self.serverInstanceID }
+            return .json(#"{"status":"available","server_instance_id":"\#(serverInstanceID)","accepted_schema_versions":[1],"max_bundle_bytes":10485760,"max_manifest_bytes":65536,"retention_days":30,"consent_notice_version":1}"#)
         }
-    }
-
-    override class func canInit(with request: URLRequest) -> Bool {
-        request.url?.host == "selfhost.test"
-    }
-
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
-        request
-    }
-
-    override func startLoading() {
-        guard let url = request.url else {
-            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
-            return
+        handler.route(StubURLProtocol.method("GET", path: "/api/v1/auth/me")) { _ in
+            .json(#"{"id":42,"username":"diagnostics-test","email":"diagnostics@example.invalid","role":"user","download_allowed":true,"impersonation":null}"#)
         }
-        let response = Self.lock.withLock { () -> (Int, String) in
-            Self.paths.append(url.path)
-            switch (request.httpMethod, url.path) {
-            case ("GET", "/api/v1/diagnostics/status"):
-                return (
-                    200,
-                    #"{"status":"available","server_instance_id":"\#(Self.serverInstanceID)","accepted_schema_versions":[1],"max_bundle_bytes":10485760,"max_manifest_bytes":65536,"retention_days":30,"consent_notice_version":1}"#
-                )
-            case ("GET", "/api/v1/auth/me"):
-                return (
-                    200,
-                    #"{"id":42,"username":"diagnostics-test","email":"diagnostics@example.invalid","role":"user","download_allowed":true,"impersonation":null}"#
-                )
-            case ("POST", "/api/v1/diagnostics/reports"):
-                return (
-                    201,
-                    #"{"report_id":"\#(Self.reportID.uuidString.lowercased())","short_id":"SILO-SELFHOSTED","state":"ready"}"#
-                )
-            default:
-                return (404, #"{"error":"not_found"}"#)
-            }
+        handler.route(StubURLProtocol.method("POST", path: "/api/v1/diagnostics/reports")) { [self] _ in
+            let reportID = lock.withLock { self.reportID }
+            return .json(#"{"report_id":"\#(reportID.uuidString.lowercased())","short_id":"SILO-SELFHOSTED","state":"ready"}"#, status: 201)
         }
-        respond(statusCode: response.0, body: response.1)
-    }
-
-    override func stopLoading() {}
-
-    private func respond(statusCode: Int, body: String) {
-        guard let url = request.url,
-              let response = HTTPURLResponse(
-                url: url,
-                statusCode: statusCode,
-                httpVersion: "HTTP/1.1",
-                headerFields: ["Content-Type": "application/json"]
-              ) else {
-            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
-            return
+        handler.route(StubURLProtocol.any) { _ in
+            .json(#"{"error":"not_found"}"#, status: 404)
         }
-        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-        client?.urlProtocol(self, didLoad: Data(body.utf8))
-        client?.urlProtocolDidFinishLoading(self)
     }
 }

--- a/iosApp/Tests/OnboardingInvitationTests.swift
+++ b/iosApp/Tests/OnboardingInvitationTests.swift
@@ -2,9 +2,11 @@ import XCTest
 @testable import Silo
 
 final class OnboardingInvitationTests: XCTestCase {
+    private var stub = OnboardingRequestStub()
+
     override func setUp() {
         super.setUp()
-        OnboardingRequestStubProtocol.reset()
+        stub = OnboardingRequestStub()
     }
 
     func testOnboardingSurfaceUsesAQueryItemInsteadOfEmbeddingQueryInPath() async throws {
@@ -14,7 +16,7 @@ final class OnboardingInvitationTests: XCTestCase {
         let flow = try await api.onboardingFlow(surface: "phone")
         XCTAssertEqual(flow.tourId, "tour-test")
 
-        let request = try XCTUnwrap(OnboardingRequestStubProtocol.requests().last)
+        let request = try XCTUnwrap(stub.requests().last)
         XCTAssertEqual(request.url?.path, "/silo/api/v1/onboarding/flow")
         XCTAssertEqual(URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)?
             .queryItems, [URLQueryItem(name: "surface", value: "phone")])
@@ -238,10 +240,8 @@ final class OnboardingInvitationTests: XCTestCase {
         await tokenStore.switchActiveServer(serverId: "active")
         await tokenStore.saveTokens(accessToken: "existing-access", refreshToken: "existing-refresh")
 
-        let configuration = URLSessionConfiguration.ephemeral
-        configuration.protocolClasses = [OnboardingRequestStubProtocol.self]
         return (
-            HTTPClient(session: URLSession(configuration: configuration), tokenStore: tokenStore),
+            HTTPClient(session: stub.handler.makeSession(), tokenStore: tokenStore),
             tokenStore
         )
     }
@@ -306,52 +306,21 @@ private final class OnboardingRuntimeSettingsRefresherStub: OnboardingRuntimeSet
     }
 }
 
-private final class OnboardingRequestStubProtocol: URLProtocol {
-    private static let lock = NSLock()
-    private static var recordedRequests: [URLRequest] = []
+/// The onboarding flow endpoint as a route on the shared stub; anything
+/// else answers 500.
+private final class OnboardingRequestStub {
+    let handler = StubURLProtocol.Handler()
 
-    static func reset() {
-        lock.withLock { recordedRequests = [] }
-    }
-
-    static func requests() -> [URLRequest] {
-        lock.withLock { recordedRequests }
-    }
-
-    override class func canInit(with request: URLRequest) -> Bool { true }
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
-
-    override func startLoading() {
-        Self.lock.withLock { Self.recordedRequests.append(request) }
-        let path = request.url?.path ?? ""
-        let status: Int
-        let body: Data
-        if path.hasSuffix("/api/v1/onboarding/flow") {
-            status = 200
-            body = Data(#"{"version":1,"tour_id":"tour-test","steps":[]}"#.utf8)
-        } else {
-            status = 500
-            body = Data()
+    init() {
+        handler.route(StubURLProtocol.pathSuffix("/api/v1/onboarding/flow")) { _ in
+            .json(#"{"version":1,"tour_id":"tour-test","steps":[]}"#)
         }
-
-        let response = HTTPURLResponse(
-            url: request.url!,
-            statusCode: status,
-            httpVersion: nil,
-            headerFields: ["Content-Type": "application/json"]
-        )!
-        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-        client?.urlProtocol(self, didLoad: body)
-        client?.urlProtocolDidFinishLoading(self)
+        handler.route(StubURLProtocol.any) { _ in
+            .json("", status: 500)
+        }
     }
 
-    override func stopLoading() {}
-}
-
-private extension NSLock {
-    func withLock<T>(_ operation: () -> T) -> T {
-        lock()
-        defer { unlock() }
-        return operation()
+    func requests() -> [URLRequest] {
+        handler.requests.map(\.underlying)
     }
 }

--- a/iosApp/Tests/PlaybackProtocolV3Tests.swift
+++ b/iosApp/Tests/PlaybackProtocolV3Tests.swift
@@ -1287,7 +1287,11 @@ final class PlaybackProtocolV3Tests: XCTestCase {
         )
         let snapshot = ApplePlaybackV3Capabilities.snapshot()
         XCTAssertEqual(snapshot.context.protocolVersion, 3)
+        #if os(tvOS)
+        XCTAssertEqual(snapshot.context.device.platform, "tvos")
+        #else
         XCTAssertEqual(snapshot.context.device.platform, "ios")
+        #endif
         XCTAssertEqual(
             Set(snapshot.context.deliveries.keys),
             [

--- a/iosApp/Tests/ProfileLaunchPolicyTests.swift
+++ b/iosApp/Tests/ProfileLaunchPolicyTests.swift
@@ -726,7 +726,13 @@ final class ProfileLaunchMigrationTests: XCTestCase {
         XCTAssertEqual(remembered.profileID, "profile-a")
         XCTAssertTrue(remembered.requiredPINAtSelection)
         XCTAssertNil(registry.entry(with: serverID)?.legacyProfileId)
+        #if os(tvOS)
+        // tvOS persists the registry in the shared keychain and clears the
+        // defaults copy, so the legacy field is gone with the whole record.
+        XCTAssertNil(defaults.data(forKey: "continuumServerRegistry.v1"))
+        #else
         let migrated = try XCTUnwrap(defaults.data(forKey: "continuumServerRegistry.v1"))
         XCTAssertFalse(String(decoding: migrated, as: UTF8.self).contains("profileId"))
+        #endif
     }
 }

--- a/iosApp/Tests/SeriesHierarchyLoadingTests.swift
+++ b/iosApp/Tests/SeriesHierarchyLoadingTests.swift
@@ -277,6 +277,9 @@ final class SeriesHierarchyLoadingTests: XCTestCase {
         XCTAssertFalse(model.isLoadingEpisodes)
     }
 
+#if os(iOS)
+    // The stale-cache resume guard is the iOS branch of hydrateFromCache;
+    // tvOS paints the preferred season and resumes through its own path.
     func testResumeEntryDoesNotPlayAnotherSeasonFromAStaleCache() throws {
         let detail = try JSONDecoder().decode(ItemDetail.self, from: Data(
             "{\"contentId\":\"\(seriesId)\",\"type\":\"series\",\"title\":\"Synthetic series\"}".utf8
@@ -296,6 +299,7 @@ final class SeriesHierarchyLoadingTests: XCTestCase {
         XCTAssertTrue(model.isLoadingSeriesHierarchy)
         XCTAssertEqual(model.initialResumeSeasonNumber, 3)
     }
+#endif
 
     func testRetryOfBackgroundHierarchyFailureKeepsTheBrowsedSeason() async throws {
         let model = ItemDetailViewModel()
@@ -325,6 +329,9 @@ final class SeriesHierarchyLoadingTests: XCTestCase {
         XCTAssertEqual(result, 42)
     }
 
+#if os(iOS)
+    // loadContinueWatchingStructure is the iOS resume-only entry (#if os(iOS)
+    // in ItemDetailViewModel).
     func testOneRetryRecoversBothContinueWatchingHierarchyFailures() async throws {
         let model = ItemDetailViewModel()
         model.seasons = try seasons([1]).seasons
@@ -346,6 +353,7 @@ final class SeriesHierarchyLoadingTests: XCTestCase {
         XCTAssertFalse(model.isLoadingSeriesHierarchy)
         XCTAssertEqual(model.episodesBySeason[1], [])
     }
+#endif
 
     private func clearCache() {
         ResponseCache.shared.remove(CacheKey.itemSeasons(seriesId))

--- a/iosApp/Tests/ServerIdentityResolverTests.swift
+++ b/iosApp/Tests/ServerIdentityResolverTests.swift
@@ -2,13 +2,15 @@ import XCTest
 @testable import Silo
 
 final class ServerIdentityResolverTests: XCTestCase {
+    private var stub = ServerIdentityStub()
+
     override func setUp() {
         super.setUp()
-        ServerIdentityStubProtocol.reset()
+        stub = ServerIdentityStub()
     }
 
     func testPrefersNativeBrandingName() async {
-        ServerIdentityStubProtocol.configure([
+        stub.configure([
             "/api/v1/theme/branding": (200, #"{"server_name":"  Home Silo  "}"#),
             "/api/v1/health": (200, #"{"status":"ok","server_name":"StreamApp"}"#),
         ])
@@ -16,11 +18,11 @@ final class ServerIdentityResolverTests: XCTestCase {
         let name = await resolver().fetchServerName(serverURL: "https://silo.example")
 
         XCTAssertEqual(name, "Home Silo")
-        XCTAssertEqual(ServerIdentityStubProtocol.requestedPaths(), ["/api/v1/theme/branding"])
+        XCTAssertEqual(stub.requestedPaths(), ["/api/v1/theme/branding"])
     }
 
     func testFallsBackToHealthForOlderServer() async {
-        ServerIdentityStubProtocol.configure([
+        stub.configure([
             "/api/v1/theme/branding": (404, #"{"error":"not_found"}"#),
             "/api/v1/health": (200, #"{"status":"ok","server_name":"Legacy Home"}"#),
         ])
@@ -29,13 +31,13 @@ final class ServerIdentityResolverTests: XCTestCase {
 
         XCTAssertEqual(name, "Legacy Home")
         XCTAssertEqual(
-            ServerIdentityStubProtocol.requestedPaths(),
+            stub.requestedPaths(),
             ["/api/v1/theme/branding", "/api/v1/health"]
         )
     }
 
     func testBlankBrandingNameFallsBackToHealth() async {
-        ServerIdentityStubProtocol.configure([
+        stub.configure([
             "/api/v1/theme/branding": (200, #"{"server_name":"  "}"#),
             "/api/v1/health": (200, #"{"status":"ok","server_name":"Fallback"}"#),
         ])
@@ -46,7 +48,7 @@ final class ServerIdentityResolverTests: XCTestCase {
     }
 
     func testBrandingFailureDoesNotFallBackToHealth() async {
-        ServerIdentityStubProtocol.configure([
+        stub.configure([
             "/api/v1/theme/branding": (500, #"{"error":"unavailable"}"#),
             "/api/v1/health": (200, #"{"status":"ok","server_name":"Compat Name"}"#),
         ])
@@ -54,11 +56,11 @@ final class ServerIdentityResolverTests: XCTestCase {
         let name = await resolver().fetchServerName(serverURL: "https://silo.example")
 
         XCTAssertNil(name)
-        XCTAssertEqual(ServerIdentityStubProtocol.requestedPaths(), ["/api/v1/theme/branding"])
+        XCTAssertEqual(stub.requestedPaths(), ["/api/v1/theme/branding"])
     }
 
     func testBrandingDecodeFailureDoesNotFallBackToHealth() async {
-        ServerIdentityStubProtocol.configure([
+        stub.configure([
             "/api/v1/theme/branding": (200, #"{"server_name":42}"#),
             "/api/v1/health": (200, #"{"status":"ok","server_name":"Compat Name"}"#),
         ])
@@ -66,7 +68,7 @@ final class ServerIdentityResolverTests: XCTestCase {
         let name = await resolver().fetchServerName(serverURL: "https://silo.example")
 
         XCTAssertNil(name)
-        XCTAssertEqual(ServerIdentityStubProtocol.requestedPaths(), ["/api/v1/theme/branding"])
+        XCTAssertEqual(stub.requestedPaths(), ["/api/v1/theme/branding"])
     }
 
     func testStaleActiveServerResponseDoesNotRenameRegistryEntries() async {
@@ -100,10 +102,10 @@ final class ServerIdentityResolverTests: XCTestCase {
         registry.addOrUpdate(serverB)
         await registry.switchTo(serverId: serverA.id)
 
-        ServerIdentityStubProtocol.configure([
+        stub.configure([
             "/api/v1/theme/branding": (200, #"{"server_name":"Updated A"}"#),
         ], blockedPaths: ["/api/v1/theme/branding"])
-        defer { ServerIdentityStubProtocol.release(path: "/api/v1/theme/branding") }
+        defer { stub.release(path: "/api/v1/theme/branding") }
 
         let service = AuthService(
             serverIdentityResolver: resolver(),
@@ -113,7 +115,7 @@ final class ServerIdentityResolverTests: XCTestCase {
         await waitForRequest(path: "/api/v1/theme/branding")
 
         await registry.switchTo(serverId: serverB.id)
-        ServerIdentityStubProtocol.release(path: "/api/v1/theme/branding")
+        stub.release(path: "/api/v1/theme/branding")
         await refresh.value
 
         XCTAssertEqual(registry.activeServerId, serverB.id)
@@ -123,102 +125,54 @@ final class ServerIdentityResolverTests: XCTestCase {
     }
 
     private func resolver() -> ServerIdentityResolver {
-        let configuration = URLSessionConfiguration.ephemeral
-        configuration.protocolClasses = [ServerIdentityStubProtocol.self]
-        return ServerIdentityResolver(
-            httpClient: HTTPClient(session: URLSession(configuration: configuration))
+        ServerIdentityResolver(
+            httpClient: HTTPClient(session: stub.handler.makeSession())
         )
     }
 
     private func waitForRequest(path: String) async {
-        for _ in 0..<100 {
-            if ServerIdentityStubProtocol.requestedPaths().contains(path) {
-                return
-            }
-            try? await Task.sleep(for: .milliseconds(10))
+        do {
+            try await stub.handler.waitForRequest(where: StubURLProtocol.path(path))
+        } catch {
+            XCTFail("Timed out waiting for request: \(path)")
         }
-        XCTFail("Timed out waiting for request: \(path)")
     }
 }
 
-private final class ServerIdentityStubProtocol: URLProtocol {
-    private static let lock = NSLock()
-    private static let responseCondition = NSCondition()
-    nonisolated(unsafe) private static var responses: [String: (status: Int, body: String)] = [:]
-    nonisolated(unsafe) private static var paths: [String] = []
-    nonisolated(unsafe) private static var blockedPaths: Set<String> = []
-    nonisolated(unsafe) private static var releasedPaths: Set<String> = []
+/// Path-keyed replies on the shared stub. A blocked path stalls its reply on
+/// a gate until `release(path:)` opens it.
+private final class ServerIdentityStub: @unchecked Sendable {
+    let handler = StubURLProtocol.Handler()
+    private let lock = NSLock()
+    private var gates: [String: StubURLProtocol.Gate] = [:]
 
-    static func configure(
-        _ configuredResponses: [String: (status: Int, body: String)],
-        blockedPaths configuredBlockedPaths: Set<String> = []
+    func configure(
+        _ responses: [String: (status: Int, body: String)],
+        blockedPaths: Set<String> = []
     ) {
+        handler.reset()
         lock.withLock {
-            responses = configuredResponses
-            paths = []
+            gates = Dictionary(uniqueKeysWithValues: blockedPaths.map { ($0, StubURLProtocol.Gate()) })
         }
-        responseCondition.withLock {
-            blockedPaths = configuredBlockedPaths
-            releasedPaths = []
-        }
-    }
-
-    static func requestedPaths() -> [String] {
-        lock.withLock { paths }
-    }
-
-    static func reset() {
-        lock.withLock {
-            responses = [:]
-            paths = []
-        }
-        responseCondition.withLock {
-            blockedPaths = []
-            releasedPaths = []
-            responseCondition.broadcast()
-        }
-    }
-
-    static func release(path: String) {
-        responseCondition.withLock {
-            releasedPaths.insert(path)
-            responseCondition.broadcast()
-        }
-    }
-
-    override class func canInit(with request: URLRequest) -> Bool { true }
-
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
-
-    override func startLoading() {
-        guard let url = request.url else {
-            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
-            return
-        }
-        let response = Self.lock.withLock {
-            Self.paths.append(url.path)
-            return Self.responses[url.path] ?? (500, #"{"error":"unexpected"}"#)
-        }
-        Self.responseCondition.withLock {
-            while Self.blockedPaths.contains(url.path),
-                  !Self.releasedPaths.contains(url.path) {
-                Self.responseCondition.wait()
+        for (path, response) in responses {
+            handler.route(StubURLProtocol.path(path)) { [weak self] _ in
+                if let gate = self?.lock.withLock({ self?.gates[path] }) {
+                    await gate.wait()
+                }
+                return .json(response.body, status: response.status)
             }
         }
-
-        guard let httpResponse = HTTPURLResponse(
-            url: url,
-            statusCode: response.status,
-            httpVersion: nil,
-            headerFields: ["Content-Type": "application/json"]
-        ) else {
-            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
-            return
+        handler.route(StubURLProtocol.any) { _ in
+            .json(#"{"error":"unexpected"}"#, status: 500)
         }
-        client?.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
-        client?.urlProtocol(self, didLoad: Data(response.body.utf8))
-        client?.urlProtocolDidFinishLoading(self)
     }
 
-    override func stopLoading() {}
+    func requestedPaths() -> [String] {
+        handler.requests.map(\.path)
+    }
+
+    func release(path: String) {
+        guard let gate = lock.withLock({ gates[path] }) else { return }
+        Task { await gate.open() }
+    }
 }

--- a/iosApp/Tests/StubURLProtocolGateTests.swift
+++ b/iosApp/Tests/StubURLProtocolGateTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import XCTest
+@testable import Silo
+
+/// The shared stub's `Gate` must not strand a waiter whose task is cancelled:
+/// `stopLoading()` cancels a gated reply, and a test that never opens the
+/// gate afterward would otherwise leak a suspended task per cancellation.
+final class StubURLProtocolGateTests: XCTestCase {
+    func testCancelledWaiterIsReleasedWithoutOpen() async {
+        let gate = StubURLProtocol.Gate()
+        let waiter = Task { await gate.wait() }
+        // Give the waiter a chance to suspend inside the gate before cancelling.
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        waiter.cancel()
+        let released = await withTaskGroup(of: Bool.self) { group in
+            group.addTask { await waiter.value; return true }
+            group.addTask { try? await Task.sleep(nanoseconds: 2_000_000_000); return false }
+            let first = await group.next() ?? false
+            group.cancelAll()
+            return first
+        }
+        XCTAssertTrue(released, "a cancelled waiter must return without the gate opening")
+    }
+
+    func testOpenStillReleasesLiveWaiters() async {
+        let gate = StubURLProtocol.Gate()
+        let waiter = Task { await gate.wait() }
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        await gate.open()
+        await waiter.value
+        // A wait after open returns immediately.
+        await gate.wait()
+    }
+}

--- a/iosApp/Tests/Support/StubURLProtocol.swift
+++ b/iosApp/Tests/Support/StubURLProtocol.swift
@@ -155,27 +155,43 @@ final class StubURLProtocol: URLProtocol {
 
     /// An async latch for stalling a reply until the test releases it.
     /// `wait()` suspends until `open()` runs; opening is idempotent and
-    /// releases every current and future waiter.
+    /// releases every current and future waiter. A waiter whose task is
+    /// cancelled (a `stopLoading()` on the gated request, for example) is
+    /// resumed and removed at once, so a test that cancels a gated request
+    /// and never opens the gate does not leave a suspended task behind.
     actor Gate {
         private var isOpen = false
-        private var waiters: [CheckedContinuation<Void, Never>] = []
+        private var waiters: [UUID: CheckedContinuation<Void, Never>] = [:]
 
         init() {}
 
         func wait() async {
-            if isOpen { return }
-            await withCheckedContinuation { continuation in
-                waiters.append(continuation)
+            if isOpen || Task.isCancelled { return }
+            let id = UUID()
+            await withTaskCancellationHandler {
+                await withCheckedContinuation { continuation in
+                    if isOpen || Task.isCancelled {
+                        continuation.resume()
+                    } else {
+                        waiters[id] = continuation
+                    }
+                }
+            } onCancel: {
+                Task { await self.cancelWaiter(id) }
             }
         }
 
         func open() {
             isOpen = true
-            let released = waiters
+            let released = waiters.values
             waiters.removeAll()
             for waiter in released {
                 waiter.resume()
             }
+        }
+
+        private func cancelWaiter(_ id: UUID) {
+            waiters.removeValue(forKey: id)?.resume()
         }
     }
 

--- a/iosApp/Tests/Support/StubURLProtocol.swift
+++ b/iosApp/Tests/Support/StubURLProtocol.swift
@@ -1,0 +1,461 @@
+import Foundation
+
+// The one URLProtocol stub for every networking test in SiloTests and
+// SiloTVTests. Do not write another private `URLProtocol` subclass; express
+// the scenario as routes on a `StubURLProtocol.Handler`.
+//
+// Usage
+//
+//     let stub = StubURLProtocol.Handler()
+//     stub.route(.method("GET", path: "/api/v1/health")) { _ in
+//         .json(#"{"status":"ok"}"#)
+//     }
+//     stub.expect(.path("/api/v1/auth/refresh")) { _ in .status(401) }   // one-shot
+//     let session = stub.makeSession()                                    // or stub.install(into: config)
+//
+//     ... exercise the code under test with `session` ...
+//
+//     XCTAssertEqual(stub.requests.map(\.path), ["/api/v1/health"])
+//
+// Vocabulary
+//
+// - A handler owns an ordered list of routes. Each route is a matcher
+//   `(Request) -> Bool` and a reply `(Request) async throws -> Response`.
+//   The first matching route answers. `expect` adds a one-shot route that is
+//   removed after it answers; `route` adds a persistent one. Both live in the
+//   same ordered list, so a one-shot placed before a persistent catch-all
+//   wins exactly once.
+// - A reply returns `Response(status:headers:body:)` or throws. A thrown
+//   `URLError` (or any error) reaches the caller as a transport failure, the
+//   way a dropped connection would.
+// - Replies are `async`. To stall a response until the test says so, await
+//   a `StubURLProtocol.Gate` inside the reply and `open()` it from the test.
+//   No `DispatchSemaphore`, no blocked loader thread.
+// - Every request is recorded, body drained, before it is answered:
+//   `requests` is the ordered snapshot, `observe()` is an `AsyncStream` for
+//   awaiting requests as they arrive, and `waitForRequest(where:)` is the
+//   common "await the request that matches" helper.
+// - A request no route matches is answered with HTTP 599 and a body naming
+//   the method and path, recorded in `unmatched`, and never left hanging.
+//
+// Sessions
+//
+// URLSession instantiates the protocol class itself and gives it no handle
+// back to the session, so the handler is found through a per-session marker
+// header that `install(into:)` adds through `httpAdditionalHeaders`. The
+// marker is stripped before the request is recorded, so tests never see it.
+// Two handlers can therefore serve two sessions in the same test without
+// stealing each other's requests.
+
+final class StubURLProtocol: URLProtocol {
+    // MARK: Request and response records
+
+    /// A recorded request: the original `URLRequest` plus the parts tests
+    /// assert on most, decoded once. Header names are lowercased because
+    /// URLSession is free to normalize casing.
+    struct Request: @unchecked Sendable {
+        let underlying: URLRequest
+        let method: String
+        let url: URL?
+        let path: String
+        let query: [String: String]
+        let headers: [String: String]
+        let body: Data?
+
+        init(_ request: URLRequest, body: Data?) {
+            var stripped = request
+            stripped.setValue(nil, forHTTPHeaderField: StubURLProtocol.markerHeader)
+            underlying = stripped
+            method = request.httpMethod ?? "GET"
+            url = request.url
+            let components = request.url.flatMap { URLComponents(url: $0, resolvingAgainstBaseURL: false) }
+            path = components?.path ?? ""
+            var query: [String: String] = [:]
+            for item in components?.queryItems ?? [] {
+                query[item.name] = item.value ?? ""
+            }
+            self.query = query
+            var headers: [String: String] = [:]
+            for (name, value) in request.allHTTPHeaderFields ?? [:]
+            where name.caseInsensitiveCompare(StubURLProtocol.markerHeader) != .orderedSame {
+                headers[name.lowercased()] = value
+            }
+            self.headers = headers
+            self.body = body
+        }
+
+        func header(_ name: String) -> String? {
+            headers[name.lowercased()]
+        }
+
+        var bodyString: String? {
+            body.map { String(decoding: $0, as: UTF8.self) }
+        }
+    }
+
+    struct Response: Sendable {
+        var status: Int
+        var headers: [String: String]
+        var body: Data
+
+        init(status: Int, headers: [String: String] = [:], body: Data = Data()) {
+            self.status = status
+            self.headers = headers
+            self.body = body
+        }
+
+        static func json(_ body: String, status: Int = 200, headers: [String: String] = [:]) -> Response {
+            var merged = ["Content-Type": "application/json"]
+            merged.merge(headers) { _, new in new }
+            return Response(status: status, headers: merged, body: Data(body.utf8))
+        }
+
+        static func text(_ body: String, status: Int = 200, contentType: String = "text/plain") -> Response {
+            Response(status: status, headers: ["Content-Type": contentType], body: Data(body.utf8))
+        }
+
+        static func data(_ body: Data, status: Int = 200, contentType: String) -> Response {
+            Response(status: status, headers: ["Content-Type": contentType], body: body)
+        }
+
+        /// An empty body with only a status code.
+        static func status(_ status: Int) -> Response {
+            Response(status: status)
+        }
+    }
+
+    typealias Matcher = @Sendable (Request) -> Bool
+    typealias Reply = @Sendable (Request) async throws -> Response
+
+    // MARK: Matchers
+
+    static let any: Matcher = { _ in true }
+
+    static func path(_ path: String) -> Matcher {
+        { $0.path == path }
+    }
+
+    static func method(_ method: String, path: String) -> Matcher {
+        { $0.method == method && $0.path == path }
+    }
+
+    static func method(_ method: String) -> Matcher {
+        { $0.method == method }
+    }
+
+    static func pathPrefix(_ prefix: String) -> Matcher {
+        { $0.path.hasPrefix(prefix) }
+    }
+
+    static func pathSuffix(_ suffix: String) -> Matcher {
+        { $0.path.hasSuffix(suffix) }
+    }
+
+    // MARK: Gate
+
+    /// An async latch for stalling a reply until the test releases it.
+    /// `wait()` suspends until `open()` runs; opening is idempotent and
+    /// releases every current and future waiter.
+    actor Gate {
+        private var isOpen = false
+        private var waiters: [CheckedContinuation<Void, Never>] = []
+
+        init() {}
+
+        func wait() async {
+            if isOpen { return }
+            await withCheckedContinuation { continuation in
+                waiters.append(continuation)
+            }
+        }
+
+        func open() {
+            isOpen = true
+            let released = waiters
+            waiters.removeAll()
+            for waiter in released {
+                waiter.resume()
+            }
+        }
+    }
+
+    // MARK: Handler
+
+    final class Handler: @unchecked Sendable {
+        private struct Route {
+            let matcher: Matcher
+            let reply: Reply
+            let oneShot: Bool
+        }
+
+        let id = UUID().uuidString
+        private let lock = NSLock()
+        private var routes: [Route] = []
+        private var recorded: [Request] = []
+        private var unmatchedRecorded: [Request] = []
+        private var observers: [UUID: AsyncStream<Request>.Continuation] = [:]
+
+        init() {
+            StubURLProtocol.register(self)
+        }
+
+        deinit {
+            for observer in observers.values {
+                observer.finish()
+            }
+        }
+
+        // Routing
+
+        /// Adds a persistent route. First match in insertion order wins.
+        func route(_ matcher: @escaping Matcher, _ reply: @escaping Reply) {
+            lock.withLock { routes.append(Route(matcher: matcher, reply: reply, oneShot: false)) }
+        }
+
+        /// Adds a one-shot route that is removed after it answers once.
+        func expect(_ matcher: @escaping Matcher, _ reply: @escaping Reply) {
+            lock.withLock { routes.append(Route(matcher: matcher, reply: reply, oneShot: true)) }
+        }
+
+        /// Removes every route and recorded request. Observers stay attached.
+        func reset() {
+            lock.withLock {
+                routes.removeAll()
+                recorded.removeAll()
+                unmatchedRecorded.removeAll()
+            }
+        }
+
+        // Observation
+
+        /// Every request this handler answered, in arrival order.
+        var requests: [Request] {
+            lock.withLock { recorded }
+        }
+
+        /// Requests no route matched. A test that cares asserts this is empty.
+        var unmatched: [Request] {
+            lock.withLock { unmatchedRecorded }
+        }
+
+        /// A stream of requests as they arrive. Each call creates an
+        /// independent stream; requests recorded before the call are not
+        /// replayed, use `requests` or `waitForRequest` for those.
+        func observe() -> AsyncStream<Request> {
+            let key = UUID()
+            return AsyncStream { continuation in
+                lock.withLock { observers[key] = continuation }
+                continuation.onTermination = { [weak self] _ in
+                    guard let self else { return }
+                    self.lock.withLock { _ = self.observers.removeValue(forKey: key) }
+                }
+            }
+        }
+
+        /// Returns the first request matching `predicate`, waiting for it to
+        /// arrive if it has not already. Throws after `timeout`.
+        @discardableResult
+        func waitForRequest(
+            timeout: Duration = .seconds(5),
+            where predicate: @escaping Matcher
+        ) async throws -> Request {
+            let stream = observe()
+            if let existing = requests.first(where: predicate) {
+                return existing
+            }
+            return try await withThrowingTaskGroup(of: Request.self) { group in
+                group.addTask {
+                    for await request in stream where predicate(request) {
+                        return request
+                    }
+                    throw StubError.handlerReleased
+                }
+                group.addTask {
+                    try await Task.sleep(for: timeout)
+                    throw StubError.timedOut
+                }
+                guard let first = try await group.next() else {
+                    throw StubError.timedOut
+                }
+                group.cancelAll()
+                return first
+            }
+        }
+
+        // Sessions
+
+        /// Points `configuration` at this handler. Every request the session
+        /// issues is answered by this handler's routes.
+        func install(into configuration: URLSessionConfiguration) {
+            configuration.protocolClasses = [StubURLProtocol.self]
+            var headers = configuration.httpAdditionalHeaders ?? [:]
+            headers[StubURLProtocol.markerHeader] = id
+            configuration.httpAdditionalHeaders = headers
+        }
+
+        /// An ephemeral session that talks only to this handler.
+        func makeSession() -> URLSession {
+            let configuration = URLSessionConfiguration.ephemeral
+            install(into: configuration)
+            return URLSession(configuration: configuration)
+        }
+
+        // Dispatch
+
+        fileprivate func record(_ request: Request) {
+            let observers = lock.withLock {
+                recorded.append(request)
+                return Array(self.observers.values)
+            }
+            for observer in observers {
+                observer.yield(request)
+            }
+        }
+
+        fileprivate func reply(for request: Request) -> Reply? {
+            lock.withLock {
+                guard let index = routes.firstIndex(where: { $0.matcher(request) }) else {
+                    unmatchedRecorded.append(request)
+                    return nil
+                }
+                let route = routes[index]
+                if route.oneShot {
+                    routes.remove(at: index)
+                }
+                return route.reply
+            }
+        }
+    }
+
+    enum StubError: Error {
+        case timedOut
+        case handlerReleased
+    }
+
+    // MARK: Registry
+
+    static let markerHeader = "X-Silo-Test-Stub-Handler"
+
+    private final class WeakHandler {
+        weak var handler: Handler?
+        init(_ handler: Handler) { self.handler = handler }
+    }
+
+    private static let registryLock = NSLock()
+    nonisolated(unsafe) private static var registry: [String: WeakHandler] = [:]
+
+    private static func register(_ handler: Handler) {
+        registryLock.withLock {
+            registry = registry.filter { $0.value.handler != nil }
+            registry[handler.id] = WeakHandler(handler)
+        }
+    }
+
+    private static func handler(for request: URLRequest) -> Handler? {
+        guard let id = request.value(forHTTPHeaderField: markerHeader) else { return nil }
+        return registryLock.withLock { registry[id]?.handler }
+    }
+
+    // MARK: URLProtocol
+
+    // `task` is a URLProtocol property; this is the in-flight reply.
+    private let replyLock = NSLock()
+    private var pendingReply: Task<Void, Never>?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        let body = Self.drainBody(of: request)
+        let recorded = Request(request, body: body)
+        guard let client else { return }
+        guard let url = request.url else {
+            client.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+        guard let handler = Self.handler(for: request) else {
+            deliver(
+                .text("StubURLProtocol: no handler installed for this session (\(recorded.method) \(recorded.path))", status: 599),
+                url: url,
+                client: client
+            )
+            return
+        }
+        handler.record(recorded)
+        guard let reply = handler.reply(for: recorded) else {
+            deliver(
+                .text("StubURLProtocol: no route matched \(recorded.method) \(recorded.path)", status: 599),
+                url: url,
+                client: client
+            )
+            return
+        }
+        let pending = Task { [weak self] in
+            let outcome: Result<Response, Error>
+            do {
+                outcome = .success(try await reply(recorded))
+            } catch {
+                outcome = .failure(error)
+            }
+            guard let self, !Task.isCancelled else { return }
+            switch outcome {
+            case .success(let response):
+                self.deliver(response, url: url, client: client)
+            case .failure(let error):
+                client.urlProtocol(self, didFailWithError: error)
+            }
+        }
+        replyLock.withLock { pendingReply = pending }
+    }
+
+    override func stopLoading() {
+        let pending = replyLock.withLock { () -> Task<Void, Never>? in
+            defer { pendingReply = nil }
+            return pendingReply
+        }
+        pending?.cancel()
+    }
+
+    private func deliver(_ response: Response, url: URL, client: URLProtocolClient) {
+        guard let httpResponse = HTTPURLResponse(
+            url: url,
+            statusCode: response.status,
+            httpVersion: "HTTP/1.1",
+            headerFields: response.headers
+        ) else {
+            client.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        client.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
+        if !response.body.isEmpty {
+            client.urlProtocol(self, didLoad: response.body)
+        }
+        client.urlProtocolDidFinishLoading(self)
+    }
+
+    /// URLSession hands outgoing bodies to a protocol as a stream, not
+    /// `httpBody`; drain whichever is present.
+    private static func drainBody(of request: URLRequest) -> Data? {
+        if let body = request.httpBody {
+            return body
+        }
+        guard let stream = request.httpBodyStream else {
+            return nil
+        }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+        while stream.hasBytesAvailable {
+            let read = stream.read(&buffer, maxLength: buffer.count)
+            guard read > 0 else { break }
+            data.append(buffer, count: read)
+        }
+        return data
+    }
+}

--- a/iosApp/Tests/UICustomizationPreferencesTests.swift
+++ b/iosApp/Tests/UICustomizationPreferencesTests.swift
@@ -557,6 +557,9 @@ final class UICustomizationPreferencesTests: XCTestCase {
         )
     }
 
+#if !os(tvOS)
+    // availablePrimaryMenuShortcuts / primaryMenuShortcutTypeTitle live in
+    // InterfaceCustomizationView, which the tvOS build compiles out.
     func testAvailableShortcutsExcludeItemsAlreadyInPrimaryMenu() {
         let availableLibrary = Library(
             id: 8,
@@ -648,6 +651,7 @@ final class UICustomizationPreferencesTests: XCTestCase {
             "Library"
         )
     }
+#endif
 
     func testPrimaryMenuItemsUseMainMenuNavigationIcons() {
         XCTAssertEqual(PrimaryMenuItem.builtin(.home).navigationIcon, AppTab.home.icon)
@@ -666,6 +670,9 @@ final class UICustomizationPreferencesTests: XCTestCase {
         )
     }
 
+#if !os(tvOS)
+    // PrimaryMenuEditorRow and its helpers live in InterfaceCustomizationView,
+    // which the tvOS build compiles out.
     func testPrimaryMenuEditorGroupsLibrariesUnderTheirVisibleMediaType() {
         let movies = Library(
             id: 1,
@@ -720,6 +727,7 @@ final class UICustomizationPreferencesTests: XCTestCase {
             [nil, nil, .movies, nil, .series, nil, nil]
         )
     }
+#endif
 
     func testMixedLibraryStaysOutsidePrimaryMenuMediaTypes() {
         let mixed = Library(
@@ -762,6 +770,9 @@ final class UICustomizationPreferencesTests: XCTestCase {
         )
     }
 
+#if !os(tvOS)
+    // PrimaryMenuEditorRow and its helpers live in InterfaceCustomizationView,
+    // which the tvOS build compiles out.
     func testPrimaryMenuEditorOnlyOffsetsLibrariesWithinTheirMediaType() {
         let rows = [
             PrimaryMenuEditorRow(item: .builtin(.movies), parentMediaType: nil),
@@ -838,6 +849,7 @@ final class UICustomizationPreferencesTests: XCTestCase {
             ]
         )
     }
+#endif
 
     func testPrimaryMenuLibraryCategoriesKeepTheirAuthoredMediaScope() {
         let movie = Library(id: 1, name: "Movies", type: "movies", sortOrder: 0, posterUrl: nil)

--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -307,58 +307,30 @@ targets:
     type: bundle.unit-test
     platform: iOS
     sources:
+      # The whole tree, fixtures included. XcodeGen's default inference puts
+      # every non-Swift file under Tests/Fixtures into the resources phase
+      # (Fixtures/DiagnosticsContract has always been bundled this way), so
+      # nothing is excluded and re-listed by hand. The two provenance files
+      # named SOURCE stay in the project but out of the bundle: nothing reads
+      # them at runtime.
       - path: Tests
         excludes:
-          # Re-declared below with an explicit build phase. Both spellings:
-          # the directory itself, and everything under it.
-          - "Fixtures/ASS"
-          - "Fixtures/ASS/**"
-          - "Fixtures/SettingsContract"
-          - "Fixtures/SettingsContract/**"
-          - "Fixtures/PlaybackV3"
-          - "Fixtures/PlaybackV3/**"
-      - path: Tests/Fixtures/ASS/SiloASSFixture.ttf
-        buildPhase: resources
-      - path: Tests/Fixtures/ASS/authored.mkv
-        buildPhase: resources
-      - path: Tests/Fixtures/ASS/authored.ass
-        buildPhase: resources
-      # The vendored settings contract. SettingsConformanceTests reads both
-      # files out of the test bundle at runtime and fails hard when either is
-      # missing, so the build phase is stated rather than left to XcodeGen's
-      # extension-based inference: a cross-platform drift gate that quietly
-      # stopped being bundled is worse than no gate at all.
-      - path: Tests/Fixtures/SettingsContract/conformance.json
-        buildPhase: resources
-      - path: Tests/Fixtures/SettingsContract/manifest.json
-        buildPhase: resources
-      # Provenance for the two files above — which server commits they came
-      # from, and how to re-vendor. In the project so it is discoverable next
-      # to them, out of the bundle because nothing reads it at runtime.
+          # Provenance and tooling next to the fixtures, not fixtures. They
+          # are re-added below with no build phase so they stay visible in
+          # the project without landing in the bundle (ASS/README.md would
+          # also collide with DiagnosticsContract/README.md when flattened).
+          - "Fixtures/ASS/README.md"
+          - "Fixtures/ASS/generate-font.py"
+          - "Fixtures/ASS/alternate.ass"
       - path: Tests/Fixtures/SettingsContract/SOURCE
         buildPhase: none
-      # Playback V3's server-generated contract corpus. List every executable
-      # fixture explicitly so an XcodeGen inference change cannot silently
-      # remove this cross-repository gate from the test bundle.
-      - path: Tests/Fixtures/PlaybackV3/attempt_keys.json
-        buildPhase: resources
-      - path: Tests/Fixtures/PlaybackV3/capability_response.json
-        buildPhase: resources
-      - path: Tests/Fixtures/PlaybackV3/conformance_matrix.json
-        buildPhase: resources
-      - path: Tests/Fixtures/PlaybackV3/decision_response.json
-        buildPhase: resources
-      - path: Tests/Fixtures/PlaybackV3/error_response.json
-        buildPhase: resources
-      - path: Tests/Fixtures/PlaybackV3/replan_request.json
-        buildPhase: resources
-      - path: Tests/Fixtures/PlaybackV3/route_event.json
-        buildPhase: resources
-      - path: Tests/Fixtures/PlaybackV3/start_request.json
-        buildPhase: resources
-      - path: Tests/Fixtures/PlaybackV3/subtitle_inventory.json
-        buildPhase: resources
       - path: Tests/Fixtures/PlaybackV3/SOURCE
+        buildPhase: none
+      - path: Tests/Fixtures/ASS/README.md
+        buildPhase: none
+      - path: Tests/Fixtures/ASS/generate-font.py
+        buildPhase: none
+      - path: Tests/Fixtures/ASS/alternate.ass
         buildPhase: none
     dependencies:
       - target: Silo
@@ -373,6 +345,67 @@ targets:
         SUPPORTED_PLATFORMS: "iphoneos iphonesimulator"
         BUNDLE_LOADER: "$(TEST_HOST)"
         TEST_HOST: "$(BUILT_PRODUCTS_DIR)/Silo.app/Silo"
+
+  # Unit-test bundle for the tvOS SiloTV app. Same Tests/ tree as SiloTests
+  # minus the files that reference iOS-only declarations (each exclusion says
+  # which). Everything else compiles against the tvOS module, so the
+  # `#if os(tvOS)` branches in shared code and tests become real coverage.
+  SiloTVTests:
+    type: bundle.unit-test
+    platform: tvOS
+    sources:
+      - path: Tests
+        excludes:
+          # UserNotifications and the ApplePush* types (Notifications/, #if os(iOS)).
+          - "ApplePushRegistrationTests.swift"
+          # PlayerOrientationCoordinator, AppRouter, DetailDismissalPolicy (iOS player/detail).
+          - "DetailDismissalNavigationTests.swift"
+          # Unguarded `import UIKit`, UIApplication.shared, phone home-feed rails.
+          - "HorizontalMediaRailTests.swift"
+          # UIApplication.shared, UIImage(systemName:), MobilePlayer* controls (iOS player).
+          - "PlayerSurfaceLayoutTests.swift"
+          # MetricKitCapture is declared under #if os(iOS).
+          - "MetricKitCaptureTests.swift"
+          # CompanionPairingCoordinator is declared under #if os(iOS).
+          - "PairingCoordinatorTests.swift"
+          # RemotePlaybackClock / RemoteVolumeReconciler / SiloControlPlaybackState (Control/iOS).
+          - "SiloControlTests.swift"
+          # SiloControlPlaybackState (Control/iOS).
+          - "SiloControlWireCompatibilityTests.swift"
+          # OnboardingTourViewModel / OnboardingTourAPI are declared under #if !os(tvOS).
+          - "OnboardingInvitationTests.swift"
+          # Same non-fixture files as SiloTests, re-added below with no phase.
+          - "Fixtures/ASS/README.md"
+          - "Fixtures/ASS/generate-font.py"
+          - "Fixtures/ASS/alternate.ass"
+      - path: Tests/Fixtures/SettingsContract/SOURCE
+        buildPhase: none
+      - path: Tests/Fixtures/PlaybackV3/SOURCE
+        buildPhase: none
+      - path: Tests/Fixtures/ASS/README.md
+        buildPhase: none
+      - path: Tests/Fixtures/ASS/generate-font.py
+        buildPhase: none
+      - path: Tests/Fixtures/ASS/alternate.ass
+        buildPhase: none
+    dependencies:
+      - target: SiloTV
+    settings:
+      base:
+        PRODUCT_NAME: SiloTVTests
+        GENERATE_INFOPLIST_FILE: "YES"
+        # Same reason as SiloTests: an explicit SDKROOT is what gives
+        # BUILT_PRODUCTS_DIR its platform suffix so TEST_HOST resolves.
+        SDKROOT: appletvos
+        SUPPORTED_PLATFORMS: "appletvos appletvsimulator"
+        BUNDLE_LOADER: "$(TEST_HOST)"
+        TEST_HOST: "$(BUILT_PRODUCTS_DIR)/SiloTV.app/SiloTV"
+        # Every shared test file says `@testable import Silo`, but the tvOS
+        # app's Swift module is `SiloTV` (its PRODUCT_NAME, which must stay
+        # for TestFlight continuity). Module aliasing resolves `Silo` to
+        # `SiloTV` for this test bundle only; the app target, its symbol
+        # mangling, and its Info.plist are untouched.
+        OTHER_SWIFT_FLAGS: "$(inherited) -module-alias Silo=SiloTV"
 
 schemes:
   Silo:
@@ -411,10 +444,13 @@ schemes:
     build:
       targets:
         SiloTV: all
+        SiloTVTests: [test]
     run:
       config: Debug
     test:
       config: Debug
+      targets:
+        - SiloTVTests
     archive:
       config: Release
     analyze:


### PR DESCRIPTION

## Problem

Nothing tests the tvOS module. `SiloTests` is an iOS-only bundle, so every `#if os(tvOS)` branch in shared code, and in the tests themselves (`DiagnosticsStorageRootTests`, `ImageSizeCapabilityTests`, `TVHeroArtworkResolverTests`, `TVMenuEntryFocusStateTests`), has never executed. Gate 3 lands tvOS-facing surfaces (the library grid in 3b, membership in 3a) that need real tvOS coverage before they merge.

Three smaller problems ride along because they block the same gate:

- Every networking test writes its own private `URLProtocol` subclass with static state and its own vocabulary. Main has six; apiv2 added sixteen near-identical ones (audit F22). Gate 2c and every gate 3 PR need one stub to write tests against.
- `project.yml` excludes three fixture directories and re-lists their files by hand (F41). `Fixtures/DiagnosticsContract` was never listed and has always been bundled, which shows the relist only makes the list mandatory.
- `.gitignore:66` is `docs/*`; the `!docs/release/*` negation on line 73 never matches because git does not descend into an excluded parent directory without a `!docs/release/` line (F38). The v2 contract docs that 2c adds (`docs/*-api-v2.md`) have no negation at all and would be silently dropped.

## Solution

Base: `origin/main` @ `f31ca261`. Not stacked; independent of 2a and 2c. Three commits on `apiv2-replay/tvos-tests`:

1. `ac510113` build(tests): add SiloTVTests target and stop relisting fixtures
2. `5e642464` test: add shared StubURLProtocol and migrate the private stubs onto it
3. `4e89fe5e` ci: run SiloTVTests on a tvOS simulator

**SiloTVTests target** (`iosApp/project.yml`). `bundle.unit-test`, `platform: tvOS`, `dependencies: [target: SiloTV]`, hosted by `SiloTV.app` with `SDKROOT: appletvos`, `SUPPORTED_PLATFORMS: appletvos appletvsimulator`, `BUNDLE_LOADER`/`TEST_HOST` pointing at `SiloTV.app/SiloTV`, mirroring `SiloTests`. Sources the whole `Tests/` tree with an `excludes` list of nine iOS-only files; each exclusion carries a one-line reason naming the iOS-only declaration. Added to the `SiloTV` scheme's build (`[test]`) and test action. `SiloTests` stays on the `Silo` scheme.

**Module import.** Every test file says `@testable import Silo`; the tvOS app's module is `SiloTV` (its `PRODUCT_NAME`). The test target sets `OTHER_SWIFT_FLAGS: $(inherited) -module-alias Silo=SiloTV` so the test compiler resolves the alias. See Decisions below for the blast radius.

**In-file guards.** Five otherwise platform-agnostic test files had blocks that reference iOS-only declarations. The blocks are wrapped in `#if !os(tvOS)` / `#if os(iOS)` with a comment naming the declaration, so the rest of each file runs on tvOS:

| File | Guarded | Reason |
|---|---|---|
| `UICustomizationPreferencesTests.swift` | 5 tests in three blocks | `PrimaryMenuEditorRow`, `groupedPrimaryMenuEditorRows`, `offsetPrimaryMenuEditorItem`, `availablePrimaryMenuShortcuts`, `primaryMenuShortcutTypeTitle` live in `InterfaceCustomizationView.swift` under `#if !os(tvOS)` |
| `DiagnosticsReviewFixesTests.swift` | 2 tests | `MetricKitCapture`, `MetricKitDiagnosticParser` under `#if os(iOS)`; the file's `ExitSentinelMarkerStore` coverage (F34) stays and runs on both |
| `SeriesHierarchyLoadingTests.swift` | 2 tests | `loadContinueWatchingStructure` and the stale-cache resume branch of `hydrateFromCache` are `#if os(iOS)` in `ItemDetailViewModel` |
| `PlaybackProtocolV3Tests.swift` | 1 assertion | `device.platform` is `"tvos"` on tvOS; asserts the platform-correct value |
| `ProfileLaunchPolicyTests.swift` | 1 assertion | tvOS persists the registry in the shared keychain and removes the defaults copy, so the test asserts the defaults key is gone rather than reading it back |

The scout inventory listed the first two; the other three surfaced only when compiling and running on tvOS.

**Fixture bundling** (F41). The three `excludes` + relist blocks are gone from `SiloTests`, and `SiloTVTests` never had them. Both targets source `Tests` and let XcodeGen infer the resources phase, the way `DiagnosticsContract` always worked. The files that are not fixtures (`SettingsContract/SOURCE`, `PlaybackV3/SOURCE`, `ASS/README.md`, `ASS/generate-font.py`, `ASS/alternate.ass`) are excluded from the glob and re-added with `buildPhase: none`, which is what main did for the two `SOURCE` files and what main's relist achieved for the three ASS files by omission. One of these was forced: without the exclusion `ASS/README.md` and `DiagnosticsContract/README.md` both flatten to `README.md` in the bundle and Xcode fails with "Multiple commands produce".

**Shared stub** (`iosApp/Tests/Support/StubURLProtocol.swift`, new, 461 lines). One `final class StubURLProtocol: URLProtocol` plus:

- `Handler`: an ordered route list of `(matcher: (Request) -> Bool, reply: (Request) async throws -> Response)`; `route` adds a persistent route, `expect` a one-shot one; first match wins.
- `Request`: the recorded request with method, path, query, lowercased headers, drained body (`httpBody` or `httpBodyStream`) and the original `URLRequest`.
- `Response` with `.json`, `.text`, `.data`, `.status` builders; a thrown error from a reply is delivered as a transport failure.
- `observe() -> AsyncStream<Request>` and `waitForRequest(timeout:where:)` so tests await a request instead of polling or blocking on a semaphore (F37).
- `Gate` actor: a reply awaits `gate.wait()`; the test calls `gate.open()`. Replaces the `NSCondition` hold in `ServerIdentityStubProtocol` and the hold/release pattern in six apiv2 stubs.
- `makeSession()` / `install(into:)`: a per-session marker header routes each request to its handler, so two stubs can coexist in one test (`HostedDiagnosticsAPITests` needs this).
- Unmatched requests get HTTP 599 with a body naming the method and path, are recorded in `unmatched`, and never hang. Missing handler likewise.
- Static matchers `path`, `method(_:path:)`, `pathPrefix`, `pathSuffix`, `any`. Thread-safe under one `NSLock`; the in-flight reply task is cancelled in `stopLoading`.

Usage is documented at the top of the file. Nothing from apiv2's sixteen stubs was ported.

**Migration of main's stubs.** Five of the six private stubs on main, in four files, are now thin scenario wrappers around a `Handler`; each test's assertions are unchanged (the diffs to test bodies are identifier renames only). `ServerIdentityResolverTests` also swaps its 10 ms polling loop for `waitForRequest`. `SettingsStubProtocol` in `SettingValuesAPITests` is not migrated; see Follow-ups.

**CI** (`.github/workflows/player-regression.yml`). The existing matrix already built SiloTV and SiloMac compile-only; the brief's "nothing in CI builds either platform" was out of date, but nothing tested them. The `SiloTV` entry switches from `build` to `test` with `platform: tvOS` and `test_target: SiloTVTests`. The simulator step takes the platform from the matrix (SDK, runtime prefix, device type: Apple TV 4K 3rd gen), and the suite step runs `-scheme $SCHEME -only-testing:$TEST_TARGET`. The iOS-only packaging, artifact, and preview-recording steps are gated on the iOS entry. `SiloMac` stays compile-only with `CODE_SIGNING_ALLOWED=NO`. **This job has not been executed**; the YAML parses (`ruby -ryaml`) and the xcodebuild invocations mirror the ones run locally below, but a hosted-runner difference (runtime availability, device type name) could still surface on the first run.

**.gitignore.** Adds `!docs/release/` and `!docs/*-api-v2.md`; every existing negation stays. `git check-ignore -v` now reports `docs/release/new.md` re-included by line 73 (`!docs/release/*`, live now that line 74 re-includes the directory) and `docs/native-api-v2.md` re-included by line 75. `docs/other.md` is still ignored by line 66, so the allowlist is intact.

## Validation evidence

All commands run from `iosApp/` on the branch tip, DerivedData `$HOME/silo-build-gate2-2b`, dedicated simulators (`gate2-2b-ios` iPhone 17 Pro / iOS 27.0, `gate2-2b-tvos` Apple TV 4K 3rd gen / tvOS 27.0), Xcode 27.0 (27A266a), XcodeGen 2.46.0. Logs under `/Users/macdev/silo-build-gate2-2b/logs/`.

```
/opt/homebrew/bin/xcodegen generate
xcodebuild build -project Silo.xcodeproj -scheme Silo   -destination "id=D7170F36-…" -derivedDataPath "$HOME/silo-build-gate2-2b" CODE_SIGNING_ALLOWED=NO
xcodebuild build -project Silo.xcodeproj -scheme SiloTV -destination "id=2E86FF7D-…" -derivedDataPath "$HOME/silo-build-gate2-2b" CODE_SIGNING_ALLOWED=NO
xcodebuild build -project Silo.xcodeproj -scheme SiloMac -destination "platform=macOS" -derivedDataPath "$HOME/silo-build-gate2-2b" CODE_SIGNING_ALLOWED=NO
xcodebuild test  -project Silo.xcodeproj -scheme Silo   -destination "id=D7170F36-…" -derivedDataPath "$HOME/silo-build-gate2-2b" -only-testing:SiloTests
xcodebuild test  -project Silo.xcodeproj -scheme SiloTV -destination "id=2E86FF7D-…" -derivedDataPath "$HOME/silo-build-gate2-2b" -only-testing:SiloTVTests
```

| Check | Log | Result line |
|---|---|---|
| Silo (iOS sim), unsigned compile | `logs/build-silo-ios.log` | `** BUILD SUCCEEDED **` |
| SiloTV (tvOS sim), unsigned compile | `logs/build-silotv.log` | `** BUILD SUCCEEDED **` |
| SiloMac, unsigned compile | `logs/build-silomac.log` | `** BUILD SUCCEEDED **` |
| SiloTests on iOS | `logs/test-silotests.log` | `Executed 1301 tests, with 2 tests skipped and 0 failures (0 unexpected) in 33.627 (33.942) seconds` / `** TEST SUCCEEDED **` |
| SiloTVTests on tvOS | `logs/test-silotvtests.log` | `Executed 1179 tests, with 2 tests skipped and 0 failures (0 unexpected) in 19.735 (19.993) seconds` / `** TEST SUCCEEDED **` |

The unsigned compiles are compile evidence only. The two test runs are signed for the simulator by default (no `CODE_SIGNING_ALLOWED=NO`).

The two skips on both platforms are `AetherPlaybackBoundaryTests` cases gated on `SILO_AETHER_LIVE_FIXTURE_PATH` / `SILO_AETHER_EMBEDDED_FIXTURE_URL`, unchanged from main.

Suites that prove the fixture and stub changes, all `passed` on both platforms (grep of the two logs): `ASSSubtitleRendererTests`, `SettingsConformanceTests`, `PlaybackProtocolV3ConformanceFixtureTests`, `DiagnosticsContractTests`, `DiagnosticsAttributeRegistryParityTests`, `DiagnosticsChunkedUploadTests`, `HostedDiagnosticsAPITests`, `ServerIdentityResolverTests`, `OnboardingInvitationTests` (iOS only, excluded on tvOS). Suites that run for the first time on tvOS and pass: `DiagnosticsStorageRootTests` (its `#if os(tvOS)` caches-directory branch), `ImageSizeCapabilityTests`, `TVHeroArtworkResolverTests`, `TVMenuEntryFocusStateTests`.

Fixture bundling, from `ls` of the built bundles: both `Debug-iphonesimulator/Silo.app/PlugIns/SiloTests.xctest` and `Debug-appletvsimulator/SiloTV.app/PlugIns/SiloTVTests.xctest` contain `SiloASSFixture.ttf authored.ass authored.mkv` (ASS), `conformance.json manifest.json` (SettingsContract), the nine PlaybackV3 JSON files, and the eighteen DiagnosticsContract files including `attr-registry.json`, the four schemas, `loglines.jsonl` and the twelve `fixtures/{valid,invalid}` JSON files. Neither bundle contains `SOURCE`, `generate-font.py`, or `alternate.ass`; the one `README.md` present is DiagnosticsContract's, as on main.

Module-alias blast radius, from the built tvOS app: `Info.plist` has `CFBundleExecutable=SiloTV`, `CFBundleIdentifier=org.siloserver.silo`, `CFBundleName=SiloTV`; `nm` on `SiloTV.debug.dylib` shows 114,013 symbols mangled `$s6SiloTV…` and 0 mangled `$s4Silo…`. The alias is visible only in the test bundle (1,099 `$s6SiloTV…` references, 0 `$s4Silo…`).

`ruby -ryaml -e 'YAML.load_file(".github/workflows/player-regression.yml")'` parses and lists the expected eight steps. `git check-ignore -v` output is quoted under Solution.

## Fence counts

This PR touches no auth or networking production code. `withOwnerFence`, `matchingIdentityOf`, and `captureOrdinaryRequestAuth` counts are **0 on apiv2 and 0 on this PR** for every touched file; no fence site exists in `project.yml`, the workflow, `.gitignore`, `Tests/Support/StubURLProtocol.swift`, or the nine test files edited. No method was deleted.

| File | apiv2 | PR |
|---|---|---|
| all touched files | 0 | 0 |

## Risks

- `-module-alias` is a compiler flag on the test target only, but it is a less common mechanism than `PRODUCT_MODULE_NAME`. If a future Xcode changes alias semantics, the failure is a compile error in `SiloTVTests`, not a runtime change in the app.
- The CI job is unexecuted. The simulator creation step assumes `com.apple.CoreSimulator.SimDeviceType.Apple-TV-4K-3rd-generation-4K` exists on the `macos-15` image with Xcode 26.3 and that `xcodebuild -downloadPlatform tvOS` works if the runtime is missing. The matrix destination string `platform=tvOS Simulator,name=Apple TV 4K (3rd generation)` is only used when the prepare step is skipped, which does not happen for `action: test`.
- The tvOS matrix entry now also uses `CODE_SIGNING_ALLOWED=YES CODE_SIGN_IDENTITY=-` ad-hoc signing for the simulator, the same as iOS. If the tvOS build needs a different entitlement handling on the hosted runner, the build-for-testing step will show it.
- `StubURLProtocol.Handler` is found through a marker header added by `httpAdditionalHeaders`. A code path that builds its own `URLSession` from a configuration the test did not install into gets a 599 with a clear body rather than a hang; that is the intended failure mode, but it is louder than main's stubs, which answered every request from static state.
- Dropping the fixture relist means a future XcodeGen inference change could stop bundling a fixture. `SettingsConformanceTests`, `PlaybackProtocolV3ConformanceFixtureTests`, and `DiagnosticsContractTests` all fail hard when their files are missing, on both platforms now, so the regression would be caught by the same CI job.

## Follow-ups

- `SettingValuesAPITests.SettingsStubProtocol` (13-mode scenario machine with delayed-release plumbing for four concurrency regressions) was not migrated. Doing it mechanically is possible but the hold/release cases would need to be re-expressed with `Gate`, which changes the timing the tests depend on. Migrate in PR 3g, which rewrites the settings tests anyway.
- PR 2c must not reintroduce the exclude-and-relist pattern for `Tests/Fixtures/APIv2` (the fourth set in F41). Sourcing `Tests` is enough; only add `buildPhase: none` entries for provenance files.
- PR 3j (cleanup) can now replace the remaining `DispatchSemaphore` waits and the three `waitUntil` helpers with `Handler.waitForRequest` / `observe()`.
- Second independent problem, not fixed here: `SeriesHierarchyLoadingTests.testResumeEntryDoesNotPlayAnotherSeasonFromAStaleCache` documents a guard (do not play a fallback season from a stale cache when `initialResumeSeasonNumber` is set) that only exists in the `#if os(iOS)` branch of `ItemDetailViewModel.hydrateFromCache`. The tvOS branch selects `preferredInitialSeason` unconditionally. Whether tvOS needs the same guard is a product question for the player owner; this PR guards the test rather than changing the view model.
- `ImageSizeCapabilityTests` and `DiagnosticsStorageRootTests` carry comments saying their tvOS branches are unreachable from the iOS host. Those comments are now stale; PR 3j should drop them.

## Decisions needed from the developer

1. **Module import mechanism.** Chosen: `OTHER_SWIFT_FLAGS: $(inherited) -module-alias Silo=SiloTV` on `SiloTVTests` only. Blast radius: zero on the shipping app. `SiloTV`'s `PRODUCT_NAME`, module name, symbol mangling (`$s6SiloTV…`, verified with `nm`), `Info.plist`, bundle identifier, entitlements, and keychain groups are unchanged; `TopShelf/Info.plist`'s `$(PRODUCT_MODULE_NAME).ContentProvider` refers to the extension's own module and is untouched. The alternative, `PRODUCT_MODULE_NAME: Silo` on the SiloTV app target, is one line but renames the app's Swift module, which changes every mangled symbol in the app binary and the string `String(reflecting:)` produces for tvOS types in `DiagLog` (`Silo.Foo` instead of `SiloTV.Foo`), so it was rejected. Rewriting 93 test files to `import SiloTV` under a condition was rejected as churn. If you prefer the module rename for symmetry with `SiloMac` (which already uses `PRODUCT_NAME: Silo`), it is a one-line swap in `project.yml` and the test target's flag comes out.
2. **CI shape.** The brief said "add a job"; the repo already had a matrix entry building SiloTV, so the entry was switched to `test` rather than adding a parallel job. Say if you want a separate job instead.
3. **`alternate.ass` in the bundle.** Main's relist omitted it, so this PR keeps it out. If it is meant to be a fixture, drop the exclusion and the `buildPhase: none` entry.

## AI disclosure

Implemented and verified by Claude Fable 5.1 (model identifier `claude-fable-5-1`, 1M-context variant) running as subagents of the Claude Code desktop app (Code tab) via its Workflow multi-agent orchestration tool, orchestrated by the same model. No other AI tooling was used.

## Rebase onto current main

Rebased onto `main` at `71299aa3` (after #284, stale server recovery) before opening. `git merge-tree` reported no textual conflicts. Rebuilt and retested on the rebased stack (branch `apiv2-replay/wire` at `dbda477f`, which contains all three gate 2 branches):

| Check | Result |
|---|---|
| Silo (iOS simulator, signed, install + launch) | PASS |
| SiloTV (tvOS simulator, signed, install + launch) | PASS |
| SiloMac (compile-only, `CODE_SIGNING_ALLOWED=NO`) | BUILD SUCCEEDED |
| SiloTests | 1459 executed, 2 skipped, 0 failures |
| SiloTVTests | 1336 executed, 2 skipped, 0 failures |

## Verification (independent verifier, pre-rebase head)

A verifier agent that did not write the branch built all three platforms with the mac-builder helper, ran both test suites, counted fence sites against apiv2 `1a546711`, and checked the 13 audit invariants. Summary below; the pre-rebase evidence refers to the pre-rebase commit SHAs.


**Ready.** After refutation, no standing violations. The verifier raised none, so the two refuters had nothing to overturn.

- Standing violations: none.
- Overturned violations: none.
- Builds and tests: Silo `** BUILD SUCCEEDED **` (signed, `/Users/macdev/silo-build-ios/gate2-apiv2-replay-tvos-tests-ios.log`, `/tmp/silo-ios-simulator-build-4e89fe5e.log`); SiloTV `** BUILD SUCCEEDED **` (signed, `/Users/macdev/silo-build-tvos/gate2-apiv2-replay-tvos-tests-tvos.log`, `/tmp/silo-tvos-simulator-build-4e89fe5e.log`); SiloMac `** BUILD SUCCEEDED **` (compile-only, `/Users/macdev/silo-build-macos/gate2-apiv2-replay-tvos-tests-mac.log`); SiloTests 1301 executed, 2 skipped, 0 failed (`/Users/macdev/silo-build-ios/gate2-apiv2-replay-tvos-tests-tests.log`); SiloTVTests 1179 executed, 2 skipped, 0 failed (`/Users/macdev/silo-build-tvos/gate2-apiv2-replay-tvos-tests-tvtests.log`).
- Fence counts (`withOwnerFence` + `matchingIdentityOf` + `captureOrdinaryRequestAuth`, all 13 touched files): apiv2 (`1a546711`) 0, PR 0.
- CI job on the hosted runner remains unexecuted, as the body discloses.

Rebased commits: e12a2f81, 00ad5ca0, b2a93803.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded automated validation to include tvOS simulator testing alongside iOS.
  - Added a dedicated tvOS test suite with platform-appropriate coverage.
  - Improved reliability and consistency of network, diagnostics, playback, onboarding, and server-identity test scenarios.
  - Added platform-specific checks for tvOS behavior and excluded unsupported iOS-only tests where appropriate.

- **Documentation**
  - Updated project tracking so release materials and API documentation can be included as intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->