### PR TITLE
fix(tvos): stabilize subtitle search and align AI subtitle dialogs

### DIFF
--- a/iosApp/iosApp/Networking/PlaybackPrefsModels.swift
+++ b/iosApp/iosApp/Networking/PlaybackPrefsModels.swift
@@ -183,7 +183,7 @@ struct PlaybackLanguageOption: Identifiable, Hashable {
             ?? code.uppercased()
     }
 
-    private static func languageIdentity(_ value: String) -> String {
+    static func languageIdentity(_ value: String) -> String {
         let normalized = value.replacingOccurrences(of: "_", with: "-")
         var components = normalized.split(separator: "-").map(String.init)
         guard let language = components.first else { return normalized.lowercased() }

--- a/iosApp/iosApp/Screens/Player/Sheets/SubtitleSearchMenu.swift
+++ b/iosApp/iosApp/Screens/Player/Sheets/SubtitleSearchMenu.swift
@@ -100,6 +100,7 @@ struct SubtitleSearchMenu: View {
             // Covers the sliver where the probe lands between the row's tap
             // and this view appearing, which `onChange` would never see.
             .onAppear { reflectUnavailabilityIfIdle() }
+            .onDisappear { searchTask?.cancel() }
     }
 
     @ViewBuilder
@@ -139,7 +140,7 @@ struct SubtitleSearchMenu: View {
         func add(_ code: String, hint: String?) {
             let trimmed = code.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else { return }
-            let key = trimmed.lowercased()
+            let key = PlaybackLanguageOption.languageIdentity(trimmed)
             guard !seen.contains(key) else { return }
             seen.insert(key)
             result.append(.init(code: trimmed, label: displayName(trimmed), hint: hint))
@@ -312,8 +313,10 @@ struct SubtitleSearchMenu: View {
             // Empty result set: land focus on the fallback row so the remote
             // isn't left with nothing focused.
             focusedRowID = results.first?.uniqueKey ?? "back-to-languages"
-        case .searching, .failed:
-            break
+        case .searching:
+            focusedRowID = "cancel-search"
+        case .failed:
+            focusedRowID = searchedLanguage == nil ? "search-back" : "retry-search"
         }
     }
 
@@ -329,73 +332,45 @@ struct SubtitleSearchMenu: View {
     }
 
     private var tvOSPanel: some View {
-        ZStack {
-            Color.black.opacity(0.55)
-                .ignoresSafeArea()
-                .contentShape(Rectangle())
-                .onTapGesture { onDismiss() }
-
-            VStack(alignment: .leading, spacing: 14) {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text(title.uppercased())
-                        .font(.system(size: 18, weight: .semibold))
-                        .tracking(1.5)
-                        .foregroundStyle(.white.opacity(0.7))
-                    if phase == .picking {
-                        Text(explainer)
-                            .font(.system(size: 16))
-                            .foregroundStyle(.white.opacity(0.45))
-                            .lineLimit(2)
-                    }
-                }
-                .padding(.horizontal, 12)
-
-                switch phase {
-                case .searching:
-                    searchingPanel
-                case .failed(let message):
-                    failurePanel(message)
-                case .picking, .results:
-                    ScrollViewReader { proxy in
-                        ScrollView(showsIndicators: false) {
-                            LazyVStack(alignment: .leading, spacing: 2) {
-                                if phase == .picking {
-                                    tvLanguageRows
-                                } else {
-                                    tvResultRows
-                                }
+        TVSubtitleDialog(
+            title: title,
+            subtitle: tvSubtitle,
+            backHint: tvBackHint,
+            statusHint: downloadingId != nil ? "Adding subtitle…"
+                : phase == .results && !results.isEmpty ? "Select a subtitle to download and use it" : "",
+            onDismiss: { if downloadingId == nil { onDismiss() } }
+        ) {
+            switch phase {
+            case .searching:
+                searchingPanel
+            case .failed(let message):
+                failurePanel(message)
+            case .picking, .results:
+                ScrollViewReader { proxy in
+                    ScrollView(showsIndicators: false) {
+                        LazyVStack(alignment: .leading, spacing: 8) {
+                            if phase == .picking {
+                                tvLanguageRows
+                            } else {
+                                tvResultRows
                             }
-                            .padding(.vertical, 2)
                         }
-                        .focusSection()
-                        .onAppear {
-                            focusFirstRow()
-                            scrollToFocusedRow(proxy, animated: false)
-                        }
-                        .onChange(of: focusedRowID) { _, value in
-                            // Focus fell off the list — pull it back rather
-                            // than letting it vanish; else keep it visible.
-                            if value == nil { focusFirstRow() }
-                            else { scrollToFocusedRow(proxy) }
-                        }
-                        .onChange(of: phase) { _, _ in focusFirstRow() }
+                        .padding(8)
                     }
+                    .focusSection()
+                    .onAppear {
+                        focusFirstRow()
+                        scrollToFocusedRow(proxy, animated: false)
+                    }
+                    .onChange(of: focusedRowID) { _, value in
+                        // Focus fell off the list — pull it back rather
+                        // than letting it vanish; else keep it visible.
+                        if value == nil { focusFirstRow() }
+                        else { scrollToFocusedRow(proxy) }
+                    }
+                    .onChange(of: phase) { _, _ in focusFirstRow() }
                 }
             }
-            .padding(28)
-            .frame(maxWidth: 1100, maxHeight: 720)
-            .background(
-                RoundedRectangle(cornerRadius: 24, style: .continuous)
-                    .fill(.ultraThinMaterial)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 24, style: .continuous)
-                            .fill(Color.black.opacity(0.35))
-                    )
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 24, style: .continuous)
-                    .stroke(Color.white.opacity(0.12), lineWidth: 1)
-            )
         }
         .onExitCommand {
             // First back-press from results returns to the language list;
@@ -415,10 +390,29 @@ struct SubtitleSearchMenu: View {
         .onChange(of: profilePrefs.preferredSubtitleLanguage) { _, _ in seedSelectedLanguage() }
     }
 
+    private var tvSubtitle: String {
+        switch phase {
+        case .picking:
+            return "Choose a language to find subtitles for this video."
+        case .searching:
+            return "Finding subtitles in \(searchedLanguage.map(displayName) ?? "your language")"
+        case .results:
+            let language = searchedLanguage.map(displayName) ?? "Subtitles"
+            return "\(language) · \(results.count) \(results.count == 1 ? "result" : "results")"
+        case .failed:
+            return "Subtitle search could not finish"
+        }
+    }
+
+    private var tvBackHint: String {
+        if downloadingId != nil { return "Please wait for the download to finish" }
+        return phase == .picking ? "Back to Subtitles" : "Back to languages"
+    }
+
     @ViewBuilder
     private var tvLanguageRows: some View {
         if !suggestedLanguages.isEmpty {
-            sectionHeader("Suggested")
+            sectionHeader("Preferred language")
             ForEach(suggestedLanguages) { tvLanguageRow($0) }
         }
         sectionHeader(suggestedLanguages.isEmpty ? "Language" : "All Languages")
@@ -427,28 +421,30 @@ struct SubtitleSearchMenu: View {
 
     @ViewBuilder
     private func tvLanguageRow(_ choice: LanguageChoice) -> some View {
-        TVSearchRow(
+        TVSubtitleMenuRow(
             rowID: choice.code,
             focusedID: $focusedRowID,
             action: { search(language: choice.code) }
         ) {
             Image(systemName: choice.hint == "Preferred" ? "star.fill" : "globe")
                 .font(.system(size: 22, weight: .regular))
-                .foregroundStyle(.white.opacity(0.8))
+                .opacity(0.8)
                 .frame(width: 34)
             VStack(alignment: .leading, spacing: 4) {
                 Text(choice.label)
                     .font(.system(size: 24, weight: .medium))
-                    .foregroundStyle(.white)
                     .lineLimit(1)
                 if let hint = choice.hint {
                     Text(hint)
                         .font(.system(size: 18))
-                        .foregroundStyle(.white.opacity(0.55))
+                        .opacity(0.65)
                         .lineLimit(1)
                 }
             }
             Spacer(minLength: 8)
+            Image(systemName: "chevron.right")
+                .font(.system(size: 18, weight: .semibold))
+                .opacity(0.55)
         }
         .id(choice.code)
     }
@@ -458,7 +454,7 @@ struct SubtitleSearchMenu: View {
     private var warningRows: some View {
         ForEach(warnings, id: \.self) { warning in
             Label(warning, systemImage: "exclamationmark.triangle")
-                .font(.system(size: 16))
+                .font(.system(size: 20))
                 .foregroundStyle(Color.siloWarning)
                 .padding(.horizontal, 16)
                 .padding(.vertical, 4)
@@ -474,23 +470,21 @@ struct SubtitleSearchMenu: View {
                 .foregroundStyle(.white.opacity(0.55))
                 .padding(.horizontal, 16)
                 .padding(.vertical, 12)
-            TVSearchRow(
+            TVSubtitleMenuRow(
                 rowID: "back-to-languages",
                 focusedID: $focusedRowID,
                 action: { backToLanguages() }
             ) {
                 Image(systemName: "chevron.backward")
                     .font(.system(size: 20, weight: .semibold))
-                    .foregroundStyle(.white.opacity(0.8))
+                    .opacity(0.8)
                     .frame(width: 34)
                 Text("Choose another language")
                     .font(.system(size: 22, weight: .medium))
-                    .foregroundStyle(.white)
                 Spacer(minLength: 8)
             }
             .id("back-to-languages")
         } else {
-            sectionHeader(searchedLanguage.map { displayName($0) } ?? "Results")
             ForEach(results, id: \.uniqueKey) { result in
                 tvResultRow(result)
             }
@@ -500,21 +494,26 @@ struct SubtitleSearchMenu: View {
     @ViewBuilder
     private func tvResultRow(_ result: SubtitleSearchResult) -> some View {
         let isDownloadingThis = downloadingId == result.uniqueKey
-        TVSearchRow(
+        TVSubtitleMenuRow(
             rowID: result.uniqueKey,
             isDisabled: downloadingId != nil && !isDownloadingThis,
             focusedID: $focusedRowID,
             action: { download(result) }
         ) {
-            scoreBadge(result.score, fontSize: 18)
+            VStack(spacing: 6) {
+                scoreBadge(result.score, fontSize: 18)
+                Text("Match")
+                    .font(.system(size: 14))
+                    .opacity(0.65)
+            }
+            .frame(width: 64)
             VStack(alignment: .leading, spacing: 4) {
                 Text(result.releaseName.isEmpty ? "Untitled release" : result.releaseName)
-                    .font(.system(size: 22, weight: .medium))
-                    .foregroundStyle(.white)
-                    .lineLimit(1)
+                    .font(.system(size: 24, weight: .medium))
+                    .lineLimit(2)
                 Text(resultDetail(result))
-                    .font(.system(size: 17))
-                    .foregroundStyle(.white.opacity(0.55))
+                    .font(.system(size: 20))
+                    .opacity(0.65)
                     .lineLimit(1)
             }
             Spacer(minLength: 8)
@@ -522,10 +521,26 @@ struct SubtitleSearchMenu: View {
                 ProgressView()
                     .scaleEffect(0.7)
             } else {
-                providerTag(result.provider, fontSize: 15)
+                VStack(alignment: .trailing, spacing: 8) {
+                    Text(tvProviderName(result.provider))
+                        .font(.system(size: 18, weight: .medium))
+                    Label(result.format.uppercased(), systemImage: "arrow.down.circle")
+                        .font(.system(size: 17))
+                        .opacity(0.6)
+                }
+                .frame(width: 150, alignment: .trailing)
             }
         }
         .id(result.uniqueKey)
+    }
+
+    private func tvProviderName(_ provider: String) -> String {
+        switch provider.lowercased() {
+        case "opensubtitles": return "OpenSubtitles"
+        case "subdl": return "SubDL"
+        case "subsource": return "Subsource"
+        default: return provider
+        }
     }
 
     @ViewBuilder
@@ -542,10 +557,12 @@ struct SubtitleSearchMenu: View {
                 .foregroundStyle(.white.opacity(0.5))
             Button("Cancel") { backToLanguages() }
                 .buttonStyle(.bordered)
+                .focused($focusedRowID, equals: "cancel-search")
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+        .onAppear { focusFirstRow() }
     }
 
     @ViewBuilder
@@ -558,14 +575,17 @@ struct SubtitleSearchMenu: View {
                 if let language = searchedLanguage {
                     Button("Try Again") { search(language: language) }
                         .buttonStyle(.bordered)
+                        .focused($focusedRowID, equals: "retry-search")
                 }
                 Button("Back") { backToLanguages() }
                     .buttonStyle(.bordered)
+                    .focused($focusedRowID, equals: "search-back")
             }
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+        .onAppear { focusFirstRow() }
     }
 
     @ViewBuilder
@@ -766,41 +786,3 @@ struct SubtitleSearchMenu: View {
         }
     }
 }
-
-// MARK: - tvOS focus row
-
-#if os(tvOS)
-/// Generic panel row for the search menu: bare `.focusable` + tap (no system
-/// halo), row-fill focus highlight, focus driven by the panel-level
-/// `@FocusState.Binding` keyed on `rowID` — the `TVLanguageRow` /
-/// `TrackSelectionSheet.TrackRow` idiom generalized over arbitrary content.
-private struct TVSearchRow<Content: View>: View {
-    let rowID: String
-    var isDisabled: Bool = false
-    @FocusState.Binding var focusedID: String?
-    let action: () -> Void
-    @ViewBuilder let content: () -> Content
-
-    private var isFocused: Bool { focusedID == rowID }
-
-    var body: some View {
-        HStack(alignment: .center, spacing: 16) {
-            content()
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
-        .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(isFocused ? Color.white.opacity(0.16) : Color.clear)
-        )
-        .contentShape(Rectangle())
-        .focusable(!isDisabled)
-        .focused($focusedID, equals: rowID)
-        .onTapGesture(perform: action)
-        .disabled(isDisabled)
-        .opacity(isDisabled ? 0.35 : 1.0)
-        .animation(.easeOut(duration: SiloTheme.fastDuration), value: isFocused)
-        .accessibilityAddTraits(.isButton)
-    }
-}
-#endif

--- a/iosApp/iosApp/Screens/Player/Sheets/SubtitleTranslateMenu.swift
+++ b/iosApp/iosApp/Screens/Player/Sheets/SubtitleTranslateMenu.swift
@@ -214,7 +214,7 @@ struct SubtitleTranslateMenu: View {
         func add(_ code: String, hint: String?) {
             let trimmed = code.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else { return }
-            let key = trimmed.lowercased()
+            let key = PlaybackLanguageOption.languageIdentity(trimmed)
             guard !seen.contains(key) else { return }
             seen.insert(key)
             result.append(.init(code: trimmed, label: displayName(trimmed), hint: hint))
@@ -256,9 +256,9 @@ struct SubtitleTranslateMenu: View {
     /// Rows in display order: suggested (priority) then the alphabetized rest.
     private var displayLanguages: [LanguageChoice] { suggestedLanguages + otherLanguages }
 
-    /// Move focus to the first serviceable row. Used on appear and to recover
-    /// when focus falls to `nil`.
+    /// Recover focus when it falls to `nil`.
     private func focusFirstServiceableLanguage() {
+        guard !isBusy, controller.phase != .failed else { return }
         focusedLanguageID = displayLanguages.first(where: { canServe($0.code) })?.code
     }
 
@@ -280,66 +280,39 @@ struct SubtitleTranslateMenu: View {
 
     #if os(tvOS)
     private var tvOSPanel: some View {
-        ZStack {
-            Color.black.opacity(0.55)
-                .ignoresSafeArea()
-                .contentShape(Rectangle())
-                .onTapGesture { onDismiss() }
-
-            VStack(alignment: .leading, spacing: 14) {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text(title.uppercased())
-                        .font(.system(size: 18, weight: .semibold))
-                        .tracking(1.5)
-                        .foregroundStyle(.white.opacity(0.7))
-                    if !isBusy, controller.phase != .failed {
-                        Text(explainer)
-                            .font(.system(size: 16))
-                            .foregroundStyle(.white.opacity(0.45))
-                            .lineLimit(2)
+        TVSubtitleDialog(
+            title: title,
+            subtitle: isBusy ? "Preparing your subtitles"
+                : controller.phase == .failed ? "AI subtitles could not finish"
+                : "Choose a language. Silo translates existing subtitles or transcribes the audio.",
+            backHint: "Back to Subtitles",
+            onDismiss: onDismiss
+        ) {
+            if isBusy || controller.phase == .failed {
+                progressPanel
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollViewReader { proxy in
+                    ScrollView(showsIndicators: false) {
+                        LazyVStack(alignment: .leading, spacing: 8) {
+                            languageRows
+                        }
+                        .padding(8)
                     }
-                }
-                .padding(.horizontal, 12)
-
-                if isBusy || controller.phase == .failed {
-                    progressPanel
-                } else {
-                    ScrollViewReader { proxy in
-                        ScrollView(showsIndicators: false) {
-                            LazyVStack(alignment: .leading, spacing: 2) {
-                                languageRows
-                            }
-                            .padding(.vertical, 2)
-                        }
-                        .focusSection()
-                        .onAppear {
-                            focusFirstServiceableLanguage()
-                            scrollToFocusedLanguage(proxy, animated: false)
-                        }
-                        .onChange(of: focusedLanguageID) { _, value in
-                            // Focus fell off the list (scrolled past an edge) —
-                            // pull it back to a serviceable row instead of letting
-                            // it vanish. Otherwise just keep the focused row visible.
-                            if value == nil { focusFirstServiceableLanguage() }
-                            else { scrollToFocusedLanguage(proxy) }
-                        }
+                    .focusSection()
+                    .defaultFocus(
+                        $focusedLanguageID,
+                        displayLanguages.first(where: { canServe($0.code) })?.code ?? ""
+                    )
+                    .onChange(of: focusedLanguageID) { _, value in
+                        // Focus fell off the list (scrolled past an edge) —
+                        // pull it back to a serviceable row instead of letting
+                        // it vanish. Otherwise just keep the focused row visible.
+                        if value == nil { focusFirstServiceableLanguage() }
+                        else { scrollToFocusedLanguage(proxy) }
                     }
                 }
             }
-            .padding(28)
-            .frame(maxWidth: 1100, maxHeight: 720)
-            .background(
-                RoundedRectangle(cornerRadius: 24, style: .continuous)
-                    .fill(.ultraThinMaterial)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 24, style: .continuous)
-                            .fill(Color.black.opacity(0.35))
-                    )
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 24, style: .continuous)
-                    .stroke(Color.white.opacity(0.12), lineWidth: 1)
-            )
         }
         .onExitCommand { onDismiss() }
         .task { await controller.refreshQuota() }
@@ -365,7 +338,7 @@ struct SubtitleTranslateMenu: View {
             }
         }
         if !suggestedLanguages.isEmpty {
-            sectionHeader("Suggested")
+            sectionHeader("Suggested languages")
             ForEach(suggestedLanguages) { tvLanguageRow($0) }
         }
         sectionHeader(suggestedLanguages.isEmpty ? "Language" : "All Languages")
@@ -576,6 +549,8 @@ private extension SubtitleTranslateMenu {
         #if os(tvOS)
         Button(title, action: action)
             .buttonStyle(.bordered)
+            .focused($focusedLanguageID, equals: "progress-action")
+            .onAppear { focusedLanguageID = "progress-action" }
         #else
         Button(title, action: action)
             .buttonStyle(.bordered)
@@ -586,12 +561,7 @@ private extension SubtitleTranslateMenu {
 // MARK: - Menu row (platform-split, mirroring TrackSelectionSheet.TrackRow)
 
 #if os(tvOS)
-/// tvOS language row: icon + two lines, row-fill focus highlight, bare
-/// `.focusable` + tap (no system halo), matching `TrackSelectionSheet`.
-///
-/// Focus is driven by a panel-level `@FocusState.Binding` keyed on the language
-/// `code` (rather than a self-owned `@FocusState`) so the list can scroll-follow
-/// focus and recover it when it falls to `nil`. Mirrors `TVSettingsPickerSheet`.
+/// AI routing hints within the shared subtitle menu row.
 private struct TVLanguageRow: View {
     let name: String
     let detail: String?
@@ -601,44 +571,36 @@ private struct TVLanguageRow: View {
     @FocusState.Binding var focusedID: String?
     let action: () -> Void
 
-    private var isFocused: Bool { focusedID == code }
-
     var body: some View {
-        HStack(alignment: .center, spacing: 16) {
+        TVSubtitleMenuRow(
+            rowID: code,
+            isDisabled: isDisabled,
+            focusedID: $focusedID,
+            action: action
+        ) {
             Image(systemName: systemImage)
                 .font(.system(size: 22, weight: .regular))
-                .foregroundStyle(.white.opacity(0.8))
+                .opacity(0.8)
                 .frame(width: 34)
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(name)
                     .font(.system(size: 24, weight: .medium))
-                    .foregroundStyle(.white)
                     .lineLimit(1)
                 if let detail {
                     Text(detail)
                         .font(.system(size: 18, weight: .regular))
-                        .foregroundStyle(.white.opacity(0.55))
+                        .opacity(0.65)
                         .lineLimit(2)
                 }
             }
             Spacer(minLength: 8)
+            Image(systemName: "chevron.right")
+                .font(.system(size: 18, weight: .semibold))
+                .opacity(0.55)
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
-        .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(isFocused ? Color.white.opacity(0.16) : Color.clear)
-        )
-        .contentShape(Rectangle())
-        .focusable(!isDisabled)
-        .focused($focusedID, equals: code)
-        .onTapGesture(perform: action)
-        .disabled(isDisabled)
-        .opacity(isDisabled ? 0.35 : 1.0)
-        .animation(.easeOut(duration: SiloTheme.fastDuration), value: isFocused)
-        .accessibilityAddTraits(.isButton)
         .accessibilityLabel(name)
+        .accessibilityValue(detail ?? "")
     }
 }
 #else

--- a/iosApp/iosApp/Screens/Player/tvOS/TVPlayerInfoHUD.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVPlayerInfoHUD.swift
@@ -19,6 +19,13 @@ struct TVPlayerInfoHUD: View {
     let viewModel: PlayerViewModel
     @Binding var activeTab: Tab
     @State private var readOnlyPaneIsAtTop = true
+    @State private var subtitleOverlayActive = false
+    @State private var showSubtitleSearchMenu = false
+    @State private var showAITranslateMenu = false
+
+    private var subtitleMenuPresented: Bool {
+        showSubtitleSearchMenu || showAITranslateMenu
+    }
     /// Focus target for the tab-bar pills, owned by `TVPlayerControls`.
     /// Sharing this via `@FocusState.Binding` lets the parent seed focus on
     /// a specific pill when the HUD opens, which is critical: without a
@@ -113,6 +120,32 @@ struct TVPlayerInfoHUD: View {
             readOnlyPaneIsAtTop = true
         }
         .onExitCommand(perform: onDismiss)
+        .disabled(subtitleMenuPresented)
+        // Keep the HUD mounted for focus restoration, but show only the
+        // search dialog over a backdrop that spans the whole player.
+        .opacity(subtitleMenuPresented ? 0 : 1)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .overlay {
+            if showAITranslateMenu {
+                SubtitleTranslateMenu(
+                    viewModel: viewModel,
+                    onDismiss: { showAITranslateMenu = false },
+                    onJobStarted: {
+                        showAITranslateMenu = false
+                        onDismiss()
+                    }
+                )
+            } else if showSubtitleSearchMenu {
+                SubtitleSearchMenu(
+                    viewModel: viewModel,
+                    onDismiss: { showSubtitleSearchMenu = false },
+                    onDownloaded: {
+                        showSubtitleSearchMenu = false
+                        onDismiss()
+                    }
+                )
+            }
+        }
     }
 
     // MARK: - Tab bar
@@ -134,7 +167,7 @@ struct TVPlayerInfoHUD: View {
         // paged below its top anchor, remove the rail from the focus graph so
         // an Up press cannot both page the pane and escape to the active tab.
         // The pane re-enables the rail when it reaches the top again.
-        .disabled(isReadOnlyPaneScrolled)
+        .disabled(isReadOnlyPaneScrolled || subtitleOverlayActive)
         // Rail: moving Up from the panel must land on the *active* pill, not
         // the geometrically nearest one — with focus-driven selection a
         // nearest-pill landing would switch panes as a side effect.
@@ -160,7 +193,13 @@ struct TVPlayerInfoHUD: View {
                 )
             case .video:     VideoPane(viewModel: viewModel)
             case .audio:     AudioPane(viewModel: viewModel)
-            case .subtitles: SubtitlesPane(viewModel: viewModel, onCloseHUD: onDismiss)
+            case .subtitles:
+                SubtitlesPane(
+                    viewModel: viewModel,
+                    overlayActive: $subtitleOverlayActive,
+                    showSubtitleSearchMenu: $showSubtitleSearchMenu,
+                    showAITranslateMenu: $showAITranslateMenu
+                )
             case .chapters:  ChaptersPane(viewModel: viewModel, onSelect: onDismiss)
             }
         }
@@ -1529,13 +1568,10 @@ private struct AudioPane: View {
 
 private struct SubtitlesPane: View {
     let viewModel: PlayerViewModel
-    /// Dismiss the whole HUD (back to the player). Used when an AI subtitle job
-    /// is accepted so the live "Preparing subtitles" overlay is visible.
-    let onCloseHUD: () -> Void
-
+    @Binding var overlayActive: Bool
+    @Binding var showSubtitleSearchMenu: Bool
+    @Binding var showAITranslateMenu: Bool
     @State private var showAppearanceDialog = false
-    @State private var showAITranslateMenu = false
-    @State private var showSubtitleSearchMenu = false
     @State private var activePicker: HUDPickerPresentation?
     @State private var pickerReturnField: Option?
     @FocusState private var focusedOption: Option?
@@ -1553,7 +1589,7 @@ private struct SubtitlesPane: View {
         case appearance
     }
 
-    private var overlayActive: Bool {
+    private var hasPresentedOverlay: Bool {
         showAppearanceDialog || activePicker != nil || showAITranslateMenu
             || showSubtitleSearchMenu
     }
@@ -1572,8 +1608,8 @@ private struct SubtitlesPane: View {
             // column. Explicitly route Down into the leftmost Tracks column
             // so entering this pane is consistent with the other track panes.
             .defaultFocus($entryTrackFocused, true, priority: .userInitiated)
-            .disabled(overlayActive)
-            .opacity(overlayActive ? 0.28 : 1)
+            .disabled(hasPresentedOverlay)
+            .opacity(hasPresentedOverlay ? 0.28 : 1)
 
             if showAppearanceDialog {
                 SubtitleAppearanceDialog(
@@ -1593,48 +1629,38 @@ private struct SubtitlesPane: View {
                 )
             }
 
-            // The AI translate/transcribe flow reuses the shared
-            // `SubtitleTranslateMenu` as a modal overlay — same presentation
-            // idiom as the appearance dialog above (columns dimmed + disabled).
-            if showAITranslateMenu {
-                SubtitleTranslateMenu(
-                    viewModel: viewModel,
-                    onDismiss: closeAITranslateMenu,
-                    // Job accepted: close the menu AND the HUD so the live
-                    // "Preparing subtitles" overlay is visible on the player.
-                    onJobStarted: {
-                        closeAITranslateMenu()
-                        onCloseHUD()
-                    }
-                )
-                .transition(.opacity)
-            }
-
-            // Provider subtitle search — same modal-overlay idiom as the AI
-            // menu above.
-            if showSubtitleSearchMenu {
-                SubtitleSearchMenu(
-                    viewModel: viewModel,
-                    onDismiss: closeSubtitleSearchMenu,
-                    // Download succeeded (track registered + selected): close
-                    // the menu AND the HUD so the player is visible.
-                    onDownloaded: {
-                        closeSubtitleSearchMenu()
-                        onCloseHUD()
-                    }
-                )
-                .transition(.opacity)
-            }
         }
         .animation(.easeOut(duration: SiloTheme.fastDuration), value: showAppearanceDialog)
         .animation(.easeOut(duration: SiloTheme.fastDuration), value: activePicker?.id)
         .animation(.easeOut(duration: SiloTheme.fastDuration), value: showAITranslateMenu)
         .animation(.easeOut(duration: SiloTheme.fastDuration), value: showSubtitleSearchMenu)
-    }
-
-    private func closeAITranslateMenu() {
-        showAITranslateMenu = false
-        focusedOption = .translate
+        // The HUD rail selects panes on focus. Keep it out of the focus graph
+        // while a dialog replaces its rows during search or other actions.
+        .onChange(of: hasPresentedOverlay, initial: true) { _, presented in
+            overlayActive = presented
+        }
+        .onDisappear { overlayActive = false }
+        .onChange(of: showSubtitleSearchMenu) { _, presented in
+            if !presented {
+                // Restore after the HUD becomes visible and focusable again.
+                DispatchQueue.main.async {
+                    guard !showSubtitleSearchMenu else { return }
+                    restoreSubtitleSearchFocus()
+                }
+            }
+        }
+        .onChange(of: showAITranslateMenu) { _, presented in
+            if !presented {
+                DispatchQueue.main.async {
+                    guard !showAITranslateMenu else { return }
+                    if aiSubtitlesAvailable {
+                        focusedOption = .translate
+                    } else {
+                        entryTrackFocused = true
+                    }
+                }
+            }
+        }
     }
 
     /// Restore focus to the "Search Subtitles…" row — unless the provider
@@ -1643,8 +1669,7 @@ private struct SubtitlesPane: View {
     /// Returning focus to an unreachable target would leave the pane with
     /// nothing focused, so fall back to the Tracks column's "Off" row, which
     /// is always present (docs/tvos-focus.md).
-    private func closeSubtitleSearchMenu() {
-        showSubtitleSearchMenu = false
+    private func restoreSubtitleSearchFocus() {
         if viewModel.subtitleSearchEnabled {
             focusedOption = .search
         } else {

--- a/iosApp/iosApp/Screens/Player/tvOS/TVSubtitleDialog.swift
+++ b/iosApp/iosApp/Screens/Player/tvOS/TVSubtitleDialog.swift
@@ -1,0 +1,97 @@
+#if os(tvOS)
+import SwiftUI
+
+/// Shared presentation for provider search and AI subtitle creation.
+struct TVSubtitleDialog<Content: View>: View {
+    let title: String
+    let subtitle: String
+    let backHint: String
+    var statusHint: String = ""
+    let onDismiss: () -> Void
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.55)
+                .ignoresSafeArea()
+                .contentShape(Rectangle())
+                .onTapGesture(perform: onDismiss)
+
+            VStack(alignment: .leading, spacing: 22) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(title)
+                        .font(.system(size: 32, weight: .semibold))
+                        .foregroundStyle(.white)
+                    Text(subtitle)
+                        .font(.system(size: 22))
+                        .foregroundStyle(.white.opacity(0.65))
+                        .lineLimit(2)
+                }
+                .padding(.horizontal, 16)
+
+                Divider().overlay(.white.opacity(0.12))
+                content()
+                Divider().overlay(.white.opacity(0.12))
+
+                HStack {
+                    Label(backHint, systemImage: "chevron.backward.circle")
+                    Spacer()
+                    Text(statusHint)
+                }
+                .font(.system(size: 18))
+                .foregroundStyle(.white.opacity(0.6))
+                .padding(.horizontal, 16)
+            }
+            .padding(34)
+            .frame(width: 1280, height: 800)
+            .siloPlayerGlass(in: RoundedRectangle(cornerRadius: 28, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 28, style: .continuous)
+                    .stroke(Color.white.opacity(0.18), lineWidth: 1)
+            )
+            .shadow(color: .black.opacity(0.6), radius: 26, y: 14)
+        }
+    }
+}
+
+/// Native button with the player HUD's white focus fill and inverted label.
+struct TVSubtitleMenuRow<Content: View>: View {
+    let rowID: String
+    var isDisabled: Bool = false
+    @FocusState.Binding var focusedID: String?
+    let action: () -> Void
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        Button(action: action) {
+            HStack(alignment: .center, spacing: 18) {
+                content()
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .buttonStyle(TVSubtitleMenuRowStyle(isFocused: focusedID == rowID))
+        .focusEffectDisabled()
+        .focused($focusedID, equals: rowID)
+        .disabled(isDisabled)
+        .opacity(isDisabled ? 0.35 : 1)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct TVSubtitleMenuRowStyle: ButtonStyle {
+    let isFocused: Bool
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .padding(.horizontal, 20)
+            .padding(.vertical, 18)
+            .foregroundStyle(isFocused ? Color.black : Color.white)
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(isFocused ? Color.white : Color.clear)
+            )
+            .contentShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .scaleEffect(configuration.isPressed ? 0.98 : 1)
+    }
+}
+#endif


### PR DESCRIPTION
Selecting a subtitle language during tvOS playback could briefly open search and then return to Info. The search dialog also had an oversized black rectangle behind it, and AI Subtitles used a different layout.

This moves both dialogs to the HUD root, prevents focus from escaping to the tab rail during search, and restores focus to the opening option on Back. Both menus use a shared larger panel and native button rows with consistent text, spacing, focus styling, and navigation hints. Language aliases now share the existing normalizer so English does not appear twice.

Reported directly during playback testing; no matching tracked issue was identified.

## Validation

- Signed SiloTV Debug build succeeded; installed, launched, and verified the process on a physical Apple TV through the paired Mac.
- Arabic provider search returned 18 results without dismissing the dialog.
- Checked result navigation, language scrolling, reopening both menus, and Back restoring focus to the correct subtitle option.
- Inspected the rendered layout and backdrop. Remote screenshots intermittently showed missing text; the user reported that the TV itself looked fine. The capture discrepancy remains unconfirmed.
- `git diff --check` passed. No new XCTest run was performed for this UI change.

## Risks and follow-up

AI generation, subtitle downloading, and failure states still need runtime verification. Shared language deduplication and search cancellation also affect iOS; iOS was not exercised in this pass.

## AI disclosure

Implemented and prepared with `gpt-6-astra` and `gpt-5.6-sol` in the Codex agent harness. No other AI tooling was used. The unslop skill was used for the PR readability pass.
